### PR TITLE
Get container app from stub

### DIFF
--- a/client_test/container_app_test.py
+++ b/client_test/container_app_test.py
@@ -102,6 +102,9 @@ async def test_is_inside_default_image(servicer, unix_servicer, aio_client, aio_
         default_image_id = default_image_handle.object_id
         app_id = app.app_id
 
+        # Copy the app objects to the container servicer
+        unix_servicer.app_objects[app_id] = servicer.app_objects[app_id]
+
         await AioApp.init_container(aio_container_client, app_id)
 
         with mock.patch.dict(os.environ, {"MODAL_IMAGE_ID": default_image_id}):

--- a/client_test/container_app_test.py
+++ b/client_test/container_app_test.py
@@ -51,7 +51,11 @@ async def test_container_function_initialization(unix_servicer, aio_container_cl
 async def test_is_inside(servicer, unix_servicer, aio_client, aio_container_client):
     image_1 = AioImage.debian_slim().pip_install(["abc"])
     image_2 = AioImage.debian_slim().pip_install(["def"])
-    stub = AioStub(image=image_1, image_2=image_2)
+
+    def get_stub():
+        return AioStub(image=image_1, image_2=image_2)
+
+    stub = get_stub()
 
     # No container is running
     assert not stub.is_inside()
@@ -70,6 +74,9 @@ async def test_is_inside(servicer, unix_servicer, aio_client, aio_container_clie
         # Pretend that we're inside the container
         await AioApp.init_container(aio_container_client, app_id)
 
+        # Create a new stub (TODO: tie it to the previous stub through name or similar)
+        stub = get_stub()
+
         # Pretend that we're inside image 1
         with mock.patch.dict(os.environ, {"MODAL_IMAGE_ID": image_1_id}):
             assert stub.is_inside()
@@ -78,7 +85,7 @@ async def test_is_inside(servicer, unix_servicer, aio_client, aio_container_clie
 
         # Pretend that we're inside image 2
         with mock.patch.dict(os.environ, {"MODAL_IMAGE_ID": image_2_id}):
-            assert not stub.is_inside()  # refers to the default image (todo: should we?)
+            assert stub.is_inside()
             assert not stub.is_inside(image_1)
             assert stub.is_inside(image_2)
 
@@ -106,6 +113,9 @@ async def test_is_inside_default_image(servicer, unix_servicer, aio_client, aio_
         unix_servicer.app_objects[app_id] = servicer.app_objects[app_id]
 
         await AioApp.init_container(aio_container_client, app_id)
+
+        # Create a new stub (TODO: tie it to the previous stub through name or similar)
+        stub = AioStub()
 
         with mock.patch.dict(os.environ, {"MODAL_IMAGE_ID": default_image_id}):
             assert stub.is_inside()

--- a/client_test/container_app_test.py
+++ b/client_test/container_app_test.py
@@ -19,14 +19,15 @@ def my_f_2(x):
 @skip_windows
 @pytest.mark.asyncio
 async def test_container_function_initialization(unix_servicer, aio_container_client):
-    stub = AioStub()
-    # my_f_1_container = stub.function(my_f_1)
-
     unix_servicer.app_objects["ap-123"] = {
         "my_f_1": "fu-123",
         "my_f_2": "fu-456",
     }
+
     await AioApp.init_container(aio_container_client, "ap-123")
+
+    stub = AioStub()
+    # my_f_1_container = stub.function(my_f_1)
 
     # Make sure these functions exist and have the right type
     my_f_1_app = aio_container_app["my_f_1"]

--- a/modal/app.py
+++ b/modal/app.py
@@ -77,7 +77,7 @@ class _App:
         self, obj: Provider, progress: Optional[Tree] = None, existing_object_id: Optional[str] = None
     ) -> Handle:
         """Send a server request to create an object in this app, and return its ID."""
-        cached_obj = self._load_cached(obj)
+        cached_obj = self._local_uuid_to_object.get(obj.local_uuid)
         if cached_obj is not None:
             # We already created this object before, shortcut this method
             return cached_obj
@@ -103,13 +103,6 @@ class _App:
 
         self._local_uuid_to_object[obj.local_uuid] = created_obj
         return created_obj
-
-    def _load_cached(self, obj: Provider) -> Optional[Handle]:
-        """Try to load a previously-loaded object, without making network requests.
-
-        Returns `None` if the object has not been previously loaded.
-        """
-        return self._local_uuid_to_object.get(obj.local_uuid)
 
     async def _create_all_objects(self, progress: Tree, new_app_state: int):  # api_pb2.AppState.V
         """Create objects that have been defined but not created on the server."""

--- a/modal/app.py
+++ b/modal/app.py
@@ -113,7 +113,6 @@ class _App:
 
     async def _create_all_objects(self, progress: Tree, new_app_state: int):  # api_pb2.AppState.V
         """Create objects that have been defined but not created on the server."""
-        print(self._stub._blueprint)
         for tag, provider in self._stub._blueprint.items():
             existing_object_id = self._tag_to_existing_id.get(tag)
             self._tag_to_object[tag] = await self._load(provider, progress, existing_object_id)

--- a/modal/app.py
+++ b/modal/app.py
@@ -113,6 +113,7 @@ class _App:
 
     async def _create_all_objects(self, progress: Tree, new_app_state: int):  # api_pb2.AppState.V
         """Create objects that have been defined but not created on the server."""
+        print(self._stub._blueprint)
         for tag, provider in self._stub._blueprint.items():
             existing_object_id = self._tag_to_existing_id.get(tag)
             self._tag_to_object[tag] = await self._load(provider, progress, existing_object_id)
@@ -167,11 +168,6 @@ class _App:
         for item in resp.items:
             obj = Handle._from_id(item.object_id, self._client, item.function)
             self._tag_to_object[item.tag] = obj
-
-        if "image" not in self._tag_to_object:
-            from .stub import _default_image
-
-            await self._load(_default_image)
 
     @staticmethod
     async def init_container(client: _Client, app_id: str) -> _App:

--- a/modal/app.py
+++ b/modal/app.py
@@ -206,8 +206,10 @@ class _App:
 
     @staticmethod
     def _reset_container():
-        global _is_container_app
+        # Just used for tests
+        global _is_container_app, _container_app
         _is_container_app = False
+        _container_app.__init__(None, None, None, None)
 
 
 App, AioApp = synchronize_apis(_App)

--- a/modal/app.py
+++ b/modal/app.py
@@ -209,7 +209,7 @@ class _App:
         # Just used for tests
         global _is_container_app, _container_app
         _is_container_app = False
-        _container_app.__init__(None, None, None, None)
+        _container_app.__init__(None, None, None, None)  # type: ignore
 
 
 App, AioApp = synchronize_apis(_App)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -460,26 +460,16 @@ class _FunctionHandle(Handle, type_prefix="fu"):
             False  # set when a user terminates the app intentionally, to prevent useless traceback spam
         )
         self._function_name = None
-        self._is_web_endpoint = None
 
         if proto is not None:
             assert isinstance(proto, api_pb2.Function)
             self._is_generator = proto.function_type == api_pb2.Function.FUNCTION_TYPE_GENERATOR
             self._web_url = proto.web_url
-            self._is_web_endpoint = bool(proto.web_url)
             self._function_name = proto.function_name
 
     def _set_output_mgr(self, output_mgr: OutputManager):
         """mdmd:hidden"""
         self._output_mgr = output_mgr
-
-    @property
-    def is_web_endpoint(self):
-        return self._is_web_endpoint
-
-    def _set_is_web_endpoint(self, value: bool):
-        # Used by provider to pre-set this for not-yet created handles
-        self._is_web_endpoint = value
 
     def _set_raw_f(self, raw_f):
         self._raw_f = raw_f

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -789,7 +789,7 @@ class _Function(Provider[_FunctionHandle]):
 
         self._function_handle = function_handle
 
-        rep = "Function({self._tag})"
+        rep = r"Function({self._tag})"
         super().__init__(self._load, rep)
 
     async def _load(self, resolver: Resolver):

--- a/modal/image.py
+++ b/modal/image.py
@@ -797,14 +797,18 @@ class _Image(Provider[_ImageHandle]):
         )
         ```
         """
-        from .functions import _Function
+        from .functions import _Function, _FunctionHandle
 
         info = FunctionInfo(raw_f)
         base_mounts = [_get_client_mount()]
         for key, mount in info.get_mounts().items():
             base_mounts.append(mount)
 
+        function_handle = _FunctionHandle._new()
+        function_handle._initialize_from_proto(None)
+
         function = _Function(
+            function_handle,
             info,
             image=self,
             secret=secret,

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -28,7 +28,7 @@ from .config import config, logger
 from .exception import InvalidError, deprecation_error
 from .functions import _Function, _FunctionHandle
 from .gpu import GPU_T
-from .image import _Image
+from .image import _Image, _ImageHandle
 from .mount import _get_client_mount, _Mount
 from .object import Provider
 from .proxy import _Proxy
@@ -195,6 +195,7 @@ class _Stub:
                 )
             )
 
+        assert isinstance(image_handle, _ImageHandle)
         return image_handle._is_inside()
 
     async def _heartbeat(self, client, app_id):


### PR DESCRIPTION
When a stub is created, try to get the container app. This is then used for (a) `is_inside` (b) initializing all functions.

The stub grabs the container app in a very greedy way. It's potentially problematic if there's multiple stubs defined and some of them do not belong to the running app. We can fix that later by checking the stub's name, making sure there's not multiple stubs, etc.

We don't (yet) expose the `stub._app` property but will do that later.

This gets rid of a bunch of hacky code in several places, although there are some things that are slightly more verbose afterwards. But there's +14 lines of test so this would be net -17 lines otherwise.