### PR TITLE
Make deprecation warnings slightly less verbose

### DIFF
--- a/modal/exception.py
+++ b/modal/exception.py
@@ -90,4 +90,4 @@ def deprecation_warning(deprecated_on: date, msg: str):
         lineno = 0
 
     # This is a lower-level function that warnings.warn uses
-    warnings.warn_explicit(f"Deprecated on {deprecated_on}: {msg}", DeprecationError, filename, lineno)
+    warnings.warn_explicit(f"{deprecated_on}: {msg}", DeprecationError, filename, lineno)


### PR DESCRIPTION
Super minor. Instead of the somewhat redundant/verbose

```
<stdin>:1: DeprecationError: Deprecated on 2022-12-09: xyz
```

do this instead:

```
<stdin>:1: DeprecationError: 2022-12-09: xyz
```