### PR TITLE
UX: provide extra info to users about webhook label edge-cases

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -919,8 +919,17 @@ class _Function(Provider[_FunctionHandle]):
             raise
 
         if response.web_url:
+            # Ensure terms used here match terms used in modal.com/docs/guide/webhook-urls doc.
+            if response.web_url_info.truncated:
+                suffix = " [grey70](label truncated)[/grey70]"
+            elif response.web_url_info.has_unique_hash:
+                suffix = " [grey70](label includes conflict-avoidance hash)[/grey70]"
+            else:
+                suffix = ""
             # TODO: this is only printed when we're showing progress. Maybe move this somewhere else.
-            message_callback(f"Created {self._tag} => [magenta underline]{response.web_url}[/magenta underline]")
+            message_callback(
+                f"Created {self._tag} => [magenta underline]{response.web_url}[/magenta underline]{suffix}"
+            )
         else:
             message_callback(f"Created {self._tag}.")
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -379,6 +379,7 @@ message FunctionCreateRequest {
 message FunctionCreateResponse {
   string function_id = 1;
   string web_url = 2;
+  WebUrlInfo web_url_info = 3;
 }
 
 message FunctionGetInputsItem {
@@ -853,6 +854,11 @@ message WebhookConfig {
   bool wait_for_response = 3 [deprecated=true]; // rolled into async_mode - remove when ending support for 0.44
   string requested_suffix = 4;
   WebhookAsyncMode async_mode = 5;
+}
+
+message WebUrlInfo {
+  bool truncated = 1;
+  bool has_unique_hash = 2;
 }
 
 service ModalClient {


### PR DESCRIPTION
A bit of UX polish for the atypical cases where we need to deviate from standard webhook label construction. 