### PR TITLE
Minor cleanup of log output management

### DIFF
--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -8,7 +8,7 @@ from grpclib import GRPCError, Status
 from rich.console import Console
 from rich.table import Table
 
-from modal._output import OutputManager, get_logs_loop
+from modal._output import OutputManager, get_app_logs_loop
 from modal.cli.utils import timestamp_to_local
 from modal.client import AioClient
 from modal_proto import api_pb2
@@ -89,7 +89,7 @@ def app_logs(app_id: str):
         output_mgr = OutputManager(None, None, "Tailing logs for {app_id}")
         try:
             with output_mgr.show_status_spinner():
-                await get_logs_loop(app_id, aio_client, "", output_mgr)
+                await get_app_logs_loop(app_id, aio_client, "", output_mgr)
         except asyncio.CancelledError:
             pass
 

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -18,7 +18,7 @@ from modal_utils.decorator_utils import decorator_with_options
 from . import _pty
 from ._function_utils import FunctionInfo
 from ._ipython import is_notebook
-from ._output import OutputManager, step_completed, step_progress, get_logs_loop
+from ._output import OutputManager, step_completed, step_progress, get_app_logs_loop
 from ._pty import exec_cmd
 from .app import _App, _container_app, is_local
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, _Client
@@ -237,7 +237,7 @@ class _Stub:
             tc.infinite_loop(lambda: _heartbeat(client, app.app_id), sleep=HEARTBEAT_INTERVAL)
 
             with output_mgr.ctx_if_visible(output_mgr.make_live(step_progress("Initializing..."))):
-                logs_loop = tc.create_task(get_logs_loop(app.app_id, client, last_log_entry_id or "", output_mgr))
+                logs_loop = tc.create_task(get_app_logs_loop(app.app_id, client, last_log_entry_id or "", output_mgr))
                 initialized_msg = (
                     f"Initialized. [grey70]View app at [underline]{app._app_page_url}[/underline][/grey70]"
                 )


### PR DESCRIPTION
This just splits up the code between stuff that's app-specific, and general log printing.

Also got rid of some intermediary methods on the output manager that didn't do a lot.

Going to rebase #369 on this since it lets me remove an ugly hack.