### PR TITLE
Don't use synchronicity as a wrapper for cli commands that run user code

### DIFF
--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -120,3 +120,4 @@ def test_app_run_custom_stub(servicer, server_url_env, test_dir):
 def test_app_run_aiostub(servicer, server_url_env, test_dir):
     modal_file = test_dir / "supports" / "app_run_tests" / "async_stub.py"
     _run(["app", "run", modal_file.as_posix()])
+    assert len(servicer.client_calls) == 1


### PR DESCRIPTION
Uses _translate_in and _translate_out hacks instead to reliably run both async and sync versions of imported code. There might be a better way?
