### PR TITLE
Interactive functions

### DIFF
--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
 from modal_version import __version__
 
+from ._pty import ipython
 from .app import App, container_app, is_local
 from .dict import Dict
 from .exception import Error
@@ -41,6 +42,7 @@ __all__ = [
     "container_app",
     "create_package_mount",
     "create_package_mounts",
+    "ipython",
     "is_local",
     "lookup",
     "ref",

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -511,7 +511,7 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
         with function_io_manager.handle_user_exception():
             cls, fun = import_function(container_args.function_def)
 
-    if container_args.function_def.pty_info.queue_id:
+    if container_args.function_def.pty_info.enabled:
         from modal import container_app
 
         input_stream_unwrapped = synchronizer._translate_in(container_app._pty_input_stream)

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -11,6 +11,7 @@ from typing import Any, AsyncIterator, Callable, Optional, Tuple, Type
 
 import cloudpickle
 from grpclib import Status
+from synchronicity.interface import Interface
 
 from modal_proto import api_pb2
 from modal_utils.async_utils import (
@@ -513,7 +514,9 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
     if container_args.function_def.pty_info.queue_id:
         from modal import container_app
 
-        fun = run_in_pty(fun, container_app._pty_input_stream, container_args.function_def.pty_info)
+        input_stream_unwrapped = synchronizer._translate_in(container_app._pty_input_stream)
+        input_stream_blocking = synchronizer._translate_out(input_stream_unwrapped, Interface.BLOCKING)
+        fun = run_in_pty(fun, input_stream_blocking, container_args.function_def.pty_info)
 
     if not is_async(fun):
         call_function_sync(function_io_manager, cls, fun, is_generator)

--- a/modal/_pty.py
+++ b/modal/_pty.py
@@ -67,7 +67,11 @@ def _pty_spawn(pty_info: api_pb2.PTYInfo, fn, args, kwargs):
 
     pid, master_fd = pty.fork()
     if pid == pty.CHILD:
-        fn(*args, **kwargs)
+        res = fn(*args, **kwargs)
+        if res is not None:
+            print(
+                "Return values from interactive functions are currently ignored. Ignoring result of %s." % fn.__name__
+            )
         os._exit(0)
 
     if pty_info.winsz_rows or pty_info.winsz_cols:

--- a/modal/_pty.py
+++ b/modal/_pty.py
@@ -113,14 +113,9 @@ def run_in_pty(fn, queue, pty_info: api_pb2.PTYInfo):
         t = threading.Thread(target=_read)
         t.start()
 
-        if pty_info.env_term:
-            os.environ["TERM"] = pty_info.env_term
-
-        if pty_info.env_colorterm:
-            os.environ["COLORTERM"] = pty_info.env_colorterm
-
-        if pty_info.env_term_program:
-            os.environ["TERM_PROGRAM"] = pty_info.env_term_program
+        os.environ.update(
+            {"TERM": pty_info.env_term, "COLORTERM": pty_info.env_colorterm, "TERM_PROGRAM": pty_info.env_term_program}
+        )
 
         _pty_spawn(pty_info, fn, args, kwargs)
         queue.put(None)
@@ -130,10 +125,10 @@ def run_in_pty(fn, queue, pty_info: api_pb2.PTYInfo):
     return wrapped_fn
 
 
-def get_pty_info(queue_id: str) -> api_pb2.PTYInfo:
+def get_pty_info() -> api_pb2.PTYInfo:
     rows, cols = get_winsz(sys.stdin.fileno())
     return api_pb2.PTYInfo(
-        queue_id=queue_id,
+        enabled=True,
         winsz_rows=rows,
         winsz_cols=cols,
         env_term=os.environ.get("TERM"),

--- a/modal/_pty.py
+++ b/modal/_pty.py
@@ -171,19 +171,12 @@ async def write_stdin_to_pty_stream(queue: _QueueHandle):
         write_task.cancel()
 
 
-def _exec_cmd(cmd: str = None):
+def exec_cmd(cmd: str = None):
     run_cmd = cmd or os.environ.get("SHELL", "sh")
 
-    print(f"Spawning {run_cmd}. Type 'exit' to exit. ")
+    print(f"Spawning {run_cmd}.")
 
     # TODO: support args.
     argv = [run_cmd]
 
     os.execlp(argv[0], *argv)
-
-
-async def image_pty(image, stub, cmd=None, **kwargs):
-    exec_cmd = stub.function(interactive=True, image=image, **kwargs)(_exec_cmd)
-
-    async with stub.run():
-        await exec_cmd()

--- a/modal/_pty.py
+++ b/modal/_pty.py
@@ -5,6 +5,7 @@ import functools
 import os
 import select
 import sys
+import traceback
 from typing import Optional, Tuple, no_type_check
 
 from modal.queue import _QueueHandle
@@ -67,7 +68,11 @@ def _pty_spawn(pty_info: api_pb2.PTYInfo, fn, args, kwargs):
 
     pid, master_fd = pty.fork()
     if pid == pty.CHILD:
-        res = fn(*args, **kwargs)
+        try:
+            res = fn(*args, **kwargs)
+        except Exception:
+            traceback.print_exc()
+            os._exit(1)
         if res is not None:
             print(
                 "Return values from interactive functions are currently ignored. Ignoring result of %s." % fn.__name__

--- a/modal/_pty.py
+++ b/modal/_pty.py
@@ -68,7 +68,7 @@ def _pty_spawn(pty_info: api_pb2.PTYInfo, fn, args, kwargs):
     pid, master_fd = pty.fork()
     if pid == pty.CHILD:
         fn(*args, **kwargs)
-        return
+        os._exit(0)
 
     if pty_info.winsz_rows or pty_info.winsz_cols:
         set_winsz(master_fd, pty_info.winsz_rows, pty_info.winsz_cols)

--- a/modal/_pty.py
+++ b/modal/_pty.py
@@ -180,3 +180,9 @@ def exec_cmd(cmd: str = None):
     argv = [run_cmd]
 
     os.execlp(argv[0], *argv)
+
+
+def ipython():
+    from IPython import embed
+
+    embed()

--- a/modal/requirements.txt
+++ b/modal/requirements.txt
@@ -10,6 +10,7 @@ fastapi==0.75.2
 fastprogress==1.0.0
 grpclib==0.4.3
 importlib_metadata==4.8.1
+ipython==8.5.0
 protobuf>=4.21.0
 python-multipart>=0.0.5
 rich==12.3.0

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -545,7 +545,7 @@ class _Stub:
             concurrency_limit=concurrency_limit,
             timeout=timeout,
             cpu=cpu,
-            interactive=True,
+            interactive=interactive,
         )
         return self._add_function(function)
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -287,7 +287,7 @@ message DictUpdateResponse {
 }
 
 message PTYInfo {
-  string queue_id = 1; // Modal queue through which interactive input is buffered.
+  bool enabled = 1;
   uint32 winsz_rows = 2;
   uint32 winsz_cols = 3;
   string env_term = 4;

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -286,6 +286,15 @@ message DictUpdateRequest {
 message DictUpdateResponse {
 }
 
+message PTYInfo {
+  string queue_id = 1; // Modal queue through which interactive input is buffered.
+  uint32 winsz_rows = 2;
+  uint32 winsz_cols = 3;
+  string env_term = 4;
+  string env_colorterm = 5;
+  string env_term_program = 6;
+}
+
 message Function {
   string module_name = 1;
   string function_name = 2;
@@ -325,6 +334,8 @@ message Function {
   bool keep_warm = 20;
 
   uint32 timeout_secs = 21;
+
+  PTYInfo pty_info = 22;
 }
 
 message FunctionCreateRequest {

--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -7,7 +7,7 @@ from ._version_generated import build_number  # Written by GitHub
 major_number = 0
 
 # Bump this manually on any major changes
-minor_number = 39
+minor_number = 40
 
 # Right now, set the patch number (the 3rd field) to the job run number in GitHub
 __version__ = f"{major_number}.{minor_number}.{build_number}"


### PR DESCRIPTION
Adding `interactive=True` runs it in a PTY. This means that `breakpoint()` works out of the box when called from inside that function:


https://user-images.githubusercontent.com/5786378/197664805-c51d67bc-3d02-4264-945d-6f2a1fd34f73.mov


Also installing ipython inside the image (but not adding to `setup.cfg`, so it's not a requirement to install Modal). `modal.ipython()` is a simple wrapper around `IPython.embed()` that you can drop in to open an IPython shell from an interactive function.

The biggest caveat is that interactive functions don't return their values anymore, because of the way the function runs in a child process. It's possible to do this better, but it's a bit gnarly so will let this rest for a bit. For now, adding a warning that lets the user know that the return value won't be sent back (if their function returns a value).
