### PR TITLE
Step 1 towards deploying standalone objects

### DIFF
--- a/client_test/lookup_test.py
+++ b/client_test/lookup_test.py
@@ -65,3 +65,10 @@ async def test_deprecated(servicer, aio_client):
     with pytest.warns(DeprecationError):
         q = await aio_lookup("my-queue", client=aio_client)
     assert q.object_id == "qu-1"
+
+
+@pytest.mark.asyncio
+async def test_deploy_exists(servicer, aio_client):
+    assert not await AioQueue._exists("my-queue", client=aio_client)
+    await AioQueue()._deploy("my-queue", client=aio_client)
+    assert await AioQueue._exists("my-queue", client=aio_client)

--- a/modal/object.py
+++ b/modal/object.py
@@ -155,6 +155,24 @@ class Provider(Generic[H]):
     def local_uuid(self):
         return self._local_uuid
 
+    async def _deploy(self, label: str, client: Optional[_Client] = None) -> H:
+        """mdmd:hidden
+
+        Note 1: this uses the single-object app method, which we're planning to get rid of later
+        Note 2: still considering this an "internal" method, but we'll make it "official" later
+        """
+        from .stub import _Stub
+
+        if client is None:
+            client = await _Client.from_env()
+
+        handle_cls = self.get_handle_cls()
+        object_entity = handle_cls._type_prefix
+        _stub = _Stub(label, _object=self)
+        await _stub.deploy(client=client, object_entity=object_entity)
+        handle: H = await handle_cls.from_app(label, client=client)
+        return handle
+
     def persist(self, label: str):
         """Deploy a Modal app containing this object. This object can then be imported from other apps using
         the returned reference, or by calling `modal.SharedVolume.from_name(label)` (or the equivalent method
@@ -178,13 +196,7 @@ class Provider(Generic[H]):
         """
 
         async def _load_persisted(resolver: Resolver) -> H:
-            from .stub import _Stub
-
-            _stub = _Stub(label, _object=self)
-            await _stub.deploy(client=resolver.client)
-            handle_cls = cls.get_handle_cls()
-            handle: H = await handle_cls.from_app(label, client=resolver.client)
-            return handle
+            return await self._deploy(label, resolver.client)
 
         # Create a class of type cls, but use the base constructor
         cls = type(self)

--- a/modal/object.py
+++ b/modal/object.py
@@ -259,3 +259,27 @@ class Provider(Generic[H]):
         handle_cls = cls.get_handle_cls()
         handle: H = await handle_cls.from_app(app_name, tag, namespace, client)
         return handle
+
+    @classmethod
+    async def _exists(
+        cls: Type[P],
+        app_name: str,
+        tag: Optional[str] = None,
+        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        client: Optional[_Client] = None,
+    ) -> bool:
+        """mdmd:hidden
+
+        Internal for now - will make this "public" later.
+        """
+        if client is None:
+            client = await _Client.from_env()
+        handle_cls = cls.get_handle_cls()
+        request = api_pb2.AppLookupObjectRequest(
+            app_name=app_name,
+            object_tag=tag,
+            namespace=namespace,
+            object_entity=handle_cls._type_prefix,
+        )
+        response = await client.stub.AppLookupObject(request)
+        return bool(response.object_id)

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -416,6 +416,7 @@ class _Stub:
         client=None,
         stdout=None,
         show_progress=None,
+        object_entity=None,
     ):
         """Deploy an app and export its objects persistently.
 
@@ -475,6 +476,7 @@ class _Stub:
                 app_id=app._app_id,
                 name=name,
                 namespace=namespace,
+                object_entity=object_entity,
             )
             deploy_response = await client.stub.AppDeploy(deploy_req)
         output_mgr.print_if_visible(f"\nView Deployment: [magenta]{deploy_response.url}[/magenta]")

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -416,7 +416,7 @@ class _Stub:
         client=None,
         stdout=None,
         show_progress=None,
-        object_entity=None,
+        object_entity="ap",
     ):
         """Deploy an app and export its objects persistently.
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -107,6 +107,7 @@ message AppDeployRequest {
   string app_id = 1;
   DeploymentNamespace namespace = 2;
   string name = 3;
+  string object_entity = 4;
 }
 
 message AppDeployResponse {


### PR DESCRIPTION
This enables you to do `._deploy(label)` on a provider and it returns a handle. It's basically what we want in the future (but named `.deploy`).

However we want to get rid of the dummy apps later. For now, I'm just going to work with the existing structure and keep the dummy apps around for a bit. This PR does change one significant thing which is that it starts to send `object_entity` to the server. The fact that this is set on the app's deployment will let us change the index structure in the DB more easily. For old clients, we can infer the object entity by looking at the objects on the app.