### PR TITLE
Simplify `Stub._run`

### DIFF
--- a/modal/stub.py
+++ b/modal/stub.py
@@ -238,7 +238,9 @@ class _Stub:
         if existing_app_id is not None:
             app = await _App._init_existing(client, existing_app_id)
         else:
-            app = await _App._init_new(client, app_name, deploying=(mode == StubRunMode.DEPLOY), detach=(mode == StubRunMode.DETACH))
+            app = await _App._init_new(
+                client, app_name, deploying=(mode == StubRunMode.DEPLOY), detach=(mode == StubRunMode.DETACH)
+            )
         self._app = app
 
         aborted = False

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -234,12 +234,11 @@ class _Stub:
         post_init_state: int = api_pb2.APP_STATE_EPHEMERAL,
     ) -> AsyncGenerator[_App, None]:
         app_name = name if name is not None else self.description
-        detach = mode == StubRunMode.DETACH
 
         if existing_app_id is not None:
             app = await _App._init_existing(client, existing_app_id)
         else:
-            app = await _App._init_new(client, app_name, deploying=(mode == StubRunMode.DEPLOY), detach=detach)
+            app = await _App._init_new(client, app_name, deploying=(mode == StubRunMode.DEPLOY), detach=(mode == StubRunMode.DETACH))
         self._app = app
 
         aborted = False
@@ -296,7 +295,7 @@ class _Stub:
                 for tag, obj in self._function_handles.items():
                     obj._set_mute_cancellation(True)
 
-                if detach:
+                if mode == StubRunMode.DETACH:
                     logs_loop.cancel()
                 else:
                     print("Disconnecting from Modal - This will terminate your Modal app in a few seconds.\n")
@@ -307,7 +306,7 @@ class _Stub:
         if mode == StubRunMode.DEPLOY:
             output_mgr.print_if_visible(step_completed("App deployed! 🎉"))
         elif aborted:
-            if detach:
+            if mode == StubRunMode.DETACH:
                 output_mgr.print_if_visible(step_completed("Shutting down Modal client."))
                 output_mgr.print_if_visible(
                     f"""The detached app keeps running. You can track its progress at: [magenta]{app.log_url()}[/magenta]"""

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -291,22 +291,21 @@ class _Stub:
                     with output_mgr.ctx_if_visible(output_mgr.make_live(status_spinner)):
                         yield app
             except KeyboardInterrupt:
-                if mode == StubRunMode.DETACH:
-                    output_mgr.print_if_visible(step_completed("Shutting down Modal client."))
-                    output_mgr.print_if_visible(
-                        f"""The detached app keeps running. You can track its progress at: [magenta]{app.log_url()}[/magenta]"""
-                    )
-                else:
-                    output_mgr.print_if_visible(step_completed("App aborted."))
-
                 # mute cancellation errors on all function handles to prevent exception spam
                 for tag, obj in self._function_handles.items():
                     obj._set_mute_cancellation(True)
 
                 if mode == StubRunMode.DETACH:
+                    output_mgr.print_if_visible(step_completed("Shutting down Modal client."))
+                    output_mgr.print_if_visible(
+                        f"""The detached app keeps running. You can track its progress at: [magenta]{app.log_url()}[/magenta]"""
+                    )
                     logs_loop.cancel()
                 else:
-                    print("Disconnecting from Modal - This will terminate your Modal app in a few seconds.\n")
+                    output_mgr.print_if_visible(step_completed("App aborted."))
+                    output_mgr.print_if_visible(
+                        "Disconnecting from Modal - This will terminate your Modal app in a few seconds.\n"
+                    )
             finally:
                 if mode != StubRunMode.SERVE_CHILD:
                     await app.disconnect()

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -367,7 +367,6 @@ class _Stub:
         stdout=None,
         show_progress=None,
         timeout=None,
-        existing_app_id: Optional[str] = None,
     ) -> None:
         """Run an app until the program is interrupted."""
         deprecation_warning(
@@ -391,7 +390,7 @@ class _Stub:
             timeout = 1e10
 
         output_mgr = OutputManager(stdout, show_progress)
-        async with self._run(client, output_mgr, mode=StubRunMode.RUN, existing_app_id=existing_app_id):
+        async with self._run(client, output_mgr, mode=StubRunMode.RUN, existing_app_id=None):
             await asyncio.sleep(timeout)
 
     async def deploy(

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -243,7 +243,6 @@ class _Stub:
             )
         self._app = app
 
-        aborted = False
         # Start tracking logs and yield context
         async with TaskContext(grace=config["logs_timeout"]) as tc:
             if mode != StubRunMode.SERVE_CHILD:


### PR DESCRIPTION
This is all relatively lightweight, just moving around stuff. The main goal is to get rid of the complexity in the `_run` method. It has a lot of boolean/enum flags controlling behavior that would be much better handled in the functions calling `_run`. Somewhat simplified, but I'm trying to refactor code like this:

```python
def do_something(mode:str):
    if mode == "a":
        do_a()
    elif mode == "b":
        do_b()
    do_xyz()


def run_a():
    do_something(mode="a")


def run_b():
    do_something(mode="b")
```

into something like

```python
def run_a():
    do_a()
    do_xyz()


def run_b():
    do_b()
    do_xyz()
```

This is just a first step of the simple stuff