### PR TITLE
unify function construction

### DIFF
--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -133,7 +133,10 @@ class MockClientServicer(api_grpc.ModalClientBase):
     async def AppGetObjects(self, stream):
         request: api_pb2.AppGetObjectsRequest = await stream.recv_message()
         object_ids = self.app_objects.get(request.app_id, {})
-        items = [api_pb2.AppGetObjectsItem(tag=tag, object_id=object_id) for tag, object_id in object_ids.items()]
+        items = [
+            api_pb2.AppGetObjectsItem(tag=tag, object_id=object_id, function=self.app_functions.get(object_id))
+            for tag, object_id in object_ids.items()
+        ]
         await stream.send_message(api_pb2.AppGetObjectsResponse(items=items))
 
     async def AppSetObjects(self, stream):

--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -251,13 +251,13 @@ class MockClientServicer(api_grpc.ModalClientBase):
             function_id = f"fu-{self.n_functions}"
         if request.schedule:
             self.function2schedule[function_id] = request.schedule
-        if request.function.webhook_config.type:
-            web_url = "http://xyz.internal"
-        else:
-            web_url = None
+        function = api_pb2.Function()
+        function.CopyFrom(request.function)
+        if function.webhook_config.type:
+            function.web_url = "http://xyz.internal"
 
-        self.app_functions[function_id] = request.function
-        await stream.send_message(api_pb2.FunctionCreateResponse(function_id=function_id, web_url=web_url))
+        self.app_functions[function_id] = function
+        await stream.send_message(api_pb2.FunctionCreateResponse(function_id=function_id, function=function))
 
     async def FunctionMap(self, stream):
         self.fcidx += 1

--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -163,7 +163,8 @@ class MockClientServicer(api_grpc.ModalClientBase):
                 object_id = app_objects.get(request.object_tag)
             else:
                 (object_id,) = list(app_objects.values())
-        await stream.send_message(api_pb2.AppLookupObjectResponse(object_id=object_id))
+        function = self.app_functions.get(object_id)
+        await stream.send_message(api_pb2.AppLookupObjectResponse(object_id=object_id, function=function))
 
     async def AppHeartbeat(self, stream):
         request: api_pb2.ClientHeartbeatRequest = await stream.recv_message()

--- a/client_test/lookup_test.py
+++ b/client_test/lookup_test.py
@@ -37,3 +37,13 @@ async def test_lookup_function(servicer, aio_client):
     # Make sure we can call this function
     assert await f.call(2, 4) == 20
     assert [r async for r in f.map([5, 2], [4, 3])] == [41, 13]
+
+
+@pytest.mark.asyncio
+async def test_webhook_lookup(servicer, aio_client):
+    stub = AioStub()
+    stub.webhook(square, method="POST")
+    await stub.deploy("my-webhook", client=aio_client)
+
+    f = await aio_lookup("my-webhook", client=aio_client)
+    assert f.web_url

--- a/client_test/webhook_test.py
+++ b/client_test/webhook_test.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 import pytest
 
-from modal.aio import AioStub
+from modal.aio import AioApp, AioStub
 
 stub = AioStub()
 
@@ -13,8 +13,12 @@ async def f(x):
 
 @pytest.mark.asyncio
 async def test_webhook(servicer, aio_client):
-    async with stub.run(client=aio_client):
+    async with stub.run(client=aio_client) as app:
         assert f.web_url
+
+        # Make sure the container gets the app id as well
+        container_app = await AioApp._init_container(aio_client, app.app_id)
+        assert container_app.f.web_url
 
 
 def test_webhook_cors():

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -114,7 +114,7 @@ class _FunctionIOManager:
 
     @wrap()
     async def initialize_app(self):
-        await _App._init_container(self._client, self.app_id, self.task_id)
+        await _App._init_container(self._client, self.app_id)
 
     async def _heartbeat(self):
         request = api_pb2.ContainerHeartbeatRequest()

--- a/modal/_serialization.py
+++ b/modal/_serialization.py
@@ -29,7 +29,9 @@ class Unpickler(pickle.Unpickler):
 
     def persistent_load(self, pid):
         object_id = pid
-        return Handle._from_id(object_id, self.client)
+        # TODO(erikbern): we should get the proto somehow,
+        # for functions
+        return Handle._from_id(object_id, self.client, None)
 
 
 def serialize(obj):

--- a/modal/app.py
+++ b/modal/app.py
@@ -193,9 +193,6 @@ class _App:
         resp = await retry_transient_errors(self._client.stub.AppGetObjects, req)
         for item in resp.items:
             obj = Handle._from_id(item.object_id, self._client)
-            if isinstance(obj, _FunctionHandle):
-                # TODO(erikbern): treating this as a special case right now, but we should generalize it
-                obj._initialize_from_proto(item.function)
             self._tag_to_object[item.tag] = obj
 
         if "image" not in self._tag_to_object:

--- a/modal/app.py
+++ b/modal/app.py
@@ -7,7 +7,6 @@ from modal_utils.grpc_utils import retry_transient_errors
 
 from .client import _Client
 from .config import logger
-from .functions import _FunctionHandle
 from .object import Handle, Provider
 
 if TYPE_CHECKING:

--- a/modal/app.py
+++ b/modal/app.py
@@ -180,7 +180,7 @@ class _App:
         return self._tag_to_object[tag]
 
     @staticmethod
-    async def _init_container(client, app_id, task_id):
+    async def _init_container(client, app_id):
         """Used by the container to bootstrap the app and all its objects."""
         # This is a bit of a hacky thing:
         global _container_app, _is_container_app
@@ -189,10 +189,10 @@ class _App:
         self._client = client
         self._app_id = app_id
 
-        req = api_pb2.AppGetObjectsRequest(app_id=app_id, task_id=task_id)
+        req = api_pb2.AppGetObjectsRequest(app_id=app_id)
         resp = await retry_transient_errors(self._client.stub.AppGetObjects, req)
         for item in resp.items:
-            obj = Handle._from_id(item.object_id, self._client)
+            obj = Handle._from_id(item.object_id, self._client, item.function)
             self._tag_to_object[item.tag] = obj
 
         if "image" not in self._tag_to_object:

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -22,6 +22,7 @@ from typing import (
 
 import cloudpickle
 from aiostream import pipe, stream
+from google.protobuf.message import Message
 from grpclib import GRPCError, Status
 from synchronicity.exceptions import UserCodeException
 
@@ -428,8 +429,10 @@ class _FunctionHandle(Handle, type_prefix="fu"):
     def _set_mute_cancellation(self, value=True):
         self._mute_cancellation = value
 
-    def _initialize_from_proto(self, function: api_pb2.Function):
-        self._is_generator = function.function_type == api_pb2.Function.FUNCTION_TYPE_GENERATOR
+    def _initialize_from_proto(self, proto: Message):
+        assert isinstance(proto, api_pb2.Function)
+        self._is_generator = proto.function_type == api_pb2.Function.FUNCTION_TYPE_GENERATOR
+        self._web_url = proto.web_url
         self._mute_cancellation = False
         self._output_mgr = None
 
@@ -939,7 +942,7 @@ class _Function(Provider[_FunctionHandle]):
         else:
             message_callback(f"Created {self._tag}.")
 
-        return _FunctionHandle(self, response.web_url, client, response.function_id)
+        return _FunctionHandle._from_id(response.function_id, client, response.function)
 
     @property
     def tag(self):

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -475,11 +475,6 @@ class _FunctionHandle(Handle, type_prefix="fu"):
     @property
     def web_url(self) -> str:
         """URL of a Function running as a web endpoint."""
-        from modal import is_local
-
-        if not is_local():
-            raise InvalidError("Function.web_url is not accessible from inside a container")
-
         function_handle = self._get_live_handle()
         return function_handle._web_url
 

--- a/modal/image.py
+++ b/modal/image.py
@@ -149,7 +149,7 @@ class _Image(Provider[_ImageHandle]):
     async def _load(self, client, stub, app_id, loader, message_callback, existing_image_id):
         if self._ref:
             image_id = await loader(self._ref)
-            return _ImageHandle._from_id(image_id, client)
+            return _ImageHandle._from_id(image_id, client, None)
 
         # Recursively build base images
         base_image_ids: list[str] = []

--- a/modal/object.py
+++ b/modal/object.py
@@ -40,7 +40,7 @@ class Handle(metaclass=ObjectMeta):
 
     def _initialize_from_proto(self, proto: Message):
         pass  # default implementation
-        
+
     @staticmethod
     def _from_id(object_id: str, client: _Client, proto: Optional[Message]):
         parts = object_id.split("-")

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -132,7 +132,6 @@ message AppGetLogsRequest {
 
 message AppGetObjectsRequest {
   string app_id = 1;
-  string task_id = 2;
 }
 
 message AppGetObjectsItem {


### PR DESCRIPTION
This unifies how functions are initialized from protos, and fixes the issue where [web_url can't be read inside the container](https://github.com/modal-labs/modal-client/pull/204/files)

There is more work to be done, since we still initialize `_FunctionHandle` in other places, meaning not all construction is unified. Will follow up with more!