### PR TITLE
Make it possible for tests to get the app object back

### DIFF
--- a/client_test/live_reload_test.py
+++ b/client_test/live_reload_test.py
@@ -1,4 +1,5 @@
 # Copyright Modal Labs 2023
+import asyncio
 import pytest
 from unittest import mock
 
@@ -8,7 +9,7 @@ from .supports.skip import skip_old_py, skip_windows
 
 @pytest.mark.asyncio
 async def test_live_reload(test_dir, server_url_env, servicer):
-    stub_file = str(test_dir / "supports" / "app_run_tests" / "default_stub.py")
+    stub_file = str(test_dir / "supports" / "app_run_tests" / "webhook.py")
     await aio_run_serve_loop(stub_file, timeout=3.0)
     assert servicer.app_set_objects_count == 1
     assert servicer.app_client_disconnect_count == 1
@@ -22,11 +23,14 @@ def test_file_changes_trigger_reloads(test_dir, server_url_env, servicer):
         for i in range(3):
             yield
 
-    stub_file = str(test_dir / "supports" / "app_run_tests" / "default_stub.py")
-    run_serve_loop(stub_file, _watcher=fake_watch())
+    app_q: asyncio.Queue = asyncio.Queue()
+    stub_file = str(test_dir / "supports" / "app_run_tests" / "webhook.py")
+    run_serve_loop(stub_file, _watcher=fake_watch(), _app_q=app_q)
     assert servicer.app_set_objects_count == 4  # 1 + number of file changes
     assert servicer.app_client_disconnect_count == 1
     assert servicer.app_get_logs_initial_count == 1
+    app = app_q.get_nowait()
+    assert app.foo.web_url.startswith("http://")
 
 
 @pytest.mark.asyncio
@@ -36,7 +40,7 @@ async def test_no_change(test_dir, server_url_env, servicer):
         if False:
             yield
 
-    stub_file = str(test_dir / "supports" / "app_run_tests" / "default_stub.py")
+    stub_file = str(test_dir / "supports" / "app_run_tests" / "webhook.py")
     await aio_run_serve_loop(stub_file, _watcher=fake_watch())
     assert servicer.app_set_objects_count == 1  # Should create the initial app once
     assert servicer.app_client_disconnect_count == 1
@@ -46,7 +50,7 @@ async def test_no_change(test_dir, server_url_env, servicer):
 @pytest.mark.asyncio
 async def test_heartbeats(test_dir, server_url_env, servicer):
     with mock.patch("modal.stub.HEARTBEAT_INTERVAL", 1):
-        stub_file = str(test_dir / "supports" / "app_run_tests" / "default_stub.py")
+        stub_file = str(test_dir / "supports" / "app_run_tests" / "webhook.py")
         await aio_run_serve_loop(stub_file, timeout=3.5)
 
     apps = list(servicer.app_heartbeats.keys())

--- a/modal/_live_reload.py
+++ b/modal/_live_reload.py
@@ -1,4 +1,5 @@
 # Copyright Modal Labs 2023
+import asyncio
 import io
 import multiprocessing
 from multiprocessing.context import SpawnProcess
@@ -57,7 +58,8 @@ async def _run_serve_loop(
     timeout: Optional[float] = None,
     stdout: Optional[io.TextIOWrapper] = None,
     show_progress: bool = True,
-    _watcher: Optional[AsyncGenerator[None, None]] = None,
+    _watcher: Optional[AsyncGenerator[None, None]] = None,  # for testing
+    _app_q: Optional[asyncio.Queue] = None,  # for testing
 ):
     stub = import_stub(stub_ref)
 
@@ -89,6 +91,8 @@ async def _run_serve_loop(
         # Run the object creation loop one time first, to make sure all images etc get built
         # This also handles the logs and the heartbeats
         async with stub._run(client, output_mgr, None) as app:
+            if _app_q:
+                await _app_q.put(app)
             client.set_pre_stop(app.disconnect)
             existing_app_id = app.app_id
             curr_proc = None


### PR DESCRIPTION
should make it much easier to rewrite the integration test