### PR TITLE
Check for set equality

### DIFF
--- a/client_test/mounted_files_test.py
+++ b/client_test/mounted_files_test.py
@@ -20,12 +20,17 @@ def venv_path(tmp_path):
 script_path = "pkg_a/script.py"
 
 
-def test_mounted_files_script(test_dir):
+@pytest.fixture
+def supports_dir(test_dir):
+    return test_dir / Path("supports")
+
+
+def test_mounted_files_script(supports_dir):
     p = subprocess.run(
         [sys.executable, str(script_path)],
         capture_output=True,
-        cwd=test_dir / Path("supports"),
-        env={**os.environ, "PYTHONPATH": str(test_dir / Path("supports"))},
+        cwd=supports_dir,
+        env={**os.environ, "PYTHONPATH": str(supports_dir)},
     )
     assert p.returncode == 0
     stdout = p.stdout.decode("utf-8")
@@ -34,33 +39,27 @@ def test_mounted_files_script(test_dir):
     print("stderr: ", stderr)
     files = set(stdout.splitlines())
 
-    assert len(files) == 7
-    # Assert everything from `pkg_a` is in the output.
-    assert any(["a.py" in f for f in files])
-    assert any(["c.py" in f for f in files])
-    assert not any(["d.py" in f for f in files])
-    assert any(["e.py" in f for f in files])
-    assert any(["script.py" in f for f in files])
-
-    # Assert everything from `pkg_b` is in the output.
-    assert any(["__init__.py" in f for f in files])
-    assert any(["f.py" in f for f in files])
-    assert any(["h.py" in f for f in files])
-
-    # Assert nothing from `pkg_c` is in the output.
-    assert not any(["i.py" in f for f in files])
-    assert not any(["k.py" in f for f in files])
+    # Assert we include everything from `pkg_a` and `pkg_b` but not `pkg_c`:
+    assert files == {
+        "/root/a.py",
+        "/root/b/c.py",
+        "/root/b/e.py",
+        "/root/pkg_b/__init__.py",
+        "/root/pkg_b/f.py",
+        "/root/pkg_b/g/h.py",
+        "/root/script.py",
+    }
 
 
 serialized_fn_path = "pkg_a/serialized_fn.py"
 
 
-def test_mounted_files_serialized(test_dir):
+def test_mounted_files_serialized(supports_dir):
     p = subprocess.run(
         [sys.executable, str(serialized_fn_path)],
         capture_output=True,
-        cwd=test_dir / Path("supports"),
-        env={**os.environ, "PYTHONPATH": str(test_dir / Path("supports"))},
+        cwd=supports_dir,
+        env={**os.environ, "PYTHONPATH": str(supports_dir)},
     )
     assert p.returncode == 0
     stdout = p.stdout.decode("utf-8")
@@ -69,26 +68,20 @@ def test_mounted_files_serialized(test_dir):
     print("stderr: ", stderr)
     files = set(stdout.splitlines())
 
-    assert len(files) == 7
-    # Assert everything from `pkg_a` is in the output.
-    assert any(["a.py" in f for f in files])
-    assert any(["c.py" in f for f in files])
-    assert not any(["d.py" in f for f in files])
-    assert any(["e.py" in f for f in files])
-    assert any(["serialized_fn.py" in f for f in files])
-
-    # Assert everything from `pkg_b` is in the output.
-    assert any(["__init__.py" in f for f in files])
-    assert any(["f.py" in f for f in files])
-    assert any(["h.py" in f for f in files])
-
-    # Assert nothing from `pkg_c` is in the output.
-    assert not any(["i.py" in f for f in files])
-    assert not any(["k.py" in f for f in files])
+    # Assert we include everything from `pkg_a` and `pkg_b` but not `pkg_c`:
+    assert files == {
+        "/root/b/c.py",
+        "/root/b/e.py",
+        "/root/pkg_a/a.py",
+        "/root/pkg_a/serialized_fn.py",
+        "/root/pkg_b/__init__.py",
+        "/root/pkg_b/f.py",
+        "/root/pkg_b/g/h.py",
+    }
 
 
-def test_mounted_files_package(test_dir):
-    p = subprocess.run([sys.executable, "-m", "pkg_a.package"], cwd=test_dir / Path("supports"), capture_output=True)
+def test_mounted_files_package(supports_dir):
+    p = subprocess.run([sys.executable, "-m", "pkg_a.package"], cwd=supports_dir, capture_output=True)
     assert p.returncode == 0
     stdout = p.stdout.decode("utf-8")
     stderr = p.stderr.decode("utf-8")
@@ -96,34 +89,31 @@ def test_mounted_files_package(test_dir):
     print("stderr: ", stderr)
     files = set(stdout.splitlines())
 
-    assert len(files) == 10
-
-    # Assert everything from `pkg_a` is in the output.
-    assert any(["a.py" in f for f in files])
-    assert any(["c.py" in f for f in files])
-    assert any(["d.py" in f for f in files])
-    assert any(["e.py" in f for f in files])
-    assert any(["script.py" in f for f in files])
-    assert any(["package.py" in f for f in files])
-
-    # Assert everything from `pkg_b` is in the output.
-    assert any(["__init__.py" in f for f in files])
-    assert any(["f.py" in f for f in files])
-    assert any(["h.py" in f for f in files])
-
-    # Assert nothing from `pkg_c` is in the output.
-    assert not any(["i.py" in f for f in files])
-    assert not any(["k.py" in f for f in files])
+    # Assert we include everything from `pkg_a` and `pkg_b` but not `pkg_c`:
+    assert files == {
+        "/root/package.py",
+        "/root/pkg_a/__init__.py",
+        "/root/pkg_a/a.py",
+        "/root/pkg_a/b/c.py",
+        "/root/pkg_a/d.py",
+        "/root/pkg_a/b/e.py",
+        "/root/pkg_a/script.py",
+        "/root/pkg_a/serialized_fn.py",
+        "/root/pkg_a/package.py",
+        "/root/pkg_b/__init__.py",
+        "/root/pkg_b/f.py",
+        "/root/pkg_b/g/h.py",
+    }
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="venvs behave differently on Windows.")
-def test_mounted_files_sys_prefix(test_dir, venv_path):
+def test_mounted_files_sys_prefix(supports_dir, venv_path):
     # Run with venv activated, so it's on sys.prefix, and modal is dev-installed in the VM
     p = subprocess.run(
         [venv_path / "bin" / "python", script_path],
         capture_output=True,
-        cwd=test_dir / Path("supports"),
-        env={**os.environ, "PYTHONPATH": str(test_dir / Path("supports"))},
+        cwd=supports_dir,
+        env={**os.environ, "PYTHONPATH": str(supports_dir)},
     )
     assert p.returncode == 0
     stdout = p.stdout.decode("utf-8")
@@ -132,30 +122,24 @@ def test_mounted_files_sys_prefix(test_dir, venv_path):
     print("stderr: ", stderr)
     files = set(stdout.splitlines())
 
-    assert len(files) == 7
-    # Assert everything from `pkg_a` is in the output.
-    assert any(["a.py" in f for f in files])
-    assert any(["c.py" in f for f in files])
-    assert not any(["d.py" in f for f in files])
-    assert any(["e.py" in f for f in files])
-    assert any(["script.py" in f for f in files])
-
-    # Assert everything from `pkg_b` is in the output.
-    assert any(["__init__.py" in f for f in files])
-    assert any(["f.py" in f for f in files])
-    assert any(["h.py" in f for f in files])
-
-    # Assert nothing from `pkg_c` is in the output.
-    assert not any(["i.py" in f for f in files])
-    assert not any(["k.py" in f for f in files])
+    # Assert we include everything from `pkg_a` and `pkg_b` but not `pkg_c`:
+    assert files == {
+        "/root/a.py",
+        "/root/b/c.py",
+        "/root/b/e.py",
+        "/root/script.py",
+        "/root/pkg_b/__init__.py",
+        "/root/pkg_b/f.py",
+        "/root/pkg_b/g/h.py",
+    }
 
 
-def test_mounted_files_config(test_dir):
+def test_mounted_files_config(supports_dir):
     p = subprocess.run(
         [sys.executable, str(script_path)],
         capture_output=True,
-        cwd=test_dir / Path("supports"),
-        env={**os.environ, "PYTHONPATH": str(test_dir / Path("supports")), "MODAL_AUTOMOUNT": ""},
+        cwd=supports_dir,
+        env={**os.environ, "PYTHONPATH": str(supports_dir), "MODAL_AUTOMOUNT": ""},
     )
     assert p.returncode == 0
     stdout = p.stdout.decode("utf-8")
@@ -164,8 +148,5 @@ def test_mounted_files_config(test_dir):
     print("stderr: ", stderr)
     files = set(stdout.splitlines())
 
-    assert len(files) == 1
-    # Assert everything from `pkg_a` is in the output.
-    assert any(["script.py" in f for f in files])
-    assert not any(["a.py" in f for f in files])
-    assert not any(["f.py" in f for f in files])
+    # Assert just the script is there
+    assert files == {"/root/script.py"}

--- a/client_test/supports/pkg_a/package.py
+++ b/client_test/supports/pkg_a/package.py
@@ -19,8 +19,8 @@ async def get_files():
     fn_info = FunctionInfo(f)
 
     for _, mount in fn_info.get_mounts().items():
-        async for file_info in mount._get_files():
-            print(file_info.rel_filename)
+        async for filename in mount._get_remote_files():
+            print(filename)
 
 
 if __name__ == "__main__":

--- a/client_test/supports/pkg_a/script.py
+++ b/client_test/supports/pkg_a/script.py
@@ -19,8 +19,8 @@ async def get_files():
     fn_info = FunctionInfo(f)
 
     for _, mount in fn_info.get_mounts().items():
-        async for file_info in mount._get_files():
-            print(file_info.rel_filename)
+        async for filename in mount._get_remote_files():
+            print(filename)
 
 
 if __name__ == "__main__":

--- a/client_test/supports/pkg_a/serialized_fn.py
+++ b/client_test/supports/pkg_a/serialized_fn.py
@@ -19,8 +19,8 @@ async def get_files():
     fn_info = FunctionInfo(f, serialized=True)
 
     for _, mount in fn_info.get_mounts().items():
-        async for file_info in mount._get_files():
-            print(file_info.rel_filename)
+        async for filename in mount._get_remote_files():
+            print(filename)
 
 
 if __name__ == "__main__":

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -205,7 +205,7 @@ class FunctionInfo:
                 relpath = os.path.relpath(os.path.dirname(path), self.base_dir)
                 mounts[path] = _Mount(
                     local_file=path,
-                    remote_dir=os.path.join(ROOT_DIR, relpath),
+                    remote_dir=os.path.normpath(os.path.join(ROOT_DIR, relpath)),
                 )
         return filter_safe_mounts(mounts)
 

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -116,6 +116,11 @@ class _Mount(Provider[_MountHandle]):
                     # Can happen with temporary files (e.g. emacs will write temp files and delete them quickly)
                     logger.info(f"Ignoring file not found: {exc}")
 
+    async def _get_remote_files(self):
+        # Used by tests
+        async for file_spec in self._get_files():
+            yield os.path.join(self._remote_dir, file_spec.rel_filename)
+
     async def _load(self, resolver: Resolver):
         # Run a threadpool to compute hash values, and use concurrent coroutines to register files.
         t0 = time.time()

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -119,7 +119,7 @@ class _Mount(Provider[_MountHandle]):
     async def _get_remote_files(self):
         # Used by tests
         async for file_spec in self._get_files():
-            yield os.path.join(self._remote_dir, file_spec.rel_filename)
+            yield (Path(self._remote_dir) / Path(file_spec.rel_filename)).as_posix()
 
     async def _load(self, resolver: Resolver):
         # Run a threadpool to compute hash values, and use concurrent coroutines to register files.


### PR DESCRIPTION
These tests have been failing for me locally for a long time and the structure of the tests have made it hard to understand why.

Checking for set equality is nicer because pytest will output the delta:

```
         # Assert we include everything from `pkg_a` and `pkg_b` but not `pkg_c`:
>       assert files == {"a.py", "c.py", "e.py", "script.py", "__init__.py", "f.py", "h.py"}
E       AssertionError: assert {'__init__.py...'g/h.py', ...} == {'__init__.py..., 'h.py', ...}
E         Extra items in the left set:
E         'g/h.py'
E         Extra items in the right set:
E         'h.py'
E         Full diff:
E         - {'a.py', 'h.py', '__init__.py', 'c.py', 'e.py', 'script.py', 'f.py'}
E         ?         --------                       --------
E         + {'a.py', '__init__.py', 'c.py', 'script.py', 'f.py', 'g/h.py', 'e.py'}
E         ?                                                    ++++++++++++++++++
```
