### PR TITLE
Upgrade almost all deprecation warnings into errors

### DIFF
--- a/client_test/image_test.py
+++ b/client_test/image_test.py
@@ -51,7 +51,7 @@ def test_image_python_packages(client, servicer):
 
 
 def test_debian_slim_deprecated(servicer, client):
-    with pytest.warns(DeprecationError):
+    with pytest.raises(DeprecationError):
         DebianSlim()
 
 
@@ -115,11 +115,8 @@ def test_conda_install(servicer, client):
 
 
 def test_conda_deprecated(servicer, client):
-    with pytest.warns(DeprecationError) as record:
+    with pytest.raises(DeprecationError):
         Conda()
-
-    # Make sure it has the right filename
-    assert record[0].filename == __file__
 
 
 def test_dockerfile_image(servicer, client):

--- a/client_test/object_test.py
+++ b/client_test/object_test.py
@@ -18,9 +18,8 @@ async def test_async_factory(servicer, client):
 @pytest.mark.asyncio
 async def test_use_object(servicer, client):
     stub = AioStub()
-    with pytest.warns(DeprecationError):
+    with pytest.raises(DeprecationError):
         stub["my_q_1"] = ref("foo-queue")
     stub["my_q_2"] = AioQueue.from_name("foo-queue")
     async with stub.run(client=client) as running_app:
-        assert running_app["my_q_1"].object_id == "qu-foo"
         assert running_app["my_q_2"].object_id == "qu-foo"

--- a/modal/exception.py
+++ b/modal/exception.py
@@ -1,5 +1,7 @@
 # Copyright Modal Labs 2022
+from datetime import date
 import sys
+from typing import Optional
 import warnings
 
 
@@ -68,12 +70,16 @@ def _is_internal_frame(frame):
     return module in _INTERNAL_MODULES
 
 
-def deprecation_warning(msg):
+def deprecation_error(deprecated_on: Optional[date], msg: str):
+    # TODO: include the date in the message!
+    raise DeprecationError(msg)
+
+
+def deprecation_warning(deprecated_on: date, msg: str):
     """Utility for getting the proper stack entry
 
     See the implementation of the built-in [warnings.warn](https://docs.python.org/3/library/warnings.html#available-functions).
     """
-
     # Find the last non-Modal line that triggered the warning
     try:
         frame = sys._getframe()
@@ -86,4 +92,4 @@ def deprecation_warning(msg):
         lineno = 0
 
     # This is a lower-level function that warnings.warn uses
-    warnings.warn_explicit(msg, DeprecationError, filename, lineno)
+    warnings.warn_explicit(f"Deprecated on {deprecated_on}: {msg}", DeprecationError, filename, lineno)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -48,7 +48,7 @@ from ._traceback import append_modal_tb
 from .client import _Client
 from .exception import ExecutionError, InvalidError, NotFoundError, RemoteError
 from .exception import TimeoutError as _TimeoutError
-from .exception import deprecation_warning
+from .exception import deprecation_error
 from .gpu import _GPUConfig
 from .image import _Image
 from .mount import _Mount
@@ -564,11 +564,7 @@ class _FunctionHandle(Handle, type_prefix="fu"):
 
         Calls the function with the given arguments, without waiting for the results.
         """
-        deprecation_warning("Function.enqueue is deprecated, use .submit() instead")
-        if self._is_generator:
-            await self._call_generator_nowait(args, kwargs)
-        else:
-            await self.call_function_nowait(args, kwargs)
+        deprecation_error(None, "Function.enqueue is deprecated, use .submit() instead")
 
     async def submit(self, *args, **kwargs) -> Optional["_FunctionCall"]:
         """Calls the function with the given arguments, without waiting for the results.

--- a/modal/image.py
+++ b/modal/image.py
@@ -13,7 +13,7 @@ from modal_utils.async_utils import synchronize_apis
 from modal_utils.grpc_utils import retry_transient_errors
 
 from .config import config, logger
-from .exception import InvalidError, NotFoundError, RemoteError, deprecation_warning
+from .exception import InvalidError, NotFoundError, RemoteError, deprecation_error
 from .object import Handle, Provider
 from .secret import _Secret
 
@@ -592,26 +592,22 @@ class _Image(Provider[_ImageHandle]):
 
 def _Conda():
     """mdmd:hidden"""
-    deprecation_warning("`modal.Conda` is deprecated. Please use `modal.Image.conda` instead")
-    return _Image.conda()
+    deprecation_error(None, "`modal.Conda` is deprecated. Please use `modal.Image.conda` instead")
 
 
 def _DockerhubImage(*args, **kwargs):
     """mdmd:hidden"""
-    deprecation_warning("`modal.DockerhubImage` is deprecated. Please use `modal.Image.from_dockerhub` instead")
-    return _Image.from_dockerhub(*args, **kwargs)
+    deprecation_error(None, "`modal.DockerhubImage` is deprecated. Please use `modal.Image.from_dockerhub` instead")
 
 
 def _DockerfileImage(*args, **kwargs):
     """mdmd:hidden"""
-    deprecation_warning("`modal.DockerfileImage` is deprecated. Please use `modal.Image.from_dockerfile` instead")
-    return _Image.from_dockerfile(*args, **kwargs)
+    deprecation_error(None, "`modal.DockerfileImage` is deprecated. Please use `modal.Image.from_dockerfile` instead")
 
 
 def _DebianSlim(*args, **kwargs):
     """mdmd:hidden"""
-    deprecation_warning("`modal.DebianSlim` is deprecated. Please use `modal.Image.debian_slim` instead")
-    return _Image.debian_slim(*args, **kwargs)
+    deprecation_error(None, "`modal.DebianSlim` is deprecated. Please use `modal.Image.debian_slim` instead")
 
 
 synchronize_apis(_ImageHandle)

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -16,7 +16,7 @@ from modal_version import __version__
 
 from ._blob_utils import FileUploadSpec, blob_upload_file, get_file_upload_spec
 from .config import logger
-from .exception import InvalidError, NotFoundError, deprecation_warning
+from .exception import InvalidError, NotFoundError, deprecation_error
 from .object import Handle, Provider
 
 
@@ -251,10 +251,7 @@ async def _create_package_mounts(module_names: Collection[str]) -> List[_Mount]:
 
 async def _create_package_mount(module_name: str):
     """mdmd:hidden"""
-    deprecation_warning("`create_package_mount` is deprecated. Please use `create_package_mounts` instead.")
-    mounts = await _create_package_mounts([module_name])
-    assert len(mounts) == 1
-    return mounts[0]
+    deprecation_error(None, "`create_package_mount` is deprecated. Please use `create_package_mounts` instead.")
 
 
 create_package_mount, aio_create_package_mount = synchronize_apis(_create_package_mount)

--- a/modal/object.py
+++ b/modal/object.py
@@ -16,7 +16,7 @@ from modal_utils.async_utils import synchronize_apis
 
 from ._object_meta import ObjectMeta
 from .client import _Client
-from .exception import InvalidError, NotFoundError, deprecation_warning
+from .exception import InvalidError, NotFoundError, deprecation_error
 
 if TYPE_CHECKING:
     from .stub import _Stub
@@ -239,7 +239,6 @@ class PersistedRef(Ref[H]):
         return cast(H, handle)
 
 
-def ref(app_name: str, tag: Optional[str] = None, namespace=api_pb2.DEPLOYMENT_NAMESPACE_ACCOUNT) -> Ref:
+def ref(app_name: str, tag: Optional[str] = None, namespace=api_pb2.DEPLOYMENT_NAMESPACE_ACCOUNT):
     """`modal.ref` is deprecated. Please use `modal.Secret.from_name` instead."""
-    deprecation_warning(ref.__doc__)
-    return RemoteRef(app_name, tag, namespace)
+    deprecation_error(None, ref.__doc__)

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -1,5 +1,6 @@
 # Copyright Modal Labs 2022
 import contextlib
+from datetime import date
 import inspect
 import os
 import sys
@@ -21,7 +22,7 @@ from ._pty import exec_cmd, write_stdin_to_pty_stream
 from .app import _App, container_app, is_local
 from .client import _Client
 from .config import config, logger
-from .exception import InvalidError, deprecation_warning
+from .exception import InvalidError, deprecation_error, deprecation_warning
 from .functions import _Function, _FunctionHandle
 from .gpu import _GPUConfig
 from .image import _Image
@@ -312,7 +313,7 @@ class _Stub:
     async def run_forever(self, client=None, stdout=None, show_progress=None) -> None:
         """**Deprecated.** Use `.serve()` instead."""
 
-        deprecation_warning("Stub.run_forever is deprecated, use .serve() instead")
+        deprecation_error(None, "Stub.run_forever is deprecated, use .serve() instead")
         await self.serve(client, stdout, show_progress)
 
     async def serve(self, client=None, stdout=None, show_progress=None, timeout=None) -> None:
@@ -579,7 +580,7 @@ class _Stub:
 
     @decorator_with_options
     def generator(self, raw_f=None, **kwargs) -> _FunctionHandle:
-        deprecation_warning("Stub.generator is deprecated. Use .function() instead.")
+        deprecation_warning(date(2022, 12, 1), "Stub.generator is deprecated. Use .function() instead.")
         kwargs.update(dict(is_generator=True))
         return self.function(raw_f, **kwargs)
 

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
 from __future__ import annotations
 import asyncio
+from datetime import date
 import time
 
 from modal import Stub
@@ -57,7 +58,7 @@ def gen_n_fail_on_m(n, m):
 
 
 def deprecated_function(x):
-    deprecation_warning("This function is deprecated")
+    deprecation_warning(date(2000, 1, 1), "This function is deprecated")
     return x**2
 
 


### PR DESCRIPTION
All the deprecations up until #100 were super old. Upgrading them to exceptions. Also adding a date argument to `deprecation_warning` so that we can track what time something was deprecated at – will make it easier to know when things are safe to remove.

I'll remove all this deprecated code in a couple of weeks.