### PR TITLE
nit: clearer warn msg for users in multi-stub case

### DIFF
--- a/modal/stub.py
+++ b/modal/stub.py
@@ -516,7 +516,9 @@ class _Stub:
                 else:
                     logger.warning(f"Object {tag} has wrong type {type(handle)}")
             except KeyError:
-                logger.warning(f"Could not find app function {tag}")
+                logger.warning(
+                    f"Could not find Modal function '{tag}' in app '{self.description}'. '{tag}' may still be invoked as local function: {tag}()"
+                )
 
         if function_handle is None:
             function_handle = _FunctionHandle._new()


### PR DESCRIPTION
Follow-up to https://modalbetatesters.slack.com/archives/C031Z7DBQFL/p1677782456650449?thread_ts=1677779674.993079&cid=C031Z7DBQFL

I think @erikbern has a plan for handling this properly. Ref: https://github.com/modal-labs/modal-client/pull/263