### PR TITLE
Adds support for exists flag in SharedVolumePUtFile responses

### DIFF
--- a/modal/shared_volume.py
+++ b/modal/shared_volume.py
@@ -1,8 +1,10 @@
 # Copyright Modal Labs 2022
 import os
+import time
 from pathlib import Path, PurePosixPath
 from typing import AsyncIterator, BinaryIO, List, Optional, Union
 
+import modal
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronize_apis, ConcurrencyPool
 from modal_utils.grpc_utils import retry_transient_errors, unary_stream
@@ -11,6 +13,10 @@ from modal_utils.hash_utils import get_sha256_hex
 from ._blob_utils import LARGE_FILE_LIMIT, blob_iter, blob_upload_file
 from ._resolver import Resolver
 from .object import Handle, Provider
+
+SHARED_VOLUME_PUT_FILE_CLIENT_TIMEOUT = (
+    10 * 60
+)  # 10 min max for transferring files (does not include upload time to s3)
 
 
 class _SharedVolumeHandle(Handle, type_prefix="sv"):
@@ -47,12 +53,26 @@ class _SharedVolumeHandle(Handle, type_prefix="sv"):
         if data_size > LARGE_FILE_LIMIT:
             blob_id = await blob_upload_file(fp, self._client.stub)
             req = api_pb2.SharedVolumePutFileRequest(
-                shared_volume_id=self._object_id, path=remote_path, data_blob_id=blob_id, sha256_hex=sha_hash
+                shared_volume_id=self._object_id,
+                path=remote_path,
+                data_blob_id=blob_id,
+                sha256_hex=sha_hash,
+                resumable=True,
             )
         else:
             data = fp.read()
-            req = api_pb2.SharedVolumePutFileRequest(shared_volume_id=self._object_id, path=remote_path, data=data)
-        await retry_transient_errors(self._client.stub.SharedVolumePutFile, req)
+            req = api_pb2.SharedVolumePutFileRequest(
+                shared_volume_id=self._object_id, path=remote_path, data=data, resumable=True
+            )
+
+        t0 = time.monotonic()
+        while time.monotonic() - t0 < SHARED_VOLUME_PUT_FILE_CLIENT_TIMEOUT:
+            response = await retry_transient_errors(self._client.stub.SharedVolumePutFile, req)
+            if response.exists:
+                break
+        else:
+            raise modal.exception.TimeoutError(f"Uploading of {remote_path} timed out")
+
         return data_size  # might be better if this is returned from the server
 
     async def read_file(self, path: str) -> AsyncIterator[bytes]:

--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -7,7 +7,7 @@ from ._version_generated import build_number  # Written by GitHub
 major_number = 0
 
 # Bump this manually on any major changes
-minor_number = 46
+minor_number = 47
 
 # Right now, set the patch number (the 3rd field) to the job run number in GitHub
 __version__ = f"{major_number}.{minor_number}.{build_number}"


### PR DESCRIPTION
Makes SharedVolumePutFile work similar to how MountPutFile works

Based on prior proto changes

Note: requires matching server changes before this is merged