### PR TITLE
Add fn modal.Image.pip_install_private_repos

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -371,7 +371,7 @@ class _Image(Provider[_ImageHandle]):
                 f"Invalid refs: {invalid_repos}. "
             )
 
-        secret_names = ",".join([s.app_name if hasattr(s, "app_name") else str(s) for s in secrets])
+        secret_names = ",".join([s.app_name if hasattr(s, "app_name") else str(s) for s in secrets])  # type: ignore
         dockerfile_commands = [
             "FROM base",
             f"RUN bash -c \"[[ -v GITHUB_TOKEN ]] || (echo 'GITHUB_TOKEN env var not set by provided modal.Secret(s): {secret_names}' && exit 1)\"",

--- a/modal/image.py
+++ b/modal/image.py
@@ -326,12 +326,14 @@ class _Image(Provider[_ImageHandle]):
         """
         Install a list of Python packages from private git repositories using pip.
 
-        Currently supports Github only, and requires a modal.Secret be provided that
-        contains GITHUB_TOKEN key-value pair. This token should have permissions to read the
-        provided list of private repositories.
+        This method currently supports Github only, and requires a `modal.Secret` be provided that
+        contains a `GITHUB_TOKEN` key-value pair. This token should have permissions to read the
+        provided list of private Github repositories.
 
-        For Github it is recommended to use a "fine-grained" access tokens (beta). These tokens
-        are repo-scoped, and avoid granting read permission across all of a user's private repos.
+        We recommend using Github's ['fine-grained' access tokens](https://github.blog/2022-10-18-introducing-fine-grained-personal-access-tokens-for-github/).
+        These tokens are repo-scoped, and avoid granting read permission across all of a user's private repos.
+
+        **Example**
 
         ```python
         image = (
@@ -341,7 +343,9 @@ class _Image(Provider[_ImageHandle]):
                 "github.com/ecorp/private-one@1.0.0",
                 "github.com/ecorp/private-two@main"
                 "github.com/ecorp/private-three@d4776502"
-                "github.com/ecorp/private-four#subdirectory=inner",  # install from 'inner' on latest of default branch
+                # install from 'inner' directory on default branch.
+                "github.com/ecorp/private-four#subdirectory=inner",
+                git_user="erikbern",
                 secrets=[modal.Secret.from_name("github-read-private")],
             )
         )
@@ -352,13 +356,31 @@ class _Image(Provider[_ImageHandle]):
                 "No secrets provided to function. Installing private packages requires tokens to be passed via modal.Secret objects."
             )
 
-        # TODO: validate user inputs
+        def valid_repo_ref(repo_ref) -> bool:
+            if not isinstance(repo_ref, str):
+                return False
+            parts = repo_ref.split("/")
+            if parts[0] != "github.com":
+                return False
+            return True
 
+        invalid_repos = [r for r in repositories if not valid_repo_ref(r)]
+        if invalid_repos:
+            raise InvalidError(
+                f"{len(invalid_repos)} out of {len(repositories)} given repository refs are invalid. "
+                f"Invalid refs: {invalid_repos}. "
+            )
+
+        secret_names = ",".join([s.app_name if hasattr(s, "app_name") else str(s) for s in secrets])
         dockerfile_commands = [
             "FROM base",
-            "RUN apt-get update",
-            f"RUN apt-get install -y git",
+            f"RUN bash -c \"[[ -v GITHUB_TOKEN ]] || (echo 'GITHUB_TOKEN env var not set by provided modal.Secret(s): {secret_names}' && exit 1)\"",
+            "RUN apt-get update && apt-get install -y git",
         ] + [f"RUN python3 -m pip install git+https://{git_user}:$GITHUB_TOKEN@{repo_ref}" for repo_ref in repositories]
+        return self.extend(
+            dockerfile_commands=dockerfile_commands,
+            secrets=secrets,
+        )
 
     def pip_install_from_requirements(
         self,


### PR DESCRIPTION
**Best described by the docs:**

(http://localhost:7601/docs/reference/modal.Image)

<img width="697" alt="image" src="https://user-images.githubusercontent.com/12058921/212408929-f11bc406-b4ba-43e7-9ce3-542d97d6eff1.png">

Works when I copy https://github.com/pypa/sampleproject into a private repo and install it with this function:

```
=> Step 3: RUN python3 -m pip install git+https://thundergolfer:$GITHUB_TOKEN@github.com/thundergolfer/sample-private-py-package@main
Collecting git+https://thundergolfer:****@github.com/thundergolfer/sample-private-py-package@main
  Cloning https://thundergolfer:****@github.com/thundergolfer/sample-private-py-package (to revision main) to /tmp/pip-req-build-mfora99g
  Running command git clone --filter=blob:none --quiet 'https://thundergolfer:****@github.com/thundergolfer/sample-private-py-package' /tmp/pip-req-build-mfora99g
  Resolved https://thundergolfer:****@github.com/thundergolfer/sample-private-py-package to commit d4776502bbf01f6265510eb806dd0a7e1e917fb4
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Collecting peppercorn
  Downloading peppercorn-0.6-py3-none-any.whl (4.8 kB)
Building wheels for collected packages: sample-private-package
  Building wheel for sample-private-package (pyproject.toml): started
  Building wheel for sample-private-package (pyproject.toml): finished with status 'done'
  Created wheel for sample-private-package: filename=sample_private_package-0.0.2-py3-none-any.whl size=2305 sha256=ac73575c6ac79aab2a730cc1f9584df8b2865cb78edaee71173161c8dd7c51d0
  Stored in directory: /tmp/pip-ephem-wheel-cache-twdjpeh3/wheels/73/b4/c3/94938784ead20fd8eee87912e42254a723ef52160af78e5e2d
Successfully built sample-private-package
Installing collected packages: peppercorn, sample-private-package
Successfully installed peppercorn-0.6 sample-private-package-0.0.2
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
Creating image snapshot...
Finished snapshot; took 196.111459ms
Finished image build for im-yjlnknacyqwfmshakckjofzwxvjh; took 10.41357161s
✓ Created objects.
├── 🔨 Created testit.
└── 🔨 Mounted /home/ubuntu/modal/test_in_modal.py at /root
Done! Adding one to 12 produces 13
✓ App completed.
```