### PR TITLE
Rename deploying into initializing and set post-init state in AppSetObjects

### DIFF
--- a/client_test/stub_test.py
+++ b/client_test/stub_test.py
@@ -69,16 +69,19 @@ async def test_redeploy(servicer, aio_client):
     app = await stub.deploy("my-app", client=aio_client)
     assert app.app_id == "ap-1"
     assert servicer.app_objects["ap-1"]["square"] == "fu-1"
+    assert servicer.app_state[app.app_id] == api_pb2.APP_STATE_DEPLOYED
 
     # Redeploy, make sure all ids are the same
     app = await stub.deploy("my-app", client=aio_client)
     assert app.app_id == "ap-1"
     assert servicer.app_objects["ap-1"]["square"] == "fu-1"
+    assert servicer.app_state[app.app_id] == api_pb2.APP_STATE_DEPLOYED
 
     # Deploy to a different name, ids should change
     app = await stub.deploy("my-app-xyz", client=aio_client)
     assert app.app_id == "ap-2"
     assert servicer.app_objects["ap-2"]["square"] == "fu-2"
+    assert servicer.app_state[app.app_id] == api_pb2.APP_STATE_DEPLOYED
 
 
 def dummy():
@@ -191,3 +194,21 @@ def test_nested_serve_invocation(client):
             # This nested call creates a second web endpoint!
             stub.serve(client=client)
     assert "existing" in str(excinfo.value)
+
+
+def test_run_state(client, servicer):
+    stub = Stub()
+    with stub.run(client=client) as app:
+        assert servicer.app_state[app.app_id] == api_pb2.APP_STATE_EPHEMERAL
+
+
+def test_deploy_state(client, servicer):
+    stub = Stub()
+    app = stub.deploy("foobar", client=client)
+    assert servicer.app_state[app.app_id] == api_pb2.APP_STATE_DEPLOYED
+
+
+def test_detach_state(client, servicer):
+    stub = Stub()
+    with stub.run(client=client, detach=True) as app:
+        assert servicer.app_state[app.app_id] == api_pb2.APP_STATE_DETACHED

--- a/modal/app.py
+++ b/modal/app.py
@@ -132,7 +132,7 @@ class _App:
         """
         return self._local_uuid_to_object.get(obj.local_uuid)
 
-    async def _create_all_objects(self, progress: Tree):
+    async def _create_all_objects(self, progress: Tree, new_app_state: api_pb2.AppState.ValueType):
         """Create objects that have been defined but not created on the server."""
         for tag, provider in self._stub._blueprint.items():
             existing_object_id = self._tag_to_existing_id.get(tag)
@@ -151,6 +151,7 @@ class _App:
             client_id=self._client.client_id,
             indexed_object_ids=indexed_object_ids,
             unindexed_object_ids=unindexed_object_ids,
+            new_app_state=new_app_state,
         )
         await self._client.stub.AppSetObjects(req_set)
         return self._tag_to_object
@@ -220,7 +221,7 @@ class _App:
         app_req = api_pb2.AppCreateRequest(
             client_id=client.client_id,
             description=description,
-            deploying=deploying,
+            initializing=deploying,
             detach=detach,
         )
         app_resp = await retry_transient_errors(client.stub.AppCreate, app_req)

--- a/modal/app.py
+++ b/modal/app.py
@@ -132,7 +132,7 @@ class _App:
         """
         return self._local_uuid_to_object.get(obj.local_uuid)
 
-    async def _create_all_objects(self, progress: Tree, new_app_state: api_pb2.AppState.ValueType):
+    async def _create_all_objects(self, progress: Tree, new_app_state: int):  # api_pb2.AppState.ValueType
         """Create objects that have been defined but not created on the server."""
         for tag, provider in self._stub._blueprint.items():
             existing_object_id = self._tag_to_existing_id.get(tag)

--- a/modal/app.py
+++ b/modal/app.py
@@ -151,7 +151,7 @@ class _App:
             client_id=self._client.client_id,
             indexed_object_ids=indexed_object_ids,
             unindexed_object_ids=unindexed_object_ids,
-            new_app_state=new_app_state,
+            new_app_state=new_app_state,  # type: ignore
         )
         await self._client.stub.AppSetObjects(req_set)
         return self._tag_to_object

--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -206,8 +206,8 @@ async def list_apps():
             state = "[green]running (detached)[/green]"
         elif app_stats.state == api_pb2.AppState.APP_STATE_EPHEMERAL:
             state = "[green]running[/green]"
-        elif app_stats.state == api_pb2.AppState.APP_STATE_DEPLOYING:
-            state = "[green]deploying...[/green]"
+        elif app_stats.state == api_pb2.AppState.APP_STATE_INITIALIZING:
+            state = "[green]initializing...[/green]"
         elif app_stats.state == api_pb2.AppState.APP_STATE_DEPLOYED:
             state = "[green]deployed[/green]"
         elif app_stats.state == api_pb2.AppState.APP_STATE_STOPPING:

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -210,7 +210,9 @@ class _Stub:
         if mode == StubRunMode.DETACH:
             post_init_state = api_pb2.APP_STATE_DETACHED
         elif mode == StubRunMode.DEPLOY:
-            post_init_state = api_pb2.APP_STATE_DEPLOYED
+            post_init_state = (
+                api_pb2.APP_STATE_UNSPECIFIED
+            )  # don't change the app state - deploy state is set by AppDeploy
         else:
             post_init_state = api_pb2.APP_STATE_EPHEMERAL
 

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -207,6 +207,13 @@ class _Stub:
     ) -> AsyncGenerator[_App, None]:
         app_name = name if name is not None else self.description
         detach = mode == StubRunMode.DETACH
+        if mode == StubRunMode.DETACH:
+            post_init_state = api_pb2.APP_STATE_DETACHED
+        elif mode == StubRunMode.DEPLOY:
+            post_init_state = api_pb2.APP_STATE_DEPLOYED
+        else:
+            post_init_state = api_pb2.APP_STATE_EPHEMERAL
+
         if existing_app_id is not None:
             app = await _App._init_existing(self, client, existing_app_id)
         else:
@@ -229,7 +236,7 @@ class _Stub:
                 # Create all members
                 create_progress = Tree(step_progress("Creating objects..."), guide_style="gray50")
                 with output_mgr.ctx_if_visible(output_mgr.make_live(create_progress)):
-                    await app._create_all_objects(create_progress)
+                    await app._create_all_objects(create_progress, post_init_state)
                 create_progress.label = step_completed("Created objects.")
                 output_mgr.print_if_visible(create_progress)
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -79,7 +79,7 @@ message AppClientDisconnectRequest {
 message AppCreateRequest {
   string client_id = 1;
   string description = 2;    // Human readable label for the website
-  bool detach = 3; // TODO: deprecate, post-init state
+  bool detach = 3; // TODO: deprecate in 0.43, remove when 0.42 is unsupported
   bool initializing = 4; // TODO: remove and make default=True when client 0.42 is unsupported
 }
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -22,7 +22,7 @@ enum AppState {
   APP_STATE_STOPPED = 5;
 
   // App is created and in process of deployment.
-  APP_STATE_DEPLOYING = 6;
+  APP_STATE_INITIALIZING = 6;
 }
 
 enum ClientType {
@@ -79,8 +79,8 @@ message AppClientDisconnectRequest {
 message AppCreateRequest {
   string client_id = 1;
   string description = 2;    // Human readable label for the website
-  bool detach = 3;
-  bool deploying = 4;
+  bool detach = 3; // TODO: deprecate, post-init state
+  bool initializing = 4; // TODO: remove and make default=True when client 0.42 is unsupported
 }
 
 message AppCreateResponse {
@@ -178,6 +178,7 @@ message AppSetObjectsRequest {
   map<string, string> indexed_object_ids = 2;
   string client_id = 3;
   repeated string unindexed_object_ids = 4;
+  AppState new_app_state = 5; // promotes an app from initializing to this new state
 }
 
 message BaseImage {


### PR DESCRIPTION
Once backend has been adjusted, we can adjust client to never send explicit state on AppCreate, and instead set it on AppSetObjects completion