### PR TITLE
another minor `Stub._run` refactor – move the interactive shell flow from `Stub._run` to `Stub.run`

### DIFF
--- a/modal/stub.py
+++ b/modal/stub.py
@@ -272,7 +272,7 @@ class _Stub:
                     logs_loop.cancel()
 
                 # Yield to context
-                yield app
+                yield
             except KeyboardInterrupt:
                 # mute cancellation errors on all function handles to prevent exception spam
                 for tag, obj in self._function_handles.items():

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -318,7 +318,9 @@ class _Stub:
         post_init_state = api_pb2.APP_STATE_DETACHED if detach else api_pb2.APP_STATE_EPHEMERAL
         app = await _App._init_new(client, self.description, detach=detach, deploying=False)
         status_spinner = step_progress("Running app...")
-        async with self._run(client, output_mgr, app, mode=mode, post_init_state=post_init_state, status_spinner=status_spinner):
+        async with self._run(
+            client, output_mgr, app, mode=mode, post_init_state=post_init_state, status_spinner=status_spinner
+        ):
             if self._pty_input_stream:
                 output_mgr._visible_progress = False
                 handle = app._pty_input_stream


### PR DESCRIPTION
Slight increase in complexity in the short term because we need to create the status spinners outside of `_run` and pass it in now. The status spinner is only used for fetching logs which I'm planning to break out next.

The idea here is to rewrite code of the type (very exaggerated example):

```python
def base(extra=False):
    do_base()
    if extra:
        do_extra()

def run_a():
    base()

def run_b():
    base(extra=True)
```

to

```python
def run_a():
    do_base()

def run_b():
    do_base()
    do_extra()
```