### PR TITLE
[mod-747] webhook reload updates Modal Fn definitions on change

### DIFF
--- a/client_test/live_reload_test.py
+++ b/client_test/live_reload_test.py
@@ -1,0 +1,112 @@
+# Copyright Modal Labs 2023
+import copy
+import pytest
+from pathlib import Path
+
+from watchfiles import Change
+
+from modal._watcher import AppChange
+
+
+@pytest.fixture(scope="function")
+def clean_up_file_changes():
+    change_reversions: dict[Path, str] = {}
+    yield change_reversions
+    for path, contents in change_reversions.items():
+        path.write_text(contents)
+
+
+def dummy():
+    pass
+
+
+def test_reload_of_function_defs(clean_up_file_changes, client, monkeypatch, servicer, test_dir):
+    from client_test.supports.live_reload_tests.webhook import stub
+
+    stub_file = test_dir / "supports" / "live_reload_tests" / "webhook.py"
+    app_functions_snapshots = []
+
+    def make_revertable_file_modification(path: Path, new_contents: str) -> None:
+        clean_up_file_changes[path] = path.read_text()
+        path.write_text(new_contents)
+
+    async def fake_watch(stub, output_mgr, timeout):
+        """
+        Provide a fixed list of events to stub.serve, recording the state of the app's
+        Modal functions in between events.
+        """
+        # begin serving
+        yield AppChange.START
+        app_functions_snapshots.append(copy.deepcopy(servicer.app_functions))
+        # Change the served module
+        make_revertable_file_modification(
+            stub_file,
+            new_contents="""
+import modal
+stub = modal.Stub()
+
+@stub.webhook(method="POST")  # change method from GET to POST
+def dummy():
+    pass
+        """,
+        )
+        yield {(Change.modified, str(stub_file))}
+        app_functions_snapshots.append(copy.deepcopy(servicer.app_functions))
+        # stop the served app
+        yield AppChange.TIMEOUT
+
+    monkeypatch.setattr("modal._watcher.watch", fake_watch)
+
+    stub.serve(client=client, timeout=None)
+
+    assert len(app_functions_snapshots) == 2
+    assert app_functions_snapshots[0]["fu-1"].webhook_config.method == "GET"
+    assert app_functions_snapshots[1]["fu-1"].webhook_config.method == "POST"
+
+
+def test_reload_on_invalid_syntax(clean_up_file_changes, client, monkeypatch, servicer, test_dir):
+    import importlib
+
+    # HACK: There is some test interference here, probably caused by the use of exec/compile in live-reloading.
+    importlib.import_module("client_test.supports.live_reload_tests.syntax")
+    from client_test.supports.live_reload_tests.syntax import stub
+
+    stub_file = test_dir / "supports" / "live_reload_tests" / "syntax.py"
+    app_functions_snapshots = []
+
+    def make_revertable_file_modification(path: Path, new_contents: str) -> None:
+        clean_up_file_changes[path] = path.read_text()
+        path.write_text(new_contents)
+
+    async def fake_watch(stub, output_mgr, timeout):
+        """
+        Provide a fixed list of events to stub.serve, recording the state of the app's
+        Modal functions in between events.
+        """
+        # begin serving
+        yield AppChange.START
+        app_functions_snapshots.append(copy.deepcopy(servicer.app_functions))
+        # Change the served module but introduce a syntax error
+        make_revertable_file_modification(
+            stub_file,
+            new_contents="""
+import modal
+stub = modal.Stub()
+
+@stub.webhook(method="GET"))  # )) syntax error
+def dummy():
+    pass
+        """,
+        )
+        yield {(Change.modified, str(stub_file))}
+        app_functions_snapshots.append(copy.deepcopy(servicer.app_functions))
+        # stop the served app
+        yield AppChange.TIMEOUT
+
+    monkeypatch.setattr("modal._watcher.watch", fake_watch)
+
+    stub.serve(client=client, timeout=None)
+
+    assert len(app_functions_snapshots) == 2
+    assert app_functions_snapshots[0]["fu-1"].webhook_config.method == "DELETE"
+    assert app_functions_snapshots[1]["fu-1"].webhook_config.method == "DELETE"

--- a/client_test/supports/live_reload_tests/syntax.py
+++ b/client_test/supports/live_reload_tests/syntax.py
@@ -1,0 +1,9 @@
+# Copyright Modal Labs 2023
+import modal
+
+stub = modal.Stub()
+
+
+@stub.webhook(method="DELETE")
+def dummy():
+    pass

--- a/client_test/supports/live_reload_tests/webhook.py
+++ b/client_test/supports/live_reload_tests/webhook.py
@@ -1,0 +1,9 @@
+# Copyright Modal Labs 2023
+import modal
+
+stub = modal.Stub()
+
+
+@stub.webhook(method="GET")
+def dummy():
+    pass

--- a/modal/_live_reload.py
+++ b/modal/_live_reload.py
@@ -1,0 +1,93 @@
+# Copyright Modal Labs 2023
+import ast
+import inspect
+import sys
+from typing import Dict, List, Optional, Union
+
+from .functions import _FunctionHandle
+
+LiveReloadResult = Union[List[str], Exception, None]
+
+
+def process_change(stub, file_changeset) -> Dict[str, LiveReloadResult]:
+    """
+    Accepts a set of FileChange events and reloads any Modal provider functions
+    contained within changed Python modules.
+    """
+    results = {}
+    for file_change in file_changeset:
+        change_type, filepath = file_change
+        if filepath.endswith(".py"):
+            results[filepath] = _reload_providers(stub, filepath)
+        else:
+            results[filepath] = None
+    return results
+
+
+def _is_stub_assignment(node: ast.Assign) -> bool:
+    if not (
+        isinstance(node.value, ast.Call)
+        and isinstance(node.value.func, ast.Attribute)
+        and isinstance(node.value.func.value, ast.Name)
+        and node.value.func.value.id == "modal"
+        and node.value.func.attr == "Stub"
+    ):
+        return False
+    return True
+
+
+def _is_reloadable_stub_method(stub_name: Optional[str], stub_obj, node: ast.Call) -> bool:
+    # TODO: Cache. Don't recalculate.
+    methods_to_reload = {
+        attr
+        for attr in dir(stub_obj)
+        if not attr.startswith("_")
+        and callable(getattr(stub_obj, attr))
+        and inspect.signature(getattr(stub_obj, attr)).return_annotation == _FunctionHandle
+    }
+    if not (
+        isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and (not stub_name or node.func.value.id == stub_name)
+        and node.func.attr in methods_to_reload
+    ):
+        return False
+
+    return True
+
+
+def _reload_providers(stub_obj, filepath: str) -> LiveReloadResult:
+    with open(filepath, "r") as f:
+        source = f.read()
+
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:
+        return exc
+
+    stub_name = None
+    reloaded_fns = []
+    # TODO: Is visitor-pattern more efficient?
+    for node in ast.walk(tree):
+        # If an obvious modal.Stub assignment in the source is available in the AST
+        # use it to determine the stub name.
+        if isinstance(node, ast.Assign) and _is_stub_assignment(node):
+            stub_name = node.targets[0].id  # type: ignore
+        if isinstance(node, ast.FunctionDef):
+            fn_name = node.name
+            for dec in node.decorator_list:
+                if isinstance(dec, ast.Call) and _is_reloadable_stub_method(stub_name, stub_obj, dec):
+                    # Reevaluate only relevant Modal function definitions, don't re-execute the entire
+                    # module which may include a myriad side-effects.
+                    try:
+                        comp_unit = ast.Module(body=[node], type_ignores=[])
+                        compiled_code = compile(comp_unit, filename=filepath, mode="exec")
+                    except SyntaxError as exc:
+                        return exc
+
+                    for name, mod in sys.modules.items():
+                        if hasattr(mod, "__file__") and mod.__file__ == filepath:
+                            exec(compiled_code, mod.__dict__)
+                            reloaded_fns.append(fn_name)
+                            break
+    return reloaded_fns

--- a/modal/_watcher.py
+++ b/modal/_watcher.py
@@ -18,7 +18,7 @@ from ._output import OutputManager
 
 class AppChange(IntEnum):
     """
-    Enum representing the type of a change in the Modal app state.
+    Enum representing the type of a change in the Modal stub serving state.
     """
 
     START = 1


### PR DESCRIPTION
'interpreter surgery' based fix for `stub.serve` reloading, which currently doesn't reload providers on change. 

* don't have enough confidence that this approach is sound, or even practical, so holding off merge.
* but this is working fine when I test out basic webhooks, adding and editing function providers.
* the implementation has a couple of obvious optimizations that aren't yet done
* opportunity to catch `SyntaxError` and abort reload of broken code [mod-727]