### PR TITLE
Add failing test for web endpoints on #245

### DIFF
--- a/client_test/stub_test.py
+++ b/client_test/stub_test.py
@@ -208,3 +208,15 @@ async def test_grpc_protocol(aio_client, servicer):
     assert isinstance(servicer.requests[1], api_pb2.AppCreateRequest)
     assert isinstance(servicer.requests[2], api_pb2.AppHeartbeatRequest)
     assert isinstance(servicer.requests[3], api_pb2.AppClientDisconnectRequest)
+
+
+async def square_webhook(x):
+    return {"square": x**2}
+
+
+def test_registered_web_endpoints(client, servicer):
+    stub = Stub()
+    stub.function(square)
+    stub.webhook(square_webhook)
+
+    assert stub.registered_web_endpoints == ["square_webhook"]


### PR DESCRIPTION
This adds a test that succeeds on main but fails in #245 – it was caught post-deploy by an internal integration tests.