### PR TITLE
Write to stdout in smaller chunks

### DIFF
--- a/modal/_output.py
+++ b/modal/_output.py
@@ -355,8 +355,12 @@ class OutputManager:
                             else:
                                 # If we're not showing progress, there's no need to buffer lines,
                                 # because the progress spinner can't interfere with output.
-                                self.stdout.write(log.data)
-                                self.stdout.flush()
+                                #
+                                # Flush data in chunks because write is blocking.
+                                # TODO: make non-blocking write work.
+                                for i in range(0, len(log.data), 64):
+                                    self.stdout.write(log.data[i : i + 64])
+                                    self.stdout.flush()
             for stream in line_buffers.values():
                 stream.finalize()
 


### PR DESCRIPTION
Fixes interactive shell freezing when outputting data that's too large. Was happening because `.write()` on a blocking underlying buffer blocks forever, and we were trying to write a payload that was too large for some buffer somewhere in the middle. Surprisingly, larger chunk sizes are too large and run into the issue. This is despite Python claiming the buffer has size `8192`. 

Experimented with making stdout non-blocking, but it doesn't seem to work. Might come back to it. 