### PR TITLE
Remove max_retries=None from FunctionPutInputs

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -179,7 +179,6 @@ class _Invocation:
         inputs_response: api_pb2.FunctionPutInputsResponse = await retry_transient_errors(
             client.stub.FunctionPutInputs,
             request_put,
-            max_retries=None,
         )
         processed_inputs = inputs_response.inputs
         if not processed_inputs:


### PR DESCRIPTION
No longer needed because we don't send `RESOURCE_EXHAUSTED` back (and if we did, it should only retry more times that case, and not on other status codes).