### PR TITLE
Support raw calls on methods

### DIFF
--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -352,3 +352,22 @@ def test_panel(client, servicer):
     assert isinstance(function, Function)
     image = stub._get_default_image()
     assert function.get_panel_items() == [repr(image)]
+
+
+dummy_stub = Stub()
+
+
+@dummy_stub.function
+def f(x):
+    return x**2
+
+
+class Class:
+    @dummy_stub.function
+    def f(self, x):
+        return x**2
+
+
+def test_raw_call():
+    assert f(111) == 12321
+    assert Class().f(1111) == 1234321

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -535,8 +535,7 @@ class _Stub:
         if function_handle is None:
             function_handle = _FunctionHandle._new()
 
-        function_handle._set_info(info)
-        function_handle._set_stub(self)
+        function_handle._initialize_from_local(self, info)
         self._function_handles[tag] = function_handle
         return function_handle
 


### PR DESCRIPTION
The direct ability to call functions had only been live for a few hours when a user ran into a bit of an edge case – method calls don't work.

This fixes it using the descriptor protocol (which is something I didn't know about a year ago, but I'm very glad I learned about – this would have taken me hours otherwise)

I think this will be quite important long term though. Once we support decorating the _class_ instead of methods, lifecycle classes will look a lot less confusing. It will work really well since you can auto-decorate every method now.