### PR TITLE
Better err msg coverage for 'modal run'

### DIFF
--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -118,14 +118,14 @@ def test_run(servicer, server_url_env, test_dir):
 
 def test_help_message_unspecified_function(servicer, server_url_env, test_dir):
     stub_file = test_dir / "supports" / "app_run_tests" / "stub_with_multiple_functions.py"
-    result = _run(["run", stub_file.as_posix()], expected_exit_code=1)
+    result = _run(["run", stub_file.as_posix()], expected_exit_code=2)
 
     # should suggest available functions on the stub:
     assert "foo" in result.stdout
     assert "bar" in result.stdout
 
     result = _run(
-        ["run", stub_file.as_posix(), "--help"], expected_exit_code=1
+        ["run", stub_file.as_posix(), "--help"], expected_exit_code=2
     )  # TODO: help should not return non-zero
     # help should also available functions on the stub:
     assert "foo" in result.stdout
@@ -177,7 +177,7 @@ def test_run_local_entrypoint(servicer, server_url_env, test_dir):
 
 def test_run_parse_args(servicer, server_url_env, test_dir):
     stub_file = test_dir / "supports" / "app_run_tests" / "cli_args.py"
-    res = _run(["run", stub_file.as_posix()], expected_exit_code=1)
+    res = _run(["run", stub_file.as_posix()], expected_exit_code=2)
     assert "You need to specify an entrypoint" in res.stdout
 
     valid_call_args = [

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -122,33 +122,39 @@ class RunGroup(click.Group):
             | set(_stub.registered_entrypoints.keys())
         )
         registered_functions_str = "\n".join(sorted(function_choices))
-        function_name = parsed_stub_ref.entrypoint_name
-        if not function_name:
+        function_name_candidate = parsed_stub_ref.entrypoint_name
+        function_name = None
+        err_msg = None
+        if not function_name_candidate:
             if len(function_choices) == 1:
                 function_name = function_choices[0]
             elif len(_stub.registered_entrypoints) == 1:
                 function_name = list(_stub.registered_entrypoints.keys())[0]
+            elif len(function_choices) == 0:
+                if _stub.registered_web_endpoints:
+                    err_msg = "App contains only webhook functions. Use `modal serve` instead of `modal run`."
+                else:
+                    err_msg = "Modal stub has no registered functions. Nothing to run."
             else:
-                # TODO(erikbern): better error message if there's *zero* functions / entrypoints
-                print(
-                    f"""You need to specify an entrypoint Modal function to run, e.g.
+                err_msg = f"""You need to specify an entrypoint Modal function to run, e.g.
 
 modal run app.py::stub.my_function [...args]
 
-Registered functions and local entrypoints on the selected stub are:
+Runnable functions and local entrypoints on the selected stub are:
 {registered_functions_str}
     """
-                )
-                exit(1)
-        elif function_name not in function_choices:
-            print(
-                f"""No function `{function_name}` could be found in the specified stub. Registered functions and entrypoints are:
+        elif function_choices and function_name not in function_choices:
+            err_msg = f"""No function `{function_name}` could be found in the specified stub. Runnable functions and entrypoints are:
 
 {registered_functions_str}"""
+        elif function_name_candidate and not function_choices:
+            err_msg = (
+                f"No function `{function_name}` could be found in the specified stub. App has zero runnable functions."
             )
-            exit(1)
 
-        if function_name in _stub.registered_functions:
+        if function_name is None:
+            sys.exit(err_msg)
+        elif function_name in _stub.registered_functions:
             click_command = _get_click_command_for_function_handle(_stub, function_name)
         else:
             click_command = _get_click_command_for_local_entrypoint(_stub, function_name)

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -8,6 +8,7 @@ from typing import List, Optional, Tuple
 
 import click
 import typer
+from click import UsageError
 from rich.console import Console, Group
 from rich.markdown import Markdown
 from rich.panel import Panel
@@ -153,7 +154,7 @@ Runnable functions and local entrypoints on the selected stub are:
             )
 
         if function_name is None:
-            sys.exit(err_msg)
+            raise UsageError(err_msg)
         elif function_name in _stub.registered_functions:
             click_command = _get_click_command_for_function_handle(_stub, function_name)
         else:
@@ -299,16 +300,14 @@ def shell(
     console = Console()
 
     if not console.is_terminal:
-        print("`modal shell` can only be run from a terminal.")
-        sys.exit(1)
+        raise UsageError("`modal shell` can only be run from a terminal.")
 
     _stub = synchronizer._translate_in(stub)
     functions = {tag: obj for tag, obj in _stub._blueprint.items() if isinstance(obj, _Function)}
     function_name = parsed_stub_ref.entrypoint_name
     if function_name is not None:
         if function_name not in functions:
-            print(f"Function {function_name} not found in stub.")
-            sys.exit(1)
+            raise UsageError(f"Function `{function_name}` not found in stub.")
         function = functions[function_name]
     else:
         function = choose_function(_stub, list(functions.items()), console)

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -133,7 +133,7 @@ class RunGroup(click.Group):
                 function_name = list(_stub.registered_entrypoints.keys())[0]
             elif len(function_choices) == 0:
                 if _stub.registered_web_endpoints:
-                    err_msg = "App contains only webhook functions. Use `modal serve` instead of `modal run`."
+                    err_msg = "Modal stub has only webhook functions. Use `modal serve` instead of `modal run`."
                 else:
                     err_msg = "Modal stub has no registered functions. Nothing to run."
             else:
@@ -144,14 +144,14 @@ modal run app.py::stub.my_function [...args]
 Runnable functions and local entrypoints on the selected stub are:
 {registered_functions_str}
     """
-        elif function_choices and function_name not in function_choices:
-            err_msg = f"""No function `{function_name}` could be found in the specified stub. Runnable functions and entrypoints are:
+        elif function_choices and function_name_candidate not in function_choices:
+            err_msg = f"""No function `{function_name_candidate}` could be found in the specified stub. Runnable functions and entrypoints are:
 
 {registered_functions_str}"""
         elif function_name_candidate and not function_choices:
-            err_msg = (
-                f"No function `{function_name}` could be found in the specified stub. App has zero runnable functions."
-            )
+            err_msg = f"No function `{function_name_candidate}` could be found in the specified stub. App has zero runnable functions."
+        else:
+            function_name = function_name_candidate
 
         if function_name is None:
             raise UsageError(err_msg)


### PR DESCRIPTION
Noticed this yesterday evening when looking at err msgs in our examples.

(In the screenshot below I'm modifying `xyz.py` between invocations to test diff scenarios)

<img width="1460" alt="image" src="https://user-images.githubusercontent.com/12058921/217870707-8ad96a34-93f3-410b-8f87-02c41c55f1fd.png">
