### PR TITLE
Require Rich >= 12.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     grpclib==0.4.3
     importlib_metadata
     protobuf>=3.19,<5.0
-    rich
+    rich>=12.0.0
     sentry-sdk
     synchronicity>=0.2.10
     tblib>=1.7.0


### PR DESCRIPTION
We're using some newer features and for some weird reason, when I build a Docker image, it installs an 11.* version