### PR TITLE
Move .lookup to sit on the class instead

### DIFF
--- a/client_test/lookup_test.py
+++ b/client_test/lookup_test.py
@@ -1,22 +1,22 @@
 # Copyright Modal Labs 2023
 import pytest
 
-from modal.aio import AioQueue, AioStub, aio_lookup
-from modal.exception import NotFoundError
+from modal.aio import AioFunction, AioQueue, AioStub, aio_lookup
+from modal.exception import DeprecationError, NotFoundError
 
 
 @pytest.mark.asyncio
 async def test_persistent_object(servicer, aio_client):
     stub = AioStub()
-    stub["q_1"] = AioQueue()
+    stub.q_1 = AioQueue()
     await stub.deploy("my-queue", client=aio_client)
 
-    q = await aio_lookup("my-queue", client=aio_client)
+    q = await AioQueue.lookup("my-queue", client=aio_client)
     # assert isinstance(q_3, AioQueue)  # TODO(erikbern): it's a AioQueueHandler
     assert q.object_id == "qu-1"
 
     with pytest.raises(NotFoundError):
-        await aio_lookup("bazbazbaz", client=aio_client)
+        await AioQueue.lookup("bazbazbaz", client=aio_client)
 
 
 def square(x):
@@ -31,7 +31,7 @@ async def test_lookup_function(servicer, aio_client):
     stub.function(square)
     await stub.deploy("my-function", client=aio_client)
 
-    f = await aio_lookup("my-function", client=aio_client)
+    f = await AioFunction.lookup("my-function", client=aio_client)
     assert f.object_id == "fu-1"
 
     # Make sure we can call this function
@@ -45,5 +45,16 @@ async def test_webhook_lookup(servicer, aio_client):
     stub.webhook(square, method="POST")
     await stub.deploy("my-webhook", client=aio_client)
 
-    f = await aio_lookup("my-webhook", client=aio_client)
+    f = await AioFunction.lookup("my-webhook", client=aio_client)
     assert f.web_url
+
+
+@pytest.mark.asyncio
+async def test_deprecated(servicer, aio_client):
+    stub = AioStub()
+    stub["q_1"] = AioQueue()
+    await stub.deploy("my-queue", client=aio_client)
+
+    with pytest.warns(DeprecationError):
+        q = await aio_lookup("my-queue", client=aio_client)
+    assert q.object_id == "qu-1"

--- a/modal/_object_meta.py
+++ b/modal/_object_meta.py
@@ -1,5 +1,5 @@
 # Copyright Modal Labs 2022
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from modal_utils.async_utils import synchronizer
 
@@ -9,17 +9,19 @@ from .config import logger
 class ObjectMeta(type):
     prefix_to_type: Dict[str, Any] = {}
 
-    def __new__(metacls, name, bases, dct, type_prefix=None):
+    def __new__(metacls, name, bases, dct, type_prefix: Optional[str] = None):
+        dct.update(dict(_type_prefix=type_prefix))
+
+        # Create class
         new_cls = type.__new__(metacls, name, bases, dct)
+
+        if type_prefix is not None:
+            # Needed for serialization, also for loading objects dynamically
+            metacls.prefix_to_type[type_prefix] = new_cls
 
         # If this is a synchronized wrapper, just return early
         # (actually, it shouldn't be possible)
         assert not synchronizer.is_synchronized(new_cls)
-
-        # Needed for serialization, also for loading objects dynamically
-        if type_prefix is not None:
-            new_cls._type_prefix = type_prefix  # type: ignore
-            metacls.prefix_to_type[type_prefix] = new_cls
 
         logger.debug(f"Created Object class {name}")
         return new_cls

--- a/modal/aio.py
+++ b/modal/aio.py
@@ -6,7 +6,7 @@ The async interfaces are mostly mirrors of the blocking ones, with the `Aio` or 
 
 from .app import AioApp, aio_container_app
 from .dict import AioDict
-from .functions import AioFunctionHandle
+from .functions import AioFunction
 from .image import AioImage
 from .mount import AioMount
 from .object import aio_lookup
@@ -18,11 +18,11 @@ __all__ = [
     "AioApp",
     "AioDict",
     "AioImage",
+    "AioFunction",
     "AioMount",
     "AioQueue",
     "AioSecret",
     "AioStub",
-    "AioFunctionHandle",
     "aio_container_app",
     "aio_lookup",
 ]

--- a/modal/object.py
+++ b/modal/object.py
@@ -42,6 +42,8 @@ class Handle(metaclass=ObjectMeta):
 
     @staticmethod
     def _from_id(object_id: str, client: _Client, proto: Optional[Message]):
+        # TOOD(erikbern): this should be a classmethod that requires cls._type_prefix
+        # to match the object_id (meaning, you have to call _from_id on a subclass).
         parts = object_id.split("-")
         if len(parts) != 2:
             raise InvalidError(f"Object id {object_id} has no dash in it")

--- a/modal/object.py
+++ b/modal/object.py
@@ -30,6 +30,8 @@ class Handle(metaclass=ObjectMeta):
     well as distributed data structures like Queues or Dicts.
     """
 
+    _type_prefix: Optional[str]
+
     def __init__(self, client=None, object_id=None):
         """mdmd:hidden"""
         self._client = client
@@ -118,7 +120,7 @@ class Provider(Generic[H]):
 
     @classmethod
     def get_handle_cls(cls):
-        (base,) = cls.__orig_bases__
+        (base,) = cls.__orig_bases__  # type: ignore
         (handle_cls,) = base.__args__
         return handle_cls
 

--- a/modal/object.py
+++ b/modal/object.py
@@ -8,7 +8,6 @@ from typing import (
     Optional,
     Type,
     TypeVar,
-    get_args,
 )
 
 from google.protobuf.message import Message
@@ -119,7 +118,9 @@ class Provider(Generic[H]):
 
     @classmethod
     def get_handle_cls(cls):
-        return get_args(cls.__orig_bases__[0])[0]
+        (base,) = cls.__orig_bases__
+        (handle_cls,) = base.__args__
+        return handle_cls
 
     def __repr__(self):
         return self._rep

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -167,6 +167,7 @@ message AppLookupObjectRequest {
   string app_name = 3;
   string object_tag = 4;
   string object_id = 5;
+  string type_prefix = 6;
 }
 
 message AppLookupObjectResponse {


### PR DESCRIPTION
This deprecates the top-level global `modal.lookup` in favor of a classmethod on each `Provider` class, e.g. `modal.Function.lookup(...)` etc.

Benefits:
* We can send the type to the server, which will let us separate the "namespaces"
* A bit more type safety in Python

This will cause warnings for everyone who currently uses `lookup` / `aio_lookup` and we'll have to support the "old" behavior for at least 1-2 months.

There's a bit of type janking right now caused by the fact that providers and handles are different classes. We should be able to remove most/all of it once we merge those two.