### PR TITLE
Fix method calls

### DIFF
--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -354,16 +354,16 @@ def test_panel(client, servicer):
     assert function.get_panel_items() == [repr(image)]
 
 
-dummy_stub = Stub()
+lc_stub = Stub()
 
 
-@dummy_stub.function
+@lc_stub.function
 def f(x):
     return x**2
 
 
 class Class:
-    @dummy_stub.function
+    @lc_stub.function
     def f(self, x):
         return x**2
 
@@ -371,3 +371,8 @@ class Class:
 def test_raw_call():
     assert f(111) == 12321
     assert Class().f(1111) == 1234321
+
+
+def test_method_call(client):
+    with lc_stub.run(client=client):
+        assert Class().f.call(111) == 12321

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -462,10 +462,9 @@ class _FunctionHandle(Handle, type_prefix="fu"):
         self._web_url = proto.web_url
         self._function_name = proto.function_name
 
-    def _initialize_from_local(self, stub, info: FunctionInfo, self_obj=None):
+    def _initialize_from_local(self, stub, info: FunctionInfo):
         self._stub = stub
         self._info = info
-        self._self_obj = self_obj
 
     def _set_mute_cancellation(self, value: bool = True):
         self._mute_cancellation = value
@@ -668,9 +667,10 @@ class _FunctionHandle(Handle, type_prefix="fu"):
 
     def __get__(self, obj, objtype=None) -> "_FunctionHandle":
         # This is needed to bind "self" to methods for direct __call__
-        function_handle = _FunctionHandle._new()
-        function_handle._initialize_from_local(self._stub, self._info, obj)
-        return function_handle
+        self._self_obj = obj
+        # TODO(erikbern): we're mutating self directly here, as opposed to returning a different _FunctionHandle
+        # We should fix this in the future since it probably precludes using classmethods/staticmethods
+        return self
 
 
 FunctionHandle, AioFunctionHandle = synchronize_apis(_FunctionHandle)


### PR DESCRIPTION
The recent change #343 broke the ability to call methods on classes which is pretty core. It's an important feature so I'm a bit disappointed at myself for not having tests for this in the client. Added one.

This fixes it in a somewhat crude way, but should work for a while.

