### PR TITLE
Addr TODO, including link to latest modal-client package on VersionError

### DIFF
--- a/modal/client.py
+++ b/modal/client.py
@@ -139,9 +139,8 @@ class _Client:
             self._connected = True
         except GRPCError as exc:
             if exc.status == Status.FAILED_PRECONDITION:
-                # TODO: include a link to the latest package
                 raise VersionError(
-                    f"The client version {self.version} is too old. Please update to the latest package."
+                    f"The client version {self.version} is too old. Please update to the latest package on PyPi: https://pypi.org/project/modal-client"
                 )
             elif exc.status == Status.UNAUTHENTICATED:
                 raise AuthError(exc.message)


### PR DESCRIPTION
One of my personal apps just hit `VersionError`, and I noticed the TODO in my investigation of the failure. 

(I got unlucky, the scheduling server letting the function schedule with version `0.35.1983` but the server that received the client connection rejected `0.35.1983` as `0.40` is the recently deployed minimum)