### PR TITLE
Use Modal serialization instead of Cloudpickle

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -11,7 +11,6 @@ import time
 import traceback
 from typing import Any, AsyncIterator, Callable, Optional
 
-import cloudpickle
 from grpclib import Status
 from synchronicity.interface import Interface
 
@@ -102,10 +101,10 @@ class _FunctionIOManager:
         # Fetch the serialized function definition
         request = api_pb2.FunctionGetSerializedRequest(function_id=self.function_id)
         response = await self.client.stub.FunctionGetSerialized(request)
-        fun = cloudpickle.loads(response.function_serialized)
+        fun = self.deserialize(response.function_serialized)
 
         if response.class_serialized:
-            cls = cloudpickle.loads(response.class_serialized)
+            cls = self.deserialize(response.class_serialized)
         else:
             cls = None
 

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -14,7 +14,6 @@ from typing import Any, AsyncIterator, Callable, Optional
 from grpclib import Status
 from synchronicity.interface import Interface
 
-from modal._function_utils import load_function_from_module
 from modal_proto import api_pb2
 from modal_utils.async_utils import (
     TaskContext,
@@ -26,6 +25,7 @@ from modal_utils.grpc_utils import retry_transient_errors
 
 from ._asgi import asgi_app_wrapper, webhook_asgi_app, wsgi_app_wrapper
 from ._blob_utils import MAX_OBJECT_SIZE_BYTES, blob_download, blob_upload
+from ._function_utils import load_function_from_module
 from ._proxy_tunnel import proxy_tunnel
 from ._pty import run_in_pty
 from ._serialization import deserialize, serialize

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -8,9 +8,8 @@ import typing
 from pathlib import Path
 from typing import Dict, Union, Any, Optional, Type, Callable
 
-import cloudpickle
-
 from modal_proto import api_pb2
+from ._serialization import serialize
 from .config import config, logger
 from .exception import InvalidError
 from .mount import _Mount
@@ -115,7 +114,7 @@ class FunctionInfo:
             self.definition_type = api_pb2.Function.DEFINITION_TYPE_SERIALIZED
             self.is_package = False
             self.is_file = False
-            self.serialized_function = cloudpickle.dumps(self.raw_f)
+            self.serialized_function = serialize(self.raw_f)
             logger.debug(f"Serializing {self.raw_f.__qualname__}, size is {len(self.serialized_function)}")
 
         if self.definition_type == api_pb2.Function.DEFINITION_TYPE_FILE:


### PR DESCRIPTION
Realized our current code wasn't correct. Sadly, this isn't enough to solve an annoying problem reported by a user. It does however replace the exception message with something that's slightly less weird.

Instead of
`KeyError: '_sync_original_inst_139793335770400'`
you now get
`InvalidError: Can't serialize object <modal.functions._FunctionHandle object at 0x114d75180> which hasn't been created.`