### PR TITLE
Allow dockerfile commands for setup + micromamba image

### DIFF
--- a/client_test/image_test.py
+++ b/client_test/image_test.py
@@ -240,13 +240,13 @@ def test_conda_update_from_environment(servicer, client):
 
 
 def test_dockerhub_install(servicer, client):
-    stub = Stub(image=Image.from_dockerhub("gisops/valhalla:latest", setup_commands=["apt-get update"]))
+    stub = Stub(image=Image.from_dockerhub("gisops/valhalla:latest", setup_dockerfile_commands=["RUN apt-get update"]))
 
     with stub.run(client=client) as running_app:
         layers = get_image_layers(running_app["image"].object_id, servicer)
 
         assert any("FROM gisops/valhalla:latest" in cmd for cmd in layers[0].dockerfile_commands)
-        assert any("apt-get update" in cmd for cmd in layers[0].dockerfile_commands)
+        assert any("RUN apt-get update" in cmd for cmd in layers[0].dockerfile_commands)
 
 
 def test_ecr_install(servicer, client):
@@ -254,7 +254,7 @@ def test_ecr_install(servicer, client):
     stub = Stub(
         image=Image.from_aws_ecr(
             image_tag,
-            setup_commands=["apt-get update"],
+            setup_dockerfile_commands=["RUN apt-get update"],
             secret=Secret({"AWS_ACCESS_KEY_ID": "", "AWS_SECRET_ACCESS_KEY": ""}),
         )
     )
@@ -263,7 +263,7 @@ def test_ecr_install(servicer, client):
         layers = get_image_layers(running_app["image"].object_id, servicer)
 
         assert any(f"FROM {image_tag}" in cmd for cmd in layers[0].dockerfile_commands)
-        assert any("apt-get update" in cmd for cmd in layers[0].dockerfile_commands)
+        assert any("RUN apt-get update" in cmd for cmd in layers[0].dockerfile_commands)
 
 
 def run_f():

--- a/modal/image.py
+++ b/modal/image.py
@@ -692,6 +692,21 @@ class _Image(Provider[_ImageHandle]):
         return self.extend(dockerfile_commands=dockerfile_commands, context_files=context_files)
 
     @staticmethod
+    @typechecked
+    def micromamba(python_version: str = "3.9") -> "_Image":
+        """A Micromamba base image. Micromamba allows for fast building of small conda-based containers."""
+        _validate_python_version(python_version)
+
+        return _Image.from_dockerhub(
+            "mambaorg/micromamba:1.3.1-bullseye-slim",
+            setup_dockerfile_commands=[
+                'SHELL ["/usr/local/bin/_dockerfile_shell.sh"]',
+                "ENV MAMBA_DOCKERFILE_ACTIVATE=1",
+                f"RUN micromamba install -n base -y python={python_version} pip -c conda-forge",
+            ],
+        )
+
+    @staticmethod
     def _registry_setup_commands(
         tag: str, setup_dockerfile_commands: List[str], setup_commands: List[str]
     ) -> List[str]:


### PR DESCRIPTION
Relies on internal change to worker runtime that adds `ENTRYPOINT` support, so will merge after that's rolled out to all workers.