### PR TITLE
image snapshots progress bar

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -159,11 +159,14 @@ class _App:
 
     @staticmethod
     async def _create_one_object(client: _Client, provider: Provider) -> Tuple[Handle, str]:
+        from ._output import OutputManager
+
         # TODO(erikbern): This will be turned into something for deploying single objects
         app_req = api_pb2.AppCreateRequest()
         app_resp = await retry_transient_errors(client.stub.AppCreate, app_req)
         app_id = app_resp.app_id
-        resolver = Resolver(None, None, client, app_id)
+        null_output_mgr = OutputManager(None, False)
+        resolver = Resolver(null_output_mgr, client, app_id)
         handle = await resolver.load(provider)
         indexed_object_ids = {"_object": handle.object_id}
         unindexed_object_ids = [obj.object_id for obj in resolver.objects() if obj is not handle]

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -339,9 +339,7 @@ class _Stub:
             # Create objects
             create_progress = Tree(step_progress("Creating objects..."), guide_style="gray50")
             with output_mgr.ctx_if_visible(output_mgr.make_live(create_progress)):
-                await app._create_all_objects(
-                    self._blueprint, create_progress, output_mgr.get_console(), api_pb2.APP_STATE_UNSPECIFIED
-                )
+                await app._create_all_objects(self._blueprint, output_mgr, api_pb2.APP_STATE_UNSPECIFIED)
             create_progress.label = step_completed("Created objects.")
 
             # Communicate to the parent process

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -251,13 +251,7 @@ class _Stub:
 
             try:
                 # Create all members
-                create_progress = Tree(step_progress("Creating objects..."), guide_style="gray50")
-                with output_mgr.ctx_if_visible(output_mgr.make_live(create_progress)):
-                    await app._create_all_objects(
-                        self._blueprint, create_progress, output_mgr.get_console(), post_init_state
-                    )
-                create_progress.label = step_completed("Created objects.")
-                output_mgr.print_if_visible(create_progress)
+                await app._create_all_objects(self._blueprint, output_mgr, post_init_state)
 
                 # Update all functions client-side to have the output mgr
                 for tag, obj in self._function_handles.items():


### PR DESCRIPTION
I realized the app logs were driving the image snapshot progress so I had to rewrite this (since I'm planning to not use app logs until the app is actually _running_)

This was a bit messier than I thought but I think it logically makes sense. Feels like we've been shoving all kinds of stuff into the app logs and at least this is one less item. This also makes it slightly easier to use progress bars for other things (e.g. mount uploads)