### PR TITLE
f.call(...) instead of f(...)

### DIFF
--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -25,7 +25,7 @@ def dummy():
 
 def test_run_function(client):
     with stub.run(client=client):
-        assert foo(2, 4) == 20
+        assert foo.call(2, 4) == 20
 
 
 def test_map(client):
@@ -194,7 +194,7 @@ def test_function_exception(client, servicer):
 
     with stub.run(client=client):
         with pytest.raises(CustomException) as excinfo:
-            failure_modal()
+            failure_modal.call()
         assert "foo!" in str(excinfo.value)
 
 
@@ -208,7 +208,7 @@ def test_function_relative_import_hint(client, servicer):
     import_failure_modal = stub.function(servicer.function_body(import_failure))
     with stub.run(client=client):
         with pytest.raises(ImportError) as excinfo:
-            import_failure_modal()
+            import_failure_modal.call()
         assert "HINT" in str(excinfo.value)
 
 

--- a/client_test/rate_limit_test.py
+++ b/client_test/rate_limit_test.py
@@ -26,5 +26,5 @@ def test_rate_limit(client):
         stub.function(dummy, rate_limit=modal.RateLimit(per_minute=15, per_second=5))
 
     with stub.run(client=client):
-        per_second_5_modal()
-        per_minute_15_modal()
+        per_second_5_modal.call()
+        per_minute_15_modal.call()

--- a/client_test/retries_test.py
+++ b/client_test/retries_test.py
@@ -52,7 +52,7 @@ def test_retries(client):
         stub.function(dummy, retries=modal.Retries(max_retries=2, backoff_coefficient=0.0))
 
     with stub.run(client=client):
-        default_retries_from_int_modal()
-        fixed_delay_retries_modal()
-        exponential_backoff_modal()
-        exponential_with_max_delay_modal()
+        default_retries_from_int_modal.call()
+        fixed_delay_retries_modal.call()
+        exponential_backoff_modal.call()
+        exponential_with_max_delay_modal.call()

--- a/client_test/shared_volume_test.py
+++ b/client_test/shared_volume_test.py
@@ -18,7 +18,7 @@ def test_shared_volume_files(client, test_dir, servicer):
     )(dummy)
 
     with stub.run(client=client):
-        dummy_modal()
+        dummy_modal.call()
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="TODO: implement client-side path check on Windows.")
@@ -32,16 +32,16 @@ def test_shared_volume_bad_paths(client, test_dir, servicer):
 
     with pytest.raises(InvalidError):
         with stub.run(client=client):
-            dummy_modal()
+            dummy_modal.call()
 
     dummy_modal = stub.function(dummy, shared_volumes={"/": modal.SharedVolume()})
 
     with pytest.raises(InvalidError):
         with stub.run(client=client):
-            dummy_modal()
+            dummy_modal.call()
 
     dummy_modal = stub.function(dummy, shared_volumes={"/tmp/": modal.SharedVolume()})
 
     with pytest.raises(InvalidError):
         with stub.run(client=client):
-            dummy_modal()
+            dummy_modal.call()

--- a/client_test/stub_test.py
+++ b/client_test/stub_test.py
@@ -118,7 +118,7 @@ def test_run_function_without_app_error():
     dummy_modal = stub.function(dummy)
 
     with pytest.raises(InvalidError) as excinfo:
-        dummy_modal()
+        dummy_modal.call()
 
     assert "stub.run" in str(excinfo.value)
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -560,7 +560,17 @@ class _FunctionHandle(Handle, type_prefix="fu"):
         client, object_id = self._get_context()
         return await _Invocation.create(object_id, args, kwargs, client)
 
+    def call(self, *args, **kwargs):
+        if self._is_generator:
+            return self.call_generator(args, kwargs)
+        else:
+            return self.call_function(args, kwargs)
+
     def __call__(self, *args, **kwargs):
+        deprecation_warning(
+            "Calling a function directly is deprecated. Use f.call(...) instead."
+            " In a future version of Modal, f(...) will be used to call a function in the same process."
+        )
         if self._is_generator:
             return self.call_generator(args, kwargs)
         else:

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1,5 +1,6 @@
 # Copyright Modal Labs 2022
 import asyncio
+from datetime import date
 import inspect
 import os
 import platform
@@ -48,6 +49,7 @@ from ._traceback import append_modal_tb
 from .client import _Client
 from .exception import ExecutionError, InvalidError, NotFoundError, RemoteError
 from .exception import TimeoutError as _TimeoutError
+from .exception import deprecation_error, deprecation_warning
 from .gpu import _GPUConfig
 from .image import _Image
 from .mount import _Mount
@@ -568,15 +570,23 @@ class _FunctionHandle(Handle, type_prefix="fu"):
 
     def __call__(self, *args, **kwargs):
         deprecation_warning(
+            date(2022, 12, 5),
             "Calling a function directly is deprecated. Use f.call(...) instead."
-            " In a future version of Modal, f(...) will be used to call a function in the same process."
+            " In a future version of Modal, f(...) will be used to call a function in the same process.",
         )
         if self._is_generator:
             return self.call_generator(args, kwargs)
         else:
             return self.call_function(args, kwargs)
 
-    async def submit(self, *args, **kwargs) -> Optional["_FunctionCall"]:
+    async def enqueue(self, *args, **kwargs):
+        """**Deprecated.** Use `.submit()` instead when possible.
+
+        Calls the function with the given arguments, without waiting for the results.
+        """
+        deprecation_error(None, "Function.enqueue is deprecated, use .spawn() instead")
+
+    async def spawn(self, *args, **kwargs) -> Optional["_FunctionCall"]:
         """Calls the function with the given arguments, without waiting for the results.
 
         Returns a `modal.functions.FunctionCall` object, that can later be polled or waited for using `.get(timeout=...)`.
@@ -591,6 +601,10 @@ class _FunctionHandle(Handle, type_prefix="fu"):
 
         invocation = await self.call_function_nowait(args, kwargs)
         return _FunctionCall(invocation.client, invocation.function_call_id)
+
+    async def submit(self, *args, **kwargs) -> Optional["_FunctionCall"]:
+        deprecation_warning(date(2022, 12, 5), "Function.submit is deprecated, use .spawn() instead")
+        return await self.spawn(*args, **kwargs)
 
     def get_raw_f(self) -> Callable:
         """Return the inner Python object wrapped by this Modal Function."""

--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -7,7 +7,7 @@ from ._version_generated import build_number  # Written by GitHub
 major_number = 0
 
 # Bump this manually on any major changes
-minor_number = 41
+minor_number = 42
 
 # Right now, set the patch number (the 3rd field) to the job run number in GitHub
 __version__ = f"{major_number}.{minor_number}.{build_number}"


### PR DESCRIPTION
This is a very major change to the Modal SDK, but very small code delta.

It deprecates the old `f(...)` syntax in favor of `f.call(...)`

The ultimate goal is for `f(...)` to call a function _in the same process_. This means decorating a function in Modal conceptually just "adds" Modal functionality to it, rather than changing it.

Some reasons I think this is the way forward:
* I think it helps shape the mental model of what functions run in what containers. I've talked to several users who are confused about what needs to be decorated. If you have a Modal function `f` and it needs to call a utility function `g` in the same process, there's confusion whether `g` needs to be decorated (it doesn't). 
* It makes it easier to read code and see calls that cross container boundaries
* It opens the door for auto-decoration of functions, in particular it will be possible for a class decorator to auto-decorate every method on a class.
* Unit testing Modal functions will be simpler – you can just call `f(...)` rather than the awkward `f.get_raw_f()(...)` today. (although to be fair, we _could_ add a `f.local(...)` method)
* Decorating `f(...)` today will sometimes change the function signature in certain cases – e.g. if you call a sync function from an async context or vice versa. This is a pretty minor thing but seems ugly to me.

I'm not particularly attached to the name "call" – open to whatever (eg remote, invoke, ...).

I expect the deprecation path to be very long for something like this. Suggested schedule:

1. This PR: Add deprecation warnings to `f(...)` and nudge people to switch to `f.call(...)`
3. At some point in Jan 2023: Turn deprecation warnings into exceptions
4. At some point in Feb 2023: Add back the `__call__` method but this time it calls the underlying function in the same process