### PR TITLE
Guard against module having __package__ but no __path__

### DIFF
--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -166,7 +166,7 @@ class FunctionInfo:
             modules.append(module)
 
         for m in modules:
-            if getattr(m, "__package__", None):
+            if getattr(m, "__package__", None) and getattr(m, "__path__", None):
                 package_path = __import__(m.__package__).__path__
                 for raw_path in package_path:
                     path = os.path.realpath(raw_path)


### PR DESCRIPTION
Didn't know this was possible, but happens in the case of `duckdb`. Couldn't repro super easily to add to `mounted_files_test.py`.