### PR TITLE
fix: @warn_if_generator_is_not_consumed needs to allow next()

### DIFF
--- a/client_test/async_utils_test.py
+++ b/client_test/async_utils_test.py
@@ -171,6 +171,21 @@ async def test_warn_if_generator_is_not_consumed(caplog):
     assert "list" in caplog.text
 
 
+@pytest.mark.asyncio
+async def test_no_warn_if_generator_is_consumed(caplog):
+    @warn_if_generator_is_not_consumed
+    async def my_generator():
+        yield 42
+
+    with caplog.at_level(logging.WARNING):
+        g = my_generator()
+        async for _ in g:
+            pass
+        del g  # Force destructor
+
+    assert len(caplog.records) == 0
+
+
 def test_exit_handler():
     result = None
     sync = Synchronizer()

--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -174,7 +174,10 @@ async def test_generator(client, servicer):
     with stub.run(client=client):
         assert later_gen_modal.is_generator
         res = later_gen_modal.call()
+        # Generators fulfil the *iterator protocol*, which requires both these methods.
+        # https://docs.python.org/3/library/stdtypes.html#typeiter
         assert hasattr(res, "__iter__")  # strangely inspect.isgenerator returns false
+        assert hasattr(res, "__next__")
         assert list(res) == ["bar", "baz"]
         assert len(servicer.cleared_function_calls) == 1
 

--- a/modal/requirements.txt
+++ b/modal/requirements.txt
@@ -14,7 +14,7 @@ ipython>=7.34.0
 protobuf>=4.21.0
 python-multipart>=0.0.5
 rich==12.3.0
-synchronicity==0.4.1
+synchronicity==0.4.2
 tblib==1.7.0
 toml==0.10.2
 typer==0.6.1

--- a/modal_utils/async_utils.py
+++ b/modal_utils/async_utils.py
@@ -265,6 +265,10 @@ class _WarnIfGeneratorIsNotConsumed:
         self.iterated = True
         return self.gen
 
+    def __anext__(self):
+        self.iterated = True
+        return self.gen.__anext__()
+
     def __repr__(self):
         return repr(self.gen)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     importlib_metadata>=3.6.0
     protobuf>=3.19,<5.0
     rich>=12.0.0
-    synchronicity==0.4.1
+    synchronicity==0.4.2
     tblib>=1.7.0
     toml
     typer>=0.6.1


### PR DESCRIPTION
⚠️  Relies on https://github.com/modal-labs/synchronicity/pull/94.

Turns out we weren't properly fulfilling the _iterator protocol_ that is provided by a Python generator. So the decorator was changing the interface.

Will remove this gotcha affecting users: https://github.com/modal-labs/modal-examples/pull/267/files#diff-7d760443a54f6d0e66b1d1204a0cc9533d249f658501b557eea183cb76659635R57.