### PR TITLE
Enable CORS by default on simple webhooks

### DIFF
--- a/client_test/webhook_test.py
+++ b/client_test/webhook_test.py
@@ -15,3 +15,26 @@ async def f(x):
 async def test_webhook(servicer, aio_client):
     async with stub.run(client=aio_client):
         assert f.web_url
+
+
+def test_webhook_cors():
+    from fastapi.testclient import TestClient
+
+    from modal._asgi import webhook_asgi_app
+
+    def handler():
+        return {"message": "Hello, World!"}
+
+    app = webhook_asgi_app(handler, method="GET")
+    client = TestClient(app)
+    resp = client.options(
+        "/",
+        headers={
+            "Origin": "http://example.com",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert resp.headers["Access-Control-Allow-Origin"] == "http://example.com"
+
+    assert client.get("/").json() == {"message": "Hello, World!"}
+    assert client.post("/").status_code == 405  # Method Not Allowed

--- a/modal/_asgi.py
+++ b/modal/_asgi.py
@@ -47,10 +47,19 @@ def wsgi_app_wrapper(wsgi_app):
     return asgi_app_wrapper(asgi_app)
 
 
-def fastAPI_function_wrapper(fn: Callable, method: str):
+def webhook_asgi_app(fn: Callable, method: str):
     """Return a FastAPI app wrapping a function handler."""
+    # Pulls in `fastapi` module, which is slow to import.
     from fastapi import FastAPI
+    from fastapi.middleware.cors import CORSMiddleware
 
     app = FastAPI()
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
     app.add_api_route("/", fn, methods=[method])
-    return asgi_app_wrapper(app)
+    return app

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -640,9 +640,14 @@ class _Stub:
     ):
         """Register a basic web endpoint with this application.
 
-        This is the simplest way to create a web endpoint on Modal. The function
+        This is the simple way to create a web endpoint on Modal. The function
         behaves as a [FastAPI](https://fastapi.tiangolo.com/) handler and should
         return a response object to the caller.
+
+        Endpoints created with `@stub.webhook` are meant to be simple, single
+        request handlers and automatically have
+        [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) enabled.
+        For more flexibility, use `@stub.asgi`.
 
         To learn how to use Modal with popular web frameworks, see the
         [guide on web endpoints](https://modal.com/docs/guide/webhooks).
@@ -693,6 +698,16 @@ class _Stub:
         keep_warm: bool = False,  # Toggles an adaptively-sized warm pool for latency-sensitive apps.
         _webhook_type=api_pb2.WEBHOOK_TYPE_ASGI_APP,
     ):
+        """Register an ASGI app with this application.
+
+        Asynchronous Server Gateway Interface (ASGI) is a standard for Python
+        synchronous and asynchronous apps, supported by all popular Python web
+        libraries. This is an advanced decorator that gives full flexibility in
+        defining one or more web endpoints on Modal.
+
+        To learn how to use Modal with popular web frameworks, see the
+        [guide on web endpoints](https://modal.com/docs/guide/webhooks).
+        """
         if image is None:
             image = self._get_default_image()
         mounts = [*self._get_function_mounts(asgi_app), *mounts]

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,6 +4,7 @@ black~=22.3.0
 flake8~=4.0.1
 grpcio-tools==1.48.0
 grpclib==0.4.3
+httpx~=0.23.0
 invoke~=1.7.0
 mypy==0.950
 mypy-protobuf~=3.2.0


### PR DESCRIPTION
This change allows webhooks to be called from browsers, using an implementation of [cross-origin resource sharing](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) standard headers.

CORS is primarily helpful to ensure that users of a website don't have their cookies or auth stolen by another website, but that's only relevant if you have a full web app and using `@stub.asgi` anyway — I don't see anyone, e.g., setting cookies in `@stub.webhook` that could be stolen or vulnerable to CSRF in a CORS context.

I also wrote some documentation for both webhook constructor functions and a test.

Resolves MOD-534