### PR TITLE
Adds support for 20G A100s variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ __pycache__
 *.output.ipynb
 *.iml
 .venv
+venv/
 build/

--- a/client_test/gpu_test.py
+++ b/client_test/gpu_test.py
@@ -90,11 +90,8 @@ def test_cloud_provider_selection(client, servicer):
         stub.function(dummy, cloud="gcp")
 
 
-A100_GPU_MEMORY_MAPPING = {
-    0: api_pb2.GPU_TYPE_A100,
-    20: api_pb2.GPU_TYPE_A100_20G,
-    40: api_pb2.GPU_TYPE_A100
-}
+A100_GPU_MEMORY_MAPPING = {0: api_pb2.GPU_TYPE_A100, 20: api_pb2.GPU_TYPE_A100_20G, 40: api_pb2.GPU_TYPE_A100}
+
 
 @pytest.mark.parametrize("memory,gpu_type", A100_GPU_MEMORY_MAPPING.items())
 def test_memory_selection_gpu_variant(client, servicer, memory, gpu_type):

--- a/modal/gpu.py
+++ b/modal/gpu.py
@@ -12,36 +12,43 @@ from .exception import InvalidError, deprecation_warning
 class _GPUConfig:
     type: "api_pb2.GPUType.V"
     count: int
+    memory: int
 
     def _to_proto(self) -> api_pb2.GPUConfig:
         """Convert this GPU config to an internal protobuf representation."""
         return api_pb2.GPUConfig(
             type=self.type,
             count=self.count,
+            memory=self.memory,
         )
 
 
 class T4(_GPUConfig):
     def __init__(self):
-        super().__init__(api_pb2.GPU_TYPE_T4, 1)
+        super().__init__(api_pb2.GPU_TYPE_T4, 1, 0)
 
 
 class A100(_GPUConfig):
-    def __init__(self, *, count: int = 1):
-        super().__init__(api_pb2.GPU_TYPE_A100, count)
+    def __init__(self, *, count: int = 1, memory: int = 0):
+        if memory == 20:
+            super().__init__(api_pb2.GPU_TYPE_A100_20G, count, memory)
+        elif memory != 0:
+            raise ValueError(f"A100s can only have memory value of 0 or 20 => {memory=}")
+        else:
+            super().__init__(api_pb2.GPU_TYPE_A100, count, memory)
 
 
 class A10G(_GPUConfig):
-    def __init__(self, *, count: int = 1):
-        super().__init__(api_pb2.GPU_TYPE_A10G, count)
+    def __init__(self, *, count: int = 1, memory: int = 0):
+        super().__init__(api_pb2.GPU_TYPE_A10G, count, memory)
 
 
 class Any(_GPUConfig):
-    def __init__(self, *, count: int = 1):
-        super().__init__(api_pb2.GPU_TYPE_ANY, count)
+    def __init__(self, *, count: int = 1, memory: int = 0):
+        super().__init__(api_pb2.GPU_TYPE_ANY, count, memory)
 
 
-STRING_TO_GPU_CONFIG = {"t4": T4(), "a100": A100(), "a10g": A10G(), "any": Any()}
+STRING_TO_GPU_CONFIG = {"t4": T4(), "a100": A100(), "a100-20g": A100(memory=20),"a10g": A10G(), "any": Any()}
 
 # bool will be deprecated in future versions.
 GPU_T = Union[None, bool, str, _GPUConfig]

--- a/modal/gpu.py
+++ b/modal/gpu.py
@@ -32,7 +32,7 @@ class A100(_GPUConfig):
     def __init__(self, *, count: int = 1, memory: int = 0):
         allowed_memory_values = {0, 20, 40}
         if memory not in allowed_memory_values:
-            raise ValueError(f"A100s can only have memory values of {allowed_memory_values} => {memory=}")
+            raise ValueError(f"A100s can only have memory values of {allowed_memory_values} => memory={memory}")
         if memory == 20:
             super().__init__(api_pb2.GPU_TYPE_A100_20G, count, memory)
         else:

--- a/modal/gpu.py
+++ b/modal/gpu.py
@@ -49,7 +49,7 @@ class Any(_GPUConfig):
         super().__init__(api_pb2.GPU_TYPE_ANY, count, memory)
 
 
-STRING_TO_GPU_CONFIG = {"t4": T4(), "a100": A100(), "a100-20g": A100(memory=20),"a10g": A10G(), "any": Any()}
+STRING_TO_GPU_CONFIG = {"t4": T4(), "a100": A100(), "a100-20g": A100(memory=20), "a10g": A10G(), "any": Any()}
 
 # bool will be deprecated in future versions.
 GPU_T = Union[None, bool, str, _GPUConfig]

--- a/modal/gpu.py
+++ b/modal/gpu.py
@@ -30,10 +30,11 @@ class T4(_GPUConfig):
 
 class A100(_GPUConfig):
     def __init__(self, *, count: int = 1, memory: int = 0):
+        allowed_memory_values = {0, 20, 40}
+        if memory not in allowed_memory_values:
+            raise ValueError(f"A100s can only have memory values of {allowed_memory_values} => {memory=}")
         if memory == 20:
             super().__init__(api_pb2.GPU_TYPE_A100_20G, count, memory)
-        elif memory != 0:
-            raise ValueError(f"A100s can only have memory value of 0 or 20 => {memory=}")
         else:
             super().__init__(api_pb2.GPU_TYPE_A100, count, memory)
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -664,11 +664,13 @@ enum GPUType {
   GPU_TYPE_A100 = 2;
   GPU_TYPE_A10G = 3;
   GPU_TYPE_ANY = 4;
+  GPU_TYPE_A100_20G = 5;
 }
 
 message GPUConfig {
   GPUType type = 1;
   uint32 count = 2;
+  uint32 memory = 3;
 }
 
 message Resources {


### PR DESCRIPTION
This adds client support for smaller A100s with 20Gb instead of the default 40gb. I decided to go with the following interface:

```python
@stub.function(gpu=modal.gpu.A100(memory=20))  # or "a100-20g"
def f(): ...
```

That’ll fail if memory not in (0, 20, 40). My other option is to create a new class (`A100_20g`). I found that confusing because the trailing `G` on `A10G` does not mean "gigabytes". It also feels repetitive to create a class per memory variant. 

`memory` also supports the higher memory variant (80Gb) whenever that is available on Modal.