### PR TITLE
Propagate allow_cross_region_volumes flag on shell usage

### DIFF
--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -240,6 +240,7 @@ def shell(
             cmd,
             mounts=_function._mounts,
             shared_volumes=_function._shared_volumes,
+            allow_cross_region_volumes=_function._allow_cross_region_volumes,
             image=_function._image,
             secrets=_function._secrets,
             gpu=_function._gpu,


### PR DESCRIPTION
Related changes: https://github.com/modal-labs/modal-client/pull/405