### PR TITLE
Bump FastAPI to 0.88.0

### DIFF
--- a/modal/requirements.txt
+++ b/modal/requirements.txt
@@ -6,7 +6,7 @@ certifi==2021.10.8
 cloudpickle==2.0.0;python_version<'3.11'
 cloudpickle==2.2.0;python_version>='3.11'
 ddtrace==1.5.2;python_version<'3.11'
-fastapi==0.75.2
+fastapi==0.88.0
 fastprogress==1.0.0
 grpclib==0.4.3
 importlib_metadata==4.8.1


### PR DESCRIPTION
This in particular removes the `default=xyz` stuff from webhooks