### PR TITLE
initialize _mute_cancellation

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -423,6 +423,7 @@ class _FunctionHandle(Handle, type_prefix="fu"):
 
     def _initialize_from_proto(self, function: api_pb2.Function):
         self._is_generator = function.function_type == api_pb2.Function.FUNCTION_TYPE_GENERATOR
+        self._mute_cancellation = False
 
     def _set_local_app(self, app):
         """mdmd:hidden"""


### PR DESCRIPTION
It wasn't set when the function was initialized from a proto object (happens when you use `modal.lookup`)

We should rethink this at some point, since it's confusing that the object can be initialized without the constructor