### PR TITLE
Simplify `modal serve`

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -8,6 +8,7 @@ env:
   # Can't be set in `pytest-env` because pytest imports the client for filterwarnings
   # before it applies the env vars for the plugin.
   MODAL_SENTRY_DSN: ""
+  PYTHONIOENCODING: utf-8
 
 jobs:
   client-test:

--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -111,12 +111,12 @@ def test_secret_create(servicer, set_env_client):
     assert servicer.created_secrets == 1
 
 
-def test_app_token_new(servicer, server_url_env):
+def test_app_token_new(servicer, set_env_client, server_url_env):
     with unittest.mock.patch("webbrowser.open_new_tab", lambda url: False):
         _run(["token", "new", "--env", "_test"])
 
 
-def test_run(servicer, server_url_env, test_dir):
+def test_run(servicer, set_env_client, test_dir):
     stub_file = test_dir / "supports" / "app_run_tests" / "default_stub.py"
     _run(["run", stub_file.as_posix()])
     _run(["run", stub_file.as_posix() + "::stub"])
@@ -129,7 +129,7 @@ def test_run(servicer, server_url_env, test_dir):
     _run(["run", file_with_entrypoint.as_posix() + "::stub.main"])
 
 
-def test_help_message_unspecified_function(servicer, server_url_env, test_dir):
+def test_help_message_unspecified_function(servicer, set_env_client, test_dir):
     stub_file = test_dir / "supports" / "app_run_tests" / "stub_with_multiple_functions.py"
     result = _run(["run", stub_file.as_posix()], expected_exit_code=2)
 
@@ -145,19 +145,19 @@ def test_help_message_unspecified_function(servicer, server_url_env, test_dir):
     assert "bar" in result.stdout
 
 
-def test_run_detach(servicer, server_url_env, test_dir):
+def test_run_detach(servicer, set_env_client, test_dir):
     stub_file = test_dir / "supports" / "app_run_tests" / "default_stub.py"
     _run(["run", "--detach", stub_file.as_posix()])
     assert servicer.app_state == {"ap-1": api_pb2.APP_STATE_DETACHED}
 
 
-def test_deploy(servicer, server_url_env, test_dir):
+def test_deploy(servicer, set_env_client, test_dir):
     stub_file = test_dir / "supports" / "app_run_tests" / "default_stub.py"
     _run(["deploy", "--name=deployment_name", stub_file.as_posix()])
     assert servicer.app_state == {"ap-1": api_pb2.APP_STATE_DEPLOYED}
 
 
-def test_run_custom_stub(servicer, server_url_env, test_dir):
+def test_run_custom_stub(servicer, set_env_client, test_dir):
     stub_file = test_dir / "supports" / "app_run_tests" / "custom_stub.py"
     res = _run(["run", stub_file.as_posix() + "::stub"], expected_exit_code=1)
     assert "Could not find" in res.stdout
@@ -168,13 +168,13 @@ def test_run_custom_stub(servicer, server_url_env, test_dir):
     _run(["run", stub_file.as_posix() + "::foo"])
 
 
-def test_run_aiostub(servicer, server_url_env, test_dir):
+def test_run_aiostub(servicer, set_env_client, test_dir):
     stub_file = test_dir / "supports" / "app_run_tests" / "async_stub.py"
     _run(["run", stub_file.as_posix()])
     assert len(servicer.client_calls) == 1
 
 
-def test_run_local_entrypoint(servicer, server_url_env, test_dir):
+def test_run_local_entrypoint(servicer, set_env_client, test_dir):
     stub_file = test_dir / "supports" / "app_run_tests" / "local_entrypoint.py"
 
     res = _run(["run", stub_file.as_posix() + "::stub.main"])  # explicit name
@@ -186,7 +186,7 @@ def test_run_local_entrypoint(servicer, server_url_env, test_dir):
     assert len(servicer.client_calls) == 4
 
 
-def test_run_parse_args(servicer, server_url_env, test_dir):
+def test_run_parse_args(servicer, set_env_client, test_dir):
     stub_file = test_dir / "supports" / "app_run_tests" / "cli_args.py"
     res = _run(["run", stub_file.as_posix()], expected_exit_code=2)
     assert "You need to specify a Modal function or local entrypoint to run" in res.stdout
@@ -223,20 +223,20 @@ def fresh_main_thread_assertion_module(test_dir):
     yield test_dir / "supports" / "app_run_tests" / "main_thread_assertion.py"
 
 
-def test_no_user_code_in_synchronicity_run(servicer, server_url_env, test_dir, fresh_main_thread_assertion_module):
+def test_no_user_code_in_synchronicity_run(servicer, set_env_client, test_dir, fresh_main_thread_assertion_module):
     pytest._did_load_main_thread_assertion = False
     _run(["run", fresh_main_thread_assertion_module.as_posix()])
     assert pytest._did_load_main_thread_assertion
     print()
 
 
-def test_no_user_code_in_synchronicity_deploy(servicer, server_url_env, test_dir, fresh_main_thread_assertion_module):
+def test_no_user_code_in_synchronicity_deploy(servicer, set_env_client, test_dir, fresh_main_thread_assertion_module):
     pytest._did_load_main_thread_assertion = False
     _run(["deploy", "--name", "foo", fresh_main_thread_assertion_module.as_posix()])
     assert pytest._did_load_main_thread_assertion
 
 
-def test_serve(servicer, server_url_env, test_dir):
+def test_serve(servicer, set_env_client, test_dir):
     with mock.patch("modal.stub.HEARTBEAT_INTERVAL", 1):
         os.environ["MODAL_HEARTBEAT_INTERVAL"] = "1"  # propagate to child processes
         stub_file = test_dir / "supports" / "app_run_tests" / "webhook.py"
@@ -247,7 +247,7 @@ def test_serve(servicer, server_url_env, test_dir):
         assert servicer.app_heartbeats[apps[0]] >= 2
 
 
-def test_shell(servicer, server_url_env, test_dir):
+def test_shell(servicer, set_env_client, test_dir):
     stub_file = test_dir / "supports" / "app_run_tests" / "default_stub.py"
 
     def mock_get_pty_info() -> api_pb2.PTYInfo:

--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -42,15 +42,13 @@ async def set_env_client(aio_client):
 
 def _run(args, expected_exit_code=0):
     runner = click.testing.CliRunner()
-    cli_command = [sys.executable, "-m", "modal.cli.entry_point", *args]
-    with mock.patch("modal._live_reload.get_restart_cli_command", return_value=cli_command):
-        res = runner.invoke(entrypoint_cli, args)
-        if res.exit_code != expected_exit_code:
-            print("stdout:", repr(res.stdout))
-            traceback.print_tb(res.exc_info[2])
-            print(res.exception, file=sys.stderr)
-            assert res.exit_code == expected_exit_code
-        return res
+    res = runner.invoke(entrypoint_cli, args)
+    if res.exit_code != expected_exit_code:
+        print("stdout:", repr(res.stdout))
+        traceback.print_tb(res.exc_info[2])
+        print(res.exception, file=sys.stderr)
+        assert res.exit_code == expected_exit_code
+    return res
 
 
 def test_app_deploy_success(servicer, mock_dir, set_env_client):

--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -237,14 +237,8 @@ def test_no_user_code_in_synchronicity_deploy(servicer, set_env_client, test_dir
 
 
 def test_serve(servicer, set_env_client, server_url_env, test_dir):
-    with mock.patch("modal.stub.HEARTBEAT_INTERVAL", 1):
-        os.environ["MODAL_HEARTBEAT_INTERVAL"] = "1"  # propagate to child processes
-        stub_file = test_dir / "supports" / "app_run_tests" / "webhook.py"
-        res = _run(["serve", stub_file.as_posix(), "--timeout", "3"], expected_exit_code=0)
-        print(res.stdout)
-        apps = list(servicer.app_heartbeats.keys())
-        assert len(apps) == 1
-        assert servicer.app_heartbeats[apps[0]] >= 2
+    stub_file = test_dir / "supports" / "app_run_tests" / "webhook.py"
+    _run(["serve", stub_file.as_posix(), "--timeout", "3"], expected_exit_code=0)
 
 
 def test_shell(servicer, set_env_client, test_dir):

--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -236,7 +236,7 @@ def test_no_user_code_in_synchronicity_deploy(servicer, set_env_client, test_dir
     assert pytest._did_load_main_thread_assertion
 
 
-def test_serve(servicer, set_env_client, test_dir):
+def test_serve(servicer, set_env_client, server_url_env, test_dir):
     with mock.patch("modal.stub.HEARTBEAT_INTERVAL", 1):
         os.environ["MODAL_HEARTBEAT_INTERVAL"] = "1"  # propagate to child processes
         stub_file = test_dir / "supports" / "app_run_tests" / "webhook.py"

--- a/client_test/client_test.py
+++ b/client_test/client_test.py
@@ -8,7 +8,7 @@ from modal.client import AioClient, Client
 from modal.exception import AuthError, ConnectionError, VersionError
 from modal_proto import api_pb2
 
-from .supports.skip import skip_windows
+from .supports.skip import skip_windows_unix_socket
 
 TEST_TIMEOUT = 4.0  # align this with the container client timeout in client.py
 
@@ -21,7 +21,7 @@ async def test_client(servicer, client):
 
 
 @pytest.mark.asyncio
-@skip_windows
+@skip_windows_unix_socket
 async def test_container_client(unix_servicer, aio_container_client):
     assert len(unix_servicer.requests) == 1  # no heartbeat, just ClientHello
     assert isinstance(unix_servicer.requests[0], Empty)
@@ -39,7 +39,7 @@ async def test_client_dns_failure():
 
 @pytest.mark.asyncio
 @pytest.mark.timeout(TEST_TIMEOUT)
-@skip_windows
+@skip_windows_unix_socket
 async def test_client_connection_failure():
     with pytest.raises(ConnectionError) as excinfo:
         async with AioClient("https://localhost:443", api_pb2.CLIENT_TYPE_CONTAINER, None):
@@ -49,7 +49,7 @@ async def test_client_connection_failure():
 
 @pytest.mark.asyncio
 @pytest.mark.timeout(TEST_TIMEOUT)
-@skip_windows
+@skip_windows_unix_socket
 async def test_client_connection_failure_unix_socket():
     with pytest.raises(ConnectionError) as excinfo:
         async with AioClient("unix:/tmp/xyz.txt", api_pb2.CLIENT_TYPE_CONTAINER, None):
@@ -59,7 +59,7 @@ async def test_client_connection_failure_unix_socket():
 
 @pytest.mark.asyncio
 @pytest.mark.timeout(TEST_TIMEOUT)
-@skip_windows
+@skip_windows_unix_socket
 async def test_client_connection_timeout(unix_servicer, monkeypatch):
     monkeypatch.setattr("modal.client.CLIENT_CREATE_ATTEMPT_TIMEOUT", 1.0)
     monkeypatch.setattr("modal.client.CLIENT_CREATE_TOTAL_TIMEOUT", 3.0)

--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -106,6 +106,8 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
         self.enforce_object_entity = True
 
+        self.app_set_objects_count = 0
+
         @self.function_body
         def default_function_body(*args, **kwargs):
             return sum(arg**2 for arg in args) + sum(value**2 for key, value in kwargs.items())
@@ -155,6 +157,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
     async def AppSetObjects(self, stream):
         request: api_pb2.AppSetObjectsRequest = await stream.recv_message()
         self.app_objects[request.app_id] = dict(request.indexed_object_ids)
+        self.app_set_objects_count += 1
         if request.new_app_state:
             self.app_state[request.app_id] = request.new_app_state
         await stream.send_message(Empty())
@@ -619,7 +622,7 @@ async def aio_container_client(unix_servicer):
 
 
 @pytest_asyncio.fixture(scope="function")
-async def server_url_env(servicer, monkeypatch, set_env_client):
+async def server_url_env(servicer, monkeypatch):
     monkeypatch.setenv("MODAL_SERVER_URL", servicer.remote_addr)
     yield
 

--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -627,6 +627,11 @@ async def server_url_env(servicer, monkeypatch):
     yield
 
 
+@pytest_asyncio.fixture(scope="function", autouse=True)
+async def reset_default_client():
+    AioClient.set_env_client(None)
+
+
 @pytest.fixture(name="mock_dir", scope="session")
 def mock_dir_factory():
     """Sets up a temp dir with content as specified in a nested dict

--- a/client_test/container_app_test.py
+++ b/client_test/container_app_test.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 from modal.aio import AioApp, AioFunctionHandle, AioImage, AioStub, aio_container_app
 
-from .supports.skip import skip_windows
+from .supports.skip import skip_windows_unix_socket
 
 
 def my_f_1(x):
@@ -16,7 +16,7 @@ def my_f_2(x):
     pass
 
 
-@skip_windows
+@skip_windows_unix_socket
 @pytest.mark.asyncio
 async def test_container_function_initialization(unix_servicer, aio_container_client):
     unix_servicer.app_objects["ap-123"] = {
@@ -47,7 +47,7 @@ async def test_container_function_initialization(unix_servicer, aio_container_cl
     assert await my_f_2_container.call(42) == 1764
 
 
-@skip_windows
+@skip_windows_unix_socket
 @pytest.mark.asyncio
 async def test_is_inside(servicer, unix_servicer, aio_client, aio_container_client):
     image_1 = AioImage.debian_slim().pip_install(["abc"])
@@ -95,7 +95,7 @@ def f():
     pass
 
 
-@skip_windows
+@skip_windows_unix_socket
 @pytest.mark.asyncio
 async def test_is_inside_default_image(servicer, unix_servicer, aio_client, aio_container_client):
     stub = AioStub()

--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -15,7 +15,7 @@ from modal.client import Client
 from modal.exception import InvalidError
 from modal_proto import api_pb2
 
-from .supports.skip import skip_windows
+from .supports.skip import skip_windows_unix_socket
 
 EXTRA_TOLERANCE_DELAY = 1.0
 FUNCTION_CALL_ID = "fc-123"
@@ -88,7 +88,7 @@ def _run_container(
         return client, items
 
 
-@skip_windows
+@skip_windows_unix_socket
 def test_success(unix_servicer, event_loop):
     t0 = time.time()
     client, items = _run_container(unix_servicer, "modal_test_support.functions", "square")
@@ -98,7 +98,7 @@ def test_success(unix_servicer, event_loop):
     assert items[0].result.data == serialize(42**2)
 
 
-@skip_windows
+@skip_windows_unix_socket
 def test_generator_success(unix_servicer, event_loop):
     client, items = _run_container(
         unix_servicer, "modal_test_support.functions", "gen_n", function_type=api_pb2.Function.FUNCTION_TYPE_GENERATOR
@@ -120,7 +120,7 @@ def test_generator_success(unix_servicer, event_loop):
     assert last_result.data == b""  # no data in generator complete marker result
 
 
-@skip_windows
+@skip_windows_unix_socket
 def test_generator_failure(unix_servicer, event_loop):
     inputs = _get_inputs(((10, 5), {}))
     client, items = _run_container(
@@ -147,7 +147,7 @@ def test_generator_failure(unix_servicer, event_loop):
     assert data.args == ("bad",)
 
 
-@skip_windows
+@skip_windows_unix_socket
 def test_async(unix_servicer):
     t0 = time.time()
     client, items = _run_container(unix_servicer, "modal_test_support.functions", "square_async")
@@ -157,7 +157,7 @@ def test_async(unix_servicer):
     assert items[0].result.data == serialize(42**2)
 
 
-@skip_windows
+@skip_windows_unix_socket
 def test_failure(unix_servicer):
     client, items = _run_container(unix_servicer, "modal_test_support.functions", "raises")
     assert len(items) == 1
@@ -166,7 +166,7 @@ def test_failure(unix_servicer):
     assert "Traceback" in items[0].result.traceback
 
 
-@skip_windows
+@skip_windows_unix_socket
 def test_raises_base_exception(unix_servicer):
     client, items = _run_container(unix_servicer, "modal_test_support.functions", "raises_sysexit")
     assert len(items) == 1
@@ -174,13 +174,13 @@ def test_raises_base_exception(unix_servicer):
     assert items[0].result.exception == "SystemExit(1)"
 
 
-@skip_windows
+@skip_windows_unix_socket
 def test_keyboardinterrupt(unix_servicer):
     with pytest.raises(KeyboardInterrupt):
         _run_container(unix_servicer, "modal_test_support.functions", "raises_keyboardinterrupt")
 
 
-@skip_windows
+@skip_windows_unix_socket
 def test_rate_limited(unix_servicer, event_loop):
     t0 = time.time()
     unix_servicer.rate_limit_sleep_duration = 0.25
@@ -191,7 +191,7 @@ def test_rate_limited(unix_servicer, event_loop):
     assert items[0].result.data == serialize(42**2)
 
 
-@skip_windows
+@skip_windows_unix_socket
 def test_grpc_failure(unix_servicer, event_loop):
     # An error in "Modal code" should cause the entire container to fail
     with pytest.raises(GRPCError):
@@ -201,7 +201,7 @@ def test_grpc_failure(unix_servicer, event_loop):
     # assert "GRPCError" in unix_servicer.task_result.exception
 
 
-@skip_windows
+@skip_windows_unix_socket
 def test_missing_main_conditional(unix_servicer, event_loop):
     _run_container(unix_servicer, "modal_test_support.missing_main_conditional", "square")
 
@@ -212,7 +212,7 @@ def test_missing_main_conditional(unix_servicer, event_loop):
     assert isinstance(exc, InvalidError)
 
 
-@skip_windows
+@skip_windows_unix_socket
 def test_startup_failure(unix_servicer, event_loop):
     _run_container(unix_servicer, "modal_test_support.startup_failure", "f")
 
@@ -222,7 +222,7 @@ def test_startup_failure(unix_servicer, event_loop):
     assert isinstance(exc, ImportError)
 
 
-@skip_windows
+@skip_windows_unix_socket
 def test_class_scoped_function(unix_servicer, event_loop):
     client, items = _run_container(unix_servicer, "modal_test_support.functions", "Cube.f")
     assert len(items) == 1
@@ -234,7 +234,7 @@ def test_class_scoped_function(unix_servicer, event_loop):
     assert Cube._events == ["init", "enter", "call", "exit"]
 
 
-@skip_windows
+@skip_windows_unix_socket
 def test_class_scoped_function_async(unix_servicer, event_loop):
     client, items = _run_container(unix_servicer, "modal_test_support.functions", "CubeAsync.f")
     assert len(items) == 1
@@ -246,7 +246,7 @@ def test_class_scoped_function_async(unix_servicer, event_loop):
     assert CubeAsync._events == ["init", "enter", "call", "exit"]
 
 
-@skip_windows
+@skip_windows_unix_socket
 def test_create_package_mounts_inside_container(unix_servicer, event_loop):
     """`create_package_mounts` shouldn't actually run inside the container, because it's possible
     that there are modules that were present locally for the user that didn't get mounted into
@@ -257,7 +257,7 @@ def test_create_package_mounts_inside_container(unix_servicer, event_loop):
     assert items[0].result.data == serialize(0)
 
 
-@skip_windows
+@skip_windows_unix_socket
 def test_webhook(unix_servicer, event_loop):
     scope = {
         "method": "GET",
@@ -299,7 +299,7 @@ def test_webhook(unix_servicer, event_loop):
     assert items[2].result.gen_status == api_pb2.GenericResult.GENERATOR_STATUS_COMPLETE
 
 
-@skip_windows
+@skip_windows_unix_socket
 def test_webhook_lifecycle(unix_servicer, event_loop):
     scope = {
         "method": "GET",
@@ -326,7 +326,7 @@ def test_webhook_lifecycle(unix_servicer, event_loop):
     assert json.loads(second_message["body"]) == {"hello": "space"}
 
 
-@skip_windows
+@skip_windows_unix_socket
 def test_serialized_function(unix_servicer, event_loop):
     def triple(x):
         return 3 * x
@@ -343,7 +343,7 @@ def test_serialized_function(unix_servicer, event_loop):
     assert items[0].result.data == serialize(3 * 42)
 
 
-@skip_windows
+@skip_windows_unix_socket
 def test_webhook_serialized(unix_servicer, event_loop):
     scope = {
         "method": "GET",
@@ -378,7 +378,7 @@ def test_webhook_serialized(unix_servicer, event_loop):
     assert second_message["body"] == b'"Hello, space"'  # Note: JSON-encoded
 
 
-@skip_windows
+@skip_windows_unix_socket
 def test_function_returning_generator(unix_servicer, event_loop):
     client, items = _run_container(
         unix_servicer,
@@ -391,7 +391,7 @@ def test_function_returning_generator(unix_servicer, event_loop):
     assert items[-1].result.gen_status == api_pb2.GenericResult.GENERATOR_STATUS_COMPLETE
 
 
-@skip_windows
+@skip_windows_unix_socket
 def test_asgi(unix_servicer, event_loop):
     scope = {
         "method": "GET",
@@ -433,7 +433,7 @@ def test_asgi(unix_servicer, event_loop):
     assert items[2].result.gen_status == api_pb2.GenericResult.GENERATOR_STATUS_COMPLETE
 
 
-@skip_windows
+@skip_windows_unix_socket
 def test_container_heartbeats(unix_servicer, event_loop):
     client, items = _run_container(unix_servicer, "modal_test_support.functions", "square")
     assert any(isinstance(request, api_pb2.ContainerHeartbeatRequest) for request in unix_servicer.requests)

--- a/client_test/live_reload_test.py
+++ b/client_test/live_reload_test.py
@@ -1,14 +1,13 @@
 # Copyright Modal Labs 2023
 import asyncio
-import platform
-import sys
 import pytest
 
 from modal._live_reload import aio_run_serve_loop, run_serve_loop
+from .supports.skip import skip_old_py, skip_windows
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="live-reload requires python3.8 or higher")
-@pytest.mark.skipif(platform.system() == "Windows", reason="live-reload not supported on windows")
+@skip_old_py("live-reload requires python3.8 or higher", (3, 8))
+@skip_windows("live-reload not supported on windows")
 def test_file_changes_trigger_reloads(client, monkeypatch, test_dir, server_url_env, servicer):
     async def fake_watch(mounts, output_mgr, timeout):
         yield  # dummy at the beginning
@@ -25,6 +24,8 @@ def test_file_changes_trigger_reloads(client, monkeypatch, test_dir, server_url_
     assert servicer.app_set_objects_count == 4  # 1 + number of file changes
 
 
+@skip_old_py("live-reload requires python3.8 or higher", (3, 8))
+@skip_windows("live-reload not supported on windows")
 @pytest.mark.asyncio
 async def test_reloadable_serve_ignores_file_changes(client, monkeypatch, test_dir, server_url_env, servicer):
     async def fake_watch(stub, output_mgr, timeout):

--- a/client_test/live_reload_test.py
+++ b/client_test/live_reload_test.py
@@ -7,7 +7,7 @@ from .supports.skip import skip_old_py, skip_windows
 
 
 @pytest.mark.asyncio
-async def test_live_reload(client, monkeypatch, test_dir, server_url_env, servicer):
+async def test_live_reload(test_dir, server_url_env, servicer):
     stub_file = str(test_dir / "supports" / "app_run_tests" / "default_stub.py")
     await aio_run_serve_loop(stub_file, timeout=3.0)
     assert servicer.app_set_objects_count == 1
@@ -15,36 +15,30 @@ async def test_live_reload(client, monkeypatch, test_dir, server_url_env, servic
 
 @skip_old_py("live-reload requires python3.8 or higher", (3, 8))
 @skip_windows("live-reload not supported on windows")
-def test_file_changes_trigger_reloads(client, monkeypatch, test_dir, server_url_env, servicer):
-    async def fake_watch(mounts, output_mgr, timeout):
+def test_file_changes_trigger_reloads(test_dir, server_url_env, servicer):
+    async def fake_watch():
         yield  # dummy at the beginning
         for i in range(3):
             await asyncio.sleep(1.5)
             yield
         await asyncio.sleep(1.5)
 
-    monkeypatch.setattr("modal._live_reload.watch", fake_watch)
-
     stub_file = str(test_dir / "supports" / "app_run_tests" / "default_stub.py")
-
-    run_serve_loop(stub_file)
+    run_serve_loop(stub_file, _watcher=fake_watch())
     assert servicer.app_set_objects_count == 4  # 1 + number of file changes
 
 
 @skip_old_py("live-reload requires python3.8 or higher", (3, 8))
 @skip_windows("live-reload not supported on windows")
 @pytest.mark.asyncio
-async def test_reloadable_serve_ignores_file_changes(client, monkeypatch, test_dir, server_url_env, servicer):
-    async def fake_watch(stub, output_mgr, timeout):
+async def test_reloadable_serve_ignores_file_changes(test_dir, server_url_env, servicer):
+    async def fake_watch():
         # Iterator that never yields
         if False:
             yield
 
-    monkeypatch.setattr("modal._live_reload.watch", fake_watch)
-
     # The app should not react to AppChange.TIMEOUT, and instead need
     # the wait_for to cancel it.
     stub_file = str(test_dir / "supports" / "app_run_tests" / "default_stub.py")
-
-    await aio_run_serve_loop(stub_file)
+    await aio_run_serve_loop(stub_file, _watcher=fake_watch())
     assert servicer.app_set_objects_count == 0

--- a/client_test/live_reload_test.py
+++ b/client_test/live_reload_test.py
@@ -1,6 +1,5 @@
 # Copyright Modal Labs 2023
 import asyncio
-import os
 import platform
 import sys
 import pytest

--- a/client_test/live_reload_test.py
+++ b/client_test/live_reload_test.py
@@ -28,14 +28,12 @@ def test_file_changes_trigger_reloads(test_dir, server_url_env, servicer):
 @skip_old_py("live-reload requires python3.8 or higher", (3, 8))
 @skip_windows("live-reload not supported on windows")
 @pytest.mark.asyncio
-async def test_reloadable_serve_ignores_file_changes(test_dir, server_url_env, servicer):
+async def test_no_change(test_dir, server_url_env, servicer):
     async def fake_watch():
         # Iterator that never yields
         if False:
             yield
 
-    # The app should not react to AppChange.TIMEOUT, and instead need
-    # the wait_for to cancel it.
     stub_file = str(test_dir / "supports" / "app_run_tests" / "default_stub.py")
     await aio_run_serve_loop(stub_file, _watcher=fake_watch())
     assert servicer.app_set_objects_count == 0

--- a/client_test/live_reload_test.py
+++ b/client_test/live_reload_test.py
@@ -6,6 +6,13 @@ from modal._live_reload import aio_run_serve_loop, run_serve_loop
 from .supports.skip import skip_old_py, skip_windows
 
 
+@pytest.mark.asyncio
+async def test_live_reload(client, monkeypatch, test_dir, server_url_env, servicer):
+    stub_file = str(test_dir / "supports" / "app_run_tests" / "default_stub.py")
+    await aio_run_serve_loop(stub_file, timeout=3.0)
+    assert servicer.app_set_objects_count == 1
+
+
 @skip_old_py("live-reload requires python3.8 or higher", (3, 8))
 @skip_windows("live-reload not supported on windows")
 def test_file_changes_trigger_reloads(client, monkeypatch, test_dir, server_url_env, servicer):

--- a/client_test/live_reload_test.py
+++ b/client_test/live_reload_test.py
@@ -11,6 +11,8 @@ async def test_live_reload(test_dir, server_url_env, servicer):
     stub_file = str(test_dir / "supports" / "app_run_tests" / "default_stub.py")
     await aio_run_serve_loop(stub_file, timeout=3.0)
     assert servicer.app_set_objects_count == 1
+    assert servicer.app_client_disconnect_count == 1
+    assert servicer.app_get_logs_initial_count == 1
 
 
 @skip_old_py("live-reload requires python3.8 or higher", (3, 8))
@@ -23,6 +25,8 @@ def test_file_changes_trigger_reloads(test_dir, server_url_env, servicer):
     stub_file = str(test_dir / "supports" / "app_run_tests" / "default_stub.py")
     run_serve_loop(stub_file, _watcher=fake_watch())
     assert servicer.app_set_objects_count == 4  # 1 + number of file changes
+    assert servicer.app_client_disconnect_count == 1
+    assert servicer.app_get_logs_initial_count == 1
 
 
 @pytest.mark.asyncio
@@ -35,6 +39,8 @@ async def test_no_change(test_dir, server_url_env, servicer):
     stub_file = str(test_dir / "supports" / "app_run_tests" / "default_stub.py")
     await aio_run_serve_loop(stub_file, _watcher=fake_watch())
     assert servicer.app_set_objects_count == 1  # Should create the initial app once
+    assert servicer.app_client_disconnect_count == 1
+    assert servicer.app_get_logs_initial_count == 1
 
 
 @pytest.mark.asyncio

--- a/client_test/live_reload_test.py
+++ b/client_test/live_reload_test.py
@@ -5,71 +5,39 @@ import platform
 import sys
 import pytest
 
-try:
-    from unittest.mock import AsyncMock
-except ImportError:
-    # Support Python 3.7
-    from unittest.mock import MagicMock
-
-    class AsyncMock(MagicMock):  # type: ignore
-        async def __call__(self, *args, **kwargs):
-            return super(AsyncMock, self).__call__(*args, **kwargs)  # type: ignore
-
-
-from modal import Stub
-from modal._live_reload import MODAL_AUTORELOAD_ENV
-from modal.aio import AioStub
-
-
-def dummy():
-    pass
-
-
-class FakeProcess:
-    def send_signal(self, signal):
-        pass
-
-    def terminate(self):
-        pass
+from modal._live_reload import aio_run_serve_loop, run_serve_loop
 
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="live-reload requires python3.8 or higher")
 @pytest.mark.skipif(platform.system() == "Windows", reason="live-reload not supported on windows")
-def test_file_changes_trigger_reloads(client, monkeypatch, servicer, test_dir):
+def test_file_changes_trigger_reloads(client, monkeypatch, test_dir, server_url_env, servicer):
     async def fake_watch(mounts, output_mgr, timeout):
         yield  # dummy at the beginning
         for i in range(3):
+            await asyncio.sleep(0.5)
             yield
+        await asyncio.sleep(0.5)
 
-    stub = Stub()
-    stub.webhook(dummy)
+    monkeypatch.setattr("modal._live_reload.watch", fake_watch)
 
-    mock_create_subprocess_exec = AsyncMock(return_value=FakeProcess())
-    monkeypatch.setattr("modal.stub.asyncio.create_subprocess_exec", mock_create_subprocess_exec)
-    monkeypatch.setattr("modal._watcher.watch", fake_watch)
+    stub_file = str(test_dir / "supports" / "app_run_tests" / "default_stub.py")
 
-    stub.serve(client=client, timeout=None)
-    assert mock_create_subprocess_exec.call_count == 4  # 1 + number of file changes
+    run_serve_loop(stub_file)
+    assert servicer.app_set_objects_count == 4  # 1 + number of file changes
 
 
 @pytest.mark.asyncio
-async def test_reloadable_serve_ignores_file_changes(client, monkeypatch, servicer, test_dir):
+async def test_reloadable_serve_ignores_file_changes(client, monkeypatch, test_dir, server_url_env, servicer):
     async def fake_watch(stub, output_mgr, timeout):
         # Iterator that never yields
         if False:
             yield
 
-    stub = AioStub()
-    stub.webhook(dummy)
-
-    mock_create_subprocess_exec = AsyncMock(return_value=FakeProcess())
-    monkeypatch.setattr("modal.stub.asyncio.create_subprocess_exec", mock_create_subprocess_exec)
-    monkeypatch.setattr("modal._watcher.watch", fake_watch)
+    monkeypatch.setattr("modal._live_reload.watch", fake_watch)
 
     # The app should not react to AppChange.TIMEOUT, and instead need
     # the wait_for to cancel it.
-    monkeypatch.setattr(os, "environ", {MODAL_AUTORELOAD_ENV: "ap-12345"})
-    with pytest.raises(asyncio.TimeoutError):
-        await asyncio.wait_for(stub.serve(client=client), timeout=1.0)
+    stub_file = str(test_dir / "supports" / "app_run_tests" / "default_stub.py")
 
-    assert mock_create_subprocess_exec.call_count == 0
+    await aio_run_serve_loop(stub_file)
+    assert servicer.app_set_objects_count == 0

--- a/client_test/live_reload_test.py
+++ b/client_test/live_reload_test.py
@@ -1,5 +1,4 @@
 # Copyright Modal Labs 2023
-import asyncio
 import pytest
 
 from modal._live_reload import aio_run_serve_loop, run_serve_loop
@@ -19,9 +18,7 @@ def test_file_changes_trigger_reloads(test_dir, server_url_env, servicer):
     async def fake_watch():
         yield  # dummy at the beginning
         for i in range(3):
-            await asyncio.sleep(1.5)
             yield
-        await asyncio.sleep(1.5)
 
     stub_file = str(test_dir / "supports" / "app_run_tests" / "default_stub.py")
     run_serve_loop(stub_file, _watcher=fake_watch())

--- a/client_test/live_reload_test.py
+++ b/client_test/live_reload_test.py
@@ -1,5 +1,6 @@
 # Copyright Modal Labs 2023
 import pytest
+from unittest import mock
 
 from modal._live_reload import aio_run_serve_loop, run_serve_loop
 from .supports.skip import skip_old_py, skip_windows
@@ -24,8 +25,6 @@ def test_file_changes_trigger_reloads(test_dir, server_url_env, servicer):
     assert servicer.app_set_objects_count == 4  # 1 + number of file changes
 
 
-@skip_old_py("live-reload requires python3.8 or higher", (3, 8))
-@skip_windows("live-reload not supported on windows")
 @pytest.mark.asyncio
 async def test_no_change(test_dir, server_url_env, servicer):
     async def fake_watch():
@@ -36,3 +35,14 @@ async def test_no_change(test_dir, server_url_env, servicer):
     stub_file = str(test_dir / "supports" / "app_run_tests" / "default_stub.py")
     await aio_run_serve_loop(stub_file, _watcher=fake_watch())
     assert servicer.app_set_objects_count == 1  # Should create the initial app once
+
+
+@pytest.mark.asyncio
+async def test_heartbeats(test_dir, server_url_env, servicer):
+    with mock.patch("modal.stub.HEARTBEAT_INTERVAL", 1):
+        stub_file = str(test_dir / "supports" / "app_run_tests" / "default_stub.py")
+        await aio_run_serve_loop(stub_file, timeout=3.5)
+
+    apps = list(servicer.app_heartbeats.keys())
+    assert len(apps) == 1
+    assert servicer.app_heartbeats[apps[0]] == 3

--- a/client_test/live_reload_test.py
+++ b/client_test/live_reload_test.py
@@ -45,4 +45,4 @@ async def test_heartbeats(test_dir, server_url_env, servicer):
 
     apps = list(servicer.app_heartbeats.keys())
     assert len(apps) == 1
-    assert servicer.app_heartbeats[apps[0]] == 3
+    assert servicer.app_heartbeats[apps[0]] == 4  # 0s, 1s, 2s, 3s

--- a/client_test/live_reload_test.py
+++ b/client_test/live_reload_test.py
@@ -16,7 +16,6 @@ async def test_live_reload(test_dir, server_url_env, servicer):
 @skip_windows("live-reload not supported on windows")
 def test_file_changes_trigger_reloads(test_dir, server_url_env, servicer):
     async def fake_watch():
-        yield  # dummy at the beginning
         for i in range(3):
             yield
 
@@ -36,4 +35,4 @@ async def test_no_change(test_dir, server_url_env, servicer):
 
     stub_file = str(test_dir / "supports" / "app_run_tests" / "default_stub.py")
     await aio_run_serve_loop(stub_file, _watcher=fake_watch())
-    assert servicer.app_set_objects_count == 0
+    assert servicer.app_set_objects_count == 1  # Should create the initial app once

--- a/client_test/live_reload_test.py
+++ b/client_test/live_reload_test.py
@@ -28,7 +28,7 @@ def test_file_changes_trigger_reloads(test_dir, server_url_env, servicer):
 @pytest.mark.asyncio
 async def test_no_change(test_dir, server_url_env, servicer):
     async def fake_watch():
-        # Iterator that never yields
+        # Iterator that returns immediately, yielding nothing
         if False:
             yield
 

--- a/client_test/live_reload_test.py
+++ b/client_test/live_reload_test.py
@@ -13,9 +13,9 @@ def test_file_changes_trigger_reloads(client, monkeypatch, test_dir, server_url_
     async def fake_watch(mounts, output_mgr, timeout):
         yield  # dummy at the beginning
         for i in range(3):
-            await asyncio.sleep(0.5)
+            await asyncio.sleep(1.5)
             yield
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(1.5)
 
     monkeypatch.setattr("modal._live_reload.watch", fake_watch)
 

--- a/client_test/mounted_files_test.py
+++ b/client_test/mounted_files_test.py
@@ -1,6 +1,5 @@
 # Copyright Modal Labs 2022
 import os
-import platform
 import pytest
 import pytest_asyncio
 import subprocess
@@ -8,6 +7,8 @@ import sys
 from pathlib import Path
 
 from modal._function_utils import FunctionInfo
+
+from .supports.skip import skip_windows
 
 
 @pytest.fixture
@@ -128,7 +129,7 @@ def test_mounted_files_package(supports_dir, env_mount_files):
     }
 
 
-@pytest.mark.skipif(platform.system() == "Windows", reason="venvs behave differently on Windows.")
+@skip_windows("venvs behave differently on Windows.")
 def test_mounted_files_sys_prefix(supports_dir, venv_path, env_mount_files):
     # Run with venv activated, so it's on sys.prefix, and modal is dev-installed in the VM
     p = subprocess.run(

--- a/client_test/shared_volume_test.py
+++ b/client_test/shared_volume_test.py
@@ -1,5 +1,4 @@
 # Copyright Modal Labs 2022
-import platform
 from unittest import mock
 
 import pytest
@@ -7,6 +6,8 @@ import pytest
 import modal
 import modal.aio
 from modal.exception import InvalidError
+
+from .supports.skip import skip_windows
 
 
 def dummy():
@@ -24,7 +25,7 @@ def test_shared_volume_files(client, test_dir, servicer):
         dummy_modal.call()
 
 
-@pytest.mark.skipif(platform.system() == "Windows", reason="TODO: implement client-side path check on Windows.")
+@skip_windows("TODO: implement client-side path check on Windows.")
 def test_shared_volume_bad_paths(client, test_dir, servicer):
     stub = modal.Stub()
 

--- a/client_test/stub_test.py
+++ b/client_test/stub_test.py
@@ -10,7 +10,7 @@ from grpclib import GRPCError, Status
 import modal.app
 from modal import Stub
 from modal.aio import AioDict, AioQueue, AioStub
-from modal.exception import InvalidError
+from modal.exception import DeprecationError, InvalidError
 from modal_proto import api_pb2
 from modal_test_support import module_1, module_2
 
@@ -152,7 +152,8 @@ def test_serve(client):
     stub = Stub()
 
     stub.wsgi(dummy)
-    stub.serve(client=client, timeout=1)
+    with pytest.warns(DeprecationError):
+        stub.serve(client=client, timeout=1)
 
 
 @skip_in_github
@@ -160,7 +161,8 @@ def test_serve_teardown(client, servicer):
     stub = Stub()
     with modal.client.Client(servicer.remote_addr, api_pb2.CLIENT_TYPE_CLIENT, ("foo-id", "foo-secret")) as client:
         stub.wsgi(dummy)
-        stub.serve(client=client, timeout=1)
+        with pytest.warns(DeprecationError):
+            stub.serve(client=client, timeout=1)
 
     disconnect_reqs = [s for s in servicer.requests if isinstance(s, api_pb2.AppClientDisconnectRequest)]
     assert len(disconnect_reqs) == 1
@@ -176,7 +178,8 @@ def test_nested_serve_invocation(client):
     with pytest.raises(InvalidError) as excinfo:
         with stub.run(client=client):
             # This nested call creates a second web endpoint!
-            stub.serve(client=client)
+            with pytest.warns(DeprecationError):
+                stub.serve(client=client)
     assert "running" in str(excinfo.value)
 
 

--- a/client_test/supports/skip.py
+++ b/client_test/supports/skip.py
@@ -1,11 +1,20 @@
 # Copyright Modal Labs 2022
 
 import platform
+import sys
 
 import pytest
 
-# TODO(erikbern): there's a few other reasons we skip windows (see eg shared_volume_test.py)
-skip_windows = pytest.mark.skipif(
-    platform.system() == "Windows",
-    reason="Windows doesn't have UNIX sockets",
-)
+
+def skip_windows(msg: str):
+    return pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason=msg,
+    )
+
+
+skip_windows_unix_socket = skip_windows("Windows doesn't have UNIX sockets")
+
+
+def skip_old_py(msg: str, min_version: tuple):
+    return pytest.mark.skipif(sys.version_info < min_version, reason=msg)

--- a/modal/_live_reload.py
+++ b/modal/_live_reload.py
@@ -67,4 +67,4 @@ async def _run_serve_loop(stub_ref: str, timeout: Optional[float] = None, stdout
                 curr_proc.terminate()
 
 
-run_serve_loop, _ = synchronize_apis(_run_serve_loop)
+run_serve_loop, aio_run_serve_loop = synchronize_apis(_run_serve_loop)

--- a/modal/_live_reload.py
+++ b/modal/_live_reload.py
@@ -1,10 +1,7 @@
 # Copyright Modal Labs 2023
-import asyncio
-import os
 import multiprocessing
-from pathlib import Path
+from multiprocessing.context import SpawnProcess
 import platform
-import signal
 import sys
 from typing import Optional
 
@@ -26,8 +23,8 @@ def _run_serve(stub_ref: str, existing_app_id: str):
     blocking_stub.serve(existing_app_id=existing_app_id)
 
 
-def restart_serve(stub_ref: str, existing_app_id: str, prev_proc: multiprocessing.Process) -> multiprocessing.Process:
-    if prev_proc:
+def restart_serve(stub_ref: str, existing_app_id: str, prev_proc: Optional[SpawnProcess]) -> SpawnProcess:
+    if prev_proc is not None:
         prev_proc.terminate()
     ctx = multiprocessing.get_context("spawn")  # Needed to reload the interpreter
     p = ctx.Process(target=_run_serve, args=(stub_ref, existing_app_id))

--- a/modal/_live_reload.py
+++ b/modal/_live_reload.py
@@ -18,6 +18,7 @@ from .app import _App
 from .cli.import_refs import import_stub
 from .client import _Client
 
+
 def _run_serve(stub_ref: str, existing_app_id: str):
     # subprocess entrypoint
     _stub = import_stub(stub_ref)
@@ -53,7 +54,7 @@ async def _run_serve_loop(stub_ref: str, timeout: Optional[float] = None, stdout
 
     if unsupported_msg:
         output_mgr.print_if_visible(unsupported_msg)
-        await stub.serve(timeout=timeout)        
+        await stub.serve(timeout=timeout)
 
     else:
         app = await _App._init_new(client, stub.description, deploying=False, detach=False)

--- a/modal/_live_reload.py
+++ b/modal/_live_reload.py
@@ -44,7 +44,7 @@ async def _terminate(proc: Optional[SpawnProcess], output_mgr: OutputManager, ti
         if proc.exitcode is not None:
             output_mgr.print_if_visible(f"Serve process {proc.pid} terminated")
         else:
-            output_mgr.print_if_visible(f"[red]Serve process {proc.pid} didn't terminate after {timeout}s, killing it")
+            output_mgr.print_if_visible(f"[red]Serve process {proc.pid} didn't terminate after {timeout}s, killing it[/red]")
             proc.kill()
     except ProcessLookupError:
         pass  # Child process already finished

--- a/modal/_live_reload.py
+++ b/modal/_live_reload.py
@@ -38,13 +38,16 @@ async def _restart_serve(stub_ref: str, existing_app_id: str, timeout: float = 5
 async def _terminate(proc: Optional[SpawnProcess], output_mgr: OutputManager, timeout: float = 5.0):
     if proc is None:
         return
-    proc.terminate()
-    await asyncify(proc.join)(timeout)
-    if proc.exitcode is not None:
-        output_mgr.print_if_visible(f"Serve process {proc.pid} terminated")
-    else:
-        output_mgr.print_if_visible(f"[red]Serve process {proc.pid} didn't terminate after {timeout}s, killing it")
-        proc.kill()
+    try:
+        proc.terminate()
+        await asyncify(proc.join)(timeout)
+        if proc.exitcode is not None:
+            output_mgr.print_if_visible(f"Serve process {proc.pid} terminated")
+        else:
+            output_mgr.print_if_visible(f"[red]Serve process {proc.pid} didn't terminate after {timeout}s, killing it")
+            proc.kill()
+    except ProcessLookupError:
+        output_mgr.print_if_visible(f"Serve process {proc.pid} disappeared during termination")
 
 
 async def _run_serve_loop(

--- a/modal/_live_reload.py
+++ b/modal/_live_reload.py
@@ -44,7 +44,9 @@ async def _terminate(proc: Optional[SpawnProcess], output_mgr: OutputManager, ti
         if proc.exitcode is not None:
             output_mgr.print_if_visible(f"Serve process {proc.pid} terminated")
         else:
-            output_mgr.print_if_visible(f"[red]Serve process {proc.pid} didn't terminate after {timeout}s, killing it[/red]")
+            output_mgr.print_if_visible(
+                f"[red]Serve process {proc.pid} didn't terminate after {timeout}s, killing it[/red]"
+            )
             proc.kill()
     except ProcessLookupError:
         pass  # Child process already finished

--- a/modal/_output.py
+++ b/modal/_output.py
@@ -121,7 +121,7 @@ class OutputManager:
     _console: Console
     _task_states: Dict[str, int]
 
-    def __init__(self, stdout, show_progress: Optional[bool]):
+    def __init__(self, stdout: io.TextIOWrapper, show_progress: Optional[bool]):
         self.stdout = stdout or sys.stdout
         if show_progress is None:
             self._visible_progress = self.stdout.isatty() or is_notebook(self.stdout)

--- a/modal/_watcher.py
+++ b/modal/_watcher.py
@@ -98,7 +98,6 @@ async def watch(
     timeout_agen = [] if timeout is None else [_sleep(timeout)]
 
     async with stream.merge(_watch_paths(paths, watch_filter), *timeout_agen).stream() as streamer:
-        yield  # yield dummy on startup
         async for event in streamer:
             if event == _TIMEOUT_SENTINEL:
                 return

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -9,6 +9,7 @@ import typer
 from rich.console import Console
 from synchronicity import Interface
 
+from modal._live_reload import run_serve_loop
 from modal.exception import InvalidError
 from modal.stub import LocalEntrypoint
 from modal_utils.async_utils import synchronizer
@@ -175,9 +176,7 @@ def serve(
     modal serve hello_world.py
     ```\n
     """
-    _stub = import_stub(stub_ref)
-    blocking_stub = synchronizer._translate_out(_stub, Interface.BLOCKING)
-    blocking_stub.serve(timeout=timeout)
+    run_serve_loop(stub_ref, timeout)
 
 
 def shell(

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -372,7 +372,7 @@ class _Stub:
             timeout = 1e10
 
         output_mgr = OutputManager(stdout, show_progress)
-        async with self._run(client, output_mgr, mode=StubRunMode.SERVE, existing_app_id=existing_app_id) as app:
+        async with self._run(client, output_mgr, mode=StubRunMode.SERVE, existing_app_id=existing_app_id):
             await asyncio.sleep(timeout)
 
     async def deploy(

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -228,7 +228,7 @@ class _Stub:
         existing_app_id: Optional[str],
         last_log_entry_id: Optional[str] = None,
         name: Optional[str] = None,
-        mode: StubRunMode = StubRunMode.RUN,        
+        mode: StubRunMode = StubRunMode.RUN,
     ) -> AsyncGenerator[_App, None]:
         app_name = name if name is not None else self.description
         detach = mode == StubRunMode.DETACH
@@ -348,7 +348,9 @@ class _Stub:
         async with self._run(client, output_mgr, existing_app_id=None, mode=mode) as app:
             yield app
 
-    async def serve(self, client=None, stdout=None, show_progress=None, timeout=None, existing_app_id: Optional[str] = None) -> None:
+    async def serve(
+        self, client=None, stdout=None, show_progress=None, timeout=None, existing_app_id: Optional[str] = None
+    ) -> None:
         """Run an app until the program is interrupted.
 
         Does not in itself handle live-reloading: see _live_reload.py for that.
@@ -372,7 +374,6 @@ class _Stub:
         output_mgr = OutputManager(stdout, show_progress)
         async with self._run(client, output_mgr, mode=StubRunMode.SERVE, existing_app_id=existing_app_id) as app:
             await asyncio.sleep(timeout)
-
 
     async def deploy(
         self,

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -358,7 +358,7 @@ class _Stub:
         existing_app_id: Optional[str] = None,
         is_ready: Optional[Event] = None,
     ) -> None:
-        """Run an app until the program is interrupted.
+        """Run an app until the program is interrupted. For development.
 
         Does not in itself handle live-reloading: see _live_reload.py for that.
         This is primarily the entrypoint for the subprocesses spawned by the live reloading,

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -355,7 +355,7 @@ class _Stub:
         existing_app_id: str,
         is_ready: Event,
     ) -> None:
-        # Used by child process to redeploy an app
+        # Used by child process to reinitialize a served app
         client = await _Client.from_env()
         try:
             output_mgr = OutputManager(None, None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ filterwarnings = [
     "error::modal.exception.DeprecationError",
     "ignore::DeprecationWarning:pytest.*:",
     "module:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning",
+    "ignore:.*pkg_resources.*:DeprecationWarning::",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
Main changes:

1. Use `multiprocessing.Process` with a "spawn" context rather than a subprocess directly. This makes it a bit easier to create a child process. We need to spawn rather than fork in order to reload all modules.
2. Instead of `stub.serve` being a "recursive" function, the live-reload thing sits outside the stub, and the CLI calls it directly.
3. child processes just update the app – they don't run anything other than that. The main process controls heartbeats and logs

The main benefits are:
* shorter code (getting rid of a django utility we used was the majority of the reduction, but there was a bunch of other things too)
* simpler tests (got rid of all mocking)
* tests aren't mocking out the subprocess – they actually launch it properly, and we verify that it works
* added a basic test for py 3.7 and windows
* fixed an issue where tests in `cli_test.py` would fail locally when run in isolation (had to do with implicit fixture dependencies)
* code isn't reading env vars anymore (outside of `modal.config`)
* less code on the `Stub` class (which does too much)
* a more straightforward control flow on the `Stub` class
* only one process pulling logs (should mean no duplicated/missing lines etc)

The reason I started working on this was the last two points – in particular I wanted to refactor `stub._run`, but some complexity with serving made it hard.

(about 50 lines delta of this is a bunch of test skip decorator stuff that's fairly unrelated, but should be harmless)