### PR TITLE
Remove `channel-priority=strict` config for Conda

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -563,8 +563,6 @@ class _Image(Provider[_ImageHandle]):
             "&& rm -rf /tmp/miniconda.sh",
             # Biggest and most stable community-led Conda channel.
             "RUN conda config --add channels conda-forge \\ ",
-            # "Strict channel priority can dramatically speed up conda operations and also reduce package incompatibility problems."
-            "&& conda config --set channel_priority strict \\ ",
             # softlinking can put conda in a broken state, surfacing error on uninstall like:
             # `No such device or address: '/usr/local/lib/libz.so' -> '/usr/local/lib/libz.so.c~'`
             "&& conda config --set allow_softlinks false \\ ",

--- a/modal/image.py
+++ b/modal/image.py
@@ -549,7 +549,7 @@ class _Image(Provider[_ImageHandle]):
         requirements_path = _get_client_requirements_path()
         # Doesn't use the official continuumio/miniconda3 image as a base. That image has maintenance
         # issues (https://github.com/ContinuumIO/docker-images/issues) and building our own is more flexible.
-        conda_install_script = "https://repo.anaconda.com/miniconda/Miniconda3-4.7.12-Linux-x86_64.sh"
+        conda_install_script = "https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh"
         dockerfile_commands = [
             "FROM debian:bullseye",  # the -slim images lack files required by Conda.
             # Temporarily add utility packages for conda installation.


### PR DESCRIPTION
This makes the `conda` image itself build way faster, and also resolves "found conflicts" issues in a user's downstream image.