### PR TITLE
Deploy shared volumes created through the CLI using the _deploy method

### DIFF
--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -64,10 +64,9 @@ def some_func():
 
 @volume_cli.command(name="create", help="Create a named shared volume.")
 def create(name: str, cloud: str = typer.Option("aws", help="Cloud provider to create the volume in. One of aws|gcp.")):
-    stub = modal.Stub()
     cloud_provider = parse_cloud_provider(cloud)
-    stub.entity = modal.SharedVolume(cloud_provider=cloud_provider)
-    stub.deploy(name=name, show_progress=False)
+    volume = modal.SharedVolume(cloud_provider=cloud_provider)
+    volume._deploy(name)
     console = Console()
     console.print(f"Created volume '{name}' in {display_location(cloud_provider)}. \n\nUsage:\n")
     usage = Syntax(gen_usage_code(name), "python")

--- a/modal/object.py
+++ b/modal/object.py
@@ -180,7 +180,7 @@ class Provider(Generic[H]):
         handle_cls = self.get_handle_cls()
         object_entity = handle_cls._type_prefix
         _stub = _Stub(label, _object=self)
-        await _stub.deploy(namespace=namespace, client=client, object_entity=object_entity)
+        await _stub.deploy(namespace=namespace, client=client, object_entity=object_entity, show_progress=False)
         handle: H = await handle_cls.from_app(label, namespace=namespace, client=client)
         return handle
 


### PR DESCRIPTION
I'm going to have to handle this in the server for old clients as well.