### PR TITLE
[mod-593] Try avoid importing rich if importing 'modal' on worker

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -1,16 +1,18 @@
-from typing import Dict, Optional
-
-from rich.tree import Tree
+from typing import TYPE_CHECKING, Dict, Optional, TypeVar
 
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronize_apis
 from modal_utils.grpc_utils import retry_transient_errors
 
-from ._output import step_completed, step_progress, step_progress_update
 from .client import _Client
 from .config import logger
 from .functions import _FunctionHandle
 from .object import Handle, Provider
+
+if TYPE_CHECKING:
+    from rich.tree import Tree
+else:
+    Tree = TypeVar("Tree")
 
 
 class _App:
@@ -72,6 +74,12 @@ class _App:
         self, obj: Provider, progress: Optional[Tree] = None, existing_object_id: Optional[str] = None
     ) -> Handle:
         """Send a server request to create an object in this app, and return its ID."""
+        from ._output import (  # Lazy import to only import `rich` when necessary.
+            step_completed,
+            step_progress,
+            step_progress_update,
+        )
+
         cached_obj = self._load_cached(obj)
         if cached_obj is not None:
             # We already created this object before, shortcut this method

--- a/modal/config.py
+++ b/modal/config.py
@@ -292,5 +292,6 @@ warnings.filterwarnings(
     module="modal",
 )
 
-# Set up rich tracebacks.
-setup_rich_traceback()
+# Set up rich tracebacks, but only on user's end.
+if _user_config:
+    setup_rich_traceback()


### PR DESCRIPTION
None of the `rich.*` imports are particularly heavy, but there's 61 modules imported for `rich`, not including the deps of `rich` that are exclusively `rich`'s. 

`rich` is essential on the user-side until we add a lite-mode that cuts out the `rich` niceness, but `rich` isn't needed on the worker-side. This reworks out imports to avoid importing `rich` if it isn't used.

----

You can paste the HAR formatted data below into http://www.softwareishard.com/har/viewer/ to see the `import` behavior of Modal right now. 

[modal-import.har.txt](https://github.com/modal-labs/modal-client/files/9825192/modal-import.har.txt)
