### PR TITLE
fix: docs build err ->  'ParseError: Expected }'

### DIFF
--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -146,7 +146,7 @@ Registered functions and local entrypoints on the selected stub are:
 
 STUB_REF should be of the format:
 
-{file or module}[::[{stub name}].{function name}]
+`{file or module}[::[{stub name}].{function name}]`
 
 Examples:
 To run the hello_world function (or local entrypoint) of stub `stub` in my_app.py:


### PR DESCRIPTION
More err context: 

```
 10 |  <p>Run a Modal function or local entrypoint</p>
 11 |  <p>STUB_REF should be of the format:</p>
 12 |  <p>{file or module}[::[{stub name}].{function name}]</p>
                ^
 13 |  <p>Examples:
 14 |  To run the hello_world function (or local entrypoint) of stub <code>stub</code> in my_app.py:</p>
error during build:
ParseError: Expected }
    at error (file:///home/ubuntu/modal/frontend/node_modules/svelte/compiler.mjs:16669:19)
    at Parser$1.error (file:///home/ubuntu/modal/frontend/node_modules/svelte/compiler.mjs:16747:9)
```

Kind of a workaround, but it does fix things locally for me. 