### PR TITLE
test for running the container through the cli interface

### DIFF
--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -7,6 +7,7 @@ import pytest
 import subprocess
 import sys
 import time
+from typing import List
 
 from grpclib.exceptions import GRPCError
 
@@ -458,7 +459,7 @@ def test_cli(unix_servicer, event_loop):
         app_id="se-123",
         function_def=function_def,
     )
-    data_base64 = base64.b64encode(container_args.SerializeToString())
+    data_base64: str = base64.b64encode(container_args.SerializeToString()).decode("ascii")
 
     # Inputs that will be consumed by the container
     unix_servicer.container_inputs = _get_inputs()
@@ -469,7 +470,7 @@ def test_cli(unix_servicer, event_loop):
         "PYTHONUTF8": "1",  # For windows
     }
     lib_dir = pathlib.Path(__file__).parent.parent
-    args = [sys.executable, "-m", "modal._container_entrypoint", data_base64]
+    args: List[str] = [sys.executable, "-m", "modal._container_entrypoint", data_base64]
     ret = subprocess.run(args, cwd=lib_dir, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout = ret.stdout.decode()
     stderr = ret.stderr.decode()

--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -465,10 +465,7 @@ def test_cli(unix_servicer, event_loop):
     unix_servicer.container_inputs = _get_inputs()
 
     # Launch subprocess
-    env = {
-        "MODAL_SERVER_URL": unix_servicer.remote_addr,
-        "PYTHONUTF8": "1",  # For windows
-    }
+    env = {"MODAL_SERVER_URL": unix_servicer.remote_addr}
     lib_dir = pathlib.Path(__file__).parent.parent
     args: List[str] = [sys.executable, "-m", "modal._container_entrypoint", data_base64]
     ret = subprocess.run(args, cwd=lib_dir, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -1,7 +1,10 @@
 # Copyright Modal Labs 2022
 from __future__ import annotations
+import base64
 import json
+import pathlib
 import pytest
+import subprocess
 import sys
 import time
 
@@ -66,7 +69,6 @@ def _run_container(
             definition_type=definition_type,
         )
 
-        # Note that main is a synchronous function, so we need to run it in a separate thread
         container_args = api_pb2.ContainerArguments(
             task_id="ta-123",
             function_id="fu-123",
@@ -437,3 +439,42 @@ def test_asgi(unix_servicer, event_loop):
 def test_container_heartbeats(unix_servicer, event_loop):
     client, items = _run_container(unix_servicer, "modal_test_support.functions", "square")
     assert any(isinstance(request, api_pb2.ContainerHeartbeatRequest) for request in unix_servicer.requests)
+
+
+@skip_windows_unix_socket
+def test_cli(unix_servicer, event_loop):
+    # This tests the container being invoked as a subprocess (the if __name__ == "__main__" block)
+
+    # Build up payload we pass through sys args
+    function_def = api_pb2.Function(
+        module_name="modal_test_support.functions",
+        function_name="square",
+        function_type=api_pb2.Function.FUNCTION_TYPE_FUNCTION,
+        definition_type=api_pb2.Function.DEFINITION_TYPE_FILE,
+    )
+    container_args = api_pb2.ContainerArguments(
+        task_id="ta-123",
+        function_id="fu-123",
+        app_id="se-123",
+        function_def=function_def,
+    )
+    data_base64 = base64.b64encode(container_args.SerializeToString())
+
+    # Inputs that will be consumed by the container
+    unix_servicer.container_inputs = _get_inputs()
+
+    # Launch subprocess
+    env = {
+        "MODAL_SERVER_URL": unix_servicer.remote_addr,
+        "PYTHONUTF8": "1",  # For windows
+    }
+    lib_dir = pathlib.Path(__file__).parent.parent
+    args = [sys.executable, "-m", "modal._container_entrypoint", data_base64]
+    ret = subprocess.run(args, cwd=lib_dir, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout = ret.stdout.decode()
+    stderr = ret.stderr.decode()
+    if ret.returncode != 0:
+        raise Exception(f"Failed with {ret.returncode} stdout: {stdout} stderr: {stderr}")
+
+    assert stdout == ""
+    # assert stderr == ""  # TODO(erikbern): this doesn't work right now:


### PR DESCRIPTION
Sadly this also doesn't reproduce the issue with async shutdown spam!

I ended up writing three different PRs with unit tests hoping to repro the issue.

This however seems useful to have and right now it catches a somewhat unrelated issue which is that we have lots of stubs without names and we tie all of them to the running app – there's a bunch of warnings because of this. We should fix this.