### PR TITLE
Adds interface for using ECR

### DIFF
--- a/client_test/image_test.py
+++ b/client_test/image_test.py
@@ -246,13 +246,16 @@ def test_dockerhub_install(servicer, client):
         assert any("FROM gisops/valhalla:latest" in cmd for cmd in layers[0].dockerfile_commands)
         assert any("apt-get update" in cmd for cmd in layers[0].dockerfile_commands)
 
+
 def test_ecr_install(servicer, client):
     image_tag = "000000000000.dkr.ecr.us-east-1.amazonaws.com/my-private-registry:latest"
     stub = Stub(
         image=Image.from_ecr(
             image_tag,
             setup_commands=["apt-get update"],
-            secret=Secret({"AWS_ACCESS_KEY_ID": "", "AWS_SECRET_ACCESS_KEY": ""})))
+            secret=Secret({"AWS_ACCESS_KEY_ID": "", "AWS_SECRET_ACCESS_KEY": ""}),
+        )
+    )
 
     with stub.run(client=client) as running_app:
         layers = get_image_layers(running_app["image"].object_id, servicer)

--- a/client_test/image_test.py
+++ b/client_test/image_test.py
@@ -246,6 +246,20 @@ def test_dockerhub_install(servicer, client):
         assert any("FROM gisops/valhalla:latest" in cmd for cmd in layers[0].dockerfile_commands)
         assert any("apt-get update" in cmd for cmd in layers[0].dockerfile_commands)
 
+def test_ecr_install(servicer, client):
+    image_tag = "000000000000.dkr.ecr.us-east-1.amazonaws.com/my-private-registry:latest"
+    stub = Stub(
+        image=Image.from_ecr(
+            image_tag,
+            setup_commands=["apt-get update"],
+            secret=Secret({"AWS_ACCESS_KEY_ID": "", "AWS_SECRET_ACCESS_KEY": ""})))
+
+    with stub.run(client=client) as running_app:
+        layers = get_image_layers(running_app["image"].object_id, servicer)
+
+        assert any(f"FROM {image_tag}" in cmd for cmd in layers[0].dockerfile_commands)
+        assert any("apt-get update" in cmd for cmd in layers[0].dockerfile_commands)
+
 
 def run_f():
     print("foo!")

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -50,7 +50,7 @@ from .proxy import _Proxy
 from .rate_limit import RateLimit
 from .retries import Retries
 from .schedule import Schedule
-from .secret import _Secret
+from .secret import _Secret, _resolve_secret
 from .shared_volume import _SharedVolume
 
 
@@ -817,15 +817,7 @@ class _Function(Provider[_FunctionHandle]):
             image_id = None  # Happens if it's a notebook function
         secret_ids = []
         for secret in self._secrets:
-            try:
-                secret_id = await resolver.load(secret)
-            except NotFoundError as ex:
-                if isinstance(secret, _Secret):
-                    msg = f"Secret {secret} was not found"
-                else:
-                    msg = str(ex)
-                msg += ". You can add secrets to your account at https://modal.com/secrets"
-                raise NotFoundError(msg)
+            secret_id = await _resolve_secret(resolver, secret)
             secret_ids.append(secret_id)
 
         mount_ids = []

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -39,7 +39,7 @@ from ._resolver import Resolver
 from ._serialization import deserialize, serialize
 from ._traceback import append_modal_tb
 from .client import _Client
-from .exception import ExecutionError, InvalidError, NotFoundError, RemoteError
+from .exception import ExecutionError, InvalidError, RemoteError
 from .exception import TimeoutError as _TimeoutError
 from .exception import deprecation_error
 from .gpu import GPU_T, parse_gpu_config

--- a/modal/image.py
+++ b/modal/image.py
@@ -728,7 +728,7 @@ class _Image(Provider[_ImageHandle]):
 
         dockerfile_commands = _Image._registry_setup_commands(tag, setup_commands)
 
-        return _Image(
+        return _Image._from_args(
             dockerfile_commands=dockerfile_commands,
             context_files={"/modal_requirements.txt": requirements_path},
             registry_type=api_pb2.RegistryType.ECR,

--- a/modal/image.py
+++ b/modal/image.py
@@ -13,8 +13,6 @@ from modal_proto import api_pb2
 from modal_utils.async_utils import synchronize_apis
 from modal_utils.grpc_utils import retry_transient_errors
 
-from google.protobuf.struct_pb2 import NullValue
-
 from . import is_local
 from ._function_utils import FunctionInfo
 from ._resolver import Resolver

--- a/modal/image.py
+++ b/modal/image.py
@@ -157,11 +157,6 @@ class _Image(Provider[_ImageHandle]):
                 image_id = await resolver.load(ref)
                 return _ImageHandle._from_id(image_id, resolver.client, None)
 
-            # Resolve private registry secrets.
-            _registry_params = registry_params
-            if registry_type in {api_pb2.RegistryType.ECR}:
-                _registry_params = await registry_params.resolve(resolver)
-
             # Recursively build base images
             base_image_ids: list[str] = []
             for image in base_images.values():
@@ -171,7 +166,8 @@ class _Image(Provider[_ImageHandle]):
                     docker_tag=docker_tag,
                     image_id=image_id,
                     registry_type=registry_type,
-                    registry_params=_registry_params,
+                    # Resolve private registry secrets.
+                    registry_params=await registry_params.resolve(resolver),
                 )
                 for docker_tag, image_id in zip(base_images.keys(), base_image_ids)
             ]

--- a/modal/image.py
+++ b/modal/image.py
@@ -118,8 +118,8 @@ class _Image(Provider[_ImageHandle]):
         gpu_config: api_pb2.GPUConfig = api_pb2.GPUConfig(),
         build_function=None,
         context_mount: Optional[_Mount] = None,
-        registry_type:Optional[api_pb2.RegistryType] = None,
-        registry_params:Optional[_RegistryParams] = None,
+        registry_type: Optional[api_pb2.RegistryType] = None,
+        registry_params: Optional[_RegistryParams] = None,
     ):
         if ref and (base_images or dockerfile_commands or context_files):
             raise InvalidError("No other arguments can be provided when initializing an image from a ref.")
@@ -160,7 +160,8 @@ class _Image(Provider[_ImageHandle]):
                     docker_tag=docker_tag,
                     image_id=image_id,
                     registry_type=registry_type,
-                    registry_params=_registry_params)
+                    registry_params=_registry_params,
+                )
                 for docker_tag, image_id in zip(base_images.keys(), base_image_ids)
             ]
 
@@ -649,7 +650,7 @@ class _Image(Provider[_ImageHandle]):
         return self.extend(dockerfile_commands=dockerfile_commands, context_files=context_files)
 
     @staticmethod
-    def _registry_setup_commands(tag: str, setup_commands:list[str]) -> list[str]:
+    def _registry_setup_commands(tag: str, setup_commands: list[str]) -> list[str]:
         """mdmd:hidden"""
         return [
             f"FROM {tag}",
@@ -684,7 +685,7 @@ class _Image(Provider[_ImageHandle]):
         ```
         """
         requirements_path = _get_client_requirements_path()
- 
+
         dockerfile_commands = _Image._registry_setup_commands(tag, setup_commands)
 
         return _Image._from_args(
@@ -702,7 +703,7 @@ class _Image(Provider[_ImageHandle]):
         Container Registry (ECR). You will need to pass a `modal.Secret` containing
         an AWS key (`AWS_ACCESS_KEY_ID`) and secret (`AWS_SECRET_ACCESS_KEY`)
         with permissions to access the target ECR registry.
-        
+
         Refer to ["Private repository policies"](https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-policies.html)
         for details about IAM configuration.
 
@@ -911,17 +912,16 @@ class _Image(Provider[_ImageHandle]):
 
 class _RegistryParams:
     """mdmd:hidden"""
-    def __init__(self, secret:Optional[_Secret] = None):
+
+    def __init__(self, secret: Optional[_Secret] = None):
         self.secret = secret
-    
-    async def resolve(self, resolver:Resolver) -> api_pb2.RegistryParams:
+
+    async def resolve(self, resolver: Resolver) -> api_pb2.RegistryParams:
         if not self.secret:
             return api_pb2.RegistryParams()
 
-        return api_pb2.RegistryParams(
-            secret_id=await 
-            _resolve_secret(resolver, self.secret)
-        )
+        return api_pb2.RegistryParams(secret_id=await _resolve_secret(resolver, self.secret))
+
 
 synchronize_apis(_ImageHandle)
 Image, AioImage = synchronize_apis(_Image)

--- a/modal/image.py
+++ b/modal/image.py
@@ -158,6 +158,7 @@ class _Image(Provider[_ImageHandle]):
                 return _ImageHandle._from_id(image_id, resolver.client, None)
 
             # Resolve private registry secrets.
+            _registry_params = registry_params
             if registry_type in {api_pb2.RegistryType.ECR}:
                 _registry_params = await registry_params.resolve(resolver)
 

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronize_apis
+from .exception import NotFoundError
 
 from ._resolver import Resolver
 from .object import Handle, Provider
@@ -36,6 +37,21 @@ class _Secret(Provider[_SecretHandle]):
 
         rep = f"Secret([{', '.join(env_dict.keys())}])"
         super().__init__(_load, rep)
+
+
+async def _resolve_secret(resolver: Resolver, secret:_Secret) -> str:
+    """mdmd:hidden"""
+    try:
+        secret_id = await resolver.load(secret)
+    except NotFoundError as ex:
+        if isinstance(secret, _Secret):
+            msg = f"Secret {secret} was not found"
+        else:
+            msg = str(ex)
+        msg += ". You can add secrets to your account at https://modal.com/secrets"
+        raise NotFoundError(msg)
+
+    return secret_id
 
 
 Secret, AioSecret = synchronize_apis(_Secret)

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -39,7 +39,7 @@ class _Secret(Provider[_SecretHandle]):
         super().__init__(_load, rep)
 
 
-async def _resolve_secret(resolver: Resolver, secret:_Secret) -> str:
+async def _resolve_secret(resolver: Resolver, secret: _Secret) -> str:
     """mdmd:hidden"""
     try:
         secret_id = await resolver.load(secret)

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -197,9 +197,20 @@ message AppHeartbeatRequest {
   string app_id = 1;
 }
 
+enum RegistryType {
+  DOCKERHUB = 0;
+  ECR = 1;
+}
+
+message RegistryParams {
+  string secret_id = 1;
+}
+
 message BaseImage {
   string image_id = 1;
   string docker_tag = 2;
+  RegistryType registry_type = 3;
+  RegistryParams registry_params = 4;
 }
 
 message BlobCreateRequest {


### PR DESCRIPTION
This adds `from_ecr` allowing users to build Modal `Image`s  using layers from a private ECR registry. In order to use such layers, users will need to provide a `secret=modal.Secret` with env vars that follow AWS' naming convention (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`).

Example:

```python
import modal

stub = modal.Stub(
    image=modal.Image.from_ecr(
        "000000000000.dkr.ecr.us-east-1.amazonaws.com/my-private-registry:latest",
        secret=modal.Secret.from_name("aws")))
```