### PR TITLE
Skip typeguard package import entirely in containers

### DIFF
--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -39,7 +39,3 @@ __all__ = [
     "lookup",
     "current_input_id",
 ]
-
-import typeguard
-
-typeguard.config.collection_check_strategy = typeguard.CollectionCheckStrategy.ALL_ITEMS

--- a/modal/_types.py
+++ b/modal/_types.py
@@ -12,8 +12,9 @@ def typechecked(f: F) -> F:
     # where it matters the most
     is_local = not bool(config.get("image_id"))
     if is_local:
-        from typeguard import typechecked
+        import typeguard
 
-        return typechecked(f)
+        typeguard.config.collection_check_strategy = typeguard.CollectionCheckStrategy.ALL_ITEMS
+        return typeguard.typechecked(f)
     else:
         return f

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -490,7 +490,7 @@ class _FunctionHandle(Handle, type_prefix="fu"):
     def is_generator(self) -> bool:
         return self._is_generator
 
-    async def _map(self, input_stream: AsyncIterable, order_outputs: bool, return_exceptions: bool, kwargs={}):
+    async def _map(self, input_stream: AsyncIterable[Any], order_outputs: bool, return_exceptions: bool, kwargs={}):
         if order_outputs and self._is_generator:
             raise ValueError("Can't return ordered results for a generator")
 


### PR DESCRIPTION
It wasn't being used, but the import still happened and seemed to incur some performance penalties. Lets see if it's improved by this