### PR TITLE
remove warning for gpu=True

### DIFF
--- a/client_test/image_test.py
+++ b/client_test/image_test.py
@@ -5,7 +5,7 @@ import sys
 from typing import List
 
 from modal import Image, Mount, Secret, SharedVolume, Stub, gpu
-from modal.exception import DeprecationError, InvalidError, NotFoundError
+from modal.exception import InvalidError, NotFoundError
 from modal.image import _dockerhub_python_version
 from modal_proto import api_pb2
 
@@ -322,8 +322,9 @@ def test_image_gpu(client, servicer):
         layers = get_image_layers(running_app["image"].object_id, servicer)
         assert layers[0].gpu_config.type == api_pb2.GPU_TYPE_UNSPECIFIED
 
-    with pytest.warns(DeprecationError):
-        stub = Stub(image=Image.debian_slim().run_commands("echo 1", gpu=True))
+    # TODO(erikbern): reenable this warning when we actually support different GPU types
+    # with pytest.warns(DeprecationError):
+    stub = Stub(image=Image.debian_slim().run_commands("echo 1", gpu=True))
     with stub.run(client=client) as running_app:
         layers = get_image_layers(running_app["image"].object_id, servicer)
         assert layers[0].gpu_config.type == api_pb2.GPU_TYPE_ANY

--- a/modal/gpu.py
+++ b/modal/gpu.py
@@ -47,7 +47,7 @@ STRING_TO_GPU_CONFIG = {"t4": T4(), "a100": A100(), "a10g": A10G(), "any": Any()
 GPU_T = Union[None, bool, str, _GPUConfig]
 
 
-def parse_gpu_config(value: GPU_T) -> api_pb2.GPUConfig:
+def parse_gpu_config(value: GPU_T, warn_on_true: bool = True) -> api_pb2.GPUConfig:
     if isinstance(value, _GPUConfig):
         return value._to_proto()
     elif isinstance(value, str):
@@ -57,9 +57,10 @@ def parse_gpu_config(value: GPU_T) -> api_pb2.GPUConfig:
             )
         return STRING_TO_GPU_CONFIG[value.lower()]._to_proto()
     elif value is True:
-        deprecation_warning(
-            date(2022, 12, 19), 'Setting gpu=True is deprecated. Use `gpu="any"` or `gpu=modal.gpu.Any()` instead.'
-        )
+        if warn_on_true:
+            deprecation_warning(
+                date(2022, 12, 19), 'Setting gpu=True is deprecated. Use `gpu="any"` or `gpu=modal.gpu.Any()` instead.'
+            )
         return Any()._to_proto()
     elif value is None or value is False:
         return api_pb2.GPUConfig()

--- a/modal/image.py
+++ b/modal/image.py
@@ -502,7 +502,7 @@ class _Image(Provider[_ImageHandle]):
             dockerfile_commands=_dockerfile_commands,
             context_files=context_files,
             secrets=secrets,
-            gpu_config=parse_gpu_config(gpu),
+            gpu_config=parse_gpu_config(gpu, warn_on_true=False),
         )
 
     def run_commands(
@@ -521,7 +521,7 @@ class _Image(Provider[_ImageHandle]):
         return self.extend(
             dockerfile_commands=dockerfile_commands,
             secrets=secrets,
-            gpu_config=parse_gpu_config(gpu),
+            gpu_config=parse_gpu_config(gpu, warn_on_true=False),
         )
 
     @staticmethod


### PR DESCRIPTION
Until we actually support different GPU types on the server, let's not warn if people provide `gpu=True` – it feels dumb to nudge people into specifying the GPU if we don't actually care.