### PR TITLE
Increase max reties for MountPutFile requests

### DIFF
--- a/modal/mount.py
+++ b/modal/mount.py
@@ -26,7 +26,7 @@ from .exception import InvalidError, NotFoundError, deprecation_warning
 from .object import Handle, Provider
 
 
-MOUNT_PUT_FILE_TIMEOUT_SECONDS = 10 * 60  # 10 min max for transferring files
+MOUNT_PUT_FILE_CLIENT_TIMEOUT = 10 * 60  # 10 min max for transferring files
 
 
 def client_mount_name():
@@ -300,7 +300,7 @@ class _Mount(Provider[_MountHandle]):
                 request2 = api_pb2.MountPutFileRequest(data=file_spec.content, sha256_hex=file_spec.sha256_hex)
 
             start_time = time.monotonic()
-            while time.monotonic() - start_time < MOUNT_PUT_FILE_TIMEOUT_SECONDS:
+            while time.monotonic() - start_time < MOUNT_PUT_FILE_CLIENT_TIMEOUT:
                 response = await retry_transient_errors(resolver.client.stub.MountPutFile, request2, base_delay=1)
                 if response.exists:
                     return mount_file

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -12,6 +12,7 @@ from typing import AsyncGenerator, Callable, Collection, List, Optional, Union, 
 
 import aiostream
 
+import modal.exception
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronize_apis
 from modal_utils.grpc_utils import retry_transient_errors
@@ -23,6 +24,9 @@ from ._resolver import Resolver
 from .config import config, logger
 from .exception import InvalidError, NotFoundError, deprecation_warning
 from .object import Handle, Provider
+
+
+MOUNT_PUT_FILE_TIMEOUT_SECONDS = 10 * 60  # 10 min max for transferring files
 
 
 def client_mount_name():
@@ -294,8 +298,14 @@ class _Mount(Provider[_MountHandle]):
             else:
                 logger.debug(f"Uploading file {file_spec.filename} to {remote_filename} ({file_spec.size} bytes)")
                 request2 = api_pb2.MountPutFileRequest(data=file_spec.content, sha256_hex=file_spec.sha256_hex)
-            await retry_transient_errors(resolver.client.stub.MountPutFile, request2, base_delay=1, max_retries=20)
-            return mount_file
+
+            start_time = time.monotonic()
+            while time.monotonic() - start_time < MOUNT_PUT_FILE_TIMEOUT_SECONDS:
+                response = await retry_transient_errors(resolver.client.stub.MountPutFile, request2, base_delay=1)
+                if response.exists:
+                    return mount_file
+
+            raise modal.exception.TimeoutError(f"Mounting of {file_spec.filename} timed out")
 
         logger.debug(f"Uploading mount using {n_concurrent_uploads} uploads")
 

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -294,7 +294,7 @@ class _Mount(Provider[_MountHandle]):
             else:
                 logger.debug(f"Uploading file {file_spec.filename} to {remote_filename} ({file_spec.size} bytes)")
                 request2 = api_pb2.MountPutFileRequest(data=file_spec.content, sha256_hex=file_spec.sha256_hex)
-            await retry_transient_errors(resolver.client.stub.MountPutFile, request2, base_delay=1)
+            await retry_transient_errors(resolver.client.stub.MountPutFile, request2, base_delay=1, max_retries=20)
             return mount_file
 
         logger.debug(f"Uploading mount using {n_concurrent_uploads} uploads")

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -639,6 +639,7 @@ message MountPutFileRequest {
 
 message MountPutFileResponse {
   bool exists = 2;
+  bool transfer_complete = 3;
 }
 
 message ProxyInfo {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -639,7 +639,6 @@ message MountPutFileRequest {
 
 message MountPutFileResponse {
   bool exists = 2;
-  bool transfer_complete = 3;
 }
 
 message ProxyInfo {


### PR DESCRIPTION
Backend will now (soon) reuse a previous transfer if one is in progress, so this effectively allows for ~15 min of processing time instead of ~3