### PR TITLE
[MOD-729] fix: serve reloading when VIM editing

### DIFF
--- a/client_test/watcher_test.py
+++ b/client_test/watcher_test.py
@@ -1,0 +1,28 @@
+# Copyright Modal Labs 2023
+import pytest
+import random
+import string
+from pathlib import Path
+
+from watchfiles import Change
+
+from modal._watcher import _watch_args_from_mounts
+from modal.mount import _Mount
+
+
+@pytest.mark.asyncio
+async def test__watch_args_from_mounts(monkeypatch, test_dir):
+    paths, watch_filter = _watch_args_from_mounts(
+        mounts=[
+            _Mount(remote_dir="/", local_file="/x/foo.py"),
+            _Mount(remote_dir="/", local_dir="/one/two/bucklemyshoe"),
+        ]
+    )
+
+    assert paths == {Path("/x"), "/one/two/bucklemyshoe"}
+    assert watch_filter(Change.modified, "/x/foo.py")
+    assert not watch_filter(Change.modified, "/x/notwatched.py")
+    assert not watch_filter(Change.modified, "/x/y/foo.py")
+    random_filename = "".join(random.choices(string.ascii_uppercase + string.digits, k=10))
+    assert watch_filter(Change.modified, f"/one/two/bucklemyshoe/{random_filename}")
+    assert not watch_filter(Change.modified, "/one/two/bucklemyshoe/.DS_Store")

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -34,7 +34,7 @@ from ._serialization import deserialize, serialize
 from ._traceback import extract_traceback
 from ._tracing import extract_tracing_context, set_span_tag, trace, wrap
 from .app import _App
-from .client import Client, _Client, HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT
+from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, Client, _Client
 from .config import logger
 from .exception import InvalidError
 from .functions import AioFunctionHandle, FunctionHandle, _set_current_input_id

--- a/modal/_watcher.py
+++ b/modal/_watcher.py
@@ -1,12 +1,13 @@
 # Copyright Modal Labs 2022
 import asyncio
+from collections import defaultdict
 from enum import IntEnum
 from pathlib import Path
-from typing import Optional, Set, Union
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 from aiostream import stream
 from rich.tree import Tree
-from watchfiles import awatch
+from watchfiles import Change, DefaultFilter, awatch
 from watchfiles.main import FileChange
 
 from modal.functions import _Function
@@ -29,14 +30,41 @@ FileChangeset = Set[FileChange]
 ChangeEvent = Union[AppChange, FileChangeset, None]
 
 
+class StubFilesFilter(DefaultFilter):
+    def __init__(
+        self,
+        *,
+        # A directory filter is used to only watch certain files within a directory.
+        # Watching specific files is discourage on Linux, so to watch a file we watch its
+        # containing directory and then filter that directory's changes for relevant files.
+        # https://github.com/notify-rs/notify/issues/394
+        dir_filters: Dict[Path, Optional[Set[str]]],
+    ) -> None:
+        self.dir_filters = dir_filters
+        super().__init__()
+
+    def __call__(self, change: Change, path: str) -> bool:
+        p = Path(path)
+        if p.name == ".DS_Store":
+            return False
+        # Vim creates this temporary file to see whether it can write
+        # into a target directory.
+        elif p.name == "4913":
+            return False
+        for root, allowlist in self.dir_filters.items():
+            if allowlist is not None and root in p.parents and path not in allowlist:
+                return False
+        return super().__call__(change, path)
+
+
 async def _sleep(timeout: float):
     await asyncio.sleep(timeout)
     yield AppChange.TIMEOUT
 
 
-async def _watch_paths(paths: Set[Union[str, Path]]):
+async def _watch_paths(paths: Set[Union[str, Path]], watch_filter: StubFilesFilter):
     try:
-        async for changes in awatch(*paths, step=500):
+        async for changes in awatch(*paths, step=500, watch_filter=watch_filter):
             yield changes
     except RuntimeError:
         # Thrown by watchfiles from Rust, when the generator is closed externally.
@@ -57,26 +85,37 @@ def _print_watched_paths(paths: Set[Union[str, Path]], output_mgr: OutputManager
     output_mgr.print_if_visible(output_tree)
 
 
-async def watch(stub: _Stub, output_mgr: OutputManager, timeout: Optional[float]):
+def _watch_args_from_mounts(mounts: List[_Mount]) -> Tuple[Set[Union[str, Path]], StubFilesFilter]:
     paths = set()
+    dir_filters: Dict[Path, Set[str]] = defaultdict(set)
+    for mount in mounts:
+        if mount._local_dir is not None:
+            paths.add(mount._local_dir)
+            dir_filters[Path(mount._local_dir)] = None
+        elif mount._local_file is not None:
+            parent = Path(mount._local_file).parent
+            paths.add(parent)
+            if dir_filters[parent] is not None:
+                dir_filters[parent].add(str(mount._local_file))
 
+    watch_filter = StubFilesFilter(dir_filters=dict(dir_filters))
+    return paths, watch_filter
+
+
+async def watch(stub: _Stub, output_mgr: OutputManager, timeout: Optional[float]):
     # Iterate through all mounts for all functions and
     # collect unique directories and files to watch
+    all_mounts = []
     for object in stub._blueprint.values():
         if isinstance(object, _Function):
-            for mount in object._mounts:
-                if isinstance(mount, _Mount):
-                    if mount._local_dir is not None:
-                        paths.add(mount._local_dir)
-                    elif mount._local_file is not None:
-                        paths.add(mount._local_file)
+            all_mounts.extend([mount for mount in object._mounts if isinstance(mount, _Mount)])
+    paths, watch_filter = _watch_args_from_mounts(mounts=all_mounts)
 
     _print_watched_paths(paths, output_mgr, timeout)
 
     yield AppChange.START
 
     timeout_agen = [] if timeout is None else [_sleep(timeout)]
-
-    async with stream.merge(_watch_paths(paths), *timeout_agen).stream() as streamer:
+    async with stream.merge(_watch_paths(paths, watch_filter), *timeout_agen).stream() as streamer:
         async for event in streamer:
             yield event

--- a/modal/_watcher.py
+++ b/modal/_watcher.py
@@ -35,7 +35,7 @@ class StubFilesFilter(DefaultFilter):
         self,
         *,
         # A directory filter is used to only watch certain files within a directory.
-        # Watching specific files is discourage on Linux, so to watch a file we watch its
+        # Watching specific files is discouraged on Linux, so to watch a file we watch its
         # containing directory and then filter that directory's changes for relevant files.
         # https://github.com/notify-rs/notify/issues/394
         dir_filters: Dict[Path, Optional[Set[str]]],


### PR DESCRIPTION
more reliable but a bit more complicated. I suspect a similar problem would exist for EMACS file saving, but I haven't checked.