### PR TITLE
Fix ASGI lifecycles (WIP)

### DIFF
--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -146,3 +146,32 @@ def fastapi_app():
         return {"hello": arg}
 
     return web_app
+
+
+class AsgiLifecycleClass:
+    _events: list[str] = []
+
+    def __init__(self):
+        self._events.append("init")
+
+    async def __aenter__(self):
+        from fastapi import FastAPI, Request
+
+        self._events.append("enter")
+
+        web_app = FastAPI()
+
+        @web_app.get("/foo")
+        async def foo(arg="world"):
+            self._events.append("call")
+            return {"hello": arg}
+
+        self._web_app = web_app
+
+    async def __aexit__(self, typ, exc, tb):
+        self._events.append("exit")
+
+    @stub.asgi
+    def fastapi_app(self):
+        self._events.append("asgi")
+        return self._web_app


### PR DESCRIPTION
WIP – so far this just adds a failing test for lifecycles with ASGI apps.

The reason this fails is that the asgi-decorated function runs before the `__enter__` method is called, which I think is the opposite of what people would expect.

I'll think about how to fix it. It feels like the interface is already a bit awkward since asgi apps are already objects that have their own lifecycle. So maybe we should come up with something more elegant that uses that.

