### PR TITLE
Unwrap the TaskLogsBatch proto on ImageJoinStreamingResponse

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -676,10 +676,9 @@ message ImageJoinStreamingRequest {
 }
 
 message ImageJoinStreamingResponse {
-  oneof result_oneof {
-    GenericResult result = 1;
-    TaskLogsBatch logs_batch = 2;
-  }
+  GenericResult result = 1;
+  repeated TaskLogs task_logs = 2;
+  string entry_id = 3;
 }
 
 message MountBuildRequest {


### PR DESCRIPTION
Simplify the proto response – think it's good not to have a super complex interface for the client response