### PR TITLE
Stacked webhook decorator

### DIFF
--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -411,7 +411,7 @@ def test_allow_cross_region_volumes_webhook(client, servicer):
     stub = Stub()
     vol1, vol2 = SharedVolume(), SharedVolume()
     # Should pass flag for all the function's SharedVolumeMounts
-    stub.webhook(dummy, shared_volumes={"/sv-1": vol1, "/sv-2": vol2}, allow_cross_region_volumes=True)
+    stub.function(shared_volumes={"/sv-1": vol1, "/sv-2": vol2}, allow_cross_region_volumes=True)(stub.webhook(dummy))
 
     with stub.run(client=client):
         assert len(servicer.app_functions) == 1


### PR DESCRIPTION
This deprecates this syntax

```python
@stub.webhook(method="POST", cpu=42)
def f():
    ....
```

and replaces it with

```python
@stub.function(cpu=42)
@stub.webhook(method="POST")
def f():
    ....
```

The benefits are:

* Less repetitive `Stub` class
* Better support in class decorators – see #400
* Every webhook is now also a function you can call internally – unlike previously, where this wasn't possible

This code is more complicated than it should be, since we have to support the old syntax too, for a while.

# TODO

* Implement this for `asgi`
* Implement this for `wsgi`
* Make sure the function is overwritten on the app (so we don't create two functions)
* Fix integration tests? Might have to leave the deprecation warning for a day

# Question

Maybe this is is a good time to deprecate the term "webhook" and replace it with something else, like "web_endpoint" or something? That would also simplify the migration since we don't have to support two "modes" with `@stub.webhook`
