### PR TITLE
Adds experimental support for cancelling individual inputs

### DIFF
--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -9,10 +9,8 @@ from unittest import mock
 import click
 import click.testing
 import pytest
-import pytest_asyncio
 
 from modal.cli.entry_point import entrypoint_cli
-from modal.client import Client
 from modal_proto import api_pb2
 
 dummy_app_file = """
@@ -29,15 +27,6 @@ assert mod.stub == stub
 """
 
 dummy_other_module_file = "x = 42"
-
-
-@pytest_asyncio.fixture
-async def set_env_client(aio_client):
-    try:
-        Client.set_env_client(aio_client)
-        yield
-    finally:
-        Client.set_env_client(None)
 
 
 def _run(args, expected_exit_code=0):

--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -6,6 +6,7 @@ import json
 import os
 import signal
 import subprocess
+import threading
 
 import pytest
 import sys
@@ -483,7 +484,9 @@ def test_sigusr1_aborts_current_input(servicer, server_url_env):
     servicer.called_function_get_inputs.wait(timeout=1)
     time.sleep(0.05)  # let the container get the input
     container_process.send_signal(signal.SIGUSR1)
-    time.sleep(0.1)  # let the container handle the exception and remaining input
+    servicer.called_function_get_inputs = threading.Event()  # new event to wait for
+    servicer.called_function_get_inputs.wait(timeout=1)
+    time.sleep(0.1)  # let the container handle the remaining input
     items = _flatten_outputs(servicer.container_outputs)
     assert len(items) == 1
     data = deserialize(items[0].result.data, client=None)
@@ -501,7 +504,9 @@ def test_sigusr1_aborts_current_input_async(servicer, server_url_env):
     servicer.called_function_get_inputs.wait(timeout=1)
     time.sleep(0.05)  # let the container get the input
     container_process.send_signal(signal.SIGUSR1)
-    time.sleep(0.1)  # let the container handle the exception and remaining input
+    servicer.called_function_get_inputs = threading.Event()  # new event to wait for
+    servicer.called_function_get_inputs.wait(timeout=1)
+    time.sleep(0.1)  # let the container handle the remaining input
     items = _flatten_outputs(servicer.container_outputs)
     assert len(items) == 1
     data = deserialize(items[0].result.data, client=None)

--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -21,7 +21,7 @@ from modal.client import Client
 from modal.exception import InvalidError
 from modal_proto import api_pb2
 
-from .supports.skip import skip_windows_unix_socket
+from .supports.skip import skip_windows_unix_socket, skip_windows
 
 EXTRA_TOLERANCE_DELAY = 1.0
 FUNCTION_CALL_ID = "fc-123"
@@ -472,7 +472,7 @@ def test_container_heartbeats(unix_servicer, event_loop):
     assert any(isinstance(request, api_pb2.ContainerHeartbeatRequest) for request in unix_servicer.requests)
 
 
-@skip_windows
+@skip_windows("signals not supported on windows")
 def test_sigusr1_aborts_current_input(servicer, server_url_env):
     container_args = _container_args("modal_test_support.functions", "delay")
     encoded_container_args = base64.b64encode(container_args.SerializeToString())
@@ -490,7 +490,7 @@ def test_sigusr1_aborts_current_input(servicer, server_url_env):
     assert data == 0.01
 
 
-@skip_windows
+@skip_windows("signals not supported on windows")
 def test_sigusr1_aborts_current_input_async(servicer, server_url_env):
     container_args = _container_args("modal_test_support.functions", "delay_async")
     encoded_container_args = base64.b64encode(container_args.SerializeToString())

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -20,6 +20,13 @@ def square(x):
 @stub.function
 def delay(t):
     time.sleep(t)
+    return t
+
+
+@stub.function
+async def delay_async(t):
+    await asyncio.sleep(t)
+    return t
 
 
 @stub.function


### PR DESCRIPTION
Using sigusr1, an exception is thrown into the user(main) thread in case of sync code, and a CancelledError is thrown in case the user code is async

Also adds some new container tests that check that signal handling works as expected for sigusr1 (might be nice to add tests for sigint/sigterm as well

There is no code in the worker yet to actually send these signals (there are some non-trivial prerequisites there), so we could either merge this and have it be unused (albeit tested) functionality for a bit, or keep the PR until we have the necessary support on the worker?