### PR TITLE
Unwrap `UserCodeException` when return_exceptions=True

### DIFF
--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -4,7 +4,6 @@ import pytest
 import time
 
 import cloudpickle
-from synchronicity.exceptions import UserCodeException
 
 from modal import Proxy, Stub, SharedVolume
 from modal.exception import InvalidError
@@ -267,7 +266,7 @@ def test_map_exceptions(client, servicer):
 
         res = list(custom_function_modal.map(range(6), return_exceptions=True))
         assert res[:4] == [0, 1, 4, 9] and res[5] == 25
-        assert type(res[4]) == UserCodeException and "bad" in str(res[4])
+        assert type(res[4]) == CustomException and "bad" in str(res[4])
 
 
 def import_failure():

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -393,7 +393,10 @@ async def _map_invocation(
             output = await _process_result(item.result, client.stub, client)
         except Exception as e:
             if return_exceptions:
-                output = e
+                if isinstance(e, UserCodeException):
+                    output = e.exc
+                else:
+                    output = e
             else:
                 raise e
         return (item.idx, output)
@@ -547,7 +550,7 @@ class _FunctionHandle(Handle, type_prefix="fu"):
                 raise Exception("ohno")
             return a ** 2
 
-        # [0, 1, UserCodeException(Exception('ohno'))]
+        # [0, 1, Exception('ohno')]
         print(list(my_func.map(range(3), return_exceptions=True)))
         ```
         """


### PR DESCRIPTION
Noticed we were propagating UserCodeExceptions from synchronicity without unwrapping them (these are meant to be internal wrappers only).