### PR TITLE
Make it possible to invoke a decorated function directly

### DIFF
--- a/client_test/decorator_test.py
+++ b/client_test/decorator_test.py
@@ -1,3 +1,4 @@
+# Copyright Modal Labs 2022
 from modal_utils.decorator_utils import decorator_with_options
 
 
@@ -72,10 +73,6 @@ def test_method_args():
         return x + 1
 
     assert g(42) == 52
-
-
-def double(x):
-    return 2 * x
 
 
 def test_method_direct():

--- a/client_test/decorator_test.py
+++ b/client_test/decorator_test.py
@@ -1,0 +1,90 @@
+from modal_utils.decorator_utils import decorator_with_options
+
+
+@decorator_with_options
+def dec(f, add=0):
+    def wrapped(x):
+        return f(x) + add
+
+    return wrapped
+
+
+def test_simple():
+    @dec
+    def f(x):
+        return x + 7
+
+    assert f(42) == 49
+
+
+def test_args():
+    @dec(add=5)
+    def g(x):
+        return x + 1
+
+    assert g(42) == 48
+
+
+def double(x):
+    return 2 * x
+
+
+def test_direct():
+    p = dec(double)
+    assert p(42) == 84
+
+
+def test_direct_args():
+    q = dec(double, add=9)
+    assert q(42) == 93
+
+
+# Test it as a method too
+
+
+class Cls:
+    def __init__(self, add_more):
+        self.add_more = add_more
+
+    @decorator_with_options
+    def dec(self, f, add=0):
+        def wrapped(x):
+            return f(x) + add + self.add_more
+
+        return wrapped
+
+
+def test_method_simple():
+    c = Cls(3)
+
+    @c.dec
+    def f(x):
+        return x + 7
+
+    assert f(42) == 52
+
+
+def test_method_args():
+    c = Cls(4)
+
+    @c.dec(add=5)
+    def g(x):
+        return x + 1
+
+    assert g(42) == 52
+
+
+def double(x):
+    return 2 * x
+
+
+def test_method_direct():
+    c = Cls(5)
+    p = c.dec(double)
+    assert p(42) == 89
+
+
+def test_method_direct_args():
+    c = Cls(6)
+    q = c.dec(double, add=9)
+    assert q(42) == 99

--- a/client_test/shared_volume_test.py
+++ b/client_test/shared_volume_test.py
@@ -26,15 +26,16 @@ def test_shared_volume_bad_paths(client, test_dir, servicer):
     def _f():
         pass
 
-    f = stub.function(shared_volumes={"/root/../../foo": modal.SharedVolume()})(_f)
+    f = stub.function(_f, shared_volumes={"/root/../../foo": modal.SharedVolume()})
 
     with pytest.raises(InvalidError):
         with stub.run(client=client):
             f()
 
     f = stub.function(
+        _f,
         shared_volumes={"/": modal.SharedVolume()},
-    )(_f)
+    )
 
     with pytest.raises(InvalidError):
         with stub.run(client=client):

--- a/modal_utils/decorator_utils.py
+++ b/modal_utils/decorator_utils.py
@@ -15,13 +15,15 @@ def decorator_with_options(dec_fun):
 
     @functools.wraps(dec_fun)
     def wrapper(*args, **kwargs):
-        if args and not kwargs and inspect.isfunction(args[-1]):
-            # The decorator is invoked without arguments
-            # Return a closure that consumes the function
-            return dec_fun(*args)
+        # Note: if the def_fun is a method, then args will contain the object the method is bound to.
+        if args and inspect.isfunction(args[-1]):
+            # The decorator is invoked with a function as its first argument
+            # Call the decorator function directly
+            return dec_fun(*args, **kwargs)
         else:
             # The function is called with arguments
             # bind those arguments to the function and decorate the next token
+            # args is only nonempty if it's the object the method is bound to
             return functools.partial(dec_fun, *args, **kwargs)
 
     return wrapper


### PR DESCRIPTION
Broke this out of #58.

This makes it possible to run

```python
fun_modal = stub.function(fun, image=image)
```

Which can be useful if you can't use the decorator form