### PR TITLE
Add minimum version for click package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ install_requires =
     asgiref
     certifi
     cloudpickle>=2.0.0
+    click>=8.1.0
     fastapi
     grpclib==0.4.3
     importlib_metadata


### PR DESCRIPTION
This fixes some issues where a lower version was previously installed, causing the following issue for some users:

```
│ /.../site-packages/click/core.py:1657 in invoke       │
│                                                                                                  │
│   1656 │   │   │   │   super().invoke(ctx)                                                       │
│ ❱ 1657 │   │   │   │   sub_ctx = cmd.make_context(cmd_name, args, parent=ctx)                    │
│   1658 │   │   │   │   with sub_ctx:                                                             │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
AttributeError: 'function' object has no attribute 'make_context'
```