### PR TITLE
Prevent exposing AssertionError on function(image=...) misuse

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -51,6 +51,7 @@ from .exception import ExecutionError, InvalidError, NotFoundError, RemoteError
 from .exception import TimeoutError as _TimeoutError
 from .exception import deprecation_warning
 from .gpu import _GPUConfig
+from .image import _Image
 from .mount import _Mount
 from .object import Handle, Provider, Ref, RemoteRef
 from .rate_limit import RateLimit
@@ -701,6 +702,8 @@ class _Function(Provider[_FunctionHandle]):
 
         # TODO: should we really join recursively here? Maybe it's better to move this logic to the app class?
         if self._image is not None:
+            if not isinstance(self._image, _Image):
+                raise InvalidError(f"Expected modal.Image object. Got {type(self._image)}.")
             image_id = await loader(self._image)
         else:
             image_id = None  # Happens if it's a notebook function


### PR DESCRIPTION
It was the morning and I certainly needed some ☕, but I wrote this broken script: 

```python
import modal

image = modal.Stub(
    image=modal.Image.debian_slim(),
)
stub = modal.Stub()

@stub.function(image=image)
def f():
    pass

if __name__ == "__main__":
    with stub.run():
        f()
```

and running produced this not so obvious error: 

```
✓ Initialized. View app at http://localhost:7601/apps/ap-NOIOw8FIXztbA4EJunSdEi.
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /home/foo/modal/pass_stub_to_image.py:13 in <module>                                          │
│                                                                                                  │
│   12 if __name__ == "__main__":                                                                  │
│ ❱ 13 │   with stub.run():                                                                        │
│   14 │   │   f()                                                                                 │
│                                                                                                  │
│ /home/foo/modal/venv/lib/python3.9/site-packages/synchronicity/synchronizer.py:412 in         │
│ proxy_method                                                                                     │
│                                                                                                  │
│ /usr/lib/python3.9/contextlib.py:175 in __aenter__                                               │
│                                                                                                  │
│   174 │   │   try:                                                                               │
│ ❱ 175 │   │   │   return await self.gen.__anext__()                                              │
│   176 │   │   except StopAsyncIteration:                                                         │
│                                                                                                  │
│ /home/foo/modal-client/modal/stub.py:309 in run                                               │
│                                                                                                  │
│   308 │   │   mode = StubRunMode.DETACH if detach else StubRunMode.RUN                           │
│ ❱ 309 │   │   async with self._run(client, output_mgr, existing_app_id=None, mode=mode) as app   │
│   310 │   │   │   yield app                                                                      │
│                                                                                                  │
│ /usr/lib/python3.9/contextlib.py:175 in __aenter__                                               │
│                                                                                                  │
│   174 │   │   try:                                                                               │
│ ❱ 175 │   │   │   return await self.gen.__anext__()                                              │
│   176 │   │   except StopAsyncIteration:                                                         │
│                                                                                                  │
│ /home/foo/modal-client/modal/stub.py:231 in _run                                              │
│                                                                                                  │
│   230 │   │   │   │   with output_mgr.ctx_if_visible(output_mgr.make_live(create_progress)):     │
│ ❱ 231 │   │   │   │   │   await app._create_all_objects(create_progress)                         │
│   232 │   │   │   │   create_progress.label = step_completed("Created objects.")                 │
│                                                                                                  │
│ /home/foo/modal-client/modal/app.py:139 in _create_all_objects                                │
│                                                                                                  │
│   138 │   │   │   existing_object_id = self._tag_to_existing_id.get(tag)                         │
│ ❱ 139 │   │   │   self._tag_to_object[tag] = await self._load(provider, progress, existing_obj   │
│   140                                                                                            │
│                                                                                                  │
│ /home/foo/modal-client/modal/app.py:107 in _load                                              │
│                                                                                                  │
│   106 │   │   # Create object                                                                    │
│ ❱ 107 │   │   created_obj = await obj._load(self.client, self._stub, self.app_id, loader, set_   │
│   108                                                                                            │
│                                                                                                  │
│ /home/foo/modal-client/modal/functions.py:704 in _load                                        │
│                                                                                                  │
│   703 │   │   if self._image is not None:                                                        │
│ ❱ 704 │   │   │   image_id = await loader(self._image)                                           │
│   705 │   │   else:                                                                              │
│                                                                                                  │
│ /home/foo/modal-client/modal/app.py:90 in loader                                              │
│                                                                                                  │
│    89 │   │   async def loader(obj: Provider) -> str:                                            │
│ ❱  90 │   │   │   assert isinstance(obj, Provider)                                               │
│    91 │   │   │   created_obj = await self._load(obj, progress=progress)                         │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
AssertionError
```

This is not a general fix to the problem of checking function inputs across our user-facing constructors — that would take more thought and work — but assertion errors are an indication of programmer error not user error so thought I'd just make this patch. 