### PR TITLE
Upgrade to grpcio-tools 1.50.0, which has Python 3.11 support

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -2,7 +2,7 @@
 
 black~=22.3.0
 flake8~=4.0.1
-grpcio-tools==1.48.0
+grpcio-tools==1.50.0
 grpclib==0.4.3
 httpx~=0.23.0
 invoke~=1.7.0


### PR DESCRIPTION
**Previously on...**

* https://github.com/modal-labs/modal-client/pull/21
* https://github.com/modal-labs/modal-client/pull/56

Python 3.11 would offer significant performance improvements to users, so it'd be great to support it soon.

---

Blocker seems to be our minimum supported protobuf version

> `grpcio-tools 1.50.0 requires protobuf<5.0dev,>=4.21.6, but you have protobuf 3.19.0 which is incompatible.`