### PR TITLE
Close channel pool in case of ClientCreate failure

### DIFF
--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -111,7 +111,10 @@ class MockClientServicer(api_grpc.ModalClientBase):
         request = await stream.recv_message()
         self.requests.append(request)
         client_id = "cl-123"
-        if request.version == "timeout":
+        print(stream.metadata)
+        if stream.metadata.get("x-modal-token-id") == "bad":
+            raise GRPCError(Status.UNAUTHENTICATED, "bad bad bad")
+        elif request.version == "timeout":
             await asyncio.sleep(60)
             await stream.send_message(api_pb2.ClientCreateResponse(client_id=client_id))
         elif request.version == "unauthenticated":

--- a/client_test/e2e_test.py
+++ b/client_test/e2e_test.py
@@ -6,20 +6,21 @@ import sys
 from typing import Tuple
 
 
-def _cli(args, server_url) -> Tuple[str, str]:
+def _cli(args, server_url, extra_env={}, check=True) -> Tuple[int, str, str]:
     lib_dir = pathlib.Path(__file__).parent.parent
     args = [sys.executable] + args
     env = {
         "MODAL_SERVER_URL": server_url,
         **os.environ,
         "PYTHONUTF8": "1",  # For windows
+        **extra_env,
     }
     ret = subprocess.run(args, cwd=lib_dir, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout = ret.stdout.decode()
     stderr = ret.stderr.decode()
-    if ret.returncode != 0:
+    if check and ret.returncode != 0:
         raise Exception(f"Failed with {ret.returncode} stdout: {stdout} stderr: {stderr}")
-    return stdout, stderr
+    return ret.returncode, stdout, stderr
 
 
 def test_run_e2e(servicer):
@@ -31,10 +32,21 @@ def test_run_profiler(servicer):
 
 
 def test_run_unconsumed_map(servicer):
-    _, err = _cli(["-m", "modal_test_support.unconsumed_map"], servicer.remote_addr)
+    _, _, err = _cli(["-m", "modal_test_support.unconsumed_map"], servicer.remote_addr)
     assert "map" in err
     assert "for-loop" in err
 
-    _, err = _cli(["-m", "modal_test_support.consumed_map"], servicer.remote_addr)
+    _, _, err = _cli(["-m", "modal_test_support.consumed_map"], servicer.remote_addr)
     assert "map" not in err
     assert "for-loop" not in err
+
+
+def test_auth_failure_last_line(servicer):
+    returncode, _, err = _cli(
+        ["-m", "modal_test_support.script"],
+        servicer.remote_addr,
+        extra_env={"MODAL_TOKEN_ID": "bad", "MODAL_TOKEN_SECRET": "bad"},
+        check=False,
+    )
+    assert returncode != 0
+    assert "bad bad bad" in err.strip().split("\n")[-1]  # err msg should be on the last line


### PR DESCRIPTION
If there was some error setting up the connection (e.g. no token provided), the output would have a confusing last line:

```
Traceback (most recent call last):
  File "/Users/erikbern/modal-examples/01_getting_started/get_started.py", line 13, in <module>
    with stub.run():
  File "/Users/erikbern/python3.10-env/lib/python3.10/site-packages/synchronicity/synchronizer.py", line 398, in proxy_method
    raise uc_exc.exc from None
  File "/Users/erikbern/python3.10-env/lib/python3.10/site-packages/synchronicity/contextlib.py", line 21, in __aenter__
    return await self._gen.__anext__()
  File "/Users/erikbern/modal-client/modal/stub.py", line 288, in run
    client = await _Client.from_env()
  File "/Users/erikbern/modal-client/modal/client.py", line 261, in from_env
    await client._start()
  File "/Users/erikbern/modal-client/modal/client.py", line 115, in _start
    raise AuthError(exc.message)
modal.exception.AuthError: Token missing: either token id+secret or task id+secret must be provided
2022-10-24T17:55:24-0400 Channel pool not properly closed
```

This makes sure to close the channel pool regardless, to make sure the last line is the `AuthError`