### PR TITLE
Fixes bug where modal serve would not show logs or heartbeat MOD-878

### DIFF
--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -1,6 +1,5 @@
 # Copyright Modal Labs 2022
 import os
-import pytest
 import sys
 import traceback
 import unittest.mock
@@ -9,6 +8,7 @@ from unittest import mock
 
 import click
 import click.testing
+import pytest
 import pytest_asyncio
 
 from modal.cli.entry_point import entrypoint_cli

--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -44,6 +44,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     def __init__(self, blob_host, blobs):
         self.app_state = {}
+        self.app_heartbeats: Dict[str, int] = defaultdict(int)
         self.n_blobs = 0
         self.blob_host = blob_host
         self.blobs = blobs  # shared dict
@@ -185,8 +186,9 @@ class MockClientServicer(api_grpc.ModalClientBase):
         await stream.send_message(api_pb2.AppLookupObjectResponse(object_id=object_id, function=function))
 
     async def AppHeartbeat(self, stream):
-        request: api_pb2.ClientHeartbeatRequest = await stream.recv_message()
+        request: api_pb2.AppHeartbeatRequest = await stream.recv_message()
         self.requests.append(request)
+        self.app_heartbeats[request.app_id] += 1
         await stream.send_message(Empty())
 
     ### Blob

--- a/client_test/live_reload_test.py
+++ b/client_test/live_reload_test.py
@@ -46,7 +46,7 @@ def test_file_changes_trigger_reloads(client, monkeypatch, servicer, test_dir):
     monkeypatch.setattr("modal._watcher.watch", fake_watch)
 
     stub.serve(client=client, timeout=None)
-    assert mock_create_subprocess_exec.call_count == 3
+    assert mock_create_subprocess_exec.call_count == 4  # 1 + number of file changes
 
 
 @pytest.mark.asyncio

--- a/client_test/live_reload_test.py
+++ b/client_test/live_reload_test.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2023
 import asyncio
 import os
+import platform
 import sys
 import pytest
 
@@ -33,6 +34,7 @@ class FakeProcess:
 
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="live-reload requires python3.8 or higher")
+@pytest.mark.skipif(platform.system() == "Windows", reason="live-reload not supported on windows")
 def test_file_changes_trigger_reloads(client, monkeypatch, servicer, test_dir):
     async def fake_watch(mounts, output_mgr, timeout):
         for i in range(3):

--- a/modal/_live_reload.py
+++ b/modal/_live_reload.py
@@ -10,6 +10,10 @@ from ._output import OutputManager
 MODAL_AUTORELOAD_ENV = "MODAL_AUTORELOAD_SERVE"
 
 
+def get_restart_cli_command():
+    return [sys.executable, *_get_child_arguments()]
+
+
 async def restart_serve(existing_app_id: str, prev_proc: Process, output_mgr: OutputManager) -> Process:
     if prev_proc:
         try:
@@ -18,8 +22,7 @@ async def restart_serve(existing_app_id: str, prev_proc: Process, output_mgr: Ou
             output_mgr.print_if_visible("[yellow]⚡️ Previous serving app process crashed.[/yellow]")
     env = {**os.environ, **{MODAL_AUTORELOAD_ENV: existing_app_id}}
     return await asyncio.create_subprocess_exec(
-        sys.executable,
-        *_get_child_arguments(),
+        *get_restart_cli_command(),
         env=env,
     )
 

--- a/modal/_watcher.py
+++ b/modal/_watcher.py
@@ -96,7 +96,12 @@ async def watch(
     _print_watched_paths(paths, output_mgr, timeout)
 
     timeout_agen = [] if timeout is None else [_sleep(timeout)]
-    async with stream.merge(_watch_paths(paths, watch_filter), *timeout_agen).stream() as streamer:
+    _STARTING_SENTINEL = object()
+
+    async def startup_gen():
+        yield _STARTING_SENTINEL
+
+    async with stream.merge(startup_gen(), _watch_paths(paths, watch_filter), *timeout_agen).stream() as streamer:
         async for event in streamer:
             if event == _TIMEOUT_SENTINEL:
                 return

--- a/modal/_watcher.py
+++ b/modal/_watcher.py
@@ -96,12 +96,8 @@ async def watch(
     _print_watched_paths(paths, output_mgr, timeout)
 
     timeout_agen = [] if timeout is None else [_sleep(timeout)]
-    _STARTING_SENTINEL = object()
 
-    async def startup_gen():
-        yield _STARTING_SENTINEL
-
-    async with stream.merge(startup_gen(), _watch_paths(paths, watch_filter), *timeout_agen).stream() as streamer:
+    async with stream.merge(_watch_paths(paths, watch_filter), *timeout_agen).stream() as streamer:
         async for event in streamer:
             if event == _TIMEOUT_SENTINEL:
                 return

--- a/modal/client.py
+++ b/modal/client.py
@@ -21,7 +21,7 @@ from ._tracing import inject_tracing_context
 from .config import config, logger
 from .exception import AuthError, ConnectionError, DeprecationError, VersionError
 
-HEARTBEAT_INTERVAL = 15.0
+HEARTBEAT_INTERVAL = config.get("heartbeat_interval")
 HEARTBEAT_TIMEOUT = 10.1
 CLIENT_CREATE_ATTEMPT_TIMEOUT = 4.0
 CLIENT_CREATE_TOTAL_TIMEOUT = 15.0

--- a/modal/config.py
+++ b/modal/config.py
@@ -147,6 +147,7 @@ _SETTINGS = {
     "automount": _Setting(True, transform=lambda x: x not in ("", "0")),
     "tracing_enabled": _Setting(False, transform=lambda x: x not in ("", "0")),
     "profiling_enabled": _Setting(False, transform=lambda x: x not in ("", "0")),
+    "heartbeat_interval": _Setting(15, float),
 }
 
 

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -386,7 +386,7 @@ class _Stub:
             if platform.system() == "Windows":
                 unsupported_msg = "Live-reload skipped. This feature is currently unsupported on Windows"
                 " This can hopefully be fixed in a future version of Modal."
-            elif sys.version_info[:2] <= (3, 7):
+            elif sys.version_info < (3, 8):
                 unsupported_msg = (
                     "Live-reload skipped. This feature is unsupported below Python 3.8."
                     " Upgrade to Python 3.8+ to enable live-reloading."

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -388,8 +388,8 @@ class _Stub:
                 " This can hopefully be fixed in a future version of Modal."
             elif sys.version_info[:2] <= (3, 7):
                 unsupported_msg = (
-                  "Live-reload skipped. This feature is unsupported below Python 3.8."
-                  " Upgrade to Python 3.8+ to enable live-reloading."
+                    "Live-reload skipped. This feature is unsupported below Python 3.8."
+                    " Upgrade to Python 3.8+ to enable live-reloading."
                 )
 
             if unsupported_msg:

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -383,19 +383,13 @@ class _Stub:
             if sys.version_info <= (3, 7):
                 async with self._run(client, output_mgr, None, mode=StubRunMode.SERVE) as app:
                     client.set_pre_stop(app.disconnect)
-                    existing_app_id = app.app_id
                     async for _ in watch(self._local_mounts, output_mgr, timeout):
                         output_mgr.print_if_visible(
                             "Live-reload skipped. This feature is unsupported below Python 3.8."
                             " Upgrade to Python 3.8+ to enable live-reloading."
                         )
             else:
-                async with self._run(client, output_mgr, None, mode=StubRunMode.SERVE) as app:
-                    client.set_pre_stop(app.disconnect)
-                    existing_app_id = app.app_id
-                    # Note: when the context manager exits, it closes the logs.
-                    # This is intentional since we run subprocesses right after that fetch logs.
-
+                app = await _App._init_new(client, self.description, deploying=False, detach=False)
                 curr_proc = None
                 try:
                     async for _ in watch(self._local_mounts, output_mgr, timeout):

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -9,6 +9,7 @@ import warnings
 from enum import Enum
 from typing import AsyncGenerator, Collection, Dict, List, Optional, Union
 
+from aiostream import stream
 from rich.tree import Tree
 
 from modal_proto import api_pb2
@@ -380,7 +381,7 @@ class _Stub:
             except asyncio.exceptions.CancelledError:
                 return
         else:
-            if sys.version_info <= (3, 7):
+            if sys.version_info[:2] <= (3, 7):
                 async with self._run(client, output_mgr, None, mode=StubRunMode.SERVE) as app:
                     client.set_pre_stop(app.disconnect)
                     async for _ in watch(self._local_mounts, output_mgr, timeout):
@@ -391,8 +392,13 @@ class _Stub:
             else:
                 app = await _App._init_new(client, self.description, deploying=False, detach=False)
                 curr_proc = None
+                _STARTING_SENTINEL = object()
+
+                async def startup_gen():
+                    yield _STARTING_SENTINEL
+
                 try:
-                    async for _ in watch(self._local_mounts, output_mgr, timeout):
+                    async for _ in stream.merge(startup_gen(), watch(self._local_mounts, output_mgr, timeout)):
                         curr_proc = await restart_serve(
                             existing_app_id=app.app_id, prev_proc=curr_proc, output_mgr=output_mgr
                         )


### PR DESCRIPTION
Previously logs and heartbeats would only appear after the first change of a watched file. Now we instead init an empty app and let watch trigger an initial update of that app

Adds some test config/magic to make the test pick up hearbeats from the subprocess
