### PR TITLE
Print app URL in underlined link.

### DIFF
--- a/modal/stub.py
+++ b/modal/stub.py
@@ -219,9 +219,8 @@ class _Stub:
                 logs_loop = tc.create_task(
                     output_mgr.get_logs_loop(app_id, client, status_spinner, last_log_entry_id or "")
                 )
-            output_mgr.print_if_visible(
-                step_completed(f"Initialized. [grey70]View app page at {app._app_page_url}.[/grey70]")
-            )
+            initialized_msg = f"Initialized. [grey70]View app at [underline]{app._app_page_url}[/underline].[/grey70]"
+            output_mgr.print_if_visible(step_completed(initialized_msg))
 
             try:
                 # Create all members


### PR DESCRIPTION
This is consistent with how we display links for webhooks.