### PR TITLE
Don't have a bunch of instance attributes on providers

### DIFF
--- a/client_test/notebook_test.py
+++ b/client_test/notebook_test.py
@@ -3,7 +3,14 @@ from pathlib import Path
 
 import jupytext
 import pytest
-from nbclient.exceptions import CellExecutionError
+import warnings
+
+try:
+    from nbclient.exceptions import CellExecutionError
+except ModuleNotFoundError:
+    # TODO(erikbern): sometimes my local jupyter packages end up in a bad state,
+    # but we don't want that to cause pytest to fail on startup.
+    warnings.warn("failed importing nbclient")
 
 
 @pytest.fixture

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -136,17 +136,17 @@ class _Dict(Provider[_DictHandle]):
 
     def __init__(self, data={}):
         """Create a new dictionary, optionally filled with initial data."""
-        self._data = data
-        super().__init__(self._load, "Dict()")
 
-    async def _load(self, resolver: Resolver):
-        serialized = _serialize_dict(self._data)
-        req = api_pb2.DictCreateRequest(
-            app_id=resolver.app_id, data=serialized, existing_dict_id=resolver.existing_object_id
-        )
-        response = await resolver.client.stub.DictCreate(req)
-        logger.debug("Created dict with id %s" % response.dict_id)
-        return _DictHandle(resolver.client, response.dict_id)
+        async def _load(resolver: Resolver) -> _DictHandle:
+            serialized = _serialize_dict(data)
+            req = api_pb2.DictCreateRequest(
+                app_id=resolver.app_id, data=serialized, existing_dict_id=resolver.existing_object_id
+            )
+            response = await resolver.client.stub.DictCreate(req)
+            logger.debug("Created dict with id %s" % response.dict_id)
+            return _DictHandle(resolver.client, response.dict_id)
+
+        super().__init__(_load, "Dict()")
 
 
 Dict, AioDict = synchronize_apis(_Dict)

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -136,12 +136,12 @@ class _Queue(Provider[_QueueHandle]):
     """
 
     def __init__(self):
-        super().__init__(self._load, "Queue()")
+        async def _load(resolver: Resolver) -> _QueueHandle:
+            request = api_pb2.QueueCreateRequest(app_id=resolver.app_id, existing_queue_id=resolver.existing_object_id)
+            response = await resolver.client.stub.QueueCreate(request)
+            return _QueueHandle(resolver.client, response.queue_id)
 
-    async def _load(self, resolver: Resolver):
-        request = api_pb2.QueueCreateRequest(app_id=resolver.app_id, existing_queue_id=resolver.existing_object_id)
-        response = await resolver.client.stub.QueueCreate(request)
-        return _QueueHandle(resolver.client, response.queue_id)
+        super().__init__(_load, "Queue()")
 
 
 Queue, AioQueue = synchronize_apis(_Queue)

--- a/modal/shared_volume.py
+++ b/modal/shared_volume.py
@@ -110,20 +110,20 @@ class _SharedVolume(Provider[_SharedVolumeHandle]):
 
     def __init__(self, cloud_provider: "Optional[api_pb2.CloudProvider.V]" = None) -> None:
         """Construct a new shared volume, which is empty by default."""
-        self._cloud_provider = cloud_provider
+
+        async def _load(resolver: Resolver) -> _SharedVolumeHandle:
+            if resolver.existing_object_id:
+                # Volume already exists; do nothing.
+                return _SharedVolumeHandle(resolver.client, resolver.existing_object_id)
+
+            resolver.set_message("Creating shared volume...")
+            req = api_pb2.SharedVolumeCreateRequest(app_id=resolver.app_id, cloud_provider=cloud_provider)
+            resp = await retry_transient_errors(resolver.client.stub.SharedVolumeCreate, req)
+            resolver.set_message("Created shared volume.")
+            return _SharedVolumeHandle(resolver.client, resp.shared_volume_id)
+
         rep = "SharedVolume()"
-        super().__init__(self._load, rep)
-
-    async def _load(self, resolver: Resolver):
-        if resolver.existing_object_id:
-            # Volume already exists; do nothing.
-            return _SharedVolumeHandle(resolver.client, resolver.existing_object_id)
-
-        resolver.set_message("Creating shared volume...")
-        req = api_pb2.SharedVolumeCreateRequest(app_id=resolver.app_id, cloud_provider=self._cloud_provider)
-        resp = await retry_transient_errors(resolver.client.stub.SharedVolumeCreate, req)
-        resolver.set_message("Created shared volume.")
-        return _SharedVolumeHandle(resolver.client, resp.shared_volume_id)
+        super().__init__(_load, rep)
 
 
 SharedVolume, AioSharedVolume = synchronize_apis(_SharedVolume)


### PR DESCRIPTION
This is a step towards getting rid of `Provider` and merging it into `Handle`. These classes are already fairly dumb, and this PR makes several subclasses even simpler by removing all internal state.

I think this will be helpful as a way to remove a source of bugs we've had – a lot of function attributes that are set in global scope when functions are defined, but aren't set from `lookup` or inside the container, leading to weird failures (like `.web_url` missing).

It will also remove lots of unnecessary code that writes a bunch of intermediate stuff to `self` then reads it back exactly once during app construction (I think we can delete 100-200 lines of code in the end).

I only did this for `Secret`, `Dict`, `Queue`, and `SharedVolume` for now. The two big ones are `Function` and `Image` but I don't want to touch them until someone else agrees this approach makes sense.