### PR TITLE
remove direct `Handle` constructor invocation

### DIFF
--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -330,8 +330,8 @@ def test_closure_valued_serialized_function(client, servicer):
 
 
 def test_from_id(client, servicer):
-    # obj = Function.from_id("fu-123", client)
+    # obj = Function._from_id("fu-123", client, None)
     # assert obj.object_id == "fu-123"
 
-    obj = FunctionCall.from_id("fc-123", client)
+    obj = FunctionCall._from_id("fc-123", client, None)
     assert obj.object_id == "fc-123"

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -144,7 +144,7 @@ class _Dict(Provider[_DictHandle]):
             )
             response = await resolver.client.stub.DictCreate(req)
             logger.debug("Created dict with id %s" % response.dict_id)
-            return _DictHandle(resolver.client, response.dict_id)
+            return _DictHandle._from_id(response.dict_id, resolver.client, None)
 
         super().__init__(_load, "Dict()")
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -445,6 +445,8 @@ class FunctionStats:
 class _FunctionHandle(Handle, type_prefix="fu"):
     """Interact with a Modal Function of a live app."""
 
+    _web_url: Optional[str]
+
     @classmethod
     def from_stub_dummy(cls, function: "_Function"):
         # This is a bit of a hack until we merge handles and providers

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -445,7 +445,19 @@ class FunctionStats:
 class _FunctionHandle(Handle, type_prefix="fu"):
     """Interact with a Modal Function of a live app."""
 
-    def __init__(self, function: "_Function", web_url=None, client=None, object_id=None):
+    @classmethod
+    def from_stub_dummy(cls, function: "_Function"):
+        # This is a bit of a hack until we merge handles and providers
+        # See Stub._add_function
+        # Basically we pre-initialize FunctionHandle before we have an object id for them
+        # Later once we merge those objects, we should be able to get rid of this
+        obj = cls.__new__(cls)
+        obj._client = None
+        obj._object_id = None
+        obj._initialize_stub_dummy(function)
+        return obj
+
+    def _initialize_stub_dummy(self, function: "_Function"):
         self._local_app = None
         self._progress = None
 
@@ -453,14 +465,12 @@ class _FunctionHandle(Handle, type_prefix="fu"):
         self._tag = function._tag
         self._is_generator = function._is_generator
         self._raw_f = function._raw_f
-        self._web_url = web_url
+        self._web_url = None
         self._output_mgr: Optional[OutputManager] = None
         self._function = function
         self._mute_cancellation = (
             False  # set when a user terminates the app intentionally, to prevent useless traceback spam
         )
-
-        super().__init__(client=client, object_id=object_id)
 
     def _set_mute_cancellation(self, value=True):
         self._mute_cancellation = value

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -681,7 +681,7 @@ class _FunctionHandle(Handle, type_prefix="fu"):
             return None
 
         invocation = await self.call_function_nowait(args, kwargs)
-        return _FunctionCall(invocation.client, invocation.function_call_id)
+        return _FunctionCall._from_id(invocation.function_call_id, invocation.client, None)
 
     async def submit(self, *args, **kwargs):
         """**Deprecated.** Use `.spawn()` instead."""

--- a/modal/image.py
+++ b/modal/image.py
@@ -226,7 +226,7 @@ class _Image(Provider[_ImageHandle]):
                 else:
                     raise RemoteError("Unknown status %s!" % response.result.status)
 
-            return _ImageHandle(resolver.client, image_id)
+            return _ImageHandle._from_id(image_id, resolver.client, None)
 
         rep = f"Image({dockerfile_commands})"
         super().__init__(_load, rep)

--- a/modal/object.py
+++ b/modal/object.py
@@ -30,7 +30,10 @@ class Handle(metaclass=ObjectMeta):
     well as distributed data structures like Queues or Dicts.
     """
 
-    def __init__(self, client=None, object_id=None):
+    def __init__(self):
+        raise Exception("__init__ disallowed, use proper classmethods")
+
+    def _initialize_handle(self, client: _Client, object_id: str):
         """mdmd:hidden"""
         self._client = client
         self._object_id = object_id
@@ -48,7 +51,7 @@ class Handle(metaclass=ObjectMeta):
             raise InvalidError(f"Object prefix {prefix} does not correspond to a type")
         object_cls = ObjectMeta.prefix_to_type[prefix]
         obj = Handle.__new__(object_cls)
-        Handle.__init__(obj, client, object_id=object_id)
+        Handle._initialize_handle(obj, client, object_id)
         if proto is not None:
             obj._initialize_from_proto(proto)
         return obj

--- a/modal/object.py
+++ b/modal/object.py
@@ -56,14 +56,6 @@ class Handle(metaclass=ObjectMeta):
             obj._initialize_from_proto(proto)
         return obj
 
-    @classmethod
-    async def from_id(cls, object_id: str, client: Optional[_Client] = None):
-        # TODO(erikbern): doesn't use _initialize_from_proto - let's use AppLookupObjectRequest?
-        # TODO(erikbern): this should probably be on the provider?
-        if client is None:
-            client = await _Client.from_env()
-        return cls._from_id(object_id, client, None)
-
     @property
     def object_id(self):
         return self._object_id

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -139,7 +139,7 @@ class _Queue(Provider[_QueueHandle]):
         async def _load(resolver: Resolver) -> _QueueHandle:
             request = api_pb2.QueueCreateRequest(app_id=resolver.app_id, existing_queue_id=resolver.existing_object_id)
             response = await resolver.client.stub.QueueCreate(request)
-            return _QueueHandle(resolver.client, response.queue_id)
+            return _QueueHandle._from_id(response.queue_id, resolver.client, None)
 
         super().__init__(_load, "Queue()")
 

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -32,7 +32,7 @@ class _Secret(Provider[_SecretHandle]):
                 existing_secret_id=resolver.existing_object_id,
             )
             resp = await resolver.client.stub.SecretCreate(req)
-            return _SecretHandle(resolver.client, resp.secret_id)
+            return _SecretHandle._from_id(resp.secret_id, resolver.client, None)
 
         rep = f"Secret([{', '.join(env_dict.keys())}])"
         super().__init__(_load, rep)

--- a/modal/shared_volume.py
+++ b/modal/shared_volume.py
@@ -114,13 +114,13 @@ class _SharedVolume(Provider[_SharedVolumeHandle]):
         async def _load(resolver: Resolver) -> _SharedVolumeHandle:
             if resolver.existing_object_id:
                 # Volume already exists; do nothing.
-                return _SharedVolumeHandle(resolver.client, resolver.existing_object_id)
+                return _SharedVolumeHandle._from_id(resolver.existing_object_id, resolver.client, None)
 
             resolver.set_message("Creating shared volume...")
             req = api_pb2.SharedVolumeCreateRequest(app_id=resolver.app_id, cloud_provider=cloud_provider)
             resp = await retry_transient_errors(resolver.client.stub.SharedVolumeCreate, req)
             resolver.set_message("Created shared volume.")
-            return _SharedVolumeHandle(resolver.client, resp.shared_volume_id)
+            return _SharedVolumeHandle._from_id(resp.shared_volume_id, resolver.client, None)
 
         rep = "SharedVolume()"
         super().__init__(_load, rep)

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -547,7 +547,7 @@ class _Stub:
         # This is a bit weird since the object isn't actually created yet,
         # but functions are weird and live and the global scope
         # These will be set with the correct object id when the app starts.
-        function_handle = _FunctionHandle(function)
+        function_handle = _FunctionHandle.from_stub_dummy(function)
         self._function_handles[function.tag] = function_handle
         return function_handle
 
@@ -661,7 +661,7 @@ class _Stub:
 
         if _is_build_step:
             # Don't add function to stub if it's a build step.
-            return _FunctionHandle(function)
+            return _FunctionHandle.from_stub_dummy(function)
 
         return self._add_function(function, [*base_mounts, *mounts])
 


### PR DESCRIPTION
This removes all custom `__init__` methods on `Handle` objects. The reason is we need to support initializing `Handle` objects in several different ways, and having overloaded construction logic makes it a bit trickier.

There's a bunch of hacky logic with functions which unfortunate gets even hackier in this PR, but in the long term this hackiness is exactly what I'll be able to remove quite soon.