### PR TITLE
Add replacement method for ClientCreate

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -219,6 +219,10 @@ message ClientCreateResponse {
   string deprecation_warning = 3;
 }
 
+message ClientHelloResponse {
+  string warning = 1;
+}
+
 message ClientHeartbeatRequest {
   string client_id = 1;
   string current_input_id = 3;
@@ -859,6 +863,7 @@ service ModalClient {
 
   // Clients
   rpc ClientCreate(ClientCreateRequest) returns (ClientCreateResponse);
+  rpc ClientHello(google.protobuf.Empty) returns (ClientHelloResponse);
   rpc ClientHeartbeat(ClientHeartbeatRequest) returns (google.protobuf.Empty);
 
   // Container


### PR DESCRIPTION
Adding this method as a lightweight replacement for `ClientCreate`. But all it does is to do a noop request against the server. Will do the server side implementation next.