### PR TITLE
Adds support for multiple A100s in function

### DIFF
--- a/client_test/gpu_test.py
+++ b/client_test/gpu_test.py
@@ -99,9 +99,36 @@ def test_memory_selection_gpu_variant(client, servicer, memory, gpu_type):
     with stub.run(client=client):
         pass
 
-    # assert len(servicer.app_functions) == 1
     func_def = next(iter(servicer.app_functions.values()))
 
     assert func_def.resources.gpu_config.count == 1
     assert func_def.resources.gpu_config.type == gpu_type
     assert func_def.resources.gpu_config.memory == memory
+
+
+A100_GPU_COUNT_MAPPING = {1: api_pb2.GPU_TYPE_A100, **{i: api_pb2.GPU_TYPE_A100_40GB_MANY for i in range(1, 4)}}
+
+
+@pytest.mark.parametrize("count,gpu_type", A100_GPU_COUNT_MAPPING.items())
+def test_gpu_type_selection_from_count(client, servicer, count, gpu_type):
+    import modal
+
+    stub = Stub()
+
+    # Functions that use A100 20GB can only request one GPU
+    # at a time.
+    with pytest.raises(ValueError):
+        stub.function(dummy, gpu=modal.gpu.A100(count=2, memory=20))
+        with stub.run(client=client):
+            pass
+
+    # Task type changes whenever user asks more than 1 GPU on
+    # an A100.
+    stub.function(dummy, gpu=modal.gpu.A100(count=count))
+    with stub.run(client=client):
+        pass
+
+    func_def = next(iter(servicer.app_functions.values()))
+
+    assert func_def.resources.gpu_config.count == count
+    assert func_def.resources.gpu_config.type == gpu_type

--- a/modal/gpu.py
+++ b/modal/gpu.py
@@ -36,10 +36,18 @@ class A100(_GPUConfig):
         allowed_memory_values = {0, 20, 40}
         if memory not in allowed_memory_values:
             raise ValueError(f"A100s can only have memory values of {allowed_memory_values} => memory={memory}")
+
+        # Multi-GPU workloads require a different GPU type.
+        gpu_type = api_pb2.GPU_TYPE_A100
+        if count > 1:
+            gpu_type = api_pb2.GPU_TYPE_A100_40GB_MANY
+
         if memory == 20:
+            if count != 1:
+                raise ValueError(f"Cannot request more than 1 A100 20GB unit. Requested {count}")
             super().__init__(api_pb2.GPU_TYPE_A100_20G, count, memory)
         else:
-            super().__init__(api_pb2.GPU_TYPE_A100, count, memory)
+            super().__init__(gpu_type, count, memory)
 
     def __repr__(self):
         if self.memory == 20:

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -752,6 +752,7 @@ enum GPUType {
   GPU_TYPE_A10G = 3;
   GPU_TYPE_ANY = 4;
   GPU_TYPE_A100_20G = 5;
+  GPU_TYPE_A100_40GB_MANY = 6;
 }
 
 message GPUConfig {


### PR DESCRIPTION
Creates a new task type for running multi-GPU workloads with A100s. Resource requests like so

```python
@stub.function(gpu=modal.gpu.A100(count=N))
def f(): ...
```
will now be granted `N` GPUs. This is useful for training large models using multiple A100 GPUs on the same node. 