### PR TITLE
Remove Image(version=) kwarg support

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -89,7 +89,6 @@ class _Image(Provider[_ImageHandle]):
         context_files={},
         dockerfile_commands: Union[list[str], Callable[[], list[str]]] = [],
         secrets=[],
-        version=None,
         ref=None,
         gpu=False,
         build_function=None,
@@ -111,7 +110,6 @@ class _Image(Provider[_ImageHandle]):
         self._base_images = base_images
         self._context_files = context_files
         self._dockerfile_commands = dockerfile_commands
-        self._version = version
         self._secrets = secrets
         self._gpu = gpu
         self._build_function = build_function
@@ -172,7 +170,6 @@ class _Image(Provider[_ImageHandle]):
             base_images=base_images_pb2s,
             dockerfile_commands=dockerfile_commands,
             context_files=context_file_pb2s,
-            version=self._version,
             secret_ids=secret_ids,
             gpu=self._gpu,
             build_function_def=build_function_def,

--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -7,7 +7,7 @@ from ._version_generated import build_number  # Written by GitHub
 major_number = 0
 
 # Bump this manually on any major changes
-minor_number = 40
+minor_number = 41
 
 # Right now, set the patch number (the 3rd field) to the job run number in GitHub
 __version__ = f"{major_number}.{minor_number}.{build_number}"


### PR DESCRIPTION
As discussed on company Slack this argument isn't used for anything and is obsolete.

No examples use it and it isn't documented anywhere, so I think the risk of breakage is low (therefore no deprecation period). I'm still bumping the client version number though, since this is technically a breaking change (public API update).