### PR TITLE
Make all pty threads daemonic

### DIFF
--- a/modal/_pty.py
+++ b/modal/_pty.py
@@ -119,7 +119,7 @@ def run_in_pty(fn, queue, pty_info: api_pb2.PTYInfo):
                 except asyncio.CancelledError:
                     return
 
-        t = threading.Thread(target=_read)
+        t = threading.Thread(target=_read, daemon=True)
         t.start()
 
         os.environ.update(


### PR DESCRIPTION
Very speculative, but a user reported that jobs seem to get stuck in a zombie state and I see pty stuff in the traceback.

Non-daemonic threads have a tendency to cause this behavior so let's give this a shot.

My confidence isn't 100% since the user mentioned this also happened to non-interactive tasks... which wouldn't explain it.