### PR TITLE
New app state DEPLOYING to support webhook UX

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -206,10 +206,15 @@ class _App:
         return _App(stub, client, existing_app_id, app_page_url, tag_to_existing_id=dict(obj_resp.object_ids))
 
     @staticmethod
-    async def _init_new(stub, client, description, detach) -> "_App":
+    async def _init_new(stub, client, description, detach, deploying) -> "_App":
         # Start app
         # TODO(erikbern): maybe this should happen outside of this method?
-        app_req = api_pb2.AppCreateRequest(client_id=client.client_id, description=description, detach=detach)
+        app_req = api_pb2.AppCreateRequest(
+            client_id=client.client_id,
+            description=description,
+            deploying=deploying,
+            detach=detach,
+        )
         app_resp = await retry_transient_errors(client.stub.AppCreate, app_req)
         app_page_url = app_resp.app_logs_url
         logger.debug(f"Created new app with id {app_resp.app_id}")

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -209,7 +209,7 @@ class _Stub:
         if existing_app_id is not None:
             app = await _App._init_existing(self, client, existing_app_id)
         else:
-            app = await _App._init_new(self, client, app_name, detach=detach)
+            app = await _App._init_new(self, client, app_name, deploying=(mode == StubRunMode.DEPLOY), detach=detach)
 
         self._app_id = app.app_id
         aborted = False

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -20,6 +20,9 @@ enum AppState {
 
   // Stopped
   APP_STATE_STOPPED = 5;
+
+  // App is created and in process of deployment.
+  APP_STATE_DEPLOYING = 6;
 }
 
 enum ClientType {
@@ -77,6 +80,7 @@ message AppCreateRequest {
   string client_id = 1;
   string description = 2;    // Human readable label for the website
   bool detach = 3;
+  bool deploying = 4;
 }
 
 message AppCreateResponse {


### PR DESCRIPTION
A deployment proceeds through these steps:

1. App creation (or reuse if previous deployment)
2. Object creation, including Function objects that are webhooks
3. App deployment

Currently webhook label assignment happens in step 2, but there's no data available to differentiate an ephemeral app from a new deployment. `app.name` allow differentiation, but it is set in step 3, once a deployment has succeeded (the name vs.description situation is already confusing, too).

This PR introduces a new app state that will be set in step 1, so that Function creation code has data to differentiate ephemeral vs. new deployment. 