### PR TITLE
Mount: static factory methods

### DIFF
--- a/client_test/image_test.py
+++ b/client_test/image_test.py
@@ -67,11 +67,11 @@ def test_image_kwargs_validation(servicer, client):
     with pytest.raises(InvalidError):
         stub["image"] = Image.debian_slim().run_commands(
             "echo hi",
-            secrets=[Secret({"xyz": "123"}), Secret.from_name("foo"), Mount(local_dir="/", remote_dir="/")],
+            secrets=[Secret({"xyz": "123"}), Secret.from_name("foo"), Mount.local_dir("/", remote_path="/")],
         )
 
     stub = Stub()
-    stub["image"] = Image.debian_slim().copy(Mount(local_dir="/", remote_dir="/"), remote_path="/dummy")
+    stub["image"] = Image.debian_slim().copy(Mount.local_dir("/", remote_path="/"), remote_path="/dummy")
     stub["image"] = Image.debian_slim().copy(Mount.from_name("foo"), remote_path="/dummy")
     with pytest.raises(InvalidError):
         stub["image"] = Image.debian_slim().copy(Secret({"xyz": "123"}), remote_path="/dummy")
@@ -300,7 +300,7 @@ def test_image_build_with_context_mount(client, servicer, tmp_path):
     (tmp_path / "data").mkdir()
     (tmp_path / "data" / "sub").write_text("world")
 
-    data_mount = Mount(local_dir=tmp_path, remote_dir="/")
+    data_mount = Mount.local_dir(tmp_path, remote_path="/")
 
     stub = Stub()
     dockerfile = NamedTemporaryFile("w", delete=False)

--- a/client_test/image_test.py
+++ b/client_test/image_test.py
@@ -67,11 +67,11 @@ def test_image_kwargs_validation(servicer, client):
     with pytest.raises(InvalidError):
         stub["image"] = Image.debian_slim().run_commands(
             "echo hi",
-            secrets=[Secret({"xyz": "123"}), Secret.from_name("foo"), Mount.local_dir("/", remote_path="/")],
+            secrets=[Secret({"xyz": "123"}), Secret.from_name("foo"), Mount.from_local_dir("/", remote_path="/")],
         )
 
     stub = Stub()
-    stub["image"] = Image.debian_slim().copy(Mount.local_dir("/", remote_path="/"), remote_path="/dummy")
+    stub["image"] = Image.debian_slim().copy(Mount.from_local_dir("/", remote_path="/"), remote_path="/dummy")
     stub["image"] = Image.debian_slim().copy(Mount.from_name("foo"), remote_path="/dummy")
     with pytest.raises(InvalidError):
         stub["image"] = Image.debian_slim().copy(Secret({"xyz": "123"}), remote_path="/dummy")
@@ -300,7 +300,7 @@ def test_image_build_with_context_mount(client, servicer, tmp_path):
     (tmp_path / "data").mkdir()
     (tmp_path / "data" / "sub").write_text("world")
 
-    data_mount = Mount.local_dir(tmp_path, remote_path="/")
+    data_mount = Mount.from_local_dir(tmp_path, remote_path="/")
 
     stub = Stub()
     dockerfile = NamedTemporaryFile("w", delete=False)

--- a/client_test/mount_test.py
+++ b/client_test/mount_test.py
@@ -25,7 +25,7 @@ async def test_get_files(servicer, client, tmpdir):
     files = {}
     stub = AioStub()
     async with stub.run(client=client) as running_app:
-        m = AioMount.local_dir(tmpdir, remote_path="/", condition=lambda fn: fn.endswith(".py"), recursive=True)
+        m = AioMount.from_local_dir(tmpdir, remote_path="/", condition=lambda fn: fn.endswith(".py"), recursive=True)
         await running_app._load(m)  # TODO: is this something we want to expose?
         async for upload_spec in m._get_files():
             files[upload_spec.mount_filename] = upload_spec
@@ -78,7 +78,7 @@ def test_create_mount(servicer, client):
         def condition(fn):
             return fn.endswith(".py")
 
-        m = Mount.local_dir(local_dir, remote_path="/foo", condition=condition)
+        m = Mount.from_local_dir(local_dir, remote_path="/foo", condition=condition)
         obj = running_app._load(m)
         assert obj.object_id == "mo-123"
         assert f"/foo/{cur_filename}" in servicer.files_name2sha
@@ -91,13 +91,13 @@ def test_create_mount(servicer, client):
 def test_create_mount_file_errors(servicer, tmpdir, client):
     stub = Stub()
     with stub.run(client=client) as running_app:
-        m = Mount.local_dir("xyz", remote_path="/xyz")
+        m = Mount.from_local_dir("xyz", remote_path="/xyz")
         with pytest.raises(FileNotFoundError):
             running_app._load(m)
 
         with open(tmpdir / "abc", "w"):
             pass
-        m = Mount.local_dir(tmpdir / "abc", remote_path="/abc")
+        m = Mount.from_local_dir(tmpdir / "abc", remote_path="/abc")
         with pytest.raises(NotADirectoryError):
             running_app._load(m)
 

--- a/client_test/watcher_test.py
+++ b/client_test/watcher_test.py
@@ -14,8 +14,8 @@ from modal.mount import _Mount
 async def test__watch_args_from_mounts(monkeypatch, test_dir):
     paths, watch_filter = _watch_args_from_mounts(
         mounts=[
-            _Mount.local_file("/x/foo.py", remote_path="/foo.py"),
-            _Mount.local_dir("/one/two/bucklemyshoe", remote_path="/"),
+            _Mount.from_local_file("/x/foo.py", remote_path="/foo.py"),
+            _Mount.from_local_dir("/one/two/bucklemyshoe", remote_path="/"),
         ]
     )
 

--- a/client_test/watcher_test.py
+++ b/client_test/watcher_test.py
@@ -14,8 +14,8 @@ from modal.mount import _Mount
 async def test__watch_args_from_mounts(monkeypatch, test_dir):
     paths, watch_filter = _watch_args_from_mounts(
         mounts=[
-            _Mount(remote_dir="/", local_file="/x/foo.py"),
-            _Mount(remote_dir="/", local_dir="/one/two/bucklemyshoe"),
+            _Mount.local_file("/x/foo.py", remote_path="/foo.py"),
+            _Mount.local_dir("/one/two/bucklemyshoe", remote_path="/"),
         ]
     )
 

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -144,18 +144,18 @@ class FunctionInfo:
     def get_mounts(self) -> Dict[str, _Mount]:
         if self.type == FunctionInfoType.PACKAGE:
             mounts = {
-                self.base_dir: _Mount(
-                    local_dir=self.base_dir,
-                    remote_dir=self.remote_dir,
+                self.base_dir: _Mount.local_dir(
+                    self.base_dir,
+                    remote_path=self.remote_dir,
                     recursive=True,
                     condition=package_mount_condition,
                 )
             }
         elif self.type == FunctionInfoType.FILE:
             mounts = {
-                self.file: _Mount(
-                    local_file=self.file,
-                    remote_dir=ROOT_DIR,
+                self.file: _Mount.local_file(
+                    self.file,
+                    remote_path=ROOT_DIR,
                 )
             }
         elif self.type == FunctionInfoType.NOTEBOOK:
@@ -193,9 +193,9 @@ class FunctionInfo:
                     ):
                         continue
                     remote_dir = ROOT_DIR / PurePosixPath(*m.__name__.split("."))
-                    mounts[path] = _Mount(
-                        local_dir=path,
-                        remote_dir=remote_dir,
+                    mounts[path] = _Mount.local_dir(
+                        path,
+                        remote_path=remote_dir,
                         condition=package_mount_condition,
                         recursive=True,
                     )
@@ -220,9 +220,9 @@ class FunctionInfo:
                     remote_dir = ROOT_DIR / relpath
                 else:
                     remote_dir = ROOT_DIR
-                mounts[path] = _Mount(
-                    local_file=path,
-                    remote_dir=remote_dir,
+                mounts[path] = _Mount.local_file(
+                    path,
+                    remote_path=remote_dir,
                 )
         return filter_safe_mounts(mounts)
 

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -144,7 +144,7 @@ class FunctionInfo:
     def get_mounts(self) -> Dict[str, _Mount]:
         if self.type == FunctionInfoType.PACKAGE:
             mounts = {
-                self.base_dir: _Mount.local_dir(
+                self.base_dir: _Mount.from_local_dir(
                     self.base_dir,
                     remote_path=self.remote_dir,
                     recursive=True,
@@ -154,7 +154,7 @@ class FunctionInfo:
         elif self.type == FunctionInfoType.FILE:
             remote_path = ROOT_DIR / Path(self.file).name
             mounts = {
-                self.file: _Mount.local_file(
+                self.file: _Mount.from_local_file(
                     self.file,
                     remote_path=remote_path,
                 )
@@ -194,7 +194,7 @@ class FunctionInfo:
                     ):
                         continue
                     remote_dir = ROOT_DIR / PurePosixPath(*m.__name__.split("."))
-                    mounts[path] = _Mount.local_dir(
+                    mounts[path] = _Mount.from_local_dir(
                         path,
                         remote_path=remote_dir,
                         condition=package_mount_condition,
@@ -221,7 +221,7 @@ class FunctionInfo:
                     remote_path = ROOT_DIR / relpath / Path(path).name
                 else:
                     remote_path = ROOT_DIR / Path(path).name
-                mounts[path] = _Mount.local_file(
+                mounts[path] = _Mount.from_local_file(
                     path,
                     remote_path=remote_path,
                 )

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -152,7 +152,7 @@ class FunctionInfo:
                 )
             }
         elif self.type == FunctionInfoType.FILE:
-            remote_path = PurePosixPath(ROOT_DIR) / Path(self.file).name
+            remote_path = ROOT_DIR / Path(self.file).name
             mounts = {
                 self.file: _Mount.local_file(
                     self.file,

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -152,10 +152,11 @@ class FunctionInfo:
                 )
             }
         elif self.type == FunctionInfoType.FILE:
+            remote_path = PurePosixPath(ROOT_DIR) / Path(self.file).name
             mounts = {
                 self.file: _Mount.local_file(
                     self.file,
-                    remote_path=ROOT_DIR,
+                    remote_path=remote_path,
                 )
             }
         elif self.type == FunctionInfoType.NOTEBOOK:
@@ -217,12 +218,12 @@ class FunctionInfo:
                     continue
 
                 if relpath != PurePosixPath("."):
-                    remote_dir = ROOT_DIR / relpath
+                    remote_path = ROOT_DIR / relpath / Path(path).name
                 else:
-                    remote_dir = ROOT_DIR
+                    remote_path = ROOT_DIR / Path(path).name
                 mounts[path] = _Mount.local_file(
                     path,
-                    remote_path=remote_dir,
+                    remote_path=remote_path,
                 )
         return filter_safe_mounts(mounts)
 

--- a/modal/image.py
+++ b/modal/image.py
@@ -259,7 +259,7 @@ class _Image(Provider[_ImageHandle]):
         ```python
         static_images_dir = "./static"
         # place all static images in root of mount
-        mount = modal.Mount(local_dir=static_images_dir, remote_dir="/")
+        mount = modal.Mount.local_dir(static_images_dir, remote_path="/")
         # place mount's contents into /static directory of image.
         image = modal.Image.debian_slim().copy(mount, remote_path="/static")
         ```

--- a/modal/image.py
+++ b/modal/image.py
@@ -259,7 +259,7 @@ class _Image(Provider[_ImageHandle]):
         ```python
         static_images_dir = "./static"
         # place all static images in root of mount
-        mount = modal.Mount.local_dir(static_images_dir, remote_path="/")
+        mount = modal.Mount.from_local_dir(static_images_dir, remote_path="/")
         # place mount's contents into /static directory of image.
         image = modal.Image.debian_slim().copy(mount, remote_path="/static")
         ```

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -164,6 +164,9 @@ class _Mount(Provider[_MountHandle]):
         rep = f"Mount({self._entries})"
         super().__init__(self._load, rep)
 
+    def extend(self, *entries) -> "_Mount":
+        return Mount(_entries=(self._entries + entries))
+
     def is_local(self) -> bool:
         """mdmd:hidden"""
         # TODO(erikbern): since any remote ref bypasses the constructor,
@@ -177,37 +180,31 @@ class _Mount(Provider[_MountHandle]):
         remote_path: Union[str, PurePosixPath] = None,  # Where the directory is placed within in the mount
         condition: Callable[[str], bool] = lambda path: True,  # Filter function for file selection
         recursive: bool = True,  # add files from subdirectories as well
-    ):
+    ) -> "_Mount":
         local_path = Path(local_path)
         if remote_path is None:
             remote_path = local_path.name
         remote_path = PurePosixPath("/", remote_path)
 
-        return _Mount(
-            _entries=self._entries
-            + [
-                _MountDir(
-                    local_dir=local_path,
-                    condition=condition,
-                    remote_path=remote_path,
-                    recursive=recursive,
-                )
-            ]
+        return self._extend(
+            _MountDir(
+                local_dir=local_path,
+                condition=condition,
+                remote_path=remote_path,
+                recursive=recursive,
+            )
         )
 
-    def add_local_file(self, local_path: Union[str, Path], remote_path: Union[str, PurePosixPath] = None):
+    def add_local_file(self, local_path: Union[str, Path], remote_path: Union[str, PurePosixPath] = None) -> "_Mount":
         local_path = Path(local_path)
         if remote_path is None:
             remote_path = local_path.name
         remote_path = PurePosixPath("/", remote_path)
-        return _Mount(
-            _entries=self._entries
-            + [
-                _MountFile(
-                    local_file=local_path,
-                    remote_path=PurePosixPath(remote_path),
-                )
-            ]
+        return self._extend(
+            _MountFile(
+                local_file=local_path,
+                remote_path=PurePosixPath(remote_path),
+            )
         )
 
     def _description(self) -> str:

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -112,7 +112,7 @@ class _Mount(Provider[_MountHandle]):
     import os
     stub = modal.Stub()
 
-    @stub.function(mounts=[modal.Mount(remote_dir="/root/foo", local_dir="~/foo")])
+    @stub.function(mounts=[modal.Mount.local_dir("~/foo", remote_path="/root/foo")])
     def f():
         # `/root/foo` has the contents of `~/foo`.
         print(os.listdir("/root/foo/"))


### PR DESCRIPTION
This replaces `Mount(local_dir="foo/bar")` with `Mount.from_local_dir("foo/var")` which is consistent with the new factory method `add_local_dir` that @freider just added in #136

For instance you can chain it using

```python
mount = Mount.from_local_dir("foo/bar").add_local_dir("foo/baz")
```

Minor improvement in terms of consistency, and getting rid of constructors also helps me doing some more refactoring later (merging providers and handles). This is also a net reduction in LOC eventually – we will be able to delete about 40 lines once we deprecate the old constructor fully.

A minor thing I realized is that `remote_path` in `add_local_file` is not the same as `remote_dir` in the `Mount` constructor – the former adds the basename of the file itself, the latter excludes it. Had to rewrite a few places, when changing code from `Mount(local_file=x, remote_dir=y)` to `Mount.from_local_file(x, remote_path=y)`