### PR TITLE
Fix mis-rendered frontend docs pages

### DIFF
--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -132,34 +132,39 @@ class RunGroup(click.Group):
 @click.group(
     cls=RunGroup,
     subcommand_metavar="FUNC_REF",
-    help="""Run a Modal function or local entrypoint
-
-FUNC_REF should be of the format:
-
-`{file or module}::{function name}`
-
-Alternatively you can refer to the function via the stub:
-
-`{file or module}::{stub variable name}.{function name}`
-
-Examples:
-To run the hello_world function (or local entrypoint) in my_app.py:
-
- > modal run my_app.py::hello_world
-
-If your module only has a single stub called `stub` and your stub has a single local entrypoint (or single function), you can omit the stub/function part:
-
- > modal run my_app.py
-
-Instead of pointing to a file, you can also use the Python module path to a a file:
-
-> modal run my_project.my_app
-
-""",
 )
 @click.option("--detach", is_flag=True, help="Don't stop the app if the local process dies or disconnects.")
 @click.pass_context
 def run(ctx, detach):
+    """Run a Modal function or local entrypoint
+
+    `FUNC_REF` should be of the format `{file or module}::{function name}`.
+    Alternatively, you can refer to the function via the stub:
+
+    `{file or module}::{stub variable name}.{function name}`
+
+    **Examples:**
+
+    To run the hello_world function (or local entrypoint) in my_app.py:
+
+    ```bash
+    modal run my_app.py::hello_world
+    ```
+
+    If your module only has a single stub called `stub` and your stub has a
+    single local entrypoint (or single function), you can omit the stub and
+    function parts:
+
+    ```bash
+    modal run my_app.py
+    ```
+
+    Instead of pointing to a file, you can also use the Python module path:
+
+    ```bash
+    modal run my_project.my_app
+    ```
+    """
     ctx.ensure_object(dict)
     ctx.obj["detach"] = detach  # if subcommand would be a click command...
 

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -182,11 +182,12 @@ def serve(
     timeout: Optional[float] = None,
 ):
     """Run a web endpoint(s) associated with a Modal stub and hot-reload code.
-    **Examples:**\n
-    \n
-    ```bash\n
+
+    **Examples:**
+
+    ```bash
     modal serve hello_world.py
-    ```\n
+    ```
     """
     run_serve_loop(stub_ref, timeout)
 
@@ -197,19 +198,23 @@ def shell(
     ),
     cmd: str = typer.Option(default="/bin/bash", help="Command to run inside the Modal image."),
 ):
-    """Run an interactive shell inside a Modal image.\n
-    **Examples:**\n
-    \n
-    - Start a bash shell using the spec for `my_function` in your stub:\n
-    ```bash\n
-    modal shell hello_world.py::my_function \n
-    ```\n
-    Note that you can select the function interactively if you omit the function name.\n
-    \n
-    - Start a `python` shell: \n
-    ```bash\n
-    modal shell hello_world.py --cmd=python \n
-    ```\n
+    """Run an interactive shell inside a Modal image.
+
+    **Examples:**
+
+    Start a bash shell using the spec for `my_function` in your stub:
+
+    ```bash
+    modal shell hello_world.py::my_function
+    ```
+
+    Note that you can select the function interactively if you omit the function name.
+
+    Start a `python` shell:
+
+    ```bash
+    modal shell hello_world.py --cmd=python
+    ```
     """
     console = Console()
     if not console.is_terminal:

--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -206,15 +206,17 @@ async def _glob_download(
 @volume_cli.command(name="get")
 @synchronizer
 async def get(volume_name: str, remote_path: str, local_destination: str = typer.Argument("."), force: bool = False):
-    """Download a file from a shared volume.\n
-    Specifying a glob pattern (using any `*` or `**` patterns) as the `remote_path` will download all matching *files*, preserving
-    the source directory structure for the matched files.\n
-    \n
-    For example, to download an entire shared volume into `dump_volume`:\n
+    """Download a file from a shared volume.
 
-    ```bash\n
-    modal volume get <volume-name> "**" dump_volume\n
-    ```\n
+    Specifying a glob pattern (using any `*` or `**` patterns) as the `remote_path` will download all matching *files*, preserving
+    the source directory structure for the matched files.
+
+    For example, to download an entire shared volume into `dump_volume`:
+
+    ```bash
+    modal volume get <volume-name> "**" dump_volume
+    ```
+
     Use "-" (a hyphen) as LOCAL_DESTINATION to write contents of file to stdout (only for non-glob paths).
     """
     destination = Path(local_destination)

--- a/modal/shared_volume.py
+++ b/modal/shared_volume.py
@@ -14,14 +14,16 @@ from .object import Handle, Provider
 
 
 class _SharedVolumeHandle(Handle, type_prefix="sv"):
-    """A handle to a Modal SharedVolume
+    """Handle to a `SharedVolume` object.
 
     Should typically not be used directly in a Modal function,
     and instead referenced through the file system, see `modal.SharedVolume`.
 
     Also see the CLI methods for accessing shared volumes:
 
-    ```modal volume --help
+    ```bash
+    modal volume --help
+    ```
 
     A SharedVolumeHandle *can* however be useful for some local scripting scenarios, e.g.:
 


### PR DESCRIPTION
The explicit `\n` characters were adding spaces in the docs. Also `modal` is not the name of a language, which was giving warnings.

Saw this because of some warnings in CI that turned out to be a red herring. fyi @freider