### PR TITLE
Add an asyncify() function to async_utils

### DIFF
--- a/modal_utils/async_utils.py
+++ b/modal_utils/async_utils.py
@@ -321,8 +321,8 @@ def asyncify(f: Callable[P, T]) -> Callable[P, Awaitable[T]]:
     """Convert a blocking function into one that runs in the current loop's executor."""
 
     @functools.wraps(f)
-    async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> Awaitable[T]:
         loop = asyncio.get_running_loop()
-        loop.run_in_executor(None, functools.partial(f, *args, **kwargs))
+        return loop.run_in_executor(None, functools.partial(f, *args, **kwargs))
 
     return wrapper

--- a/modal_utils/async_utils.py
+++ b/modal_utils/async_utils.py
@@ -4,7 +4,8 @@ import concurrent.futures
 import functools
 import inspect
 import time
-from typing import Any, List, Optional, Set
+from typing import Any, Awaitable, Callable, List, Optional, Set, TypeVar
+from typing_extensions import ParamSpec
 
 import synchronicity
 
@@ -310,3 +311,18 @@ def on_shutdown(coro):
             raise
 
     asyncio.create_task(wrapper())
+
+
+T = TypeVar("T")
+P = ParamSpec("P")
+
+
+def asyncify(f: Callable[P, T]) -> Callable[P, Awaitable[T]]:
+    """Convert a blocking function into one that runs in the current loop's executor."""
+
+    @functools.wraps(f)
+    async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+        loop = asyncio.get_running_loop()
+        loop.run_in_executor(None, functools.partial(f, *args, **kwargs))
+
+    return wrapper


### PR DESCRIPTION
This function is used like

```python
output = await asyncify(f)(*args, **kwargs)
```

and is roughly equivalent to just:

```python
output = await asyncio.get_running_loop().run_in_executor(None, lambda: f(*args, **kwargs))`
```

It can be used both inline and as a decorator.