### PR TITLE
Fix is_inside

### DIFF
--- a/client_test/container_app_test.py
+++ b/client_test/container_app_test.py
@@ -58,13 +58,13 @@ async def test_is_inside(servicer, unix_servicer, aio_client, aio_container_clie
 
     stub = get_stub()
 
-    # No container is running
-    assert not stub.is_inside()
-    assert not stub.is_inside(image_1)
-    assert not stub.is_inside(image_2)
-
     # Run container
     async with stub.run(client=aio_client) as app:
+        # We're not inside the container (yet)
+        assert not stub.is_inside()
+        assert not stub.is_inside(image_1)
+        assert not stub.is_inside(image_2)
+
         app_id = app.app_id
         image_1_id = app["image"].object_id
         image_2_id = app["image_2"].object_id

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -181,7 +181,9 @@ class _Stub:
 
     def is_inside(self, image: Optional[_Image] = None) -> bool:
         """Returns if the program is currently running inside a container for this app."""
-        if not self._app:
+        if self._app is None:
+            return False
+        elif self._app != _container_app:
             return False
         elif image is None:
             # stub.app is set, which means we're inside this stub (no specific image)


### PR DESCRIPTION
The problem is that we now set `stub._app` locally too.

Updated to test to catch this as well, and fixing it.