### PR TITLE
Move the lookup function to sit on the Provider class

### DIFF
--- a/client_test/lookup_test.py
+++ b/client_test/lookup_test.py
@@ -2,7 +2,7 @@
 import pytest
 
 from modal.aio import AioQueue, AioStub, aio_lookup
-from modal.exception import NotFoundError
+from modal.exception import DeprecationError, NotFoundError
 
 
 @pytest.mark.asyncio
@@ -11,12 +11,12 @@ async def test_persistent_object(servicer, aio_client):
     stub["q_1"] = AioQueue()
     await stub.deploy("my-queue", client=aio_client)
 
-    q = await aio_lookup("my-queue", client=aio_client)
+    q = await AioQueue.lookup("my-queue", client=aio_client)
     # assert isinstance(q_3, AioQueue)  # TODO(erikbern): it's a AioQueueHandler
     assert q.object_id == "qu-1"
 
     with pytest.raises(NotFoundError):
-        await aio_lookup("bazbazbaz", client=aio_client)
+        await AioQueue.lookup("bazbazbaz", client=aio_client)
 
 
 def square(x):
@@ -31,7 +31,7 @@ async def test_lookup_function(servicer, aio_client):
     stub.function(square)
     await stub.deploy("my-function", client=aio_client)
 
-    f = await aio_lookup("my-function", client=aio_client)
+    f = await AioQueue.lookup("my-function", client=aio_client)
     assert f.object_id == "fu-1"
 
     # Make sure we can call this function
@@ -45,5 +45,16 @@ async def test_webhook_lookup(servicer, aio_client):
     stub.webhook(square, method="POST")
     await stub.deploy("my-webhook", client=aio_client)
 
-    f = await aio_lookup("my-webhook", client=aio_client)
+    f = await AioQueue.lookup("my-webhook", client=aio_client)
     assert f.web_url
+
+
+@pytest.mark.asyncio
+async def test_deprecated(servicer, aio_client):
+    stub = AioStub()
+    stub["q_1"] = AioQueue()
+    await stub.deploy("my-queue", client=aio_client)
+
+    with pytest.warns(DeprecationError):
+        q = await aio_lookup("my-queue", client=aio_client)
+    assert q.object_id == "qu-1"

--- a/modal/object.py
+++ b/modal/object.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
+from datetime import date
 import uuid
-from typing import Awaitable, Callable, Generic, Optional, Type, TypeVar, cast
+from typing import Awaitable, Callable, Generic, Optional, Type, TypeVar
 
 from google.protobuf.message import Message
 
@@ -10,7 +11,7 @@ from modal_utils.async_utils import synchronize_apis
 from ._object_meta import ObjectMeta
 from ._resolver import Resolver
 from .client import _Client
-from .exception import InvalidError, NotFoundError
+from .exception import InvalidError, NotFoundError, deprecation_warning
 
 H = TypeVar("H", bound="Handle")
 
@@ -100,21 +101,10 @@ async def _lookup(
     namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
     client: Optional[_Client] = None,
 ) -> Handle:
-    """
-    General purpose method to retrieve Modal objects such as
-    functions, shared volumes, and secrets.
-
-    ```python notest
-    import modal
-
-    square = modal.lookup("my-shared-app", "square")
-    assert square.call(3) == 9
-
-    vol = modal.lookup("my-shared-volume")
-    for chunk in vol.read_file("my_db_dump.csv"):
-        ...
-    ```
-    """
+    deprecation_warning(
+        date(2023, 2, 11),
+        "modal.lookup is deprecated. Use corresponding class methods instead," " e.g. modal.Secret.lookup, etc.",
+    )
     return await Handle.from_app(app_name, tag, namespace, client)
 
 
@@ -138,6 +128,12 @@ class Provider(Generic[H]):
         obj = Handle.__new__(cls)
         obj._init(load, rep)
         return obj
+
+    @classmethod
+    def get_handle_cls(cls):
+        (base,) = cls.__orig_bases__  # type: ignore
+        (handle_cls,) = base.__args__
+        return handle_cls
 
     def __repr__(self):
         return self._rep
@@ -173,8 +169,9 @@ class Provider(Generic[H]):
 
             _stub = _Stub(label, _object=self)
             await _stub.deploy(client=resolver.client)
-            handle = await Handle.from_app(label, client=resolver.client)
-            return cast(H, handle)
+            handle_cls = cls.get_handle_cls()
+            handle: H = await handle_cls.from_app(label, client=resolver.client)
+            return handle
 
         # Create a class of type cls, but use the base constructor
         cls = type(self)
@@ -203,8 +200,9 @@ class Provider(Generic[H]):
         """
 
         async def _load_remote(resolver: Resolver) -> H:
-            handle = await Handle.from_app(app_name, tag, namespace, resolver.client)
-            return cast(H, handle)
+            handle_cls = cls.get_handle_cls()
+            handle: H = await handle_cls.from_app(app_name, tag, namespace, client=resolver.client)
+            return handle
 
         # Create a class of type cls, but use the base constructor
         # TODO(erikbern): No Provider subclass should override __init__
@@ -212,3 +210,27 @@ class Provider(Generic[H]):
         rep = f"Ref({app_name})"
         Provider.__init__(obj, _load_remote, rep)
         return obj
+
+    @classmethod
+    async def lookup(
+        cls: Type[P],
+        app_name: str,
+        tag: Optional[str] = None,
+        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        client: Optional[_Client] = None,
+    ) -> H:
+        """
+        General purpose method to retrieve Modal objects such as
+        functions, shared volumes, and secrets.
+        ```python notest
+        import modal
+        square = modal.Function.lookup("my-shared-app", "square")
+        assert square(3) == 9
+        vol = modal.SharedVolume.lookup("my-shared-volume")
+        for chunk in vol.read_file("my_db_dump.csv"):
+            ...
+        ```
+        """
+        handle_cls = cls.get_handle_cls()
+        handle: H = await handle_cls.from_app(app_name, tag, namespace, client)
+        return handle


### PR DESCRIPTION
New attempt for https://github.com/modal-labs/modal-client/pull/229

Doesn't change the proto etc. This is a pure client-side change. The only benefit at this point is marginally better typing.