### PR TITLE
Fix pytest warnings

### DIFF
--- a/client_test/container_app_test.py
+++ b/client_test/container_app_test.py
@@ -126,7 +126,6 @@ async def test_is_inside_default_image(servicer, unix_servicer, aio_client, aio_
         assert stub.is_inside()
 
 
-@pytest.mark.asyncio
 def test_typechecking_not_enforced_in_container():
     def incorrect_usage():
         class InvalidType:

--- a/client_test/grpc_utils_test.py
+++ b/client_test/grpc_utils_test.py
@@ -9,7 +9,7 @@ from grpclib import GRPCError, Status
 from modal_proto import api_grpc, api_pb2
 from modal_utils.grpc_utils import ChannelPool, create_channel, retry_transient_errors
 
-from .supports.skip import skip_windows
+from .supports.skip import skip_windows_unix_socket
 
 
 @pytest.mark.asyncio
@@ -25,7 +25,7 @@ async def test_http_channel(servicer):
     channel.close()
 
 
-@skip_windows
+@skip_windows_unix_socket
 @pytest.mark.asyncio
 async def test_unix_channel(unix_servicer):
     assert unix_servicer.remote_addr.startswith("unix://")


### PR DESCRIPTION
noticed some pytest warnings that were easy to fix:

```
../python3.10-env/lib/python3.10/site-packages/_pytest/mark/structures.py:347
  /Users/erikbern/python3.10-env/lib/python3.10/site-packages/_pytest/mark/structures.py:347: PytestCollectionWarning: cannot collect 'test_unix_channel' because it is not a function.
    def __call__(self, *args: object, **kwargs: object):
```

and 

```
client_test/container_app_test.py::test_typechecking_not_enforced_in_container
  client_test/container_app_test.py:129: PytestWarning: The test <Function test_typechecking_not_enforced_in_container> is marked with '@pytest.mark.asyncio' but it is not an async function. Please remove asyncio marker. If the test is not marked explicitly, check for global markers applied via 'pytestmark'.
    @pytest.mark.asyncio
```