### PR TITLE
Store image_id on TaskLogsBatch

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -905,6 +905,7 @@ message TaskLogsBatch {
   bool app_done = 10;
   string function_id = 11;
   string input_id = 12;
+  string image_id = 13;  // Used for image logs
 }
 
 message TaskResultRequest {


### PR DESCRIPTION
This will be used to distinguish image build logs from regular app logs.

Almost all of the complexity is on the server though