### PR TITLE
Fix shared volume path checks

### DIFF
--- a/client_test/shared_volume_test.py
+++ b/client_test/shared_volume_test.py
@@ -20,14 +20,27 @@ def test_shared_volume_files(client, test_dir, servicer):
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="TODO: implement client-side path check on Windows.")
-def test_shared_volume_bad_path(client, test_dir, servicer):
+def test_shared_volume_bad_paths(client, test_dir, servicer):
     stub = modal.Stub()
 
-    @stub.function(
-        shared_volumes={"/root/../../foo": modal.SharedVolume()},
-    )
-    def f():
+    def _f():
         pass
+
+    f = stub.function(shared_volumes={"/root/../../foo": modal.SharedVolume()})(_f)
+
+    with pytest.raises(InvalidError):
+        with stub.run(client=client):
+            f()
+
+    f = stub.function(
+        shared_volumes={"/": modal.SharedVolume()},
+    )(_f)
+
+    with pytest.raises(InvalidError):
+        with stub.run(client=client):
+            f()
+
+    f = stub.function(shared_volumes={"/tmp/": modal.SharedVolume()})(_f)
 
     with pytest.raises(InvalidError):
         with stub.run(client=client):


### PR DESCRIPTION
Fixes client-side `SharedVolume` path check to not use `.resolve()` (because that resolves local symlinks), and also not allow mounting at `/tmp` (to prevent conflicts with our Unix socket).