### PR TITLE
Adds clear_on_success flag for FunctionGetOutputs

### DIFF
--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -95,6 +95,8 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
         self.dicts = {}
 
+        self.cleared_function_calls = set()
+
         @self.function_body
         def default_function_body(*args, **kwargs):
             return sum(arg**2 for arg in args) + sum(value**2 for key, value in kwargs.items())
@@ -301,12 +303,13 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def FunctionGetOutputs(self, stream):
         request: api_pb2.FunctionGetOutputsRequest = await stream.recv_message()
+        if request.clear_on_success:
+            self.cleared_function_calls.add(request.function_call_id)
 
         client_calls = self.client_calls.get(request.function_call_id, [])
         if client_calls and not self.function_is_running:
             popidx = len(client_calls) // 2  # simulate that results don't always come in order
             (idx, input_id), (args, kwargs) = client_calls.pop(popidx)
-            # Just return the sum of squares of all args
             try:
                 res = self._function_body(*args, **kwargs)
             except Exception as exc:
@@ -324,15 +327,20 @@ class MockClientServicer(api_grpc.ModalClientBase):
             if inspect.iscoroutine(res):
                 results = [await res]
             elif inspect.isgenerator(res):
-                results = list(res)
+                results = res
             else:
                 results = [res]
 
             outputs = []
             for index, value in enumerate(results):
+                gen_status = api_pb2.GenericResult.GENERATOR_STATUS_UNSPECIFIED
+                if inspect.isgenerator(res):
+                    gen_status = api_pb2.GenericResult.GENERATOR_STATUS_INCOMPLETE
+
                 result = api_pb2.GenericResult(
                     status=api_pb2.GenericResult.GENERIC_STATUS_SUCCESS,
                     data=cloudpickle.dumps(value),
+                    gen_status=gen_status,
                 )
                 item = api_pb2.FunctionGetOutputsItem(
                     input_id=input_id,
@@ -341,6 +349,17 @@ class MockClientServicer(api_grpc.ModalClientBase):
                     gen_index=index,
                 )
                 outputs.append(item)
+
+            if inspect.isgenerator(res):
+                finish_item = api_pb2.FunctionGetOutputsItem(
+                    input_id=input_id,
+                    idx=idx,
+                    result=api_pb2.GenericResult(
+                        status=api_pb2.GenericResult.GENERIC_STATUS_SUCCESS,
+                        gen_status=api_pb2.GenericResult.GENERATOR_STATUS_COMPLETE,
+                    ),
+                )
+                outputs.append(finish_item)
 
             await stream.send_message(api_pb2.FunctionGetOutputsResponse(outputs=outputs))
         else:

--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -327,7 +327,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
             if inspect.iscoroutine(res):
                 results = [await res]
             elif inspect.isgenerator(res):
-                results = res
+                results = list(res)
             else:
                 results = [res]
 

--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -116,7 +116,7 @@ def test_function_future(client, servicer):
         assert future.object_id not in servicer.cleared_function_calls
 
         with pytest.warns(DeprecationError):
-            future = later_modal.spawn()
+            future = later_modal.submit()
             assert isinstance(future, FunctionCall)
 
         servicer.function_is_running = True

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -42,10 +42,10 @@ from ._blob_utils import (
 )
 from ._call_graph import InputInfo, reconstruct_call_graph
 from ._function_utils import FunctionInfo, LocalFunctionError, load_function_from_module
-from ._resolver import Resolver
 from ._location import CloudProvider, parse_cloud_provider
 from ._output import OutputManager
 from ._pty import get_pty_info
+from ._resolver import Resolver
 from ._serialization import deserialize, serialize
 from ._traceback import append_modal_tb
 from .client import _Client
@@ -197,7 +197,7 @@ class _Invocation:
             raise Exception("Could not create function call - the input queue seems to be full")
         return _Invocation(client.stub, function_call_id, client)
 
-    async def pop_function_call_outputs(self, timeout: Optional[float] = None):
+    async def pop_function_call_outputs(self, timeout: Optional[float], clear_on_success: bool):
         t0 = time.time()
         if timeout is None:
             backend_timeout = 55.0
@@ -210,6 +210,7 @@ class _Invocation:
                 function_call_id=self.function_call_id,
                 timeout=backend_timeout,
                 last_entry_id="0-0",
+                clear_on_success=clear_on_success,
             )
             response = await retry_transient_errors(
                 self.stub.FunctionGetOutputs,
@@ -227,12 +228,19 @@ class _Invocation:
                     break
 
     async def run_function(self):
-        result = (await stream.list(self.pop_function_call_outputs()))[0]
+        # waits indefinitely for a single result for the function, and clear the outputs buffer after
+        result = (await stream.list(self.pop_function_call_outputs(timeout=None, clear_on_success=True)))[0]
         assert not result.gen_status
         return await _process_result(result, self.stub, self.client)
 
-    async def poll_function(self, timeout: Optional[float] = 0):
-        results = await stream.list(self.pop_function_call_outputs(timeout=timeout))
+    async def poll_function(self, timeout: Optional[float] = None):
+        # waits up to timeout for a result from a function
+        # * timeout=0 means a single poll
+        # * timeout=None means wait indefinitely
+        # raises TimeoutError if there is no result before timeout
+        # Intended to be used for future polling, and as such keeps
+        # results around after returning them
+        results = await stream.list(self.pop_function_call_outputs(timeout=timeout, clear_on_success=False))
 
         if len(results) == 0:
             raise TimeoutError()
@@ -242,23 +250,34 @@ class _Invocation:
     async def run_generator(self):
         last_entry_id = "0-0"
         completed = False
-        while not completed:
+        try:
+            while not completed:
+                request = api_pb2.FunctionGetOutputsRequest(
+                    function_call_id=self.function_call_id,
+                    timeout=55.0,
+                    last_entry_id=last_entry_id,
+                    clear_on_success=False,  # there could be more results
+                )
+                response = await retry_transient_errors(
+                    self.stub.FunctionGetOutputs,
+                    request,
+                )
+                if len(response.outputs) > 0:
+                    last_entry_id = response.last_entry_id
+                    for item in response.outputs:
+                        if item.result.gen_status == api_pb2.GenericResult.GENERATOR_STATUS_COMPLETE:
+                            completed = True
+                            break
+                        yield await _process_result(item.result, self.stub, self.client)
+        finally:
+            # "ack" that we have all outputs we are interested in and let backend clear results
             request = api_pb2.FunctionGetOutputsRequest(
                 function_call_id=self.function_call_id,
-                timeout=55.0,
-                last_entry_id=last_entry_id,
+                timeout=0,
+                last_entry_id="0-0",
+                clear_on_success=True,
             )
-            response = await retry_transient_errors(
-                self.stub.FunctionGetOutputs,
-                request,
-            )
-            if len(response.outputs) > 0:
-                last_entry_id = response.last_entry_id
-                for item in response.outputs:
-                    if item.result.gen_status == api_pb2.GenericResult.GENERATOR_STATUS_COMPLETE:
-                        completed = True
-                        break
-                    yield await _process_result(item.result, self.stub, self.client)
+            await self.stub.FunctionGetOutputs(request)
 
 
 MAP_INVOCATION_CHUNK_SIZE = 100
@@ -329,6 +348,7 @@ async def _map_invocation(
                 function_call_id=function_call_id,
                 timeout=55,
                 last_entry_id=last_entry_id,
+                clear_on_success=False,
             )
             response = await retry_transient_errors(
                 client.stub.FunctionGetOutputs,
@@ -355,6 +375,20 @@ async def _map_invocation(
                     del pending_outputs[item.input_id]
                     yield item
 
+    async def get_all_outputs_and_clean_up():
+        try:
+            async for item in get_all_outputs():
+                yield item
+        finally:
+            # "ack" that we have all outputs we are interested in and let backend clear results
+            request = api_pb2.FunctionGetOutputsRequest(
+                function_call_id=function_call_id,
+                timeout=0,
+                last_entry_id="0-0",
+                clear_on_success=True,
+            )
+            await client.stub.FunctionGetOutputs(request)
+
     async def fetch_output(item):
         try:
             output = await _process_result(item.result, client.stub, client)
@@ -366,7 +400,7 @@ async def _map_invocation(
         return (item.idx, output)
 
     async def poll_outputs():
-        outputs = stream.iterate(get_all_outputs())
+        outputs = stream.iterate(get_all_outputs_and_clean_up())
         outputs_fetched = outputs | pipe.map(fetch_output, ordered=True, task_limit=BLOB_MAX_PARALLELISM)
 
         # map to store out-of-order outputs received

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -415,6 +415,7 @@ message FunctionGetOutputsRequest {
   int32 max_values = 2;
   float timeout = 3;
   string last_entry_id = 6;
+  bool clear_on_success = 7; // expires *any* remaining outputs soon after this call, not just the returned ones
 }
 
 message FunctionGetOutputsResponse {


### PR DESCRIPTION
This allows the backend to set a short ttl for clearing outputs soon after they have been consumed.

For now we use the flag to clear except when we poll a future


This is a mix of what you suggested @erikbern with the "ack" solution that I suggested. For single input function calls no ack is needed, but for maps and generators the same call is used to "ack" after consuming all outputs