### PR TITLE
Keep reference to shutdown task to prevent garbage collection

### DIFF
--- a/modal_utils/async_utils.py
+++ b/modal_utils/async_utils.py
@@ -301,6 +301,9 @@ def warn_if_generator_is_not_consumed(gen_f):
     return f_wrapped
 
 
+_shutdown_tasks = []
+
+
 def on_shutdown(coro):
     # hook into event loop shutdown when all active tasks get cancelled
     async def wrapper():
@@ -310,7 +313,7 @@ def on_shutdown(coro):
             await coro
             raise
 
-    asyncio.create_task(wrapper())
+    _shutdown_tasks.append(asyncio.create_task(wrapper()))
 
 
 T = TypeVar("T")


### PR DESCRIPTION
Got reminded of this behavior seeing this: https://news.ycombinator.com/item?id=34754276
Did a quick search of our code base and found this as the only place were we create tasks without using our `TaskContext` or otherwise saving a reference to the task