### PR TITLE
auto-bump patch number immediately

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -91,6 +91,12 @@ jobs:
       - name: Bump the version number
         run: inv update-build-number $GITHUB_RUN_NUMBER
 
+      - uses: EndBug/add-and-commit@v9
+        with:
+          add: modal_version/_version_generated.py
+          message: "[auto-commit] Bump the build number"
+          pull: "--rebase --autostash"
+
       - name: Build protobuf
         run: inv protoc
 
@@ -106,12 +112,6 @@ jobs:
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         run: python -m modal_base_images.client_mount
-
-      - uses: EndBug/add-and-commit@v9
-        with:
-          add: modal_version/_version_generated.py
-          message: "[auto-commit] Bump the build number"
-          pull: "--rebase --autostash"
 
       - name: Upload to PyPI
         env:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -81,6 +81,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     needs: [client-test]
     runs-on: ubuntu-20.04
+    concurrency: publish-client
     steps:
       - uses: actions/checkout@v3
 

--- a/tasks.py
+++ b/tasks.py
@@ -52,6 +52,7 @@ def check_copyright(ctx, fix=False):
 def update_build_number(ctx, new_build_number):
     new_build_number = int(new_build_number)
     from modal_version import build_number as current_build_number
+
     assert new_build_number > current_build_number
     with open("modal_version/_version_generated.py", "w") as f:
         f.write(f"{copyright_header_full}\nbuild_number = {new_build_number}\n")

--- a/tasks.py
+++ b/tasks.py
@@ -49,6 +49,9 @@ def check_copyright(ctx, fix=False):
 
 
 @task
-def update_build_number(ctx, build_number):
+def update_build_number(ctx, new_build_number):
+    new_build_number = int(new_build_number)
+    from modal_version import build_number as current_build_number
+    assert new_build_number > current_build_number
     with open("modal_version/_version_generated.py", "w") as f:
-        f.write(f"{copyright_header_full}\nbuild_number = {build_number}\n")
+        f.write(f"{copyright_header_full}\nbuild_number = {new_build_number}\n")


### PR DESCRIPTION
This should reduce the potential for race conditions in CI. The race condition happens in the publish step

PR 1: clone the repo
PR 2: clone the repo
PR 1: push a new build number
PR 2: push a new build number  – CONFLICT

If we can make the "critical section" smaller, that reduces this risk. Unfortunately we can't make it super small because we need to install some Python tooling to run `inv update-build-number` but this at least makes it a bit smaller

Also added a sanity check to the inv task to make sure the number is always higher