### PR TITLE
Raise an exception if you try to decorate local functions

### DIFF
--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -112,7 +112,6 @@ class MockClientServicer(api_grpc.ModalClientBase):
         request = await stream.recv_message()
         self.requests.append(request)
         client_id = "cl-123"
-        print(stream.metadata)
         if stream.metadata.get("x-modal-token-id") == "bad":
             raise GRPCError(Status.UNAUTHENTICATED, "bad bad bad")
         elif request.version == "timeout":

--- a/client_test/mount_test.py
+++ b/client_test/mount_test.py
@@ -81,14 +81,16 @@ def test_create_mount_file_errors(servicer, tmpdir, client):
             running_app._load(m)
 
 
+def dummy():
+    pass
+
+
 def test_create_package_mounts(servicer, client, test_dir):
     stub = Stub()
 
     sys.path.append((test_dir / "supports").as_posix())
 
-    @stub.function(mounts=create_package_mounts(["pkg_a", "pkg_b", "standalone_file"]))
-    def f():
-        pass
+    stub.function(dummy, mounts=create_package_mounts(["pkg_a", "pkg_b", "standalone_file"]))
 
     with stub.run(client=client):
         files = servicer.files_name2sha.keys()
@@ -106,9 +108,7 @@ def test_stub_mounts(servicer, client, test_dir):
 
     stub = Stub(mounts=create_package_mounts(["pkg_b"]))
 
-    @stub.function(mounts=create_package_mounts(["pkg_a"]))
-    def f():
-        pass
+    stub.function(dummy, mounts=create_package_mounts(["pkg_a"]))
 
     with stub.run(client=client):
         files = servicer.files_name2sha.keys()
@@ -124,7 +124,4 @@ def test_create_package_mounts_missing_module(servicer, client, test_dir):
     stub = Stub()
 
     with pytest.raises(NotFoundError):
-
-        @stub.function(mounts=create_package_mounts(["nonexistent_package"]))
-        def f():
-            pass
+        stub.function(dummy, mounts=create_package_mounts(["nonexistent_package"]))

--- a/client_test/rate_limit_test.py
+++ b/client_test/rate_limit_test.py
@@ -5,23 +5,26 @@ import modal
 from modal.exception import InvalidError
 
 
+def per_second_5():
+    return 42
+
+
+def per_minute_15():
+    return 67
+
+
+def dummy():
+    pass
+
+
 def test_rate_limit(client):
     stub = modal.Stub()
 
-    @stub.function(rate_limit=modal.RateLimit(per_second=5))
-    def per_second_5():
-        return 42
-
-    @stub.function(rate_limit=modal.RateLimit(per_minute=15))
-    def per_minute_15():
-        return 67
-
+    per_second_5_modal = stub.function(per_second_5, rate_limit=modal.RateLimit(per_second=5))
+    per_minute_15_modal = stub.function(per_minute_15, rate_limit=modal.RateLimit(per_minute=15))
     with pytest.raises(InvalidError):
-
-        @stub.function(rate_limit=modal.RateLimit(per_minute=15, per_second=5))
-        def two_params_limit():
-            pass
+        stub.function(dummy, rate_limit=modal.RateLimit(per_minute=15, per_second=5))
 
     with stub.run(client=client):
-        per_second_5()
-        per_minute_15()
+        per_second_5_modal()
+        per_minute_15_modal()

--- a/client_test/retries_test.py
+++ b/client_test/retries_test.py
@@ -5,46 +5,54 @@ import modal
 from modal.exception import InvalidError
 
 
+def default_retries_from_int():
+    pass
+
+
+def fixed_delay_retries():
+    pass
+
+
+def exponential_backoff():
+    return 67
+
+
+def exponential_with_max_delay():
+    return 67
+
+
+def dummy():
+    pass
+
+
 def test_retries(client):
     stub = modal.Stub()
 
-    @stub.function(retries=5)
-    def default_retries_from_int():
-        pass
-
-    @stub.function(retries=modal.Retries(max_retries=5, backoff_coefficient=1.0))
-    def fixed_delay_retries():
-        pass
-
-    @stub.function(retries=modal.Retries(max_retries=2, initial_delay=2.0, backoff_coefficient=2.0))
-    def exponential_backoff():
-        return 67
-
-    @stub.function(retries=modal.Retries(max_retries=2, backoff_coefficient=2.0, max_delay=30.0))
-    def exponential_with_max_delay():
-        return 67
+    default_retries_from_int_modal = stub.function(default_retries_from_int, retries=5)
+    fixed_delay_retries_modal = stub.function(
+        fixed_delay_retries, retries=modal.Retries(max_retries=5, backoff_coefficient=1.0)
+    )
+    exponential_backoff_modal = stub.function(
+        exponential_backoff, retries=modal.Retries(max_retries=2, initial_delay=2.0, backoff_coefficient=2.0)
+    )
+    exponential_with_max_delay_modal = stub.function(
+        exponential_with_max_delay, retries=modal.Retries(max_retries=2, backoff_coefficient=2.0, max_delay=30.0)
+    )
 
     with pytest.raises(TypeError):
-
-        @stub.function(retries=modal.Retries())  # type: ignore
-        def default_retries_from_class():
-            # Reject no-args constructions, which is unreadable and harder to support long-term
-            pass
+        # Reject no-args constructions, which is unreadable and harder to support long-term
+        stub.function(dummy, retries=modal.Retries())  # type: ignore
 
     # Reject weird inputs:
     # Don't need server to detect and reject nonsensical input. Can do client-side.
     with pytest.raises(InvalidError):
+        stub.function(dummy, retries=modal.Retries(max_retries=-2))
 
-        @stub.function(retries=modal.Retries(max_retries=-2))
-        def negative_retries():
-            pass
-
-        @stub.function(retries=modal.Retries(max_retries=2, backoff_coefficient=0.0))
-        def zero_backoff_coeff():
-            pass
+    with pytest.raises(InvalidError):
+        stub.function(dummy, retries=modal.Retries(max_retries=2, backoff_coefficient=0.0))
 
     with stub.run(client=client):
-        default_retries_from_int()
-        fixed_delay_retries()
-        exponential_backoff()
-        exponential_with_max_delay()
+        default_retries_from_int_modal()
+        fixed_delay_retries_modal()
+        exponential_backoff_modal()
+        exponential_with_max_delay_modal()

--- a/client_test/shared_volume_test.py
+++ b/client_test/shared_volume_test.py
@@ -6,17 +6,19 @@ import modal
 from modal.exception import InvalidError
 
 
+def dummy():
+    pass
+
+
 def test_shared_volume_files(client, test_dir, servicer):
     stub = modal.Stub()
 
-    @stub.function(
+    dummy_modal = stub.function(
         shared_volumes={"/root/foo": modal.SharedVolume()},
-    )
-    def f():
-        pass
+    )(dummy)
 
     with stub.run(client=client):
-        f()
+        dummy_modal()
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="TODO: implement client-side path check on Windows.")
@@ -26,23 +28,20 @@ def test_shared_volume_bad_paths(client, test_dir, servicer):
     def _f():
         pass
 
-    f = stub.function(_f, shared_volumes={"/root/../../foo": modal.SharedVolume()})
+    dummy_modal = stub.function(dummy, shared_volumes={"/root/../../foo": modal.SharedVolume()})
 
     with pytest.raises(InvalidError):
         with stub.run(client=client):
-            f()
+            dummy_modal()
 
-    f = stub.function(
-        _f,
-        shared_volumes={"/": modal.SharedVolume()},
-    )
+    dummy_modal = stub.function(dummy, shared_volumes={"/": modal.SharedVolume()})
 
     with pytest.raises(InvalidError):
         with stub.run(client=client):
-            f()
+            dummy_modal()
 
-    f = stub.function(shared_volumes={"/tmp/": modal.SharedVolume()})(_f)
+    dummy_modal = stub.function(dummy, shared_volumes={"/tmp/": modal.SharedVolume()})
 
     with pytest.raises(InvalidError):
         with stub.run(client=client):
-            f()
+            dummy_modal()


### PR DESCRIPTION
Issue that a user ran into. It would previously trigger a pretty confusing error in the container:

```
Traceback (most recent call last):
  File "/pkg/modal/_container_entrypoint.py", line 246, in handle_user_exception
    yield
  File "/pkg/modal/_container_entrypoint.py", line 493, in main
    cls, fun = import_function(container_args.function_def)
  File "/pkg/modal/_container_entrypoint.py", line 449, in import_function
    fun, cls = load_function_from_module(module, function_def.function_name)
  File "/pkg/modal/_function_utils.py", line 185, in load_function_from_module
    objs.append(getattr(objs[-1], path))
AttributeError: 'function' object has no attribute '<locals>'
```

After this change, it recognizes the error before launching the app:

```
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /Users/erikbern/modal-client/local_function_thing.py:13 in <module>                              │
│                                                                                                  │
│   12 @wrap                                                                                       │
│ ❱ 13 def ping():                                                                                 │
│   14 │   return "pong"                                                                           │
│                                                                                                  │
│ /Users/erikbern/modal-client/local_function_thing.py:7 in wrap                                   │
│                                                                                                  │
│    6 │   @stub.function                                                                          │
│ ❱  7 │   def wrapped():                                                                          │
│    8 │   │   return f()                                                                          │
│                                                                                                  │
│ /Users/erikbern/python3.10-env/lib/python3.10/site-packages/synchronicity/synchronizer.py:396 in │
│ proxy_method                                                                                     │
│                                                                                                  │
│ /Users/erikbern/python3.10-env/lib/python3.10/site-packages/synchronicity/synchronizer.py:329 in │
│ f_wrapped                                                                                        │
│                                                                                                  │
│ /Users/erikbern/modal-client/modal_utils/decorator_utils.py:21 in wrapper                        │
│                                                                                                  │
│ /Users/erikbern/modal-client/modal/stub.py:533 in function                                       │
│                                                                                                  │
│   532 │   │   │   image = self._get_default_image()                                              │
│ ❱ 533 │   │   mounts = [*self._get_function_mounts(raw_f), *mounts]                              │
│   534 │   │   secrets = self._get_function_secrets(raw_f, secret, secrets)                       │
│                                                                                                  │
│ /Users/erikbern/modal-client/modal/stub.py:465 in _get_function_mounts                           │
│                                                                                                  │
│   464 │   │   # Create function mounts                                                           │
│ ❱ 465 │   │   info = FunctionInfo(raw_f)                                                         │
│   466 │   │   for key, mount in info.get_mounts().items():                                       │
│                                                                                                  │
│ /Users/erikbern/modal-client/modal/_function_utils.py:104 in __init__                            │
│                                                                                                  │
│   103 │   │   │   if inspect.getclosurevars(f).nonlocals:                                        │
│ ❱ 104 │   │   │   │   raise InvalidError("Modal can only import functions defined in global sc   │
│   105                                                                                            │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
InvalidError: Modal can only import functions defined in global scope
```

Most of this PR is just changing a bunch of tests that used to define functions in local scope (which sort of worked in tests, because there's no container that tries to import them)