### PR TITLE
fix: AttributeError: '_FunctionHandle' object has no attribute '_func…

### DIFF
--- a/modal/stub.py
+++ b/modal/stub.py
@@ -548,7 +548,9 @@ class _Stub:
         return list(
             tag
             for tag, handle in self._function_handles.items()
-            if handle._function._webhook_config and handle._function._webhook_config.type
+            if hasattr(handle, "_function")
+            and handle._function._webhook_config
+            and handle._function._webhook_config.type
         )
 
     @decorator_with_options


### PR DESCRIPTION
Just tried this new code on the whisper app and it broke. 

```python
(Pdb) Stub.registered_web_endpoints
*** NameError: name 'Stub' is not defined
(Pdb) _Stub.registered_web_endpoints
<property object at 0x10b7b5a40>
(Pdb) _Stub.registered_web_endpoints.__get__(_stub)
*** AttributeError: '_FunctionHandle' object has no attribute '_function'
```

The error from user perspective (ie. not in a debugger) is this: 

```
│                                                                                                  │
│   156 │   │   # Return a reference to an object that will be created in the future               │
│ ❱ 157 │   │   return self._blueprint[tag]                                                        │
│   158                                                                                            │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
KeyError: 'registered_web_endpoints'
```

If the property fails to be set, then the object acts as if it doesn't exist (though it still appears in `dir(obj)`)

For some reason `_FunctionHandle` objects don't always set that attribute. I don't know why, but this should stop `modal run` breaking for now. 
