### PR TITLE
bump synchronicity to 0.2.11

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     protobuf>=3.19,<5.0
     rich>=12.0.0
     sentry-sdk
-    synchronicity>=0.2.10
+    synchronicity>=0.2.11
     tblib>=1.7.0
     toml
     typer==0.6.1


### PR DESCRIPTION
I have a bunch of bigger changes to synchronicity coming up, but I'll make that 0.3.0 instead.