### PR TITLE
Move stub output to app

### DIFF
--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -276,4 +276,4 @@ def test_shell(servicer, set_env_client, test_dir):
 def test_logs(servicer, server_url_env):
     servicer.done = True
     res = _run(["app", "logs", "ap-123"], expected_exit_code=0)
-    assert res.stdout == "hello, world\n"  # from servicer mock
+    assert res.stdout == "hello, world (1)\n"  # from servicer mock

--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -151,8 +151,8 @@ class MockClientServicer(api_grpc.ModalClientBase):
             last_entry_id = "1"
         else:
             last_entry_id = str(int(request.last_entry_id) + 1)
-        await asyncio.sleep(0.1)
-        log = api_pb2.TaskLogs(data="hello, world\n", file_descriptor=api_pb2.FILE_DESCRIPTOR_STDOUT)
+        await asyncio.sleep(0.5)
+        log = api_pb2.TaskLogs(data=f"hello, world ({last_entry_id})\n", file_descriptor=api_pb2.FILE_DESCRIPTOR_STDOUT)
         await stream.send_message(api_pb2.TaskLogsBatch(entry_id=last_entry_id, items=[log]))
         if self.done:
             await stream.send_message(api_pb2.TaskLogsBatch(app_done=True))

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -42,7 +42,7 @@ class Resolver:
     _tree: Tree
     _local_uuid_to_object: Dict[str, Any]
 
-    def __init__(self, output_mgr: "OutputManager", client, app_id: Optional[str] = None):
+    def __init__(self, output_mgr, client, app_id: Optional[str] = None):
         from ._output import step_progress
         from rich.tree import Tree
 

--- a/modal/app.py
+++ b/modal/app.py
@@ -71,14 +71,15 @@ class _App:
         return self._app_id
 
     async def _create_all_objects(
-        self, blueprint: Dict[str, Provider], progress: Tree, new_app_state: int
+        self, blueprint: Dict[str, Provider], output_mgr: "OutputMgr", new_app_state: int
     ):  # api_pb2.AppState.V
         """Create objects that have been defined but not created on the server."""
-        resolver = Resolver(progress, self._client, self.app_id)
-        for tag, provider in blueprint.items():
-            existing_object_id = self._tag_to_existing_id.get(tag)
-            created_obj = await resolver.load(provider, existing_object_id)
-            self._tag_to_object[tag] = created_obj
+        resolver = Resolver(output_mgr, self._client, self.app_id)
+        with resolver.display():
+            for tag, provider in blueprint.items():
+                existing_object_id = self._tag_to_existing_id.get(tag)
+                created_obj = await resolver.load(provider, existing_object_id)
+                self._tag_to_object[tag] = created_obj
 
         # Create the app (and send a list of all tagged obs)
         # TODO(erikbern): we should delete objects from a previous version that are no longer needed

--- a/modal/app.py
+++ b/modal/app.py
@@ -71,7 +71,7 @@ class _App:
         return self._app_id
 
     async def _create_all_objects(
-        self, blueprint: Dict[str, Provider], output_mgr: "OutputMgr", new_app_state: int
+        self, blueprint: Dict[str, Provider], output_mgr, new_app_state: int
     ):  # api_pb2.AppState.V
         """Create objects that have been defined but not created on the server."""
         resolver = Resolver(output_mgr, self._client, self.app_id)

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -247,11 +247,7 @@ class _Stub:
 
             try:
                 # Create all members
-                create_progress = Tree(step_progress("Creating objects..."), guide_style="gray50")
-                with output_mgr.ctx_if_visible(output_mgr.make_live(create_progress)):
-                    await app._create_all_objects(self._blueprint, create_progress, post_init_state)
-                create_progress.label = step_completed("Created objects.")
-                output_mgr.print_if_visible(create_progress)
+                await app._create_all_objects(self._blueprint, output_mgr, post_init_state)
 
                 # Update all functions client-side to have the output mgr
                 for tag, obj in self._function_handles.items():
@@ -335,10 +331,7 @@ class _Stub:
             app = await _App._init_existing(client, existing_app_id)
 
             # Create objects
-            create_progress = Tree(step_progress("Creating objects..."), guide_style="gray50")
-            with output_mgr.ctx_if_visible(output_mgr.make_live(create_progress)):
-                await app._create_all_objects(self._blueprint, create_progress, api_pb2.APP_STATE_UNSPECIFIED)
-            create_progress.label = step_completed("Created objects.")
+            await app._create_all_objects(self._blueprint, output_mgr, api_pb2.APP_STATE_UNSPECIFIED)
 
             # Communicate to the parent process
             is_ready.set()

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -10,8 +10,6 @@ import warnings
 from enum import Enum
 from typing import AsyncGenerator, Collection, Dict, List, Optional, Union
 
-from rich.tree import Tree
-
 from modal_proto import api_pb2
 from modal_utils.app_utils import is_valid_app_name
 from modal_utils.async_utils import TaskContext, synchronize_apis


### PR DESCRIPTION
Essentially same as #365 but in itself

Nice to make `Stub._run` a bit smaller. This will also make it a bit easier to support image build logs – I'm just going to send it to the output manager directly (instead of implementing a separate console in image.py)
