### PR TITLE
[MOD-593] Don't enable Sentry SDK default integrations to avoid fastapi import

### DIFF
--- a/modal/config.py
+++ b/modal/config.py
@@ -272,10 +272,11 @@ if config["sentry_dsn"] and "localhost" not in config["server_url"]:
         sentry_sdk.init(
             # Sentry DSN for the client project; not secret.
             config["sentry_dsn"],
-            integrations=[AtexitIntegration(callback=_sentry_exit_callback), sentry_logging],
-            traces_sample_rate=1,
+            auto_enabling_integrations=False,
             before_send=_filter_exceptions,
             ignore_errors=FILTERED_ERROR_TYPES,  # type: ignore
+            integrations=[AtexitIntegration(callback=_sentry_exit_callback), sentry_logging],
+            traces_sample_rate=1,
         )  # type: ignore
 
         sentry_sdk.set_tag("token_id", config["token_id"])


### PR DESCRIPTION
Copy over of https://github.com/modal-labs/modal/pull/3761