### PR TITLE
[MOD-661] prevent coro task collections growing indefinitely

### DIFF
--- a/modal_utils/async_utils.py
+++ b/modal_utils/async_utils.py
@@ -168,6 +168,7 @@ class TaskContext:
         else:
             raise Exception(f"Object of type {type(coro_or_task)} is not a coroutine or Task")
         self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
         return task
 
     def infinite_loop(self, async_f, timeout: Optional[float] = 90, sleep: float = 10) -> asyncio.Task:
@@ -197,6 +198,7 @@ class TaskContext:
         if hasattr(t, "set_name"):  # Was added in Python 3.8:
             t.set_name(f"{function_name} loop")
         self._loops.add(t)
+        t.add_done_callback(self._loops.discard)
         return t
 
     async def wait(self, *tasks):


### PR DESCRIPTION
**Details** in [Linear MOD-661](https://linear.app/modal-labs/issue/MOD-661/modal-server-backgroundpy-memory-leak). 

Started looking at this because a long-running background k8s container kept growing its memory until it hit OOM and got restarted.

**TLDR** is that this change significantly reduces the memory usage reported by the [scalene](https://github.com/plasma-umass/scalene) profiler's memory profiling.

Getting review because this module is kinda complicated and I may have missed something when making this change.