### PR TITLE
object deploy cleanup

### DIFF
--- a/client_test/container_app_test.py
+++ b/client_test/container_app_test.py
@@ -105,7 +105,9 @@ async def test_is_inside_default_image(servicer, unix_servicer, aio_client, aio_
 
     from modal.stub import _default_image
 
-    default_image_handle, app_id = await AioApp._create_one_object(aio_client, _default_image)
+    app = await AioApp._init_new(aio_client)
+    app_id = app.app_id
+    default_image_handle = await app.create_one_object(_default_image)
     default_image_id = default_image_handle.object_id
 
     # Copy the app objects to the container servicer

--- a/client_test/mount_test.py
+++ b/client_test/mount_test.py
@@ -38,7 +38,8 @@ async def test_get_files(servicer, aio_client, tmpdir):
     assert files["/large.py"].content is None
     assert files["/large.py"].sha256_hex == hashlib.sha256(large_content).hexdigest()
 
-    await AioApp._create_one_object(aio_client, m)
+    app = await AioApp._init_new(aio_client)
+    await app.create_one_object(m)
     blob_id = max(servicer.blobs.keys())  # last uploaded one
     assert len(servicer.blobs[blob_id]) == len(large_content)
     assert servicer.blobs[blob_id] == large_content
@@ -60,7 +61,8 @@ def test_create_mount_legacy_constructor(servicer, client):
     with pytest.warns(DeprecationError):
         m = Mount(local_dir=local_dir, remote_dir=remote_dir, condition=condition)
 
-    obj, _ = App._create_one_object(client, m)
+    app = App._init_new(client)
+    obj = app.create_one_object(m)
 
     assert obj.object_id == "mo-123"
     assert f"/foo/{cur_filename}" in servicer.files_name2sha
@@ -77,7 +79,8 @@ def test_create_mount(servicer, client):
 
     m = Mount.from_local_dir(local_dir, remote_path="/foo", condition=condition)
 
-    obj, _ = App._create_one_object(client, m)
+    app = App._init_new(client)
+    obj = app.create_one_object(m)
 
     assert obj.object_id == "mo-123"
     assert f"/foo/{cur_filename}" in servicer.files_name2sha
@@ -88,15 +91,16 @@ def test_create_mount(servicer, client):
 
 
 def test_create_mount_file_errors(servicer, tmpdir, client):
-    m = Mount.from_local_dir("xyz", remote_path="/xyz")
+    app = App._init_new(client)
+    m = Mount.from_local_dir(tmpdir / "xyz", remote_path="/xyz")
     with pytest.raises(FileNotFoundError):
-        App._create_one_object(client, m)
+        app.create_one_object(m)
 
     with open(tmpdir / "abc", "w"):
         pass
     m = Mount.from_local_dir(tmpdir / "abc", remote_path="/abc")
     with pytest.raises(NotADirectoryError):
-        App._create_one_object(client, m)
+        app.create_one_object(m)
 
 
 def dummy():

--- a/modal/app.py
+++ b/modal/app.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, Optional, Tuple, TypeVar
+from typing import TYPE_CHECKING, Dict, Optional, TypeVar
 
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronize_apis
@@ -149,7 +149,7 @@ class _App:
         return _App(client, existing_app_id, app_page_url, tag_to_existing_id=object_ids)
 
     @staticmethod
-    async def _init_new(client: _Client, description: Optional[str], detach: bool, deploying: bool) -> _App:
+    async def _init_new(client: _Client, description: Optional[str] = None, detach: bool = False, deploying: bool = False) -> _App:
         # Start app
         # TODO(erikbern): maybe this should happen outside of this method?
         app_req = api_pb2.AppCreateRequest(
@@ -175,24 +175,19 @@ class _App:
         else:
             return await _App._init_new(client, name, detach=False, deploying=True)
 
-    @staticmethod
-    async def _create_one_object(client: _Client, provider: Provider) -> Tuple[Handle, str]:
-        # TODO(erikbern): This will be turned into something for deploying single objects
-        app_req = api_pb2.AppCreateRequest()
-        app_resp = await retry_transient_errors(client.stub.AppCreate, app_req)
-        app_id = app_resp.app_id
-        resolver = Resolver(None, client, app_id)
+    async def create_one_object(self, provider: Provider) -> Handle:
+        resolver = Resolver(None, self._client, self.app_id)
         handle = await resolver.load(provider)
         indexed_object_ids = {"_object": handle.object_id}
         unindexed_object_ids = [obj.object_id for obj in resolver.objects() if obj is not handle]
         req_set = api_pb2.AppSetObjectsRequest(
-            app_id=app_id,
+            app_id=self.app_id,
             indexed_object_ids=indexed_object_ids,
             unindexed_object_ids=unindexed_object_ids,
         )
-        await retry_transient_errors(client.stub.AppSetObjects, req_set)
+        await retry_transient_errors(self._client.stub.AppSetObjects, req_set)
 
-        return (handle, app_resp.app_id)
+        return handle
 
     @staticmethod
     def _reset_container():

--- a/modal/app.py
+++ b/modal/app.py
@@ -189,6 +189,16 @@ class _App:
 
         return handle
 
+    async def deploy(self, name: str, namespace: int, object_entity: str) -> str:
+        deploy_req = api_pb2.AppDeployRequest(
+            app_id=self.app_id,
+            name=name,
+            namespace=namespace,
+            object_entity=object_entity,
+        )
+        deploy_response = await retry_transient_errors(self._client.stub.AppDeploy, deploy_req)
+        return deploy_response.url
+
     @staticmethod
     def _reset_container():
         # Just used for tests

--- a/modal/object.py
+++ b/modal/object.py
@@ -177,16 +177,16 @@ class Provider(Generic[H]):
         Note 1: this uses the single-object app method, which we're planning to get rid of later
         Note 2: still considering this an "internal" method, but we'll make it "official" later
         """
-        from .stub import _Stub
+        from .app import _App
 
         if client is None:
             client = await _Client.from_env()
 
         handle_cls = self.get_handle_cls()
         object_entity = handle_cls._type_prefix
-        _stub = _Stub(label, _object=self)
-        await _stub.deploy(namespace=namespace, client=client, object_entity=object_entity, show_progress=False)
-        handle: H = await handle_cls.from_app(label, namespace=namespace, client=client)
+        app = await _App._init_from_name(client, label, namespace)
+        handle = await app.create_one_object(self)
+        await app.deploy(label, namespace, object_entity)  # TODO(erikbern): not needed if the app already existed
         return handle
 
     def persist(self, label: str, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE):

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -161,13 +161,9 @@ async def deploy_stub(
         # Create all members
         await app._create_all_objects(stub._blueprint, output_mgr, post_init_state)
 
-        deploy_req = api_pb2.AppDeployRequest(
-            app_id=app._app_id,
-            name=name,
-            namespace=namespace,
-            object_entity=object_entity,
-        )
-        deploy_response = await retry_transient_errors(client.stub.AppDeploy, deploy_req)
+        # Deploy app
+        url = await app.deploy(name, namespace, object_entity)
+
     output_mgr.print_if_visible(step_completed("App deployed! 🎉"))
-    output_mgr.print_if_visible(f"\nView Deployment: [magenta]{deploy_response.url}[/magenta]")
+    output_mgr.print_if_visible(f"\nView Deployment: [magenta]{url}[/magenta]")
     return app

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -162,6 +162,7 @@ async def deploy_stub(
         await app._create_all_objects(stub._blueprint, output_mgr, post_init_state)
 
         # Deploy app
+        # TODO(erikbern): not needed if the app already existed
         url = await app.deploy(name, namespace, object_entity)
 
     output_mgr.print_if_visible(step_completed("App deployed! 🎉"))

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -147,16 +147,7 @@ async def deploy_stub(
     if client is None:
         client = await _Client.from_env()
 
-    # Look up any existing deployment
-    app_req = api_pb2.AppGetByDeploymentNameRequest(name=name, namespace=namespace)
-    app_resp = await retry_transient_errors(client.stub.AppGetByDeploymentName, app_req)
-    existing_app_id = app_resp.app_id or None
-
-    # Grab the app
-    if existing_app_id is not None:
-        app = await _App._init_existing(client, existing_app_id)
-    else:
-        app = await _App._init_new(client, name, detach=False, deploying=True)
+    app = await _App._init_from_name(client, name, namespace)
 
     output_mgr = OutputManager(stdout, show_progress)
 


### PR DESCRIPTION
We have the `Provider._deploy` method which deploys a single-object app and returns a `Handle`.

This previously used the `Stub` functionality, but that's considered more of a CLI interface at this point (and possibly slated for deprecation). It now uses the internal `App.create_one_object` method, which is also used by a bunch of tests.

Should be a pure refactoring with zero side effects.

This gets me back on my original track where I wanted to support
1. Apps with different types sharing names
2. An easier SDK for deploying single objects