### PR TITLE
widen cloudpickle requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,8 +22,7 @@ install_requires =
     aiostream
     asgiref
     certifi
-    cloudpickle>=2.0.0,<2.1.0;python_version<'3.11'
-    cloudpickle>=2.2.0,<2.3.0;python_version>='3.11'
+    cloudpickle>=2.0.0
     fastapi
     grpclib==0.4.3
     importlib_metadata


### PR DESCRIPTION
I don't remember why we had it pinned like this (besides the 3.11 issues) but I think it's safe to unpin it at this point.