### PR TITLE
Improve ref docs for: modal.Error, modal.lookup, modal.ref

### DIFF
--- a/modal/exception.py
+++ b/modal/exception.py
@@ -4,7 +4,22 @@ import warnings
 
 
 class Error(Exception):
-    """Base error class for all Modal errors"""
+    """
+    Base error class for all Modal errors.
+
+    **Usage**
+
+    ```python
+    import modal
+
+    try:
+        with stub.run():
+            f()
+    except modal.Error:
+        # Catch any exception raised by Modal's systems.
+        print("Responding to error...")
+    ```
+    """
 
 
 class RemoteError(Error):
@@ -56,7 +71,7 @@ def _is_internal_frame(frame):
 def deprecation_warning(msg):
     """Utility for getting the proper stack entry
 
-    See the implementation of the built-in warnings.warn
+    See the implementation of the built-in [warnings.warn](https://docs.python.org/3/library/warnings.html#available-functions).
     """
 
     # Find the last non-Modal line that triggered the warning

--- a/modal/object.py
+++ b/modal/object.py
@@ -94,6 +94,21 @@ async def _lookup(
     namespace=api_pb2.DEPLOYMENT_NAMESPACE_ACCOUNT,
     client: Optional[_Client] = None,
 ) -> Handle:
+    """
+    General purpose method to retrieve Modal objects such as
+    functions, shared volumes, and secrets.
+
+    ```python notest
+    import modal
+
+    square = modal.lookup("my-shared-app", "square")
+    assert square(3) == 9
+
+    vol = modal.lookup("my-shared-volume")
+    for chunk in vol.read_file("my_db_dump.csv"):
+        ...
+    ```
+    """
     return await Handle.from_app(app_name, tag, namespace, client)
 
 
@@ -225,5 +240,6 @@ class PersistedRef(Ref[H]):
 
 
 def ref(app_name: str, tag: Optional[str] = None, namespace=api_pb2.DEPLOYMENT_NAMESPACE_ACCOUNT) -> Ref:
-    deprecation_warning("`modal.ref` is deprecated. Please use `modal.Secret.from_name` instead")
+    """`modal.ref` is deprecated. Please use `modal.Secret.from_name` instead."""
+    deprecation_warning(ref.__doc__)
     return RemoteRef(app_name, tag, namespace)


### PR DESCRIPTION
Addressing some too thin `/docs/reference` pages I came across when addressing https://github.com/modal-labs/modal-client/pull/64.