### PR TITLE
[MOD 567] better err msg on stub lookup fail

### DIFF
--- a/client_test/package_utils_test.py
+++ b/client_test/package_utils_test.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from pathlib import Path
 
-from modal_utils.package_utils import get_module_mount_info, import_stub_by_ref
+from modal_utils.package_utils import get_module_mount_info, import_stub, parse_stub_ref
 
 
 def test_get_module_mount_info():
@@ -20,7 +20,7 @@ def test_get_module_mount_info():
     assert res[0][0] == False
 
 
-# Some helper vars for import_stub_by_ref tests:
+# Some helper vars for import_stub tests:
 
 python_module_src = """
 stub = "FOO"
@@ -75,7 +75,7 @@ dir_containing_python_package = {
 )
 def test_import_stub_by_ref(dir_structure, ref, expected_stub_value, mock_dir):
     with mock_dir(dir_structure):
-        imported_stub = import_stub_by_ref(ref)
+        imported_stub = import_stub(*parse_stub_ref(ref, "stub"))
         assert imported_stub == expected_stub_value
 
 
@@ -89,5 +89,5 @@ def test_import_package_properly():
     rel_p = str(p.relative_to(os.getcwd()))
     print(f"abs_p={abs_p} rel_p={rel_p}")
 
-    assert import_stub_by_ref(rel_p) == "xyz"
-    assert import_stub_by_ref(abs_p) == "xyz"
+    assert import_stub(*parse_stub_ref(rel_p, "stub")) == "xyz"
+    assert import_stub(*parse_stub_ref(abs_p, "stub")) == "xyz"

--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -37,7 +37,6 @@ def run(
     function_name: Optional[str] = typer.Option(default=None, help="Name of the Modal function to run"),
     detach: bool = typer.Option(default=False, help="Allows app to continue running if local terminal disconnects."),
 ):
-    default_stub_name = "stub"
     try:
         import_path, stub_name = parse_stub_ref(stub_ref, DEFAULT_STUB_NAME)
         stub = import_stub(import_path, stub_name)

--- a/modal_utils/package_utils.py
+++ b/modal_utils/package_utils.py
@@ -4,6 +4,7 @@ import inspect
 import os
 import sys
 from pathlib import Path
+from typing import Tuple
 
 from importlib_metadata import PackageNotFoundError, files
 
@@ -42,7 +43,7 @@ def get_module_mount_info(module: str):
         return [(False, filename, lambda f: os.path.basename(f) == os.path.basename(filename))]
 
 
-def parse_stub_ref(stub_ref: str, default_stub_name: str) -> tuple[str, str]:
+def parse_stub_ref(stub_ref: str, default_stub_name: str) -> Tuple[str, str]:
     if stub_ref.find("::") > 1:
         import_path, stub_name = stub_ref.split("::")
     elif stub_ref.find(":") > 1:  # don't catch windows abs paths, e.g. C:\foo\bar

--- a/modal_utils/package_utils.py
+++ b/modal_utils/package_utils.py
@@ -42,14 +42,17 @@ def get_module_mount_info(module: str):
         return [(False, filename, lambda f: os.path.basename(f) == os.path.basename(filename))]
 
 
-def import_stub_by_ref(stub_ref: str):
+def parse_stub_ref(stub_ref: str, default_stub_name: str) -> tuple[str, str]:
     if stub_ref.find("::") > 1:
-        import_path, var_name = stub_ref.split("::")
+        import_path, stub_name = stub_ref.split("::")
     elif stub_ref.find(":") > 1:  # don't catch windows abs paths, e.g. C:\foo\bar
-        import_path, var_name = stub_ref.split(":")
+        import_path, stub_name = stub_ref.split(":")
     else:
-        import_path, var_name = stub_ref, "stub"
+        import_path, stub_name = stub_ref, default_stub_name
+    return import_path, stub_name
 
+
+def import_stub(import_path: str, stub_name: str):
     if "" not in sys.path:
         # This seems to happen when running from a CLI
         sys.path.insert(0, "")
@@ -81,5 +84,5 @@ def import_stub_by_ref(stub_ref: str):
     else:
         module = importlib.import_module(import_path)
 
-    stub = getattr(module, var_name)
+    stub = getattr(module, stub_name)
     return stub


### PR DESCRIPTION
Nice warm-up task for a Friday morning. 

`modal app run nostub.py`

<img width="1002" alt="image" src="https://user-images.githubusercontent.com/12058921/202765715-92806b52-fbad-4376-b1da-b0fd991aca61.png">

`modal app run nostub.py:barstub`

<img width="994" alt="image" src="https://user-images.githubusercontent.com/12058921/202765453-b0854094-144a-495f-bf21-a58c1196cd5d.png">

----

Could improve this further by outputting the name of any variable with type `modal.Stub`. 
