### PR TITLE
`modal serve` command line

### DIFF
--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -224,3 +224,8 @@ def test_no_user_code_in_synchronicity_deploy(servicer, server_url_env, test_dir
     _run(["deploy", "--name", "foo", fresh_main_thread_assertion_module.as_posix()])
     assert pytest._did_load_main_thread_assertion
     print()
+
+
+def test_serve(servicer, server_url_env, test_dir):
+    stub_file = test_dir / "supports" / "app_run_tests" / "webhook.py"
+    _run(["serve", stub_file.as_posix(), "--timeout", "3"])

--- a/client_test/supports/app_run_tests/webhook.py
+++ b/client_test/supports/app_run_tests/webhook.py
@@ -1,0 +1,9 @@
+# Copyright Modal Labs 2022
+import modal
+
+stub = modal.Stub()
+
+
+@stub.webhook
+def foo():
+    return {"bar": "baz"}

--- a/modal/cli/entry_point.py
+++ b/modal/cli/entry_point.py
@@ -49,6 +49,7 @@ entrypoint_cli_typer.add_typer(volume_cli)
 
 # entrypoint_cli_typer.command("run", help="Run a Modal function.", context_settings={"allow_extra_args": True})(run.run)
 entrypoint_cli_typer.command("deploy", help="Deploy a Modal stub as an application.", no_args_is_help=True)(run.deploy)
+entrypoint_cli_typer.command("serve", no_args_is_help=True)(run.serve)
 entrypoint_cli_typer.command("shell", no_args_is_help=True)(run.shell)
 
 entrypoint_cli = typer.main.get_command(entrypoint_cli_typer)

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -4,7 +4,7 @@ import datetime
 import inspect
 import sys
 import traceback
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import click
 import typer
@@ -240,6 +240,7 @@ def choose_function(stub: _Stub, functions: List[Tuple[str, _Function]], console
 
 def serve(
     stub_ref: str = typer.Argument(..., help="Path to a Python file with a stub."),
+    timeout: Optional[float] = None,
 ):
     """Run an web endpoint(s) associated with a Modal stub and hot-reload code.
     **Examples:**\n
@@ -260,7 +261,7 @@ def serve(
 
     _stub = synchronizer._translate_in(stub)
     blocking_stub = synchronizer._translate_out(_stub, Interface.BLOCKING)
-    blocking_stub.serve()
+    blocking_stub.serve(timeout=timeout)
 
 
 def shell(

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -238,6 +238,31 @@ def choose_function(stub: _Stub, functions: List[Tuple[str, _Function]], console
     return functions[int(choice)][1]
 
 
+def serve(
+    stub_ref: str = typer.Argument(..., help="Path to a Python file with a stub."),
+):
+    """Run an web endpoint(s) associated with a Modal stub and hot-reload code.
+    **Examples:**\n
+    \n
+    ```bash\n
+    modal serve hello_world.py
+    ```\n
+    """
+    parsed_stub_ref = parse_stub_ref(stub_ref)
+    try:
+        stub = import_stub(parsed_stub_ref)
+    except NoSuchStub:
+        _show_stub_ref_failure_help(parsed_stub_ref)
+        sys.exit(1)
+    except Exception:
+        traceback.print_exc()
+        sys.exit(1)
+
+    _stub = synchronizer._translate_in(stub)
+    blocking_stub = synchronizer._translate_out(_stub, Interface.BLOCKING)
+    blocking_stub.serve()
+
+
 def shell(
     stub_ref: str = typer.Argument(..., help="Path to a Python file with a stub."),
     cmd: str = typer.Option(default="/bin/bash", help="Command to run inside the Modal image."),


### PR DESCRIPTION
It supports a `--timeout` flag which is really only useful for tests