### PR TITLE
Take args list for image build functions

### DIFF
--- a/client_test/image_test.py
+++ b/client_test/image_test.py
@@ -79,7 +79,14 @@ def test_image_requirements_txt(servicer, client):
 
 def test_empty_install(servicer, client):
     # Install functions with no packages should be ignored.
-    stub = Stub(image=Image.debian_slim().pip_install().pip_install([], []).apt_install([]))
+    stub = Stub(
+        image=Image.debian_slim()
+        .pip_install()
+        .pip_install([], [], [], [])
+        .apt_install([])
+        .run_commands()
+        .conda_install()
+    )
 
     with stub.run(client=client) as running_app:
         layers = get_image_layers(running_app["image"].object_id, servicer)

--- a/client_test/image_test.py
+++ b/client_test/image_test.py
@@ -44,7 +44,7 @@ def get_image_layers(image_id: str, servicer) -> List[api_pb2.Image]:
 
 def test_image_python_packages(client, servicer):
     stub = Stub()
-    stub["image"] = Image.debian_slim().pip_install(["numpy"])
+    stub["image"] = Image.debian_slim().pip_install("numpy")
     with stub.run(client=client) as running_app:
         layers = get_image_layers(running_app["image"].object_id, servicer)
         assert any("pip install numpy" in cmd for cmd in layers[0].dockerfile_commands)
@@ -54,8 +54,14 @@ def test_wrong_type(servicer, client):
     image = Image.debian_slim()
     for method in [image.pip_install, image.apt_install, image.run_commands]:
         method(["xyz"])
+        method("xyz")
+        method("xyz", ["def", "foo"], "ghi")
         with pytest.raises(InvalidError):
-            method("xyz")
+            method(3)
+        with pytest.raises(InvalidError):
+            method([3])
+        with pytest.raises(InvalidError):
+            method([["double-nested-package"]])
 
 
 def test_image_requirements_txt(servicer, client):
@@ -72,11 +78,8 @@ def test_image_requirements_txt(servicer, client):
 
 
 def test_empty_install(servicer, client):
-    with pytest.raises(TypeError):
-        Image.debian_slim().pip_install()  # Missing positional argument `packages`
-
     # Install functions with no packages should be ignored.
-    stub = Stub(image=Image.debian_slim().pip_install([]).apt_install([]))
+    stub = Stub(image=Image.debian_slim().pip_install().pip_install([], []).apt_install([]))
 
     with stub.run(client=client) as running_app:
         layers = get_image_layers(running_app["image"].object_id, servicer)
@@ -84,9 +87,7 @@ def test_empty_install(servicer, client):
 
 
 def test_debian_slim_apt_install(servicer, client):
-    stub = Stub(
-        image=Image.debian_slim().pip_install(["numpy"]).apt_install(["git", "ssh"]).pip_install(["scikit-learn"])
-    )
+    stub = Stub(image=Image.debian_slim().pip_install("numpy").apt_install("git", "ssh").pip_install("scikit-learn"))
 
     with stub.run(client=client) as running_app:
         layers = get_image_layers(running_app["image"].object_id, servicer)
@@ -109,9 +110,7 @@ def test_image_pip_install_pyproject(servicer, client):
 
 
 def test_conda_install(servicer, client):
-    stub = Stub(
-        image=Image.conda().pip_install(["numpy"]).conda_install(["pymc3", "theano"]).pip_install(["scikit-learn"])
-    )
+    stub = Stub(image=Image.conda().pip_install("numpy").conda_install("pymc3", "theano").pip_install("scikit-learn"))
 
     with stub.run(client=client) as running_app:
         layers = get_image_layers(running_app["image"].object_id, servicer)
@@ -164,7 +163,7 @@ def test_image_run_function(client, servicer):
     volume = SharedVolume().persist("test-vol")
     stub["image"] = (
         Image.debian_slim()
-        .pip_install(["pandas"])
+        .pip_install("pandas")
         .run_function(run_f, secrets=[Secret({"xyz": "123"})], shared_volumes={"/foo": volume})
     )
 

--- a/modal/extensions/pymc.py
+++ b/modal/extensions/pymc.py
@@ -13,8 +13,8 @@ from modal_utils.async_utils import synchronize_apis, synchronizer
 
 pymc_stub = modal.Stub(
     image=modal.Image.conda()
-    .conda_install(["theano-pymc==1.1.2", "pymc3==3.11.2", "scikit-learn", "mkl-service"])
-    .apt_install(["zlib1g"])
+    .conda_install("theano-pymc==1.1.2", "pymc3==3.11.2", "scikit-learn", "mkl-service")
+    .apt_install("zlib1g")
 )
 
 # HACK: we need the aio version of the pymc app, so we can merge the sample processes

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -77,7 +77,7 @@ HINT: For relative imports to work, you might need to run your modal app as a mo
 HINT: This error usually indicates an outdated CUDA version. Older versions of torch (<=1.12)
 come with CUDA 10.2 by default. If pinning to an older torch version, you can specify a CUDA version
 manually, for example:
--  image.pip_install(["torch==1.12.1+cu116"], "https://download.pytorch.org/whl/torch_stable.html")
+-  image.pip_install("torch==1.12.1+cu116", find_links="https://download.pytorch.org/whl/torch_stable.html")
 """
         )
         exc.args = (msg,)

--- a/modal/image.py
+++ b/modal/image.py
@@ -61,12 +61,31 @@ def _get_client_requirements_path():
     return os.path.join(modal_path, "requirements.txt")
 
 
-def _assert_list_of_str(function_name: str, arg_name: str, args: list[str]):
+def _flatten_str_list(function_name: str, arg_name: str, args: list[Union[str, list[str]]]) -> list[str]:
+    """Takes a list of strings, or string lists, and flattens it.
+
+    Raises an error if the argument is not a list, or if any of the elements are
+    not strings or string lists.
+    """
     # TODO(erikbern): maybe we can just build somthing intelligent that checks
     # based on type annotations in real time?
     # Or use something like this? https://github.com/FelixTheC/strongtyping
-    if not isinstance(args, list) or any(not isinstance(arg, str) for arg in args):
-        raise InvalidError(f"{function_name}: {arg_name} must be a list of strings")
+
+    def is_str_list(x):
+        return isinstance(x, list) and all(isinstance(y, str) for y in x)
+
+    if not isinstance(args, list):
+        raise InvalidError(f"{function_name}: {arg_name} must be a list")
+
+    ret: list[str] = []
+    for x in args:
+        if isinstance(x, str):
+            ret.append(x)
+        elif is_str_list(x):
+            ret.extend(x)
+        else:
+            raise InvalidError(f"{function_name}: {arg_name} must only contain strings")
+    return ret
 
 
 class _ImageHandle(Handle, type_prefix="im"):
@@ -246,16 +265,16 @@ class _Image(Provider[_ImageHandle]):
 
     def pip_install(
         self,
-        packages: list[str],  # A list of Python packages, eg. ["numpy", "matplotlib>=3.5.0"]
+        *packages: list[Union[str, list[str]]],  # A list of Python packages, eg. ["numpy", "matplotlib>=3.5.0"]
         find_links: Optional[str] = None,
     ) -> "_Image":
         """Install a list of Python packages using pip."""
-        _assert_list_of_str("pip_install", "packages", packages)
-        if not packages:
+        pkgs = _flatten_str_list("pip_install", "packages", packages)
+        if not pkgs:
             return self
 
         find_links_arg = f"-f {find_links}" if find_links else ""
-        package_args = " ".join(shlex.quote(pkg) for pkg in packages)
+        package_args = " ".join(shlex.quote(pkg) for pkg in pkgs)
 
         dockerfile_commands = [
             "FROM base",
@@ -302,7 +321,7 @@ class _Image(Provider[_ImageHandle]):
 
         config = toml.load(pyproject_toml)
 
-        return self.pip_install(config["project"]["dependencies"])
+        return self.pip_install(*config["project"]["dependencies"])
 
     def poetry_install_from_file(
         self,
@@ -377,13 +396,13 @@ class _Image(Provider[_ImageHandle]):
 
     def run_commands(
         self,
-        commands: list[str],
+        *commands: list[Union[str, list[str]]],
         secrets: Collection[_Secret] = [],
         gpu: bool = False,
     ):
         """Extend an image with a list of shell commands to run."""
-        _assert_list_of_str("run_commands", "commands", commands)
-        dockerfile_commands = ["FROM base"] + [f"RUN {cmd}" for cmd in commands]
+        cmds = _flatten_str_list("run_commands", "commands", commands)
+        dockerfile_commands = ["FROM base"] + [f"RUN {cmd}" for cmd in cmds]
 
         return self.extend(
             dockerfile_commands=dockerfile_commands,
@@ -442,15 +461,15 @@ class _Image(Provider[_ImageHandle]):
 
     def conda_install(
         self,
-        packages: list[str],  # A list of Python packages, eg. ["numpy", "matplotlib>=3.5.0"]
-        *,
+        *packages: list[Union[str, list[str]]],  # A list of Python packages, eg. ["numpy", "matplotlib>=3.5.0"]
         channels: list[str] = [],  # A list of Conda channels, eg. ["conda-forge", "nvidia"]
     ) -> "_Image":
         """Install a list of additional packages using conda."""
-        if not packages:
+        pkgs = _flatten_str_list("conda_install", "packages", packages)
+        if not pkgs:
             return self
 
-        package_args = " ".join(shlex.quote(pkg) for pkg in packages)
+        package_args = " ".join(shlex.quote(pkg) for pkg in pkgs)
         channel_args = "".join(f" -c {channel}" for channel in channels)
 
         dockerfile_commands = [
@@ -576,10 +595,10 @@ class _Image(Provider[_ImageHandle]):
 
     def apt_install(
         self,
-        packages: list[str],  # A list of packages, e.g. ["ssh", "libpq-dev"]
+        *packages: list[Union[str, list[str]]],  # A list of packages, e.g. ["ssh", "libpq-dev"]
     ) -> "_Image":
         """Install a list of Debian packages using `apt`."""
-        _assert_list_of_str("apt_install", "packages", packages)
+        _flatten_str_list("apt_install", "packages", packages)
         if not packages:
             return self
 
@@ -618,7 +637,7 @@ class _Image(Provider[_ImageHandle]):
         image = (
             modal.Image
                 .debian_slim()
-                .pip_install(["torch"])
+                .pip_install("torch")
                 .run_function(my_build_function, secrets=[...], mounts=[...])
         )
         ```

--- a/modal/image.py
+++ b/modal/image.py
@@ -398,6 +398,9 @@ class _Image(Provider[_ImageHandle]):
     ):
         """Extend an image with a list of shell commands to run."""
         cmds = _flatten_str_args("run_commands", "commands", commands)
+        if not cmds:
+            return self
+
         dockerfile_commands = ["FROM base"] + [f"RUN {cmd}" for cmd in cmds]
 
         return self.extend(

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -743,7 +743,7 @@ class _Stub:
         ```python
         import modal
 
-        stub = modal.Stub(image=modal.Image.debian_slim().apt_install(["vim"]))
+        stub = modal.Stub(image=modal.Image.debian_slim().apt_install("vim"))
 
         if __name__ == "__main__":
             stub.interactive_shell("/bin/bash")
@@ -755,7 +755,7 @@ class _Stub:
         import modal
 
         stub = modal.Stub()
-        app_image = modal.Image.debian_slim().apt_install(["vim"])
+        app_image = modal.Image.debian_slim().apt_install("vim")
 
         if __name__ == "__main__":
             stub.interactive_shell(cmd="/bin/bash", image=app_image)

--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -7,7 +7,7 @@ from ._version_generated import build_number  # Written by GitHub
 major_number = 0
 
 # Bump this manually on any major changes
-minor_number = 43
+minor_number = 44
 
 # Right now, set the patch number (the 3rd field) to the job run number in GitHub
 __version__ = f"{major_number}.{minor_number}.{build_number}"


### PR DESCRIPTION
### Motivation

When building large images from Python I often have to write things like (this one taken from youtube face detection example):

```python
image = (
    modal.Image.debian_slim()
    .run_commands(
        [
            "apt-get install -y libgl1-mesa-glx libglib2.0-0 wget",
            f"wget https://raw.githubusercontent.com/opencv/opencv/master/data/haarcascades/{FACE_CASCADE_FN} -P /root",
        ]
    )
    .pip_install(["pytube", "opencv-python", "moviepy"])
)
```

These brackets aren't really necessary; they don't seem to help make the API clearer.

```python
image = (
    modal.Image.debian_slim()
    .run_commands(
        "apt-get install -y libgl1-mesa-glx libglib2.0-0 wget",
        f"wget https://raw.githubusercontent.com/opencv/opencv/master/data/haarcascades/{FACE_CASCADE_FN} -P /root",
    )
    .pip_install("pytube", "opencv-python", "moviepy")
)
```

If we remove them, we also get to eliminate another level of indentation from Black-formatted code.

### Description

Changes the following functions that build images:

- `apt_install`
- `pip_install`
- `run_commands`
- `conda_install`

The specific change is to the function signature, which is modified from

```python
def pip_install(
    self,
    packages: list[str],  # A list of Python packages, eg. ["numpy", "matplotlib>=3.5.0"]
    find_links: Optional[str] = None,
) -> "_Image":
```

to a new signature

```python
def pip_install(
    self,
    *packages: Union[str, list[str]],  # A list of Python packages, eg. ["numpy", "matplotlib>=3.5.0"]
    find_links: Optional[str] = None,
) -> "_Image":
```

We could gradually deprecate `list[str]` being accepted far in the future (e.g., by showing warnings), but I don't think it's important immediately. Just changing all the docs should be good enough.

### Compatibility

We still support code like `image.pip_install(["pip"])` due to the `Union[]` type and some flattening at runtime.

**However, this PR introduces a limited breaking change because it turns a positional argument into a keyword argument.**

This breaking change only affects `pip_install()` and `run_commands()`. Other functions already don't take extra positional arguments. In practice I think `pip_install()` will be the only function that causes real-world breakage because users are probably passing `secrets=[...]` to `run_commands`, not using the argument as positional.

I think this is minor enough that it's fine to just bump the release number though. The error happens immediately, and the fix is really simple.

```python
# broken
image.pip_install(["torch==1.12.1+cu116"], "https://download.pytorch.org/whl/torch_stable.html")

# fix
image.pip_install(["torch==1.12.1+cu116"], find_links="https://download.pytorch.org/whl/torch_stable.html")

# or, even better
image.pip_install("torch==1.12.1+cu116", find_links="https://download.pytorch.org/whl/torch_stable.html")
```

We could send a message in the beta testers Slack about this to make it clear.

(internal note: I need to add `find_links=` to two places in our monorepo's tests before we merge this)