### PR TITLE
fix: restore still-used MODAL_SERVE_TIMEOUT functionality

### DIFF
--- a/modal/_live_reload.py
+++ b/modal/_live_reload.py
@@ -16,6 +16,7 @@ from ._output import OutputManager
 from ._watcher import watch
 from .cli.import_refs import import_stub
 from .client import _Client
+from .config import config
 
 
 def _run_serve(stub_ref: str, existing_app_id: str, is_ready: Event):
@@ -74,6 +75,9 @@ async def _run_serve_loop(
     stub = import_stub(stub_ref)
     if stub._description is None:
         stub._description = _get_clean_stub_description(stub_ref)
+
+    if timeout is None:
+        timeout = config["serve_timeout"]
 
     unsupported_msg = None
     if platform.system() == "Windows":

--- a/modal/config.py
+++ b/modal/config.py
@@ -139,6 +139,7 @@ _SETTINGS = {
     "token_secret": _Setting(),
     "task_id": _Setting(),
     "task_secret": _Setting(),
+    "serve_timeout": _Setting(transform=float),
     "sync_entrypoint": _Setting(),
     "logs_timeout": _Setting(10, float),
     "image_python_version": _Setting(),


### PR DESCRIPTION
Found the reason our webhook benchmarks/demos were failing, which was partially hidden by _another_ client bug. We need this functionality in synmon still.

cc @erikbern unless you actually want to be rid of this setting.