### PR TITLE
Enable async stubs/functions in `modal app run`

### DIFF
--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -104,13 +104,14 @@ def test_secret_create(servicer, set_env_client):
 def test_app_token_new(servicer, server_url_env):
     _run(["token", "new", "--env", "_test"])
 
+
 def test_app_run(servicer, server_url_env, test_dir):
     modal_file = test_dir / "supports" / "app_run_tests" / "default_stub.py"
     _run(["app", "run", modal_file.as_posix()])
+
 
 def test_app_run_custom_stub(servicer, server_url_env, test_dir):
     modal_file = test_dir / "supports" / "app_run_tests" / "custom_stub.py"
     res = _run(["app", "run", modal_file.as_posix()], expected_exit_code=1)
     assert "stub variable" in res.stdout  # error output
-    _run(["app", "run", modal_file.as_posix()  + "::my_stub"])
-
+    _run(["app", "run", modal_file.as_posix() + "::my_stub"])

--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -115,3 +115,8 @@ def test_app_run_custom_stub(servicer, server_url_env, test_dir):
     res = _run(["app", "run", modal_file.as_posix()], expected_exit_code=1)
     assert "stub variable" in res.stdout  # error output
     _run(["app", "run", modal_file.as_posix() + "::my_stub"])
+
+
+def test_app_run_aiostub(servicer, server_url_env, test_dir):
+    modal_file = test_dir / "supports" / "app_run_tests" / "async_stub.py"
+    _run(["app", "run", modal_file.as_posix()])

--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -103,3 +103,7 @@ def test_secret_create(servicer, set_env_client):
 
 def test_app_token_new(servicer, server_url_env):
     _run(["token", "new", "--env", "_test"])
+
+def test_app_run(servicer, server_url_env, test_dir):
+    modal_file = test_dir / "supports" / "app_run_tests" / "default_stub.py"
+    _run(["app", "run", modal_file.as_posix()])

--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -107,3 +107,10 @@ def test_app_token_new(servicer, server_url_env):
 def test_app_run(servicer, server_url_env, test_dir):
     modal_file = test_dir / "supports" / "app_run_tests" / "default_stub.py"
     _run(["app", "run", modal_file.as_posix()])
+
+def test_app_run_custom_stub(servicer, server_url_env, test_dir):
+    modal_file = test_dir / "supports" / "app_run_tests" / "custom_stub.py"
+    res = _run(["app", "run", modal_file.as_posix()], expected_exit_code=1)
+    assert "stub variable" in res.stdout  # error output
+    _run(["app", "run", modal_file.as_posix()  + "::my_stub"])
+

--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -1,5 +1,6 @@
 # Copyright Modal Labs 2022
 from __future__ import annotations
+
 import asyncio
 import contextlib
 import inspect
@@ -490,7 +491,7 @@ async def aio_container_client(unix_servicer):
 
 
 @pytest_asyncio.fixture(scope="function")
-async def server_url_env(servicer, monkeypatch):
+async def server_url_env(servicer, monkeypatch, set_env_client):
     monkeypatch.setenv("MODAL_SERVER_URL", servicer.remote_addr)
     yield
 

--- a/client_test/supports/app_run_tests/async_stub.py
+++ b/client_test/supports/app_run_tests/async_stub.py
@@ -1,0 +1,9 @@
+# Copyright Modal Labs 2022
+import modal.aio
+
+stub = modal.aio.AioStub()
+
+
+@stub.function
+async def foo():
+    pass

--- a/client_test/supports/app_run_tests/custom_stub.py
+++ b/client_test/supports/app_run_tests/custom_stub.py
@@ -1,3 +1,4 @@
+# Copyright Modal Labs 2022
 import modal
 
 my_stub = modal.Stub()

--- a/client_test/supports/app_run_tests/custom_stub.py
+++ b/client_test/supports/app_run_tests/custom_stub.py
@@ -1,0 +1,7 @@
+import modal
+
+my_stub = modal.Stub()
+
+@my_stub.function
+def foo():
+    pass

--- a/client_test/supports/app_run_tests/custom_stub.py
+++ b/client_test/supports/app_run_tests/custom_stub.py
@@ -2,6 +2,7 @@ import modal
 
 my_stub = modal.Stub()
 
+
 @my_stub.function
 def foo():
     pass

--- a/client_test/supports/app_run_tests/default_stub.py
+++ b/client_test/supports/app_run_tests/default_stub.py
@@ -2,6 +2,7 @@ import modal
 
 stub = modal.Stub()
 
+
 @stub.function
 def foo():
     pass

--- a/client_test/supports/app_run_tests/default_stub.py
+++ b/client_test/supports/app_run_tests/default_stub.py
@@ -1,3 +1,4 @@
+# Copyright Modal Labs 2022
 import modal
 
 stub = modal.Stub()

--- a/client_test/supports/app_run_tests/default_stub.py
+++ b/client_test/supports/app_run_tests/default_stub.py
@@ -1,0 +1,7 @@
+import modal
+
+stub = modal.Stub()
+
+@stub.function
+def foo():
+    pass

--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -66,7 +66,7 @@ Registered functions on the selected stub are: {registered_functions_str}"""
 
     async with _stub.run(detach=detach) as app:
         func_handle = getattr(app, function_name)
-        await func_handle()
+        await func_handle.call()
 
 
 @app_cli.command("deploy", help="Deploy a Modal stub as an application.")

--- a/modal_utils/package_utils.py
+++ b/modal_utils/package_utils.py
@@ -8,6 +8,8 @@ from typing import Tuple
 
 from importlib_metadata import PackageNotFoundError, files
 
+import modal.exception
+
 
 def get_file_formats(module):
     try:
@@ -52,6 +54,8 @@ def parse_stub_ref(stub_ref: str, default_stub_name: str) -> Tuple[str, str]:
         import_path, stub_name = stub_ref, default_stub_name
     return import_path, stub_name
 
+class NoSuchStub(modal.exception.NotFoundError):
+    pass
 
 def import_stub(import_path: str, stub_name: str):
     if "" not in sys.path:
@@ -85,5 +89,8 @@ def import_stub(import_path: str, stub_name: str):
     else:
         module = importlib.import_module(import_path)
 
-    stub = getattr(module, stub_name)
+    try:
+        stub = getattr(module, stub_name)
+    except AttributeError:
+        raise NoSuchStub(f"No stub named {stub_name} could be found in module {module}")
     return stub

--- a/modal_utils/package_utils.py
+++ b/modal_utils/package_utils.py
@@ -54,8 +54,10 @@ def parse_stub_ref(stub_ref: str, default_stub_name: str) -> Tuple[str, str]:
         import_path, stub_name = stub_ref, default_stub_name
     return import_path, stub_name
 
+
 class NoSuchStub(modal.exception.NotFoundError):
     pass
+
 
 def import_stub(import_path: str, stub_name: str):
     if "" not in sys.path:


### PR DESCRIPTION
* Support for both sync and async stubs/functions

Also adds better error handling when importing stubs so that only stub specific attribute errors trigger stub specific error text (previously any AttributeError in global scope of the user's code would also trigger the same error output, which was confusing)

TODO:
- [x] Test

TODO:
As part of a larger refactor I might also add in interactive function selection, but that'll be part of another PR