### PR TITLE
Add flag to explicitly allow shared volumes to be used cross regions

### DIFF
--- a/modal/stub.py
+++ b/modal/stub.py
@@ -449,6 +449,7 @@ class _Stub:
         serialized: bool = False,  # Whether to send the function over using cloudpickle.
         mounts: Collection[_Mount] = (),
         shared_volumes: Dict[str, _SharedVolume] = {},
+        allow_cross_region_volumes: bool = False,  # Whether using shared volumes from other regions is allowed.
         cpu: Optional[float] = None,  # How many CPU cores to request. This is a soft limit.
         memory: Optional[int] = None,  # How much memory to request, in MiB. This is a soft limit.
         proxy: Optional[_Proxy] = None,  # Reference to a Modal Proxy to use in front of this function.
@@ -495,6 +496,7 @@ class _Stub:
             base_mounts=base_mounts,
             mounts=mounts,
             shared_volumes=shared_volumes,
+            allow_cross_region_volumes=allow_cross_region_volumes,
             memory=memory,
             proxy=proxy,
             retries=retries,

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -891,6 +891,7 @@ message SharedVolumeMount {
   string mount_path = 1;
   string shared_volume_id = 2;
   CloudProvider cloud_provider = 3;
+  bool allow_cross_region = 4;
 }
 
 message TaskLogs {


### PR DESCRIPTION
Using shared volumes from other regions (cloud providers) triggers a warning today. This warning is commonly overlooked so the behaviour will change to triggering an error unless you explicitly allow it by setting `allow_cross_region_volumes=True`, e.g.:

```python
@stub.function(shared_volumes={"/root/cache": volume}, allow_cross_region_volumes=True)
def f(x):
  ...
```

For maximum control, the flag should be specified per (function,shared-volume) pair (i.e. "allow function f to access volume1 cross-region, but not volume2") - but there's no easy way to expose that in the Python API as is today.
Proto API-wise we have this fine-grained control however, as the flag is added to `SharedVolumeMount` (it's just not exposed).