### PR TITLE
Remove special secret resolution code

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -50,7 +50,7 @@ from .proxy import _Proxy
 from .rate_limit import RateLimit
 from .retries import Retries
 from .schedule import Schedule
-from .secret import _Secret, _resolve_secret
+from .secret import _Secret
 from .shared_volume import _SharedVolume
 
 
@@ -829,7 +829,7 @@ class _Function(Provider[_FunctionHandle]):
             image_id = None  # Happens if it's a notebook function
         secret_ids = []
         for secret in self._secrets:
-            secret_id = await _resolve_secret(resolver, secret)
+            secret_id = (await resolver.load(secret)).object_id
             secret_ids.append(secret_id)
 
         mount_ids = []

--- a/modal/image.py
+++ b/modal/image.py
@@ -21,7 +21,7 @@ from .exception import InvalidError, NotFoundError, RemoteError
 from .gpu import GPU_T, parse_gpu_config
 from .mount import _get_client_mount, _Mount
 from .object import Handle, Provider
-from .secret import _Secret, _resolve_secret
+from .secret import _Secret
 from .shared_volume import _SharedVolume
 
 
@@ -113,7 +113,7 @@ class _ImageRegistryConfig:
             return api_pb2.ImageRegistryConfig(registry_type=self.registry_type)
 
         return api_pb2.ImageRegistryConfig(
-            registry_type=self.registry_type, secret_id=await _resolve_secret(resolver, self.secret)
+            registry_type=self.registry_type, secret_id=(await resolver.load(self.secret)).object_id
         )
 
 
@@ -175,7 +175,7 @@ class _Image(Provider[_ImageHandle]):
 
             secret_ids = []
             for secret in secrets:
-                secret_id = await _resolve_secret(resolver, secret)
+                secret_id = (await resolver.load(secret)).object_id
                 secret_ids.append(secret_id)
 
             context_file_pb2s = []

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2022
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronize_apis
-from .exception import NotFoundError
 
 from ._resolver import Resolver
 from .object import Handle, Provider
@@ -37,21 +36,6 @@ class _Secret(Provider[_SecretHandle]):
 
         rep = f"Secret([{', '.join(env_dict.keys())}])"
         super().__init__(_load, rep)
-
-
-async def _resolve_secret(resolver: Resolver, secret: _Secret) -> str:
-    """mdmd:hidden"""
-    try:
-        secret_id = (await resolver.load(secret)).object_id
-    except NotFoundError as ex:
-        if isinstance(secret, _Secret):
-            msg = f"Secret {secret} was not found"
-        else:
-            msg = str(ex)
-        msg += ". You can add secrets to your account at https://modal.com/secrets"
-        raise NotFoundError(msg)
-
-    return secret_id
 
 
 Secret, AioSecret = synchronize_apis(_Secret)


### PR DESCRIPTION
It just displays the error message from the server, which now includes the error (although dumb me meant to make it an f-string but didn't lol – fixing it):

```
>>> modal.Secret.lookup("xyz")
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ <stdin>:1 in <module>                                                                            │
│                                                                                                  │
│                                                                                                  │
│ /Users/erikbern/synchronicity/synchronicity/synchronizer.py:425 in proxy_classmethod             │
│                                                                                                  │
│ /Users/erikbern/synchronicity/synchronicity/synchronizer.py:372 in f_wrapped                     │
│                                                                                                  │
│ /Users/erikbern/modal-client/modal/object.py:271 in lookup                                       │
│                                                                                                  │
│   270 │   │   handle_cls = cls.get_handle_cls()                                                  │
│ ❱ 271 │   │   handle: H = await handle_cls.from_app(app_name, tag, namespace, client)            │
│   272 │   │   return handle                                                                      │
│                                                                                                  │
│ /Users/erikbern/modal-client/modal/object.py:108 in from_app                                     │
│                                                                                                  │
│   107 │   │   │   │   # Legacy error message: remove soon                                        │
│ ❱ 108 │   │   │   │   raise NotFoundError(response.error_message)                                │
│   109 │   │   except GRPCError as exc:                                                           │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
NotFoundError: No secret named {app_display_name}. You can add secrets to your account at https://modal.com/secrets
```