### PR TITLE
Improve container app test

### DIFF
--- a/client_test/container_app_test.py
+++ b/client_test/container_app_test.py
@@ -102,6 +102,9 @@ async def test_is_inside_default_image(servicer, unix_servicer, aio_client, aio_
         default_image_id = default_image_handle.object_id
         app_id = app.app_id
 
+        # Copy the app objects to the container servicer
+        unix_servicer.app_objects[app_id] = servicer.app_objects[app_id]
+
         await AioApp.init_container(aio_container_client, app_id)
 
         with mock.patch.dict(os.environ, {"MODAL_IMAGE_ID": default_image_id}):

--- a/modal/app.py
+++ b/modal/app.py
@@ -206,8 +206,10 @@ class _App:
 
     @staticmethod
     def _reset_container():
-        global _is_container_app
+        # Just used for tests
+        global _is_container_app, _container_app
         _is_container_app = False
+        _container_app.__init__(None, None, None, None)
 
 
 App, AioApp = synchronize_apis(_App)

--- a/modal/app.py
+++ b/modal/app.py
@@ -209,7 +209,7 @@ class _App:
         # Just used for tests
         global _is_container_app, _container_app
         _is_container_app = False
-        _container_app.__init__(None, None, None, None)
+        _container_app.__init__(None, None, None, None)  # type: ignore
 
 
 App, AioApp = synchronize_apis(_App)


### PR DESCRIPTION
It didn't quite catch what I wanted it to catch, and it turned out it was primarily caused by some fixture leakage during tests – since we weren't resetting the container app. Fixed that.

Hopefully this should make it a lot easier to refactor the `is_inside` logic