### PR TITLE
Add unit test for exceptions during async call

### DIFF
--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -236,6 +236,18 @@ def test_function_exception(client, servicer):
         assert "foo!" in str(excinfo.value)
 
 
+@pytest.mark.asyncio
+async def test_function_exception_async(aio_client, servicer):
+    stub = AioStub()
+
+    failure_modal = stub.function(servicer.function_body(failure))
+
+    async with stub.run(client=aio_client):
+        with pytest.raises(CustomException) as excinfo:
+            await failure_modal.call()
+        assert "foo!" in str(excinfo.value)
+
+
 def custom_exception_function(x):
     if x == 4:
         raise CustomException("bad")


### PR DESCRIPTION
While running integration tests against #420, I ran into an issue with exceptions.

I was able to verify that this is a real regression. This client test reproduces the regression – it fails in #420 but passes on main.

Going to try to reproduce this in synchronicity 0.3.0 next and patch it. After it's fixed, I'll release synchronicity 0.3.1 and will pin #420 to 0.3.1 instead.