### PR TITLE
Adds basic copy support to Image

### DIFF
--- a/client_test/image_test.py
+++ b/client_test/image_test.py
@@ -207,5 +207,5 @@ def test_image_build_with_context_mount(client, servicer, tmp_path):
         assert layers[0].context_mount_id == "mo-123"
         files = {f.rel_filename: f.content for f in data_mount._get_files()}
         assert files["data.txt"] == b"hello"
-        assert files["data/sub"] == b"world"
+        assert files[os.path.join("data", "sub")] == b"world"
         assert len(files) == 2

--- a/client_test/image_test.py
+++ b/client_test/image_test.py
@@ -4,7 +4,7 @@ import pytest
 import sys
 from typing import List
 
-from modal import Image, Secret, SharedVolume, Stub
+from modal import Image, Mount, Secret, SharedVolume, Stub
 from modal.exception import InvalidError, NotFoundError
 from modal.image import _dockerhub_python_version
 from modal_proto import api_pb2
@@ -191,22 +191,21 @@ def test_poetry(client, servicer):
         assert context_files == {"/.poetry.lock", "/.pyproject.toml", "/modal_requirements.txt"}
 
 
-def test_image_run_function(client, servicer):
+def test_image_build_with_context_mount(client, servicer, tmp_path):
+    (tmp_path / "data.txt").write_text("hello")
+    (tmp_path / "data").mkdir()
+    (tmp_path / "data" / "sub").write_text("world")
+
+    data_mount = Mount(local_dir=tmp_path, remote_dir="/")
+
     stub = Stub()
-    volume = SharedVolume().persist("test-vol")
-    stub["image"] = (
-        Image.debian_slim()
-        .pip_install(["pandas"])
-        .run_function(run_f, secrets=[Secret({"xyz": "123"})], shared_volumes={"/foo": volume})
-    )
+    stub["image"] = Image.debian_slim().copy(data_mount, remote_path="/dummy")
 
     with stub.run(client=client) as running_app:
         layers = get_image_layers(running_app["image"].object_id, servicer)
-        assert "foo!" in layers[0].build_function_def
-        assert "Secret([xyz])" in layers[0].build_function_def
-        assert "Ref<SharedVolume()>(test-vol)" in layers[0].build_function_def
-
-    function_id = servicer.image_build_function_ids[2]
-    assert function_id
-    assert servicer.app_functions[function_id].function_name == "run_f"
-    assert len(servicer.app_functions[function_id].secret_ids) == 1
+        assert "COPY . /dummy" in layers[0].dockerfile_commands
+        assert layers[0].context_mount_id == "mo-123"
+        files = {f.rel_filename: f.content for f in data_mount._get_files()}
+        assert files["data.txt"] == b"hello"
+        assert files["data/sub"] == b"world"
+        assert len(files) == 2

--- a/modal/image.py
+++ b/modal/image.py
@@ -93,6 +93,7 @@ class _Image(Provider[_ImageHandle]):
         ref=None,
         gpu=False,
         build_function=None,
+        context_mount=None,
     ):
         if ref and (base_images or dockerfile_commands or context_files):
             raise InvalidError("No other arguments can be provided when initializing an image from a ref.")
@@ -114,6 +115,7 @@ class _Image(Provider[_ImageHandle]):
         self._secrets = secrets
         self._gpu = gpu
         self._build_function = build_function
+        self._context_mount = context_mount
         super().__init__()
 
     def __repr__(self):
@@ -167,6 +169,13 @@ class _Image(Provider[_ImageHandle]):
             dockerfile_commands = self._dockerfile_commands()
         else:
             dockerfile_commands = self._dockerfile_commands
+
+
+        if self._context_mount:
+            context_mount_id = await loader(self._context_mount)
+        else:
+            context_mount_id = None
+
         image_definition = api_pb2.Image(
             base_images=base_images_pb2s,
             dockerfile_commands=dockerfile_commands,
@@ -174,6 +183,7 @@ class _Image(Provider[_ImageHandle]):
             secret_ids=secret_ids,
             gpu=self._gpu,
             build_function_def=build_function_def,
+            context_mount_id=context_mount_id
         )
 
         req = api_pb2.ImageGetOrCreateRequest(


### PR DESCRIPTION
Lets users copy data from a Mount into an image during image build.
Either using the convenience `copy` method on Image, or using the more low level `context_mount=..., dockerfile_commands=["COPY ..."]` options for `.extend()`

Next step is to improve the semantics of creating Mounts to make mount composition easier than it is today.


This is what the new functionality looks like:
```python
mount = Mount(remote_dir="/", local_dir=Path(__file__).parent / "static")
Image.debian_slim().copy(mount, remote_path="/static")
```