### PR TITLE
fix: restore .set_pre_stop because it succeeds in stopping served app

### DIFF
--- a/modal/stub.py
+++ b/modal/stub.py
@@ -20,7 +20,7 @@ from ._ipython import is_notebook
 from ._output import OutputManager, step_completed, step_progress
 from ._pty import exec_cmd, write_stdin_to_pty_stream
 from .app import _App, container_app, is_local
-from .client import _Client, HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT
+from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, _Client
 from .config import config, logger
 from .exception import InvalidError, deprecation_warning
 from .functions import _Function, _FunctionHandle
@@ -382,11 +382,11 @@ class _Stub:
                     output_mgr.print_if_visible(f"⚡️ Updating app {existing_app_id}...")
 
                 async with self._run(client, output_mgr, existing_app_id, mode=StubRunMode.SERVE) as app:
+                    client.set_pre_stop(app.disconnect)
                     existing_app_id = app.app_id
                     event = await event_agen.__anext__()
         finally:
             await event_agen.aclose()
-            await app.disconnect()
 
     async def deploy(
         self,


### PR DESCRIPTION
Removal of `set_pre_stop` technique broke app disconnect, meaning webhooks aren't stable again. Reintroducing the (hacky) technique because it does successfully shutdown the app immediately. 

Also this change deals with another issue I ran into. eg. 

```
=> Step 6: RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
Creating image snapshot...
Finished snapshot; took 5.1020998s
Finished image build for im-12345ichangedthis6890; took 40.968158297s
2023-01-06T19:55:00+0000 Logging cancelled
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /home/ubuntu/modal/dictexample.py:15 in <module>                                                 │
│                                                                                                  │
│   14 if __name__ == "__main__":                                                                  │
│ ❱ 15 │   stub.serve()                                                                            │
│   16                                                                                             │
│                                                                                                  │
│ /home/ubuntu/modal/venv/lib/python3.9/site-packages/synchronicity/synchronizer.py:412 in         │
│ proxy_method                                                                                     │
│                                                                                                  │
│ /home/ubuntu/modal-client/modal/stub.py:389 in serve                                             │
│                                                                                                  │
│   388 │   │   │   await event_agen.aclose()                                                      │
│ ❱ 389 │   │   │   await app.disconnect()                                                         │
│   390                                                                                            │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
AttributeError: 'NoneType' object has no attribute 'disconnect'
```

