### PR TITLE
Sort of merge FunctionHandle into Function

### DIFF
--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -156,7 +156,6 @@ async def test_generator(client, servicer):
         stub.generator(later_gen)
 
     later_gen_modal = stub.function(later_gen)
-    assert later_gen_modal.is_generator
 
     def dummy():
         yield "bar"
@@ -166,6 +165,7 @@ async def test_generator(client, servicer):
 
     assert len(servicer.cleared_function_calls) == 0
     with stub.run(client=client):
+        assert later_gen_modal.is_generator
         res = later_gen_modal.call()
         assert hasattr(res, "__iter__")  # strangely inspect.isgenerator returns false
         assert list(res) == ["bar", "baz"]

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -126,6 +126,7 @@ class RunGroup(click.Group):
             elif len(_stub.registered_entrypoints) == 1:
                 function_name = list(_stub.registered_entrypoints.keys())[0]
             else:
+                # TODO(erikbern): better error message if there's *zero* functions / entrypoints
                 print(
                     f"""You need to specify an entrypoint Modal function to run, e.g.
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -16,7 +16,6 @@ from typing import (
     Dict,
     List,
     Optional,
-    Tuple,
     Union,
 )
 
@@ -447,84 +446,37 @@ class _FunctionHandle(Handle, type_prefix="fu"):
 
     _web_url: Optional[str]
 
-    @classmethod
-    def from_stub_dummy(cls, function: "_Function"):
-        # This is a bit of a hack until we merge handles and providers
-        # See Stub._add_function
-        # Basically we pre-initialize FunctionHandle before we have an object id for them
-        # Later once we merge those objects, we should be able to get rid of this
-        obj = cls.__new__(cls)
-        obj._client = None
-        obj._object_id = None
-        obj._initialize_stub_dummy(function)
-        return obj
-
-    def _initialize_stub_dummy(self, function: "_Function"):
-        self._local_app = None
-        self._progress = None
-
-        # These are some stupid lines, let's rethink
-        self._tag = function._tag
-        self._is_generator = function._is_generator
-        self._raw_f = function._raw_f
-        self._web_url = None
-        self._output_mgr: Optional[OutputManager] = None
-        self._function = function
-        self._mute_cancellation = (
-            False  # set when a user terminates the app intentionally, to prevent useless traceback spam
-        )
-
     def _set_mute_cancellation(self, value=True):
         self._mute_cancellation = value
 
-    def _initialize_from_proto(self, proto: Message):
-        assert isinstance(proto, api_pb2.Function)
-        self._is_generator = proto.function_type == api_pb2.Function.FUNCTION_TYPE_GENERATOR
-        self._web_url = proto.web_url
-        self._mute_cancellation = False
-        self._output_mgr = None
+    def _initialize_from_proto(self, proto: Optional[Message]):
+        self._progress = None
+        self._is_generator = None
+        self._raw_f = None
+        self._web_url = None
+        self._output_mgr: Optional[OutputManager] = None
+        self._mute_cancellation = (
+            False  # set when a user terminates the app intentionally, to prevent useless traceback spam
+        )
+        self._function_name = None
 
-    def _set_local_app(self, app):
-        """mdmd:hidden"""
-        self._local_app = app
+        if proto is not None:
+            assert isinstance(proto, api_pb2.Function)
+            self._is_generator = proto.function_type == api_pb2.Function.FUNCTION_TYPE_GENERATOR
+            self._web_url = proto.web_url
+            self._function_name = proto.function_name
 
     def _set_output_mgr(self, output_mgr: OutputManager):
         """mdmd:hidden"""
         self._output_mgr = output_mgr
 
-    def _get_live_handle(self) -> "_FunctionHandle":
-        # Functions are sort of "special" in the sense that they are just global objects not attached to an app
-        # the way other objects are. So in order to work with functions, we need to look up the running app
-        # in runtime. Either we're inside a container, in which case it's a singleton, or we're in the client,
-        # in which case we can set the running app on all functions when we run the app.
-        if self._client and self._object_id:
-            # Can happen if this is a function loaded from a different app or something
-            return self
-
-        # avoid circular import
-        from .app import _container_app, is_local
-
-        if is_local():
-            if self._local_app is None:
-                raise InvalidError(
-                    "App is not running. You might need to put the function call inside a `with stub.run():` block."
-                )
-            app = self._local_app
-        else:
-            app = _container_app
-        obj = app[self._tag]
-        assert isinstance(obj, _FunctionHandle)
-        return obj
-
-    def _get_context(self) -> Tuple[_Client, str]:
-        function_handle = self._get_live_handle()
-        return (function_handle._client, function_handle._object_id)
+    def _set_raw_f(self, raw_f):
+        self._raw_f = raw_f
 
     @property
     def web_url(self) -> str:
         """URL of a Function running as a web endpoint."""
-        function_handle = self._get_live_handle()
-        return function_handle._web_url
+        return self._web_url
 
     @property
     def is_generator(self) -> bool:
@@ -534,15 +486,15 @@ class _FunctionHandle(Handle, type_prefix="fu"):
         if order_outputs and self._is_generator:
             raise ValueError("Can't return ordered results for a generator")
 
-        client, object_id = self._get_context()
-
-        count_update_callback = self._output_mgr.function_progress_callback(self._tag) if self._output_mgr else None
+        count_update_callback = (
+            self._output_mgr.function_progress_callback(self._function_name) if self._output_mgr else None
+        )
 
         async for item in _map_invocation(
-            object_id,
+            self._object_id,
             input_stream,
             kwargs,
-            client,
+            self._client,
             self._is_generator,
             order_outputs,
             return_exceptions,
@@ -633,8 +585,7 @@ class _FunctionHandle(Handle, type_prefix="fu"):
 
     async def call_function(self, args, kwargs):
         """mdmd:hidden"""
-        client, object_id = self._get_context()
-        invocation = await _Invocation.create(object_id, args, kwargs, client)
+        invocation = await _Invocation.create(self._object_id, args, kwargs, self._client)
         try:
             return await invocation.run_function()
         except asyncio.CancelledError:
@@ -644,20 +595,17 @@ class _FunctionHandle(Handle, type_prefix="fu"):
 
     async def call_function_nowait(self, args, kwargs):
         """mdmd:hidden"""
-        client, object_id = self._get_context()
-        return await _Invocation.create(object_id, args, kwargs, client)
+        return await _Invocation.create(self._object_id, args, kwargs, self._client)
 
     @warn_if_generator_is_not_consumed
     async def call_generator(self, args, kwargs):
         """mdmd:hidden"""
-        client, object_id = self._get_context()
-        invocation = await _Invocation.create(object_id, args, kwargs, client)
+        invocation = await _Invocation.create(self._object_id, args, kwargs, self._client)
         async for res in invocation.run_generator():
             yield res
 
     async def _call_generator_nowait(self, args, kwargs):
-        client, object_id = self._get_context()
-        return await _Invocation.create(object_id, args, kwargs, client)
+        return await _Invocation.create(self._object_id, args, kwargs, self._client)
 
     def call(self, *args, **kwargs):
         if self._is_generator:
@@ -706,8 +654,9 @@ class _FunctionHandle(Handle, type_prefix="fu"):
     async def get_current_stats(self) -> FunctionStats:
         """Return a `FunctionStats` object describing the current function's queue and runner counts."""
 
-        client, object_id = self._get_context()
-        resp = await client.stub.FunctionGetCurrentStats(api_pb2.FunctionGetCurrentStatsRequest(function_id=object_id))
+        resp = await self._client.stub.FunctionGetCurrentStats(
+            api_pb2.FunctionGetCurrentStatsRequest(function_id=self._object_id)
+        )
         return FunctionStats(
             backlog=resp.backlog, num_active_runners=resp.num_active_tasks, num_total_runners=resp.num_total_tasks
         )
@@ -829,6 +778,11 @@ class _Function(Provider[_FunctionHandle]):
                 raise InvalidError("Cloud selection only supported for functions running with A100 GPUs.")
         else:
             self._cloud_provider = None
+
+        self._precreated_function_handle = _FunctionHandle._new()
+        self._precreated_function_handle._initialize_from_proto(None)
+        self._precreated_function_handle._set_raw_f(raw_f)
+
         rep = "Function({self._tag})"
         super().__init__(self._load, rep)
 
@@ -993,7 +947,12 @@ class _Function(Provider[_FunctionHandle]):
         else:
             resolver.set_message(f"Created {self._tag}.")
 
-        return _FunctionHandle._from_id(response.function_id, resolver.client, response.function)
+        # Update the precreated function handle (todo: hack until we merge providers/handles)
+        self._precreated_function_handle._initialize_handle(resolver.client, response.function_id)
+        self._precreated_function_handle._initialize_from_proto(response.function)
+
+        # Instead of returning a new object, just return the precreated one
+        return self._precreated_function_handle
 
     @property
     def tag(self):

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -175,8 +175,8 @@ class _Invocation:
                 "\n"
                 "Modal functions can only be called within an app. "
                 "Try calling it from another running modal function or from an app run context:\n\n"
-                "with app.run():\n"
-                "    my_modal_function()\n"
+                "with stub.run():\n"
+                "    my_modal_function.call()\n"
             )
         request = api_pb2.FunctionMapRequest(function_id=function_id, parent_input_id=current_input_id())
         response = await retry_transient_errors(client.stub.FunctionMap, request)

--- a/modal/object.py
+++ b/modal/object.py
@@ -33,12 +33,22 @@ class Handle(metaclass=ObjectMeta):
     def __init__(self):
         raise Exception("__init__ disallowed, use proper classmethods")
 
+    def _init(self):
+        self._client = None
+        self._object_id = None
+
+    @classmethod
+    def _new(cls):
+        obj = Handle.__new__(cls)
+        obj._init()
+        return obj
+
     def _initialize_handle(self, client: _Client, object_id: str):
         """mdmd:hidden"""
         self._client = client
         self._object_id = object_id
 
-    def _initialize_from_proto(self, proto: Message):
+    def _initialize_from_proto(self, proto: Optional[Message]):
         pass  # default implementation
 
     @staticmethod
@@ -50,8 +60,8 @@ class Handle(metaclass=ObjectMeta):
         if prefix not in ObjectMeta.prefix_to_type:
             raise InvalidError(f"Object prefix {prefix} does not correspond to a type")
         object_cls = ObjectMeta.prefix_to_type[prefix]
-        obj = Handle.__new__(object_cls)
-        Handle._initialize_handle(obj, client, object_id)
+        obj = object_cls._new()
+        obj._initialize_handle(client, object_id)
         if proto is not None:
             obj._initialize_from_proto(proto)
         return obj

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -528,7 +528,9 @@ class _Stub:
             if mount.is_local():
                 self._local_mounts.append(mount)
 
-        return function._precreated_function_handle
+        function_handle = function._precreated_function_handle
+        self._function_handles[function.tag] = function_handle
+        return function_handle
 
     @property
     def registered_functions(self) -> List[str]:

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -263,9 +263,8 @@ class _Stub:
                 create_progress.label = step_completed("Created objects.")
                 output_mgr.print_if_visible(create_progress)
 
-                # Update all functions client-side to point to the running app
+                # Update all functions client-side to have the output mgr
                 for tag, obj in self._function_handles.items():
-                    obj._set_local_app(app)
                     obj._set_output_mgr(output_mgr)
 
                 # Cancel logs loop after creating objects for a deployment.
@@ -289,7 +288,6 @@ class _Stub:
                 # mute cancellation errors on all function handles to prevent exception spam
                 for tag, obj in self._function_handles.items():
                     obj._set_mute_cancellation(True)
-                    getattr(app, tag)._set_mute_cancellation(True)  # app has a separate function handle
 
                 if detach:
                     logs_loop.cancel()
@@ -530,13 +528,7 @@ class _Stub:
             if mount.is_local():
                 self._local_mounts.append(mount)
 
-        # We now need to create an actual handle.
-        # This is a bit weird since the object isn't actually created yet,
-        # but functions are weird and live and the global scope
-        # These will be set with the correct object id when the app starts.
-        function_handle = _FunctionHandle.from_stub_dummy(function)
-        self._function_handles[function.tag] = function_handle
-        return function_handle
+        return function._precreated_function_handle
 
     @property
     def registered_functions(self) -> List[str]:


### PR DESCRIPTION
My goal here is to merge back Handles and Providers.

This PRs does the first step for functions by tying the objects together – we now pre-create a `FunctionHandle` for every `Function`. It also cleans up the custom constructors for function objects so that everything goes through `_initialize_from_proto`, which means there's exactly one way to initialize a function handle. This is good because it removes a source of errors that we've had before.

The other object types are much easier to do the same thing with.