### PR TITLE
Remove closed channels from channel pool

### DIFF
--- a/client_test/grpc_utils_test.py
+++ b/client_test/grpc_utils_test.py
@@ -55,6 +55,19 @@ async def test_channel_pool(servicer, n=1000):
 
     channel_pool.close()
 
+@pytest.mark.asyncio
+async def test_channel_pool_closed_transport(servicer):
+    channel_pool = create_channel(servicer.remote_addr, use_pool=True)
+    assert isinstance(channel_pool, ChannelPool)
+
+    connection = await channel_pool.__connect__()
+    connection.connection_lost(None)  # simulates a h2 connection being closed
+
+    client_stub = api_grpc.ModalClientStub(channel_pool)
+    req = api_pb2.BlobCreateRequest()
+    resp = await client_stub.BlobCreate(req)  # this should close the terminated connection and start a new one
+    assert resp.blob_id
+    channel_pool.close()
 
 @pytest.mark.asyncio
 async def test_channel_pool_max_active(servicer):

--- a/client_test/grpc_utils_test.py
+++ b/client_test/grpc_utils_test.py
@@ -55,6 +55,7 @@ async def test_channel_pool(servicer, n=1000):
 
     channel_pool.close()
 
+
 @pytest.mark.asyncio
 async def test_channel_pool_closed_transport(servicer):
     channel_pool = create_channel(servicer.remote_addr, use_pool=True)
@@ -68,6 +69,7 @@ async def test_channel_pool_closed_transport(servicer):
     resp = await client_stub.BlobCreate(req)  # this should close the terminated connection and start a new one
     assert resp.blob_id
     channel_pool.close()
+
 
 @pytest.mark.asyncio
 async def test_channel_pool_max_active(servicer):

--- a/modal_utils/grpc_utils.py
+++ b/modal_utils/grpc_utils.py
@@ -40,7 +40,10 @@ class Subchannel:
         self.requests = 0
 
     def connected(self):
-        return not self.protocol.handler.connection_lost  # noqa
+        if hasattr(self.protocol.handler, "connection_lost"):
+            # AbstractHandler doesn't have connection_lost, but Handler does
+            return not self.protocol.handler.connection_lost
+        return True
 
 
 class ChannelPool(Channel):

--- a/modal_utils/grpc_utils.py
+++ b/modal_utils/grpc_utils.py
@@ -42,7 +42,7 @@ class Subchannel:
     def connected(self):
         if hasattr(self.protocol.handler, "connection_lost"):
             # AbstractHandler doesn't have connection_lost, but Handler does
-            return not self.protocol.handler.connection_lost
+            return not self.protocol.handler.connection_lost  # type: ignore
         return True
 
 


### PR DESCRIPTION
Fixes the `AttributeError: 'Connection' object has no attribute '_transport'` error.

The connection pool will still raise an error if a connection is closed mid-request (StreamTerminatedError) or if it can't create a new connection, but that shouldn't happen unless something is wrong with the server/load balancer logic (I think)