### PR TITLE
nit: consistent 'mypy' command with other repo

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,7 +42,7 @@ jobs:
 
       - run: inv protoc
 
-      - run: mypy .
+      - run: inv mypy
 
   check-copyright:
     name: Check copyright

--- a/tasks.py
+++ b/tasks.py
@@ -24,6 +24,11 @@ def protoc(ctx):
 
 
 @task
+def mypy(ctx):
+    ctx.run("mypy .", pty=True)
+
+
+@task
 def check_copyright(ctx, fix=False):
     invalid_files = []
     d = str(Path(__file__).parent)


### PR DESCRIPTION
Very minor, but it's nice do just do `inv mypy` everywhere. Muscle memory and all that.