### PR TITLE
Run Modal functions for image build steps

### DIFF
--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -73,6 +73,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
         self.shared_volume_files = []
         self.images = {}
+        self.image_build_function_ids = {}
         self.fail_blob_create = []
         self.blob_create_metadata = None
 
@@ -152,6 +153,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         request = await stream.recv_message()
         idx = len(self.images)
         self.images[idx] = request.image
+        self.image_build_function_ids[idx] = request.build_function_id
         await stream.send_message(api_pb2.ImageGetOrCreateResponse(image_id=f"im-{idx}"))
 
     async def ImageJoin(self, stream):

--- a/modal/app.py
+++ b/modal/app.py
@@ -104,7 +104,7 @@ class _App:
                 step_progress_update(spinner, message)
 
         # Create object
-        created_obj = await obj._load(self.client, self.app_id, loader, set_message, existing_object_id)
+        created_obj = await obj._load(self.client, self._stub, self.app_id, loader, set_message, existing_object_id)
 
         # Change message to a completed step
         if progress and last_message:

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -113,7 +113,7 @@ class _Dict(Provider[_DictHandle]):
         self._data = data
         super().__init__()
 
-    async def _load(self, client, app_id, loader, message_callback, existing_dict_id):
+    async def _load(self, client, stub, app_id, loader, message_callback, existing_dict_id):
         serialized = _serialize_dict(self._data)
         req = api_pb2.DictCreateRequest(app_id=app_id, data=serialized, existing_dict_id=existing_dict_id)
         response = await client.stub.DictCreate(req)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -395,7 +395,7 @@ class _FunctionHandle(Handle, type_prefix="fu"):
     def _set_mute_cancellation(self, value=True):
         self._mute_cancellation = value
 
-    def _buiinitialize_from_proto(self, function: api_pb2.Function):
+    def _initialize_from_proto(self, function: api_pb2.Function):
         self._is_generator = function.function_type == api_pb2.Function.FUNCTION_TYPE_GENERATOR
 
     def _set_local_app(self, app):
@@ -620,7 +620,6 @@ class _Function(Provider[_FunctionHandle]):
         cpu: Optional[float] = None,
         keep_warm: bool = False,
         interactive: bool = False,
-        _is_build_step: bool = False,
     ) -> None:
         """mdmd:hidden"""
         assert callable(raw_f)
@@ -684,7 +683,6 @@ class _Function(Provider[_FunctionHandle]):
         self._concurrency_limit = concurrency_limit
         self._keep_warm = keep_warm
         self._interactive = interactive
-        self._is_build_step = _is_build_step
         self._tag = self._info.get_tag()
         super().__init__()
 
@@ -798,7 +796,6 @@ class _Function(Provider[_FunctionHandle]):
             concurrency_limit=self._concurrency_limit,
             keep_warm=self._keep_warm,
             pty_info=pty_info,
-            _is_build_step=self._is_build_step,
         )
         request = api_pb2.FunctionCreateRequest(
             app_id=app_id,

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -32,6 +32,7 @@ from modal_utils.async_utils import (
     warn_if_generator_is_not_consumed,
 )
 from modal_utils.grpc_utils import retry_transient_errors
+
 from ._blob_utils import (
     BLOB_MAX_PARALLELISM,
     MAX_OBJECT_SIZE_BYTES,
@@ -685,7 +686,7 @@ class _Function(Provider[_FunctionHandle]):
         self._tag = self._info.get_tag()
         super().__init__()
 
-    async def _load(self, client, app_id, loader, message_callback, existing_function_id):
+    async def _load(self, client, stub, app_id, loader, message_callback, existing_function_id):
         message_callback(f"Creating {self._tag}...")
 
         if self._proxy:

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -376,7 +376,7 @@ async def _map_invocation(
 class _FunctionHandle(Handle, type_prefix="fu"):
     """Interact with a Modal Function of a live app."""
 
-    def __init__(self, function, web_url=None, client=None, object_id=None):
+    def __init__(self, function: "_Function", web_url=None, client=None, object_id=None):
         self._local_app = None
         self._progress = None
 
@@ -386,6 +386,7 @@ class _FunctionHandle(Handle, type_prefix="fu"):
         self._raw_f = function._raw_f
         self._web_url = web_url
         self._output_mgr: Optional[OutputManager] = None
+        self._function = function
         self._mute_cancellation = (
             False  # set when a user terminates the app intentionally, to prevent useless traceback spam
         )

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -395,7 +395,7 @@ class _FunctionHandle(Handle, type_prefix="fu"):
     def _set_mute_cancellation(self, value=True):
         self._mute_cancellation = value
 
-    def _initialize_from_proto(self, function: api_pb2.Function):
+    def _buiinitialize_from_proto(self, function: api_pb2.Function):
         self._is_generator = function.function_type == api_pb2.Function.FUNCTION_TYPE_GENERATOR
 
     def _set_local_app(self, app):
@@ -620,6 +620,7 @@ class _Function(Provider[_FunctionHandle]):
         cpu: Optional[float] = None,
         keep_warm: bool = False,
         interactive: bool = False,
+        _is_build_step: bool = False,
     ) -> None:
         """mdmd:hidden"""
         assert callable(raw_f)
@@ -683,6 +684,7 @@ class _Function(Provider[_FunctionHandle]):
         self._concurrency_limit = concurrency_limit
         self._keep_warm = keep_warm
         self._interactive = interactive
+        self._is_build_step = _is_build_step
         self._tag = self._info.get_tag()
         super().__init__()
 
@@ -796,6 +798,7 @@ class _Function(Provider[_FunctionHandle]):
             concurrency_limit=self._concurrency_limit,
             keep_warm=self._keep_warm,
             pty_info=pty_info,
+            _is_build_step=self._is_build_step,
         )
         request = api_pb2.FunctionCreateRequest(
             app_id=app_id,

--- a/modal/image.py
+++ b/modal/image.py
@@ -142,8 +142,8 @@ class _Image(Provider[_ImageHandle]):
             base_images = list(self._base_images.values())
             assert len(base_images) == 1
             kwargs = {**kwargs, "image": base_images[0], "_is_build_step": True}
-            wrapped_build_function = stub.function(*args, **kwargs)(fn)
-            build_function_id = await loader(wrapped_build_function)
+            build_function_handle = stub.function(*args, **kwargs)(fn)
+            build_function_id = await loader(build_function_handle._function)
         else:
             build_function_def = None
             build_function_id = None

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -114,7 +114,7 @@ class _Mount(Provider[_MountHandle]):
                     # Can happen with temporary files (e.g. emacs will write temp files and delete them quickly)
                     logger.info(f"Ignoring file not found: {exc}")
 
-    async def _load(self, client, app_id, loader, message_callback, existing_mount_id):
+    async def _load(self, client, stub, app_id, loader, message_callback, existing_mount_id):
         # Run a threadpool to compute hash values, and use concurrent coroutines to register files.
         t0 = time.time()
         n_concurrent_uploads = 16

--- a/modal/object.py
+++ b/modal/object.py
@@ -1,6 +1,15 @@
 # Copyright Modal Labs 2022
 import uuid
-from typing import Awaitable, Callable, Generic, Optional, Type, TypeVar, cast
+from typing import (
+    TYPE_CHECKING,
+    Awaitable,
+    Callable,
+    Generic,
+    Optional,
+    Type,
+    TypeVar,
+    cast,
+)
 
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronize_apis
@@ -8,6 +17,9 @@ from modal_utils.async_utils import synchronize_apis
 from ._object_meta import ObjectMeta
 from .client import _Client
 from .exception import InvalidError, NotFoundError, deprecation_warning
+
+if TYPE_CHECKING:
+    from .stub import _Stub
 
 H = TypeVar("H", bound="Handle")
 
@@ -124,6 +136,7 @@ class Provider(Generic[H]):
     async def _load(
         self,
         client: _Client,
+        stub: "_Stub",
         app_id: str,
         loader: Callable[["Provider"], Awaitable[str]],
         message_callback: Callable[[str], None],

--- a/modal/object.py
+++ b/modal/object.py
@@ -188,6 +188,7 @@ class RemoteRef(Ref[H]):
     async def _load(
         self,
         client: _Client,
+        stub: "_Stub",
         app_id: str,
         loader: Callable[["Provider"], Awaitable[str]],
         message_callback: Callable[[str], None],
@@ -206,6 +207,7 @@ class PersistedRef(Ref[H]):
     async def _load(
         self,
         client: _Client,
+        stub: "_Stub",
         app_id: str,
         loader: Callable[["Provider"], Awaitable[str]],
         message_callback: Callable[[str], None],

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -134,7 +134,7 @@ class _Queue(Provider[_QueueHandle]):
     The queue can contain any object serializable by `cloudpickle`.
     """
 
-    async def _load(self, client, app_id, loader, message_callback, existing_object_id):
+    async def _load(self, client, stub, app_id, loader, message_callback, existing_object_id):
         request = api_pb2.QueueCreateRequest(app_id=app_id, existing_queue_id=existing_object_id)
         response = await client.stub.QueueCreate(request)
         return _QueueHandle(client, response.queue_id)

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -28,7 +28,7 @@ class _Secret(Provider[_SecretHandle]):
         super().__init__()
 
     def __repr__(self):
-        return f"Secret({self._env_dict.keys()})"
+        return f"Secret([{', '.join(self._env_dict.keys())}])"
 
     async def _load(self, client, stub, app_id, loader, message_callback, existing_secret_id):
         req = api_pb2.SecretCreateRequest(

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -30,7 +30,7 @@ class _Secret(Provider[_SecretHandle]):
     def __repr__(self):
         return f"Secret({self._env_dict.keys()})"
 
-    async def _load(self, client, app_id, loader, message_callback, existing_secret_id):
+    async def _load(self, client, stub, app_id, loader, message_callback, existing_secret_id):
         req = api_pb2.SecretCreateRequest(
             app_id=app_id,
             env_dict=self._env_dict,

--- a/modal/shared_volume.py
+++ b/modal/shared_volume.py
@@ -117,7 +117,7 @@ class _SharedVolume(Provider[_SharedVolumeHandle]):
     def _get_creating_message(self) -> str:
         return "Creating shared volume..."
 
-    async def _load(self, client, app_id, loader, message_callback, existing_shared_volume_id):
+    async def _load(self, client, stub, app_id, loader, message_callback, existing_shared_volume_id):
         if existing_shared_volume_id:
             # Volume already exists; do nothing.
             return _SharedVolumeHandle(client, existing_shared_volume_id)

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -525,6 +525,7 @@ class _Stub:
         concurrency_limit: Optional[int] = None,  # Limit for max concurrent containers running the function.
         timeout: Optional[int] = None,  # Maximum execution time of the function in seconds.
         interactive: bool = False,  # Whether to run the function in interactive mode.
+        _is_build_step: bool = False,  # Whether function is a build step; reserved for internal use.
     ) -> _FunctionHandle:  # Function object - callable as a regular function within a Modal app
         """Decorator to register a new Modal function with this stub."""
         if image is None:
@@ -559,6 +560,11 @@ class _Stub:
             cpu=cpu,
             interactive=interactive,
         )
+
+        if _is_build_step:
+            # Don't add function to stub if it's a build step.
+            return function
+
         return self._add_function(function)
 
     @decorator_with_options

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -559,6 +559,7 @@ class _Stub:
             timeout=timeout,
             cpu=cpu,
             interactive=interactive,
+            _is_build_step=_is_build_step,
         )
 
         if _is_build_step:

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -563,7 +563,7 @@ class _Stub:
 
         if _is_build_step:
             # Don't add function to stub if it's a build step.
-            return function
+            return _FunctionHandle(function)
 
         return self._add_function(function)
 

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -559,7 +559,6 @@ class _Stub:
             timeout=timeout,
             cpu=cpu,
             interactive=interactive,
-            _is_build_step=_is_build_step,
         )
 
         if _is_build_step:

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -338,6 +338,8 @@ message Function {
 
   PTYInfo pty_info = 22;
   bytes class_serialized = 23;
+
+  bool _is_build_step = 24;
 }
 
 message FunctionCreateRequest {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -338,8 +338,6 @@ message Function {
 
   PTYInfo pty_info = 22;
   bytes class_serialized = 23;
-
-  bool _is_build_step = 24;
 }
 
 message FunctionCreateRequest {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -524,6 +524,7 @@ message Image {
   // Part of Image definition, because presence of GPU drivers
   // affects the image that's built.
   bool gpu = 13;
+  bytes build_function_def = 14;
 }
 
 message ImageContextFile {
@@ -535,6 +536,7 @@ message ImageGetOrCreateRequest {
   Image image = 2;
   string app_id = 4;
   string existing_image_id = 5;  // ignored
+  string builder_function_id = 6;
 }
 
 message ImageGetOrCreateResponse {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -524,7 +524,7 @@ message Image {
   // Part of Image definition, because presence of GPU drivers
   // affects the image that's built.
   bool gpu = 13;
-  bytes build_function_def = 14;
+  string build_function_def = 14;
 }
 
 message ImageContextFile {
@@ -536,7 +536,7 @@ message ImageGetOrCreateRequest {
   Image image = 2;
   string app_id = 4;
   string existing_image_id = 5;  // ignored
-  string builder_function_id = 6;
+  string build_function_id = 6;
 }
 
 message ImageGetOrCreateResponse {


### PR DESCRIPTION
Client-side counterpart to https://github.com/modal-labs/modal/pull/3973. Lets you run arbitrary functions as part of image build, and those functions can use existing Modal primitives like `Mount`s and `SharedVolume`s.