### PR TITLE
Assert for not naming the deployment modal.py

### DIFF
--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -243,6 +243,7 @@ def shell(
     modal shell hello_world.py --cmd=python \n
     ```\n
     """
+    assert not stub_ref.endswith("modal.py"), "Stub can't be named modal.py"
     parsed_stub_ref = parse_stub_ref(stub_ref)
     try:
         stub = import_stub(parsed_stub_ref)


### PR DESCRIPTION
If you name your stub modal.py it will cause a lot of errors.