### PR TITLE
Pin cloudpickle for proto compatibility

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,10 @@ install_requires =
     aiostream
     asgiref
     certifi
-    cloudpickle>=2.0.0
+    # These are pinned to be protocol-compatible with the version of 
+    # cloudpickle inside the container (defined in requirements.txt).
+    cloudpickle>=2.0.0,<2.1.0;python_version<'3.11'
+    cloudpickle>=2.2.0,<2.3.0;python_version>='3.11'
     click>=8.1.0
     fastapi
     grpclib==0.4.3


### PR DESCRIPTION
Reverting this change from a few weeks ago. These need to be pinned because cloudpickle minor versions are not protocol-compatible with each other.