### PR TITLE
Fix bug in persist() synchronization

### DIFF
--- a/modal/object.py
+++ b/modal/object.py
@@ -125,7 +125,7 @@ class Provider(Generic[H]):
     def local_uuid(self):
         return self._local_uuid
 
-    async def persist(self, label: str):
+    def persist(self, label: str):
         """Deploy a Modal app containing this object. This object can then be imported from other apps using
         the returned reference, or by calling `modal.SharedVolume.from_name(label)` (or the equivalent method
         on respective class).


### PR DESCRIPTION
There was a typo where `persist` was previously an async function when it should not have been. This still worked in ordinary function calls, but when running an app that called `.persist()` in `modal app run`, it would immediately crash with a cryptic error.

```python
import modal

stub = modal.Stub()

stub.q = modal.Queue().persist("temp-delete-this")

@stub.function
def main():
    modal.container_app.q.put(3)
    print("Hello world!")
    assert modal.container_app.q.get() == 3
```

```sh-session
$ modal app run repro.py
Traceback (most recent call last):
  File "/opt/homebrew/lib/python3.10/site-packages/modal/cli/app.py", line 42, in run
    stub = import_stub(import_path, stub_name)
  File "/opt/homebrew/lib/python3.10/site-packages/modal_utils/package_utils.py", line 90, in import_stub
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/ezhang/Documents/temp/sd/repro.py", line 5, in <module>
    stub.q = modal.Queue().persist("temp-delete-this")
  File "/opt/homebrew/lib/python3.10/site-packages/synchronicity/synchronizer.py", line 410, in proxy_method
    return method(instance, *args, **kwargs)
  File "/opt/homebrew/lib/python3.10/site-packages/synchronicity/synchronizer.py", line 368, in f_wrapped
    return self._run_function_sync(res, interface)
  File "/opt/homebrew/lib/python3.10/site-packages/synchronicity/synchronizer.py", line 245, in _run_function_sync
    raise Exception(
Exception: Deadlock detected: calling a sync function from the synchronizer loop
/opt/homebrew/lib/python3.10/site-packages/synchronicity/synchronizer.py:372: RuntimeWarning: coroutine 'Provider.persist' was never awaited
  raise uc_exc.exc from None
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

Removing the `async` fixes this issue.

I don't know about synchronicity internals, so I don't know _why_ this code was even working before, that seems strange? It seems unlikely, but are there any other problems that could result from this in places where things aren't synchronized properly? Hopefully it's just an internal unsafe usage.