### PR TITLE
Adds response message for SharedVolumePutFile

### DIFF
--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -513,7 +513,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
     async def SharedVolumePutFile(self, stream):
         req = await stream.recv_message()
         self.shared_volume_files[req.shared_volume_id][req.path] = req
-        await stream.send_message(Empty())
+        await stream.send_message(api_pb2.SharedVolumePutFileResponse(exists=True))
 
     ### Task
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -848,6 +848,11 @@ message SharedVolumePutFileRequest {
     bytes data = 4;
     string data_blob_id = 5;
   }
+  bool resumable = 6;  // remove when required client version >= 47
+}
+
+message SharedVolumePutFileResponse {
+  bool exists = 1;
 }
 
 message SharedVolumeGetFileRequest {
@@ -1030,7 +1035,7 @@ service ModalClient {
   rpc SharedVolumeList(google.protobuf.Empty) returns (SharedVolumeListResponse);
   rpc SharedVolumeListFiles(SharedVolumeListFilesRequest) returns (SharedVolumeListFilesResponse);
   rpc SharedVolumeListFilesStream(SharedVolumeListFilesRequest) returns (stream SharedVolumeListFilesResponse);
-  rpc SharedVolumePutFile(SharedVolumePutFileRequest) returns (google.protobuf.Empty);
+  rpc SharedVolumePutFile(SharedVolumePutFileRequest) returns (SharedVolumePutFileResponse);
   rpc SharedVolumeGetFile(SharedVolumeGetFileRequest) returns (SharedVolumeGetFileResponse);
   rpc SharedVolumeRemoveFile(SharedVolumeRemoveFileRequest) returns (google.protobuf.Empty);
 


### PR DESCRIPTION
Similar to MountPutFile, this will allow us to respond with True/False depending on if the operation has succeeded or not.

Also adds 'feature flag' to request message to signal if client can understand the retry