### PR TITLE
fix: get_call_graph TypeError 

### DIFF
--- a/modal/_call_graph.py
+++ b/modal/_call_graph.py
@@ -10,8 +10,10 @@ class InputStatus(IntEnum):
     PENDING = 0
     SUCCESS = api_pb2.GenericResult.GENERIC_STATUS_SUCCESS
     FAILURE = api_pb2.GenericResult.GENERIC_STATUS_FAILURE
+    TERMINATED = api_pb2.GenericResult.GENERIC_STATUS_TERMINATED
     TIMEOUT = api_pb2.GenericResult.GENERIC_STATUS_TIMEOUT
 
+    @classmethod
     def _missing_(cls, value):
         return cls.PENDING
 


### PR DESCRIPTION
[modalbetatesters.slack.com/archives/C031Z7H15DG/p1678322711034919](https://modalbetatesters.slack.com/archives/C031Z7H15DG/p1678322711034919)

Looks like there's an unhandled state, TERMINATED, which is triggering `_missing_`, and that doesn't have the `@classmethod` annotation so it's not passing `cls` as first arg. 

I checked some relevant inputs and they do indeed have state = 3. I think that this state might be new for inputs, by way of input cancellation? cc @freider. 