### PR TITLE
Get rid of `cuda-python` in the container

### DIFF
--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2022
 from modal_version import __version__
 
-from ._pty import ipython
 from .app import App, container_app, is_local
 from .dict import Dict
 from .exception import Error
@@ -42,7 +41,6 @@ __all__ = [
     "container_app",
     "create_package_mount",
     "create_package_mounts",
-    "ipython",
     "is_local",
     "lookup",
     "ref",

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -433,19 +433,6 @@ async def call_function_async(
                     cls.__exit__(self, *sys.exc_info())
 
 
-def _wait_for_gpu_init():
-    from cuda import cuda
-
-    for i in range(3):
-        try:
-            cuda.cuInit(0)
-            logger.info("CUDA device initialized successfully.")
-            return
-        except Exception:
-            time.sleep(1)
-    logger.info("Failed to initialize CUDA device.")
-
-
 @wrap()
 def import_function(function_def: api_pb2.Function) -> Tuple[Optional[Type], Callable]:
     # This is not in function_io_manager, so that any global scope code that runs during import
@@ -492,9 +479,6 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
     # we could catch that exception and set it properly serialized to the client. Right now the
     # whole container fails with a non-zero exit code and we send back a more opaque error message.
     function_type = container_args.function_def.function_type
-
-    if container_args.function_def.resources.gpu:
-        _wait_for_gpu_init()
 
     # This is a bit weird but we need both the blocking and async versions of FunctionIOManager.
     # At some point, we should fix that by having built-in support for running "user code"

--- a/modal/_pty.py
+++ b/modal/_pty.py
@@ -185,9 +185,3 @@ def exec_cmd(cmd: str = None):
     argv = [run_cmd]
 
     os.execlp(argv[0], *argv)
-
-
-def ipython():
-    from IPython import embed
-
-    embed()

--- a/modal/requirements.txt
+++ b/modal/requirements.txt
@@ -4,7 +4,6 @@ aiostream==0.4.4
 asgiref==3.5.2
 certifi==2021.10.8
 cloudpickle==2.0.0
-cuda-python==11.7.1
 ddtrace==1.5.2
 fastapi==0.75.2
 fastprogress==1.0.0


### PR DESCRIPTION
We're doing our GPU health checks somewhere else now.