### PR TITLE
Fix outputs lost when putting inputs returns slowly

### DIFF
--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -31,7 +31,11 @@ def test_run_function(client, servicer):
         assert len(servicer.cleared_function_calls) == 1
 
 
-def test_map(client, servicer):
+@pytest.mark.parametrize("slow_put_inputs", [False, True])
+@pytest.mark.timeout(120)
+def test_map(client, servicer, slow_put_inputs):
+    servicer.slow_put_inputs = slow_put_inputs
+
     stub = Stub()
     dummy_modal = stub.function(dummy)
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -292,10 +292,8 @@ async def _map_invocation(
     have_all_inputs = False
     num_inputs = 0
     num_outputs = 0
-    # Map input_id -> next expected gen_index value, or -1 if complete
-    # Could contain keys which are not yet in the pending_inputs set
-    pending_outputs: Dict[str, int] = {}
-    completed_outputs: Set[str] = set()
+    pending_outputs: Dict[str, int] = {}  # Map input_id -> next expected gen_index value
+    completed_outputs: Set[str] = set()  # Set of input_ids whose outputs are complete (expecting no more values)
 
     input_queue: asyncio.Queue = asyncio.Queue()
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -8,7 +8,7 @@ import warnings
 from dataclasses import dataclass
 from datetime import date, timedelta
 from pathlib import Path
-from typing import Any, AsyncIterable, Callable, Collection, Dict, List, Optional, Union
+from typing import Any, AsyncIterable, Callable, Collection, Dict, List, Optional, Set, Union
 
 import cloudpickle
 from aiostream import pipe, stream
@@ -273,6 +273,7 @@ class _Invocation:
 
 MAP_INVOCATION_CHUNK_SIZE = 100
 
+
 async def _map_invocation(
     function_id: str,
     input_stream: AsyncIterable,
@@ -293,8 +294,8 @@ async def _map_invocation(
     num_outputs = 0
     # Map input_id -> next expected gen_index value, or -1 if complete
     # Could contain keys which are not yet in the pending_inputs set
-    pending_outputs = {}
-    completed_outputs = set()
+    pending_outputs: Dict[str, int] = {}
+    completed_outputs: Set[str] = set()
 
     input_queue: asyncio.Queue = asyncio.Queue()
 


### PR DESCRIPTION
Pumping inputs awaits a gRPC call and then populates the map.
Receiving outputs will ignore inputs that are not in the map.
Existing bug involved ignoring outputs that were legitimate, but their inputs were not yet populated in the map.

**This PR adds a test that times out as a result of this bug, and fixes the bug.**