### PR TITLE
Fix incorrect docs

### DIFF
--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -230,7 +230,7 @@ async def list_apps():
 
 @app_cli.command("logs")
 def app_logs(app_id: str):
-    """List all running or recently running Modal apps for the current account"""
+    """Output logs for a running app."""
 
     @synchronizer
     async def sync_command():


### PR DESCRIPTION
User pointed out that the docs were duplicated between `modal app list` and `modal app logs`

<img width="647" alt="image" src="https://user-images.githubusercontent.com/1027979/206235712-aec56b37-f302-48ed-b9fe-1f533fb4e1fd.png">
