### PR TITLE
Sort pip packages lexicographically (minor optimization)

### DIFF
--- a/client_test/image_test.py
+++ b/client_test/image_test.py
@@ -155,7 +155,7 @@ def test_image_pip_install_pyproject_with_optionals(servicer, client):
 
         print(layers[0].dockerfile_commands)
         assert any(
-            "pip install 'banana >=1.2.0' 'potato >=0.1.0' 'linting-tool >=0.0.0' 'pytest >=1.2.0'" in cmd
+            "pip install 'banana >=1.2.0' 'linting-tool >=0.0.0' 'potato >=0.1.0' 'pytest >=1.2.0'" in cmd
             for cmd in layers[0].dockerfile_commands
         )
         assert not (any("'mkdocs >=1.4.2'" in cmd for cmd in layers[0].dockerfile_commands))

--- a/modal/image.py
+++ b/modal/image.py
@@ -345,7 +345,7 @@ class _Image(Provider[_ImageHandle]):
         extra_args = " ".join(flag + " " + shlex.quote(value) for flag, value in flags if value is not None)
         if pre:
             extra_args += " --pre"
-        package_args = " ".join(shlex.quote(pkg) for pkg in pkgs)
+        package_args = " ".join(shlex.quote(pkg) for pkg in sorted(pkgs))
 
         dockerfile_commands = [
             "FROM base",


### PR DESCRIPTION
super minor optimization, since it will improve image caching

https://pip-python3.readthedocs.io/en/latest/reference/pip_install.html

> As of v6.1.0, pip installs dependencies before their dependents, i.e. in “topological order”. This is the only commitment pip currently makes related to order. While it may be coincidentally true that pip will install things in the order of the install arguments or in the order of the items in a requirements file, this is not a promise.