### PR TITLE
remove deprecated fields

### DIFF
--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -131,7 +131,8 @@ class MockClientServicer(api_grpc.ModalClientBase):
     async def AppGetObjects(self, stream):
         request: api_pb2.AppGetObjectsRequest = await stream.recv_message()
         object_ids = self.app_objects.get(request.app_id, {})
-        await stream.send_message(api_pb2.AppGetObjectsResponse(object_ids=object_ids))
+        items = [api_pb2.AppGetObjectsItem(tag=tag, object_id=object_id) for tag, object_id in object_ids.items()]
+        await stream.send_message(api_pb2.AppGetObjectsResponse(items=items))
 
     async def AppSetObjects(self, stream):
         request: api_pb2.AppSetObjectsRequest = await stream.recv_message()
@@ -223,7 +224,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
             self.rate_limit_sleep_duration = None
             await stream.send_message(api_pb2.FunctionGetInputsResponse(rate_limit_sleep_duration=s))
         elif not self.container_inputs:
-            await asyncio.sleep(request.timeout)
+            await asyncio.sleep(1.0)
             await stream.send_message(api_pb2.FunctionGetInputsResponse(inputs=[]))
         else:
             await stream.send_message(self.container_inputs.pop(0))

--- a/modal/app.py
+++ b/modal/app.py
@@ -212,7 +212,8 @@ class _App:
         obj_req = api_pb2.AppGetObjectsRequest(app_id=existing_app_id)
         obj_resp = await retry_transient_errors(client.stub.AppGetObjects, obj_req)
         app_page_url = f"https://modal.com/apps/{existing_app_id}"  # TODO (elias): this should come from the backend
-        return _App(stub, client, existing_app_id, app_page_url, tag_to_existing_id=dict(obj_resp.object_ids))
+        object_ids = {item.tag: item.object_id for item in obj_resp.items}
+        return _App(stub, client, existing_app_id, app_page_url, tag_to_existing_id=object_ids)
 
     @staticmethod
     async def _init_new(stub, client, description, detach, deploying) -> "_App":

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -137,7 +137,7 @@ message AppGetObjectsItem {
 }
 
 message AppGetObjectsResponse {
-  map<string, string> object_ids = 1 [deprecated=true];  // remove once support for 0.0.22 is dropped
+  map<string, string> object_ids = 1 [deprecated=true]; // remove once support for 0.43.0 is dropped
   repeated AppGetObjectsItem items = 2;
 }
 
@@ -218,7 +218,6 @@ message ClientCreateResponse {
 
 message ClientHeartbeatRequest {
   string client_id = 1;
-  int32 num_connections = 2 [deprecated=true];
   string current_input_id = 3;
   double current_input_started_at = 4;
 }
@@ -306,7 +305,6 @@ message Function {
   string function_name = 2;
   repeated string mount_ids = 3;
   string image_id = 4;
-  string secret_id = 5 [deprecated=true];
   bytes function_serialized = 6;
 
   enum DefinitionType {
@@ -370,7 +368,6 @@ message FunctionGetInputsItem {
 message FunctionGetInputsRequest {
   string function_id = 1;
   int32 max_values = 3;
-  float timeout = 4 [deprecated=true];
   float average_call_time = 5;
 }
 
@@ -390,7 +387,6 @@ message FunctionGetOutputsRequest {
   string function_call_id = 1;
   int32 max_values = 2;
   float timeout = 3;
-  bool return_empty_on_timeout = 5;  // deprecated - remove in followup PR
   string last_entry_id = 6;
 }
 
@@ -452,7 +448,6 @@ message FunctionPutOutputsItem {
   GenericResult result = 2;
   double input_started_at = 3;
   double output_created_at = 4;
-  string task_id = 5 [deprecated=true];
   int32 gen_index = 6; // ordering for generator outputs
 }
 
@@ -470,7 +465,6 @@ message FunctionRetryPolicy {
 
 message FunctionGetCallGraphRequest {
   // TODO: use input_id once we switch client submit API to return those.
-  string root_function_call_id = 1 [deprecated=true];
   string function_call_id = 2;
 }
 
@@ -618,10 +612,8 @@ message QueueCreateResponse {
 
 message QueueGetRequest {
   string queue_id = 1;
-  bool block = 2 [deprecated=true];
   float timeout = 3;
   int32 n_values = 4;
-  string idempotency_key = 5 [deprecated=true];
 }
 
 message QueueGetResponse {
@@ -630,7 +622,6 @@ message QueueGetResponse {
 
 message QueuePutRequest {
   string queue_id = 1;
-  string idempotency_key = 3 [deprecated=true];
   repeated bytes values = 4;
 }
 


### PR DESCRIPTION
Super minor housekeeping

```
% git blame modal_proto/api.proto | grep deprecated
ac0eed18 modal_proto/api.proto       (Erik Bernhardsson 2022-08-27 22:47:33 +0200 140)   map<string, string> object_ids = 1 [deprecated=true];  // remove once support for 0.0.22 is dropped
0f7e4fe9 modal_proto/api.proto       (Erik Bernhardsson 2022-10-12 18:52:31 -0400 221)   int32 num_connections = 2 [deprecated=true];
05aac794 modal_proto/proto/api.proto (Akshat Bubna      2022-03-14 13:56:16 -0400 309)   string secret_id = 5 [deprecated=true];
df0bedf0 modal_proto/api.proto       (Akshat Bubna      2022-10-21 14:23:37 -0400 373)   float timeout = 4 [deprecated=true];
ccfc58e3 modal_proto/api.proto       (Elias Freider     2022-10-13 13:51:26 +0200 393)   bool return_empty_on_timeout = 5;  // deprecated - remove in followup PR
6b2daad0 modal_proto/api.proto       (Richard Gong      2022-10-10 14:50:36 -0400 455)   string task_id = 5 [deprecated=true];
5a70dd42 modal_proto/api.proto       (Akshat Bubna      2022-10-17 00:13:33 -0400 473)   string root_function_call_id = 1 [deprecated=true];
fb41811e modal_proto/api.proto       (Akshat Bubna      2022-10-18 14:27:44 -0400 621)   bool block = 2 [deprecated=true];
fb41811e modal_proto/api.proto       (Akshat Bubna      2022-10-18 14:27:44 -0400 624)   string idempotency_key = 5 [deprecated=true];
fb41811e modal_proto/api.proto       (Akshat Bubna      2022-10-18 14:27:44 -0400 633)   string idempotency_key = 3 [deprecated=true];
```