### PR TITLE
workaround closed connection issue with MODAL_OUTPUTS_TIMEOUT

### DIFF
--- a/modal/config.py
+++ b/modal/config.py
@@ -142,6 +142,7 @@ _SETTINGS = {
     "serve_timeout": _Setting(transform=float),
     "sync_entrypoint": _Setting(),
     "logs_timeout": _Setting(10, float),
+    "outputs_timeout": _Setting(55.0, float),
     "image_python_version": _Setting(),
     "image_id": _Setting(),
     "automount": _Setting(True, transform=lambda x: x not in ("", "0")),

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -204,6 +204,7 @@ class _Invocation:
             response = await retry_transient_errors(
                 self.stub.FunctionGetOutputs,
                 request,
+                attempt_timeout=backend_timeout + 1.0,
             )
             if len(response.outputs) > 0:
                 for item in response.outputs:
@@ -250,6 +251,7 @@ class _Invocation:
                 response = await retry_transient_errors(
                     self.stub.FunctionGetOutputs,
                     request,
+                    attempt_timeout=config["outputs_timeout"] + 1.0,
                 )
                 if len(response.outputs) > 0:
                     last_entry_id = response.last_entry_id
@@ -352,6 +354,7 @@ async def _map_invocation(
                 client.stub.FunctionGetOutputs,
                 request,
                 max_retries=10,
+                attempt_timeout=config["outputs_timeout"] + 1.0,
             )
             last_entry_id = response.last_entry_id
             for item in response.outputs:


### PR DESCRIPTION
setting env var `MODAL_OUTPUTS_TIMEOUT` will change the timeout of `FunctionGetOutputs` requests