### PR TITLE
Remove client-side cloud provider check

### DIFF
--- a/client_test/gpu_test.py
+++ b/client_test/gpu_test.py
@@ -85,10 +85,6 @@ def test_cloud_provider_selection(client, servicer):
     with pytest.raises(InvalidError):
         stub.function(dummy, cloud="foo")
 
-    # Cannot select cloud provider without A100.
-    with pytest.raises(InvalidError):
-        stub.function(dummy, cloud="gcp")
-
 
 A100_GPU_MEMORY_MAPPING = {0: api_pb2.GPU_TYPE_A100, 20: api_pb2.GPU_TYPE_A100_20G, 40: api_pb2.GPU_TYPE_A100}
 

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -109,7 +109,7 @@ class FunctionInfo:
                 raise Exception("Wasn't able to find the package directory!")
             elif len(base_dirs) > 1:
                 # Base_dirs should all be prefixes of each other since they all contain `module_file`.
-                base_dirs.sort(key=lambda x: len(x))
+                base_dirs.sort(key=len)
 
             self.base_dir = base_dirs[0]
             self.module_name = module.__spec__.name

--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -21,7 +21,7 @@ from typer import Typer
 import modal
 from modal._location import display_location, parse_cloud_provider
 from modal.client import AioClient
-from modal.shared_volume import AioSharedVolumeHandle, _SharedVolumeHandle
+from modal.shared_volume import AioSharedVolumeHandle, _SharedVolumeHandle, AioSharedVolume
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronizer
 
@@ -75,8 +75,6 @@ def create(name: str, cloud: str = typer.Option("aws", help="Cloud provider to c
 
 
 async def volume_from_name(deployment_name) -> _SharedVolumeHandle:
-    from modal.aio import AioSharedVolume
-
     shared_volume = await AioSharedVolume.lookup(deployment_name)
     if not isinstance(shared_volume, AioSharedVolumeHandle):
         raise Exception("The specified app entity is not a shared volume")

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -33,7 +33,7 @@ from ._blob_utils import (
 )
 from ._call_graph import InputInfo, reconstruct_call_graph
 from ._function_utils import FunctionInfo, LocalFunctionError, load_function_from_module
-from ._location import CloudProvider, parse_cloud_provider
+from ._location import parse_cloud_provider
 from ._output import OutputManager
 from ._resolver import Resolver
 from ._serialization import deserialize, serialize
@@ -783,8 +783,6 @@ class _Function(Provider[_FunctionHandle]):
         self._gpu_config = parse_gpu_config(gpu)
         if cloud_provider:
             self._cloud_provider = parse_cloud_provider(cloud_provider)
-            if self._cloud_provider != CloudProvider.AWS and self._gpu_config.type != api_pb2.GPU_TYPE_A100:
-                raise InvalidError("Cloud selection only supported for functions running with A100 GPUs.")
         else:
             self._cloud_provider = None
 

--- a/modal/shared_volume.py
+++ b/modal/shared_volume.py
@@ -83,10 +83,7 @@ class _SharedVolumeHandle(Handle, type_prefix="sv"):
         * Passing a file path returns a list containing only that file's listing description
         * Passing a glob path (including at least one * or ** sequence) returns all files matching that glob path (using absolute paths)
         """
-        entries = []
-        async for entry in self.iterdir(path):
-            entries.append(entry)
-        return entries
+        return [entry async for entry in self.iterdir(path)]
 
     async def remove_file(self, path: str, recursive=False):
         """Remove a file in a shared volume."""


### PR DESCRIPTION
Instead we re-raise `InvalidErrors` from the server here too. Gives us flexibility with removing or changing these restrictions without needing client-side changes.