### PR TITLE
Add a MODAL_FUNCTION_RUNTIME override variable

### DIFF
--- a/modal/config.py
+++ b/modal/config.py
@@ -149,6 +149,7 @@ _SETTINGS = {
     "tracing_enabled": _Setting(False, transform=lambda x: x not in ("", "0")),
     "profiling_enabled": _Setting(False, transform=lambda x: x not in ("", "0")),
     "heartbeat_interval": _Setting(15, float),
+    "function_runtime": _Setting(),
 }
 
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -948,6 +948,7 @@ class _Function(Provider[_FunctionHandle]):
             pty_info=pty_info,
             cloud_provider=self._cloud_provider,
             warm_pool_size=warm_pool_size,
+            runtime=config.get("function_runtime"),
         )
         request = api_pb2.FunctionCreateRequest(
             app_id=resolver.app_id,

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -396,6 +396,9 @@ message Function {
 
   string web_url = 28;
   WebUrlInfo web_url_info = 29;
+
+  // If set, overrides the runtime used by the function, either "runc" or "gvisor".
+  string runtime = 30;
 }
 
 message FunctionCreateRequest {


### PR DESCRIPTION
This environment variable is meant to let us test the gVisor runtime more easily. The short story is that we can do:

```
export MODAL_FUNCTION_RUNTIME=gvisor
modal run app.py
```

And it will create all functions in the app with a Function protobuf field set to use gVisor. It's meant for testing to force-activate gVisor. There is a Notion doc summarizing the gVisor API changes, please see it for details.