### PR TITLE
Add `pip_install_from_pyproject`

### DIFF
--- a/client_test/image_test.py
+++ b/client_test/image_test.py
@@ -96,6 +96,18 @@ def test_debian_slim_apt_install(servicer, client):
         assert any("pip install numpy" in cmd for cmd in layers[2].dockerfile_commands)
 
 
+def test_image_pip_install_pyproject(servicer, client):
+    pyproject_toml = os.path.join(os.path.dirname(__file__), "supports/test-pyproject.toml")
+
+    stub = Stub()
+    stub["image"] = Image.debian_slim().pip_install_from_pyproject(pyproject_toml)
+    with stub.run(client=client) as running_app:
+        layers = get_image_layers(running_app["image"].object_id, servicer)
+
+        print(layers[0].dockerfile_commands)
+        assert any("pip install 'banana >=1.2.0' 'potato >=0.1.0'" in cmd for cmd in layers[0].dockerfile_commands)
+
+
 def test_conda_install(servicer, client):
     stub = Stub(
         image=Image.conda().pip_install(["numpy"]).conda_install(["pymc3", "theano"]).pip_install(["scikit-learn"])

--- a/client_test/supports/test-pyproject.toml
+++ b/client_test/supports/test-pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length = 120
+
+[tool.mypy]
+python_version = "3.9"
+exclude = "build"
+ignore_missing_imports = true
+check_untyped_defs = true
+no_strict_optional = true
+namespace_packages = true
+
+[[tool.mypy.overrides]]
+module = [
+    "ddtrace.*",
+]
+check_untyped_defs = false
+follow_imports = "skip"
+
+[project]
+name = "foo"
+description = "bar"
+requires-python = ">=3.9"
+dependencies = [
+    "banana >=1.2.0",
+    "potato >=0.1.0",
+]

--- a/modal/image.py
+++ b/modal/image.py
@@ -292,6 +292,11 @@ class _Image(Provider[_ImageHandle]):
         pyproject_toml: str,
     ):
         """Install dependencies specified by a pyproject.toml file."""
+        from modal import is_local
+
+        # Don't re-run inside container.
+        if not is_local():
+            return []
 
         pyproject_toml = os.path.expanduser(pyproject_toml)
 

--- a/modal/image.py
+++ b/modal/image.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import Any, Callable, Collection, Optional, Union
 
+import toml
+
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronize_apis
 from modal_utils.grpc_utils import retry_transient_errors
@@ -284,6 +286,18 @@ class _Image(Provider[_ImageHandle]):
             dockerfile_commands=dockerfile_commands,
             context_files=context_files,
         )
+
+    def pip_install_from_pyproject(
+        self,
+        pyproject_toml: str,
+    ):
+        """Install dependencies specified by a pyproject.toml file."""
+
+        pyproject_toml = os.path.expanduser(pyproject_toml)
+
+        config = toml.load(pyproject_toml)
+
+        return self.pip_install(config["project"]["dependencies"])
 
     def poetry_install_from_file(
         self,


### PR DESCRIPTION
First tried doing this by copying `pyproject.toml` over with `pip install .` but this runs into issues when [dynamic metadata](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#dynamic-metadata) fields are specified. Parsing works a lot better here. 