### PR TITLE
Use `buffer.write` for pty output

### DIFF
--- a/modal/_output.py
+++ b/modal/_output.py
@@ -3,7 +3,6 @@ import asyncio
 import contextlib
 import functools
 import io
-import os
 import platform
 import re
 import sys
@@ -361,11 +360,12 @@ class OutputManager:
                                 written = 0
                                 while written < len(data):
                                     try:
-                                        written += os.write(self.stdout.fileno(), data[written:])
+                                        written += self.stdout.buffer.write(data[written:])
                                         self.stdout.flush()
                                     except BlockingIOError:
+                                        pass
                                         # Just try again.
-                                        self.stdout.flush()
+                                        # self.stdout.flush()
             for stream in line_buffers.values():
                 stream.finalize()
 

--- a/modal/_output.py
+++ b/modal/_output.py
@@ -358,14 +358,17 @@ class OutputManager:
 
                                 data = log.data.encode("utf-8")
                                 written = 0
+                                n_retries = 0
                                 while written < len(data):
                                     try:
                                         written += self.stdout.buffer.write(data[written:])
                                         self.stdout.flush()
                                     except BlockingIOError:
-                                        pass
-                                        # Just try again.
-                                        # self.stdout.flush()
+                                        if n_retries >= 5:
+                                            raise
+                                        n_retries += 1
+                                        await asyncio.sleep(0.1)
+
             for stream in line_buffers.values():
                 stream.finalize()
 


### PR DESCRIPTION
Our internal integration tests use a `io.TextIOWrapper` that does not have a `fileno()` associated. This is slightly worse for normal use because each write either writes everything or nothing, but not by that much.