### PR TITLE
fix: live-reload special casing for <= py3.7 

### DIFF
--- a/client_test/live_reload_test.py
+++ b/client_test/live_reload_test.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2023
 import asyncio
 import os
+import sys
 import pytest
 
 try:
@@ -34,6 +35,7 @@ class FakeProcess:
         pass
 
 
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="live-reload requires python3.8 or higher")
 def test_file_changes_trigger_reloads(client, monkeypatch, servicer, test_dir):
     async def fake_watch(stub, output_mgr, timeout):
         yield AppChange.START

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -397,7 +397,7 @@ class _Stub:
                     if sys.version_info.major == 3 and sys.version_info.minor <= 7:
                         while event != AppChange.TIMEOUT:
                             output_mgr.print_if_visible(
-                                "Live-reload skipped. This feature is unsupported on Python 3.7. Upgrade to Python 3.8+ to enable live-reloading."
+                                "Live-reload skipped. This feature is unsupported below Python 3.8. Upgrade to Python 3.8+ to enable live-reloading."
                             )
                             event = await event_agen.__anext__()
 

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -393,7 +393,13 @@ class _Stub:
                 async with self._run(client, output_mgr, None, mode=StubRunMode.SERVE) as app:
                     client.set_pre_stop(app.disconnect)
                     existing_app_id = app.app_id
-                    event = await event_agen.__anext__()  # wait for 1st modification before restarting
+                    event = await event_agen.__anext__()
+                    if sys.version_info.major == 3 and sys.version_info.minor <= 7:
+                        while event != AppChange.TIMEOUT:
+                            output_mgr.print_if_visible(
+                                "Live-reload skipped. This feature is unsupported on Python 3.7. Upgrade to Python 3.8+ to enable live-reloading."
+                            )
+                            event = await event_agen.__anext__()
 
                 while event != AppChange.TIMEOUT:
                     curr_proc = await restart_serve(

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -402,6 +402,7 @@ class _Stub:
                             event = await event_agen.__anext__()
                         return
 
+                # live-reloading loop
                 while event != AppChange.TIMEOUT:
                     curr_proc = await restart_serve(
                         existing_app_id=app.app_id, prev_proc=curr_proc, output_mgr=output_mgr

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -400,6 +400,7 @@ class _Stub:
                                 "Live-reload skipped. This feature is unsupported below Python 3.8. Upgrade to Python 3.8+ to enable live-reloading."
                             )
                             event = await event_agen.__anext__()
+                        return
 
                 while event != AppChange.TIMEOUT:
                     curr_proc = await restart_serve(


### PR DESCRIPTION
https://modalbetatesters.slack.com/archives/C031Z7H15DG/p1674678448536299?thread_ts=1674178183.705229&cid=C031Z7H15DG

I looked into supporting Python 3.7 but it looks non-trivial given the current use of `asyncio.create_subprocess_exec`. Here I at least stop the process crashing and provide a message to users.