### PR TITLE
Set `stub.app` to the container app inside containers

### DIFF
--- a/client_test/container_app_test.py
+++ b/client_test/container_app_test.py
@@ -20,13 +20,13 @@ def my_f_2(x):
 @pytest.mark.asyncio
 async def test_container_function_initialization(unix_servicer, aio_container_client):
     stub = AioStub()
-    # my_f_1_container = stub.function(my_f_1)
+    my_f_1_container = stub.function(my_f_1)
 
     unix_servicer.app_objects["ap-123"] = {
         "my_f_1": "fu-123",
         "my_f_2": "fu-456",
     }
-    await AioApp.init_container(aio_container_client, "ap-123")
+    await AioApp.init_container(aio_container_client, "ap-123", stub)
 
     # Make sure these functions exist and have the right type
     my_f_1_app = aio_container_app["my_f_1"]
@@ -35,10 +35,7 @@ async def test_container_function_initialization(unix_servicer, aio_container_cl
     assert isinstance(my_f_2_app, AioFunctionHandle)
 
     # Make sure we can call my_f_1 inside the container
-    # assert await my_f_1_container.call(42) == 1764
-    # TODO(erikbern): it's actually impossible for a stub function
-    # to be created before the app inside a container, so let's
-    # ignore this issue for now. It's just theoretical.
+    assert await my_f_1_container.call(42) == 1764
 
     # Now, let's create my_f_2 after the app started running
     # This might happen if some local module is imported lazily

--- a/client_test/container_app_test.py
+++ b/client_test/container_app_test.py
@@ -65,7 +65,7 @@ async def test_is_inside(servicer, unix_servicer, aio_client, aio_container_clie
         unix_servicer.app_objects[app_id] = servicer.app_objects[app_id]
 
         # Pretend that we're inside the container
-        await AioApp.init_container(aio_container_client, app_id)
+        await AioApp.init_container(aio_container_client, app_id, stub)
 
         # Pretend that we're inside image 1
         with mock.patch.dict(os.environ, {"MODAL_IMAGE_ID": image_1_id}):

--- a/client_test/webhook_test.py
+++ b/client_test/webhook_test.py
@@ -17,7 +17,7 @@ async def test_webhook(servicer, aio_client):
         assert f.web_url
 
         # Make sure the container gets the app id as well
-        container_app = await AioApp.init_container(aio_client, app.app_id)
+        container_app = await AioApp.init_container(aio_client, app.app_id, stub)
         assert container_app.f.web_url
 
 

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -472,7 +472,7 @@ async def call_function_async(
 
 
 @wrap()
-def import_function(function_def: api_pb2.Function, ser_cls, ser_fun) -> tuple[Any, Callable, bool, Optional["_Stub"]]:
+def import_function(function_def: api_pb2.Function, ser_cls, ser_fun) -> tuple[Any, Callable, bool, Any]:
     # This is not in function_io_manager, so that any global scope code that runs during import
     # runs on the main thread.
 
@@ -484,7 +484,7 @@ def import_function(function_def: api_pb2.Function, ser_cls, ser_fun) -> tuple[A
         module = importlib.import_module(function_def.module_name)
         cls, fun = load_function_from_module(module, function_def.function_name)
 
-    stub: Optional["_Stub"] = None
+    stub = None  # TODO(erikbern): type annotation
 
     # The decorator is typically in global scope, but may have been applied independently
     if isinstance(fun, (FunctionHandle, AioFunctionHandle)):

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -116,8 +116,8 @@ class _FunctionIOManager:
         _App.set_is_container(True)
 
     @wrap()
-    async def init_container(self):
-        await _App.init_container(self._client, self.app_id)
+    async def init_container(self, stub):
+        await _App.init_container(self._client, self.app_id, stub)
 
     async def _heartbeat(self):
         request = api_pb2.ContainerHeartbeatRequest()
@@ -552,7 +552,7 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
             obj, fun, is_async, stub = import_function(container_args.function_def, ser_cls, ser_fun)
 
         # Initialize the app
-        function_io_manager.init_container()
+        function_io_manager.init_container(stub)
 
         if container_args.function_def.pty_info.enabled:
             from modal import container_app

--- a/modal/app.py
+++ b/modal/app.py
@@ -186,7 +186,8 @@ class _App:
             await self._load(_default_image)
 
         # Set the app of the stub
-        stub.set_app(self)
+        if stub is not None:
+            stub.set_app(self)
 
     @staticmethod
     def set_is_container(is_container_app: bool):

--- a/modal/app.py
+++ b/modal/app.py
@@ -185,6 +185,9 @@ class _App:
 
             await self._load(_default_image)
 
+        # Set the app of the stub
+        stub.set_app(self)
+
     @staticmethod
     def set_is_container(is_container_app: bool):
         global _is_container_app

--- a/modal/app.py
+++ b/modal/app.py
@@ -174,10 +174,14 @@ class _App:
             await self._load(_default_image)
 
     @staticmethod
+    def set_is_container(is_container_app: bool):
+        global _is_container_app
+        _is_container_app = is_container_app
+
+    @staticmethod
     async def init_container(client: _Client, app_id: str) -> _App:
         """Used by the container to bootstrap the app and all its objects."""
-        global _container_app, _is_container_app
-        _is_container_app = True
+        global _container_app
         await _container_app._init_container(client, app_id)
         return _container_app
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1,4 +1,6 @@
 # Copyright Modal Labs 2022
+from __future__ import annotations
+
 import asyncio
 import inspect
 import os
@@ -445,8 +447,8 @@ class _FunctionHandle(Handle, type_prefix="fu"):
     """Interact with a Modal Function of a live app."""
 
     _web_url: Optional[str]
-    _function: "_Function"
-    _stub: "_Stub"  # Used by the container entrypoint to look up the stub
+    _function: _Function
+    # _stub: "_Stub"  # Used by the container entrypoint to look up the stub
 
     def _set_mute_cancellation(self, value=True):
         self._mute_cancellation = value
@@ -485,11 +487,11 @@ class _FunctionHandle(Handle, type_prefix="fu"):
     def _set_raw_f(self, raw_f):
         self._raw_f = raw_f
 
-    def set_stub(self, stub: "_Stub"):
+    def set_stub(self, stub):  # TODO(erikbern): type annotation
         self._stub = stub
 
     @property
-    def stub(self) -> "_Stub":
+    def stub(self):  # TODO(erikbern): type annotation
         return self._stub
 
     @property

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -446,6 +446,7 @@ class _FunctionHandle(Handle, type_prefix="fu"):
 
     _web_url: Optional[str]
     _function: "_Function"
+    _stub: "_Stub"  # Used by the container entrypoint to look up the stub
 
     def _set_mute_cancellation(self, value=True):
         self._mute_cancellation = value
@@ -483,6 +484,13 @@ class _FunctionHandle(Handle, type_prefix="fu"):
 
     def _set_raw_f(self, raw_f):
         self._raw_f = raw_f
+
+    def set_stub(self, stub: "_Stub"):
+        self._stub = stub
+
+    @property
+    def stub(self) -> "_Stub":
+        return self._stub
 
     @property
     def web_url(self) -> str:

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -487,7 +487,7 @@ class _FunctionHandle(Handle, type_prefix="fu"):
     def _set_raw_f(self, raw_f):
         self._raw_f = raw_f
 
-    def set_stub(self, stub):  # TODO(erikbern): type annotation
+    def _set_stub(self, stub):  # TODO(erikbern): type annotation
         self._stub = stub
 
     @property
@@ -686,28 +686,6 @@ class _FunctionHandle(Handle, type_prefix="fu"):
 FunctionHandle, AioFunctionHandle = synchronize_apis(_FunctionHandle)
 
 
-def _get_container_function(tag: str):
-    # TODO(erikbern): this is a bit if a janky solution to the problem of assigning
-    # ids to all global functions. We can't do this from the app, since the app doesn't
-    # "know" its stub and its providers. So we "steal" the objects from here just based
-    # on the tag. This is ugly but will work 99.99% of the time. I'll think of something
-    # better!
-    from .app import _container_app
-
-    if _container_app is None:
-        return None
-
-    try:
-        handle = _container_app[tag]
-    except KeyError:
-        return None
-
-    if isinstance(handle, _FunctionHandle):
-        return handle
-    else:
-        return None
-
-
 class _Function(Provider[_FunctionHandle]):
     """Functions are the basic units of serverless execution on Modal.
 
@@ -720,6 +698,7 @@ class _Function(Provider[_FunctionHandle]):
 
     def __init__(
         self,
+        function_handle: _FunctionHandle,
         function_info: FunctionInfo,
         image=None,
         secret: Optional[_Secret] = None,
@@ -828,14 +807,7 @@ class _Function(Provider[_FunctionHandle]):
         if self._gpu:
             self._panel_items.append("GPU")
 
-        function_handle = _get_container_function(self._tag)
-        if function_handle is None:
-            function_handle = _FunctionHandle._new()
-        function_handle._initialize_from_proto(None)
-        function_handle._set_raw_f(raw_f)
-        function_handle._set_is_web_endpoint(webhook_config is not None)
-
-        self._precreated_function_handle = function_handle
+        self._function_handle = function_handle
 
         rep = "Function({self._tag})"
         super().__init__(self._load, rep)
@@ -996,11 +968,11 @@ class _Function(Provider[_FunctionHandle]):
             resolver.set_message(f"Created {self._tag}.")
 
         # Update the precreated function handle (todo: hack until we merge providers/handles)
-        self._precreated_function_handle._initialize_handle(resolver.client, response.function_id)
-        self._precreated_function_handle._initialize_from_proto(response.function)
+        self._function_handle._initialize_handle(resolver.client, response.function_id)
+        self._function_handle._initialize_from_proto(response.function)
 
         # Instead of returning a new object, just return the precreated one
-        return self._precreated_function_handle
+        return self._function_handle
 
     def get_panel_items(self) -> List[str]:
         return self._panel_items

--- a/modal/image.py
+++ b/modal/image.py
@@ -797,14 +797,18 @@ class _Image(Provider[_ImageHandle]):
         )
         ```
         """
-        from .functions import _Function
+        from .functions import _Function, _FunctionHandle
 
         info = FunctionInfo(raw_f)
         base_mounts = [_get_client_mount()]
         for key, mount in info.get_mounts().items():
             base_mounts.append(mount)
 
+        function_handle = _FunctionHandle._new()
+        function_handle._initialize_from_proto(None)
+
         function = _Function(
+            function_handle,
             info,
             image=self,
             secret=secret,

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -529,6 +529,7 @@ class _Stub:
                 self._local_mounts.append(mount)
 
         function_handle = function._precreated_function_handle
+        function_handle.set_stub(self)  # Used by the container entrypoint to find the stub
         self._function_handles[function.tag] = function_handle
         return function_handle
 

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -514,13 +514,14 @@ class _Stub:
 
         return mounts
 
-    def _create_function_handle(self, info: FunctionInfo, is_web_endpoint: bool = False):
+    def _create_function_handle(self, info: FunctionInfo, is_web_endpoint: bool = False) -> _FunctionHandle:
         tag = info.get_tag()
         if self._app:
             # This case only happens if the function is created lazily inside a container,
             # so it's a bit of an edge case
-            return self._app[tag]
-            # TOOD(erikbern): handle KeyError
+            handle = self._app[tag]  # TOOD(erikbern): handle KeyError
+            assert isinstance(handle, _FunctionHandle)  # TODO(erikbern): handle failure
+            return handle
         else:
             function_handle = _FunctionHandle._new()
             function_handle._initialize_from_proto(None)
@@ -530,7 +531,7 @@ class _Stub:
             self._function_handles[tag] = function_handle
             return function_handle
 
-    def _add_function(self, function: _Function, mounts: List[_Mount]) -> _FunctionHandle:
+    def _add_function(self, function: _Function, mounts: List[_Mount]):
         if function.tag in self._blueprint:
             old_function = self._blueprint[function.tag]
             if isinstance(old_function, _Function):

--- a/modal_test_support/missing_main_conditional.py
+++ b/modal_test_support/missing_main_conditional.py
@@ -11,4 +11,4 @@ def square(x):
 
 # This should fail in a container
 with stub.run():
-    print(square(42))
+    print(square.call(42))


### PR DESCRIPTION
This also uses the stub app to initialize function handles in the container.

I'm a bit annoyed this PR is +43 lines net, since it's supposed to be a reduction in complexity. I suspect we'll be able to clean up a lot more stuff once we merge `_Function` and `_FunctionHandle`

This will break some rare cases. If the stub is defined in the global scope, but not used for a function `g`, then `g` won't be able to call any other functions defined on the stub (in global scope). For instance this case below:
```python
stub = Stub()

@stub.function
def f():
    print("hello")

def g():
    f.call()  # this will fail

if __name__ == "__main__":
    g_modal = stub.function(g)
    with stub.run():
        g_modal()
```

This feels acceptable? The reason it breaks is that `g` isn't associated with the stub, so the container will fail to initialize the stub properly.