### PR TITLE
Add support and tests for Python 3.11

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: ./.github/actions/setup-cached-python
         with:
-          version: "3.10"
+          version: "3.11"
 
       - name: Check files using the black formatter
         run: black --check .
@@ -25,7 +25,7 @@ jobs:
 
       - uses: ./.github/actions/setup-cached-python
         with:
-          version: "3.10"
+          version: "3.11"
 
       - run: flake8 .
 
@@ -38,7 +38,7 @@ jobs:
 
       - uses: ./.github/actions/setup-cached-python
         with:
-          version: "3.10"
+          version: "3.11"
 
       - run: inv protoc
 
@@ -53,6 +53,6 @@ jobs:
 
       - uses: ./.github/actions/setup-cached-python
         with:
-          version: "3.10"
+          version: "3.11"
 
       - run: inv check-copyright

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -15,13 +15,13 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: ["ubuntu-20.04"]
         include:
           - os: "macos-latest"
-            python-version: "3.10"
+            python-version: "3.11"
           - os: "windows-latest"
-            python-version: "3.10"
+            python-version: "3.11"
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -42,7 +42,6 @@ jobs:
 
       - name: Run docstring tests
         run: pytest -s --markdown-docs -m markdown-docs modal
-       
 
   publish-base-images:
     name: |
@@ -56,7 +55,7 @@ jobs:
       MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         image-name: ["debian_slim", "conda"]
 
     steps:
@@ -64,7 +63,7 @@ jobs:
 
       - uses: ./.github/actions/setup-cached-python
         with:
-          version: "3.10"
+          version: "3.11"
 
       - name: Build protobuf
         run: inv protoc
@@ -87,7 +86,7 @@ jobs:
 
       - uses: ./.github/actions/setup-cached-python
         with:
-          version: "3.10"
+          version: "3.11"
 
       - name: Bump the version number
         run: inv update-build-number $GITHUB_RUN_NUMBER

--- a/modal/image.py
+++ b/modal/image.py
@@ -25,6 +25,7 @@ def _dockerhub_python_version(python_version=None):
     # We use the same major/minor version, but the highest micro version
     # See https://hub.docker.com/_/python
     latest_micro_version = {
+        "3.11": "0",
         "3.10": "8",
         "3.9": "15",
         "3.8": "15",


### PR DESCRIPTION
Python 3.11 is between 10-60% faster than Python 3.10.

https://docs.python.org/3/whatsnew/3.11.html