### PR TITLE
minor stub.serve cleanup

### DIFF
--- a/client_test/live_reload_test.py
+++ b/client_test/live_reload_test.py
@@ -15,11 +15,8 @@ except ImportError:
             return super(AsyncMock, self).__call__(*args, **kwargs)  # type: ignore
 
 
-from watchfiles import Change
-
 from modal import Stub
 from modal._live_reload import MODAL_AUTORELOAD_ENV
-from modal._watcher import AppChange
 from modal.aio import AioStub
 
 
@@ -38,11 +35,8 @@ class FakeProcess:
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="live-reload requires python3.8 or higher")
 def test_file_changes_trigger_reloads(client, monkeypatch, servicer, test_dir):
     async def fake_watch(mounts, output_mgr, timeout):
-        yield AppChange.START
-        yield {(Change.modified, "fake-test-data.py")}
-        yield {(Change.modified, "fake-test-data.py")}
-        yield {(Change.added, "another-file.py")}
-        yield AppChange.TIMEOUT
+        for i in range(3):
+            yield
 
     stub = Stub()
     stub.webhook(dummy)
@@ -58,8 +52,9 @@ def test_file_changes_trigger_reloads(client, monkeypatch, servicer, test_dir):
 @pytest.mark.asyncio
 async def test_reloadable_serve_ignores_file_changes(client, monkeypatch, servicer, test_dir):
     async def fake_watch(stub, output_mgr, timeout):
-        yield AppChange.START
-        yield AppChange.TIMEOUT
+        # Iterator that never yields
+        if False:
+            yield
 
     stub = AioStub()
     stub.webhook(dummy)

--- a/modal/_watcher.py
+++ b/modal/_watcher.py
@@ -1,31 +1,19 @@
 # Copyright Modal Labs 2022
 import asyncio
 from collections import defaultdict
-from enum import IntEnum
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import AsyncGenerator, Dict, List, Optional, Set, Tuple
 
 from aiostream import stream
 from rich.tree import Tree
 from watchfiles import Change, DefaultFilter, awatch
-from watchfiles.main import FileChange
 
 from modal.mount import _Mount
 
 from ._output import OutputManager
 
 
-class AppChange(IntEnum):
-    """
-    Enum representing the type of a change in the Modal stub serving state.
-    """
-
-    START = 1
-    TIMEOUT = 2
-
-
-FileChangeset = Set[FileChange]
-ChangeEvent = Union[AppChange, FileChangeset, None]
+_TIMEOUT_SENTINEL = object()
 
 
 class StubFilesFilter(DefaultFilter):
@@ -57,7 +45,7 @@ class StubFilesFilter(DefaultFilter):
 
 async def _sleep(timeout: float):
     await asyncio.sleep(timeout)
-    yield AppChange.TIMEOUT
+    yield _TIMEOUT_SENTINEL
 
 
 async def _watch_paths(paths: Set[Path], watch_filter: StubFilesFilter):
@@ -100,14 +88,17 @@ def _watch_args_from_mounts(mounts: List[_Mount]) -> Tuple[Set[Path], StubFilesF
     return paths, watch_filter
 
 
-async def watch(mounts: List[_Mount], output_mgr: OutputManager, timeout: Optional[float]):
+async def watch(
+    mounts: List[_Mount], output_mgr: OutputManager, timeout: Optional[float]
+) -> AsyncGenerator[None, None]:
     paths, watch_filter = _watch_args_from_mounts(mounts)
 
     _print_watched_paths(paths, output_mgr, timeout)
 
-    yield AppChange.START
-
     timeout_agen = [] if timeout is None else [_sleep(timeout)]
     async with stream.merge(_watch_paths(paths, watch_filter), *timeout_agen).stream() as streamer:
         async for event in streamer:
-            yield event
+            if event == _TIMEOUT_SENTINEL:
+                return
+            else:
+                yield

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -375,9 +375,10 @@ class _Stub:
             curr_proc = None
             try:
                 async for _ in watch(self._local_mounts, output_mgr, timeout):
-                    if sys.version_info.major == 3 and sys.version_info.minor <= 7:
-                        output_mgr.print_if_visible(
-                            "Live-reload skipped. This feature is unsupported below Python 3.8. Upgrade to Python 3.8+ to enable live-reloading."
+                    if sys.version_info <= (3, 7):
+                        warnings.warn(
+                            "Live-reload skipped. This feature is unsupported below Python 3.8."
+                            " Upgrade to Python 3.8+ to enable live-reloading."
                         )
                     else:
                         curr_proc = await restart_serve(

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -375,7 +375,9 @@ class _Stub:
                 curr_proc = None
                 try:
                     async for event in watch(self._local_mounts, output_mgr, timeout):
-                        if event in [AppChange.START, AppChange.TIMEOUT]:
+                        if event == AppChange.TIMEOUT:
+                            return
+                        elif event == AppChange.START:
                             continue
                         if sys.version_info.major == 3 and sys.version_info.minor <= 7:
                             output_mgr.print_if_visible(

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -368,36 +368,29 @@ class _Stub:
             except asyncio.exceptions.CancelledError:
                 return
         else:
-            event_agen = watch(self._local_mounts, output_mgr, timeout)
-            event = await event_agen.__anext__()
+            async with self._run(client, output_mgr, None, mode=StubRunMode.SERVE) as app:
+                client.set_pre_stop(app.disconnect)
+                existing_app_id = app.app_id
 
-            curr_proc = None
-            try:
-                async with self._run(client, output_mgr, None, mode=StubRunMode.SERVE) as app:
-                    client.set_pre_stop(app.disconnect)
-                    existing_app_id = app.app_id
-                    event = await event_agen.__anext__()
-                    if sys.version_info.major == 3 and sys.version_info.minor <= 7:
-                        while event != AppChange.TIMEOUT:
+                curr_proc = None
+                try:
+                    async for event in watch(self._local_mounts, output_mgr, timeout):
+                        if event in [AppChange.START, AppChange.TIMEOUT]:
+                            continue
+                        if sys.version_info.major == 3 and sys.version_info.minor <= 7:
                             output_mgr.print_if_visible(
                                 "Live-reload skipped. This feature is unsupported below Python 3.8. Upgrade to Python 3.8+ to enable live-reloading."
                             )
-                            event = await event_agen.__anext__()
-                        return
-
-                # live-reloading loop
-                while event != AppChange.TIMEOUT:
-                    curr_proc = await restart_serve(
-                        existing_app_id=app.app_id, prev_proc=curr_proc, output_mgr=output_mgr
-                    )
-                    event = await event_agen.__anext__()
-            finally:
-                if curr_proc:
-                    try:
-                        curr_proc.send_signal(signal.SIGINT)
-                    except ProcessLookupError:
-                        logger.warning("Could not interrupt app serve. Supervised process already terminated.")
-                await event_agen.aclose()
+                        else:
+                            curr_proc = await restart_serve(
+                                existing_app_id=app.app_id, prev_proc=curr_proc, output_mgr=output_mgr
+                            )
+                finally:
+                    if curr_proc:
+                        try:
+                            curr_proc.send_signal(signal.SIGINT)
+                        except ProcessLookupError:
+                            logger.warning("Could not interrupt app serve. Supervised process already terminated.")
 
     async def deploy(
         self,

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -342,7 +342,7 @@ class _Stub:
 
         **Note:** live-reloading is not supported on Python 3.7. Please upgrade to Python 3.8+.
         """
-        from ._watcher import AppChange, watch
+        from ._watcher import watch
 
         if self._app is not None:
             raise InvalidError(
@@ -374,11 +374,7 @@ class _Stub:
 
                 curr_proc = None
                 try:
-                    async for event in watch(self._local_mounts, output_mgr, timeout):
-                        if event == AppChange.TIMEOUT:
-                            return
-                        elif event == AppChange.START:
-                            continue
+                    async for _ in watch(self._local_mounts, output_mgr, timeout):
                         if sys.version_info.major == 3 and sys.version_info.minor <= 7:
                             output_mgr.print_if_visible(
                                 "Live-reload skipped. This feature is unsupported below Python 3.8. Upgrade to Python 3.8+ to enable live-reloading."

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -371,6 +371,8 @@ class _Stub:
             async with self._run(client, output_mgr, None, mode=StubRunMode.SERVE) as app:
                 client.set_pre_stop(app.disconnect)
                 existing_app_id = app.app_id
+                # Note: when the context manager exits, it closes the logs.
+                # This is intentional since we run subprocesses right after that fetch logs.
 
             curr_proc = None
             try:

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -368,30 +368,34 @@ class _Stub:
             except asyncio.exceptions.CancelledError:
                 return
         else:
-            async with self._run(client, output_mgr, None, mode=StubRunMode.SERVE) as app:
-                client.set_pre_stop(app.disconnect)
-                existing_app_id = app.app_id
-                # Note: when the context manager exits, it closes the logs.
-                # This is intentional since we run subprocesses right after that fetch logs.
-
-            curr_proc = None
-            try:
-                async for _ in watch(self._local_mounts, output_mgr, timeout):
-                    if sys.version_info <= (3, 7):
-                        warnings.warn(
+            if sys.version_info <= (3, 7):
+                async with self._run(client, output_mgr, None, mode=StubRunMode.SERVE) as app:
+                    client.set_pre_stop(app.disconnect)
+                    existing_app_id = app.app_id
+                    async for _ in watch(self._local_mounts, output_mgr, timeout):
+                        output_mgr.print_if_visible(
                             "Live-reload skipped. This feature is unsupported below Python 3.8."
                             " Upgrade to Python 3.8+ to enable live-reloading."
                         )
-                    else:
+            else:
+                async with self._run(client, output_mgr, None, mode=StubRunMode.SERVE) as app:
+                    client.set_pre_stop(app.disconnect)
+                    existing_app_id = app.app_id
+                    # Note: when the context manager exits, it closes the logs.
+                    # This is intentional since we run subprocesses right after that fetch logs.
+
+                curr_proc = None
+                try:
+                    async for _ in watch(self._local_mounts, output_mgr, timeout):
                         curr_proc = await restart_serve(
                             existing_app_id=app.app_id, prev_proc=curr_proc, output_mgr=output_mgr
                         )
-            finally:
-                if curr_proc:
-                    try:
-                        curr_proc.send_signal(signal.SIGINT)
-                    except ProcessLookupError:
-                        logger.warning("Could not interrupt app serve. Supervised process already terminated.")
+                finally:
+                    if curr_proc:
+                        try:
+                            curr_proc.send_signal(signal.SIGINT)
+                        except ProcessLookupError:
+                            logger.warning("Could not interrupt app serve. Supervised process already terminated.")
 
     async def deploy(
         self,

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -372,23 +372,23 @@ class _Stub:
                 client.set_pre_stop(app.disconnect)
                 existing_app_id = app.app_id
 
-                curr_proc = None
-                try:
-                    async for _ in watch(self._local_mounts, output_mgr, timeout):
-                        if sys.version_info.major == 3 and sys.version_info.minor <= 7:
-                            output_mgr.print_if_visible(
-                                "Live-reload skipped. This feature is unsupported below Python 3.8. Upgrade to Python 3.8+ to enable live-reloading."
-                            )
-                        else:
-                            curr_proc = await restart_serve(
-                                existing_app_id=app.app_id, prev_proc=curr_proc, output_mgr=output_mgr
-                            )
-                finally:
-                    if curr_proc:
-                        try:
-                            curr_proc.send_signal(signal.SIGINT)
-                        except ProcessLookupError:
-                            logger.warning("Could not interrupt app serve. Supervised process already terminated.")
+            curr_proc = None
+            try:
+                async for _ in watch(self._local_mounts, output_mgr, timeout):
+                    if sys.version_info.major == 3 and sys.version_info.minor <= 7:
+                        output_mgr.print_if_visible(
+                            "Live-reload skipped. This feature is unsupported below Python 3.8. Upgrade to Python 3.8+ to enable live-reloading."
+                        )
+                    else:
+                        curr_proc = await restart_serve(
+                            existing_app_id=app.app_id, prev_proc=curr_proc, output_mgr=output_mgr
+                        )
+            finally:
+                if curr_proc:
+                    try:
+                        curr_proc.send_signal(signal.SIGINT)
+                    except ProcessLookupError:
+                        logger.warning("Could not interrupt app serve. Supervised process already terminated.")
 
     async def deploy(
         self,


### PR DESCRIPTION
Not sure why we had all the `__anext__` stuff instead of just an `async for` loop – this seems to work.

Also removed all the `AppChange` stuff – afaict it was never consumed. Now `watch` is just a dummy generator yielding `None`