### PR TITLE
FunctionCreateResponse returns the created function

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -367,6 +367,9 @@ message Function {
   CloudProvider cloud_provider = 26;
 
   uint32 warm_pool_size = 27;
+
+  string web_url = 28;
+  WebUrlInfo web_url_info = 29;
 }
 
 message FunctionCreateRequest {
@@ -378,8 +381,9 @@ message FunctionCreateRequest {
 
 message FunctionCreateResponse {
   string function_id = 1;
-  string web_url = 2;
-  WebUrlInfo web_url_info = 3;
+  string web_url = 2;  // TODO(erikbern): deprecated shortly (moving it into Function)
+  WebUrlInfo web_url_info = 3;  // TODO(erikbern): deprecated shortly (moving it into Function)
+  Function function = 4;
 }
 
 message FunctionGetInputsItem {


### PR DESCRIPTION
The idea is that `FunctionCreateResponse` contains the created function protobuf, and we'll initialize the function object from that. That way we can unify the function construction logic, as well as solving a problem looking up `web_url` inside containers.

I need to make this change first, then update the server code, then update the client again to initialize from the result.