### PR TITLE
Fixes two issues with serialized functions

### DIFF
--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -253,7 +253,7 @@ def test_closure_valued_serialized_function(client, servicer):
         def returner():
             return s
 
-    with stub.run(client=client) as app:
+    with stub.run(client=client):
         pass
 
     functions = {}

--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -236,6 +236,26 @@ def test_nonglobal_function():
     assert "global scope" in str(excinfo.value)
 
 
+def test_non_global_serialized_function():
+    stub = Stub()
+    @stub.function(serialized=True)
+    def f():
+        pass
+
+
+def test_closure_valued_serialized_function(client):
+    stub = Stub()
+
+    for s in ["foo", "bar"]:
+        @stub.function(name=f"add_{s}", serialized=True)
+        def adder(x):
+            return x + s
+
+    with stub.run(client=client) as app:
+        assert app.add_foo("hello") == "hellofoo"
+        assert app.add_bar("hello") == "hellobar"
+
+
 def test_gpu_true_function(client, servicer):
     stub = Stub()
 

--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -238,6 +238,7 @@ def test_nonglobal_function():
 
 def test_non_global_serialized_function():
     stub = Stub()
+
     @stub.function(serialized=True)
     def f():
         pass
@@ -247,6 +248,7 @@ def test_closure_valued_serialized_function(client, servicer):
     stub = Stub()
 
     for s in ["foo", "bar"]:
+
         @stub.function(name=f"ret_{s}", serialized=True)
         def returner():
             return s

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -8,6 +8,8 @@ import typing
 from pathlib import Path
 from typing import Dict, Union, Any, Optional, Type, Callable
 
+import cloudpickle
+
 from modal_proto import api_pb2
 from .config import config, logger
 from .exception import InvalidError
@@ -54,12 +56,13 @@ def filter_safe_mounts(mounts: typing.Dict[str, _Mount]):
 
 
 class FunctionInfo:
-    """Class the helps us extracting a bunch of information about a function."""
+    """Class the helps us extract a bunch of information about a function."""
 
     # TODO: we should have a bunch of unit tests for this
     # TODO: if the function is declared in a local scope, this function still "works": we should throw an exception
-    def __init__(self, f, serialized=False):
-        self.function_name = f.__qualname__
+    def __init__(self, f, serialized=False, name_override: Optional[str] = None):
+        self.raw_f = f
+        self.function_name = name_override if name_override is not None else f.__qualname__
         self.signature = inspect.signature(f)
         module = inspect.getmodule(f)
 
@@ -85,6 +88,7 @@ class FunctionInfo:
             self.definition_type = api_pb2.Function.DEFINITION_TYPE_FILE
             self.is_package = True
             self.is_file = False
+            self.serialized_function = None
         elif hasattr(module, "__file__") and not serialized:
             # This generally covers the case where it's invoked with
             # python foo/bar/baz.py
@@ -94,12 +98,15 @@ class FunctionInfo:
             self.definition_type = api_pb2.Function.DEFINITION_TYPE_FILE
             self.is_package = False
             self.is_file = True
+            self.serialized_function = None
         else:
             self.module_name = None
             self.base_dir = os.path.abspath("")  # get current dir
             self.definition_type = api_pb2.Function.DEFINITION_TYPE_SERIALIZED
             self.is_package = False
             self.is_file = False
+            self.serialized_function = cloudpickle.dumps(self.raw_f)
+            logger.debug(f"Serializing {self.raw_f.__qualname__}, size is {len(self.serialized_function)}")
 
         if self.definition_type == api_pb2.Function.DEFINITION_TYPE_FILE:
             # Sanity check that this function is defined in global scope
@@ -186,10 +193,18 @@ class FunctionInfo:
         return all(param.default is not param.empty for param in self.signature.parameters.values())
 
 
+class LocalFunctionError(Exception):
+    pass
+
+
 def load_function_from_module(module, qual_name):
     # The function might be defined inside a class scope (e.g mymodule.MyClass.f)
     objs: list[Any] = [module]
     for path in qual_name.split("."):
+        if path == "<locals>":
+            raise LocalFunctionError()
+        # if a serialized function is defined within a function scope
+        # we can't load it from the module and detect a class
         objs.append(getattr(objs[-1], path))
 
     # If this function is defined on a class, return that too

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -122,7 +122,9 @@ class FunctionInfo:
             # Sanity check that this function is defined in global scope
             # Unfortunately, there's no "clean" way to do this in Python
             if not is_global_function(f.__qualname__):
-                raise LocalFunctionError("Modal can only import functions defined in global scope unless they are `serialized=True`")
+                raise LocalFunctionError(
+                    "Modal can only import functions defined in global scope unless they are `serialized=True`"
+                )
 
     def get_mounts(self) -> Dict[str, _Mount]:
         if self.is_package:

--- a/modal/exception.py
+++ b/modal/exception.py
@@ -41,9 +41,12 @@ class ConnectionError(Error):
 class InvalidError(Error):
     """Raised when user does something invalid."""
 
+
 class LocalFunctionError(InvalidError):
     """Raised if a function declared in a non-global scope is used in an impermissible way"""
+
     pass
+
 
 class VersionError(Error):
     """Raised when the current client version of Modal is unsupported."""

--- a/modal/exception.py
+++ b/modal/exception.py
@@ -41,6 +41,9 @@ class ConnectionError(Error):
 class InvalidError(Error):
     """Raised when user does something invalid."""
 
+class LocalFunctionError(InvalidError):
+    """Raised if a function declared in a non-global scope is used in an impermissible way"""
+    pass
 
 class VersionError(Error):
     """Raised when the current client version of Modal is unsupported."""

--- a/modal/exception.py
+++ b/modal/exception.py
@@ -42,12 +42,6 @@ class InvalidError(Error):
     """Raised when user does something invalid."""
 
 
-class LocalFunctionError(InvalidError):
-    """Raised if a function declared in a non-global scope is used in an impermissible way"""
-
-    pass
-
-
 class VersionError(Error):
     """Raised when the current client version of Modal is unsupported."""
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -46,7 +46,6 @@ from ._pty import get_pty_info
 from ._serialization import deserialize, serialize
 from ._traceback import append_modal_tb
 from .client import _Client
-from .config import logger
 from .exception import ExecutionError, InvalidError, NotFoundError, RemoteError
 from .exception import TimeoutError as _TimeoutError
 from .exception import deprecation_warning


### PR DESCRIPTION
* There was a bug with get_function_mounts erroring for serialized functions (should return no code mount)
* Closure values were determined at postponed _load time instead of function registration time, so all functions decorated in a loop using the loop variable would get the value of the last loop var.
* Adds a name override option to the function decorator which sets the modal name/tag of the function.

TODO:
* There are obviously some missing tests for serialized functions since the first bug wasn't caught, so will add some now
* Lifecycle classes for function local serialized functions aren't working at the moment since it still relies on loading the class from global scope. Postponing a fix for that, as it might be simplified if we change lifecycle syntax. 