### PR TITLE
fix: handle non-app-IDs in 'app logs' command

### DIFF
--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -2,8 +2,9 @@
 import asyncio
 
 import typer
-from click import ClickException
+from click import ClickException, UsageError
 from google.protobuf import empty_pb2
+from grpclib import GRPCError, Status
 from rich.console import Console
 from rich.markdown import Markdown
 from rich.table import Table
@@ -100,6 +101,11 @@ def app_logs(app_id: str):
 
     try:
         sync_command()
+    except GRPCError as exc:
+        if exc.status in (Status.INVALID_ARGUMENT, Status.NOT_FOUND):
+            raise UsageError(exc.message)
+        else:
+            raise
     except KeyboardInterrupt:
         pass
 

--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -10,6 +10,7 @@ from tempfile import NamedTemporaryFile
 from typing import Optional, Tuple
 
 import typer
+from click import UsageError
 from google.protobuf import empty_pb2
 from grpclib import GRPCError, Status
 from rich.console import Console
@@ -89,8 +90,7 @@ async def ls(volume_name: str, path: str = typer.Argument(default="/")):
         entries = await volume.listdir(path)
     except GRPCError as exc:
         if exc.status in (Status.INVALID_ARGUMENT, Status.NOT_FOUND):
-            print(exc.message, file=sys.stderr)
-            return
+            raise UsageError(exc.message)
         raise
 
     if sys.stdout.isatty():


### PR DESCRIPTION
Following up https://modalbetatesters.slack.com/archives/C031Z7H15DG/p1673415690367319.

This doesn't add support for getting logs by app name or description, but it does do better error handling when a user gives an app name as argument. 