### PR TITLE
fix: Do a 'conda clean' after install to avoid bloating image index and doing unneeded uploading to blobnet

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -401,8 +401,8 @@ class _Image(Provider[_ImageHandle]):
 
         dockerfile_commands = [
             "FROM base",
-            f"RUN conda install {package_args}{channel_args} --yes",
-            "RUN conda clean --index-cache --tarballs --tempfiles --logfiles",
+            f"RUN conda install {package_args}{channel_args} --yes \\ ",
+            "&& conda clean --yes --index-cache --tarballs --tempfiles --logfiles",
         ]
 
         return self.extend(dockerfile_commands=dockerfile_commands)
@@ -420,8 +420,8 @@ class _Image(Provider[_ImageHandle]):
         dockerfile_commands = [
             "FROM base",
             "COPY /environment.yml /environment.yml",
-            "RUN conda env update --name base -f /environment.yml",
-            "RUN conda clean --index-cache --tarballs --tempfiles --logfiles",
+            "RUN conda env update --name base -f /environment.yml \\ ",
+            "&& conda clean --yes --index-cache --tarballs --tempfiles --logfiles",
         ]
 
         return self.extend(dockerfile_commands=dockerfile_commands, context_files=context_files)

--- a/modal/image.py
+++ b/modal/image.py
@@ -402,6 +402,7 @@ class _Image(Provider[_ImageHandle]):
         dockerfile_commands = [
             "FROM base",
             f"RUN conda install {package_args}{channel_args} --yes",
+            "RUN conda clean --index-cache --tarballs --tempfiles --logfiles",
         ]
 
         return self.extend(dockerfile_commands=dockerfile_commands)
@@ -420,6 +421,7 @@ class _Image(Provider[_ImageHandle]):
             "FROM base",
             "COPY /environment.yml /environment.yml",
             "RUN conda env update --name base -f /environment.yml",
+            "RUN conda clean --index-cache --tarballs --tempfiles --logfiles",
         ]
 
         return self.extend(dockerfile_commands=dockerfile_commands, context_files=context_files)


### PR DESCRIPTION
Delete extraneous files after installation to avoid bloating blobnet and slowing down snapshot uploads.

I wanted to merge this last week, but in trying to test it I ran into MOD-685, which I've attempted to address in https://github.com/modal-labs/modal-client/pull/79.

**example**

```
Retrieving notices: ...working... done
Will remove 110 (294.7 MB) tarball(s).
Will remove 1 index cache(s).
There are no tempfile(s) to remove.
```

```
Retrieving notices: ...working... done
Will remove 79 (63.1 MB) tarball(s).
Will remove 1 index cache(s).
There are no tempfile(s) to remove.
There are no logfile(s) to remove.
```

295MB and 63MB saved from upload is not too bad.

* https://github.com/conda/conda/issues/7741 (issue suggesting `conda` should have a `--no-cache-dir` feature like `pip`)