### PR TITLE
followup to #337

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -319,6 +319,9 @@ async def _map_invocation(
             request = api_pb2.FunctionPutInputsRequest(
                 function_id=function_id, inputs=items, function_call_id=function_call_id
             )
+            logger.debug(
+                f"Pushing {len(items)} inputs to server. Num queued inputs awaiting push is {input_queue.qsize()}."
+            )
             resp = await retry_transient_errors(
                 client.stub.FunctionPutInputs,
                 request,


### PR DESCRIPTION
Logging after the RPC call `await` has returned is insufficient, as it seems the event loop can get blocked by sleeps. See this repro script: 

```
import time
import modal

stub = modal.Stub()

@stub.function
def run(i: float):
    time.sleep(i)
    print(f"finished {i}s of fake work (sleeping)")


def repro_inputs():
    for i in range(60):
        if i == 0:
            yield 0.3
        elif i == 1:
            yield 15
        elif i == 2:
            # Try simulate the 15s headstart for the first container,
            # observed in ap-LRTjDqNxpxSfGiDLAyTbTY. 
            for _ in range(15):
                time.sleep(1)
            yield 0.7
        else:
            yield 15.0


if __name__ == "__main__":
    with stub.run(show_progress=False):
       list(run.map(i for i in repro_inputs()))
```

Currently the `Successfully pushed 1...` and `Successfully pushed 59...` loglines will show up at the same time, even though the RPC call to push the first input happened 15 seconds before the RPC call to push the reset of the inputs.