### PR TITLE
Bump client version to 0.45

### DIFF
--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -7,7 +7,7 @@ from ._version_generated import build_number  # Written by GitHub
 major_number = 0
 
 # Bump this manually on any major changes
-minor_number = 44
+minor_number = 45
 
 # Right now, set the patch number (the 3rd field) to the job run number in GitHub
 __version__ = f"{major_number}.{minor_number}.{build_number}"


### PR DESCRIPTION
Even though the client refactoring has already been released in the last release of 0.44 (it's on PyPI as [0.44.693](https://pypi.org/project/modal-client/0.44.693/)), let's bump the minor version to 0.45. That makes it easier to deprecate old clients in a few months.
