### PR TITLE
Refactor private registry protos

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -103,7 +103,7 @@ class _ImageRegistryConfig:
     """mdmd:hidden"""
 
     def __init__(
-        self, registry_type: api_pb2.RegistryType = api_pb2.RegistryType.DOCKERHUB, secret: Optional[_Secret] = None
+        self, registry_type: api_pb2.RegistryType.V = api_pb2.RegistryType.DOCKERHUB, secret: Optional[_Secret] = None
     ):
         self.registry_type = registry_type
         self.secret = secret

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -202,15 +202,15 @@ enum RegistryType {
   ECR = 1;
 }
 
-message RegistryParams {
-  string secret_id = 1;
+message ImageRegistryConfig {
+  RegistryType registry_type = 1;
+  string secret_id = 2;
 }
 
 message BaseImage {
   string image_id = 1;
   string docker_tag = 2;
-  RegistryType registry_type = 3;
-  RegistryParams registry_params = 4;
+  // fields 3 and 4 are deprecated
 }
 
 message BlobCreateRequest {
@@ -598,6 +598,7 @@ message Image {
   string build_function_def = 14;
   string context_mount_id = 15;
   GPUConfig gpu_config = 16;
+  ImageRegistryConfig image_registry_config = 17;
 }
 
 message ImageContextFile {


### PR DESCRIPTION
The private registry configs should not go in the `BaseImage` but in the `Image` definition. That's because `BaseImage` is an internal reference, not a mapping to a Docker `FROM` command. 

I also refactored the interface a bit to make it easier to read.

`BaseImage` registry fields are now deprecated.