### PR TITLE
Extra tests of container requirements.txt

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Install dev dependencies
         run: pip install -r requirements.dev.txt
 
+      - name: Build protobuf
+        run: inv protoc
+
       - name: Install modal itself but no dependencies
         run: pip install --no-dependencies -e .
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -79,7 +79,9 @@ jobs:
         run: pip install --no-dependencies -e .
 
       - name: Run container tests
-        run: pytest -v -s client_test/container_test.py
+        env:
+           JUPYTER_PLATFORM_DIRS: 1  # weird error?
+        run: pytest -v -s client_test
 
   publish-base-images:
     name: |

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -52,7 +52,28 @@ jobs:
 
       - name: Run docstring tests
         run: pytest -s --markdown-docs -m markdown-docs modal
-       
+
+  client-test-requirements-txt:
+    name: Run container tests using modal/requirements.txt
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Python
+        uses: actions/setup-python@v4
+
+      - name: Install pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install container requirements
+        run: pip install -r modal/requirements.txt
+
+      - name: Install dev dependencies
+        run: pip install -r requirements.dev.txt
+
+      - name: Run container tests
+        run: pytest -v -s client_test/container_test.py
 
   publish-base-images:
     name: |

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Install dev dependencies
         run: pip install -r requirements.dev.txt
 
+      - name: Install modal itself but no dependencies
+        run: pip install --no-dependencies -e .
+
       - name: Run container tests
         run: pytest -v -s client_test/container_test.py
 

--- a/modal/_ipython.py
+++ b/modal/_ipython.py
@@ -9,5 +9,5 @@ def is_notebook(stdout=None):
         import ipykernel.iostream
 
         return isinstance(stdout, ipykernel.iostream.OutStream)
-    except ImportError:
+    except Exception:
         return False


### PR DESCRIPTION
Spent a bunch of time trying to parse pip dependencies and whatnot but realized the most direct way to test that `modal/requirements.txt` works is to just run the container tests with it.

Could potentially also run all tests and use an environment variable to disable any tests that's "local only" (e.g. any test of stub.serve)