### PR TITLE
Raise deprecation warnings to errors

### DIFF
--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -115,9 +115,10 @@ def test_function_future(client, servicer):
         assert future.get(0.01) == "hello"
         assert future.object_id not in servicer.cleared_function_calls
 
-        with pytest.warns(DeprecationError):
-            future = later_modal.submit()
-            assert isinstance(future, FunctionCall)
+        with pytest.raises(DeprecationError):
+            later_modal.submit()
+
+        future = later_modal.spawn()
 
         servicer.function_is_running = True
         assert future.object_id == "fc-2"
@@ -151,9 +152,8 @@ def later_gen():
 async def test_generator(client, servicer):
     stub = Stub()
 
-    with pytest.warns(DeprecationError):
-        later_gen_modal = stub.generator(later_gen)
-    assert later_gen_modal.is_generator
+    with pytest.raises(DeprecationError):
+        stub.generator(later_gen)
 
     later_gen_modal = stub.function(later_gen)
     assert later_gen_modal.is_generator

--- a/client_test/supports/notebooks/simple.notebook.py
+++ b/client_test/supports/notebooks/simple.notebook.py
@@ -35,5 +35,5 @@ def hello():
 # + tags=["main"]
 with client:
     with stub.run(client=client, show_progress=True):
-        hello()
+        hello.call()
 # -

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -51,7 +51,7 @@ from ._traceback import append_modal_tb
 from .client import _Client
 from .exception import ExecutionError, InvalidError, NotFoundError, RemoteError
 from .exception import TimeoutError as _TimeoutError
-from .exception import deprecation_error, deprecation_warning
+from .exception import deprecation_error
 from .gpu import GPU_T, parse_gpu_config
 from .image import _Image
 from .mount import _Mount
@@ -654,15 +654,11 @@ class _FunctionHandle(Handle, type_prefix="fu"):
             return self.call_function(args, kwargs)
 
     def __call__(self, *args, **kwargs):
-        deprecation_warning(
+        deprecation_error(
             date(2022, 12, 5),
-            "Calling a function directly is deprecated. Use f.call(...) instead."
+            "Calling a function directly is no longer possible. Use f.call(...) instead."
             " In a future version of Modal, f(...) will be used to call a function in the same process.",
         )
-        if self._is_generator:
-            return self.call_generator(args, kwargs)
-        else:
-            return self.call_function(args, kwargs)
 
     async def enqueue(self, *args, **kwargs):
         """**Deprecated.** Use `.spawn()` instead when possible.
@@ -687,10 +683,9 @@ class _FunctionHandle(Handle, type_prefix="fu"):
         invocation = await self.call_function_nowait(args, kwargs)
         return _FunctionCall(invocation.client, invocation.function_call_id)
 
-    async def submit(self, *args, **kwargs) -> Optional["_FunctionCall"]:
+    async def submit(self, *args, **kwargs):
         """**Deprecated.** Use `.spawn()` instead."""
-        deprecation_warning(date(2022, 12, 5), "Function.submit is deprecated, use .spawn() instead")
-        return await self.spawn(*args, **kwargs)
+        deprecation_error(date(2022, 12, 5), "Function.submit is no longer supported. Use .spawn() instead")
 
     def get_raw_f(self) -> Callable:
         """Return the inner Python object wrapped by this Modal Function."""

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -25,7 +25,7 @@ from ._pty import exec_cmd, write_stdin_to_pty_stream
 from .app import _App, container_app, is_local
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, _Client
 from .config import config, logger
-from .exception import InvalidError, deprecation_warning
+from .exception import InvalidError, deprecation_error
 from .functions import _Function, _FunctionHandle
 from .gpu import GPU_T
 from .image import _Image
@@ -658,10 +658,8 @@ class _Stub:
         return self._add_function(function)
 
     @decorator_with_options
-    def generator(self, raw_f=None, **kwargs) -> _FunctionHandle:
-        deprecation_warning(date(2022, 12, 1), "Stub.generator is deprecated. Use .function() instead.")
-        kwargs.update(dict(is_generator=True))
-        return self.function(raw_f, **kwargs)
+    def generator(self, raw_f=None, **kwargs):
+        deprecation_error(date(2022, 12, 1), "Stub.generator is no longer supported. Use .function() instead.")
 
     @decorator_with_options
     def webhook(


### PR DESCRIPTION
This promotes three `deprecation_warning` from early Dec into `deprecation_error` instead.

Keeping the same error message etc. We'll keep it there for another month or two before we can finally remove it.