### PR TITLE
Graceful handling for KeyboardInterrupts with async functions

### DIFF
--- a/modal/_asgi.py
+++ b/modal/_asgi.py
@@ -29,7 +29,10 @@ def asgi_app_wrapper(asgi_app):
             while True:
                 pop_task = tc.create_task(messages_from_app.get())
 
-                done, pending = await asyncio.wait([pop_task, app_task], return_when=asyncio.FIRST_COMPLETED)
+                try:
+                    done, pending = await asyncio.wait([pop_task, app_task], return_when=asyncio.FIRST_COMPLETED)
+                except asyncio.CancelledError:
+                    break
 
                 if pop_task in done:
                     yield pop_task.result()

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -1,11 +1,13 @@
 # Copyright Modal Labs 2022
 from __future__ import annotations
+
 import asyncio
 import base64
 import contextlib
 import importlib
 import inspect
 import math
+import signal
 import sys
 import time
 import traceback
@@ -72,6 +74,22 @@ def get_is_async(function):
         return False
     else:
         raise RuntimeError(f"Function {function} is a strange type {type(function)}")
+
+
+def run_with_signal_handler(coro):
+    """Execute coro in an event loop, with a signal handler that cancels
+    the task in the case of SIGINT or SIGTERM. Prevents stray cancellation errors
+    from propagating up."""
+
+    loop = asyncio.get_event_loop()
+    task = asyncio.ensure_future(coro)
+    for s in [signal.SIGINT, signal.SIGTERM]:
+        loop.add_signal_handler(s, task.cancel)
+    try:
+        result = loop.run_until_complete(task)
+    finally:
+        loop.close()
+    return result
 
 
 class _FunctionIOManager:
@@ -513,7 +531,7 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
     if not is_async:
         call_function_sync(function_io_manager, obj, fun, is_generator)
     else:
-        asyncio.run(call_function_async(aio_function_io_manager, obj, fun, is_generator))
+        run_with_signal_handler(call_function_async(aio_function_io_manager, obj, fun, is_generator))
 
 
 if __name__ == "__main__":

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -81,8 +81,8 @@ def run_with_signal_handler(coro):
     the task in the case of SIGINT or SIGTERM. Prevents stray cancellation errors
     from propagating up."""
 
-    loop = asyncio.get_event_loop()
-    task = asyncio.ensure_future(coro)
+    loop = asyncio.new_event_loop()
+    task = asyncio.ensure_future(coro, loop=loop)
     for s in [signal.SIGINT, signal.SIGTERM]:
         loop.add_signal_handler(s, task.cancel)
     try:


### PR DESCRIPTION
We weren't canceling the task inside `asyncio.run` on receiving `KeyboardInterrupt`s. Created a bunch of log vomit for async functions (including all webhooks). 

Separately also handles a `CancelledError` that's raised in `_asgi` wrapper from the task being cancelled.

### Before 

(async function, not a webhook)

![image](https://user-images.githubusercontent.com/5786378/208266302-93b378b3-e2e4-4fc8-b084-4e82720cc88b.png)


### After


![image](https://user-images.githubusercontent.com/5786378/208266300-ee407487-e689-43d6-bacb-4695e6975f68.png)


