### PR TITLE
Try something for the console_scripts

### DIFF
--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -5,7 +5,7 @@ import traceback
 import pytest_asyncio
 import typer.testing
 
-from modal import cli
+from modal.cli.entry_point import entrypoint_cli
 from modal.client import Client
 
 dummy_app_file = """
@@ -35,7 +35,7 @@ async def set_env_client(aio_client):
 
 def _run(args, expected_exit_code=0):
     runner = typer.testing.CliRunner()
-    res = runner.invoke(cli.entrypoint_cli, args)
+    res = runner.invoke(entrypoint_cli, args)
     if res.exit_code != expected_exit_code:
         print(res.stdout, "Trace:")
         traceback.print_tb(res.exc_info[2])

--- a/modal/__main__.py
+++ b/modal/__main__.py
@@ -1,0 +1,10 @@
+# Copyright Modal Labs 2022
+from .cli.entry_point import entrypoint_cli
+
+
+def main():
+    entrypoint_cli()
+
+
+if __name__ == "__main__":
+    entrypoint_cli()

--- a/modal/cli/__init__.py
+++ b/modal/cli/__init__.py
@@ -1,10 +1,1 @@
 # Copyright Modal Labs 2022
-from .entry_point import entrypoint_cli
-
-
-def main():
-    entrypoint_cli()
-
-
-if __name__ == "__main__":
-    main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
 
 [options.entry_points]
 console_scripts =
-    modal = modal.cli:main
+    modal = modal.__main__:main
 
 [options.package_data]
 modal =


### PR DESCRIPTION
A user reported this:

After pip installation of modal, I tried "modal token new" and encountered this error 
```
│ [Errno 2] No such file or directory:                                                             │
│ 'C:\\Users\\xyz\\anaconda3\\Scripts\\modal.exe\\__main__.py'
```

Googling it a bit and I'm not sure what's happening but it generally seemed like people use `__main__.py` for console_scripts so I'm going to try to see if that helps.