### PR TITLE
Add a test for calling functions inside containers

### DIFF
--- a/client_test/client_test.py
+++ b/client_test/client_test.py
@@ -1,5 +1,4 @@
 # Copyright Modal Labs 2022
-import platform
 import pytest
 
 from google.protobuf.empty_pb2 import Empty
@@ -9,12 +8,9 @@ from modal.client import AioClient, Client
 from modal.exception import AuthError, ConnectionError, VersionError
 from modal_proto import api_pb2
 
-TEST_TIMEOUT = 4.0  # align this with the container client timeout in client.py
+from .supports.skip import skip_windows
 
-skip_windows = pytest.mark.skipif(
-    platform.system() == "Windows",
-    reason="Windows doesn't have UNIX sockets",
-)
+TEST_TIMEOUT = 4.0  # align this with the container client timeout in client.py
 
 
 @pytest.mark.asyncio

--- a/client_test/container_app_test.py
+++ b/client_test/container_app_test.py
@@ -1,0 +1,30 @@
+# Copyright Modal Labs 2022
+import pytest
+
+from modal.aio import AioApp, AioFunctionHandle, AioStub, aio_container_app
+
+
+def my_f_1(x):
+    # Body doesn't matter, the fixture overrides this anyway
+    return x**3
+
+
+@pytest.mark.asyncio
+async def test_container_function_initialization(unix_servicer, aio_container_client):
+    unix_servicer.app_objects["ap-123"] = {
+        "my_f_1": "fu-123",
+        "my_f_2": "fu-456",
+    }
+    await AioApp._init_container(aio_container_client, "ap-123")
+
+    # Make sure the app has a handle for this function
+    f = aio_container_app["my_f_1"]
+    assert isinstance(f, AioFunctionHandle)
+
+    # Now, let's create a function with this name
+    stub = AioStub()
+    f = stub.function(my_f_1)
+    assert isinstance(f, AioFunctionHandle)
+
+    # We should be able to call this function inside the container
+    assert await f.call(42) == 1764

--- a/client_test/container_app_test.py
+++ b/client_test/container_app_test.py
@@ -3,12 +3,15 @@ import pytest
 
 from modal.aio import AioApp, AioFunctionHandle, AioStub, aio_container_app
 
+from .supports.skip import skip_windows
+
 
 def my_f_1(x):
     # Body doesn't matter, the fixture overrides this anyway
     return x**3
 
 
+@skip_windows
 @pytest.mark.asyncio
 async def test_container_function_initialization(unix_servicer, aio_container_client):
     unix_servicer.app_objects["ap-123"] = {

--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2022
 from __future__ import annotations
 import json
-import platform
 import pytest
 import sys
 import time
@@ -16,15 +15,11 @@ from modal.client import Client
 from modal.exception import InvalidError
 from modal_proto import api_pb2
 
+from .supports.skip import skip_windows
+
 EXTRA_TOLERANCE_DELAY = 1.0
 FUNCTION_CALL_ID = "fc-123"
 SLEEP_DELAY = 0.1
-
-
-skip_windows = pytest.mark.skipif(
-    platform.system() == "Windows",
-    reason="Windows doesn't have UNIX sockets",
-)
 
 
 def _get_inputs(args=((42,), {})) -> list[api_pb2.FunctionGetInputsResponse]:

--- a/client_test/grpc_utils_test.py
+++ b/client_test/grpc_utils_test.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2022
 import asyncio
 import math
-import platform
 import pytest
 import time
 
@@ -9,6 +8,8 @@ from grpclib import GRPCError, Status
 
 from modal_proto import api_grpc, api_pb2
 from modal_utils.grpc_utils import ChannelPool, create_channel, retry_transient_errors
+
+from .supports.skip import skip_windows
 
 
 @pytest.mark.asyncio
@@ -24,7 +25,7 @@ async def test_http_channel(servicer):
     channel.close()
 
 
-@pytest.mark.skipif(platform.system() == "Windows", reason="Windows doesn't have UNIX sockets")
+@skip_windows
 @pytest.mark.asyncio
 async def test_unix_channel(unix_servicer):
     assert unix_servicer.remote_addr.startswith("unix://")

--- a/client_test/supports/skip.py
+++ b/client_test/supports/skip.py
@@ -1,0 +1,11 @@
+# Copyright Modal Labs 2022
+
+import platform
+
+import pytest
+
+# TODO(erikbern): there's a few other reasons we skip windows (see eg shared_volume_test.py)
+skip_windows = pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="Windows doesn't have UNIX sockets",
+)


### PR DESCRIPTION
This reproduces an (internal) integration test which passes on main but fails on #245

Useful to have as a unit test to prevent future regressions. Will rebase #245 on this and fix it separately.
