### PR TITLE
[mod-835] Don't give webhooks as function options in CLI

### DIFF
--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -118,7 +118,7 @@ class RunGroup(click.Group):
         _stub = synchronizer._translate_in(stub)
 
         function_choices = list(
-            (set(_stub.registered_functions) - set(_stub.registered_endpoints))
+            (set(_stub.registered_functions) - set(_stub.registered_web_endpoints))
             | set(_stub.registered_entrypoints.keys())
         )
         registered_functions_str = "\n".join(sorted(function_choices))

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -117,7 +117,10 @@ class RunGroup(click.Group):
 
         _stub = synchronizer._translate_in(stub)
 
-        function_choices = list(set(_stub.registered_functions) | set(_stub.registered_entrypoints.keys()))
+        function_choices = list(
+            (set(_stub.registered_functions) - set(_stub.registered_endpoints))
+            | set(_stub.registered_entrypoints.keys())
+        )
         registered_functions_str = "\n".join(sorted(function_choices))
         function_name = parsed_stub_ref.entrypoint_name
         if not function_name:

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -446,6 +446,7 @@ class _FunctionHandle(Handle, type_prefix="fu"):
     """Interact with a Modal Function of a live app."""
 
     _web_url: Optional[str]
+    _function: "_Function"
 
     @classmethod
     def from_stub_dummy(cls, function: "_Function"):

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -549,7 +549,7 @@ class _Stub:
         return self._local_entrypoints
 
     @property
-    def registered_endpoints(self) -> List[str]:
+    def registered_web_endpoints(self) -> List[str]:
         """Names of web endpoint (ie. webhook) functions registered on the stub."""
         return list(
             tag

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -540,11 +540,22 @@ class _Stub:
 
     @property
     def registered_functions(self) -> List[str]:
+        """Names of modal.Function objects registered on the stub."""
         return list(self._function_handles.keys())
 
     @property
     def registered_entrypoints(self) -> Dict[str, Callable]:
+        """Names of local CLI entrypoints registered on the stub."""
         return self._local_entrypoints
+
+    @property
+    def registered_endpoints(self) -> List[str]:
+        """Names of web endpoint (ie. webhook) functions registered on the stub."""
+        return list(
+            tag
+            for tag, handle in self._function_handles.items()
+            if handle._function._webhook_config and handle._function._webhook_config.type
+        )
 
     @decorator_with_options
     def local_entrypoint(self, raw_f=None, name: Optional[str] = None):
@@ -650,6 +661,7 @@ class _Stub:
 
     @decorator_with_options
     def generator(self, raw_f=None, **kwargs):
+        """Stub.generator is no longer supported. Use .function() instead."""
         deprecation_error(date(2022, 12, 1), "Stub.generator is no longer supported. Use .function() instead.")
 
     @decorator_with_options


### PR DESCRIPTION
* Not useful to have webhooks available in `modal run`, and they don't seem to work anyway
* Add missing docstrings that are conspicuous on [modal.com/docs/reference/modal.Stub](https://modal.com/docs/reference/modal.Stub).