### PR TITLE
Let the container control its own heartbeats

### DIFF
--- a/client_test/client_test.py
+++ b/client_test/client_test.py
@@ -32,11 +32,9 @@ async def test_client(servicer, client):
 @pytest.mark.asyncio
 @skip_windows
 async def test_container_client(unix_servicer, aio_container_client):
-    await asyncio.sleep(0.1)  # wait for heartbeat
-    assert len(unix_servicer.requests) == 2
+    assert len(unix_servicer.requests) == 1  # no heartbeat, just ClientCreate
     assert isinstance(unix_servicer.requests[0], api_pb2.ClientCreateRequest)
     assert unix_servicer.requests[0].client_type == api_pb2.CLIENT_TYPE_CONTAINER
-    assert isinstance(unix_servicer.requests[1], api_pb2.ClientHeartbeatRequest)
 
 
 @pytest.mark.asyncio

--- a/client_test/client_test.py
+++ b/client_test/client_test.py
@@ -27,6 +27,7 @@ async def test_client(servicer, client):
     assert isinstance(servicer.requests[0], api_pb2.ClientCreateRequest)
     assert servicer.requests[0].client_type == api_pb2.CLIENT_TYPE_CLIENT
     assert isinstance(servicer.requests[1], api_pb2.ClientHeartbeatRequest)
+    assert servicer.requests[1].client_id
 
 
 @pytest.mark.asyncio

--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -212,6 +212,13 @@ class MockClientServicer(api_grpc.ModalClientBase):
             raise GRPCError(self.heartbeat_status_code, f"Client {request.client_id} heartbeat failed.")
         await stream.send_message(Empty())
 
+    # Container
+
+    async def ContainerHeartbeat(self, stream):
+        request: api_pb2.ContainerHeartbeatRequest = await stream.recv_message()
+        self.requests.append(request)
+        await stream.send_message(Empty())
+
     ### Function
 
     async def FunctionGetInputs(self, stream):

--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -436,3 +436,9 @@ def test_asgi(unix_servicer, event_loop):
     # Check EOF
     assert items[2].result.status == api_pb2.GenericResult.GENERIC_STATUS_SUCCESS
     assert items[2].result.gen_status == api_pb2.GenericResult.GENERATOR_STATUS_COMPLETE
+
+
+@skip_windows
+def test_container_heartbeats(unix_servicer, event_loop):
+    client, items = _run_container(unix_servicer, "modal_test_support.functions", "square")
+    assert any(isinstance(request, api_pb2.ContainerHeartbeatRequest) for request in unix_servicer.requests)

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -131,14 +131,14 @@ class _FunctionIOManager:
             current_input_started_at=started_at,
         )
         # TODO(erikbern): capture exceptions?
-        await self.client.stub.ContainerHeartbeat(request, timeout=HEARTBEAT_TIMEOUT)        
+        await self.client.stub.ContainerHeartbeat(request, timeout=HEARTBEAT_TIMEOUT)
 
     @contextlib.asynccontextmanager
     async def heartbeats(self):
         async with TaskContext(grace=1) as tc:
             tc.infinite_loop(self._heartbeat, sleep=HEARTBEAT_INTERVAL)
             yield
-        
+
     async def get_serialized_function(self) -> tuple[Optional[Any], Callable]:
         # Fetch the serialized function definition
         request = api_pb2.FunctionGetSerializedRequest(function_id=self.function_id)

--- a/modal/client.py
+++ b/modal/client.py
@@ -192,7 +192,7 @@ class _Client:
 
     async def _heartbeat(self):
         if self._stub is not None:
-            req = api_pb2.ClientHeartbeatRequest()
+            req = api_pb2.ClientHeartbeatRequest(client_id=self._client_id)
             try:
                 await self.stub.ClientHeartbeat(req, timeout=HEARTBEAT_TIMEOUT)
                 self._last_heartbeat = time.time()


### PR DESCRIPTION
This removes the use of `ClientHeartbeat` for containers, which now have their own heartbeat loop in `_container_entrypoint.py`

It will make it possible to clean up some of the global state where we set the current input id etc – I'll do it in a subsequent PR just to keep it simple and focused.

The other use of client heartbeats is for apps, so that will be its own PR as well.