### PR TITLE
Adds Modal user agent header data

### DIFF
--- a/modal_utils/grpc_utils.py
+++ b/modal_utils/grpc_utils.py
@@ -29,7 +29,7 @@ from modal_version import __version__
 from .logger import logger
 
 # Monkey patches grpclib to have a Modal User Agent header.
-grpclib.client.USER_AGENT: str = "modal-client/{version} ({sys}; {py}/{py_ver})'".format(
+grpclib.client.USER_AGENT = "modal-client/{version} ({sys}; {py}/{py_ver})'".format(
     version=__version__,
     sys=platform.system(),
     py=platform.python_implementation(),

--- a/modal_utils/grpc_utils.py
+++ b/modal_utils/grpc_utils.py
@@ -3,6 +3,7 @@ import asyncio
 import contextlib
 import socket
 import time
+import platform
 import urllib.parse
 import uuid
 from typing import (
@@ -28,7 +29,12 @@ from modal_version import __version__
 from .logger import logger
 
 # Monkey patches grpclib to have a Modal User Agent header.
-grpclib.client.USER_AGENT: str = f"modal-client/{__version__}"
+grpclib.client.USER_AGENT: str = "modal-client/{version} ({sys}; {py}/{py_ver})'".format(
+    version=__version__,
+    sys=platform.system(),
+    py=platform.python_implementation(),
+    py_ver=platform.python_version(),
+).lower()
 
 
 class Subchannel:

--- a/modal_utils/grpc_utils.py
+++ b/modal_utils/grpc_utils.py
@@ -18,12 +18,17 @@ from typing import (
 )
 
 import grpclib.events
+import grpclib.client
 from grpclib import GRPCError, Status
-from grpclib.client import Channel, UnaryStreamMethod
 from grpclib.exceptions import StreamTerminatedError
 from grpclib.protocol import H2Protocol
 
+from modal_version import __version__
+
 from .logger import logger
+
+# Monkey patches grpclib to have a Modal User Agent header.
+grpclib.client.USER_AGENT: str = f"modal-client/{__version__}"
 
 
 class Subchannel:
@@ -43,7 +48,7 @@ class Subchannel:
         return True
 
 
-class ChannelPool(Channel):
+class ChannelPool(grpclib.client.Channel):
     """Use multiple channels under the hood. A drop-in replacement for the grpclib Channel.
 
     The main reason is to get around limitations with TCP connections over the internet,
@@ -133,7 +138,7 @@ def create_channel(
     *,
     inject_tracing_context: Optional[Callable[[Dict[str, str]], None]] = None,
     use_pool: Optional[bool] = None,  # If None, inferred from the scheme
-) -> Channel:
+) -> grpclib.client.Channel:
     """Creates a grpclib.Channel.
 
     Either to be used directly by a GRPC stub, or indirectly used through the channel pool.
@@ -144,13 +149,13 @@ def create_channel(
     if use_pool is None:
         use_pool = o.scheme in ("http", "https")
 
-    channel_cls: Type[Channel]
+    channel_cls: Type[grpclib.client.Channel]
     if use_pool:
         channel_cls = ChannelPool
     else:
-        channel_cls = Channel
+        channel_cls = grpclib.client.Channel
 
-    channel: Channel
+    channel: grpclib.client.Channel
     if o.scheme == "unix":
         channel = channel_cls(path=o.path)  # probably pointless to use a pool ever
     elif o.scheme in ("http", "https"):
@@ -179,7 +184,7 @@ def create_channel(
 
 
 async def unary_stream(
-    method: UnaryStreamMethod[_SendType, _RecvType],
+    method: grpclib.client.UnaryStreamMethod[_SendType, _RecvType],
     request: _SendType,
     metadata: Optional[Any] = None,
 ) -> AsyncIterator[_RecvType]:


### PR DESCRIPTION
This will appear as `modal-client/$VERSION`. Example:

```
modal-client/0.47.1573 (darwin; cpython/3.9.13)
```
<img width="438" alt="Screenshot 2023-03-14 at 11 02 01" src="https://user-images.githubusercontent.com/953118/225044939-bf36318f-9ea1-4e4f-93b0-4f8233a7e6c3.png">
