### PR TITLE
Remove the typeguard library entirely

### DIFF
--- a/client_test/container_app_test.py
+++ b/client_test/container_app_test.py
@@ -4,9 +4,8 @@ import os
 import pytest
 from unittest import mock
 
-from typeguard import TypeCheckError
-
 from modal.aio import AioApp, AioFunctionHandle, AioImage, AioStub, aio_container_app
+from modal.exception import InvalidError
 
 from .supports.skip import skip_windows_unix_socket
 import modal.secret
@@ -126,6 +125,7 @@ async def test_is_inside_default_image(servicer, unix_servicer, aio_client, aio_
         assert stub.is_inside()
 
 
+@pytest.mark.skip("runtime type checking has been temporarily disabled")
 def test_typechecking_not_enforced_in_container():
     def incorrect_usage():
         class InvalidType:
@@ -133,7 +133,7 @@ def test_typechecking_not_enforced_in_container():
 
         modal.secret.Secret(env_dict={"foo": InvalidType()})  # type: ignore
 
-    with pytest.raises(TypeCheckError):
+    with pytest.raises(InvalidError):
         incorrect_usage()  # should throw when running locally
 
     with mock.patch.dict(os.environ, {"MODAL_IMAGE_ID": "im-123"}):

--- a/client_test/image_test.py
+++ b/client_test/image_test.py
@@ -67,13 +67,18 @@ def test_image_kwargs_validation(servicer, client):
     with pytest.raises(InvalidError):
         stub["image"] = Image.debian_slim().run_commands(
             "echo hi",
-            secrets=[Secret({"xyz": "123"}), Secret.from_name("foo"), Mount.from_local_dir("/", remote_path="/")],
+            secrets=[
+                Secret({"xyz": "123"}),
+                Secret.from_name("foo"),
+                Mount.from_local_dir("/", remote_path="/"),
+            ],  # Mount is not a valid Secret
         )
 
     stub = Stub()
     stub["image"] = Image.debian_slim().copy(Mount.from_local_dir("/", remote_path="/"), remote_path="/dummy")
     stub["image"] = Image.debian_slim().copy(Mount.from_name("foo"), remote_path="/dummy")
     with pytest.raises(InvalidError):
+        # Secret is not a valid Mount
         stub["image"] = Image.debian_slim().copy(Secret({"xyz": "123"}), remote_path="/dummy")  # type: ignore
 
 

--- a/client_test/image_test.py
+++ b/client_test/image_test.py
@@ -5,8 +5,6 @@ import sys
 from tempfile import NamedTemporaryFile
 from typing import List
 
-from typeguard import TypeCheckError
-
 from modal import Image, Mount, Secret, SharedVolume, Stub, gpu
 from modal.exception import InvalidError, NotFoundError
 from modal.image import _dockerhub_python_version
@@ -66,7 +64,7 @@ def test_image_kwargs_validation(servicer, client):
     stub["image"] = Image.debian_slim().run_commands(
         "echo hi", secrets=[Secret({"xyz": "123"}), Secret.from_name("foo")]
     )
-    with pytest.raises(TypeCheckError):
+    with pytest.raises(InvalidError):
         stub["image"] = Image.debian_slim().run_commands(
             "echo hi",
             secrets=[Secret({"xyz": "123"}), Secret.from_name("foo"), Mount.from_local_dir("/", remote_path="/")],
@@ -75,7 +73,7 @@ def test_image_kwargs_validation(servicer, client):
     stub = Stub()
     stub["image"] = Image.debian_slim().copy(Mount.from_local_dir("/", remote_path="/"), remote_path="/dummy")
     stub["image"] = Image.debian_slim().copy(Mount.from_name("foo"), remote_path="/dummy")
-    with pytest.raises(TypeCheckError):
+    with pytest.raises(InvalidError):
         stub["image"] = Image.debian_slim().copy(Secret({"xyz": "123"}), remote_path="/dummy")  # type: ignore
 
 
@@ -85,11 +83,11 @@ def test_wrong_type(servicer, client):
         method(["xyz"])  # type: ignore
         method("xyz")  # type: ignore
         method("xyz", ["def", "foo"], "ghi")  # type: ignore
-        with pytest.raises(TypeCheckError):
+        with pytest.raises(InvalidError):
             method(3)  # type: ignore
-        with pytest.raises(TypeCheckError):
+        with pytest.raises(InvalidError):
             method([3])  # type: ignore
-        with pytest.raises(TypeCheckError):
+        with pytest.raises(InvalidError):
             method([["double-nested-package"]])  # type: ignore
 
 

--- a/client_test/secret_test.py
+++ b/client_test/secret_test.py
@@ -1,8 +1,8 @@
 # Copyright Modal Labs 2022
 import pytest
-import typeguard
 
 from modal import Secret, Stub
+from modal.exception import InvalidError
 from modal.secret import AioSecret
 
 
@@ -14,8 +14,8 @@ def test_secret(servicer, client):
 
 
 def test_init_types():
-    with pytest.raises(typeguard.TypeCheckError):
+    with pytest.raises(InvalidError):
         Secret({"foo": None})
 
-    with pytest.raises(typeguard.TypeCheckError):
+    with pytest.raises(InvalidError):
         AioSecret({"foo": None})

--- a/client_test/secret_test.py
+++ b/client_test/secret_test.py
@@ -15,7 +15,7 @@ def test_secret(servicer, client):
 
 def test_init_types():
     with pytest.raises(InvalidError):
-        Secret({"foo": None})
+        Secret({"foo": None})  # type: ignore
 
     with pytest.raises(InvalidError):
-        AioSecret({"foo": None})
+        AioSecret({"foo": None})  # type: ignore

--- a/client_test/stub_test.py
+++ b/client_test/stub_test.py
@@ -2,8 +2,8 @@
 import asyncio
 import logging
 import os
+
 import pytest
-import typeguard
 
 from google.protobuf.empty_pb2 import Empty
 from grpclib import GRPCError, Status
@@ -44,7 +44,7 @@ async def test_attrs(servicer, aio_client):
 
 @pytest.mark.asyncio
 async def test_stub_type_validation(servicer, aio_client):
-    with pytest.raises(typeguard.TypeCheckError):
+    with pytest.raises(InvalidError):
         stub = AioStub(
             foo=4242,  # type: ignore
         )
@@ -247,21 +247,21 @@ def test_registered_web_endpoints(client, servicer):
 
 
 def test_init_types():
-    with pytest.raises(typeguard.TypeCheckError):
+    with pytest.raises(InvalidError):
         # singular secret to plural argument
         Stub(secrets=modal.Secret())  # type: ignore
-    with pytest.raises(typeguard.TypeCheckError):
+    with pytest.raises(InvalidError):
         # not a Secret Object
         Stub(secrets=[{"foo": "bar"}])  # type: ignore
-    with pytest.raises(typeguard.TypeCheckError):
+    with pytest.raises(InvalidError):
         # blueprint needs to use _Providers
         Stub(some_arg=5)  # type: ignore
-    with pytest.raises(typeguard.TypeCheckError):
+    with pytest.raises(InvalidError):
         # should be an Image
         Stub(image=modal.Secret())  # type: ignore
 
     Stub(
-        image=modal.Image.debian_slim().pip_install("typeguard"),
+        image=modal.Image.debian_slim().pip_install("pandas"),
         secrets=[modal.Secret()],
         mounts=[modal.Mount.from_local_file(__file__)],
         some_dict=modal.Dict(),

--- a/modal/_types.py
+++ b/modal/_types.py
@@ -8,14 +8,10 @@ F = TypeVar("F", bound=typing.Callable[..., typing.Any])
 
 
 def typechecked(f: F) -> F:
-    # type checking function adds significant overhead when
-    # the typeguard.typechecked is applied, so only do it locally
-    # where it matters the most
     is_local = not bool(config.get("image_id"))
     if is_local:
-        import typeguard
-
-        typeguard.config.collection_check_strategy = typeguard.CollectionCheckStrategy.ALL_ITEMS
-        return typeguard.typechecked(f)  # noqa
+        # TODO: add back run-time type checking based on signature
+        # The `typeguard` package was too slow at import time, adding roughly 1s latency due to function recompilation etc.
+        return f
     else:
         return f

--- a/modal/image.py
+++ b/modal/image.py
@@ -150,6 +150,9 @@ class _Image(_Provider[_ImageHandle]):
             raise InvalidError(
                 "No commands were provided for the image — have you tried using modal.Image.debian_slim()?"
             )
+        for secret in secrets:
+            if not isinstance(secret, _Secret):
+                raise InvalidError("All secrets of an image needs to be modal.Secret/AioSecret instances")
 
         if build_function and dockerfile_commands:
             raise InvalidError("Cannot provide both a build function and Dockerfile commands!")
@@ -313,6 +316,8 @@ class _Image(_Provider[_ImageHandle]):
         image = modal.Image.debian_slim().copy(mount, remote_path="/static")
         ```
         """
+        if not isinstance(mount, _Mount):
+            raise InvalidError("The mount argument to copy has to be a Modal Mount object")
         return self.extend(
             dockerfile_commands=["FROM base", f"COPY . {remote_path}"],  # copy everything from the supplied mount
             context_mount=mount,

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -52,7 +52,7 @@ class LocalEntrypoint:
         return self.raw_f(*args, **kwargs)
 
 
-def check_sequence(items: typing.Sequence[typing.Any], item_type: typing.Type, error_msg: str):
+def check_sequence(items: typing.Sequence[typing.Any], item_type: typing.Type[typing.Any], error_msg: str):
     if not isinstance(items, (list, tuple)):
         raise InvalidError(error_msg)
     if not all(isinstance(v, item_type) for v in items):

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -52,6 +52,13 @@ class LocalEntrypoint:
         return self.raw_f(*args, **kwargs)
 
 
+def check_sequence(items: typing.Sequence[typing.Any], item_type: typing.Type, error_msg: str):
+    if not isinstance(items, (list, tuple)):
+        raise InvalidError(error_msg)
+    if not all(isinstance(v, item_type) for v in items):
+        raise InvalidError(error_msg)
+
+
 class _Stub:
     """A `Stub` is a description of how to create a Modal application.
 
@@ -124,6 +131,11 @@ class _Stub:
 
         self._name = name
         self._description = name
+
+        check_sequence(mounts, _Mount, "mounts has to be a list or tuple of Mount/AioMount objects")
+        check_sequence(secrets, _Secret, "secrets has to be a list or tuple of Secret/AioSecret objects")
+        if image is not None and not isinstance(image, _Image):
+            raise InvalidError("image has to be a modal Image or AioImage object")
 
         for k, v in blueprint.items():
             self._validate_blueprint_value(k, v)

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -8,6 +8,7 @@ import os
 import sys
 import warnings
 from typing import AsyncGenerator, Dict, List, Optional, Union, Any, Sequence, Callable
+
 from synchronicity.async_wrap import asynccontextmanager
 from modal._types import typechecked
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ install_requires =
     types-certifi
     types-toml
     watchfiles
-    typeguard>=3.0.0
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Experimented with beartype, but it seems to perform much worse for actually finding errors while still doing code generation etc. on import... So for now, I'm disabling type checking altogether (falling back on "manual" checks for common mistakes)