### PR TITLE
Make Client (almost) stateless

### DIFF
--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -39,7 +39,7 @@ def _run(args, expected_exit_code=0):
     runner = click.testing.CliRunner()
     res = runner.invoke(entrypoint_cli, args)
     if res.exit_code != expected_exit_code:
-        print(res.stdout, "Trace:")
+        print("stdout:", repr(res.stdout))
         traceback.print_tb(res.exc_info[2])
         assert res.exit_code == expected_exit_code
     return res

--- a/client_test/client_test.py
+++ b/client_test/client_test.py
@@ -29,7 +29,7 @@ async def test_client(servicer, client):
 async def test_container_client(unix_servicer, aio_container_client):
     assert len(unix_servicer.requests) == 1  # no heartbeat, just ClientHello
     assert isinstance(unix_servicer.requests[0], Empty)
-    assert servicer.client_create_metadata["x-modal-client-type"] == str(api_pb2.CLIENT_TYPE_CONTAINER)
+    assert unix_servicer.client_create_metadata["x-modal-client-type"] == str(api_pb2.CLIENT_TYPE_CONTAINER)
 
 
 @pytest.mark.asyncio
@@ -135,7 +135,7 @@ def test_client_from_env(servicer):
         assert client_1 == client_2
 
     finally:
-        Client.close_env_client()
+        Client.set_env_client(None)
 
     try:
         # After stopping, creating a new client should return a new one
@@ -144,4 +144,4 @@ def test_client_from_env(servicer):
         assert client_3 != client_1
         assert client_4 == client_3
     finally:
-        Client.close_env_client()
+        Client.set_env_client(None)

--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -91,6 +91,8 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.function_serialized = None
         self.class_serialized = None
 
+        self.client_hello_metadata = None
+
         @self.function_body
         def default_function_body(*args, **kwargs):
             return sum(arg**2 for arg in args) + sum(value**2 for key, value in kwargs.items())
@@ -210,9 +212,13 @@ class MockClientServicer(api_grpc.ModalClientBase):
         else:
             await stream.send_message(api_pb2.ClientCreateResponse(client_id=client_id))
 
-        # Check new fields (TODO: use ClientHello for this)
+    async def ClientHello(self, stream):
+        request: Empty = await stream.recv_message()
+        self.requests.append(request)
+        self.client_create_metadata = stream.metadata
         assert "x-modal-client-version" in stream.metadata
         assert "x-modal-client-type" in stream.metadata
+        await stream.send_message(api_pb2.ClientHelloResponse())
 
     # Container
 

--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -192,33 +192,27 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     ### Client
 
-    async def ClientCreate(self, stream):
-        request: api_pb2.ClientCreateRequest = await stream.recv_message()
-        self.requests.append(request)
-        client_id = "cl-123"
-        if stream.metadata.get("x-modal-token-id") == "bad":
-            raise GRPCError(Status.UNAUTHENTICATED, "bad bad bad")
-        elif request.version == "timeout":
-            await asyncio.sleep(60)
-            await stream.send_message(api_pb2.ClientCreateResponse(client_id=client_id))
-        elif request.version == "unauthenticated":
-            raise GRPCError(Status.UNAUTHENTICATED, "failed authentication")
-        elif request.version == "deprecated":
-            await stream.send_message(
-                api_pb2.ClientCreateResponse(client_id=client_id, deprecation_warning="SUPER OLD")
-            )
-        elif pkg_resources.parse_version(request.version) < pkg_resources.parse_version(__version__):
-            raise GRPCError(Status.FAILED_PRECONDITION, "Old client")
-        else:
-            await stream.send_message(api_pb2.ClientCreateResponse(client_id=client_id))
-
     async def ClientHello(self, stream):
         request: Empty = await stream.recv_message()
         self.requests.append(request)
         self.client_create_metadata = stream.metadata
-        assert "x-modal-client-version" in stream.metadata
-        assert "x-modal-client-type" in stream.metadata
-        await stream.send_message(api_pb2.ClientHelloResponse())
+        client_version = stream.metadata["x-modal-client-version"]
+        client_type = stream.metadata["x-modal-client-type"]
+        if stream.metadata.get("x-modal-token-id") == "bad":
+            raise GRPCError(Status.UNAUTHENTICATED, "bad bad bad")
+        elif client_version == "timeout":
+            await asyncio.sleep(60)
+            await stream.send_message(api_pb2.ClientHelloResponse())
+        elif client_version == "unauthenticated":
+            raise GRPCError(Status.UNAUTHENTICATED, "failed authentication")
+        elif client_version == "deprecated":
+            await stream.send_message(
+                api_pb2.ClientHelloResponse(warning="SUPER OLD")
+            )
+        elif pkg_resources.parse_version(client_version) < pkg_resources.parse_version(__version__):
+            raise GRPCError(Status.FAILED_PRECONDITION, "Old client")
+        else:
+            await stream.send_message(api_pb2.ClientHelloResponse())
 
     # Container
 

--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -197,7 +197,6 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.requests.append(request)
         self.client_create_metadata = stream.metadata
         client_version = stream.metadata["x-modal-client-version"]
-        client_type = stream.metadata["x-modal-client-type"]
         if stream.metadata.get("x-modal-token-id") == "bad":
             raise GRPCError(Status.UNAUTHENTICATED, "bad bad bad")
         elif client_version == "timeout":
@@ -206,9 +205,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         elif client_version == "unauthenticated":
             raise GRPCError(Status.UNAUTHENTICATED, "failed authentication")
         elif client_version == "deprecated":
-            await stream.send_message(
-                api_pb2.ClientHelloResponse(warning="SUPER OLD")
-            )
+            await stream.send_message(api_pb2.ClientHelloResponse(warning="SUPER OLD"))
         elif pkg_resources.parse_version(client_version) < pkg_resources.parse_version(__version__):
             raise GRPCError(Status.FAILED_PRECONDITION, "Old client")
         else:

--- a/client_test/e2e_test.py
+++ b/client_test/e2e_test.py
@@ -42,11 +42,16 @@ def test_run_unconsumed_map(servicer):
 
 
 def test_auth_failure_last_line(servicer):
-    returncode, _, err = _cli(
+    returncode, out, err = _cli(
         ["-m", "modal_test_support.script"],
         servicer.remote_addr,
         extra_env={"MODAL_TOKEN_ID": "bad", "MODAL_TOKEN_SECRET": "bad"},
         check=False,
     )
-    assert returncode != 0
-    assert "bad bad bad" in err.strip().split("\n")[-1]  # err msg should be on the last line
+    try:
+        assert returncode != 0
+        assert "bad bad bad" in err.strip().split("\n")[-1]  # err msg should be on the last line
+    except Exception:
+        print("out:", repr(out))
+        print("err:", repr(err))
+        raise

--- a/client_test/stub_test.py
+++ b/client_test/stub_test.py
@@ -4,6 +4,7 @@ import logging
 import os
 import pytest
 
+from google.protobuf.empty_pb2 import Empty
 from grpclib import GRPCError, Status
 
 import modal.app
@@ -221,7 +222,7 @@ async def test_grpc_protocol(aio_client, servicer):
     async with stub.run(client=aio_client):
         await asyncio.sleep(0.01)  # wait for heartbeat
     assert len(servicer.requests) == 4
-    assert isinstance(servicer.requests[0], api_pb2.ClientCreateRequest)
+    assert isinstance(servicer.requests[0], Empty)  # ClientHello
     assert isinstance(servicer.requests[1], api_pb2.AppCreateRequest)
     assert isinstance(servicer.requests[2], api_pb2.AppHeartbeatRequest)
     assert isinstance(servicer.requests[3], api_pb2.AppClientDisconnectRequest)

--- a/modal/app.py
+++ b/modal/app.py
@@ -148,7 +148,6 @@ class _App:
         )
         req_set = api_pb2.AppSetObjectsRequest(
             app_id=self._app_id,
-            client_id=self._client.client_id,
             indexed_object_ids=indexed_object_ids,
             unindexed_object_ids=unindexed_object_ids,
             new_app_state=new_app_state,  # type: ignore
@@ -220,7 +219,6 @@ class _App:
         # Start app
         # TODO(erikbern): maybe this should happen outside of this method?
         app_req = api_pb2.AppCreateRequest(
-            client_id=client.client_id,
             description=description,
             initializing=deploying,
             detach=detach,

--- a/modal/client.py
+++ b/modal/client.py
@@ -5,7 +5,7 @@ import asyncio
 import platform
 import warnings
 import webbrowser
-from typing import Callable, Optional
+from typing import Optional
 
 from aiohttp import ClientConnectorError, ClientResponseError
 from google.protobuf import empty_pb2
@@ -28,7 +28,6 @@ from .exception import (
     AuthError,
     ConnectionError,
     DeprecationError,
-    InvalidError,
     VersionError,
 )
 
@@ -222,7 +221,6 @@ class _Client:
             cls._client_from_env_lock = asyncio.Lock()
 
         async with cls._client_from_env_lock:
-            print("from env:", cls._client_from_env)
             if cls._client_from_env:
                 return cls._client_from_env
             else:

--- a/modal/client.py
+++ b/modal/client.py
@@ -8,6 +8,7 @@ import webbrowser
 from typing import Callable, Optional
 
 from aiohttp import ClientConnectorError, ClientResponseError
+from google.protobuf import empty_pb2
 from grpclib import GRPCError, Status
 from rich.console import Console
 
@@ -95,46 +96,35 @@ class _Client:
         self.client_type = client_type
         self.credentials = credentials
         self.version = version
-        self._stub = None
-        self._connected = False
-        self._pre_stop: Optional[Callable[[], None]] = None
         self._channel = None
+        self._stub = None
 
     @property
     def stub(self):
         if self._stub is None:
-            raise ConnectionError("The client is not connected to the modal server")
+            metadata = _get_metadata(self.client_type, self.credentials, self.version)
+            self._channel = create_channel(
+                self.server_url,
+                metadata=metadata,
+                inject_tracing_context=inject_tracing_context,
+            )
+            self._stub = api_grpc.ModalClientStub(self._channel)  # type: ignore
+
         return self._stub
 
-    async def _start(self):
+    async def verify(self):
         logger.debug("Client: Starting")
-        if self._stub:
-            raise Exception("Client is already running")
-        metadata = _get_metadata(self.client_type, self.credentials, self.version)
-        self._channel = create_channel(
-            self.server_url,
-            metadata=metadata,
-            inject_tracing_context=inject_tracing_context,
-        )
-        self._stub = api_grpc.ModalClientStub(self._channel)  # type: ignore
         try:
-            req = api_pb2.ClientCreateRequest(
-                client_type=self.client_type,
-                version=self.version,
-            )
+            req = empty_pb2.Empty()
             resp = await retry_transient_errors(
-                self.stub.ClientCreate,
+                self.stub.ClientHello,
                 req,
                 attempt_timeout=CLIENT_CREATE_ATTEMPT_TIMEOUT,
                 total_timeout=CLIENT_CREATE_TOTAL_TIMEOUT,
             )
-            if resp.deprecation_warning:
+            if resp.warning:
                 ALARM_EMOJI = chr(0x1F6A8)
                 warnings.warn(f"{ALARM_EMOJI} {resp.deprecation_warning} {ALARM_EMOJI}", DeprecationError)
-            if not resp.client_id:
-                raise InvalidError("Did not get a client id from server")
-            self._client_id = resp.client_id
-            self._connected = True
         except GRPCError as exc:
             if exc.status == Status.FAILED_PRECONDITION:
                 raise VersionError(
@@ -147,58 +137,17 @@ class _Client:
                 raise ConnectionError(exc_string)
         except (OSError, asyncio.TimeoutError) as exc:
             raise ConnectionError(str(exc))
-        finally:
-            if not self._connected:
-                # Tear down the channel pool etc
-                await self._stop()
 
-        logger.debug("Client: Done starting")
-
-    def set_pre_stop(self, pre_stop: Callable[[], None]):
-        """mdmd:hidden"""
-        # hack: stub.serve() gets into a losing race with the `on_shutdown` client
-        # teardown when an interrupt signal is received (eg. KeyboardInterrupt).
-        # By registering a pre-stop fn stub.serve() can have its teardown
-        # performed before the client is disconnected.
-        #
-        # ref: github.com/modal-labs/modal-client/pull/108
-        self._pre_stop = pre_stop
-
-    async def _stop(self):
-        if self._pre_stop:
-            logger.debug("Client: running pre-stop coroutine before shutting down")
-            await self._pre_stop()  # type: ignore
-        # TODO: we should trigger this using an exit handler
-        logger.debug("Client: Shutting down")
-        self._stub = None  # prevent any additional calls
-        if self._channel:
+    async def close(self):
+        if self._channel is not None:
             self._channel.close()
-            self._channel = None
-        logger.debug("Client: Done shutting down")
-        # Needed to catch straggling CancelledErrors and GeneratorExits that propagate
-        # through our chains of async generators.
-        await asyncio.sleep(0.01)
 
     async def __aenter__(self):
-        try:
-            await self._start()
-        except BaseException:
-            await self._stop()
-            raise
+        await self.verify()
         return self
 
     async def __aexit__(self, exc_type, exc, tb):
-        await self._stop()
-
-    async def verify(self):
-        async with self:
-            # Just connect and disconnect
-            pass
-
-    @property
-    def client_id(self):
-        """A unique identifier for the Client."""
-        return self._client_id
+        await self.close()
 
     @classmethod
     async def token_flow(cls, env: str, server_url: str):
@@ -278,7 +227,7 @@ class _Client:
             else:
                 client = _Client(server_url, client_type, credentials)
                 try:
-                    await client._start()
+                    await client.verify()
                 except AuthError:
                     if not credentials:
                         creds_missing_msg = (
@@ -290,7 +239,7 @@ class _Client:
                     else:
                         raise
                 cls._client_from_env = client
-                async_utils.on_shutdown(AioClient.stop_env_client())
+                async_utils.on_shutdown(AioClient.close_env_client())
                 return client
 
     @classmethod
@@ -299,10 +248,10 @@ class _Client:
         cls._client_from_env = client
 
     @classmethod
-    async def stop_env_client(cls):
+    async def close_env_client(cls):
         # Only called from atexit handler and from tests
         if cls._client_from_env is not None:
-            await cls._client_from_env._stop()
+            await cls._client_from_env.close()
             cls._client_from_env = None
 
 

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -290,7 +290,8 @@ class _Stub:
                 if mode == StubRunMode.SERVE:
                     # Cancel logs loop since we're going to start another one.
                     logs_loop.cancel()
-                await app.disconnect()
+                else:
+                    await app.disconnect()
 
         if mode == StubRunMode.DEPLOY:
             output_mgr.print_if_visible(step_completed("App deployed! 🎉"))
@@ -385,6 +386,7 @@ class _Stub:
                     event = await event_agen.__anext__()
         finally:
             await event_agen.aclose()
+            await app.disconnect()
 
     async def deploy(
         self,

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -290,8 +290,7 @@ class _Stub:
                 if mode == StubRunMode.SERVE:
                     # Cancel logs loop since we're going to start another one.
                     logs_loop.cancel()
-                else:
-                    await app.disconnect()
+                await app.disconnect()
 
         if mode == StubRunMode.DEPLOY:
             output_mgr.print_if_visible(step_completed("App deployed! 🎉"))
@@ -439,7 +438,7 @@ class _Stub:
             client = await _Client.from_env()
 
         # Look up any existing deployment
-        app_req = api_pb2.AppGetByDeploymentNameRequest(name=name, namespace=namespace, client_id=client.client_id)
+        app_req = api_pb2.AppGetByDeploymentNameRequest(name=name, namespace=namespace)
         app_resp = await client.stub.AppGetByDeploymentName(app_req)
         existing_app_id = app_resp.app_id or None
         last_log_entry_id = app_resp.last_log_entry_id

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -382,7 +382,6 @@ class _Stub:
                     output_mgr.print_if_visible(f"⚡️ Updating app {existing_app_id}...")
 
                 async with self._run(client, output_mgr, existing_app_id, mode=StubRunMode.SERVE) as app:
-                    client.set_pre_stop(app.disconnect)
                     existing_app_id = app.app_id
                     event = await event_agen.__anext__()
         finally:

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -113,7 +113,6 @@ message AppDeployResponse {
 message AppGetByDeploymentNameRequest {
   DeploymentNamespace namespace = 1;
   string name = 2;
-  string client_id = 3;  // todo, not strictly needed
 }
 
 message AppGetByDeploymentNameResponse {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -113,6 +113,7 @@ message AppDeployResponse {
 message AppGetByDeploymentNameRequest {
   DeploymentNamespace namespace = 1;
   string name = 2;
+  string client_id = 3 [deprecated=true];
 }
 
 message AppGetByDeploymentNameResponse {

--- a/modal_test_support/script.py
+++ b/modal_test_support/script.py
@@ -3,4 +3,4 @@ from .stub import f, stub
 
 if __name__ == "__main__":
     with stub.run():
-        assert f(2, 4) == 20
+        assert f.call(2, 4) == 20


### PR DESCRIPTION
This PR gets rid of the client_id and `ClientCreate`. It turns the `Client` into basically just a wrapper around a GRPC connection pool, with convenience functions for accessing the singleton and for verifying the connection.

Big reduction in total complexity imo. The only "state" left to manage is that we want to close the connection pool or else grpclib prints a warning.

Have been running a bunch of examples against prod with this client and it seems to work fine.