### PR TITLE
Mounts using builder pattern rather than constructor

### DIFF
--- a/client_test/image_test.py
+++ b/client_test/image_test.py
@@ -318,7 +318,7 @@ def test_image_build_with_context_mount(client, servicer, tmp_path):
             assert "COPY . /dummy" in layers[expected_layer].dockerfile_commands
 
         files = {f.mount_filename: f.content for f in data_mount._get_files()}
-        assert files == {"data.txt": b"hello", "data/sub": b"world"}
+        assert files == {"/data.txt": b"hello", "/data/sub": b"world"}
 
 
 def test_image_env(client, servicer):

--- a/client_test/image_test.py
+++ b/client_test/image_test.py
@@ -317,7 +317,7 @@ def test_image_build_with_context_mount(client, servicer, tmp_path):
             assert layers[expected_layer].context_mount_id == "mo-123", f"error in {image_name}"
             assert "COPY . /dummy" in layers[expected_layer].dockerfile_commands
 
-        files = {f.rel_filename: f.content for f in data_mount._get_files()}
+        files = {f.mount_filename: f.content for f in data_mount._get_files()}
         assert files["data.txt"] == b"hello"
         assert files[os.path.join("data", "sub")] == b"world"
         assert len(files) == 2

--- a/client_test/image_test.py
+++ b/client_test/image_test.py
@@ -318,9 +318,7 @@ def test_image_build_with_context_mount(client, servicer, tmp_path):
             assert "COPY . /dummy" in layers[expected_layer].dockerfile_commands
 
         files = {f.mount_filename: f.content for f in data_mount._get_files()}
-        assert files["data.txt"] == b"hello"
-        assert files[os.path.join("data", "sub")] == b"world"
-        assert len(files) == 2
+        assert files == {"data.txt": b"hello", "data/sub": b"world"}
 
 
 def test_image_env(client, servicer):

--- a/client_test/mount_test.py
+++ b/client_test/mount_test.py
@@ -49,7 +49,7 @@ async def test_get_files(servicer, client, tmpdir):
         }
 
 
-def test_create_mount_legacy_syntax(servicer, client):
+def test_create_mount_legacy_constructor(servicer, client):
     stub = Stub()
     with stub.run(client=client) as running_app:
         local_dir, cur_filename = os.path.split(__file__)
@@ -75,7 +75,7 @@ def test_create_mount(servicer, client):
         def condition(fn):
             return fn.endswith(".py")
 
-        m = Mount().add_local_dir(local_dir, path_within_mount="/foo", condition=condition)
+        m = Mount().add_local_dir(local_dir, remote_path="/foo", condition=condition)
         obj = running_app._load(m)
         assert obj.object_id == "mo-123"
         assert f"/foo/{cur_filename}" in servicer.files_name2sha

--- a/client_test/mount_test.py
+++ b/client_test/mount_test.py
@@ -61,8 +61,8 @@ def test_create_mount_legacy_constructor(servicer, client):
         m = Mount(local_dir=local_dir, remote_dir=remote_dir, condition=condition)
         obj = running_app._load(m)  # TODO: is this something we want to expose?
         assert obj.object_id == "mo-123"
-        assert f"/foo/{cur_filename}" in servicer.files_name2sha
-        sha256_hex = servicer.files_name2sha[f"/foo/{cur_filename}"]
+        assert f"foo/{cur_filename}" in servicer.files_name2sha
+        sha256_hex = servicer.files_name2sha[f"foo/{cur_filename}"]
         assert sha256_hex in servicer.files_sha2data
         assert servicer.files_sha2data[sha256_hex]["data"] == open(__file__, "rb").read()
 
@@ -78,8 +78,8 @@ def test_create_mount(servicer, client):
         m = Mount().add_local_dir(local_dir, remote_path="/foo", condition=condition)
         obj = running_app._load(m)
         assert obj.object_id == "mo-123"
-        assert f"/foo/{cur_filename}" in servicer.files_name2sha
-        sha256_hex = servicer.files_name2sha[f"/foo/{cur_filename}"]
+        assert f"foo/{cur_filename}" in servicer.files_name2sha
+        sha256_hex = servicer.files_name2sha[f"foo/{cur_filename}"]
         assert sha256_hex in servicer.files_sha2data
         assert servicer.files_sha2data[sha256_hex]["data"] == open(__file__, "rb").read()
 
@@ -111,13 +111,13 @@ def test_create_package_mounts(servicer, client, test_dir):
 
     with stub.run(client=client):
         files = servicer.files_name2sha.keys()
-        assert any(["/pkg/pkg_a/a.py" in f for f in files])
-        assert any(["/pkg/pkg_a/b/c.py" in f for f in files])
-        assert any(["/pkg/pkg_b/f.py" in f for f in files])
-        assert any(["/pkg/pkg_b/g/h.py" in f for f in files])
-        assert any(["/pkg/standalone_file.py" in f for f in files])
-        assert not any(["/pkg/pkg_c/i.py" in f for f in files])
-        assert not any(["/pkg/pkg_c/j/k.py" in f for f in files])
+        assert any(["pkg/pkg_a/a.py" in f for f in files])
+        assert any(["pkg/pkg_a/b/c.py" in f for f in files])
+        assert any(["pkg/pkg_b/f.py" in f for f in files])
+        assert any(["pkg/pkg_b/g/h.py" in f for f in files])
+        assert any(["pkg/standalone_file.py" in f for f in files])
+        assert not any(["pkg/pkg_c/i.py" in f for f in files])
+        assert not any(["pkg/pkg_c/j/k.py" in f for f in files])
 
 
 def test_stub_mounts(servicer, client, test_dir):
@@ -129,12 +129,12 @@ def test_stub_mounts(servicer, client, test_dir):
 
     with stub.run(client=client):
         files = servicer.files_name2sha.keys()
-        assert any(["/pkg/pkg_a/a.py" in f for f in files])
-        assert any(["/pkg/pkg_a/b/c.py" in f for f in files])
-        assert any(["/pkg/pkg_b/f.py" in f for f in files])
-        assert any(["/pkg/pkg_b/g/h.py" in f for f in files])
-        assert not any(["/pkg/pkg_c/i.py" in f for f in files])
-        assert not any(["/pkg/pkg_c/j/k.py" in f for f in files])
+        assert any(["pkg/pkg_a/a.py" in f for f in files])
+        assert any(["pkg/pkg_a/b/c.py" in f for f in files])
+        assert any(["pkg/pkg_b/f.py" in f for f in files])
+        assert any(["pkg/pkg_b/g/h.py" in f for f in files])
+        assert not any(["pkg/pkg_c/i.py" in f for f in files])
+        assert not any(["pkg/pkg_c/j/k.py" in f for f in files])
 
 
 def test_create_package_mounts_missing_module(servicer, client, test_dir):

--- a/client_test/mount_test.py
+++ b/client_test/mount_test.py
@@ -28,22 +28,22 @@ async def test_get_files(servicer, client, tmpdir):
         async for upload_spec in m._get_files():
             files[str(upload_spec.mount_filename)] = upload_spec
 
-        assert "/small.py" in files
-        assert "/large.py" in files
-        assert "/fluff" not in files
-        assert files["/small.py"].use_blob is False
-        assert files["/small.py"].content == small_content
-        assert files["/small.py"].sha256_hex == hashlib.sha256(small_content).hexdigest()
+        assert "small.py" in files
+        assert "large.py" in files
+        assert "fluff" not in files
+        assert files["small.py"].use_blob is False
+        assert files["small.py"].content == small_content
+        assert files["small.py"].sha256_hex == hashlib.sha256(small_content).hexdigest()
 
-        assert files["/large.py"].use_blob is True
-        assert files["/large.py"].content is None
-        assert files["/large.py"].sha256_hex == hashlib.sha256(large_content).hexdigest()
+        assert files["large.py"].use_blob is True
+        assert files["large.py"].content is None
+        assert files["large.py"].sha256_hex == hashlib.sha256(large_content).hexdigest()
         blob_id = max(servicer.blobs.keys())  # last uploaded one
         assert len(servicer.blobs[blob_id]) == len(large_content)
         assert servicer.blobs[blob_id] == large_content
 
-        assert servicer.files_sha2data[files["/large.py"].sha256_hex] == {"data": b"", "data_blob_id": blob_id}
-        assert servicer.files_sha2data[files["/small.py"].sha256_hex] == {
+        assert servicer.files_sha2data[files["large.py"].sha256_hex] == {"data": b"", "data_blob_id": blob_id}
+        assert servicer.files_sha2data[files["small.py"].sha256_hex] == {
             "data": small_content,
             "data_blob_id": "",
         }

--- a/client_test/mount_test.py
+++ b/client_test/mount_test.py
@@ -26,7 +26,7 @@ async def test_get_files(servicer, client, tmpdir):
         m = AioMount("/", local_dir=tmpdir, condition=lambda fn: fn.endswith(".py"), recursive=True)
         await running_app._load(m)  # TODO: is this something we want to expose?
         async for upload_spec in m._get_files():
-            files[upload_spec.mount_filename.as_posix()] = upload_spec
+            files[upload_spec.mount_filename] = upload_spec
 
         assert "small.py" in files
         assert "large.py" in files

--- a/client_test/mount_test.py
+++ b/client_test/mount_test.py
@@ -28,22 +28,22 @@ async def test_get_files(servicer, client, tmpdir):
         async for upload_spec in m._get_files():
             files[upload_spec.mount_filename] = upload_spec
 
-        assert "small.py" in files
-        assert "large.py" in files
-        assert "fluff" not in files
-        assert files["small.py"].use_blob is False
-        assert files["small.py"].content == small_content
-        assert files["small.py"].sha256_hex == hashlib.sha256(small_content).hexdigest()
+        assert "/small.py" in files
+        assert "/large.py" in files
+        assert "/fluff" not in files
+        assert files["/small.py"].use_blob is False
+        assert files["/small.py"].content == small_content
+        assert files["/small.py"].sha256_hex == hashlib.sha256(small_content).hexdigest()
 
-        assert files["large.py"].use_blob is True
-        assert files["large.py"].content is None
-        assert files["large.py"].sha256_hex == hashlib.sha256(large_content).hexdigest()
+        assert files["/large.py"].use_blob is True
+        assert files["/large.py"].content is None
+        assert files["/large.py"].sha256_hex == hashlib.sha256(large_content).hexdigest()
         blob_id = max(servicer.blobs.keys())  # last uploaded one
         assert len(servicer.blobs[blob_id]) == len(large_content)
         assert servicer.blobs[blob_id] == large_content
 
-        assert servicer.files_sha2data[files["large.py"].sha256_hex] == {"data": b"", "data_blob_id": blob_id}
-        assert servicer.files_sha2data[files["small.py"].sha256_hex] == {
+        assert servicer.files_sha2data[files["/large.py"].sha256_hex] == {"data": b"", "data_blob_id": blob_id}
+        assert servicer.files_sha2data[files["/small.py"].sha256_hex] == {
             "data": small_content,
             "data_blob_id": "",
         }
@@ -61,8 +61,8 @@ def test_create_mount_legacy_constructor(servicer, client):
         m = Mount(local_dir=local_dir, remote_dir=remote_dir, condition=condition)
         obj = running_app._load(m)  # TODO: is this something we want to expose?
         assert obj.object_id == "mo-123"
-        assert f"foo/{cur_filename}" in servicer.files_name2sha
-        sha256_hex = servicer.files_name2sha[f"foo/{cur_filename}"]
+        assert f"/foo/{cur_filename}" in servicer.files_name2sha
+        sha256_hex = servicer.files_name2sha[f"/foo/{cur_filename}"]
         assert sha256_hex in servicer.files_sha2data
         assert servicer.files_sha2data[sha256_hex]["data"] == open(__file__, "rb").read()
 
@@ -78,8 +78,8 @@ def test_create_mount(servicer, client):
         m = Mount().add_local_dir(local_dir, remote_path="/foo", condition=condition)
         obj = running_app._load(m)
         assert obj.object_id == "mo-123"
-        assert f"foo/{cur_filename}" in servicer.files_name2sha
-        sha256_hex = servicer.files_name2sha[f"foo/{cur_filename}"]
+        assert f"/foo/{cur_filename}" in servicer.files_name2sha
+        sha256_hex = servicer.files_name2sha[f"/foo/{cur_filename}"]
         assert sha256_hex in servicer.files_sha2data
         assert servicer.files_sha2data[sha256_hex]["data"] == open(__file__, "rb").read()
 
@@ -111,13 +111,13 @@ def test_create_package_mounts(servicer, client, test_dir):
 
     with stub.run(client=client):
         files = servicer.files_name2sha.keys()
-        assert any(["pkg/pkg_a/a.py" in f for f in files])
-        assert any(["pkg/pkg_a/b/c.py" in f for f in files])
-        assert any(["pkg/pkg_b/f.py" in f for f in files])
-        assert any(["pkg/pkg_b/g/h.py" in f for f in files])
-        assert any(["pkg/standalone_file.py" in f for f in files])
-        assert not any(["pkg/pkg_c/i.py" in f for f in files])
-        assert not any(["pkg/pkg_c/j/k.py" in f for f in files])
+        assert any(["/pkg/pkg_a/a.py" in f for f in files])
+        assert any(["/pkg/pkg_a/b/c.py" in f for f in files])
+        assert any(["/pkg/pkg_b/f.py" in f for f in files])
+        assert any(["/pkg/pkg_b/g/h.py" in f for f in files])
+        assert any(["/pkg/standalone_file.py" in f for f in files])
+        assert not any(["/pkg/pkg_c/i.py" in f for f in files])
+        assert not any(["/pkg/pkg_c/j/k.py" in f for f in files])
 
 
 def test_stub_mounts(servicer, client, test_dir):

--- a/client_test/mount_test.py
+++ b/client_test/mount_test.py
@@ -1,6 +1,8 @@
 # Copyright Modal Labs 2022
 import hashlib
 import os
+from pathlib import Path
+
 import pytest
 import sys
 
@@ -82,7 +84,7 @@ def test_create_mount(servicer, client):
         sha256_hex = servicer.files_name2sha[f"/foo/{cur_filename}"]
         assert sha256_hex in servicer.files_sha2data
         assert servicer.files_sha2data[sha256_hex]["data"] == open(__file__, "rb").read()
-        assert local_dir in repr(m)
+        assert repr(Path(local_dir)) in repr(m)
 
 
 def test_create_mount_file_errors(servicer, tmpdir, client):

--- a/client_test/mount_test.py
+++ b/client_test/mount_test.py
@@ -82,6 +82,7 @@ def test_create_mount(servicer, client):
         sha256_hex = servicer.files_name2sha[f"/foo/{cur_filename}"]
         assert sha256_hex in servicer.files_sha2data
         assert servicer.files_sha2data[sha256_hex]["data"] == open(__file__, "rb").read()
+        assert local_dir in repr(m)
 
 
 def test_create_mount_file_errors(servicer, tmpdir, client):

--- a/client_test/mount_test.py
+++ b/client_test/mount_test.py
@@ -26,7 +26,7 @@ async def test_get_files(servicer, client, tmpdir):
         m = AioMount("/", local_dir=tmpdir, condition=lambda fn: fn.endswith(".py"), recursive=True)
         await running_app._load(m)  # TODO: is this something we want to expose?
         async for upload_spec in m._get_files():
-            files[str(upload_spec.mount_filename)] = upload_spec
+            files[upload_spec.mount_filename.as_posix()] = upload_spec
 
         assert "small.py" in files
         assert "large.py" in files

--- a/client_test/mount_test.py
+++ b/client_test/mount_test.py
@@ -26,30 +26,30 @@ async def test_get_files(servicer, client, tmpdir):
         m = AioMount("/", local_dir=tmpdir, condition=lambda fn: fn.endswith(".py"), recursive=True)
         await running_app._load(m)  # TODO: is this something we want to expose?
         async for upload_spec in m._get_files():
-            files[upload_spec.rel_filename] = upload_spec
+            files[str(upload_spec.mount_filename)] = upload_spec
 
-        assert "small.py" in files
-        assert "large.py" in files
-        assert "fluff" not in files
-        assert files["small.py"].use_blob is False
-        assert files["small.py"].content == small_content
-        assert files["small.py"].sha256_hex == hashlib.sha256(small_content).hexdigest()
+        assert "/small.py" in files
+        assert "/large.py" in files
+        assert "/fluff" not in files
+        assert files["/small.py"].use_blob is False
+        assert files["/small.py"].content == small_content
+        assert files["/small.py"].sha256_hex == hashlib.sha256(small_content).hexdigest()
 
-        assert files["large.py"].use_blob is True
-        assert files["large.py"].content is None
-        assert files["large.py"].sha256_hex == hashlib.sha256(large_content).hexdigest()
+        assert files["/large.py"].use_blob is True
+        assert files["/large.py"].content is None
+        assert files["/large.py"].sha256_hex == hashlib.sha256(large_content).hexdigest()
         blob_id = max(servicer.blobs.keys())  # last uploaded one
         assert len(servicer.blobs[blob_id]) == len(large_content)
         assert servicer.blobs[blob_id] == large_content
 
-        assert servicer.files_sha2data[files["large.py"].sha256_hex] == {"data": b"", "data_blob_id": blob_id}
-        assert servicer.files_sha2data[files["small.py"].sha256_hex] == {
+        assert servicer.files_sha2data[files["/large.py"].sha256_hex] == {"data": b"", "data_blob_id": blob_id}
+        assert servicer.files_sha2data[files["/small.py"].sha256_hex] == {
             "data": small_content,
             "data_blob_id": "",
         }
 
 
-def test_create_mount(servicer, client):
+def test_create_mount_legacy_syntax(servicer, client):
     stub = Stub()
     with stub.run(client=client) as running_app:
         local_dir, cur_filename = os.path.split(__file__)
@@ -60,6 +60,23 @@ def test_create_mount(servicer, client):
 
         m = Mount(local_dir=local_dir, remote_dir=remote_dir, condition=condition)
         obj = running_app._load(m)  # TODO: is this something we want to expose?
+        assert obj.object_id == "mo-123"
+        assert f"/foo/{cur_filename}" in servicer.files_name2sha
+        sha256_hex = servicer.files_name2sha[f"/foo/{cur_filename}"]
+        assert sha256_hex in servicer.files_sha2data
+        assert servicer.files_sha2data[sha256_hex]["data"] == open(__file__, "rb").read()
+
+
+def test_create_mount(servicer, client):
+    stub = Stub()
+    with stub.run(client=client) as running_app:
+        local_dir, cur_filename = os.path.split(__file__)
+
+        def condition(fn):
+            return fn.endswith(".py")
+
+        m = Mount().add_local_dir(local_dir, path_within_mount="/foo", condition=condition)
+        obj = running_app._load(m)
         assert obj.object_id == "mo-123"
         assert f"/foo/{cur_filename}" in servicer.files_name2sha
         sha256_hex = servicer.files_name2sha[f"/foo/{cur_filename}"]

--- a/client_test/mounted_files_test.py
+++ b/client_test/mounted_files_test.py
@@ -42,13 +42,13 @@ def test_mounted_files_script(supports_dir):
 
     # Assert we include everything from `pkg_a` and `pkg_b` but not `pkg_c`:
     assert files == {
-        "root/a.py",
-        "root/b/c.py",
-        "root/b/e.py",
-        "root/pkg_b/__init__.py",
-        "root/pkg_b/f.py",
-        "root/pkg_b/g/h.py",
-        "root/script.py",
+        "/root/a.py",
+        "/root/b/c.py",
+        "/root/b/e.py",
+        "/root/pkg_b/__init__.py",
+        "/root/pkg_b/f.py",
+        "/root/pkg_b/g/h.py",
+        "/root/script.py",
     }
 
 
@@ -71,13 +71,13 @@ def test_mounted_files_serialized(supports_dir):
 
     # Assert we include everything from `pkg_a` and `pkg_b` but not `pkg_c`:
     assert files == {
-        "root/b/c.py",
-        "root/b/e.py",
-        "root/pkg_a/a.py",
-        "root/pkg_a/serialized_fn.py",
-        "root/pkg_b/__init__.py",
-        "root/pkg_b/f.py",
-        "root/pkg_b/g/h.py",
+        "/root/b/c.py",
+        "/root/b/e.py",
+        "/root/pkg_a/a.py",
+        "/root/pkg_a/serialized_fn.py",
+        "/root/pkg_b/__init__.py",
+        "/root/pkg_b/f.py",
+        "/root/pkg_b/g/h.py",
     }
 
 
@@ -92,18 +92,18 @@ def test_mounted_files_package(supports_dir):
 
     # Assert we include everything from `pkg_a` and `pkg_b` but not `pkg_c`:
     assert files == {
-        "root/package.py",
-        "root/pkg_a/__init__.py",
-        "root/pkg_a/a.py",
-        "root/pkg_a/b/c.py",
-        "root/pkg_a/d.py",
-        "root/pkg_a/b/e.py",
-        "root/pkg_a/script.py",
-        "root/pkg_a/serialized_fn.py",
-        "root/pkg_a/package.py",
-        "root/pkg_b/__init__.py",
-        "root/pkg_b/f.py",
-        "root/pkg_b/g/h.py",
+        "/root/package.py",
+        "/root/pkg_a/__init__.py",
+        "/root/pkg_a/a.py",
+        "/root/pkg_a/b/c.py",
+        "/root/pkg_a/d.py",
+        "/root/pkg_a/b/e.py",
+        "/root/pkg_a/script.py",
+        "/root/pkg_a/serialized_fn.py",
+        "/root/pkg_a/package.py",
+        "/root/pkg_b/__init__.py",
+        "/root/pkg_b/f.py",
+        "/root/pkg_b/g/h.py",
     }
 
 
@@ -125,13 +125,13 @@ def test_mounted_files_sys_prefix(supports_dir, venv_path):
 
     # Assert we include everything from `pkg_a` and `pkg_b` but not `pkg_c`:
     assert files == {
-        "root/a.py",
-        "root/b/c.py",
-        "root/b/e.py",
-        "root/script.py",
-        "root/pkg_b/__init__.py",
-        "root/pkg_b/f.py",
-        "root/pkg_b/g/h.py",
+        "/root/a.py",
+        "/root/b/c.py",
+        "/root/b/e.py",
+        "/root/script.py",
+        "/root/pkg_b/__init__.py",
+        "/root/pkg_b/f.py",
+        "/root/pkg_b/g/h.py",
     }
 
 
@@ -150,4 +150,4 @@ def test_mounted_files_config(supports_dir):
     files = set(stdout.splitlines())
 
     # Assert just the script is there
-    assert files == {"root/script.py"}
+    assert files == {"/root/script.py"}

--- a/client_test/mounted_files_test.py
+++ b/client_test/mounted_files_test.py
@@ -42,13 +42,13 @@ def test_mounted_files_script(supports_dir):
 
     # Assert we include everything from `pkg_a` and `pkg_b` but not `pkg_c`:
     assert files == {
-        "/root/a.py",
-        "/root/b/c.py",
-        "/root/b/e.py",
-        "/root/pkg_b/__init__.py",
-        "/root/pkg_b/f.py",
-        "/root/pkg_b/g/h.py",
-        "/root/script.py",
+        "root/a.py",
+        "root/b/c.py",
+        "root/b/e.py",
+        "root/pkg_b/__init__.py",
+        "root/pkg_b/f.py",
+        "root/pkg_b/g/h.py",
+        "root/script.py",
     }
 
 
@@ -71,13 +71,13 @@ def test_mounted_files_serialized(supports_dir):
 
     # Assert we include everything from `pkg_a` and `pkg_b` but not `pkg_c`:
     assert files == {
-        "/root/b/c.py",
-        "/root/b/e.py",
-        "/root/pkg_a/a.py",
-        "/root/pkg_a/serialized_fn.py",
-        "/root/pkg_b/__init__.py",
-        "/root/pkg_b/f.py",
-        "/root/pkg_b/g/h.py",
+        "root/b/c.py",
+        "root/b/e.py",
+        "root/pkg_a/a.py",
+        "root/pkg_a/serialized_fn.py",
+        "root/pkg_b/__init__.py",
+        "root/pkg_b/f.py",
+        "root/pkg_b/g/h.py",
     }
 
 
@@ -92,18 +92,18 @@ def test_mounted_files_package(supports_dir):
 
     # Assert we include everything from `pkg_a` and `pkg_b` but not `pkg_c`:
     assert files == {
-        "/root/package.py",
-        "/root/pkg_a/__init__.py",
-        "/root/pkg_a/a.py",
-        "/root/pkg_a/b/c.py",
-        "/root/pkg_a/d.py",
-        "/root/pkg_a/b/e.py",
-        "/root/pkg_a/script.py",
-        "/root/pkg_a/serialized_fn.py",
-        "/root/pkg_a/package.py",
-        "/root/pkg_b/__init__.py",
-        "/root/pkg_b/f.py",
-        "/root/pkg_b/g/h.py",
+        "root/package.py",
+        "root/pkg_a/__init__.py",
+        "root/pkg_a/a.py",
+        "root/pkg_a/b/c.py",
+        "root/pkg_a/d.py",
+        "root/pkg_a/b/e.py",
+        "root/pkg_a/script.py",
+        "root/pkg_a/serialized_fn.py",
+        "root/pkg_a/package.py",
+        "root/pkg_b/__init__.py",
+        "root/pkg_b/f.py",
+        "root/pkg_b/g/h.py",
     }
 
 
@@ -125,13 +125,13 @@ def test_mounted_files_sys_prefix(supports_dir, venv_path):
 
     # Assert we include everything from `pkg_a` and `pkg_b` but not `pkg_c`:
     assert files == {
-        "/root/a.py",
-        "/root/b/c.py",
-        "/root/b/e.py",
-        "/root/script.py",
-        "/root/pkg_b/__init__.py",
-        "/root/pkg_b/f.py",
-        "/root/pkg_b/g/h.py",
+        "root/a.py",
+        "root/b/c.py",
+        "root/b/e.py",
+        "root/script.py",
+        "root/pkg_b/__init__.py",
+        "root/pkg_b/f.py",
+        "root/pkg_b/g/h.py",
     }
 
 
@@ -150,4 +150,4 @@ def test_mounted_files_config(supports_dir):
     files = set(stdout.splitlines())
 
     # Assert just the script is there
-    assert files == {"/root/script.py"}
+    assert files == {"root/script.py"}

--- a/client_test/mounted_files_test.py
+++ b/client_test/mounted_files_test.py
@@ -27,11 +27,12 @@ def test_mounted_files_script(test_dir):
         cwd=test_dir / Path("supports"),
         env={**os.environ, "PYTHONPATH": str(test_dir / Path("supports"))},
     )
-    assert p.returncode == 0
+
     stdout = p.stdout.decode("utf-8")
     stderr = p.stderr.decode("utf-8")
     print("stdout: ", stdout)
     print("stderr: ", stderr)
+    assert p.returncode == 0
     files = set(stdout.splitlines())
 
     assert len(files) == 7
@@ -105,9 +106,10 @@ def test_mounted_files_package(test_dir):
     assert any(["e.py" in f for f in files])
     assert any(["script.py" in f for f in files])
     assert any(["package.py" in f for f in files])
+    assert any(["pkg_a/__init__.py" in f for f in files])
 
     # Assert everything from `pkg_b` is in the output.
-    assert any(["__init__.py" in f for f in files])
+    assert any(["pkg_b/__init__.py" in f for f in files])
     assert any(["f.py" in f for f in files])
     assert any(["h.py" in f for f in files])
 

--- a/client_test/mounted_files_test.py
+++ b/client_test/mounted_files_test.py
@@ -97,7 +97,7 @@ def test_mounted_files_package(test_dir):
     print("stderr: ", stderr)
     files = set(stdout.splitlines())
 
-    assert len(files) == 10
+    assert len(files) == 12
 
     # Assert everything from `pkg_a` is in the output.
     assert any(["a.py" in f for f in files])

--- a/client_test/supports/pkg_a/package.py
+++ b/client_test/supports/pkg_a/package.py
@@ -20,7 +20,7 @@ async def get_files():
 
     for _, mount in fn_info.get_mounts().items():
         async for file_info in mount._get_files():
-            print(file_info.rel_filename)
+            print(file_info.mount_filename)
 
 
 if __name__ == "__main__":

--- a/client_test/supports/pkg_a/script.py
+++ b/client_test/supports/pkg_a/script.py
@@ -20,7 +20,7 @@ async def get_files():
 
     for _, mount in fn_info.get_mounts().items():
         async for file_info in mount._get_files():
-            print(file_info.rel_filename)
+            print(file_info.mount_filename)
 
 
 if __name__ == "__main__":

--- a/client_test/supports/pkg_a/serialized_fn.py
+++ b/client_test/supports/pkg_a/serialized_fn.py
@@ -20,7 +20,7 @@ async def get_files():
 
     for _, mount in fn_info.get_mounts().items():
         async for file_info in mount._get_files():
-            print(file_info.rel_filename)
+            print(file_info.mount_filename)
 
 
 if __name__ == "__main__":

--- a/client_test/watcher_test.py
+++ b/client_test/watcher_test.py
@@ -19,7 +19,7 @@ async def test__watch_args_from_mounts(monkeypatch, test_dir):
         ]
     )
 
-    assert paths == {Path("/x"), "/one/two/bucklemyshoe"}
+    assert paths == {Path("/x"), Path("/one/two/bucklemyshoe")}
     assert watch_filter(Change.modified, "/x/foo.py")
     assert not watch_filter(Change.modified, "/x/notwatched.py")
     assert not watch_filter(Change.modified, "/x/y/foo.py")

--- a/modal/_blob_utils.py
+++ b/modal/_blob_utils.py
@@ -3,7 +3,6 @@ import asyncio
 import dataclasses
 import io
 import os
-from pathlib import Path
 from typing import AsyncIterator, BinaryIO, Optional, Union
 
 from modal.exception import ExecutionError
@@ -122,7 +121,7 @@ async def blob_iter(blob_id, stub) -> AsyncIterator[bytes]:
 @dataclasses.dataclass
 class FileUploadSpec:
     filename: str
-    mount_filename: Path
+    mount_filename: str
 
     use_blob: bool
     content: Optional[bytes]  # typically None if using blob, required otherwise
@@ -130,7 +129,7 @@ class FileUploadSpec:
     size: int
 
 
-def get_file_upload_spec(filename: str, mount_filename: Path) -> FileUploadSpec:
+def get_file_upload_spec(filename: str, mount_filename: str) -> FileUploadSpec:
     # Somewhat CPU intensive, so we run it in a thread/process
     size = os.path.getsize(filename)
     if size >= LARGE_FILE_LIMIT:

--- a/modal/_blob_utils.py
+++ b/modal/_blob_utils.py
@@ -3,6 +3,7 @@ import asyncio
 import dataclasses
 import io
 import os
+from pathlib import Path
 from typing import AsyncIterator, BinaryIO, Optional, Union
 
 from modal.exception import ExecutionError
@@ -121,7 +122,7 @@ async def blob_iter(blob_id, stub) -> AsyncIterator[bytes]:
 @dataclasses.dataclass
 class FileUploadSpec:
     filename: str
-    rel_filename: str
+    mount_filename: Path
 
     use_blob: bool
     content: Optional[bytes]  # typically None if using blob, required otherwise
@@ -129,7 +130,7 @@ class FileUploadSpec:
     size: int
 
 
-def get_file_upload_spec(filename: str, rel_filename: str) -> FileUploadSpec:
+def get_file_upload_spec(filename: str, mount_filename: Path) -> FileUploadSpec:
     # Somewhat CPU intensive, so we run it in a thread/process
     size = os.path.getsize(filename)
     if size >= LARGE_FILE_LIMIT:
@@ -142,4 +143,6 @@ def get_file_upload_spec(filename: str, rel_filename: str) -> FileUploadSpec:
         with open(filename, "rb") as fp:
             content = fp.read()
         sha256_hex = get_sha256_hex(content)
-    return FileUploadSpec(filename, rel_filename, use_blob=use_blob, content=content, sha256_hex=sha256_hex, size=size)
+    return FileUploadSpec(
+        filename, mount_filename, use_blob=use_blob, content=content, sha256_hex=sha256_hex, size=size
+    )

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -209,8 +209,8 @@ class FunctionInfo:
                     or not os.path.exists(path)
                 ):
                     continue
-                dirpath = Path(os.path.dirname(path)).resolve()
-                if not dirpath.is_relative_to(self.base_dir):
+                dirpath = PurePosixPath(Path(os.path.dirname(path)).resolve().as_posix())
+                if not dirpath.as_posix().startswith(Path(self.base_dir).as_posix()):
                     continue  # TODO(elias) some kind of heuristic for how to handle things outside of the cwd?
 
                 relpath = dirpath.relative_to(self.base_dir)

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -213,13 +213,11 @@ class FunctionInfo:
                 if not dirpath.as_posix().startswith(Path(self.base_dir).as_posix()):
                     continue  # TODO(elias) some kind of heuristic for how to handle things outside of the cwd?
 
-                relpath = dirpath.relative_to(self.base_dir)
+                relpath = dirpath.relative_to(Path(self.base_dir).as_posix())
+
                 mounts[path] = _Mount(
                     local_file=path,
-                    remote_dir=ROOT_DIR
-                    / PurePosixPath(
-                        relpath.as_posix()
-                    ),  # TODO(elias): check with Erik for a case where we need normpath/resolve here
+                    remote_dir=ROOT_DIR / relpath if relpath != PurePosixPath(".") else ROOT_DIR,
                 )
         return filter_safe_mounts(mounts)
 

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -192,7 +192,7 @@ class FunctionInfo:
                         or not os.path.exists(path)
                     ):
                         continue
-                    remote_dir = ROOT_DIR / PurePosixPath( *m.__name__.split("."))
+                    remote_dir = ROOT_DIR / PurePosixPath(*m.__name__.split("."))
                     mounts[path] = _Mount(
                         local_dir=path,
                         remote_dir=remote_dir,
@@ -212,7 +212,10 @@ class FunctionInfo:
                 relpath = Path(os.path.relpath(os.path.dirname(path), self.base_dir))
                 mounts[path] = _Mount(
                     local_file=path,
-                    remote_dir=ROOT_DIR / PurePosixPath(relpath.as_posix()),  # TODO(elias): check with Erik for a case where we need normpath/resolve here
+                    remote_dir=ROOT_DIR
+                    / PurePosixPath(
+                        relpath.as_posix()
+                    ),  # TODO(elias): check with Erik for a case where we need normpath/resolve here
                 )
         return filter_safe_mounts(mounts)
 

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -54,12 +54,12 @@ def package_mount_condition(filename):
 
 
 def _is_modal_path(remote_path: PurePosixPath):
-    path_prefix = remote_path.parts[:2]
+    path_prefix = remote_path.parts[:3]
     is_modal_path = path_prefix in [
-        ("root", "modal"),
-        ("root", "modal_proto"),
-        ("root", "modal_utils"),
-        ("root", "modal_version"),
+        ("/", "root", "modal"),
+        ("/", "root", "modal_proto"),
+        ("/", "root", "modal_utils"),
+        ("/", "root", "modal_version"),
     ]
     return is_modal_path
 
@@ -209,7 +209,11 @@ class FunctionInfo:
                     or not os.path.exists(path)
                 ):
                     continue
-                relpath = Path(os.path.relpath(os.path.dirname(path), self.base_dir))
+                dirpath = Path(os.path.dirname(path)).resolve()
+                if not dirpath.is_relative_to(self.base_dir):
+                    continue  # TODO(elias) some kind of heuristic for how to handle things outside of the cwd?
+
+                relpath = dirpath.relative_to(self.base_dir)
                 mounts[path] = _Mount(
                     local_file=path,
                     remote_dir=ROOT_DIR

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -69,7 +69,7 @@ def filter_safe_mounts(mounts: typing.Dict[str, _Mount]):
     safe_mounts = {}
     for local_dir, mount in mounts.items():
         for entry in mount._entries:
-            if _is_modal_path(entry.path_within_mount):
+            if _is_modal_path(entry.remote_path):
                 break
         else:
             safe_mounts[local_dir] = mount

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -209,10 +209,10 @@ class FunctionInfo:
                     or not os.path.exists(path)
                 ):
                     continue
-                relpath = Path(os.path.relpath(os.path.dirname(path), self.base_dir)).resolve()
+                relpath = Path(os.path.relpath(os.path.dirname(path), self.base_dir))
                 mounts[path] = _Mount(
                     local_file=path,
-                    remote_dir=ROOT_DIR / PurePosixPath(relpath.as_posix()),
+                    remote_dir=ROOT_DIR / PurePosixPath(relpath.as_posix()),  # TODO(elias): check with Erik for a case where we need normpath/resolve here
                 )
         return filter_safe_mounts(mounts)
 

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -66,7 +66,14 @@ def _is_modal_path(remote_path: Union[str, Path]):
 
 def filter_safe_mounts(mounts: typing.Dict[str, _Mount]):
     # exclude mounts that would overwrite Modal
-    return {local_dir: mount for local_dir, mount in mounts.items() if not _is_modal_path(mount._remote_dir)}
+    safe_mounts = {}
+    for local_dir, mount in mounts.items():
+        for entry in mount._entries:
+            if _is_modal_path(entry.path_within_mount):
+                break
+        else:
+            safe_mounts[local_dir] = mount
+    return safe_mounts
 
 
 def is_global_function(function_qual_name):

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -210,14 +210,19 @@ class FunctionInfo:
                 ):
                     continue
                 dirpath = PurePosixPath(Path(os.path.dirname(path)).resolve().as_posix())
-                if not dirpath.as_posix().startswith(Path(self.base_dir).as_posix()):
-                    continue  # TODO(elias) some kind of heuristic for how to handle things outside of the cwd?
+                try:
+                    relpath = dirpath.relative_to(Path(self.base_dir).resolve().as_posix())
+                except ValueError:
+                    # TODO(elias) some kind of heuristic for how to handle things outside of the cwd?
+                    continue
 
-                relpath = dirpath.relative_to(Path(self.base_dir).as_posix())
-
+                if relpath != PurePosixPath("."):
+                    remote_dir = ROOT_DIR / relpath
+                else:
+                    remote_dir = ROOT_DIR
                 mounts[path] = _Mount(
                     local_file=path,
-                    remote_dir=ROOT_DIR / relpath if relpath != PurePosixPath(".") else ROOT_DIR,
+                    remote_dir=remote_dir,
                 )
         return filter_safe_mounts(mounts)
 

--- a/modal/_watcher.py
+++ b/modal/_watcher.py
@@ -89,14 +89,13 @@ def _watch_args_from_mounts(mounts: List[_Mount]) -> Tuple[Set[Union[str, Path]]
     dir_filters: Dict[Path, Optional[Set[str]]] = defaultdict(set)
     for mount in mounts:
         # TODO(elias): Make this part of the mount class instead, since it uses so much internals
-        # TODO: this code seems untested?
         for entry in mount._entries:
             path, filter_file = entry.watch_entry()
             paths.add(path)
             if filter_file is None:
                 dir_filters[path] = None
             elif dir_filters[path] is not None:
-                dir_filters[path].add(filter_file)
+                dir_filters[path].add(filter_file.as_posix())
 
     watch_filter = StubFilesFilter(dir_filters=dict(dir_filters))
     return paths, watch_filter

--- a/modal/_watcher.py
+++ b/modal/_watcher.py
@@ -61,7 +61,7 @@ async def _sleep(timeout: float):
     yield AppChange.TIMEOUT
 
 
-async def _watch_paths(paths: Set[Union[str, Path]], watch_filter: StubFilesFilter):
+async def _watch_paths(paths: Set[Path], watch_filter: StubFilesFilter):
     try:
         async for changes in awatch(*paths, step=500, watch_filter=watch_filter):
             yield changes
@@ -70,7 +70,7 @@ async def _watch_paths(paths: Set[Union[str, Path]], watch_filter: StubFilesFilt
         pass
 
 
-def _print_watched_paths(paths: Set[Union[str, Path]], output_mgr: OutputManager, timeout: Optional[float]):
+def _print_watched_paths(paths: Set[Path], output_mgr: OutputManager, timeout: Optional[float]):
     if timeout:
         msg = f"⚡️ Serving for {timeout} seconds... hit Ctrl-C to stop!"
     else:
@@ -84,7 +84,7 @@ def _print_watched_paths(paths: Set[Union[str, Path]], output_mgr: OutputManager
     output_mgr.print_if_visible(output_tree)
 
 
-def _watch_args_from_mounts(mounts: List[_Mount]) -> Tuple[Set[Union[str, Path]], StubFilesFilter]:
+def _watch_args_from_mounts(mounts: List[_Mount]) -> Tuple[Set[Path], StubFilesFilter]:
     paths = set()
     dir_filters: Dict[Path, Optional[Set[str]]] = defaultdict(set)
     for mount in mounts:

--- a/modal/_watcher.py
+++ b/modal/_watcher.py
@@ -89,6 +89,7 @@ def _watch_args_from_mounts(mounts: List[_Mount]) -> Tuple[Set[Union[str, Path]]
     dir_filters: Dict[Path, Optional[Set[str]]] = defaultdict(set)
     for mount in mounts:
         # TODO(elias): Make this part of the mount class instead, since it uses so much internals
+        # TODO: this code seems untested?
         for entry in mount._entries:
             path, filter_file = entry.watch_entry()
             paths.add(path)

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -42,6 +42,10 @@ class _MountFile:
         rel_filename = mount_path.relative_to("/").as_posix()
         yield local_file, rel_filename
 
+    def watch_entry(self):
+        parent = self.local_file.parent
+        return parent, self.local_file
+
 
 @dataclasses.dataclass
 class _MountDir:
@@ -72,6 +76,9 @@ class _MountDir:
                 mount_path = self.remote_path / Path(local_filename).relative_to(local_dir)
                 rel_filename = mount_path.relative_to("/").as_posix()
                 yield local_filename, rel_filename
+
+    def watch_entry(self):
+        return self.local_dir, None
 
 
 _MountEntry = Union[_MountFile, _MountDir]

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -174,9 +174,7 @@ class _Mount(Provider[_MountHandle]):
         local_path = Path(local_path)
         if remote_path is None:
             remote_path = local_path.name
-        remote_path = PurePosixPath(remote_path)
-        if remote_path.is_absolute():
-            remote_path = remote_path.relative_to("/")
+        remote_path = PurePosixPath("/", remote_path)
 
         self._entries.append(
             _MountDir(
@@ -192,10 +190,7 @@ class _Mount(Provider[_MountHandle]):
         local_path = Path(local_path)
         if remote_path is None:
             remote_path = local_path.name
-        remote_path = PurePosixPath(remote_path)
-        if remote_path.is_absolute():
-            remote_path = remote_path.relative_to("/")
-
+        remote_path = PurePosixPath("/", remote_path)
         self._entries.append(
             _MountFile(
                 local_file=local_path,

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -230,11 +230,6 @@ class _Mount(Provider[_MountHandle]):
                     # Can happen with temporary files (e.g. emacs will write temp files and delete them quickly)
                     logger.info(f"Ignoring file not found: {exc}")
 
-    async def _get_remote_files(self):
-        # Used by tests
-        async for file_spec in self._get_files():
-            yield (Path(self._remote_dir) / Path(file_spec.rel_filename)).as_posix()
-
     async def _load(self, resolver: Resolver):
         # Run a threadpool to compute hash values, and use concurrent coroutines to register files.
         t0 = time.time()

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -47,7 +47,7 @@ class _MountFile(_MountEntry):
     remote_path: PurePosixPath
 
     def description(self) -> str:
-        return self.local_file.as_posix()
+        return str(self.local_file)
 
     def get_files_to_upload(self):
         local_file = self.local_file.expanduser()
@@ -70,7 +70,7 @@ class _MountDir(_MountEntry):
     recursive: bool
 
     def description(self):
-        return self.local_dir.as_posix()
+        return str(self.local_dir)
 
     def get_files_to_upload(self):
         local_dir = self.local_dir.expanduser()
@@ -121,6 +121,8 @@ class _Mount(Provider[_MountHandle]):
     the file's contents to skip uploading files that have been uploaded before.
     """
 
+    _entries: List[_MountEntry]
+
     def __init__(
         self,
         # Mount path within the container.
@@ -140,7 +142,7 @@ class _Mount(Provider[_MountHandle]):
             self._entries = _entries
             assert local_file is None and local_dir is None
         else:
-            self._entries: List[_MountEntry] = []
+            self._entries = []
             if local_file or local_dir:
                 # TODO: add deprecation warning here for legacy API
                 if local_file is not None and local_dir is not None:
@@ -185,7 +187,7 @@ class _Mount(Provider[_MountHandle]):
             _entries=self._entries
             + [
                 _MountDir(
-                    local_dir=Path(local_path),
+                    local_dir=local_path,
                     condition=condition,
                     remote_path=remote_path,
                     recursive=recursive,


### PR DESCRIPTION
Instead of constructing mounts using a singular path + optional filter function, this lets the user add path's to mounts iteratively:

```python
mount = modal.Mount()\
    .add_local_dir("/home/my/project")\
    .add_local_file("/home/my/logo.png", remote_path="/project/logo.png")
```
Besides allowing more complex mount structures, this also makes the old `remote_dir` argument optional.

TODO: 
- [x] More test cases
- [x] Fix broken stuff
- [ ] Add deprecation warning when using old constructor?