### PR TITLE
Move heartbeats to sit in an app level

### DIFF
--- a/client_test/client_test.py
+++ b/client_test/client_test.py
@@ -1,11 +1,6 @@
 # Copyright Modal Labs 2022
-import asyncio
-import os
 import platform
 import pytest
-import time
-
-from grpclib import Status
 
 import modal.exception
 from modal.client import AioClient, Client

--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -163,6 +163,11 @@ class MockClientServicer(api_grpc.ModalClientBase):
                 (object_id,) = list(app_objects.values())
         await stream.send_message(api_pb2.AppLookupObjectResponse(object_id=object_id))
 
+    async def AppHeartbeat(self, stream):
+        request: api_pb2.ClientHeartbeatRequest = await stream.recv_message()
+        self.requests.append(request)
+        await stream.send_message(Empty())
+
     ### Blob
 
     async def BlobCreate(self, stream):
@@ -204,13 +209,6 @@ class MockClientServicer(api_grpc.ModalClientBase):
             raise GRPCError(Status.FAILED_PRECONDITION, "Old client")
         else:
             await stream.send_message(api_pb2.ClientCreateResponse(client_id=client_id))
-
-    async def ClientHeartbeat(self, stream):
-        request: api_pb2.ClientHeartbeatRequest = await stream.recv_message()
-        self.requests.append(request)
-        if self.heartbeat_status_code:
-            raise GRPCError(self.heartbeat_status_code, f"Client {request.client_id} heartbeat failed.")
-        await stream.send_message(Empty())
 
     # Container
 

--- a/client_test/stub_test.py
+++ b/client_test/stub_test.py
@@ -1,4 +1,5 @@
 # Copyright Modal Labs 2022
+import asyncio
 import logging
 import os
 import pytest
@@ -212,3 +213,15 @@ def test_detach_state(client, servicer):
     stub = Stub()
     with stub.run(client=client, detach=True) as app:
         assert servicer.app_state[app.app_id] == api_pb2.APP_STATE_DETACHED
+
+
+@pytest.mark.asyncio
+async def test_grpc_protocol(aio_client, servicer):
+    stub = AioStub()
+    async with stub.run(client=aio_client):
+        await asyncio.sleep(0.01)  # wait for heartbeat
+    assert len(servicer.requests) == 4
+    assert isinstance(servicer.requests[0], api_pb2.ClientCreateRequest)
+    assert isinstance(servicer.requests[1], api_pb2.AppCreateRequest)
+    assert isinstance(servicer.requests[2], api_pb2.AppHeartbeatRequest)
+    assert isinstance(servicer.requests[3], api_pb2.AppClientDisconnectRequest)

--- a/modal/client.py
+++ b/modal/client.py
@@ -3,22 +3,18 @@ from __future__ import annotations
 
 import asyncio
 import platform
-import time
 import warnings
 import webbrowser
 from typing import Callable, Optional
 
 from aiohttp import ClientConnectorError, ClientResponseError
 from grpclib import GRPCError, Status
-from grpclib.exceptions import StreamTerminatedError
 from rich.console import Console
-from sentry_sdk import capture_exception
 
 from modal_proto import api_grpc, api_pb2
 from modal_utils import async_utils
-from modal_utils.async_utils import TaskContext, synchronize_apis
+from modal_utils.async_utils import synchronize_apis
 from modal_utils.grpc_utils import (
-    RETRYABLE_GRPC_STATUS_CODES,
     create_channel,
     retry_transient_errors,
 )


### PR DESCRIPTION
This gets rid of the heartbeat loop on the `Client` class and replaces it with one on the `Stub` class instead.

It doesn't preserve the full handling of different error cases. This is intentional, since the old code had a lot of complexity, but still many issues. I think it's better to start over from scratch and add back error handling gradually.

This _almost_ turns the `Client` class into a stateless class, but we still call `ClientCreate` when starting the client, and will have to do that for a while. I want to get rid of `ClientCreate` on the server, but it's hard to do so until old clients are fully deprecated and we can drop support. In particular, we need the client that sends the client version as a part of the metadata. So I'm not going to do that last part until a few months out.