### PR TITLE
Refactor `_Image.run_function`

### DIFF
--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -17,7 +17,7 @@ class Resolver:
     _spinner: Optional[Spinner]
     _step_node: Optional[Tree]
 
-    def __init__(self, stub, app, progress: Optional[Tree], client, app_id: str, existing_object_id: Optional[str]):
+    def __init__(self, app, progress: Optional[Tree], client, app_id: str, existing_object_id: Optional[str]):
         self._app = app
         self._progress = progress
         self._last_message = None
@@ -25,7 +25,6 @@ class Resolver:
         self._step_node = None
 
         # Accessible by objects
-        self.stub = stub
         self.client = client
         self.app_id = app_id
         self.existing_object_id = existing_object_id

--- a/modal/app.py
+++ b/modal/app.py
@@ -80,7 +80,7 @@ class _App:
             # We already created this object before, shortcut this method
             return cached_obj
 
-        resolver = Resolver(self._stub, self, progress, self._client, self.app_id, existing_object_id)
+        resolver = Resolver(self, progress, self._client, self.app_id, existing_object_id)
 
         # Create object
         created_obj = await obj._load(resolver)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -730,6 +730,7 @@ class _Function(Provider[_FunctionHandle]):
         self,
         function_info: FunctionInfo,
         image=None,
+        secret: Optional[_Secret] = None,
         secrets: Collection[_Secret] = (),
         schedule: Optional[Schedule] = None,
         is_generator=False,
@@ -766,7 +767,10 @@ class _Function(Provider[_FunctionHandle]):
 
         self._raw_f = raw_f
         self._image = image
-        self._secrets = secrets
+        if secret:
+            self._secrets = [secret, *secrets]
+        else:
+            self._secrets = secrets
 
         if retries:
             if isinstance(retries, int):

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1000,6 +1000,18 @@ class _Function(Provider[_FunctionHandle]):
         """mdmd:hidden"""
         return self._tag
 
+    def get_build_def(self):
+        # Used to check whether we should rebuild an image using run_function
+        # Plaintext source and arg definition for the function, so it's part of the image
+        # hash. We can't use the cloudpickle hash because it's not very stable.
+        kwargs = dict(
+            secrets=repr(self._secrets),
+            gpu_config=repr(self._gpu_config),
+            mounts=repr(self._mounts),
+            shared_volumes=repr(self._shared_volumes),
+        )
+        return f"{inspect.getsource(self._raw_f)}\n{repr(kwargs)}"
+
 
 Function, AioFunction = synchronize_apis(_Function)
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1001,6 +1001,7 @@ class _Function(Provider[_FunctionHandle]):
         return self._tag
 
     def get_build_def(self):
+        """mdmd:hidden"""
         # Used to check whether we should rebuild an image using run_function
         # Plaintext source and arg definition for the function, so it's part of the image
         # hash. We can't use the cloudpickle hash because it's not very stable.

--- a/modal/image.py
+++ b/modal/image.py
@@ -5,7 +5,7 @@ import os
 import shlex
 import sys
 from pathlib import Path
-from typing import Any, Callable, Collection, List, Optional, Union
+from typing import Any, Callable, Collection, Dict, List, Optional, Union
 
 import toml
 
@@ -18,9 +18,11 @@ from ._function_utils import FunctionInfo
 from ._resolver import Resolver
 from .config import config, logger
 from .exception import InvalidError, NotFoundError, RemoteError
+from .gpu import GPU_T
 from .mount import _get_client_mount, _Mount
 from .object import Handle, Provider
 from .secret import _Secret
+from .shared_volume import _SharedVolume
 
 
 def _validate_python_version(version: str) -> None:

--- a/modal/image.py
+++ b/modal/image.py
@@ -754,6 +754,7 @@ class _Image(Provider[_ImageHandle]):
         shared_volumes: Dict[str, _SharedVolume] = {},
         cpu: Optional[float] = None,  # How many CPU cores to request. This is a soft limit.
         memory: Optional[int] = None,  # How much memory to request, in MB. This is a soft limit.
+        timeout: Optional[int] = 86400,  # Maximum execution time of the function in seconds.
         cloud: Optional[str] = None,  # Cloud provider to run the function on. Possible values are aws, gcp, auto.
     ) -> "_Image":
         """Run user-defined function `raw_function` as an image build step. The function runs just like an ordinary Modal
@@ -798,7 +799,7 @@ class _Image(Provider[_ImageHandle]):
             mounts=mounts,
             shared_volumes=shared_volumes,
             memory=memory,
-            timeout=86400,
+            timeout=timeout,
             cpu=cpu,
             cloud_provider=cloud,
         )

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -16,7 +16,7 @@ from modal_version import __version__
 
 from ._blob_utils import FileUploadSpec, blob_upload_file, get_file_upload_spec
 from ._resolver import Resolver
-from .config import logger
+from .config import config, logger
 from .exception import InvalidError, NotFoundError
 from .object import Handle, Provider
 
@@ -196,6 +196,15 @@ def _create_client_mount():
 
 
 _, aio_create_client_mount = synchronize_apis(_create_client_mount)
+
+
+def _get_client_mount():
+    if config["sync_entrypoint"]:
+        return _create_client_mount()
+    else:
+        return _Mount.from_name(
+            client_mount_name(), namespace=api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL
+        )
 
 
 async def _create_package_mounts(module_names: Collection[str]) -> List[_Mount]:

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -202,9 +202,7 @@ def _get_client_mount():
     if config["sync_entrypoint"]:
         return _create_client_mount()
     else:
-        return _Mount.from_name(
-            client_mount_name(), namespace=api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL
-        )
+        return _Mount.from_name(client_mount_name(), namespace=api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL)
 
 
 async def _create_package_mounts(module_names: Collection[str]) -> List[_Mount]:

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -29,7 +29,7 @@ from .exception import InvalidError, deprecation_error
 from .functions import _Function, _FunctionHandle
 from .gpu import GPU_T
 from .image import _Image
-from .mount import _create_client_mount, _Mount, client_mount_name
+from .mount import _get_client_mount, _Mount
 from .object import Provider
 from .proxy import _Proxy
 from .queue import _Queue
@@ -500,12 +500,7 @@ class _Stub:
 
         # Create client mount
         if self._client_mount is None:
-            if config["sync_entrypoint"]:
-                self._client_mount = _create_client_mount()
-            else:
-                self._client_mount = _Mount.from_name(
-                    client_mount_name(), namespace=api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL
-                )
+            self._client_mount = _get_client_mount()
         mounts.append(self._client_mount)
 
         # Create function mounts

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -597,7 +597,6 @@ class _Stub:
         container_idle_timeout: Optional[int] = None,  # Timeout for idle containers waiting for inputs to shut down.
         timeout: Optional[int] = None,  # Maximum execution time of the function in seconds.
         interactive: bool = False,  # Whether to run the function in interactive mode.
-        _is_build_step: bool = False,  # Whether function is a build step; reserved for internal use.
         keep_warm: Union[bool, int] = False,  # Toggles an adaptively-sized warm pool for latency-sensitive apps.
         name: Optional[str] = None,  # Sets the Modal name of the function within the stub
         is_generator: Optional[bool] = None,  # If not set, it's inferred from the function signature
@@ -646,10 +645,6 @@ class _Stub:
             name=name,
             cloud_provider=cloud,
         )
-
-        if _is_build_step:
-            # Don't add function to stub if it's a build step.
-            return _FunctionHandle.from_stub_dummy(function)
 
         return self._add_function(function, [*base_mounts, *mounts])
 

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -511,14 +511,6 @@ class _Stub:
 
         return mounts
 
-    def _get_function_secrets(self, raw_f, secret: Optional[_Secret] = None, secrets: Collection[_Secret] = ()):
-        if secret and secrets:
-            raise InvalidError(f"Function {raw_f} has both singular `secret` and plural `secrets` attached")
-        if secret:
-            return [secret, *self._secrets]
-        else:
-            return [*secrets, *self._secrets]
-
     def _add_function(self, function: _Function, mounts: List[_Mount]) -> _FunctionHandle:
         if function.tag in self._blueprint:
             old_function = self._blueprint[function.tag]
@@ -616,7 +608,7 @@ class _Stub:
             image = self._get_default_image()
         info = FunctionInfo(raw_f, serialized=serialized, name_override=name)
         base_mounts = self._get_function_mounts(info)
-        secrets = self._get_function_secrets(raw_f, secret, secrets)
+        secrets = [*self._secrets, *secrets]
 
         if interactive:
             if self._pty_input_stream:
@@ -632,6 +624,7 @@ class _Stub:
         function = _Function(
             info,
             image=image,
+            secret=secret,
             secrets=secrets,
             schedule=schedule,
             is_generator=is_generator,
@@ -713,7 +706,7 @@ class _Stub:
             image = self._get_default_image()
         info = FunctionInfo(raw_f)
         base_mounts = self._get_function_mounts(info)
-        secrets = self._get_function_secrets(raw_f, secret, secrets)
+        secrets = [*self._secrets, *secrets]
 
         if not wait_for_response:
             _response_mode = api_pb2.WEBHOOK_ASYNC_MODE_TRIGGER
@@ -723,6 +716,7 @@ class _Stub:
         function = _Function(
             info,
             image=image,
+            secret=secret,
             secrets=secrets,
             is_generator=True,
             gpu=gpu,
@@ -789,7 +783,7 @@ class _Stub:
             image = self._get_default_image()
         info = FunctionInfo(asgi_app)
         base_mounts = self._get_function_mounts(info)
-        secrets = self._get_function_secrets(asgi_app, secret, secrets)
+        secrets = [*self._secrets, *secrets]
 
         if not wait_for_response:
             _response_mode = api_pb2.WEBHOOK_ASYNC_MODE_TRIGGER
@@ -799,6 +793,7 @@ class _Stub:
         function = _Function(
             info,
             image=image,
+            secret=secret,
             secrets=secrets,
             is_generator=True,
             gpu=gpu,


### PR DESCRIPTION
This changes `_Image.run_function` so that it doesn't use the user-facing `stub.function` SDK, but instead it uses the internal lower level interface and creates a `_Function` directly.

Reason for doing this is
1. The resulting code fits more nicely the pattern I'm trying to get to with providers/handles (and more tactically it blocks #239 for related reasons) – it removes a bit of a hack (imo) where `_Image._load` would create other objects "dynamically"
2. I think we should try to avoid `kwargs` logic on the user-facing interface (even though unwrapping it does lead to a bit more redundancy). Makes autogenerated docs nicer.