### PR TITLE
Adds runtime typechecking using `typeguard` MOD-763

### DIFF
--- a/client_test/secret_test.py
+++ b/client_test/secret_test.py
@@ -1,5 +1,9 @@
 # Copyright Modal Labs 2022
+import pytest
+import typeguard
+
 from modal import Secret, Stub
+from modal.secret import AioSecret
 
 
 def test_secret(servicer, client):
@@ -7,3 +11,11 @@ def test_secret(servicer, client):
     stub.secret = Secret({"FOO": "BAR"})
     with stub.run(client=client) as running_app:
         assert running_app.secret.object_id == "st-123"
+
+
+def test_init_types():
+    with pytest.raises(typeguard.TypeCheckError):
+        Secret({"foo": None})
+
+    with pytest.raises(typeguard.TypeCheckError):
+        AioSecret({"foo": None})

--- a/client_test/stub_test.py
+++ b/client_test/stub_test.py
@@ -43,12 +43,10 @@ async def test_attrs(servicer, aio_client):
 
 @pytest.mark.asyncio
 async def test_stub_type_validation(servicer, aio_client):
-    with pytest.raises(InvalidError) as excinfo:
+    with pytest.raises(typeguard.TypeCheckError) as excinfo:
         stub = AioStub(
             foo=4242,
         )
-
-    assert "4242" in str(excinfo.value)
 
     stub = AioStub()
 

--- a/client_test/stub_test.py
+++ b/client_test/stub_test.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 import os
 import pytest
+import typeguard
 
 from google.protobuf.empty_pb2 import Empty
 from grpclib import GRPCError, Status
@@ -240,3 +241,22 @@ def test_registered_web_endpoints(client, servicer):
     stub.webhook(square_webhook)
 
     assert stub.registered_web_endpoints == ["square_webhook"]
+
+
+def test_init_types():
+    with pytest.raises(typeguard.TypeCheckError):
+        Stub(secrets=modal.Secret())  # singular secret to plural argument
+    with pytest.raises(typeguard.TypeCheckError):
+        Stub(secrets=[{"foo": "bar"}])  # not a Secret Object
+    with pytest.raises(typeguard.TypeCheckError):
+        Stub(some_arg=5)  # blueprint needs to use Providers
+    with pytest.raises(typeguard.TypeCheckError):
+        Stub(image=modal.Secret())  # should be an Image
+
+    Stub(
+        image=modal.Image.debian_slim().pip_install("typeguard"),
+        secrets=[modal.Secret()],
+        mounts=[modal.Mount.from_local_file(__file__)],
+        some_dict=modal.Dict(),
+        some_queue=modal.Queue(),
+    )

--- a/modal/requirements.txt
+++ b/modal/requirements.txt
@@ -20,3 +20,4 @@ toml==0.10.2
 typer==0.6.1
 types-certifi==2021.10.8.3
 types-toml==0.10.4
+typeguard>=3.0.0

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -1,4 +1,8 @@
 # Copyright Modal Labs 2022
+from typing import Dict
+
+from typeguard import typechecked
+
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronize_apis
 
@@ -23,7 +27,14 @@ class _Secret(Provider[_SecretHandle]):
     See [the secrets guide page](/docs/guide/secrets) for more information.
     """
 
-    def __init__(self, env_dict={}, template_type=""):
+    @typechecked
+    def __init__(
+        self,
+        env_dict: Dict[
+            str, str
+        ] = {},  # dict of entries to be inserted as environment variables in functions using the secret
+        template_type="",  # internal use only
+    ):
         async def _load(resolver: Resolver, existing_object_id: str) -> _SecretHandle:
             req = api_pb2.SecretCreateRequest(
                 app_id=resolver.app_id,

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -7,7 +7,9 @@ from multiprocessing.synchronize import Event
 import os
 import sys
 import warnings
-from typing import AsyncGenerator, Collection, Dict, List, Optional, Union, Any
+from typing import AsyncGenerator, Collection, Dict, List, Optional, Union, Any, Sequence
+
+from typeguard import typechecked
 
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronize_apis
@@ -85,14 +87,15 @@ class _Stub:
     _blueprint: Dict[str, Provider]
     _client_mount: Optional[_Mount]
     _function_mounts: Dict[str, _Mount]
-    _mounts: Collection[_Mount]
-    _secrets: Collection[_Secret]
+    _mounts: Sequence[_Mount]
+    _secrets: Sequence[_Secret]
     _function_handles: Dict[str, _FunctionHandle]
     _web_endpoints: List[str]  # Used by the CLI
     _local_entrypoints: Dict[str, LocalEntrypoint]
     _local_mounts: List[_Mount]
     _app: Optional[_App]
 
+    @typechecked
     def __init__(
         self,
         name: Optional[str] = None,
@@ -100,8 +103,8 @@ class _Stub:
         image: Optional[
             _Image
         ] = _default_image,  # default image for all functions (default is modal.Image.debian_Slim)
-        mounts: Collection[_Mount] = [],  # default mounts for all functions
-        secrets: Collection[_Secret] = [],  # default secrets for all functions
+        mounts: Sequence[_Mount] = [],  # default mounts for all functions
+        secrets: Sequence[_Secret] = [],  # default secrets for all functions
         **blueprint: Provider,  # any Modal Object dependencies (Dict, Queue, etc.)
     ) -> None:
         """Construct a new app stub, optionally with default image, mounts, secrets

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -94,6 +94,7 @@ class _Stub:
     _local_entrypoints: Dict[str, LocalEntrypoint]
     _local_mounts: List[_Mount]
     _app: Optional[_App]
+    _default_image: _Image = _default_image
 
     @typechecked
     def __init__(
@@ -102,7 +103,7 @@ class _Stub:
         *,
         image: Optional[
             _Image
-        ] = _default_image,  # default image for all functions (default is modal.Image.debian_Slim)
+        ] = _default_image,  # default image for all functions (default is `modal.Image.debian_slim()`)
         mounts: Sequence[_Mount] = [],  # default mounts for all functions
         secrets: Sequence[_Secret] = [],  # default secrets for all functions
         **blueprint: Provider,  # any Modal Object dependencies (Dict, Queue, etc.)

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -128,8 +128,6 @@ class _Stub:
         if image is not None:
             self._blueprint["image"] = image  # backward compatibility since "image" used to be on the blueprint
             self._default_image = image
-        else:
-            self._default_image = _default_image
 
         self._client_mount = None
         self._function_mounts = {}

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -127,6 +127,7 @@ class _Stub:
             self._validate_blueprint_value(k, v)
 
         self._blueprint = blueprint
+        self._blueprint["image"] = image  # backward compatibility since "image" used to be on the blueprint
         self._client_mount = None
         self._function_mounts = {}
         self._mounts = mounts

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -101,9 +101,7 @@ class _Stub:
         self,
         name: Optional[str] = None,
         *,
-        image: Optional[
-            _Image
-        ] = _default_image,  # default image for all functions (default is `modal.Image.debian_slim()`)
+        image: Optional[_Image] = None,  # default image for all functions (default is `modal.Image.debian_slim()`)
         mounts: Sequence[_Mount] = [],  # default mounts for all functions
         secrets: Sequence[_Secret] = [],  # default secrets for all functions
         **blueprint: Provider,  # any Modal Object dependencies (Dict, Queue, etc.)
@@ -127,7 +125,12 @@ class _Stub:
             self._validate_blueprint_value(k, v)
 
         self._blueprint = blueprint
-        self._blueprint["image"] = image  # backward compatibility since "image" used to be on the blueprint
+        if image is not None:
+            self._blueprint["image"] = image  # backward compatibility since "image" used to be on the blueprint
+            self._default_image = image
+        else:
+            self._default_image = _default_image
+
         self._client_mount = None
         self._function_mounts = {}
         self._mounts = mounts
@@ -136,7 +139,6 @@ class _Stub:
         self._local_entrypoints = {}
         self._local_mounts = []
         self._web_endpoints = []
-        self._default_image = image
 
         self._app = None
         if not is_local():

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     types-certifi
     types-toml
     watchfiles
+    typeguard>=3.0.0
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
In this PR only:
* Stub constructor
* Secret constructor

+ tests for above

If this works well and we think it looks good enough we can easily add the same decorators to the rest of the Modal objects

Example output for the following:
```python
stub = modal.Stub(secrets=[modal.Secret({"foo": None})])  # None is not a valid value
```

```
╭───────────────────── Traceback (most recent call last) ──────────────────────╮
│ /home/elias/code/modal/playground/stub_type_errors.py:5 in <module>          │
│                                                                              │
│    4                                                                         │
│ ❱  5 stub = modal.Stub(secrets=[modal.Secret({"foo": None})])                │
│    6                                                                         │
│                                                                              │
│ /home/elias/code/synchronicity/synchronicity/synchronizer.py:443 in my_init  │
│                                                                              │
│ /home/elias/code/modal-client/modal/secret.py:31 in __init__                 │
│                                                                              │
│   30 │   @typechecked                                                        │
│ ❱ 31 │   def __init__(                                                       │
│   32 │   │   self,                                                           │
│                                                                              │
│ /home/elias/code/modal/.venv/lib/python3.9/site-packages/typeguard/_function │
│ s.py:113 in check_argument_types                                             │
│                                                                              │
│   112 │   │   │   try:                                                       │
│ ❱ 113 │   │   │   │   check_type_internal(value, expected_type, memo=memo)   │
│   114 │   │   │   except TypeCheckError as exc:                              │
│                                                                              │
│ /home/elias/code/modal/.venv/lib/python3.9/site-packages/typeguard/_checkers │
│ .py:667 in check_type_internal                                               │
│                                                                              │
│   666 │   │   if checker:                                                    │
│ ❱ 667 │   │   │   checker(value, origin_type, args, memo)                    │
│   668 │   │   │   return                                                     │
│                                                                              │
│ /home/elias/code/modal/.venv/lib/python3.9/site-packages/typeguard/_checkers │
│ .py:227 in check_mapping                                                     │
│                                                                              │
│   226 │   │   │   │   try:                                                   │
│ ❱ 227 │   │   │   │   │   check_type_internal(v, value_type, memo)           │
│   228 │   │   │   │   except TypeCheckError as exc:                          │
│                                                                              │
│ /home/elias/code/modal/.venv/lib/python3.9/site-packages/typeguard/_checkers │
│ .py:671 in check_type_internal                                               │
│                                                                              │
│   670 │   if not isinstance(value, origin_type):                             │
│ ❱ 671 │   │   raise TypeCheckError(f"is not an instance of {qualified_name(o │
│   672                                                                        │
╰──────────────────────────────────────────────────────────────────────────────╯
TypeCheckError: value of key 'foo' of argument "env_dict" (dict) is not an 
instance of str
```