### PR TITLE
require parentheses on web_endpoint, asgi_app, and wsgi_app

### DIFF
--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -414,7 +414,7 @@ def test_allow_cross_region_volumes_webhook(client, servicer):
     vol1, vol2 = SharedVolume(), SharedVolume()
     # Should pass flag for all the function's SharedVolumeMounts
     stub.function(
-        stub.web_endpoint(dummy), shared_volumes={"/sv-1": vol1, "/sv-2": vol2}, allow_cross_region_volumes=True
+        stub.web_endpoint()(dummy), shared_volumes={"/sv-1": vol1, "/sv-2": vol2}, allow_cross_region_volumes=True
     )
 
     with stub.run(client=client):

--- a/client_test/lookup_test.py
+++ b/client_test/lookup_test.py
@@ -50,7 +50,7 @@ async def test_lookup_function(servicer, aio_client):
 @pytest.mark.asyncio
 async def test_webhook_lookup(servicer, aio_client):
     stub = AioStub()
-    stub.function(stub.web_endpoint(square, method="POST"))
+    stub.function(stub.web_endpoint(method="POST")(square))
     await stub.deploy("my-webhook", client=aio_client)
 
     f = await AioFunction.lookup("my-webhook", client=aio_client)

--- a/client_test/stub_test.py
+++ b/client_test/stub_test.py
@@ -172,7 +172,7 @@ skip_in_github = pytest.mark.skipif(
 def test_serve(client):
     stub = Stub()
 
-    stub.function(stub.wsgi_app(dummy))
+    stub.function(stub.wsgi_app()(dummy))
     with pytest.warns(DeprecationError):
         stub.serve(client=client, timeout=1)
 
@@ -181,7 +181,7 @@ def test_serve(client):
 def test_serve_teardown(client, servicer):
     stub = Stub()
     with Client(servicer.remote_addr, api_pb2.CLIENT_TYPE_CLIENT, ("foo-id", "foo-secret")) as client:
-        stub.function(stub.wsgi_app(dummy))
+        stub.function(stub.wsgi_app()(dummy))
         with pytest.warns(DeprecationError):
             stub.serve(client=client, timeout=1)
 
@@ -195,7 +195,7 @@ def test_serve_teardown(client, servicer):
 def test_nested_serve_invocation(client):
     stub = Stub()
 
-    stub.function(stub.wsgi_app(dummy))
+    stub.function(stub.wsgi_app()(dummy))
     with pytest.raises(InvalidError) as excinfo:
         with stub.run(client=client):
             # This nested call creates a second web endpoint!
@@ -247,7 +247,7 @@ def test_registered_web_endpoints(client, servicer):
     stub.function(square)
     with pytest.warns(DeprecationError):
         stub.webhook(web1)
-    stub.function(stub.web_endpoint(web2))
+    stub.function(stub.web_endpoint()(web2))
 
     assert stub.registered_web_endpoints == ["web1", "web2"]
 

--- a/client_test/supports/app_run_tests/webhook.py
+++ b/client_test/supports/app_run_tests/webhook.py
@@ -5,6 +5,6 @@ stub = modal.Stub()
 
 
 @stub.function
-@stub.web_endpoint
+@stub.web_endpoint()
 def foo():
     return {"bar": "baz"}

--- a/client_test/webhook_test.py
+++ b/client_test/webhook_test.py
@@ -73,7 +73,7 @@ def test_webhook_generator():
     with pytest.raises(InvalidError) as excinfo:
 
         @stub.function(serialized=True)
-        @stub.web_endpoint
+        @stub.web_endpoint()
         def web_gen():
             yield None
 
@@ -84,7 +84,7 @@ def test_webhook_generator():
 async def test_webhook_forgot_function(servicer, aio_client):
     stub = AioStub()
 
-    @stub.web_endpoint
+    @stub.web_endpoint()
     async def g(x):
         pass
 
@@ -106,7 +106,7 @@ async def test_webhook_decorator_in_wrong_order(servicer, aio_client):
 
     with pytest.raises(InvalidError) as excinfo:
 
-        @stub.web_endpoint
+        @stub.web_endpoint()
         @stub.function(serialized=True)
         async def g(x):
             pass
@@ -119,12 +119,12 @@ async def test_asgi_wsgi(servicer, aio_client):
     stub = AioStub()
 
     @stub.function(serialized=True)
-    @stub.asgi_app
+    @stub.asgi_app()
     async def my_asgi(x):
         pass
 
     @stub.function(serialized=True)
-    @stub.wsgi_app
+    @stub.wsgi_app()
     async def my_wsgi(x):
         pass
 

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -14,7 +14,7 @@ from modal._types import typechecked
 
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronize_apis
-from modal_utils.decorator_utils import decorator_with_options
+from modal_utils.decorator_utils import decorator_with_options, decorator_with_options_deprecated
 from .retries import Retries
 
 from ._function_utils import FunctionInfo
@@ -647,7 +647,7 @@ class _Stub:
         self._add_function(function, [*base_mounts, *mounts])
         return function_handle
 
-    @decorator_with_options
+    @decorator_with_options_deprecated
     @typechecked
     def web_endpoint(
         self,
@@ -702,7 +702,7 @@ class _Stub:
             ),
         )
 
-    @decorator_with_options
+    @decorator_with_options_deprecated
     @typechecked
     def asgi_app(
         self,
@@ -742,7 +742,7 @@ class _Stub:
             ),
         )
 
-    @decorator_with_options
+    @decorator_with_options_deprecated
     @typechecked
     def wsgi_app(
         self,
@@ -782,7 +782,7 @@ class _Stub:
             "stub.webhook() is deprecated. Use stub.function in combination with stub.web_endpoint instead. Usage:\n\n"
             '@stub.function(cpu=42)\n@stub.web_endpoint(method="POST")\ndef my_function():\n    ...',
         )
-        web_endpoint = self.web_endpoint(raw_f, method, label, wait_for_response)
+        web_endpoint = self.web_endpoint(method=method, label=label, wait_for_response=wait_for_response)(raw_f)
         return self.function(web_endpoint, **function_args)
 
     @decorator_with_options
@@ -800,7 +800,7 @@ class _Stub:
             "stub.asgi() is deprecated. Use stub.function in combination with stub.asgi_app instead. Usage:\n\n"
             "@stub.function(cpu=42)\n@stub.asgi_app()\ndef my_asgi_app():\n    ...",
         )
-        web_endpoint = self.asgi_app(raw_f, label, wait_for_response)
+        web_endpoint = self.asgi_app(label=label, wait_for_response=wait_for_response)(raw_f)
         return self.function(web_endpoint, **function_args)
 
     @decorator_with_options
@@ -816,7 +816,7 @@ class _Stub:
             "stub.wsgi() is deprecated. Use stub.function in combination with stub.wsgi_app instead. Usage:\n\n"
             "@stub.function(cpu=42)\n@stub.wsgi_app()\ndef my_wsgi_app():\n    ...",
         )
-        web_endpoint = self.wsgi_app(raw_f, label, wait_for_response)
+        web_endpoint = self.wsgi_app(label=label, wait_for_response=wait_for_response)(raw_f)
         return self.function(web_endpoint, **function_args)
 
     async def interactive_shell(self, cmd=None, image=None, **kwargs):

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -706,7 +706,7 @@ class _Stub:
     @typechecked
     def asgi_app(
         self,
-        raw_f,
+        raw_f=None,
         label: Optional[
             str
         ] = None,  # Label for created endpoint. Final subdomain will be <workspace>--<label>.modal.run.
@@ -746,7 +746,7 @@ class _Stub:
     @typechecked
     def wsgi_app(
         self,
-        raw_f,
+        raw_f=None,
         label: Optional[
             str
         ] = None,  # Label for created endpoint. Final subdomain will be <workspace>--<label>.modal.run.

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -101,7 +101,7 @@ class CubeAsync:
 
 
 @stub.function
-@stub.web_endpoint
+@stub.web_endpoint()
 def webhook(arg="world"):
     return {"hello": arg}
 
@@ -126,7 +126,7 @@ class WebhookLifecycleClass:
         self._events.append("exit")
 
     @stub.function
-    @stub.web_endpoint
+    @stub.web_endpoint()
     def webhook(self, arg="world"):
         self._events.append("call")
         return {"hello": arg}
@@ -139,7 +139,7 @@ def stream():
 
 
 @stub.function
-@stub.web_endpoint
+@stub.web_endpoint()
 def webhook_streaming():
     from fastapi.responses import StreamingResponse
 
@@ -153,7 +153,7 @@ async def stream_async():
 
 
 @stub.function
-@stub.web_endpoint
+@stub.web_endpoint()
 async def webhook_streaming_async():
     from fastapi.responses import StreamingResponse
 
@@ -175,7 +175,7 @@ def fun_returning_gen(n):
 
 
 @stub.function
-@stub.asgi_app
+@stub.asgi_app()
 def fastapi_app():
     from fastapi import FastAPI
 

--- a/modal_utils/decorator_utils.py
+++ b/modal_utils/decorator_utils.py
@@ -30,3 +30,16 @@ def decorator_with_options(dec_fun):
             return functools.partial(dec_fun, *args, **kwargs)
 
     return wrapper
+
+
+def decorator_with_options_deprecated(dec_fun):
+    # Used when we are removing support for decorator_with_options
+    @functools.wraps(dec_fun)
+    def wrapper(*args, **kwargs):
+        if len(args) >= 2 or (len(args) == 1 and inspect.isfunction(args[-1])):
+            name = dec_fun.__name__
+            raise RuntimeError(f"The function {name} needs to be used with arguments. Add () to it if there are none.")
+        else:
+            return functools.partial(dec_fun, *args, **kwargs)
+
+    return wrapper


### PR DESCRIPTION
This throws an exception if those aren't used. I think it's OK to break user code in this case since those decorators were added just hours ago, so very little user code will be broken.

I'm not touching `@stub.function` – that's a much bigger one that we should deal with separately, and will require a long deprecation path (probably like 3 months)