### PR TITLE
Re-enable state management for AppSetObjects

### DIFF
--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -149,16 +149,26 @@ def test_help_message_unspecified_function(servicer, set_env_client, test_dir):
     assert "bar" in result.stderr
 
 
+def test_run_states(servicer, set_env_client, test_dir):
+    stub_file = test_dir / "supports" / "app_run_tests" / "default_stub.py"
+    _run(["run", stub_file.as_posix()])
+    assert servicer.app_state_history["ap-1"] == [
+        api_pb2.APP_STATE_INITIALIZING,
+        api_pb2.APP_STATE_EPHEMERAL,
+        api_pb2.APP_STATE_STOPPED,
+    ]
+
+
 def test_run_detach(servicer, set_env_client, test_dir):
     stub_file = test_dir / "supports" / "app_run_tests" / "default_stub.py"
     _run(["run", "--detach", stub_file.as_posix()])
-    assert servicer.app_state == {"ap-1": api_pb2.APP_STATE_DETACHED}
+    assert servicer.app_state_history["ap-1"] == [api_pb2.APP_STATE_INITIALIZING, api_pb2.APP_STATE_DETACHED]
 
 
 def test_deploy(servicer, set_env_client, test_dir):
     stub_file = test_dir / "supports" / "app_run_tests" / "default_stub.py"
     _run(["deploy", "--name=deployment_name", stub_file.as_posix()])
-    assert servicer.app_state == {"ap-1": api_pb2.APP_STATE_DEPLOYED}
+    assert servicer.app_state_history["ap-1"] == [api_pb2.APP_STATE_INITIALIZING, api_pb2.APP_STATE_DEPLOYED]
 
 
 def test_run_custom_stub(servicer, set_env_client, test_dir):

--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -42,7 +42,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
     container_outputs: list[api_pb2.FunctionPutOutputsRequest]
 
     def __init__(self, blob_host, blobs):
-        self.app_state = {}
+        self.app_state_history = defaultdict(list)
         self.app_heartbeats: Dict[str, int] = defaultdict(int)
         self.n_blobs = 0
         self.blob_host = blob_host
@@ -127,13 +127,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.requests.append(request)
         self.n_apps += 1
         app_id = f"ap-{self.n_apps}"
-        if request.initializing:
-            state = api_pb2.APP_STATE_INITIALIZING
-        elif request.detach:
-            state = api_pb2.APP_STATE_DETACHED
-        else:
-            state = api_pb2.APP_STATE_EPHEMERAL
-        self.app_state[app_id] = state
+        self.app_state_history[app_id].append(api_pb2.APP_STATE_INITIALIZING)
         await stream.send_message(api_pb2.AppCreateResponse(app_id=app_id))
 
     async def AppClientDisconnect(self, stream):
@@ -141,6 +135,9 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.requests.append(request)
         self.done = True
         self.app_client_disconnect_count += 1
+        state_history = self.app_state_history[request.app_id]
+        if state_history[-1] not in [api_pb2.APP_STATE_DETACHED, api_pb2.APP_STATE_DEPLOYED]:
+            state_history.append(api_pb2.APP_STATE_STOPPED)
         await stream.send_message(Empty())
 
     async def AppGetLogs(self, stream):
@@ -171,13 +168,13 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.app_objects[request.app_id] = dict(request.indexed_object_ids)
         self.app_set_objects_count += 1
         if request.new_app_state:
-            self.app_state[request.app_id] = request.new_app_state
+            self.app_state_history[request.app_id].append(request.new_app_state)
         await stream.send_message(Empty())
 
     async def AppDeploy(self, stream):
         request: api_pb2.AppDeployRequest = await stream.recv_message()
         self.deployed_apps[request.name] = request.app_id
-        self.app_state[request.app_id] = api_pb2.APP_STATE_DEPLOYED
+        self.app_state_history[request.app_id].append(api_pb2.APP_STATE_DEPLOYED)
         await stream.send_message(api_pb2.AppDeployResponse(url="http://test.modal.com/foo/bar"))
 
     async def AppGetByDeploymentName(self, stream):

--- a/modal/app.py
+++ b/modal/app.py
@@ -93,6 +93,7 @@ class _App:
             app_id=self._app_id,
             indexed_object_ids=indexed_object_ids,
             unindexed_object_ids=unindexed_object_ids,
+            new_app_state=new_app_state,
         )
         await retry_transient_errors(self._client.stub.AppSetObjects, req_set)
         return self._tag_to_object
@@ -187,6 +188,7 @@ class _App:
             app_id=self.app_id,
             indexed_object_ids=indexed_object_ids,
             unindexed_object_ids=unindexed_object_ids,
+            new_app_state=api_pb2.APP_STATE_UNSPECIFIED,  # app is either already deployed or will be set to deployed after this call
         )
         await retry_transient_errors(self._client.stub.AppSetObjects, req_set)
 

--- a/modal/app.py
+++ b/modal/app.py
@@ -93,7 +93,7 @@ class _App:
             app_id=self._app_id,
             indexed_object_ids=indexed_object_ids,
             unindexed_object_ids=unindexed_object_ids,
-            new_app_state=new_app_state,
+            new_app_state=new_app_state,  # type: ignore
         )
         await retry_transient_errors(self._client.stub.AppSetObjects, req_set)
         return self._tag_to_object

--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -7,7 +7,7 @@ from ._version_generated import build_number  # Written by GitHub
 major_number = 0
 
 # Bump this manually on any major changes
-minor_number = 47
+minor_number = 48
 
 # Right now, set the patch number (the 3rd field) to the job run number in GitHub
 __version__ = f"{major_number}.{minor_number}.{build_number}"


### PR DESCRIPTION
Also adds a bunch of tests replicating state management from backend, to make sure we don't regress this behavior again