### PR TITLE
fix: ex code in docstring misleads user about SharedVolume usage

### DIFF
--- a/modal/shared_volume.py
+++ b/modal/shared_volume.py
@@ -95,10 +95,15 @@ class _SharedVolume(Provider[_SharedVolumeHandle]):
     ```python
     import modal
 
+    volume = modal.SharedVolume()
     stub = modal.Stub()
 
-    @stub.function(shared_volumes={"/root/foo": modal.SharedVolume()})
+    @stub.function(shared_volumes={"/root/foo": volume})
     def f():
+        pass
+
+    @stub.function(shared_volumes={"/root/goo": volume})
+    def g():
         pass
     ```
 


### PR DESCRIPTION
Copied from Treehacks hackathon notes:

> - We have some inappropriate code in the docs that looks like `shared_volumes={"/foo": modal.SharedVolume()}`. This doesn’t seem to be a useful way to instantiate a volume because you lose a reference to it and thus can’t share it around.
    - A user was confused about why their caching wasn’t working, and it was because they had two functions each doing the above, so each had their own volume and no data was being shared. 