### PR TITLE
client should be forward-compatible with new ProgressType

### DIFF
--- a/modal/_output.py
+++ b/modal/_output.py
@@ -254,8 +254,8 @@ class OutputManager:
                 total=None if total == 0 else total,
                 description=description,
             )
-        else:
-            raise Exception(f"Unknown {progress_type} type for progress update.")
+        else:  # Ensure forward-compatible with new types.
+            logger.debug(f"Received unrecognized progress type: {progress_type}")
 
     def _update_snapshot_progress(
         self, *, task_id: str, completed: int, total: int, description: Optional[str]


### PR DESCRIPTION
Just realized that old-clients aren't forward compatible with new progress types, they'll raise an exception. Fix this for clients  going forward. Will announce the function queuing progress logs in beta channel before releasing the feature server-side, as A100 users will need to upgrade their client. 