### PR TITLE
Fix disconnects (wip)

### DIFF
--- a/modal/stub.py
+++ b/modal/stub.py
@@ -267,7 +267,12 @@ class _Stub:
                     # Cancel logs loop since we're going to start another one.
                     logs_loop.cancel()
                 else:
-                    await app.disconnect()
+                    try:
+                        # TODO(erikbern): don't disconnect if the heartbeat failed with NOT_FOUND
+                        await app.disconnect()
+                    except:
+                        # Don't override the previous exception
+                        logger.exception("Failed disconnecting")
 
         if mode == StubRunMode.DEPLOY:
             output_mgr.print_if_visible(step_completed("App deployed! 🎉"))


### PR DESCRIPTION
Spent like 2h tracking this down. There was multiple issues all making this pretty annoying to figure out:

- [X] The channel pool would happily reconnect even though the pool had been closed (by the heartbeat stopping the app). Fixing this. This problem was in our channel pool code.
- [X] The same problem but for Channel. The problem comes from grpclib so I ended up overriding relevant method
- [ ] There's a finally handler which tells the app to stop, but we shouldn't call that method if the app already stopped

There's some other general issues with socket disconnects etc that we're not handling properly either – going to spend some time on better tests and trying to catch those ones too

Finally what I want to do is also to say something to the user about detached apps – think it would be quite helpful to promote those in all the error messages