### PR TITLE
Clean up file watching mount logic

### DIFF
--- a/modal/_watcher.py
+++ b/modal/_watcher.py
@@ -10,7 +10,6 @@ from rich.tree import Tree
 from watchfiles import Change, DefaultFilter, awatch
 from watchfiles.main import FileChange
 
-from modal.functions import _Function
 from modal.mount import _Mount
 from modal.stub import _Stub
 
@@ -102,22 +101,8 @@ def _watch_args_from_mounts(mounts: List[_Mount]) -> Tuple[Set[Union[str, Path]]
     return paths, watch_filter
 
 
-def _is_local_mount(mount) -> bool:
-    if not isinstance(mount, _Mount):
-        return False
-    # TODO(erikbern): this is pretty ugly, but we want to ignore
-    # any _Mount that's just a remote reference. Let's rethink this.
-    return getattr(mount, "_local_dir", None) or getattr(mount, "_local_file", None)
-
-
 async def watch(stub: _Stub, output_mgr: OutputManager, timeout: Optional[float]):
-    # Iterate through all mounts for all functions and
-    # collect unique directories and files to watch
-    all_mounts = []
-    for object in stub._blueprint.values():
-        if isinstance(object, _Function):
-            all_mounts.extend([mount for mount in object._mounts if _is_local_mount(mount)])
-    paths, watch_filter = _watch_args_from_mounts(mounts=all_mounts)
+    paths, watch_filter = _watch_args_from_mounts(mounts=stub._local_mounts)
 
     _print_watched_paths(paths, output_mgr, timeout)
 

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -78,8 +78,14 @@ class _Mount(Provider[_MountHandle]):
         self._remote_dir = remote_dir
         self._condition = condition
         self._recursive = recursive
+        self._is_local = True
         rep = f"Mount({self._local_file or self._local_dir})"
         super().__init__(self._load, rep)
+
+    def is_local(self):
+        # TODO(erikbern): since any remote ref bypasses the constructor,
+        # we can rely on it to be set. Let's clean this up later.
+        return getattr(self, "_is_local", False)
 
     async def _get_files(self):
         if self._local_file:

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -84,7 +84,7 @@ class _Mount(Provider[_MountHandle]):
 
     def is_local(self):
         # TODO(erikbern): since any remote ref bypasses the constructor,
-        # we can rely on it to be set. Let's clean this up later.
+        # we can't rely on it to be set. Let's clean this up later.
         return getattr(self, "_is_local", False)
 
     async def _get_files(self):


### PR DESCRIPTION
This is something I ran into while implementing #225

In general, we have a few places that touch "internal" attributes on Objects, which makes it harder to refactor things. Cleaning it up will make it easier to rewrite how functions are created, which will make it possible down the road to merge providers and handles.