### PR TITLE
import _watcher in local scope

### DIFF
--- a/client_test/live_reload_test.py
+++ b/client_test/live_reload_test.py
@@ -49,7 +49,7 @@ def test_file_changes_trigger_reloads(client, monkeypatch, servicer, test_dir):
 
     mock_create_subprocess_exec = AsyncMock(return_value=FakeProcess())
     monkeypatch.setattr("modal.stub.asyncio.create_subprocess_exec", mock_create_subprocess_exec)
-    monkeypatch.setattr("modal.stub.watch", fake_watch)
+    monkeypatch.setattr("modal._watcher.watch", fake_watch)
 
     stub.serve(client=client, timeout=None)
     assert mock_create_subprocess_exec.call_count == 3

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -21,7 +21,6 @@ from ._ipython import is_notebook
 from ._live_reload import MODAL_AUTORELOAD_ENV, restart_serve
 from ._output import OutputManager, step_completed, step_progress
 from ._pty import exec_cmd, write_stdin_to_pty_stream
-from ._watcher import AppChange, watch
 from .app import _App, _container_app, is_local
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, _Client
 from .config import config, logger
@@ -343,6 +342,8 @@ class _Stub:
 
         **Note:** live-reloading is not supported on Python 3.7. Please upgrade to Python 3.8+.
         """
+        from ._watcher import AppChange, watch
+
         if self._app is not None:
             raise InvalidError(
                 "The stub already has an app running."


### PR DESCRIPTION
since `watchfiles` isn't present in containers