### PR TITLE
Don't create FunctionInfo for local_entrypoint

### DIFF
--- a/modal/stub.py
+++ b/modal/stub.py
@@ -422,8 +422,8 @@ class _Stub:
         information on usage.
 
         """
-        info = FunctionInfo(raw_f, False, name_override=name)
-        entrypoint = self._local_entrypoints[info.get_tag()] = LocalEntrypoint(raw_f, self)
+        tag = name if name is not None else raw_f.__qualname__
+        entrypoint = self._local_entrypoints[tag] = LocalEntrypoint(raw_f, self)
         return entrypoint
 
     @decorator_with_options


### PR DESCRIPTION
Quick fix for internal doc tests to pass. Creating a `FunctionInfo` from within doctests tries to serialize the entrypoint function, which fails because it refers to another Modal function. 

Longer-term fix is making serialized functions able to call each other, however in this case it seems unnecessary to construct the entire `FunctionInfo` object if all we need is the name.