### PR TITLE
Revert "object deploy cleanup"

### DIFF
--- a/client_test/container_app_test.py
+++ b/client_test/container_app_test.py
@@ -105,9 +105,7 @@ async def test_is_inside_default_image(servicer, unix_servicer, aio_client, aio_
 
     from modal.stub import _default_image
 
-    app = await AioApp._init_new(aio_client)
-    app_id = app.app_id
-    default_image_handle = await app.create_one_object(_default_image)
+    default_image_handle, app_id = await AioApp._create_one_object(aio_client, _default_image)
     default_image_id = default_image_handle.object_id
 
     # Copy the app objects to the container servicer

--- a/client_test/mount_test.py
+++ b/client_test/mount_test.py
@@ -38,8 +38,7 @@ async def test_get_files(servicer, aio_client, tmpdir):
     assert files["/large.py"].content is None
     assert files["/large.py"].sha256_hex == hashlib.sha256(large_content).hexdigest()
 
-    app = await AioApp._init_new(aio_client)
-    await app.create_one_object(m)
+    await AioApp._create_one_object(aio_client, m)
     blob_id = max(servicer.blobs.keys())  # last uploaded one
     assert len(servicer.blobs[blob_id]) == len(large_content)
     assert servicer.blobs[blob_id] == large_content
@@ -61,8 +60,7 @@ def test_create_mount_legacy_constructor(servicer, client):
     with pytest.warns(DeprecationError):
         m = Mount(local_dir=local_dir, remote_dir=remote_dir, condition=condition)
 
-    app = App._init_new(client)
-    obj = app.create_one_object(m)
+    obj, _ = App._create_one_object(client, m)
 
     assert obj.object_id == "mo-123"
     assert f"/foo/{cur_filename}" in servicer.files_name2sha
@@ -79,8 +77,7 @@ def test_create_mount(servicer, client):
 
     m = Mount.from_local_dir(local_dir, remote_path="/foo", condition=condition)
 
-    app = App._init_new(client)
-    obj = app.create_one_object(m)
+    obj, _ = App._create_one_object(client, m)
 
     assert obj.object_id == "mo-123"
     assert f"/foo/{cur_filename}" in servicer.files_name2sha
@@ -91,16 +88,15 @@ def test_create_mount(servicer, client):
 
 
 def test_create_mount_file_errors(servicer, tmpdir, client):
-    app = App._init_new(client)
-    m = Mount.from_local_dir(tmpdir / "xyz", remote_path="/xyz")
+    m = Mount.from_local_dir("xyz", remote_path="/xyz")
     with pytest.raises(FileNotFoundError):
-        app.create_one_object(m)
+        App._create_one_object(client, m)
 
     with open(tmpdir / "abc", "w"):
         pass
     m = Mount.from_local_dir(tmpdir / "abc", remote_path="/abc")
     with pytest.raises(NotADirectoryError):
-        app.create_one_object(m)
+        App._create_one_object(client, m)
 
 
 def dummy():

--- a/modal/object.py
+++ b/modal/object.py
@@ -177,16 +177,16 @@ class Provider(Generic[H]):
         Note 1: this uses the single-object app method, which we're planning to get rid of later
         Note 2: still considering this an "internal" method, but we'll make it "official" later
         """
-        from .app import _App
+        from .stub import _Stub
 
         if client is None:
             client = await _Client.from_env()
 
         handle_cls = self.get_handle_cls()
         object_entity = handle_cls._type_prefix
-        app = await _App._init_from_name(client, label, namespace)
-        handle = await app.create_one_object(self)
-        await app.deploy(label, namespace, object_entity)  # TODO(erikbern): not needed if the app already existed
+        _stub = _Stub(label, _object=self)
+        await _stub.deploy(namespace=namespace, client=client, object_entity=object_entity, show_progress=False)
+        handle: H = await handle_cls.from_app(label, namespace=namespace, client=client)
         return handle
 
     def persist(self, label: str, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE):

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -147,7 +147,16 @@ async def deploy_stub(
     if client is None:
         client = await _Client.from_env()
 
-    app = await _App._init_from_name(client, name, namespace)
+    # Look up any existing deployment
+    app_req = api_pb2.AppGetByDeploymentNameRequest(name=name, namespace=namespace)
+    app_resp = await retry_transient_errors(client.stub.AppGetByDeploymentName, app_req)
+    existing_app_id = app_resp.app_id or None
+
+    # Grab the app
+    if existing_app_id is not None:
+        app = await _App._init_existing(client, existing_app_id)
+    else:
+        app = await _App._init_new(client, name, detach=False, deploying=True)
 
     output_mgr = OutputManager(stdout, show_progress)
 
@@ -161,10 +170,13 @@ async def deploy_stub(
         # Create all members
         await app._create_all_objects(stub._blueprint, output_mgr, post_init_state)
 
-        # Deploy app
-        # TODO(erikbern): not needed if the app already existed
-        url = await app.deploy(name, namespace, object_entity)
-
+        deploy_req = api_pb2.AppDeployRequest(
+            app_id=app._app_id,
+            name=name,
+            namespace=namespace,
+            object_entity=object_entity,
+        )
+        deploy_response = await retry_transient_errors(client.stub.AppDeploy, deploy_req)
     output_mgr.print_if_visible(step_completed("App deployed! 🎉"))
-    output_mgr.print_if_visible(f"\nView Deployment: [magenta]{url}[/magenta]")
+    output_mgr.print_if_visible(f"\nView Deployment: [magenta]{deploy_response.url}[/magenta]")
     return app


### PR DESCRIPTION
Reverts modal-labs/modal-client#378

Breaks internal integration tests because of a minor issue. This is an undocumented feature only used internally anyway, so there should be no user impact.