### PR TITLE
Remove old deprecated code, add a date to deprecations going forward

### DIFF
--- a/modal/exception.py
+++ b/modal/exception.py
@@ -1,4 +1,5 @@
 # Copyright Modal Labs 2022
+from datetime import date
 import sys
 import warnings
 
@@ -68,7 +69,7 @@ def _is_internal_frame(frame):
     return module in _INTERNAL_MODULES
 
 
-def deprecation_warning(msg):
+def deprecation_warning(deprecated_on: date, msg: str):
     """Utility for getting the proper stack entry
 
     See the implementation of the built-in [warnings.warn](https://docs.python.org/3/library/warnings.html#available-functions).
@@ -86,4 +87,4 @@ def deprecation_warning(msg):
         lineno = 0
 
     # This is a lower-level function that warnings.warn uses
-    warnings.warn_explicit(msg, DeprecationError, filename, lineno)
+    warnings.warn_explicit(f"Deprecated on {deprecated_on}: {msg}", DeprecationError, filename, lineno)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -48,7 +48,6 @@ from ._traceback import append_modal_tb
 from .client import _Client
 from .exception import ExecutionError, InvalidError, NotFoundError, RemoteError
 from .exception import TimeoutError as _TimeoutError
-from .exception import deprecation_warning
 from .gpu import _GPUConfig
 from .image import _Image
 from .mount import _Mount
@@ -558,17 +557,6 @@ class _FunctionHandle(Handle, type_prefix="fu"):
             return self.call_generator(args, kwargs)
         else:
             return self.call_function(args, kwargs)
-
-    async def enqueue(self, *args, **kwargs):
-        """**Deprecated.** Use `.submit()` instead when possible.
-
-        Calls the function with the given arguments, without waiting for the results.
-        """
-        deprecation_warning("Function.enqueue is deprecated, use .submit() instead")
-        if self._is_generator:
-            await self._call_generator_nowait(args, kwargs)
-        else:
-            await self.call_function_nowait(args, kwargs)
 
     async def submit(self, *args, **kwargs) -> Optional["_FunctionCall"]:
         """Calls the function with the given arguments, without waiting for the results.

--- a/modal/image.py
+++ b/modal/image.py
@@ -13,7 +13,7 @@ from modal_utils.async_utils import synchronize_apis
 from modal_utils.grpc_utils import retry_transient_errors
 
 from .config import config, logger
-from .exception import InvalidError, NotFoundError, RemoteError, deprecation_warning
+from .exception import InvalidError, NotFoundError, RemoteError
 from .object import Handle, Provider
 from .secret import _Secret
 
@@ -590,33 +590,4 @@ class _Image(Provider[_ImageHandle]):
         return self.extend(build_function=(raw_function, kwargs))
 
 
-def _Conda():
-    """mdmd:hidden"""
-    deprecation_warning("`modal.Conda` is deprecated. Please use `modal.Image.conda` instead")
-    return _Image.conda()
-
-
-def _DockerhubImage(*args, **kwargs):
-    """mdmd:hidden"""
-    deprecation_warning("`modal.DockerhubImage` is deprecated. Please use `modal.Image.from_dockerhub` instead")
-    return _Image.from_dockerhub(*args, **kwargs)
-
-
-def _DockerfileImage(*args, **kwargs):
-    """mdmd:hidden"""
-    deprecation_warning("`modal.DockerfileImage` is deprecated. Please use `modal.Image.from_dockerfile` instead")
-    return _Image.from_dockerfile(*args, **kwargs)
-
-
-def _DebianSlim(*args, **kwargs):
-    """mdmd:hidden"""
-    deprecation_warning("`modal.DebianSlim` is deprecated. Please use `modal.Image.debian_slim` instead")
-    return _Image.debian_slim(*args, **kwargs)
-
-
 synchronize_apis(_ImageHandle)
-Image, AioImage = synchronize_apis(_Image)
-Conda, AioConda = synchronize_apis(_Conda)
-DebianSlim, AioDebianSlim = synchronize_apis(_DebianSlim)
-DockerhubImage, AioDockerhubImage = synchronize_apis(_DockerhubImage)
-DockerfileImage, AioDockerfileImage = synchronize_apis(_DockerfileImage)

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -16,7 +16,7 @@ from modal_version import __version__
 
 from ._blob_utils import FileUploadSpec, blob_upload_file, get_file_upload_spec
 from .config import logger
-from .exception import InvalidError, NotFoundError, deprecation_warning
+from .exception import InvalidError, NotFoundError
 from .object import Handle, Provider
 
 
@@ -247,14 +247,6 @@ async def _create_package_mounts(module_names: Collection[str]) -> List[_Mount]:
                     )
                 )
     return mounts
-
-
-async def _create_package_mount(module_name: str):
-    """mdmd:hidden"""
-    deprecation_warning("`create_package_mount` is deprecated. Please use `create_package_mounts` instead.")
-    mounts = await _create_package_mounts([module_name])
-    assert len(mounts) == 1
-    return mounts[0]
 
 
 create_package_mount, aio_create_package_mount = synchronize_apis(_create_package_mount)

--- a/modal/object.py
+++ b/modal/object.py
@@ -16,7 +16,7 @@ from modal_utils.async_utils import synchronize_apis
 
 from ._object_meta import ObjectMeta
 from .client import _Client
-from .exception import InvalidError, NotFoundError, deprecation_warning
+from .exception import InvalidError, NotFoundError
 
 if TYPE_CHECKING:
     from .stub import _Stub
@@ -237,9 +237,3 @@ class PersistedRef(Ref[H]):
         await _stub.deploy(client=client)
         handle = await Handle.from_app(self.app_name, client=client)
         return cast(H, handle)
-
-
-def ref(app_name: str, tag: Optional[str] = None, namespace=api_pb2.DEPLOYMENT_NAMESPACE_ACCOUNT) -> Ref:
-    """`modal.ref` is deprecated. Please use `modal.Secret.from_name` instead."""
-    deprecation_warning(ref.__doc__)
-    return RemoteRef(app_name, tag, namespace)

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -1,5 +1,6 @@
 # Copyright Modal Labs 2022
 import contextlib
+from datetime import date
 import inspect
 import os
 import sys
@@ -309,12 +310,6 @@ class _Stub:
         async with self._run(client, output_mgr, existing_app_id=None, mode=mode) as app:
             yield app
 
-    async def run_forever(self, client=None, stdout=None, show_progress=None) -> None:
-        """**Deprecated.** Use `.serve()` instead."""
-
-        deprecation_warning("Stub.run_forever is deprecated, use .serve() instead")
-        await self.serve(client, stdout, show_progress)
-
     async def serve(self, client=None, stdout=None, show_progress=None, timeout=None) -> None:
         """Run an app until the program is interrupted. Modal watches source files
         and mounts for the app, and live updates the app when any changes are detected.
@@ -579,7 +574,7 @@ class _Stub:
 
     @decorator_with_options
     def generator(self, raw_f=None, **kwargs) -> _FunctionHandle:
-        deprecation_warning("Stub.generator is deprecated. Use .function() instead.")
+        deprecation_warning(date(2022, 12, 1), "Stub.generator is deprecated. Use .function() instead.")
         kwargs.update(dict(is_generator=True))
         return self.function(raw_f, **kwargs)
 


### PR DESCRIPTION
We had a lot of deprecated code that was more than 3 months old – removing all of it.

Added a date argument to `deprecation_warning` to track _when_ we deprecate code