### PR TITLE
add keep warm support for general functions

### DIFF
--- a/modal/stub.py
+++ b/modal/stub.py
@@ -588,6 +588,7 @@ class _Stub:
         retries: Optional[int] = None,  # Number of times to retry each input in case of failure.
         concurrency_limit: Optional[int] = None,  # Limit for max concurrent containers running the function.
         timeout: Optional[int] = None,  # Maximum execution time of the function in seconds.
+        keep_warm: bool = False,  # Toggles an adaptively-sized warm pool for latency-sensitive apps.
     ) -> _FunctionHandle:
         """Decorator similar to `@modal.function`, but it wraps Python generators."""
         if image is None:
@@ -609,6 +610,7 @@ class _Stub:
             retries=retries,
             concurrency_limit=concurrency_limit,
             timeout=timeout,
+            keep_warm=keep_warm,
             cpu=cpu,
         )
         return self._add_function(function)

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -526,6 +526,7 @@ class _Stub:
         timeout: Optional[int] = None,  # Maximum execution time of the function in seconds.
         interactive: bool = False,  # Whether to run the function in interactive mode.
         _is_build_step: bool = False,  # Whether function is a build step; reserved for internal use.
+        keep_warm: bool = False,  # Toggles an adaptively-sized warm pool for latency-sensitive apps.
     ) -> _FunctionHandle:  # Function object - callable as a regular function within a Modal app
         """Decorator to register a new Modal function with this stub."""
         if image is None:
@@ -559,6 +560,7 @@ class _Stub:
             timeout=timeout,
             cpu=cpu,
             interactive=interactive,
+            keep_warm=keep_warm,
         )
 
         if _is_build_step:


### PR DESCRIPTION
keep warm functionality has been tested for webhooks

tested locally for functions, making sure latency stays low between random calls with interval longer than the task idleness timeout

### before (notice that there is a 1.1s cold start on the 3rd call)

![Screenshot 2022-11-09 at 5 09 36 PM](https://user-images.githubusercontent.com/8001209/200952617-2c289d64-fe99-4834-8871-44e9441131a8.png)


### after (no cold start except for the 1st call)

![Screenshot 2022-11-09 at 5 09 19 PM](https://user-images.githubusercontent.com/8001209/200952568-af3166bd-692a-4cb7-a019-434bb12892bc.png)
