### PR TITLE
Add back object.from_id

### DIFF
--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -305,3 +305,11 @@ def test_closure_valued_serialized_function(client, servicer):
     assert len(functions) == 2
     assert functions["ret_foo"]() == "foo"
     assert functions["ret_bar"]() == "bar"
+
+
+def test_from_id(client, servicer):
+    # obj = Function.from_id("fu-123", client)
+    # assert obj.object_id == "fu-123"
+
+    obj = FunctionCall.from_id("fc-123", client)
+    assert obj.object_id == "fc-123"

--- a/modal/object.py
+++ b/modal/object.py
@@ -51,6 +51,14 @@ class Handle(metaclass=ObjectMeta):
             obj._initialize_from_proto(proto)
         return obj
 
+    @classmethod
+    async def from_id(cls, object_id: str, client: Optional[_Client] = None):
+        # TODO(erikbern): doesn't use _initialize_from_proto - let's use AppLookupObjectRequest?
+        # TODO(erikbern): this should probably be on the provider?
+        if client is None:
+            client = await _Client.from_env()
+        return cls._from_id(object_id, client, None)
+
     @property
     def object_id(self):
         return self._object_id

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -166,6 +166,7 @@ message AppLookupObjectRequest {
   DeploymentNamespace namespace = 2;
   string app_name = 3;
   string object_tag = 4;
+  string object_id = 5;
 }
 
 message AppLookupObjectResponse {


### PR DESCRIPTION
I removed it in https://github.com/modal-labs/modal-client/pull/210 but shouldn't have done that – it's used in a few places.

It's not entirely correct though. We should use `initialize_from_proto` with it. I'll have to modify `AppLookupObject` for that a bit though.

It's also a bit strange that this is on the handle not the provider. I think it's used in 1 or 2 examples with FunctionCall only. Let's maybe revisit later.