### PR TITLE
Standalone resolver

### DIFF
--- a/client_test/container_app_test.py
+++ b/client_test/container_app_test.py
@@ -103,20 +103,18 @@ async def test_is_inside_default_image(servicer, unix_servicer, aio_client, aio_
 
     assert not stub.is_inside()
 
-    async with stub.run(client=aio_client) as app:
-        from modal.stub import _default_image
+    from modal.stub import _default_image
 
-        default_image_handle = await app._load(_default_image)
-        default_image_id = default_image_handle.object_id
-        app_id = app.app_id
+    default_image_handle, app_id = await AioApp._create_one_object(aio_client, _default_image)
+    default_image_id = default_image_handle.object_id
 
-        # Copy the app objects to the container servicer
-        unix_servicer.app_objects[app_id] = servicer.app_objects[app_id]
+    # Copy the app objects to the container servicer
+    unix_servicer.app_objects[app_id] = servicer.app_objects[app_id]
 
-        await AioApp.init_container(aio_container_client, app_id)
+    await AioApp.init_container(aio_container_client, app_id)
 
-        # Create a new stub (TODO: tie it to the previous stub through name or similar)
-        stub = AioStub()
+    # Create a new stub (TODO: tie it to the previous stub through name or similar)
+    stub = AioStub()
 
-        with mock.patch.dict(os.environ, {"MODAL_IMAGE_ID": default_image_id}):
-            assert stub.is_inside()
+    with mock.patch.dict(os.environ, {"MODAL_IMAGE_ID": default_image_id}):
+        assert stub.is_inside()

--- a/client_test/lookup_test.py
+++ b/client_test/lookup_test.py
@@ -70,5 +70,7 @@ async def test_deprecated(servicer, aio_client):
 @pytest.mark.asyncio
 async def test_deploy_exists(servicer, aio_client):
     assert not await AioQueue._exists("my-queue", client=aio_client)
-    await AioQueue()._deploy("my-queue", client=aio_client)
+    h1 = await AioQueue()._deploy("my-queue", client=aio_client)
     assert await AioQueue._exists("my-queue", client=aio_client)
+    h2 = await AioQueue().lookup("my-queue", client=aio_client)
+    assert h1.object_id == h2.object_id

--- a/client_test/mount_test.py
+++ b/client_test/mount_test.py
@@ -9,7 +9,6 @@ import sys
 from modal import Stub, create_package_mounts
 from modal._blob_utils import LARGE_FILE_LIMIT
 from modal._resolver import AioResolver, Resolver
-from modal.aio import AioStub
 from modal.exception import DeprecationError, NotFoundError
 from modal.mount import AioMount, Mount
 

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -12,7 +12,7 @@ from modal_utils.async_utils import synchronize_apis
 
 
 class StatusRow:
-    def __init__(self, progress):
+    def __init__(self, progress: Optional[Tree]):
         from ._output import step_progress  # Lazy import to only import `rich` when necessary.
 
         self._spinner = None

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -8,6 +8,8 @@ else:
     Spinner = TypeVar("Spinner")
     Tree = TypeVar("Tree")
 
+from modal_utils.async_utils import synchronize_apis
+
 
 class StatusRow:
     def __init__(self, progress):
@@ -33,7 +35,7 @@ class StatusRow:
             self._step_node.label = step_completed(message, is_substep=True)
 
 
-class Resolver:
+class _Resolver:
     # Unfortunately we can't use type annotations much in this file,
     # since that leads to circular dependencies
     _progress: Optional[Tree]
@@ -43,8 +45,16 @@ class Resolver:
         self._local_uuid_to_object = {}
 
         # Accessible by objects
-        self.client = client
-        self.app_id = app_id
+        self._client = client
+        self._app_id = app_id
+
+    @property
+    def app_id(self):
+        return self._app_id
+
+    @property
+    def client(self):
+        return self._client
 
     async def load(self, obj, existing_object_id: Optional[str] = None):
         cached_obj = self._local_uuid_to_object.get(obj.local_uuid)
@@ -57,3 +67,6 @@ class Resolver:
 
     def add_status_row(self) -> StatusRow:
         return StatusRow(self._progress)
+
+
+Resolver, AioResolver = synchronize_apis(_Resolver)

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -17,7 +17,7 @@ class Resolver:
     _spinner: Optional[Spinner]
     _step_node: Optional[Tree]
 
-    def __init__(self, app, progress: Optional[Tree], client, app_id: str, existing_object_id: Optional[str]):
+    def __init__(self, app, progress: Optional[Tree], client, app_id: str):
         self._app = app
         self._progress = progress
         self._last_message = None
@@ -27,7 +27,6 @@ class Resolver:
         # Accessible by objects
         self.client = client
         self.app_id = app_id
-        self.existing_object_id = existing_object_id
 
     async def load(self, obj) -> str:
         # assert isinstance(obj, Provider)

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -1,5 +1,5 @@
 # Copyright Modal Labs 2023
-from typing import TYPE_CHECKING, Any, Dict, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypeVar
 
 if TYPE_CHECKING:
     from rich.spinner import Spinner
@@ -85,6 +85,9 @@ class _Resolver:
 
     def add_status_row(self) -> StatusRow:
         return StatusRow(self._progress)
+
+    def objects(self) -> List:
+        return list(self._local_uuid_to_object.values())
 
 
 Resolver, AioResolver = synchronize_apis(_Resolver)

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -1,5 +1,5 @@
 # Copyright Modal Labs 2023
-from typing import TYPE_CHECKING, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, Optional, TypeVar
 
 if TYPE_CHECKING:
     from rich.spinner import Spinner
@@ -39,6 +39,7 @@ class _Resolver:
     # Unfortunately we can't use type annotations much in this file,
     # since that leads to circular dependencies
     _progress: Optional[Tree]
+    _local_uuid_to_object: Dict[str, Any]
 
     def __init__(self, progress: Optional[Tree], client, app_id: Optional[str] = None):
         self._progress = progress

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -1,4 +1,4 @@
- # Copyright Modal Labs 2023
+# Copyright Modal Labs 2023
 from typing import TYPE_CHECKING, Optional, TypeVar
 
 if TYPE_CHECKING:
@@ -41,15 +41,19 @@ class Resolver:
     def __init__(self, app, progress: Optional[Tree], client, app_id: str):
         self._app = app
         self._progress = progress
+        self._local_uuid_to_object = {}
 
         # Accessible by objects
         self.client = client
         self.app_id = app_id
 
-    async def load(self, obj):
-        # assert isinstance(obj, Provider)
-        created_obj = await self._app._load(self, obj, progress=self._progress)
-        # assert isinstance(created_obj, Handle)
+    async def load(self, obj, existing_object_id: Optional[str] = None):
+        cached_obj = self._local_uuid_to_object.get(obj.local_uuid)
+        if cached_obj is not None:
+            # We already created this object before, shortcut this method
+            return cached_obj
+        created_obj = await obj._load(self, existing_object_id)
+        self._local_uuid_to_object[obj.local_uuid] = created_obj
         return created_obj
 
     def add_status_row(self) -> StatusRow:

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -1,4 +1,4 @@
-# Copyright Modal Labs 2023
+ # Copyright Modal Labs 2023
 from typing import TYPE_CHECKING, Optional, TypeVar
 
 if TYPE_CHECKING:
@@ -48,7 +48,7 @@ class Resolver:
 
     async def load(self, obj):
         # assert isinstance(obj, Provider)
-        created_obj = await self._app._load(obj, progress=self._progress)
+        created_obj = await self._app._load(self, obj, progress=self._progress)
         # assert isinstance(created_obj, Handle)
         return created_obj
 

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -46,11 +46,11 @@ class Resolver:
         self.client = client
         self.app_id = app_id
 
-    async def load(self, obj) -> str:
+    async def load(self, obj):
         # assert isinstance(obj, Provider)
         created_obj = await self._app._load(obj, progress=self._progress)
         # assert isinstance(created_obj, Handle)
-        return created_obj.object_id
+        return created_obj
 
     def add_status_row(self) -> StatusRow:
         return StatusRow(self._progress)

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -62,7 +62,21 @@ class _Resolver:
         if cached_obj is not None:
             # We already created this object before, shortcut this method
             return cached_obj
+
         created_obj = await obj._load(self, existing_object_id)
+
+        if existing_object_id is not None and created_obj.object_id != existing_object_id:
+            # TODO(erikbern): this is a very ugly fix to a problem that's on the server side.
+            # Unlike every other object, images are not assigned random ids, but rather an
+            # id given by the hash of its contents. This means we can't _force_ an image to
+            # have a particular id. The better solution is probably to separate "images"
+            # from "image definitions" or something like that, but that's a big project.
+            if not existing_object_id.startswith("im-"):
+                raise Exception(
+                    f"Tried creating an object using existing id {existing_object_id}"
+                    f" but it has id {created_obj.object_id}"
+                )
+
         self._local_uuid_to_object[obj.local_uuid] = created_obj
         return created_obj
 

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -9,6 +9,7 @@ else:
     Tree = TypeVar("Tree")
 
 from modal_utils.async_utils import synchronize_apis
+from modal.exception import ExecutionError
 
 
 class StatusRow:
@@ -50,7 +51,9 @@ class _Resolver:
         self._app_id = app_id
 
     @property
-    def app_id(self):
+    def app_id(self) -> str:
+        if self._app_id is None:
+            raise ExecutionError("Resolver has no app")
         return self._app_id
 
     @property

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -12,6 +12,7 @@ else:
 class StatusRow:
     def __init__(self, progress):
         from ._output import step_progress  # Lazy import to only import `rich` when necessary.
+
         self._spinner = None
         self._step_node = None
         if progress is not None:

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -8,7 +8,6 @@ else:
     Spinner = TypeVar("Spinner")
     Tree = TypeVar("Tree")
 
-from modal_utils.async_utils import synchronize_apis
 from modal.exception import ExecutionError
 
 
@@ -36,7 +35,7 @@ class StatusRow:
             self._step_node.label = step_completed(message, is_substep=True)
 
 
-class _Resolver:
+class Resolver:
     # Unfortunately we can't use type annotations much in this file,
     # since that leads to circular dependencies
     _progress: Optional[Tree]
@@ -88,6 +87,3 @@ class _Resolver:
 
     def objects(self) -> List:
         return list(self._local_uuid_to_object.values())
-
-
-Resolver, AioResolver = synchronize_apis(_Resolver)

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -38,8 +38,7 @@ class Resolver:
     # since that leads to circular dependencies
     _progress: Optional[Tree]
 
-    def __init__(self, app, progress: Optional[Tree], client, app_id: str):
-        self._app = app
+    def __init__(self, progress: Optional[Tree], client, app_id: Optional[str] = None):
         self._progress = progress
         self._local_uuid_to_object = {}
 

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -9,20 +9,37 @@ else:
     Tree = TypeVar("Tree")
 
 
+class StatusRow:
+    def __init__(self, progress):
+        from ._output import step_progress  # Lazy import to only import `rich` when necessary.
+        self._spinner = None
+        self._step_node = None
+        if progress is not None:
+            self._spinner = step_progress()
+            self._step_node = progress.add(self._spinner)
+
+    def message(self, message):
+        from ._output import step_progress_update
+
+        if self._spinner is not None:
+            step_progress_update(self._spinner, message)
+
+    def finish(self, message):
+        from ._output import step_progress_update, step_completed
+
+        if self._step_node is not None:
+            step_progress_update(self._spinner, message)
+            self._step_node.label = step_completed(message, is_substep=True)
+
+
 class Resolver:
     # Unfortunately we can't use type annotations much in this file,
     # since that leads to circular dependencies
     _progress: Optional[Tree]
-    _last_message: Optional[str]
-    _spinner: Optional[Spinner]
-    _step_node: Optional[Tree]
 
     def __init__(self, app, progress: Optional[Tree], client, app_id: str):
         self._app = app
         self._progress = progress
-        self._last_message = None
-        self._spinner = None
-        self._step_node = None
 
         # Accessible by objects
         self.client = client
@@ -34,23 +51,5 @@ class Resolver:
         # assert isinstance(created_obj, Handle)
         return created_obj.object_id
 
-    def set_message(self, message: str):
-        from ._output import (  # Lazy import to only import `rich` when necessary.
-            step_progress,
-            step_progress_update,
-        )
-
-        self._last_message = message
-        if self._progress:
-            if self._step_node is None:
-                self._spinner = step_progress()
-                self._step_node = self._progress.add(self._spinner)
-            step_progress_update(self._spinner, message)
-
-    def set_finish(self):
-        # Change message to a completed step
-        # TODO: make this a context mgr __exit__ ?
-        from ._output import step_completed
-
-        if self._progress and self._last_message:
-            self._step_node.label = step_completed(self._last_message, is_substep=True)
+    def add_status_row(self) -> StatusRow:
+        return StatusRow(self._progress)

--- a/modal/app.py
+++ b/modal/app.py
@@ -72,15 +72,13 @@ class _App:
         return self._app_id
 
     async def _load(
-        self, obj: Provider, progress: Optional[Tree] = None, existing_object_id: Optional[str] = None
+        self, resolver: Resolver, obj: Provider, progress: Optional[Tree] = None, existing_object_id: Optional[str] = None
     ) -> Handle:
         """Send a server request to create an object in this app, and return its ID."""
         cached_obj = self._local_uuid_to_object.get(obj.local_uuid)
         if cached_obj is not None:
             # We already created this object before, shortcut this method
             return cached_obj
-
-        resolver = Resolver(self, progress, self._client, self.app_id)
 
         # Create object
         created_obj = await obj._load(resolver, existing_object_id)
@@ -104,9 +102,10 @@ class _App:
         self, blueprint: Dict[str, Provider], progress: Tree, new_app_state: int
     ):  # api_pb2.AppState.V
         """Create objects that have been defined but not created on the server."""
+        resolver = Resolver(self, progress, self._client, self.app_id)
         for tag, provider in blueprint.items():
             existing_object_id = self._tag_to_existing_id.get(tag)
-            self._tag_to_object[tag] = await self._load(provider, progress, existing_object_id)
+            self._tag_to_object[tag] = await self._load(resolver, provider, progress, existing_object_id)
 
         # Create the app (and send a list of all tagged obs)
         # TODO(erikbern): we should delete objects from a previous version that are no longer needed

--- a/modal/app.py
+++ b/modal/app.py
@@ -85,8 +85,6 @@ class _App:
         # Create object
         created_obj = await obj._load(resolver, existing_object_id)
 
-        resolver.set_finish()  # finishes any message
-
         if existing_object_id is not None and created_obj.object_id != existing_object_id:
             # TODO(erikbern): this is a very ugly fix to a problem that's on the server side.
             # Unlike every other object, images are not assigned random ids, but rather an

--- a/modal/app.py
+++ b/modal/app.py
@@ -43,6 +43,7 @@ class _App:
     _tag_to_existing_id: Dict[str, str]
     _client: _Client
     _app_id: str
+    _resolver: Optional[_Resolver]
 
     def __init__(
         self,

--- a/modal/app.py
+++ b/modal/app.py
@@ -79,17 +79,6 @@ class _App:
         for tag, provider in blueprint.items():
             existing_object_id = self._tag_to_existing_id.get(tag)
             created_obj = await self._resolver.load(provider, existing_object_id)
-            if existing_object_id is not None and created_obj.object_id != existing_object_id:
-                # TODO(erikbern): this is a very ugly fix to a problem that's on the server side.
-                # Unlike every other object, images are not assigned random ids, but rather an
-                # id given by the hash of its contents. This means we can't _force_ an image to
-                # have a particular id. The better solution is probably to separate "images"
-                # from "image definitions" or something like that, but that's a big project.
-                if not existing_object_id.startswith("im-"):
-                    raise Exception(
-                        f"Tried creating an object using existing id {existing_object_id}"
-                        f" but it has id {created_obj.object_id}"
-                    )
             self._tag_to_object[tag] = created_obj
 
         # Create the app (and send a list of all tagged obs)

--- a/modal/app.py
+++ b/modal/app.py
@@ -80,10 +80,10 @@ class _App:
             # We already created this object before, shortcut this method
             return cached_obj
 
-        resolver = Resolver(self, progress, self._client, self.app_id, existing_object_id)
+        resolver = Resolver(self, progress, self._client, self.app_id)
 
         # Create object
-        created_obj = await obj._load(resolver)
+        created_obj = await obj._load(resolver, existing_object_id)
 
         resolver.set_finish()  # finishes any message
 

--- a/modal/app.py
+++ b/modal/app.py
@@ -73,7 +73,7 @@ class _App:
         self, blueprint: Dict[str, Provider], progress: Tree, new_app_state: int
     ):  # api_pb2.AppState.V
         """Create objects that have been defined but not created on the server."""
-        resolver = Resolver(self, progress, self._client, self.app_id)
+        resolver = Resolver(progress, self._client, self.app_id)
         for tag, provider in blueprint.items():
             existing_object_id = self._tag_to_existing_id.get(tag)
             created_obj = await resolver.load(provider, existing_object_id)

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -137,10 +137,10 @@ class _Dict(Provider[_DictHandle]):
     def __init__(self, data={}):
         """Create a new dictionary, optionally filled with initial data."""
 
-        async def _load(resolver: Resolver) -> _DictHandle:
+        async def _load(resolver: Resolver, existing_object_id: str) -> _DictHandle:
             serialized = _serialize_dict(data)
             req = api_pb2.DictCreateRequest(
-                app_id=resolver.app_id, data=serialized, existing_dict_id=resolver.existing_object_id
+                app_id=resolver.app_id, data=serialized, existing_dict_id=existing_object_id
             )
             response = await resolver.client.stub.DictCreate(req)
             logger.debug("Created dict with id %s" % response.dict_id)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -806,7 +806,7 @@ class _Function(Provider[_FunctionHandle]):
         rep = r"Function({self._tag})"
         super().__init__(self._load, rep)
 
-    async def _load(self, resolver: Resolver):
+    async def _load(self, resolver: Resolver, existing_object_id: str):
         resolver.set_message(f"Creating {self._tag}...")
 
         if self._proxy:
@@ -929,7 +929,7 @@ class _Function(Provider[_FunctionHandle]):
             app_id=resolver.app_id,
             function=function_definition,
             schedule=self._schedule.proto_message if self._schedule is not None else None,
-            existing_function_id=resolver.existing_object_id,
+            existing_function_id=existing_object_id,
         )
         try:
             response = await resolver.client.stub.FunctionCreate(request)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -811,7 +811,7 @@ class _Function(Provider[_FunctionHandle]):
         status_row.message(f"Creating {self._tag}...")
 
         if self._proxy:
-            proxy_id = await resolver.load(self._proxy)
+            proxy_id = (await resolver.load(self._proxy)).object_id
             # HACK: remove this once we stop using ssh tunnels for this.
             if self._image:
                 self._image = self._image.apt_install("autossh")
@@ -822,7 +822,7 @@ class _Function(Provider[_FunctionHandle]):
         if self._image is not None:
             if not isinstance(self._image, _Image):
                 raise InvalidError(f"Expected modal.Image object. Got {type(self._image)}.")
-            image_id = await resolver.load(self._image)
+            image_id = (await resolver.load(self._image)).object_id
         else:
             image_id = None  # Happens if it's a notebook function
         secret_ids = []
@@ -832,7 +832,7 @@ class _Function(Provider[_FunctionHandle]):
 
         mount_ids = []
         for mount in [*self._base_mounts, *self._mounts]:
-            mount_ids.append(await resolver.load(mount))
+            mount_ids.append((await resolver.load(mount)).object_id)
 
         if not isinstance(self._shared_volumes, dict):
             raise InvalidError("shared_volumes must be a dict[str, SharedVolume] where the keys are paths")
@@ -851,7 +851,9 @@ class _Function(Provider[_FunctionHandle]):
                 raise InvalidError(f"Shared volume {abs_path} cannot be mounted at /tmp.")
 
             shared_volume_mounts.append(
-                api_pb2.SharedVolumeMount(mount_path=path, shared_volume_id=await resolver.load(shared_volume))
+                api_pb2.SharedVolumeMount(
+                    mount_path=path, shared_volume_id=(await resolver.load(shared_volume)).object_id
+                )
             )
 
         if self._is_generator:

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -807,7 +807,8 @@ class _Function(Provider[_FunctionHandle]):
         super().__init__(self._load, rep)
 
     async def _load(self, resolver: Resolver, existing_object_id: str):
-        resolver.set_message(f"Creating {self._tag}...")
+        status_row = resolver.add_status_row()
+        status_row.message(f"Creating {self._tag}...")
 
         if self._proxy:
             proxy_id = await resolver.load(self._proxy)
@@ -949,11 +950,11 @@ class _Function(Provider[_FunctionHandle]):
             else:
                 suffix = ""
             # TODO: this is only printed when we're showing progress. Maybe move this somewhere else.
-            resolver.set_message(
+            status_row.finish(
                 f"Created {self._tag} => [magenta underline]{response.web_url}[/magenta underline]{suffix}"
             )
         else:
-            resolver.set_message(f"Created {self._tag}.")
+            status_row.finish(f"Created {self._tag}.")
 
         # Update the precreated function handle (todo: hack until we merge providers/handles)
         self._function_handle._initialize_handle(resolver.client, response.function_id)

--- a/modal/image.py
+++ b/modal/image.py
@@ -154,13 +154,13 @@ class _Image(Provider[_ImageHandle]):
 
         async def _load(resolver: Resolver, existing_object_id: str):
             if ref:
-                image_id = await resolver.load(ref)
+                image_id = (await resolver.load(ref)).object_id
                 return _ImageHandle._from_id(image_id, resolver.client, None)
 
             # Recursively build base images
             base_image_ids: list[str] = []
             for image in base_images.values():
-                base_image_ids.append(await resolver.load(image))
+                base_image_ids.append((await resolver.load(image)).object_id)
             base_images_pb2s = [
                 api_pb2.BaseImage(
                     docker_tag=docker_tag,
@@ -184,7 +184,7 @@ class _Image(Provider[_ImageHandle]):
 
             if build_function:
                 build_function_def = build_function.get_build_def()
-                build_function_id = await resolver.load(build_function)
+                build_function_id = (await resolver.load(build_function)).object_id
             else:
                 build_function_def = None
                 build_function_id = None
@@ -197,7 +197,7 @@ class _Image(Provider[_ImageHandle]):
                 dockerfile_commands_list = dockerfile_commands
 
             if context_mount:
-                context_mount_id = await resolver.load(context_mount)
+                context_mount_id = (await resolver.load(context_mount)).object_id
             else:
                 context_mount_id = None
 

--- a/modal/image.py
+++ b/modal/image.py
@@ -152,7 +152,7 @@ class _Image(Provider[_ImageHandle]):
         if context_mount is not None and not isinstance(context_mount, _Mount):
             raise InvalidError(f"Context mount {context_mount!r} must be a modal.Mount object")
 
-        async def _load(resolver: Resolver):
+        async def _load(resolver: Resolver, existing_object_id: str):
             if ref:
                 image_id = await resolver.load(ref)
                 return _ImageHandle._from_id(image_id, resolver.client, None)
@@ -215,7 +215,7 @@ class _Image(Provider[_ImageHandle]):
             req = api_pb2.ImageGetOrCreateRequest(
                 app_id=resolver.app_id,
                 image=image_definition,
-                existing_image_id=resolver.existing_object_id,  # TODO: ignored
+                existing_image_id=existing_object_id,  # TODO: ignored
                 build_function_id=build_function_id,
             )
             resp = await resolver.client.stub.ImageGetOrCreate(req)

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -253,7 +253,7 @@ class _Mount(Provider[_MountHandle]):
                     # Can happen with temporary files (e.g. emacs will write temp files and delete them quickly)
                     logger.info(f"Ignoring file not found: {exc}")
 
-    async def _load(self, resolver: Resolver):
+    async def _load(self, resolver: Resolver, existing_object_id: str):
         # Run a threadpool to compute hash values, and use concurrent coroutines to register files.
         t0 = time.time()
         n_concurrent_uploads = 16
@@ -311,7 +311,7 @@ class _Mount(Provider[_MountHandle]):
         # Build mounts
         resolver.set_message(f"Creating mount {message_label}: Building mount")
         req = api_pb2.MountBuildRequest(
-            app_id=resolver.app_id, existing_mount_id=resolver.existing_object_id, files=files
+            app_id=resolver.app_id, existing_mount_id=existing_object_id, files=files
         )
         resp = await retry_transient_errors(resolver.client.stub.MountBuild, req, base_delay=1)
         resolver.set_message(f"Created mount {message_label}")

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -311,9 +311,7 @@ class _Mount(Provider[_MountHandle]):
 
         # Build mounts
         status_row.message(f"Creating mount {message_label}: Building mount")
-        req = api_pb2.MountBuildRequest(
-            app_id=resolver.app_id, existing_mount_id=existing_object_id, files=files
-        )
+        req = api_pb2.MountBuildRequest(app_id=resolver.app_id, existing_mount_id=existing_object_id, files=files)
         resp = await retry_transient_errors(resolver.client.stub.MountBuild, req, base_delay=1)
         status_row.finish(f"Created mount {message_label}")
 

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -262,10 +262,11 @@ class _Mount(Provider[_MountHandle]):
         uploaded_hashes: set[str] = set()
         total_bytes = 0
         message_label = self._description()
+        status_row = resolver.add_status_row()
 
         async def _put_file(file_spec: FileUploadSpec) -> api_pb2.MountFile:
             nonlocal n_files, uploaded_hashes, total_bytes
-            resolver.set_message(
+            status_row.message(
                 f"Creating mount {message_label}: Uploaded {len(uploaded_hashes)}/{n_files} inspected files"
             )
 
@@ -309,12 +310,12 @@ class _Mount(Provider[_MountHandle]):
             logger.warning(f"Mount of '{message_label}' is empty.")
 
         # Build mounts
-        resolver.set_message(f"Creating mount {message_label}: Building mount")
+        status_row.message(f"Creating mount {message_label}: Building mount")
         req = api_pb2.MountBuildRequest(
             app_id=resolver.app_id, existing_mount_id=existing_object_id, files=files
         )
         resp = await retry_transient_errors(resolver.client.stub.MountBuild, req, base_delay=1)
-        resolver.set_message(f"Created mount {message_label}")
+        status_row.finish(f"Created mount {message_label}")
 
         logger.debug(f"Uploaded {len(uploaded_hashes)}/{n_files} files and {total_bytes} bytes in {time.time() - t0}s")
         return _MountHandle._from_id(resp.mount_id, resolver.client, None)

--- a/modal/object.py
+++ b/modal/object.py
@@ -136,17 +136,17 @@ P = TypeVar("P", bound="Provider")
 
 
 class Provider(Generic[H]):
-    def _init(self, load, rep):
+    def _init(self, load: Callable[[Resolver, str], Awaitable[H]], rep: str):
         self._local_uuid = str(uuid.uuid4())
         self._load = load
         self._rep = rep
 
-    def __init__(self, load: Callable[[Resolver], Awaitable[H]], rep: str):
+    def __init__(self, load: Callable[[Resolver, str], Awaitable[H]], rep: str):
         # TODO(erikbern): this is semi-deprecated - subclasses should use _from_loader
         self._init(load, rep)
 
     @classmethod
-    def _from_loader(cls, load: Callable[[Resolver], Awaitable[H]], rep: str):
+    def _from_loader(cls, load: Callable[[Resolver, str], Awaitable[H]], rep: str):
         obj = Handle.__new__(cls)
         obj._init(load, rep)
         return obj
@@ -206,7 +206,7 @@ class Provider(Generic[H]):
 
         """
 
-        async def _load_persisted(resolver: Resolver) -> H:
+        async def _load_persisted(resolver: Resolver, existing_object_id: str) -> H:
             return await self._deploy(label, namespace, resolver.client)
 
         # Create a class of type cls, but use the base constructor
@@ -235,7 +235,7 @@ class Provider(Generic[H]):
         ```
         """
 
-        async def _load_remote(resolver: Resolver) -> H:
+        async def _load_remote(resolver: Resolver, existing_object_id: str) -> H:
             handle_cls = cls.get_handle_cls()
             handle: H = await handle_cls.from_app(app_name, tag, namespace, client=resolver.client)
             return handle

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -136,8 +136,8 @@ class _Queue(Provider[_QueueHandle]):
     """
 
     def __init__(self):
-        async def _load(resolver: Resolver) -> _QueueHandle:
-            request = api_pb2.QueueCreateRequest(app_id=resolver.app_id, existing_queue_id=resolver.existing_object_id)
+        async def _load(resolver: Resolver, existing_object_id: str) -> _QueueHandle:
+            request = api_pb2.QueueCreateRequest(app_id=resolver.app_id, existing_queue_id=existing_object_id)
             response = await resolver.client.stub.QueueCreate(request)
             return _QueueHandle._from_id(response.queue_id, resolver.client, None)
 

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -25,12 +25,12 @@ class _Secret(Provider[_SecretHandle]):
     """
 
     def __init__(self, env_dict={}, template_type=""):
-        async def _load(resolver: Resolver) -> _SecretHandle:
+        async def _load(resolver: Resolver, existing_object_id: str) -> _SecretHandle:
             req = api_pb2.SecretCreateRequest(
                 app_id=resolver.app_id,
                 env_dict=env_dict,
                 template_type=template_type,
-                existing_secret_id=resolver.existing_object_id,
+                existing_secret_id=existing_object_id,
             )
             resp = await resolver.client.stub.SecretCreate(req)
             return _SecretHandle._from_id(resp.secret_id, resolver.client, None)

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -42,7 +42,7 @@ class _Secret(Provider[_SecretHandle]):
 async def _resolve_secret(resolver: Resolver, secret: _Secret) -> str:
     """mdmd:hidden"""
     try:
-        secret_id = await resolver.load(secret)
+        secret_id = (await resolver.load(secret)).object_id
     except NotFoundError as ex:
         if isinstance(secret, _Secret):
             msg = f"Secret {secret} was not found"

--- a/modal/shared_volume.py
+++ b/modal/shared_volume.py
@@ -156,10 +156,10 @@ class _SharedVolume(Provider[_SharedVolumeHandle]):
     def __init__(self, cloud_provider: "Optional[api_pb2.CloudProvider.V]" = None) -> None:
         """Construct a new shared volume, which is empty by default."""
 
-        async def _load(resolver: Resolver) -> _SharedVolumeHandle:
-            if resolver.existing_object_id:
+        async def _load(resolver: Resolver, existing_object_id: str) -> _SharedVolumeHandle:
+            if existing_object_id:
                 # Volume already exists; do nothing.
-                return _SharedVolumeHandle._from_id(resolver.existing_object_id, resolver.client, None)
+                return _SharedVolumeHandle._from_id(existing_object_id, resolver.client, None)
 
             resolver.set_message("Creating shared volume...")
             req = api_pb2.SharedVolumeCreateRequest(app_id=resolver.app_id, cloud_provider=cloud_provider)

--- a/modal/shared_volume.py
+++ b/modal/shared_volume.py
@@ -157,14 +157,15 @@ class _SharedVolume(Provider[_SharedVolumeHandle]):
         """Construct a new shared volume, which is empty by default."""
 
         async def _load(resolver: Resolver, existing_object_id: str) -> _SharedVolumeHandle:
+            status_row = resolver.add_status_row()
             if existing_object_id:
                 # Volume already exists; do nothing.
                 return _SharedVolumeHandle._from_id(existing_object_id, resolver.client, None)
 
-            resolver.set_message("Creating shared volume...")
+            status_row.message("Creating shared volume...")
             req = api_pb2.SharedVolumeCreateRequest(app_id=resolver.app_id, cloud_provider=cloud_provider)
             resp = await retry_transient_errors(resolver.client.stub.SharedVolumeCreate, req)
-            resolver.set_message("Created shared volume.")
+            status_row.finish("Created shared volume.")
             return _SharedVolumeHandle._from_id(resp.shared_volume_id, resolver.client, None)
 
         rep = "SharedVolume()"

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -33,7 +33,7 @@ from .image import _Image, _ImageHandle
 from .mount import _get_client_mount, _Mount
 from .object import Provider
 from .proxy import _Proxy
-from .queue import _Queue
+from .queue import _Queue, _QueueHandle
 from .rate_limit import RateLimit
 from .schedule import Schedule
 from .secret import _Secret
@@ -284,7 +284,9 @@ class _Stub:
 
                 if self._pty_input_stream:
                     output_mgr._visible_progress = False
-                    async with _pty.write_stdin_to_pty_stream(app._pty_input_stream):
+                    handle = app._pty_input_stream
+                    assert isinstance(handle, _QueueHandle)
+                    async with _pty.write_stdin_to_pty_stream(handle):
                         yield app
                     output_mgr._visible_progress = True
                 else:


### PR DESCRIPTION
This PR makes it possible to use the resolver without the app, which
1. Reduces some complexity of the `App` class
2. Should make it possible to clean up `Provider._deploy` so we don't have to use the app at all (makes it possible to deploy a single object without creating an app client-side)