### PR TITLE
Stub reduction: prep

### DIFF
--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -208,7 +208,7 @@ def test_missing_main_conditional(unix_servicer, event_loop):
     _run_container(unix_servicer, "modal_test_support.missing_main_conditional", "square")
 
     assert unix_servicer.task_result.status == api_pb2.GenericResult.GENERIC_STATUS_FAILURE
-    assert 'if __name__ == "__main__":' in unix_servicer.task_result.traceback
+    assert "modal run" in unix_servicer.task_result.traceback
 
     exc = deserialize(unix_servicer.task_result.data, None)
     assert isinstance(exc, InvalidError)

--- a/client_test/live_reload_test.py
+++ b/client_test/live_reload_test.py
@@ -37,7 +37,7 @@ class FakeProcess:
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="live-reload requires python3.8 or higher")
 def test_file_changes_trigger_reloads(client, monkeypatch, servicer, test_dir):
-    async def fake_watch(stub, output_mgr, timeout):
+    async def fake_watch(mounts, output_mgr, timeout):
         yield AppChange.START
         yield {(Change.modified, "fake-test-data.py")}
         yield {(Change.modified, "fake-test-data.py")}
@@ -49,7 +49,7 @@ def test_file_changes_trigger_reloads(client, monkeypatch, servicer, test_dir):
 
     mock_create_subprocess_exec = AsyncMock(return_value=FakeProcess())
     monkeypatch.setattr("modal.stub.asyncio.create_subprocess_exec", mock_create_subprocess_exec)
-    monkeypatch.setattr("modal._watcher.watch", fake_watch)
+    monkeypatch.setattr("modal.stub.watch", fake_watch)
 
     stub.serve(client=client, timeout=None)
     assert mock_create_subprocess_exec.call_count == 3

--- a/client_test/stub_test.py
+++ b/client_test/stub_test.py
@@ -177,7 +177,7 @@ def test_nested_serve_invocation(client):
         with stub.run(client=client):
             # This nested call creates a second web endpoint!
             stub.serve(client=client)
-    assert "existing" in str(excinfo.value)
+    assert "running" in str(excinfo.value)
 
 
 def test_run_state(client, servicer):

--- a/modal/_watcher.py
+++ b/modal/_watcher.py
@@ -11,7 +11,6 @@ from watchfiles import Change, DefaultFilter, awatch
 from watchfiles.main import FileChange
 
 from modal.mount import _Mount
-from modal.stub import _Stub
 
 from ._output import OutputManager
 
@@ -101,8 +100,8 @@ def _watch_args_from_mounts(mounts: List[_Mount]) -> Tuple[Set[Path], StubFilesF
     return paths, watch_filter
 
 
-async def watch(stub: _Stub, output_mgr: OutputManager, timeout: Optional[float]):
-    paths, watch_filter = _watch_args_from_mounts(mounts=stub._local_mounts)
+async def watch(mounts: List[_Mount], output_mgr: OutputManager, timeout: Optional[float]):
+    paths, watch_filter = _watch_args_from_mounts(mounts)
 
     _print_watched_paths(paths, output_mgr, timeout)
 

--- a/modal/app.py
+++ b/modal/app.py
@@ -102,7 +102,9 @@ class _App:
         self._local_uuid_to_object[obj.local_uuid] = created_obj
         return created_obj
 
-    async def _create_all_objects(self, blueprint: Dict[str, Provider], progress: Tree, new_app_state: int):  # api_pb2.AppState.V
+    async def _create_all_objects(
+        self, blueprint: Dict[str, Provider], progress: Tree, new_app_state: int
+    ):  # api_pb2.AppState.V
         """Create objects that have been defined but not created on the server."""
         for tag, provider in blueprint.items():
             existing_object_id = self._tag_to_existing_id.get(tag)

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -21,6 +21,7 @@ from ._ipython import is_notebook
 from ._live_reload import MODAL_AUTORELOAD_ENV, restart_serve
 from ._output import OutputManager, step_completed, step_progress
 from ._pty import exec_cmd, write_stdin_to_pty_stream
+from ._watcher import AppChange, watch
 from .app import _App, _container_app, is_local
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, _Client
 from .config import config, logger
@@ -343,8 +344,6 @@ class _Stub:
 
         **Note:** live-reloading is not supported on Python 3.7. Please upgrade to Python 3.8+.
         """
-        from ._watcher import AppChange, watch
-
         if self._app is not None:
             raise InvalidError(
                 "The stub already has an app running."
@@ -369,7 +368,7 @@ class _Stub:
             except asyncio.exceptions.CancelledError:
                 return
         else:
-            event_agen = watch(self, output_mgr, timeout)
+            event_agen = watch(self._local_mounts, output_mgr, timeout)
             event = await event_agen.__anext__()
 
             curr_proc = None

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -322,10 +322,9 @@ class _Stub:
         """
         if not is_local():
             raise InvalidError(
-                "Can not run an app from within a container. You might need to do something like this: \n"
-                'if __name__ == "__main__":\n'
-                "    with stub.run():\n"
-                "        ...\n"
+                "Can not run an app from within a container."
+                " Are you calling stub.run() directly?"
+                " Consider using the `modal run` shell command."
             )
         if client is None:
             client = await _Client.from_env()
@@ -867,6 +866,7 @@ class _Stub:
             stub.interactive_shell(cmd="/bin/bash", image=app_image)
         ```
         """
+        # TODO(erikbern): rewrite the docstring above to point the user towards `modal shell`
         wrapped_fn = self.function(interactive=True, timeout=86400, image=image or self._get_default_image(), **kwargs)(
             exec_cmd
         )

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -228,9 +228,9 @@ class _Stub:
             post_init_state = api_pb2.APP_STATE_EPHEMERAL
 
         if existing_app_id is not None:
-            app = await _App._init_existing(self, client, existing_app_id)
+            app = await _App._init_existing(client, existing_app_id)
         else:
-            app = await _App._init_new(self, client, app_name, deploying=(mode == StubRunMode.DEPLOY), detach=detach)
+            app = await _App._init_new(client, app_name, deploying=(mode == StubRunMode.DEPLOY), detach=detach)
 
         self._app_id = app.app_id
         aborted = False
@@ -255,7 +255,7 @@ class _Stub:
                 # Create all members
                 create_progress = Tree(step_progress("Creating objects..."), guide_style="gray50")
                 with output_mgr.ctx_if_visible(output_mgr.make_live(create_progress)):
-                    await app._create_all_objects(create_progress, post_init_state)
+                    await app._create_all_objects(self._blueprint, create_progress, post_init_state)
                 create_progress.label = step_completed("Created objects.")
                 output_mgr.print_if_visible(create_progress)
 


### PR DESCRIPTION
`modal/stub.py` is nearly 900 lines and I'm thinking about merging it with the app which would make things even bigger.

However, turns out a lot of the code in stub.py does very little with the stub itself – it's a lot of methods that could really be functions instead. `run` and `serve` for instance do very little with the stub.

This PR itself is a bit of prep work that removes some places internally where we access stub properties when it's not needed.