### PR TITLE
fix: allow set_pre_stop() multiple times, because of live-reloading in .serve()

### DIFF
--- a/modal/client.py
+++ b/modal/client.py
@@ -147,8 +147,6 @@ class _Client:
         # performed before the client is disconnected.
         #
         # ref: github.com/modal-labs/modal-client/pull/108
-        if self._pre_stop:
-            raise ValueError("Client's pre-stop is already set.")
         self._pre_stop = pre_stop
 
     async def _stop(self):


### PR DESCRIPTION
Eugh, my unit test and inadequate manual testing didn't catch what should have been an obvious problem. I only had the `ValueError` to prevent misusing the method, but turns out its simplest to allow re-setting.