### PR TITLE
fix: stub.serve() shutdown

### DIFF
--- a/client_test/stub_test.py
+++ b/client_test/stub_test.py
@@ -168,6 +168,7 @@ def test_serve(client):
     stub.serve(client=client, timeout=1)
 
 
+@skip_in_github
 def test_serve_teardown(client, servicer):
     stub = Stub()
     with modal.client.Client(servicer.remote_addr, api_pb2.CLIENT_TYPE_CLIENT, ("foo-id", "foo-secret")) as client:

--- a/modal/app.py
+++ b/modal/app.py
@@ -160,6 +160,7 @@ class _App:
         logger.debug("Sending app disconnect/stop request")
         req_disconnect = api_pb2.AppClientDisconnectRequest(app_id=self._app_id)
         await retry_transient_errors(self._client.stub.AppClientDisconnect, req_disconnect)
+        logger.debug("App disconnected")
 
     def log_url(self):
         return self._app_page_url

--- a/modal/client.py
+++ b/modal/client.py
@@ -139,7 +139,7 @@ class _Client:
 
         logger.debug("Client: Done starting")
 
-    async def set_pre_stop(self, pre_stop: Callable[[], None]):
+    def set_pre_stop(self, pre_stop: Callable[[], None]):
         """mdmd:hidden"""
         if self._pre_stop:
             raise ValueError("Client's pre-stop is already set.")

--- a/modal/client.py
+++ b/modal/client.py
@@ -141,6 +141,12 @@ class _Client:
 
     def set_pre_stop(self, pre_stop: Callable[[], None]):
         """mdmd:hidden"""
+        # hack: stub.serve() gets into a losing race with the `on_shutdown` client
+        # teardown when an interrupt signal is received (eg. KeyboardInterrupt).
+        # By registering a pre-stop fn stub.serve() can have its teardown
+        # performed before the client is disconnected.
+        #
+        # ref: github.com/modal-labs/modal-client/pull/108
         if self._pre_stop:
             raise ValueError("Client's pre-stop is already set.")
         self._pre_stop = pre_stop

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -1,10 +1,10 @@
 # Copyright Modal Labs 2022
 import contextlib
-from datetime import date
 import inspect
 import os
 import sys
 import warnings
+from datetime import date
 from enum import Enum
 from typing import AsyncGenerator, Collection, Dict, List, Optional, Union
 
@@ -362,12 +362,11 @@ class _Stub:
                     output_mgr.print_if_visible(f"⚡️ Updating app {existing_app_id}...")
 
                 async with self._run(client, output_mgr, existing_app_id, mode=StubRunMode.SERVE) as app:
+                    client.set_pre_stop(app.disconnect)
                     existing_app_id = app.app_id
                     event = await event_agen.__anext__()
         finally:
             await event_agen.aclose()
-            if app:
-                await app.disconnect()
 
     async def deploy(
         self,


### PR DESCRIPTION
`stub.serve()` is currently unable to `await app.disconnect()` and stop an app, because `async_utils.on_shutdown(AioClient.stop_env_client())` runs before the disconnect call and disconnects the `client`. (it's a race that the `disconnect()` never wins)

I tried a couple dozen things, but can't get around the fact that once <kbd>Ctrl</kbd> + <kbd>C</kbd> has initiated the async loop's shutdown, you can't control the ordering of the app disconnection and the client stop.

The proper fix is probably to rewrite all `client` usage to be done by context manager, but that's much more involved than this stop-gap I've done here. 

----

**Ref:** Shutdown hook is from https://github.com/modal-labs/modal/pull/2957.