### PR TITLE
Adds disabled app state

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -23,6 +23,9 @@ enum AppState {
 
   // App is created and in process of deployment.
   APP_STATE_INITIALIZING = 6;
+
+  // Same as stopped but prevented from being garbage collected
+  APP_STATE_DISABLED = 7;
 }
 
 enum ClientType {


### PR DESCRIPTION
Will be used to mark apps as stopped without triggering garbage collection. For example, when an app uses an unsupported client version. Could potentially be used by end users as well to temporarily disable and re-enable deployed apps without affecting deployed objects in the app.