### PR TITLE
fix: descriptions of apps created by modal CLI. crude impl

### DIFF
--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -276,11 +276,19 @@ def test_shell(servicer, set_env_client, test_dir):
 
 def test_app_descriptions(servicer, server_url_env, test_dir):
     stub_file = test_dir / "supports" / "app_run_tests" / "prints_desc_stub.py"
-    result = _run(["run", "--detach", stub_file.as_posix() + "::stub.foo"])
+    _run(["run", "--detach", stub_file.as_posix() + "::stub.foo"])
 
-    assert "prints_desc_stub.py::stub.foo" in result.stdout
-    assert "run --detach " not in result.stdout
+    create_reqs = [s for s in servicer.requests if isinstance(s, api_pb2.AppCreateRequest)]
+    assert len(create_reqs) == 1
+    assert create_reqs[0].detach
+    description = create_reqs[0].description
+    assert "prints_desc_stub.py::stub.foo" in description
+    assert "run --detach " not in description
 
-    result = _run(["serve", "--timeout", "0.0", stub_file.as_posix()])
-    assert "prints_desc_stub.py" in result.stdout
-    assert "serve --timeout 0.0 " not in result.stdout
+    _run(["serve", "--timeout", "0.0", stub_file.as_posix()])
+    create_reqs = [s for s in servicer.requests if isinstance(s, api_pb2.AppCreateRequest)]
+    assert len(create_reqs) == 2
+    description = create_reqs[1].description
+    assert "prints_desc_stub.py" in description
+    assert "serve" not in description
+    assert "--timeout 0.0" not in description

--- a/client_test/supports/app_run_tests/prints_desc_stub.py
+++ b/client_test/supports/app_run_tests/prints_desc_stub.py
@@ -1,0 +1,11 @@
+# Copyright Modal Labs 2022
+import modal
+
+stub = modal.Stub()
+
+print(f"stub.description: {stub.description}")
+
+
+@stub.function
+def foo():
+    pass

--- a/client_test/supports/app_run_tests/prints_desc_stub.py
+++ b/client_test/supports/app_run_tests/prints_desc_stub.py
@@ -3,6 +3,9 @@ import modal
 
 stub = modal.Stub()
 
+# This is in module scope, so will show what the `description`
+# value is at import time, which may be different if some code
+# changes the `description` post-import.
 print(f"stub.description: {stub.description}")
 
 

--- a/modal/_live_reload.py
+++ b/modal/_live_reload.py
@@ -54,6 +54,16 @@ async def _terminate(proc: Optional[SpawnProcess], output_mgr: OutputManager, ti
         pass  # Child process already finished
 
 
+def _get_clean_stub_description(stub_ref: str) -> str:
+    # If possible, consider the 'ref' argument the start of the app's args. Everything
+    # before it Modal CLI cruft (eg. `modal serve --timeout 1.0`).
+    try:
+        func_ref_arg_idx = sys.argv.index(stub_ref)
+        return " ".join(sys.argv[func_ref_arg_idx:])
+    except ValueError:
+        return " ".join(sys.argv)
+
+
 async def _run_serve_loop(
     stub_ref: str,
     timeout: Optional[float] = None,
@@ -63,6 +73,8 @@ async def _run_serve_loop(
     _app_q: Optional[asyncio.Queue] = None,  # for testing
 ):
     stub = import_stub(stub_ref)
+    if stub._description is None:
+        stub._description = _get_clean_stub_description(stub_ref)
 
     unsupported_msg = None
     if platform.system() == "Windows":

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -20,10 +20,6 @@ from ..functions import _FunctionHandle
 
 run_cli = typer.Typer(name="run")
 
-# Used to set Modal cleaner app descriptions which don't include modal CLI parts, only
-# user code parts.
-modal_cli_app_desc: str = None
-
 # Why do we need to support both types and the strings? Because something weird with
 # how __annotations__ works in Python (which inspect.signature uses). See #220.
 option_parsers = {

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -165,6 +165,10 @@ class _Stub:
             # be really long an not very helpful
             return "Notebook"  # TODO: use actual name of notebook
 
+        from modal.cli import run
+
+        if run.modal_cli_app_desc:
+            return run.modal_cli_app_desc
         script_filename = os.path.split(sys.argv[0])[-1]
         args = [script_filename] + sys.argv[1:]
         return " ".join(args)

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -126,7 +126,7 @@ class _Stub:
         if name is not None:
             self._description = name
         else:
-            self._description = self._infer_app_desc()
+            self._description = None
         self._blueprint = blueprint
         self._client_mount = None
         self._function_mounts = {}
@@ -157,7 +157,7 @@ class _Stub:
     @property
     def description(self) -> str:
         """The Stub's `name`, if available, or a fallback descriptive identifier."""
-        return self._description
+        return self._description or self._infer_app_desc()
 
     def _infer_app_desc(self):
         if is_notebook():
@@ -165,10 +165,6 @@ class _Stub:
             # be really long an not very helpful
             return "Notebook"  # TODO: use actual name of notebook
 
-        from modal.cli import run
-
-        if run.modal_cli_app_desc:
-            return run.modal_cli_app_desc
         script_filename = os.path.split(sys.argv[0])[-1]
         args = [script_filename] + sys.argv[1:]
         return " ".join(args)

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -111,7 +111,7 @@ class _Stub:
 
     def __init__(
         self,
-        name: str = None,
+        name: Optional[str] = None,
         *,
         mounts: Collection[_Mount] = [],
         secrets: Collection[_Secret] = [],
@@ -120,10 +120,7 @@ class _Stub:
         """Construct a new app stub, optionally with default mounts."""
 
         self._name = name
-        if name is not None:
-            self._description = name
-        else:
-            self._description = None
+        self._description = name
         self._blueprint = blueprint
         self._client_mount = None
         self._function_mounts = {}


### PR DESCRIPTION
This afternoon may end up having been a waste of time, as this fix is pretty crude. 

The issue is that after moving away from `python3 app.py` invocation to usage of the `modal` CLI, unnamed ephemeral apps get a name which often includes CLI window dressing:

* `modal run dee.py...`
* `modal run --detached dee.py...`
* `modal serve dee.py...`

<img width="1158" alt="image" src="https://user-images.githubusercontent.com/12058921/221986156-1b797169-ce60-4edc-a6fe-00fa1f32edd7.png">

Some users apparently find the inclusion of program args in a stub's `description` useful, but I doubt any find the CLI stuff useful.

---

The implementation of the fix is quite ugly though. It uses a `global`. I think most of the complication comes from the fact that we don't create a new process via the CLI, it's the same process, unlike say `poetry run ...`. 

If anyone has a better implementation than this that'd be great.
