### PR TITLE
Class decorator v0

### DIFF
--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -9,7 +9,7 @@ from modal_proto import api_pb2
 stub = modal.Stub()
 
 
-@stub.service(cpu=42)
+@stub.cls(cpu=42)
 class Foo:
     def bar(self, x):
         return x**3
@@ -37,7 +37,7 @@ def test_call_class_sync(client, servicer):
 aio_stub = modal.aio.AioStub()
 
 
-@aio_stub.service(cpu=42)
+@aio_stub.cls(cpu=42)
 class Bar:
     def baz(self, x):
         return x**3
@@ -56,7 +56,7 @@ def test_run_class_serialized(client, servicer):
             return x**3
 
     stub_ser = modal.Stub()
-    stub_ser.service(cpu=42, serialized=True)(FooSer)
+    stub_ser.cls(cpu=42, serialized=True)(FooSer)
 
     assert servicer.n_functions == 0
     with stub_ser.run(client=client):
@@ -81,7 +81,7 @@ def test_run_class_serialized(client, servicer):
 stub_local = modal.Stub()
 
 
-@stub_local.service(cpu=42)
+@stub_local.cls(cpu=42)
 class FooLocal:
     def bar(self, x):
         return x**3

--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -32,7 +32,7 @@ def test_run_class(client, servicer):
 def test_call_class_sync(client, servicer):
     with stub.run(client=client):
         foo = Foo()
-        assert foo.bar.call(42) == 1764  # type: ignore
+        assert foo.bar.call(42) == 1764
 
 
 aio_stub = modal.aio.AioStub()
@@ -49,7 +49,7 @@ class Bar:
 async def test_call_class_async(aio_client, servicer):
     async with aio_stub.run(client=aio_client):
         bar = Bar()
-        assert await bar.baz.call(42) == 1764  # type: ignore
+        assert await bar.baz.call(42) == 1764
 
 
 def test_run_class_serialized(client, servicer):
@@ -106,5 +106,5 @@ def test_can_call_remotely_from_local(client):
         foo = FooLocal()
         # remote calls use the mockservicer func impl
         # which just squares the arguments
-        assert foo.bar.call(8) == 64  # type: ignore
-        assert foo.baz.call(9) == 81  # type: ignore
+        assert foo.bar.call(8) == 64
+        assert foo.baz.call(9) == 81

--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -11,6 +11,7 @@ stub = modal.Stub()
 
 @stub.cls(cpu=42)
 class Foo:
+    @stub.method()
     def bar(self, x):
         return x**3
 
@@ -39,6 +40,7 @@ aio_stub = modal.aio.AioStub()
 
 @aio_stub.cls(cpu=42)
 class Bar:
+    @aio_stub.method()
     def baz(self, x):
         return x**3
 
@@ -51,12 +53,13 @@ async def test_call_class_async(aio_client, servicer):
 
 
 def test_run_class_serialized(client, servicer):
+    stub_ser = modal.Stub()
+
+    @stub_ser.cls(cpu=42, serialized=True)
     class FooSer:
+        @stub_ser.method()
         def bar(self, x):
             return x**3
-
-    stub_ser = modal.Stub()
-    stub_ser.cls(cpu=42, serialized=True)(FooSer)
 
     assert servicer.n_functions == 0
     with stub_ser.run(client=client):
@@ -83,9 +86,11 @@ stub_local = modal.Stub()
 
 @stub_local.cls(cpu=42)
 class FooLocal:
+    @stub_local.method()
     def bar(self, x):
         return x**3
 
+    @stub_local.method()
     def baz(self, y):
         return self.bar(y + 1)
 

--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -2,16 +2,16 @@
 import cloudpickle
 import pytest
 
-import modal
-import modal.aio
+from modal import Stub, method
+from modal.aio import AioStub, aio_method
 from modal_proto import api_pb2
 
-stub = modal.Stub()
+stub = Stub()
 
 
 @stub.cls(cpu=42)
 class Foo:
-    @stub.method()
+    @method()
     def bar(self, x):
         return x**3
 
@@ -35,12 +35,12 @@ def test_call_class_sync(client, servicer):
         assert foo.bar.call(42) == 1764
 
 
-aio_stub = modal.aio.AioStub()
+aio_stub = AioStub()
 
 
 @aio_stub.cls(cpu=42)
 class Bar:
-    @aio_stub.method()
+    @aio_method()
     def baz(self, x):
         return x**3
 
@@ -53,11 +53,11 @@ async def test_call_class_async(aio_client, servicer):
 
 
 def test_run_class_serialized(client, servicer):
-    stub_ser = modal.Stub()
+    stub_ser = Stub()
 
     @stub_ser.cls(cpu=42, serialized=True)
     class FooSer:
-        @stub_ser.method()
+        @method()
         def bar(self, x):
             return x**3
 
@@ -81,16 +81,16 @@ def test_run_class_serialized(client, servicer):
     assert meth(100) == 1000000
 
 
-stub_local = modal.Stub()
+stub_local = Stub()
 
 
 @stub_local.cls(cpu=42)
 class FooLocal:
-    @stub_local.method()
+    @method()
     def bar(self, x):
         return x**3
 
-    @stub_local.method()
+    @method()
     def baz(self, y):
         return self.bar(y + 1)
 

--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -465,7 +465,7 @@ def test_service_function(unix_servicer, event_loop):
     client, items = _run_container(unix_servicer, "modal_test_support.functions", "Service.f")
     assert len(items) == 1
     assert items[0].result.status == api_pb2.GenericResult.GENERIC_STATUS_SUCCESS
-    assert items[0].result.data == serialize(42*111)
+    assert items[0].result.data == serialize(42 * 111)
 
 
 @skip_windows_unix_socket
@@ -484,6 +484,28 @@ def test_service_web_endpoint(unix_servicer, event_loop):
     assert items[1].result.gen_status == api_pb2.GenericResult.GENERATOR_STATUS_INCOMPLETE
     second_message = deserialize(items[1].result.data, client)
     assert json.loads(second_message["body"]) == {"ret": "space" * 111}
+
+
+@skip_windows_unix_socket
+def test_serialized_service(unix_servicer, event_loop):
+    class Service:
+        def __enter__(self):
+            self.power = 5
+
+        def method(self, x):
+            return x**self.power
+
+    unix_servicer.class_serialized = serialize(Service)
+    unix_servicer.function_serialized = serialize(Service.method)
+    client, items = _run_container(
+        unix_servicer,
+        "module.doesnt.matter",
+        "function.doesnt.matter",
+        definition_type=api_pb2.Function.DEFINITION_TYPE_SERIALIZED,
+    )
+    assert len(items) == 1
+    assert items[0].result.status == api_pb2.GenericResult.GENERIC_STATUS_SUCCESS
+    assert items[0].result.data == serialize(42**5)
 
 
 @skip_windows_unix_socket

--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -461,20 +461,20 @@ def test_webhook_streaming_async(unix_servicer, event_loop):
 
 
 @skip_windows_unix_socket
-def test_service_function(unix_servicer, event_loop):
-    client, items = _run_container(unix_servicer, "modal_test_support.functions", "Service.f")
+def test_cls_function(unix_servicer, event_loop):
+    client, items = _run_container(unix_servicer, "modal_test_support.functions", "Cls.f")
     assert len(items) == 1
     assert items[0].result.status == api_pb2.GenericResult.GENERIC_STATUS_SUCCESS
     assert items[0].result.data == serialize(42 * 111)
 
 
 @skip_windows_unix_socket
-def test_service_web_endpoint(unix_servicer, event_loop):
+def test_cls_web_endpoint(unix_servicer, event_loop):
     inputs = _get_web_inputs()
     client, items = _run_container(
         unix_servicer,
         "modal_test_support.functions",
-        "Service.web",
+        "Cls.web",
         inputs=inputs,
         webhook_type=api_pb2.WEBHOOK_TYPE_FUNCTION,
     )
@@ -487,16 +487,16 @@ def test_service_web_endpoint(unix_servicer, event_loop):
 
 
 @skip_windows_unix_socket
-def test_serialized_service(unix_servicer, event_loop):
-    class Service:
+def test_serialized_cls(unix_servicer, event_loop):
+    class Cls:
         def __enter__(self):
             self.power = 5
 
         def method(self, x):
             return x**self.power
 
-    unix_servicer.class_serialized = serialize(Service)
-    unix_servicer.function_serialized = serialize(Service.method)
+    unix_servicer.class_serialized = serialize(Cls)
+    unix_servicer.function_serialized = serialize(Cls.method)
     client, items = _run_container(
         unix_servicer,
         "module.doesnt.matter",

--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -10,7 +10,6 @@ from modal import Proxy, Stub, SharedVolume
 from modal.exception import InvalidError
 from modal.functions import Function, FunctionCall, gather
 from modal.stub import AioStub
-from modal_proto import api_pb2
 
 stub = Stub()
 
@@ -316,30 +315,6 @@ def test_function_relative_import_hint(client, servicer):
         with pytest.raises(ImportError) as excinfo:
             import_failure_modal.call()
         assert "HINT" in str(excinfo.value)
-
-
-lifecycle_stub = Stub()
-
-
-class Foo:
-    bar = "hello"
-
-    @lifecycle_stub.function(serialized=True)
-    def run(self):
-        return self.bar
-
-
-def test_serialized_function_includes_lifecycle_class(client, servicer):
-    with lifecycle_stub.run(client=client):
-        pass
-
-    assert len(servicer.app_functions) == 1
-    func_def = next(iter(servicer.app_functions.values()))
-    assert func_def.definition_type == api_pb2.Function.DEFINITION_TYPE_SERIALIZED
-
-    func = cloudpickle.loads(func_def.function_serialized)
-    cls = cloudpickle.loads(func_def.class_serialized)
-    assert func(cls()) == "hello"
 
 
 def test_nonglobal_function():

--- a/client_test/service_test.py
+++ b/client_test/service_test.py
@@ -27,8 +27,8 @@ def test_run_class(client, servicer):
 
 
 def test_call_class(client, servicer):
-    with stub.run(client=client) as app:
-        foo = Foo()
+    with stub.run(client=client):
+        Foo()
 
         # TODO(erikbern): this fails! because foo.bar.call is async
         # assert foo.bar.call(42) == 1764  # Note: uses Mockservicer's impl
@@ -40,10 +40,10 @@ def test_run_class_serialized(client, servicer):
             return x**3
 
     stub_ser = modal.Stub()
-    ret = stub_ser.service(cpu=42, serialized=True)(FooSer)
+    stub_ser.service(cpu=42, serialized=True)(FooSer)
 
     assert servicer.n_functions == 0
-    with stub_ser.run(client=client) as app:
+    with stub_ser.run(client=client):
         pass
 
     assert servicer.n_functions == 1
@@ -81,8 +81,8 @@ def test_can_call_locally():
 
 
 def test_can_call_remotely_from_local(client):
-    with stub_local.run(client=client) as app:
-        foo = FooLocal()
+    with stub_local.run(client=client):
+        FooLocal()
 
         # remote calls use the mockservicer func impl
         # which just squares the arguments

--- a/client_test/service_test.py
+++ b/client_test/service_test.py
@@ -52,3 +52,21 @@ def test_run_class_serialized(client, servicer):
 
     # Make sure it's callable
     assert meth(100) == 1000000
+
+
+stub_local = modal.Stub()
+
+
+@stub_local.service(cpu=42)
+class FooLocal:
+    def bar(self, x):
+        return x**3
+
+    def baz(self, y):
+        return self.bar(y + 1)
+
+
+def test_can_call_locally():
+    foo = FooLocal()
+    assert foo.bar(4) == 64
+    assert foo.baz(4) == 125

--- a/client_test/service_test.py
+++ b/client_test/service_test.py
@@ -28,10 +28,8 @@ def test_run_class(client, servicer):
 
 def test_call_class(client, servicer):
     with stub.run(client=client):
-        Foo()
-
-        # TODO(erikbern): this fails! because foo.bar.call is async
-        # assert foo.bar.call(42) == 1764  # Note: uses Mockservicer's impl
+        foo = Foo()
+        assert foo.bar.call(42) == 1764  # Note: uses Mockservicer's impl
 
 
 def test_run_class_serialized(client, servicer):
@@ -82,10 +80,8 @@ def test_can_call_locally():
 
 def test_can_call_remotely_from_local(client):
     with stub_local.run(client=client):
-        FooLocal()
-
+        foo = FooLocal()
         # remote calls use the mockservicer func impl
         # which just squares the arguments
-        # TODO(erikbern): this fails, because foo.bar.call is async!!
-        # assert foo.bar.call(8) == 64
-        # assert foo.baz.call(9) == 81
+        assert foo.bar.call(8) == 64
+        assert foo.baz.call(9) == 81

--- a/client_test/service_test.py
+++ b/client_test/service_test.py
@@ -78,3 +78,14 @@ def test_can_call_locally():
     foo = FooLocal()
     assert foo.bar(4) == 64
     assert foo.baz(4) == 125
+
+
+def test_can_call_remotely_from_local(client):
+    with stub_local.run(client=client) as app:
+        foo = FooLocal()
+
+        # remote calls use the mockservicer func impl
+        # which just squares the arguments
+        # TODO(erikbern): this fails, because foo.bar.call is async!!
+        # assert foo.bar.call(8) == 64
+        # assert foo.baz.call(9) == 81

--- a/client_test/service_test.py
+++ b/client_test/service_test.py
@@ -31,7 +31,7 @@ def test_run_class(client, servicer):
 def test_call_class_sync(client, servicer):
     with stub.run(client=client):
         foo = Foo()
-        assert foo.bar.call(42) == 1764  # Note: uses Mockservicer's impl
+        assert foo.bar.call(42) == 1764  # type: ignore
 
 
 aio_stub = modal.aio.AioStub()
@@ -47,7 +47,7 @@ class Bar:
 async def test_call_class_async(aio_client, servicer):
     async with aio_stub.run(client=aio_client):
         bar = Bar()
-        assert await bar.baz.call(42) == 1764  # Note: uses Mockservicer's impl
+        assert await bar.baz.call(42) == 1764  # type: ignore
 
 
 def test_run_class_serialized(client, servicer):
@@ -101,5 +101,5 @@ def test_can_call_remotely_from_local(client):
         foo = FooLocal()
         # remote calls use the mockservicer func impl
         # which just squares the arguments
-        assert foo.bar.call(8) == 64
-        assert foo.baz.call(9) == 81
+        assert foo.bar.call(8) == 64  # type: ignore
+        assert foo.baz.call(9) == 81  # type: ignore

--- a/client_test/service_test.py
+++ b/client_test/service_test.py
@@ -1,0 +1,23 @@
+# Copyright Modal Labs 2022
+import modal
+
+stub = modal.Stub()
+
+
+@stub.service(cpu=42)
+class Foo:
+    def bar(self, x):
+        return x**3
+
+
+def test_run_class(client, servicer):
+    assert servicer.n_functions == 0
+    with stub.run(client=client) as app:
+        pass
+
+    assert servicer.n_functions == 1
+    (function_id,) = servicer.app_functions.keys()
+    function = servicer.app_functions[function_id]
+    assert function.function_name == "Foo.bar"
+    objects = servicer.app_objects[app.app_id]
+    assert objects == {"Foo.bar": function_id}

--- a/client_test/service_test.py
+++ b/client_test/service_test.py
@@ -26,6 +26,14 @@ def test_run_class(client, servicer):
     assert objects == {"Foo.bar": function_id}
 
 
+def test_call_class(client, servicer):
+    with stub.run(client=client) as app:
+        foo = Foo()
+
+        # TODO(erikbern): this fails! because foo.bar.call is async
+        # assert foo.bar.call(42) == 1764  # Note: uses Mockservicer's impl
+
+
 def test_run_class_serialized(client, servicer):
     class FooSer:
         def bar(self, x):

--- a/client_test/service_test.py
+++ b/client_test/service_test.py
@@ -1,5 +1,8 @@
 # Copyright Modal Labs 2022
+import cloudpickle
+
 import modal
+from modal_proto import api_pb2
 
 stub = modal.Stub()
 
@@ -21,3 +24,31 @@ def test_run_class(client, servicer):
     assert function.function_name == "Foo.bar"
     objects = servicer.app_objects[app.app_id]
     assert objects == {"Foo.bar": function_id}
+
+
+def test_run_class_serialized(client, servicer):
+    class FooSer:
+        def bar(self, x):
+            return x**3
+
+    stub_ser = modal.Stub()
+    ret = stub_ser.service(cpu=42, serialized=True)(FooSer)
+
+    assert servicer.n_functions == 0
+    with stub_ser.run(client=client) as app:
+        pass
+
+    assert servicer.n_functions == 1
+    (function_id,) = servicer.app_functions.keys()
+    function = servicer.app_functions[function_id]
+    assert function.function_name.endswith("FooSer.bar")  # because it's defined in a local scope
+    assert function.definition_type == api_pb2.Function.DEFINITION_TYPE_SERIALIZED
+    cls = cloudpickle.loads(function.class_serialized)
+    fun = cloudpickle.loads(function.function_serialized)
+
+    # Create bound method
+    obj = cls()
+    meth = fun.__get__(obj, cls)
+
+    # Make sure it's callable
+    assert meth(100) == 1000000

--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -5,7 +5,7 @@ from .app import App, container_app, is_local
 from .client import Client
 from .dict import Dict
 from .exception import Error
-from .functions import Function, current_input_id
+from .functions import Function, current_input_id, method
 from .image import Image
 from .mount import Mount, create_package_mounts
 from .object import lookup
@@ -39,5 +39,6 @@ __all__ = [
     "create_package_mounts",
     "is_local",
     "lookup",
+    "method",
     "current_input_id",
 ]

--- a/modal/aio.py
+++ b/modal/aio.py
@@ -7,7 +7,7 @@ The async interfaces are mostly mirrors of the blocking ones, with the `Aio` or 
 from .app import AioApp, aio_container_app
 from .client import AioClient
 from .dict import AioDict
-from .functions import AioFunction, AioFunctionHandle, AioFunctionCall
+from .functions import AioFunction, AioFunctionHandle, AioFunctionCall, aio_method
 from .image import AioImage
 from .mount import AioMount
 from .object import aio_lookup
@@ -33,4 +33,5 @@ __all__ = [
     "AioFunctionHandle",  # noqa
     "aio_container_app",
     "aio_lookup",
+    "aio_method",
 ]

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1138,3 +1138,6 @@ class _PartialFunction:
         else:  # Cls.fun
             function_handle = objtype._modal_function_handles[k]
         return function_handle.__get__(obj, objtype)
+
+
+PartialFunction, AioPartialFunction = synchronize_apis(_PartialFunction)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1144,9 +1144,7 @@ def class_decorator(cls: type, method_decorator):
     new_dict = {}
     for k, v in cls.__dict__.items():
         if callable(v):
+            # TODO(erikbern): ignore classmethod, staticmethod etc
             new_dict[k] = method_decorator(v)
-        else:
-            new_dict[k] = v
-
-    new_cls = type.__new__(type, cls.__name__, cls.__bases__, new_dict)
+    new_cls = type.__new__(type, cls.__name__, (cls,), new_dict)
     return new_cls

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -469,6 +469,11 @@ class WebhookConfig:
         self.webhook_config = webhook_config
 
 
+class Method:
+    def __init__(self, raw_f: Callable[..., Any]):
+        self.raw_f = raw_f
+
+
 class _FunctionHandle(_Handle, type_prefix="fu"):
     """Interact with a Modal Function of a live app."""
 
@@ -1134,7 +1139,7 @@ def _set_current_input_id(input_id: Optional[str]):
 def class_decorator(cls: type, method_decorator):
     new_dict = {}
     for k, v in cls.__dict__.items():
-        if callable(v) or isinstance(v, WebhookConfig):
+        if isinstance(v, (Method, WebhookConfig)):
             # TODO(erikbern): ignore classmethod, staticmethod etc
             new_dict[k] = method_decorator(v)
     new_cls = type.__new__(type, cls.__name__, (cls,), new_dict)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -463,6 +463,12 @@ class FunctionStats:
     num_total_runners: int
 
 
+class WebhookConfig:
+    def __init__(self, raw_f: Callable[..., Any], webhook_config: api_pb2.WebhookConfig):
+        self.raw_f = raw_f
+        self.webhook_config = webhook_config
+
+
 class _FunctionHandle(_Handle, type_prefix="fu"):
     """Interact with a Modal Function of a live app."""
 
@@ -1143,7 +1149,7 @@ def _set_current_input_id(input_id: Optional[str]):
 def class_decorator(cls: type, method_decorator):
     new_dict = {}
     for k, v in cls.__dict__.items():
-        if callable(v):
+        if callable(v) or isinstance(v, WebhookConfig):
             # TODO(erikbern): ignore classmethod, staticmethod etc
             new_dict[k] = method_decorator(v)
     new_cls = type.__new__(type, cls.__name__, (cls,), new_dict)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1135,7 +1135,7 @@ class _PartialFunction:
         self.raw_f = raw_f
         self.webhook_config = webhook_config
 
-    def __get__(self, obj, objtype=None):
+    def __get__(self, obj, objtype=None) -> _FunctionHandle:
         k = self.raw_f.__name__
         if obj:  # Cls().fun
             function_handle = obj._modal_function_handles[k]

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1145,3 +1145,21 @@ class _PartialFunction:
 
 
 PartialFunction, AioPartialFunction = synchronize_apis(_PartialFunction)
+
+
+def _method() -> Callable[[Callable[..., Any]], _PartialFunction]:
+    """Decorator for methods that should be transformed by Modal.
+
+    Usage:
+    ```
+    @stub.cls(cpu=8)
+    class MyCls:
+        @method()
+        def f(self):
+            ...
+    ```
+    """
+    return _PartialFunction
+
+
+method, aio_method = synchronize_apis(_method)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -832,11 +832,20 @@ class _Function(_Provider[_FunctionHandle]):
         self._tag = self._info.get_tag()
         self._gpu_config = parse_gpu_config(gpu)
         self._cloud = cloud
-        self._cls = _cls
         if cloud:
             self._cloud_provider = parse_cloud_provider(cloud)
         else:
             self._cloud_provider = None
+
+        if self._info.definition_type == api_pb2.Function.DEFINITION_TYPE_SERIALIZED:
+            # Use cloudpickle. Used when working w/ Jupyter notebooks.
+            # serialize at _load time, not function decoration time
+            # otherwise we can't capture a surrounding class for lifetime methods etc.
+            self._function_serialized = self._info.serialized_function
+            self._class_serialized = cloudpickle.dumps(_cls) if _cls is not None else None
+        else:
+            self._function_serialized = None
+            self._class_serialized = None
 
         self._panel_items = [
             str(i)
@@ -930,16 +939,6 @@ class _Function(_Provider[_FunctionHandle]):
         else:
             pty_info = None
 
-        function_serialized = None
-        class_serialized = None
-        if self._info.definition_type == api_pb2.Function.DEFINITION_TYPE_SERIALIZED:
-            # Use cloudpickle. Used when working w/ Jupyter notebooks.
-            # serialize at _load time, not function decoration time
-            # otherwise we can't capture a surrounding class for lifetime methods etc.
-            function_serialized = self._info.serialized_function
-            if self._cls is not None:
-                class_serialized = cloudpickle.dumps(self._cls)
-
         if self._keep_warm is True:
             deprecation_warning(
                 date(2023, 3, 3),
@@ -957,8 +956,8 @@ class _Function(_Provider[_FunctionHandle]):
             secret_ids=secret_ids,
             image_id=image_id,
             definition_type=self._info.definition_type,
-            function_serialized=function_serialized,
-            class_serialized=class_serialized,
+            function_serialized=self._function_serialized,
+            class_serialized=self._class_serialized,
             function_type=function_type,
             resources=api_pb2.Resources(milli_cpu=milli_cpu, gpu_config=self._gpu_config, memory_mb=self._memory),
             webhook_config=self._webhook_config,

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -463,15 +463,12 @@ class FunctionStats:
     num_total_runners: int
 
 
-class WebhookConfig:
-    def __init__(self, raw_f: Callable[..., Any], webhook_config: api_pb2.WebhookConfig):
+class _PartialFunction:
+    """Intermediate function, produced by @method or @web_endpoint"""
+
+    def __init__(self, raw_f: Callable[..., Any], webhook_config: Optional[api_pb2.WebhookConfig] = None):
         self.raw_f = raw_f
         self.webhook_config = webhook_config
-
-
-class Method:
-    def __init__(self, raw_f: Callable[..., Any]):
-        self.raw_f = raw_f
 
 
 class _FunctionHandle(_Handle, type_prefix="fu"):
@@ -1139,7 +1136,7 @@ def _set_current_input_id(input_id: Optional[str]):
 def class_decorator(cls: type, method_decorator):
     new_dict = {}
     for k, v in cls.__dict__.items():
-        if isinstance(v, (Method, WebhookConfig)):
+        if isinstance(v, _PartialFunction):
             # TODO(erikbern): ignore classmethod, staticmethod etc
             new_dict[k] = method_decorator(v)
     new_cls = type.__new__(type, cls.__name__, (cls,), new_dict)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1133,5 +1133,8 @@ class _PartialFunction:
 
     def __get__(self, obj, objtype=None):
         k = self.raw_f.__name__
-        function_handle = obj._modal_function_handles[k]
+        if obj:  # Cls().fun
+            function_handle = obj._modal_function_handles[k]
+        else:  # Cls.fun
+            function_handle = objtype._modal_function_handles[k]
         return function_handle.__get__(obj, objtype)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -32,7 +32,7 @@ from ._blob_utils import (
     blob_download,
     blob_upload,
 )
-from ._function_utils import FunctionInfo, LocalFunctionError, load_function_from_module
+from ._function_utils import FunctionInfo
 from ._location import parse_cloud_provider
 from ._output import OutputManager
 from ._resolver import Resolver
@@ -935,23 +935,8 @@ class _Function(_Provider[_FunctionHandle]):
             # serialize at _load time, not function decoration time
             # otherwise we can't capture a surrounding class for lifetime methods etc.
             function_serialized = self._info.serialized_function
-            mod = inspect.getmodule(self._raw_f)
-
             if self._cls is not None:
-                cls = self._cls
-            else:
-                # This is probably the case of a function in global scope,
-                # but it *might* be a function decorated on a class.
-                # We should probably deprecate it, since it's a messy case
-                try:
-                    cls, _ = load_function_from_module(mod, self._raw_f.__qualname__)
-                except LocalFunctionError:
-                    # if a serialized function is defined within a function scope
-                    # we can't load it from the module and detect its parent class
-                    cls = None
-
-            if cls:
-                class_serialized = cloudpickle.dumps(cls)
+                class_serialized = cloudpickle.dumps(self._cls)
 
         if self._keep_warm is True:
             deprecation_warning(

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1127,6 +1127,10 @@ def _set_current_input_id(input_id: Optional[str]):
 class _PartialFunction:
     """Intermediate function, produced by @method or @web_endpoint"""
 
+    @staticmethod
+    def initialize_cls(user_cls: type, function_handles: Dict[str, _FunctionHandle]):
+        user_cls._modal_function_handles = function_handles
+
     def __init__(self, raw_f: Callable[..., Any], webhook_config: Optional[api_pb2.WebhookConfig] = None):
         self.raw_f = raw_f
         self.webhook_config = webhook_config

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -863,20 +863,20 @@ class _Stub:
             await wrapped_fn.call(cmd)
 
     @decorator_with_options_unsupported
-    def cls(self, cls=None, **kwargs):
+    def cls(self, user_cls=None, **kwargs):
         # TOOD(erikbern): include all the docstring from stub.function
 
-        # All methods to know what class they are on
-        kwargs.update(_cls=cls)
+        # All methods need to know what class they are on
+        kwargs.update(_cls=user_cls)
 
-        function_handles = {}
-        for k, v in cls.__dict__.items():
+        function_handles: Dict[str, _FunctionHandle] = {}
+        for k, v in user_cls.__dict__.items():
             if isinstance(v, (PartialFunction, AioPartialFunction)):
                 partial_function = synchronizer._translate_in(v)  # TODO: remove need for?
                 function_handles[k] = self.function(**kwargs)(partial_function)
 
-        cls._modal_function_handles = function_handles
-        return cls
+        _PartialFunction.initialize_cls(user_cls, function_handles)
+        return user_cls
 
 
 Stub, AioStub = synchronize_apis(_Stub)

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -26,7 +26,7 @@ from .app import _App, _container_app, is_local
 from .client import _Client
 from .config import logger
 from .exception import InvalidError, deprecation_warning
-from .functions import _Function, _FunctionHandle, class_decorator
+from .functions import _Function, _FunctionHandle, class_decorator, WebhookConfig
 from .gpu import GPU_T
 from .image import _Image, _ImageHandle
 from .mount import _get_client_mount, _Mount
@@ -51,12 +51,6 @@ class LocalEntrypoint:
 
     def __call__(self, *args, **kwargs):
         return self.raw_f(*args, **kwargs)
-
-
-class WebhookConfig:
-    def __init__(self, raw_f: Callable[..., Any], webhook_config: api_pb2.WebhookConfig):
-        self.raw_f = raw_f
-        self.webhook_config = webhook_config
 
 
 def check_sequence(items: typing.Sequence[typing.Any], item_type: typing.Type[typing.Any], error_msg: str):

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -856,7 +856,7 @@ class _Stub:
 
     @synchronizer.nowrap
     @decorator_with_options
-    def service(self, cls=None, **kwargs):
+    def cls(self, cls=None, **kwargs):
         # TOOD(erikbern): include all the docstring from stub.function
 
         # All methods to know what class they are on

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -862,7 +862,7 @@ class _Stub:
 
     @synchronizer.nowrap
     @decorator_with_options
-    def service(self, cls, **kwargs):
+    def service(self, cls=None, **kwargs):
         # TOOD(erikbern): include all the docstring from stub.function
 
         # All methods to know what class they are on

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -646,13 +646,6 @@ class _Stub:
         return function_handle
 
     @decorator_with_options_unsupported
-    def method(
-        self,
-        raw_f: Optional[Callable[..., Any]] = None,
-    ):  # TODO: return type!
-        return _PartialFunction(raw_f)
-
-    @decorator_with_options_unsupported
     @typechecked
     def web_endpoint(
         self,
@@ -663,6 +656,7 @@ class _Stub:
         ] = None,  # Label for created endpoint. Final subdomain will be <workspace>--<label>.modal.run.
         wait_for_response: bool = True,  # Whether requests should wait for and return the function response.
     ):  # TODO: return type!
+        # TODO(erikbern): let's move this out to not sit on the stub
         """Register a basic web endpoint with this application.
 
         This is the simple way to create a web endpoint on Modal. The function

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -863,17 +863,53 @@ class _Stub:
             await wrapped_fn.call(cmd)
 
     @decorator_with_options_unsupported
-    def cls(self, user_cls=None, **kwargs):
-        # TOOD(erikbern): include all the docstring from stub.function
-
-        # All methods need to know what class they are on
-        kwargs.update(_cls=user_cls)
-
+    def cls(
+        self,
+        user_cls: Optional[type] = None,
+        image: Optional[_Image] = None,  # The image to run as the container for the function
+        secret: Optional[_Secret] = None,  # An optional Modal Secret with environment variables for the container
+        secrets: Sequence[_Secret] = (),  # Plural version of `secret` when multiple secrets are needed
+        gpu: GPU_T = None,  # GPU specification as string ("any", "T4", "A10G", ...) or object (`modal.GPU.A100()`, ...)
+        serialized: bool = False,  # Whether to send the function over using cloudpickle.
+        mounts: Sequence[_Mount] = (),
+        shared_volumes: Dict[str, _SharedVolume] = {},
+        allow_cross_region_volumes: bool = False,  # Whether using shared volumes from other regions is allowed.
+        cpu: Optional[float] = None,  # How many CPU cores to request. This is a soft limit.
+        memory: Optional[int] = None,  # How much memory to request, in MiB. This is a soft limit.
+        proxy: Optional[_Proxy] = None,  # Reference to a Modal Proxy to use in front of this function.
+        retries: Optional[Union[int, Retries]] = None,  # Number of times to retry each input in case of failure.
+        concurrency_limit: Optional[int] = None,  # Limit for max concurrent containers running the function.
+        container_idle_timeout: Optional[int] = None,  # Timeout for idle containers waiting for inputs to shut down.
+        timeout: Optional[int] = None,  # Maximum execution time of the function in seconds.
+        interactive: bool = False,  # Whether to run the function in interactive mode.
+        keep_warm: Union[bool, int, None] = None,  # An optional number of containers to always keep warm.
+        cloud: Optional[str] = None,  # Cloud provider to run the function on. Possible values are aws, gcp, auto.
+    ) -> type:
         function_handles: Dict[str, _FunctionHandle] = {}
         for k, v in user_cls.__dict__.items():
             if isinstance(v, (PartialFunction, AioPartialFunction)):
                 partial_function = synchronizer._translate_in(v)  # TODO: remove need for?
-                function_handles[k] = self.function(**kwargs)(partial_function)
+                function_handles[k] = self.function(
+                    _cls=user_cls,
+                    image=image,
+                    secret=secret,
+                    secrets=secrets,
+                    gpu=gpu,
+                    serialized=serialized,
+                    mounts=mounts,
+                    shared_volumes=shared_volumes,
+                    allow_cross_region_volumes=allow_cross_region_volumes,
+                    cpu=cpu,
+                    memory=memory,
+                    proxy=proxy,
+                    retries=retries,
+                    concurrency_limit=concurrency_limit,
+                    container_idle_timeout=container_idle_timeout,
+                    timeout=timeout,
+                    interactive=interactive,
+                    keep_warm=keep_warm,
+                    cloud=cloud,
+                )(partial_function)
 
         _PartialFunction.initialize_cls(user_cls, function_handles)
         return user_cls

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -652,7 +652,7 @@ class _Stub:
     @decorator_with_options_unsupported
     def method(
         self,
-        raw_f: Callable[..., Any],
+        raw_f: Optional[Callable[..., Any]] = None,
     ) -> Method:
         return Method(raw_f)
 

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -13,7 +13,8 @@ from synchronicity.async_wrap import asynccontextmanager
 from modal._types import typechecked
 
 from modal_proto import api_pb2
-from modal_utils.async_utils import synchronize_apis
+
+from modal_utils.async_utils import synchronize_apis, synchronizer
 from modal_utils.decorator_utils import decorator_with_options_unsupported, decorator_with_options
 from .retries import Retries
 
@@ -859,6 +860,7 @@ class _Stub:
         async with self.run():
             await wrapped_fn.call(cmd)
 
+    @synchronizer.nowrap
     @decorator_with_options
     def service(self, cls, **kwargs):
         # TOOD(erikbern): include all the docstring from stub.function

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -653,7 +653,7 @@ class _Stub:
     def method(
         self,
         raw_f: Optional[Callable[..., Any]] = None,
-    ) -> Method:
+    ):  # TODO: return type!
         return Method(raw_f)
 
     @decorator_with_options_unsupported
@@ -666,7 +666,7 @@ class _Stub:
             str
         ] = None,  # Label for created endpoint. Final subdomain will be <workspace>--<label>.modal.run.
         wait_for_response: bool = True,  # Whether requests should wait for and return the function response.
-    ):
+    ):  # TODO: return type!
         """Register a basic web endpoint with this application.
 
         This is the simple way to create a web endpoint on Modal. The function

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -186,3 +186,16 @@ def fastapi_app():
         return {"hello": arg}
 
     return web_app
+
+
+@stub.service()
+class Service:
+    def __enter__(self):
+        self._k = 111
+
+    def f(self, x):
+        return self._k * x
+
+    @stub.web_endpoint()
+    def web(self, arg):
+        return {"ret": arg * self._k}

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -188,8 +188,8 @@ def fastapi_app():
     return web_app
 
 
-@stub.service()
-class Service:
+@stub.cls()
+class Cls:
     def __enter__(self):
         self._k = 111
 

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -6,7 +6,7 @@ import time
 
 import pytest
 
-from modal import Stub
+from modal import Stub, method
 from modal.exception import DeprecationError, deprecation_warning
 
 SLEEP_DELAY = 0.1
@@ -193,7 +193,7 @@ class Cls:
     def __enter__(self):
         self._k = 111
 
-    @stub.method()
+    @method()
     def f(self, x):
         return self._k * x
 

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -193,6 +193,7 @@ class Cls:
     def __enter__(self):
         self._k = 111
 
+    @stub.method()
     def f(self, x):
         return self._k * x
 


### PR DESCRIPTION
The main benefit is for container lifecycle management. Instead of the awkward (imo) syntax

```python
class FooModel:
    def __enter__(self):
        self.model = load_model()

    @stub.function(cpu=8)
    def predict(self, x):
        return self.model(x)
```

this PR enables you to write this:

```python
@stub.cls(cpu=8)
class FooModel:
    def __enter__(self):
        self.model = load_model()

    @stub.method()
    def predict(self, x):
        return self.model(x)
```

Slightly bigger example:

```python
import modal

stub = modal.Stub()

@stub.cls(cpu=8)
class Foo:
    @stub.method()
    def bar(self, x):
        print("bar!", x)
        return x ** 2

    @stub.method()
    def baz(self, x):
        return x ** 3


@stub.local_entrypoint
def run():
    foo = Foo()
    assert foo.bar(42) == 1764
    assert foo.baz(100) == 1000000
```

#  TESTS MISSING

* [X] Serialization
* [X] Lifecycle methods (container test)
* [X] Test that you can call one method from another method (both using `.call` and "internally")
* [X] Web endpoint tests

# Questions?

* Should we require some special syntax for the constructor
* ~Might not want to wrap special (dunder) methods~
* ~I just shoved all the decorator args for `stub.cls` into a `kwargs` but we should expand for better docs~
* ~Naming? "service" isn't maybe ideal~ – edit: going for `cls`
* Make sure the constructor takes no arguments
