### PR TITLE
get deployment out of _run

### DIFF
--- a/modal/_live_reload.py
+++ b/modal/_live_reload.py
@@ -86,14 +86,14 @@ async def _run_serve_loop(
     app = await _App._init_new(client, stub.description, detach=False, deploying=False)
 
     if unsupported_msg:
-        async with stub._run(client, output_mgr, app):
+        async with stub._run_ephemeral(client, output_mgr, app):
             client.set_pre_stop(app.disconnect)
             async for _ in watcher:
                 output_mgr.print_if_visible(unsupported_msg)
     else:
         # Run the object creation loop one time first, to make sure all images etc get built
         # This also handles the logs and the heartbeats
-        async with stub._run(client, output_mgr, app):
+        async with stub._run_ephemeral(client, output_mgr, app):
             if _app_q:
                 await _app_q.put(app)
             client.set_pre_stop(app.disconnect)

--- a/modal/_output.py
+++ b/modal/_output.py
@@ -344,7 +344,9 @@ class OutputManager:
             yield
 
 
-async def get_app_logs_loop(app_id: str, client: _Client, last_log_batch_entry_id: str, output_mgr: OutputManager):
+async def get_app_logs_loop(app_id: str, client: _Client, output_mgr: OutputManager):
+    last_log_batch_entry_id = ""
+
     async def _put_log(log_batch: api_pb2.TaskLogsBatch, log: api_pb2.TaskLogs):
         if log.task_state:
             output_mgr.update_task_state(log_batch.task_id, log.task_state)

--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -89,7 +89,7 @@ def app_logs(app_id: str):
         output_mgr = OutputManager(None, None, "Tailing logs for {app_id}")
         try:
             with output_mgr.show_status_spinner():
-                await get_app_logs_loop(app_id, aio_client, "", output_mgr)
+                await get_app_logs_loop(app_id, aio_client, output_mgr)
         except asyncio.CancelledError:
             pass
 

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -219,7 +219,7 @@ class _Stub:
         return image_handle._is_inside()
 
     @contextlib.asynccontextmanager
-    async def _run(
+    async def _run_ephemeral(
         self,
         client,
         output_mgr: OutputManager,
@@ -290,7 +290,7 @@ class _Stub:
         mode = StubRunMode.DETACH if detach else StubRunMode.RUN
         post_init_state = api_pb2.APP_STATE_DETACHED if detach else api_pb2.APP_STATE_EPHEMERAL
         app = await _App._init_new(client, self.description, detach=detach, deploying=False)
-        async with self._run(client, output_mgr, app, mode=mode, post_init_state=post_init_state):
+        async with self._run_ephemeral(client, output_mgr, app, mode=mode, post_init_state=post_init_state):
             if self._pty_input_stream:
                 output_mgr._visible_progress = False
                 handle = app._pty_input_stream
@@ -353,7 +353,7 @@ class _Stub:
 
         output_mgr = OutputManager(stdout, show_progress, "Serving app...")
         app = await _App._init_new(client, self.description, detach=False, deploying=False)
-        async with self._run(client, output_mgr, app, mode=StubRunMode.RUN):
+        async with self._run_ephemeral(client, output_mgr, app, mode=StubRunMode.RUN):
             await asyncio.sleep(timeout)
 
     async def deploy(

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -224,7 +224,6 @@ class _Stub:
         client,
         output_mgr: OutputManager,
         app: _App,
-        last_log_entry_id: Optional[str] = None,
         mode: StubRunMode = StubRunMode.RUN,
         post_init_state: int = api_pb2.APP_STATE_EPHEMERAL,
     ) -> AsyncGenerator[None, None]:
@@ -235,7 +234,7 @@ class _Stub:
             tc.infinite_loop(lambda: _heartbeat(client, app.app_id), sleep=HEARTBEAT_INTERVAL)
 
             # Start logs loop
-            logs_loop = tc.create_task(get_app_logs_loop(app.app_id, client, last_log_entry_id or "", output_mgr))
+            logs_loop = tc.create_task(get_app_logs_loop(app.app_id, client, output_mgr))
 
             try:
                 # Create all members
@@ -413,7 +412,6 @@ class _Stub:
         app_req = api_pb2.AppGetByDeploymentNameRequest(name=name, namespace=namespace)
         app_resp = await client.stub.AppGetByDeploymentName(app_req)
         existing_app_id = app_resp.app_id or None
-        last_log_entry_id = app_resp.last_log_entry_id
 
         # Grab the app
         if existing_app_id is not None:

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -18,7 +18,7 @@ from modal_utils.decorator_utils import decorator_with_options
 from . import _pty
 from ._function_utils import FunctionInfo
 from ._ipython import is_notebook
-from ._output import OutputManager, step_completed, step_progress, get_app_logs_loop
+from ._output import OutputManager, step_completed, get_app_logs_loop
 from ._pty import exec_cmd
 from .app import _App, _container_app, is_local
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, _Client
@@ -40,7 +40,6 @@ _default_image = _Image.debian_slim()
 
 class StubRunMode(Enum):
     RUN = "run"
-    DEPLOY = "deploy"
     DETACH = "detach"
 
 
@@ -231,17 +230,12 @@ class _Stub:
     ) -> AsyncGenerator[None, None]:
         self._app = app
 
-        # Start tracking logs and yield context
         async with TaskContext(grace=config["logs_timeout"]) as tc:
             # Start heartbeats loop to keep the client alive
             tc.infinite_loop(lambda: _heartbeat(client, app.app_id), sleep=HEARTBEAT_INTERVAL)
 
-            with output_mgr.ctx_if_visible(output_mgr.make_live(step_progress("Initializing..."))):
-                logs_loop = tc.create_task(get_app_logs_loop(app.app_id, client, last_log_entry_id or "", output_mgr))
-                initialized_msg = (
-                    f"Initialized. [grey70]View app at [underline]{app._app_page_url}[/underline][/grey70]"
-                )
-                output_mgr.print_if_visible(step_completed(initialized_msg))
+            # Start logs loop
+            logs_loop = tc.create_task(get_app_logs_loop(app.app_id, client, last_log_entry_id or "", output_mgr))
 
             try:
                 # Create all members
@@ -250,13 +244,6 @@ class _Stub:
                 # Update all functions client-side to have the output mgr
                 for tag, obj in self._function_handles.items():
                     obj._set_output_mgr(output_mgr)
-
-                # Cancel logs loop after creating objects for a deployment.
-                # TODO: we can get rid of this once we have 1) a way to separate builder
-                # logs from runner logs and 2) a termination signal that's sent after object
-                # creation is complete, that is also triggered on exceptions (`app.disconnect()`)
-                if mode == StubRunMode.DEPLOY:
-                    logs_loop.cancel()
 
                 # Yield to context
                 with output_mgr.show_status_spinner():
@@ -434,19 +421,18 @@ class _Stub:
         else:
             app = await _App._init_new(client, name, detach=False, deploying=True)
 
-        # Don't change the app state - deploy state is set by AppDeploy
-        post_init_state = api_pb2.APP_STATE_UNSPECIFIED
-
-        # The `_run` method contains the logic for starting and running an app
         output_mgr = OutputManager(stdout, show_progress)
-        async with self._run(
-            client,
-            output_mgr,
-            app,
-            last_log_entry_id=last_log_entry_id,
-            mode=StubRunMode.DEPLOY,
-            post_init_state=post_init_state,
-        ):
+
+        async with TaskContext(0) as tc:
+            # Start heartbeats loop to keep the client alive
+            tc.infinite_loop(lambda: _heartbeat(client, app.app_id), sleep=HEARTBEAT_INTERVAL)
+
+            # Don't change the app state - deploy state is set by AppDeploy
+            post_init_state = api_pb2.APP_STATE_UNSPECIFIED
+
+            # Create all members
+            await app._create_all_objects(self._blueprint, output_mgr, post_init_state)
+
             deploy_req = api_pb2.AppDeployRequest(
                 app_id=app._app_id,
                 name=name,
@@ -454,6 +440,7 @@ class _Stub:
                 object_entity=object_entity,
             )
             deploy_response = await client.stub.AppDeploy(deploy_req)
+
         output_mgr.print_if_visible(step_completed("App deployed! 🎉"))
         output_mgr.print_if_visible(f"\nView Deployment: [magenta]{deploy_response.url}[/magenta]")
         return app


### PR DESCRIPTION
`Stub.deploy` no longer uses `Stub._run` after this change.

This also resolves a minor issue where we currently print a spurious warning `Timed out waiting for logs. View logs at https://modal.com/logs/ap-Z28N8kYIalZGaZM6XJSWVN for remaining output.` (not sure if that's a recent regression or has been there before).

A nice improvement is we no longer rely on the cancellation of the logs task (during deploys) – we don't have to run a logs task since image build logs are separate now.