### PR TITLE
new weburlinfo state — label_stolen

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -8,16 +8,7 @@ import warnings
 from dataclasses import dataclass
 from datetime import date, timedelta
 from pathlib import Path
-from typing import (
-    Any,
-    AsyncIterable,
-    Callable,
-    Collection,
-    Dict,
-    List,
-    Optional,
-    Union,
-)
+from typing import Any, AsyncIterable, Callable, Collection, Dict, List, Optional, Union
 
 import cloudpickle
 from aiostream import pipe, stream
@@ -976,6 +967,8 @@ class _Function(Provider[_FunctionHandle]):
                 suffix = " [grey70](label truncated)[/grey70]"
             elif response.web_url_info.has_unique_hash:
                 suffix = " [grey70](label includes conflict-avoidance hash)[/grey70]"
+            elif response.web_url_info.label_stolen:
+                suffix = " [grey70](label stolen)[/grey70]"
             else:
                 suffix = ""
             # TODO: this is only printed when we're showing progress. Maybe move this somewhere else.

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -867,6 +867,7 @@ message WebhookConfig {
 message WebUrlInfo {
   bool truncated = 1;
   bool has_unique_hash = 2;
+  bool label_stolen = 3;
 }
 
 service ModalClient {


### PR DESCRIPTION
Used when we take a webhook label from a running _ephemeral_ app to give it to a newer ephemeral app.