### PR TITLE
Remove all Ref classes

### DIFF
--- a/client_test/object_test.py
+++ b/client_test/object_test.py
@@ -16,6 +16,8 @@ async def test_async_factory(servicer, client):
 @pytest.mark.asyncio
 async def test_use_object(servicer, client):
     stub = AioStub()
-    stub["my_q"] = AioQueue.from_name("foo-queue")
+    q = AioQueue.from_name("foo-queue")
+    assert isinstance(q, AioQueue)
+    stub["my_q"] = q
     async with stub.run(client=client) as running_app:
         assert running_app["my_q"].object_id == "qu-foo"

--- a/modal/_watcher.py
+++ b/modal/_watcher.py
@@ -66,10 +66,11 @@ async def watch(stub: _Stub, output_mgr: OutputManager, timeout: Optional[float]
         if isinstance(object, _Function):
             for mount in object._mounts:
                 if isinstance(mount, _Mount):
-                    if mount._local_dir is not None:
-                        paths.add(mount._local_dir)
-                    elif mount._local_file is not None:
-                        paths.add(mount._local_file)
+                    # TODO(erikbern): this is pretty ugly, but we want to ignore
+                    # any _Mount that's just a remote reference. Let's rethink this.
+                    for attr in ["_local_dir", "_local_file"]:
+                        if getattr(mount, attr, None):
+                            paths.add(getattr(mount, attr))
 
     _print_watched_paths(paths, output_mgr, timeout)
 

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -137,7 +137,7 @@ class _Dict(Provider[_DictHandle]):
     def __init__(self, data={}):
         """Create a new dictionary, optionally filled with initial data."""
         self._data = data
-        super().__init__(self._load)
+        super().__init__(self._load, "Dict()")
 
     async def _load(self, resolver: Resolver):
         serialized = _serialize_dict(self._data)

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -137,7 +137,7 @@ class _Dict(Provider[_DictHandle]):
     def __init__(self, data={}):
         """Create a new dictionary, optionally filled with initial data."""
         self._data = data
-        super().__init__()
+        super().__init__(self._load)
 
     async def _load(self, resolver: Resolver):
         serialized = _serialize_dict(self._data)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -55,7 +55,8 @@ from .exception import deprecation_error, deprecation_warning
 from .gpu import GPU_T, parse_gpu_config
 from .image import _Image
 from .mount import _Mount
-from .object import Handle, Provider, Ref
+from .object import Handle, Provider
+from .proxy import _Proxy
 from .rate_limit import RateLimit
 from .retries import Retries
 from .schedule import Schedule
@@ -699,7 +700,7 @@ class _Function(Provider[_FunctionHandle]):
         shared_volumes: Dict[str, _SharedVolume] = {},
         webhook_config: Optional[api_pb2.WebhookConfig] = None,
         memory: Optional[int] = None,
-        proxy: Optional[Ref] = None,
+        proxy: Optional[_Proxy] = None,
         retries: Optional[Union[int, Retries]] = None,
         timeout: Optional[int] = None,
         concurrency_limit: Optional[int] = None,

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -782,7 +782,8 @@ class _Function(Provider[_FunctionHandle]):
                 raise InvalidError("Cloud selection only supported for functions running with A100 GPUs.")
         else:
             self._cloud_provider = None
-        super().__init__(self._load)
+        rep = "Function({self._tag})"
+        super().__init__(self._load, rep)
 
     async def _load(self, resolver: Resolver):
         resolver.set_message(f"Creating {self._tag}...")
@@ -807,8 +808,8 @@ class _Function(Provider[_FunctionHandle]):
             try:
                 secret_id = await resolver.load(secret)
             except NotFoundError as ex:
-                if isinstance(secret, _Secret) and secret.tag is None:
-                    msg = "Secret {!r} was not found".format(secret.app_name)
+                if isinstance(secret, _Secret):
+                    msg = f"Secret {secret} was not found"
                 else:
                     msg = str(ex)
                 msg += ". You can add secrets to your account at https://modal.com/secrets"

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -55,7 +55,7 @@ from .exception import deprecation_error, deprecation_warning
 from .gpu import GPU_T, parse_gpu_config
 from .image import _Image
 from .mount import _Mount
-from .object import Handle, Provider, Ref, RemoteRef
+from .object import Handle, Provider, Ref
 from .rate_limit import RateLimit
 from .retries import Retries
 from .schedule import Schedule
@@ -806,7 +806,7 @@ class _Function(Provider[_FunctionHandle]):
             try:
                 secret_id = await resolver.load(secret)
             except NotFoundError as ex:
-                if isinstance(secret, RemoteRef) and secret.tag is None:
+                if isinstance(secret, _Secret) and secret.tag is None:
                     msg = "Secret {!r} was not found".format(secret.app_name)
                 else:
                     msg = str(ex)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -781,7 +781,7 @@ class _Function(Provider[_FunctionHandle]):
                 raise InvalidError("Cloud selection only supported for functions running with A100 GPUs.")
         else:
             self._cloud_provider = None
-        super().__init__()
+        super().__init__(self._load)
 
     async def _load(self, resolver: Resolver):
         resolver.set_message(f"Creating {self._tag}...")

--- a/modal/image.py
+++ b/modal/image.py
@@ -143,10 +143,8 @@ class _Image(Provider[_ImageHandle]):
         self._gpu = gpu
         self._build_function = build_function
         self._context_mount = context_mount
-        super().__init__(self._load)
-
-    def __repr__(self):
-        return f"Image({self._dockerfile_commands})"
+        rep = f"Image({self._dockerfile_commands})"
+        super().__init__(self._load, rep)
 
     async def _load(self, resolver: Resolver):
         if self._ref:

--- a/modal/image.py
+++ b/modal/image.py
@@ -143,7 +143,7 @@ class _Image(Provider[_ImageHandle]):
         self._gpu = gpu
         self._build_function = build_function
         self._context_mount = context_mount
-        super().__init__()
+        super().__init__(self._load)
 
     def __repr__(self):
         return f"Image({self._dockerfile_commands})"

--- a/modal/image.py
+++ b/modal/image.py
@@ -19,7 +19,7 @@ from ._resolver import Resolver
 from .config import config, logger
 from .exception import InvalidError, NotFoundError, RemoteError
 from .mount import _Mount
-from .object import Handle, Provider, Ref
+from .object import Handle, Provider
 from .secret import _Secret
 
 
@@ -129,10 +129,10 @@ class _Image(Provider[_ImageHandle]):
             raise InvalidError("Cannot run a build function with multiple base images!")
 
         for secret in secrets:
-            if not isinstance(secret, _Secret) and not isinstance(secret, Ref):
+            if not isinstance(secret, _Secret):
                 raise InvalidError(f"Secret {secret!r} must be a modal.Secret object")
 
-        if context_mount is not None and not isinstance(context_mount, _Mount) and not isinstance(context_mount, Ref):
+        if context_mount is not None and not isinstance(context_mount, _Mount):
             raise InvalidError(f"Context mount {context_mount!r} must be a modal.Mount object")
 
         self._ref = ref

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -78,7 +78,7 @@ class _Mount(Provider[_MountHandle]):
         self._remote_dir = remote_dir
         self._condition = condition
         self._recursive = recursive
-        super().__init__()
+        super().__init__(self._load)
 
     def __repr__(self):
         return f"Mount({self._local_file or self._local_dir})"

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -78,10 +78,8 @@ class _Mount(Provider[_MountHandle]):
         self._remote_dir = remote_dir
         self._condition = condition
         self._recursive = recursive
-        super().__init__(self._load)
-
-    def __repr__(self):
-        return f"Mount({self._local_file or self._local_dir})"
+        rep = f"Mount({self._local_file or self._local_dir})"
+        super().__init__(self._load, rep)
 
     async def _get_files(self):
         if self._local_file:

--- a/modal/object.py
+++ b/modal/object.py
@@ -110,9 +110,13 @@ P = TypeVar("P", bound="Provider")
 
 
 class Provider(Generic[H]):
-    def __init__(self, load: Callable[[Resolver], Awaitable[None]]):
+    def __init__(self, load: Callable[[Resolver], Awaitable[H]], rep: str):
         self._local_uuid = str(uuid.uuid4())
         self._load = load
+        self._rep = rep
+
+    def __repr__(self):
+        return self._rep
 
     @property
     def local_uuid(self):
@@ -139,6 +143,7 @@ class Provider(Generic[H]):
         ```
 
         """
+
         async def _load_persisted(resolver: Resolver) -> H:
             from .stub import _Stub
 
@@ -150,7 +155,8 @@ class Provider(Generic[H]):
         # Create a class of type cls, but use the base constructor
         cls = type(self)
         obj = cls.__new__(cls)
-        Provider.__init__(obj, _load_persisted)
+        rep = f"PersistedRef<{self}>({label})"
+        Provider.__init__(obj, _load_persisted, rep)
         return obj
 
     @classmethod
@@ -179,5 +185,6 @@ class Provider(Generic[H]):
         # Create a class of type cls, but use the base constructor
         # TODO(erikbern): No Provider subclass should override __init__
         obj = cls.__new__(cls)
-        Provider.__init__(obj, _load_remote)
+        rep = f"Ref({app_name})"
+        Provider.__init__(obj, _load_remote, rep)
         return obj

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -134,8 +134,9 @@ class _Queue(Provider[_QueueHandle]):
 
     The queue can contain any object serializable by `cloudpickle`.
     """
+
     def __init__(self):
-        super().__init__(self._load)
+        super().__init__(self._load, "Queue()")
 
     async def _load(self, resolver: Resolver):
         request = api_pb2.QueueCreateRequest(app_id=resolver.app_id, existing_queue_id=resolver.existing_object_id)

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -134,6 +134,8 @@ class _Queue(Provider[_QueueHandle]):
 
     The queue can contain any object serializable by `cloudpickle`.
     """
+    def __init__(self):
+        super().__init__(self._load)
 
     async def _load(self, resolver: Resolver):
         request = api_pb2.QueueCreateRequest(app_id=resolver.app_id, existing_queue_id=resolver.existing_object_id)

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -26,7 +26,7 @@ class _Secret(Provider[_SecretHandle]):
     def __init__(self, env_dict={}, template_type=""):
         self._env_dict = env_dict
         self._template_type = template_type
-        super().__init__()
+        super().__init__(self._load)
 
     def __repr__(self):
         return f"Secret([{', '.join(self._env_dict.keys())}])"

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -26,10 +26,8 @@ class _Secret(Provider[_SecretHandle]):
     def __init__(self, env_dict={}, template_type=""):
         self._env_dict = env_dict
         self._template_type = template_type
-        super().__init__(self._load)
-
-    def __repr__(self):
-        return f"Secret([{', '.join(self._env_dict.keys())}])"
+        rep = f"Secret([{', '.join(self._env_dict.keys())}])"
+        super().__init__(self._load, rep)
 
     async def _load(self, resolver: Resolver):
         req = api_pb2.SecretCreateRequest(

--- a/modal/shared_volume.py
+++ b/modal/shared_volume.py
@@ -111,19 +111,15 @@ class _SharedVolume(Provider[_SharedVolumeHandle]):
     def __init__(self, cloud_provider: "Optional[api_pb2.CloudProvider.V]" = None) -> None:
         """Construct a new shared volume, which is empty by default."""
         self._cloud_provider = cloud_provider
-        super().__init__(self._load)
-
-    def __repr__(self):
-        return "SharedVolume()"
-
-    def _get_creating_message(self) -> str:
-        return "Creating shared volume..."
+        rep = "SharedVolume()"
+        super().__init__(self._load, rep)
 
     async def _load(self, resolver: Resolver):
         if resolver.existing_object_id:
             # Volume already exists; do nothing.
             return _SharedVolumeHandle(resolver.client, resolver.existing_object_id)
 
+        resolver.set_message("Creating shared volume...")
         req = api_pb2.SharedVolumeCreateRequest(app_id=resolver.app_id, cloud_provider=self._cloud_provider)
         resp = await retry_transient_errors(resolver.client.stub.SharedVolumeCreate, req)
         resolver.set_message("Created shared volume.")

--- a/modal/shared_volume.py
+++ b/modal/shared_volume.py
@@ -111,7 +111,7 @@ class _SharedVolume(Provider[_SharedVolumeHandle]):
     def __init__(self, cloud_provider: "Optional[api_pb2.CloudProvider.V]" = None) -> None:
         """Construct a new shared volume, which is empty by default."""
         self._cloud_provider = cloud_provider
-        super().__init__()
+        super().__init__(self._load)
 
     def __repr__(self):
         return "SharedVolume()"

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -30,7 +30,8 @@ from .functions import _Function, _FunctionHandle
 from .gpu import GPU_T
 from .image import _Image
 from .mount import _create_client_mount, _Mount, client_mount_name
-from .object import Provider, Ref
+from .object import Provider
+from .proxy import _Proxy
 from .queue import _Queue
 from .rate_limit import RateLimit
 from .schedule import Schedule
@@ -597,7 +598,7 @@ class _Stub:
         shared_volumes: Dict[str, _SharedVolume] = {},
         cpu: Optional[float] = None,  # How many CPU cores to request. This is a soft limit.
         memory: Optional[int] = None,  # How much memory to request, in MB. This is a soft limit.
-        proxy: Optional[Ref] = None,  # Reference to a Modal Proxy to use in front of this function.
+        proxy: Optional[_Proxy] = None,  # Reference to a Modal Proxy to use in front of this function.
         retries: Optional[int] = None,  # Number of times to retry each input in case of failure.
         concurrency_limit: Optional[int] = None,  # Limit for max concurrent containers running the function.
         container_idle_timeout: Optional[int] = None,  # Timeout for idle containers waiting for inputs to shut down.
@@ -679,7 +680,7 @@ class _Stub:
         shared_volumes: Dict[str, _SharedVolume] = {},
         cpu: Optional[float] = None,  # How many CPU cores to request. This is a soft limit.
         memory: Optional[int] = None,  # How much memory to request, in MB. This is a soft limit.
-        proxy: Optional[Ref] = None,  # Reference to a Modal Proxy to use in front of this function.
+        proxy: Optional[_Proxy] = None,  # Reference to a Modal Proxy to use in front of this function.
         retries: Optional[int] = None,  # Number of times to retry each input in case of failure.
         concurrency_limit: Optional[int] = None,  # Limit for max concurrent containers running the function.
         container_idle_timeout: Optional[int] = None,  # Timeout for idle containers waiting for inputs to shut down.
@@ -760,7 +761,7 @@ class _Stub:
         shared_volumes: Dict[str, _SharedVolume] = {},
         cpu: Optional[float] = None,  # How many CPU cores to request. This is a soft limit.
         memory: Optional[int] = None,  # How much memory to request, in MB. This is a soft limit.
-        proxy: Optional[Ref] = None,  # Reference to a Modal Proxy to use in front of this function.
+        proxy: Optional[_Proxy] = None,  # Reference to a Modal Proxy to use in front of this function.
         retries: Optional[int] = None,  # Number of times to retry each input in case of failure.
         concurrency_limit: Optional[int] = None,  # Limit for max concurrent containers running the function.
         container_idle_timeout: Optional[int] = None,  # Timeout for idle containers waiting for inputs to shut down.


### PR DESCRIPTION
This removes the special `Ref`, `RemoteRef`, and `PersistedRef`. Going forward, `Secret.from_name("my-secret")` will return an object of type `Secret`, not `RemoteRef` as previously. This both simplifies the code a bit, and removes some runtime type inconsistencies (we had several places with checks similar to `isinstance(obj, Secret) or isinstance(obj, Ref)`.

The trick is for the `Provider` classes to store a constructor function on the instance, rather than having a per-class overloaded abstract method. This means you can create any subclass of Provider with any construction logic.

This change makes the `Provider` class pretty "dumb", and less useful on its own – any subclass of `Provider[H]` is basically just a bunch of class methods that returns `Handle` creation closures. So we can potentially remove the Provider classes later.