### PR TITLE
Validation and error message for stub._blueprint objects

### DIFF
--- a/client_test/stub_test.py
+++ b/client_test/stub_test.py
@@ -40,6 +40,23 @@ async def test_attrs(servicer, aio_client):
         assert await app.q.get() == "baz"
 
 
+@pytest.mark.asyncio
+async def test_stub_type_validation(servicer, aio_client):
+    with pytest.raises(InvalidError) as excinfo:
+        stub = AioStub(
+            foo=4242,
+        )
+
+    assert "4242" in str(excinfo.value)
+
+    stub = AioStub()
+
+    with pytest.raises(InvalidError) as excinfo:
+        stub.bar = 4242
+
+    assert "4242" in str(excinfo.value)
+
+
 def square(x):
     return x**2
 

--- a/modal/cli/import_refs.py
+++ b/modal/cli/import_refs.py
@@ -33,6 +33,8 @@ class ImportRef:
 def parse_import_ref(object_ref: str) -> ImportRef:
     if object_ref.find("::") > 1:
         file_or_module, object_path = object_ref.split("::", 1)
+    elif object_ref.find(":") > 1:
+        raise modal.exception.InvalidError(f"Invalid object reference: {object_ref}. Did you mean '::' instead of ':'?")
     else:
         file_or_module, object_path = object_ref, None
 
@@ -50,7 +52,7 @@ def import_file_or_module(file_or_module: str):
     if "" not in sys.path:
         # This seems to happen when running from a CLI
         sys.path.insert(0, "")
-    if ".py" in file_or_module:
+    if file_or_module.endswith(".py"):
         # walk to the closest python package in the path and add that to the path
         # before importing, in case of imports etc. of other modules in that package
         # are needed
@@ -71,6 +73,7 @@ def import_file_or_module(file_or_module: str):
 
         # Import the module - see https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly
         spec = importlib.util.spec_from_file_location(module_name, file_or_module)
+        print("importing", spec, module_name, file_or_module)
         module = importlib.util.module_from_spec(spec)
         sys.modules[module_name] = module
         spec.loader.exec_module(module)


### PR DESCRIPTION
Fixes the previously cryptic `AttributeError: 'int' object has no attribute 'local_uuid'` error.

Also sneaking in a better exception for CLI imports.