### PR TITLE
Use _deploy for deploying the client mount

### DIFF
--- a/modal/client.py
+++ b/modal/client.py
@@ -145,7 +145,7 @@ class _Client:
             elif exc.status == Status.UNAUTHENTICATED:
                 raise AuthError(exc.message)
             else:
-                exc_string = await _grpc_exc_string(exc, "ClientCreate", self.server_url, CLIENT_CREATE_TOTAL_TIMEOUT)
+                exc_string = await _grpc_exc_string(exc, "ClientHello", self.server_url, CLIENT_CREATE_TOTAL_TIMEOUT)
                 raise ConnectionError(exc_string)
         except (OSError, asyncio.TimeoutError) as exc:
             raise ConnectionError(str(exc))

--- a/modal/object.py
+++ b/modal/object.py
@@ -155,7 +155,9 @@ class Provider(Generic[H]):
     def local_uuid(self):
         return self._local_uuid
 
-    async def _deploy(self, label: str, client: Optional[_Client] = None) -> H:
+    async def _deploy(
+        self, label: str, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, client: Optional[_Client] = None
+    ) -> H:
         """mdmd:hidden
 
         Note 1: this uses the single-object app method, which we're planning to get rid of later
@@ -169,11 +171,11 @@ class Provider(Generic[H]):
         handle_cls = self.get_handle_cls()
         object_entity = handle_cls._type_prefix
         _stub = _Stub(label, _object=self)
-        await _stub.deploy(client=client, object_entity=object_entity)
+        await _stub.deploy(namespace=namespace, client=client, object_entity=object_entity)
         handle: H = await handle_cls.from_app(label, client=client)
         return handle
 
-    def persist(self, label: str):
+    def persist(self, label: str, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE):
         """Deploy a Modal app containing this object. This object can then be imported from other apps using
         the returned reference, or by calling `modal.SharedVolume.from_name(label)` (or the equivalent method
         on respective class).
@@ -196,7 +198,7 @@ class Provider(Generic[H]):
         """
 
         async def _load_persisted(resolver: Resolver) -> H:
-            return await self._deploy(label, resolver.client)
+            return await self._deploy(label, namespace, resolver.client)
 
         # Create a class of type cls, but use the base constructor
         cls = type(self)

--- a/modal_base_images/client_mount.py
+++ b/modal_base_images/client_mount.py
@@ -1,15 +1,13 @@
 # Copyright Modal Labs 2022
 import asyncio
 
-import modal.aio
 from modal.mount import aio_create_client_mount, client_mount_name
 from modal_proto import api_pb2
 
 
 async def main(client=None):
-    stub = modal.aio.AioStub()
-    stub["mount"] = aio_create_client_mount()
-    await stub.deploy(client_mount_name(), api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL, client=client)
+    mount = aio_create_client_mount()
+    await mount._deploy(client_mount_name(), api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL, client=client)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Just standardizing on how we deploy single-object apps for now, will make later refactoring easier