### PR TITLE
Deprecate the argument-less version of decorator_with_options

### DIFF
--- a/client_test/cli_imports_test.py
+++ b/client_test/cli_imports_test.py
@@ -18,7 +18,7 @@ local_entrypoint_src = """
 import modal
 
 stub = modal.Stub()
-@stub.local_entrypoint
+@stub.local_entrypoint()
 def main():
     pass
 """

--- a/client_test/cli_imports_test.py
+++ b/client_test/cli_imports_test.py
@@ -26,7 +26,7 @@ python_module_src = """
 import modal
 stub = modal.Stub("FOO")
 other_stub = modal.Stub("BAR")
-@other_stub.function
+@other_stub.function()
 def func():
     pass
 class Parent:
@@ -41,7 +41,7 @@ python_package_src = """
 import modal
 stub = modal.Stub("FOO")
 other_stub = modal.Stub("BAR")
-@other_stub.function
+@other_stub.function()
 def func():
     pass
 assert __package__ == "pack"
@@ -51,7 +51,7 @@ python_subpackage_src = """
 import modal
 stub = modal.Stub("FOO")
 other_stub = modal.Stub("BAR")
-@other_stub.function
+@other_stub.function()
 def func():
     pass
 assert __package__ == "pack.sub"

--- a/client_test/cli_imports_test.py
+++ b/client_test/cli_imports_test.py
@@ -30,7 +30,7 @@ other_stub = modal.Stub("BAR")
 def func():
     pass
 class Parent:
-    @stub.function
+    @stub.function()
     def meth(self):
         pass
 

--- a/client_test/container_app_test.py
+++ b/client_test/container_app_test.py
@@ -30,7 +30,7 @@ async def test_container_function_initialization(unix_servicer, aio_container_cl
     await AioApp.init_container(aio_container_client, "ap-123")
 
     stub = AioStub()
-    # my_f_1_container = stub.function(my_f_1)
+    # my_f_1_container = stub.function()(my_f_1)
 
     # Make sure these functions exist and have the right type
     my_f_1_app = aio_container_app["my_f_1"]
@@ -46,7 +46,7 @@ async def test_container_function_initialization(unix_servicer, aio_container_cl
 
     # Now, let's create my_f_2 after the app started running
     # This might happen if some local module is imported lazily
-    my_f_2_container = stub.function(my_f_2)
+    my_f_2_container = stub.function()(my_f_2)
     assert await my_f_2_container.call(42) == 1764  # type: ignore
 
 
@@ -102,7 +102,7 @@ def f():
 @pytest.mark.asyncio
 async def test_is_inside_default_image(servicer, unix_servicer, aio_client, aio_container_client):
     stub = AioStub()
-    stub.function(f)
+    stub.function()(f)
 
     assert not stub.is_inside()
 

--- a/client_test/decorator_test.py
+++ b/client_test/decorator_test.py
@@ -83,7 +83,7 @@ class Cls:
 def test_method_simple_warns():
     c = Cls(3)
 
-    with pytest.warns(DeprecationError, match="Cls.dec"):
+    with pytest.warns(DeprecationError, match="cls.dec"):
 
         @c.dec
         def f(x):
@@ -104,7 +104,7 @@ def test_method_args():
 
 def test_method_direct_warns():
     c = Cls(5)
-    with pytest.warns(DeprecationError, match="Cls.dec"):
+    with pytest.warns(DeprecationError, match="cls.dec"):
         p = c.dec(double)
     assert p(42) == 89
 
@@ -117,7 +117,7 @@ def test_method_indirect_ok():
 
 def test_method_direct_args_warns():
     c = Cls(6)
-    with pytest.warns(DeprecationError, match="Cls.dec"):
+    with pytest.warns(DeprecationError, match="cls.dec"):
         q = c.dec(double, add=9)
     assert q(42) == 99
 

--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -312,7 +312,7 @@ def test_nonglobal_function():
 
     with pytest.raises(InvalidError) as excinfo:
 
-        @stub.function
+        @stub.function()
         def f():
             pass
 

--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -44,7 +44,7 @@ def test_map(client, servicer, slow_put_inputs):
     servicer.slow_put_inputs = slow_put_inputs
 
     stub = Stub()
-    dummy_modal = stub.function(dummy)
+    dummy_modal = stub.function()(dummy)
 
     assert len(servicer.cleared_function_calls) == 0
     with stub.run(client=client):
@@ -64,7 +64,7 @@ def side_effect(_):
 
 def test_for_each(client, servicer):
     stub = Stub()
-    side_effect_modal = stub.function(servicer.function_body(side_effect))
+    side_effect_modal = stub.function()(servicer.function_body(side_effect))
     assert _side_effect_count == 0
     with stub.run(client=client):
         side_effect_modal.for_each(range(10))
@@ -79,7 +79,7 @@ def custom_function(x):
 def test_map_none_values(client, servicer):
     stub = Stub()
 
-    custom_function_modal = stub.function(servicer.function_body(custom_function))
+    custom_function_modal = stub.function()(servicer.function_body(custom_function))
 
     with stub.run(client=client):
         assert list(custom_function_modal.map(range(4))) == [0, None, 2, None]
@@ -88,19 +88,19 @@ def test_map_none_values(client, servicer):
 def test_starmap(client):
     stub = Stub()
 
-    dummy_modal = stub.function(dummy)
+    dummy_modal = stub.function()(dummy)
     with stub.run(client=client):
         assert list(dummy_modal.starmap([[5, 2], [4, 3]])) == [29, 25]
 
 
 def test_function_memory_request(client):
     stub = Stub()
-    stub.function(dummy, memory=2048)
+    stub.function(memory=2048)(dummy)
 
 
 def test_function_cpu_request(client):
     stub = Stub()
-    stub.function(dummy, cpu=2.0)
+    stub.function(cpu=2.0)(dummy)
 
 
 def later():
@@ -110,7 +110,7 @@ def later():
 def test_function_future(client, servicer):
     stub = Stub()
 
-    later_modal = stub.function(servicer.function_body(later))
+    later_modal = stub.function()(servicer.function_body(later))
     with stub.run(client=client):
         future = later_modal.spawn()
         assert isinstance(future, FunctionCall)
@@ -140,7 +140,7 @@ def test_function_future(client, servicer):
 async def test_function_future_async(client, servicer):
     stub = AioStub()
 
-    later_modal = stub.function(servicer.function_body(later))
+    later_modal = stub.function()(servicer.function_body(later))
 
     async with stub.run(client=client):
         future = await later_modal.spawn()
@@ -162,7 +162,7 @@ def later_gen():
 async def test_generator(client, servicer):
     stub = Stub()
 
-    later_gen_modal = stub.function(later_gen)
+    later_gen_modal = stub.function()(later_gen)
 
     def dummy():
         yield "bar"
@@ -183,7 +183,7 @@ async def test_generator(client, servicer):
 async def test_generator_future(client, servicer):
     stub = Stub()
 
-    later_gen_modal = stub.function(later_gen)
+    later_gen_modal = stub.function()(later_gen)
     with stub.run(client=client):
         assert later_gen_modal.spawn() is None  # until we have a nice interface for polling generator futures
 
@@ -198,7 +198,7 @@ async def slo1(sleep_seconds):
 def test_sync_parallelism(client, servicer):
     stub = Stub()
 
-    slo1_modal = stub.function(servicer.function_body(slo1))
+    slo1_modal = stub.function()(servicer.function_body(slo1))
     with stub.run(client=client):
         t0 = time.time()
         # NOTE tests breaks in macOS CI if the smaller time is smaller than ~300ms
@@ -211,7 +211,7 @@ def test_sync_parallelism(client, servicer):
 def test_proxy(client, servicer):
     stub = Stub()
 
-    stub.function(dummy, proxy=Proxy.from_name("my-proxy"))
+    stub.function(proxy=Proxy.from_name("my-proxy"))(dummy)
     with stub.run(client=client):
         pass
 
@@ -227,7 +227,7 @@ def failure():
 def test_function_exception(client, servicer):
     stub = Stub()
 
-    failure_modal = stub.function(servicer.function_body(failure))
+    failure_modal = stub.function()(servicer.function_body(failure))
     with stub.run(client=client):
         with pytest.raises(CustomException) as excinfo:
             failure_modal.call()
@@ -238,7 +238,7 @@ def test_function_exception(client, servicer):
 async def test_function_exception_async(aio_client, servicer):
     stub = AioStub()
 
-    failure_modal = stub.function(servicer.function_body(failure))
+    failure_modal = stub.function()(servicer.function_body(failure))
     async with stub.run(client=aio_client):
         with pytest.raises(CustomException) as excinfo:
             await failure_modal.call()
@@ -254,7 +254,7 @@ def custom_exception_function(x):
 def test_map_exceptions(client, servicer):
     stub = Stub()
 
-    custom_function_modal = stub.function(servicer.function_body(custom_exception_function))
+    custom_function_modal = stub.function()(servicer.function_body(custom_exception_function))
 
     with stub.run(client=client):
         assert list(custom_function_modal.map(range(4))) == [0, 1, 4, 9]
@@ -275,7 +275,7 @@ def import_failure():
 def test_function_relative_import_hint(client, servicer):
     stub = Stub()
 
-    import_failure_modal = stub.function(servicer.function_body(import_failure))
+    import_failure_modal = stub.function()(servicer.function_body(import_failure))
 
     with stub.run(client=client):
         with pytest.raises(ImportError) as excinfo:
@@ -361,7 +361,7 @@ def test_from_id(client, servicer):
 
 def test_panel(client, servicer):
     stub = Stub()
-    stub.function(dummy)
+    stub.function()(dummy)
     function = stub["dummy"]
     assert isinstance(function, Function)
     image = stub._get_default_image()
@@ -398,7 +398,7 @@ def test_allow_cross_region_volumes(client, servicer):
     stub = Stub()
     vol1, vol2 = SharedVolume(), SharedVolume()
     # Should pass flag for all the function's SharedVolumeMounts
-    stub.function(dummy, shared_volumes={"/sv-1": vol1, "/sv-2": vol2}, allow_cross_region_volumes=True)
+    stub.function(shared_volumes={"/sv-1": vol1, "/sv-2": vol2}, allow_cross_region_volumes=True)(dummy)
 
     with stub.run(client=client):
         assert len(servicer.app_functions) == 1
@@ -413,8 +413,8 @@ def test_allow_cross_region_volumes_webhook(client, servicer):
     stub = Stub()
     vol1, vol2 = SharedVolume(), SharedVolume()
     # Should pass flag for all the function's SharedVolumeMounts
-    stub.function(
-        stub.web_endpoint()(dummy), shared_volumes={"/sv-1": vol1, "/sv-2": vol2}, allow_cross_region_volumes=True
+    stub.function(shared_volumes={"/sv-1": vol1, "/sv-2": vol2}, allow_cross_region_volumes=True)(
+        stub.web_endpoint()(dummy)
     )
 
     with stub.run(client=client):

--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -371,13 +371,13 @@ def test_panel(client, servicer):
 lc_stub = Stub()
 
 
-@lc_stub.function
+@lc_stub.function()
 def f(x):
     return x**2
 
 
 class Class:
-    @lc_stub.function
+    @lc_stub.function()
     def f(self, x):
         return x**2
 

--- a/client_test/gpu_test.py
+++ b/client_test/gpu_test.py
@@ -14,13 +14,13 @@ def test_gpu_true_function(client, servicer):
     stub = Stub()
 
     with pytest.raises(DeprecationError):
-        stub.function(dummy, gpu=True)
+        stub.function(gpu=True)(dummy)
 
 
 def test_gpu_any_function(client, servicer):
     stub = Stub()
 
-    stub.function(dummy, gpu="any")
+    stub.function(gpu="any")(dummy)
     with stub.run(client=client):
         pass
 
@@ -36,9 +36,9 @@ def test_gpu_string_config(client, servicer):
 
     # Invalid enum value.
     with pytest.raises(InvalidError):
-        stub.function(dummy, gpu="foo")
+        stub.function(gpu="foo")(dummy)
 
-    stub.function(dummy, gpu="A100")
+    stub.function(gpu="A100")(dummy)
     with stub.run(client=client):
         pass
 
@@ -54,7 +54,7 @@ def test_gpu_config_function(client, servicer):
 
     stub = Stub()
 
-    stub.function(dummy, gpu=modal.gpu.A100())
+    stub.function(gpu=modal.gpu.A100())(dummy)
     with stub.run(client=client):
         pass
 
@@ -70,7 +70,7 @@ def test_cloud_provider_selection(client, servicer):
 
     stub = Stub()
 
-    stub.function(dummy, gpu=modal.gpu.A100(), cloud="gcp")
+    stub.function(gpu=modal.gpu.A100(), cloud="gcp")(dummy)
     with stub.run(client=client):
         pass
 
@@ -83,7 +83,7 @@ def test_cloud_provider_selection(client, servicer):
 
     # Invalid enum value.
     with pytest.raises(InvalidError):
-        stub.function(dummy, cloud="foo")
+        stub.function(cloud="foo")(dummy)
 
 
 A100_GPU_MEMORY_MAPPING = {0: api_pb2.GPU_TYPE_A100, 20: api_pb2.GPU_TYPE_A100_20G, 40: api_pb2.GPU_TYPE_A100}
@@ -95,7 +95,7 @@ def test_memory_selection_gpu_variant(client, servicer, memory, gpu_type):
 
     stub = Stub()
 
-    stub.function(dummy, gpu=modal.gpu.A100(memory=memory))
+    stub.function(gpu=modal.gpu.A100(memory=memory))(dummy)
     with stub.run(client=client):
         pass
 
@@ -118,13 +118,13 @@ def test_gpu_type_selection_from_count(client, servicer, count, gpu_type):
     # Functions that use A100 20GB can only request one GPU
     # at a time.
     with pytest.raises(ValueError):
-        stub.function(dummy, gpu=modal.gpu.A100(count=2, memory=20))
+        stub.function(gpu=modal.gpu.A100(count=2, memory=20))(dummy)
         with stub.run(client=client):
             pass
 
     # Task type changes whenever user asks more than 1 GPU on
     # an A100.
-    stub.function(dummy, gpu=modal.gpu.A100(count=count))
+    stub.function(gpu=modal.gpu.A100(count=count))(dummy)
     with stub.run(client=client):
         pass
 

--- a/client_test/lookup_test.py
+++ b/client_test/lookup_test.py
@@ -30,7 +30,7 @@ def square(x):
 async def test_lookup_function(servicer, aio_client):
     stub = AioStub()
 
-    stub.function(square)
+    stub.function()(square)
     await stub.deploy("my-function", client=aio_client)
 
     f = await AioFunction.lookup("my-function", client=aio_client)
@@ -50,7 +50,7 @@ async def test_lookup_function(servicer, aio_client):
 @pytest.mark.asyncio
 async def test_webhook_lookup(servicer, aio_client):
     stub = AioStub()
-    stub.function(stub.web_endpoint(method="POST")(square))
+    stub.function()(stub.web_endpoint(method="POST")(square))
     await stub.deploy("my-webhook", client=aio_client)
 
     f = await AioFunction.lookup("my-webhook", client=aio_client)

--- a/client_test/mount_test.py
+++ b/client_test/mount_test.py
@@ -112,7 +112,7 @@ def test_create_package_mounts(servicer, client, test_dir):
 
     sys.path.append((test_dir / "supports").as_posix())
 
-    stub.function(dummy, mounts=create_package_mounts(["pkg_a", "pkg_b", "standalone_file"]))
+    stub.function(mounts=create_package_mounts(["pkg_a", "pkg_b", "standalone_file"]))(dummy)
 
     with stub.run(client=client):
         files = servicer.files_name2sha.keys()
@@ -130,7 +130,7 @@ def test_stub_mounts(servicer, client, test_dir):
 
     stub = Stub(mounts=create_package_mounts(["pkg_b"]))
 
-    stub.function(dummy, mounts=create_package_mounts(["pkg_a"]))
+    stub.function(mounts=create_package_mounts(["pkg_a"]))(dummy)
 
     with stub.run(client=client):
         files = servicer.files_name2sha.keys()
@@ -146,4 +146,4 @@ def test_create_package_mounts_missing_module(servicer, client, test_dir):
     stub = Stub()
 
     with pytest.raises(NotFoundError):
-        stub.function(dummy, mounts=create_package_mounts(["nonexistent_package"]))
+        stub.function(mounts=create_package_mounts(["nonexistent_package"]))(dummy)

--- a/client_test/retries_test.py
+++ b/client_test/retries_test.py
@@ -28,28 +28,30 @@ def dummy():
 def test_retries(client):
     stub = modal.Stub()
 
-    default_retries_from_int_modal = stub.function(default_retries_from_int, retries=5)
-    fixed_delay_retries_modal = stub.function(
-        fixed_delay_retries, retries=modal.Retries(max_retries=5, backoff_coefficient=1.0)
+    default_retries_from_int_modal = stub.function(retries=5)(default_retries_from_int)
+    fixed_delay_retries_modal = stub.function(retries=modal.Retries(max_retries=5, backoff_coefficient=1.0))(
+        fixed_delay_retries
     )
+
     exponential_backoff_modal = stub.function(
-        exponential_backoff, retries=modal.Retries(max_retries=2, initial_delay=2.0, backoff_coefficient=2.0)
-    )
+        retries=modal.Retries(max_retries=2, initial_delay=2.0, backoff_coefficient=2.0)
+    )(exponential_backoff)
+
     exponential_with_max_delay_modal = stub.function(
-        exponential_with_max_delay, retries=modal.Retries(max_retries=2, backoff_coefficient=2.0, max_delay=30.0)
-    )
+        retries=modal.Retries(max_retries=2, backoff_coefficient=2.0, max_delay=30.0)
+    )(exponential_with_max_delay)
 
     with pytest.raises(TypeError):
         # Reject no-args constructions, which is unreadable and harder to support long-term
-        stub.function(dummy, retries=modal.Retries())  # type: ignore
+        stub.function(retries=modal.Retries())(dummy)  # type: ignore
 
     # Reject weird inputs:
     # Don't need server to detect and reject nonsensical input. Can do client-side.
     with pytest.raises(InvalidError):
-        stub.function(dummy, retries=modal.Retries(max_retries=-2))
+        stub.function(retries=modal.Retries(max_retries=-2))(dummy)
 
     with pytest.raises(InvalidError):
-        stub.function(dummy, retries=modal.Retries(max_retries=2, backoff_coefficient=0.0))
+        stub.function(retries=modal.Retries(max_retries=2, backoff_coefficient=0.0))(dummy)
 
     with stub.run(client=client):
         default_retries_from_int_modal.call()

--- a/client_test/shared_volume_test.py
+++ b/client_test/shared_volume_test.py
@@ -33,17 +33,17 @@ def test_shared_volume_bad_paths(client, test_dir, servicer):
     def _f():
         pass
 
-    dummy_modal = stub.function(dummy, shared_volumes={"/root/../../foo": modal.SharedVolume()})
+    dummy_modal = stub.function(shared_volumes={"/root/../../foo": modal.SharedVolume()})(dummy)
     with pytest.raises(InvalidError):
         with stub.run(client=client):
             dummy_modal.call()
 
-    dummy_modal = stub.function(dummy, shared_volumes={"/": modal.SharedVolume()})
+    dummy_modal = stub.function(shared_volumes={"/": modal.SharedVolume()})(dummy)
     with pytest.raises(InvalidError):
         with stub.run(client=client):
             dummy_modal.call()
 
-    dummy_modal = stub.function(dummy, shared_volumes={"/tmp/": modal.SharedVolume()})
+    dummy_modal = stub.function(shared_volumes={"/tmp/": modal.SharedVolume()})(dummy)
     with pytest.raises(InvalidError):
         with stub.run(client=client):
             dummy_modal.call()

--- a/client_test/stub_test.py
+++ b/client_test/stub_test.py
@@ -64,7 +64,7 @@ def square(x):
 @pytest.mark.asyncio
 async def test_redeploy(servicer, aio_client):
     stub = AioStub()
-    stub.function(square)
+    stub.function()(square)
 
     # Deploy app
     app = await stub.deploy("my-app", client=aio_client)
@@ -99,7 +99,7 @@ def test_create_object_exception(servicer, client):
     servicer.function_create_error = True
 
     stub = Stub()
-    stub.function(dummy)
+    stub.function()(dummy)
 
     with pytest.raises(GRPCError) as excinfo:
         with stub.run(client=client):
@@ -123,7 +123,7 @@ def test_deploy_uses_deployment_name_if_specified(servicer, client):
 
 def test_run_function_without_app_error():
     stub = Stub()
-    dummy_modal = stub.function(dummy)
+    dummy_modal = stub.function()(dummy)
 
     with pytest.raises(InvalidError) as excinfo:
         dummy_modal.call()
@@ -150,12 +150,12 @@ def test_same_function_name(caplog):
 
     # Add first function
     with caplog.at_level(logging.WARNING):
-        stub.function(module_1.square)
+        stub.function()(module_1.square)
     assert len(caplog.records) == 0
 
     # Add second function: check warning
     with caplog.at_level(logging.WARNING):
-        stub.function(module_2.square)
+        stub.function()(module_2.square)
     assert len(caplog.records) == 1
     assert "module_1" in caplog.text
     assert "module_2" in caplog.text
@@ -172,7 +172,7 @@ skip_in_github = pytest.mark.skipif(
 def test_serve(client):
     stub = Stub()
 
-    stub.function(stub.wsgi_app()(dummy))
+    stub.function()(stub.wsgi_app()(dummy))
     with pytest.warns(DeprecationError):
         stub.serve(client=client, timeout=1)
 
@@ -181,7 +181,7 @@ def test_serve(client):
 def test_serve_teardown(client, servicer):
     stub = Stub()
     with Client(servicer.remote_addr, api_pb2.CLIENT_TYPE_CLIENT, ("foo-id", "foo-secret")) as client:
-        stub.function(stub.wsgi_app()(dummy))
+        stub.function()(stub.wsgi_app()(dummy))
         with pytest.warns(DeprecationError):
             stub.serve(client=client, timeout=1)
 
@@ -195,7 +195,7 @@ def test_serve_teardown(client, servicer):
 def test_nested_serve_invocation(client):
     stub = Stub()
 
-    stub.function(stub.wsgi_app()(dummy))
+    stub.function()(stub.wsgi_app()(dummy))
     with pytest.raises(InvalidError) as excinfo:
         with stub.run(client=client):
             # This nested call creates a second web endpoint!
@@ -244,10 +244,10 @@ async def web2(x):
 
 def test_registered_web_endpoints(client, servicer):
     stub = Stub()
-    stub.function(square)
+    stub.function()(square)
     with pytest.warns(DeprecationError):
         stub.webhook(web1)
-    stub.function(stub.web_endpoint()(web2))
+    stub.function()(stub.web_endpoint()(web2))
 
     assert stub.registered_web_endpoints == ["web1", "web2"]
 

--- a/client_test/supports/app_run_tests/async_stub.py
+++ b/client_test/supports/app_run_tests/async_stub.py
@@ -4,6 +4,6 @@ import modal.aio
 stub = modal.aio.AioStub()
 
 
-@stub.function
+@stub.function()
 async def foo():
     pass

--- a/client_test/supports/app_run_tests/cli_args.py
+++ b/client_test/supports/app_run_tests/cli_args.py
@@ -27,6 +27,6 @@ def unannotated_arg(i):
 
 
 class ALifecycle:
-    @stub.function
+    @stub.function()
     def some_method(self, i):
         print(repr(i))

--- a/client_test/supports/app_run_tests/cli_args.py
+++ b/client_test/supports/app_run_tests/cli_args.py
@@ -6,22 +6,22 @@ import modal
 stub = modal.Stub()
 
 
-@stub.local_entrypoint
+@stub.local_entrypoint()
 def dt_arg(dt: datetime):
     print(f"the day is {dt.day}")
 
 
-@stub.local_entrypoint
+@stub.local_entrypoint()
 def int_arg(i: int):
     print(repr(i))
 
 
-@stub.local_entrypoint
+@stub.local_entrypoint()
 def default_arg(i: int = 10):
     print(repr(i))
 
 
-@stub.local_entrypoint
+@stub.local_entrypoint()
 def unannotated_arg(i):
     print(repr(i))
 

--- a/client_test/supports/app_run_tests/custom_stub.py
+++ b/client_test/supports/app_run_tests/custom_stub.py
@@ -4,6 +4,6 @@ import modal
 my_stub = modal.Stub()
 
 
-@my_stub.function
+@my_stub.function()
 def foo():
     pass

--- a/client_test/supports/app_run_tests/default_stub.py
+++ b/client_test/supports/app_run_tests/default_stub.py
@@ -4,6 +4,6 @@ import modal
 stub = modal.Stub()
 
 
-@stub.function
+@stub.function()
 def foo():
     print("foo")

--- a/client_test/supports/app_run_tests/local_entrypoint.py
+++ b/client_test/supports/app_run_tests/local_entrypoint.py
@@ -5,7 +5,7 @@ import modal
 stub = modal.Stub()
 
 
-@stub.function
+@stub.function()
 def foo():
     pass
 

--- a/client_test/supports/app_run_tests/local_entrypoint.py
+++ b/client_test/supports/app_run_tests/local_entrypoint.py
@@ -10,7 +10,7 @@ def foo():
     pass
 
 
-@stub.local_entrypoint
+@stub.local_entrypoint()
 def main():
     print("called locally")
     foo.call()

--- a/client_test/supports/app_run_tests/main_thread_assertion.py
+++ b/client_test/supports/app_run_tests/main_thread_assertion.py
@@ -10,6 +10,6 @@ pytest._did_load_main_thread_assertion = True  # can be checked to ensure module
 stub = modal.Stub()
 
 
-@stub.function
+@stub.function()
 def dummy():
     pass

--- a/client_test/supports/app_run_tests/prints_desc_stub.py
+++ b/client_test/supports/app_run_tests/prints_desc_stub.py
@@ -9,6 +9,6 @@ stub = modal.Stub()
 print(f"stub.description: {stub.description}")
 
 
-@stub.function
+@stub.function()
 def foo():
     pass

--- a/client_test/supports/app_run_tests/stub_with_multiple_functions.py
+++ b/client_test/supports/app_run_tests/stub_with_multiple_functions.py
@@ -4,11 +4,11 @@ import modal
 stub = modal.Stub()
 
 
-@stub.function
+@stub.function()
 def foo():
     pass
 
 
-@stub.function
+@stub.function()
 def bar():
     pass

--- a/client_test/supports/app_run_tests/webhook.py
+++ b/client_test/supports/app_run_tests/webhook.py
@@ -4,7 +4,7 @@ import modal
 stub = modal.Stub()
 
 
-@stub.function
+@stub.function()
 @stub.web_endpoint()
 def foo():
     return {"bar": "baz"}

--- a/client_test/supports/notebooks/simple.notebook.py
+++ b/client_test/supports/notebooks/simple.notebook.py
@@ -27,7 +27,7 @@ import modal
 stub = modal.Stub()
 
 
-@stub.function
+@stub.function()
 def hello():
     print("running")
 

--- a/client_test/webhook_test.py
+++ b/client_test/webhook_test.py
@@ -92,12 +92,12 @@ async def test_webhook_forgot_function(servicer, aio_client):
         async with stub.run(client=aio_client):
             pass
 
-    assert "@stub.function" in str(excinfo.value)
+    assert "@stub.function()" in str(excinfo.value)
 
     with pytest.raises(InvalidError) as excinfo:
         await stub.deploy("webhook-test", client=aio_client)
 
-    assert "@stub.function" in str(excinfo.value)
+    assert "@stub.function()" in str(excinfo.value)
 
 
 @pytest.mark.asyncio

--- a/modal/app.py
+++ b/modal/app.py
@@ -224,7 +224,7 @@ Useful for accessing object handles for any Modal objects declared on the stub, 
 stub = modal.Stub()
 stub.data = modal.Dict()
 
-@stub.function
+@stub.function()
 def store_something(key, value):
     data: modal.DictHandle = modal.container_app.data
     data.put(key, value)

--- a/modal/cli/import_refs.py
+++ b/modal/cli/import_refs.py
@@ -237,7 +237,7 @@ Given the following example `app.py`:
 ```
 stub = modal.Stub()
 
-@stub.function
+@stub.function()
 def foo():
     ...
 ```

--- a/modal/exception.py
+++ b/modal/exception.py
@@ -10,7 +10,7 @@ class Error(Exception):
 
     **Usage**
 
-    ```python
+    ```python notest
     import modal
 
     try:

--- a/modal/extensions/pymc.py
+++ b/modal/extensions/pymc.py
@@ -62,7 +62,7 @@ def rebuild_exc(exc, tb):
     return exc
 
 
-@aio_pymc_stub.function
+@aio_pymc_stub.function()
 async def sample_process(
     draws: int,
     tune: int,

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -546,7 +546,7 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
 
         Example:
         ```python notest
-        @stub.function
+        @stub.function()
         def my_func(a):
             return a ** 2
 
@@ -563,7 +563,7 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
 
         `return_exceptions` can be used to treat exceptions as successful results:
         ```python notest
-        @stub.function
+        @stub.function()
         def my_func(a):
             if a == 2:
                 raise Exception("ohno")
@@ -599,7 +599,7 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
 
         Example:
         ```python notest
-        @stub.function
+        @stub.function()
         def my_func(a, b):
             return a + b
 
@@ -707,7 +707,7 @@ class _Function(_Provider[_FunctionHandle]):
     """Functions are the basic units of serverless execution on Modal.
 
     Generally, you will not construct a `Function` directly. Instead, use the
-    `@stub.function` decorator on the `Stub` object for your application.
+    `@stub.function()` decorator on the `Stub` object for your application.
     """
 
     # TODO: more type annotations
@@ -1120,7 +1120,7 @@ def current_input_id() -> str:
     ```python
     from modal import current_input_id
 
-    @stub.function
+    @stub.function()
     def process_stuff():
         print(f"Starting to process {current_input_id()}")
     ```

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -37,7 +37,7 @@ async def run_stub(
 ) -> AsyncGenerator[_App, None]:
     if stub._loose_webhook_configs:
         raise InvalidError(
-            f"Web endpoints {stub._loose_webhook_configs} need to be decorated with @stub.function too.\nUsage:\n\n"
+            f"Web endpoints {stub._loose_webhook_configs} need to be decorated with @stub.function() too.\nUsage:\n\n"
             "@stub.function()\n@stub.web_endpoint()\ndef my_webhook():\n    ..."
         )
     if not is_local():
@@ -136,7 +136,7 @@ async def deploy_stub(
 ) -> _App:
     if stub._loose_webhook_configs:
         raise InvalidError(
-            f"Web endpoints {stub._loose_webhook_configs} need to be decorated with @stub.function too. Usage:\n\n"
+            f"Web endpoints {stub._loose_webhook_configs} need to be decorated with @stub.function() too. Usage:\n\n"
             "@stub.function()\n@stub.web_endpoint()\ndef my_webhook():\n    ..."
         )
     if not is_local():

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -14,7 +14,7 @@ from modal._types import typechecked
 
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronize_apis
-from modal_utils.decorator_utils import decorator_with_options, decorator_with_options_deprecated
+from modal_utils.decorator_utils import decorator_with_options_unsupported, decorator_with_options
 from .retries import Retries
 
 from ._function_utils import FunctionInfo
@@ -434,7 +434,7 @@ class _Stub:
         """Names of web endpoint (ie. webhook) functions registered on the stub."""
         return self._web_endpoints
 
-    @decorator_with_options
+    @decorator_with_options_unsupported
     def local_entrypoint(self, raw_f=None, name: Optional[str] = None):
         """Decorate a function to be used as a CLI entrypoint for a Modal App.
 
@@ -647,7 +647,7 @@ class _Stub:
         self._add_function(function, [*base_mounts, *mounts])
         return function_handle
 
-    @decorator_with_options_deprecated
+    @decorator_with_options_unsupported
     @typechecked
     def web_endpoint(
         self,
@@ -702,7 +702,7 @@ class _Stub:
             ),
         )
 
-    @decorator_with_options_deprecated
+    @decorator_with_options_unsupported
     @typechecked
     def asgi_app(
         self,
@@ -742,7 +742,7 @@ class _Stub:
             ),
         )
 
-    @decorator_with_options_deprecated
+    @decorator_with_options_unsupported
     @typechecked
     def wsgi_app(
         self,

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -80,7 +80,7 @@ class _Stub:
     **Registering functions with an app**
 
     The most common way to explicitly register an Object with an app is through the
-    `@stub.function` decorator. It both registers the annotated function itself and
+    `@stub.function()` decorator. It both registers the annotated function itself and
     other passed objects, like schedules and secrets, with the app:
 
     ```python

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -446,7 +446,7 @@ class _Stub:
         **Example**
 
         ```python
-        @stub.local_entrypoint
+        @stub.local_entrypoint()
         def main():
             some_modal_function.call()
         ```
@@ -474,7 +474,7 @@ class _Stub:
         CLI options. For example, the following function can be called with `modal run stub_module.py --foo 1 --bar "hello"`:
 
         ```python
-        @stub.local_entrypoint
+        @stub.local_entrypoint()
         def main(foo: int, bar: str):
             some_modal_function.call(foo, bar)
         ```

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -434,7 +434,7 @@ class _Stub:
         """Names of web endpoint (ie. webhook) functions registered on the stub."""
         return self._web_endpoints
 
-    @decorator_with_options_unsupported
+    @decorator_with_options
     def local_entrypoint(self, raw_f=None, name: Optional[str] = None):
         """Decorate a function to be used as a CLI entrypoint for a Modal App.
 

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -14,44 +14,44 @@ SLEEP_DELAY = 0.1
 stub = Stub()
 
 
-@stub.function
+@stub.function()
 def square(x):
     return x * x
 
 
-@stub.function
+@stub.function()
 def delay(t):
     time.sleep(t)
 
 
-@stub.function
+@stub.function()
 async def square_async(x):
     await asyncio.sleep(SLEEP_DELAY)
     return x * x
 
 
-@stub.function
+@stub.function()
 def raises(x):
     raise Exception("Failure!")
 
 
-@stub.function
+@stub.function()
 def raises_sysexit(x):
     raise SystemExit(1)
 
 
-@stub.function
+@stub.function()
 def raises_keyboardinterrupt(x):
     raise KeyboardInterrupt()
 
 
-@stub.function
+@stub.function()
 def gen_n(n):
     for i in range(n):
         yield i**2
 
 
-@stub.function
+@stub.function()
 def gen_n_fail_on_m(n, m):
     for i in range(n):
         if i == m:
@@ -76,7 +76,7 @@ class Cube:
     def __exit__(self, typ, exc, tb):
         self._events.append("exit")
 
-    @stub.function
+    @stub.function()
     def f(self, x):
         self._events.append("call")
         return x**3
@@ -94,13 +94,13 @@ class CubeAsync:
     async def __aexit__(self, typ, exc, tb):
         self._events.append("exit")
 
-    @stub.function
+    @stub.function()
     async def f(self, x):
         self._events.append("call")
         return x**3
 
 
-@stub.function
+@stub.function()
 @stub.web_endpoint()
 def webhook(arg="world"):
     return {"hello": arg}
@@ -125,7 +125,7 @@ class WebhookLifecycleClass:
     async def __aexit__(self, typ, exc, tb):
         self._events.append("exit")
 
-    @stub.function
+    @stub.function()
     @stub.web_endpoint()
     def webhook(self, arg="world"):
         self._events.append("call")
@@ -138,7 +138,7 @@ def stream():
         yield f"{i}..."
 
 
-@stub.function
+@stub.function()
 @stub.web_endpoint()
 def webhook_streaming():
     from fastapi.responses import StreamingResponse
@@ -152,7 +152,7 @@ async def stream_async():
         yield f"{i}..."
 
 
-@stub.function
+@stub.function()
 @stub.web_endpoint()
 async def webhook_streaming_async():
     from fastapi.responses import StreamingResponse
@@ -174,7 +174,7 @@ def fun_returning_gen(n):
     return gen(n)
 
 
-@stub.function
+@stub.function()
 @stub.asgi_app()
 def fastapi_app():
     from fastapi import FastAPI

--- a/modal_test_support/missing_main_conditional.py
+++ b/modal_test_support/missing_main_conditional.py
@@ -4,7 +4,7 @@ import modal
 stub = modal.Stub()
 
 
-@stub.function
+@stub.function()
 def square(x):
     return x**2
 

--- a/modal_test_support/startup_failure.py
+++ b/modal_test_support/startup_failure.py
@@ -7,6 +7,6 @@ if not modal.is_local():
     import nonexistent_package  # noqa
 
 
-@stub.function
+@stub.function()
 def f(i):
     pass

--- a/modal_test_support/stub.py
+++ b/modal_test_support/stub.py
@@ -4,7 +4,7 @@ import modal
 stub = modal.Stub()
 
 
-@stub.function
+@stub.function()
 def f(x):
     # not actually used in test (servicer returns sum of square of all args)
     pass

--- a/modal_utils/decorator_utils.py
+++ b/modal_utils/decorator_utils.py
@@ -6,6 +6,15 @@ import inspect
 from modal.exception import deprecation_warning
 
 
+def pretty_name(qualname):
+    if "." in qualname:
+        # convert _Stub.function to stub.function
+        qualname = qualname.lstrip("_")
+        qualname = qualname[0].lower() + qualname[1:]
+
+    return qualname
+
+
 def decorator_with_options(dec_fun):
     """Makes it possible for function fun to be used with and without arguments:
 
@@ -25,7 +34,7 @@ def decorator_with_options(dec_fun):
         if len(args) >= 2 or (len(args) == 1 and inspect.isfunction(args[-1])):
             # The decorator is invoked with a function as its first argument
             # Call the decorator function directly
-            name = dec_fun.__qualname__
+            name = pretty_name(dec_fun.__qualname__)
             deprecation_warning(
                 datetime.date(2023, 4, 5),
                 f"The decorator {name} without arguments will soon be deprecated. Add () to it if there are no arguments",
@@ -45,7 +54,7 @@ def decorator_with_options_unsupported(dec_fun):
     @functools.wraps(dec_fun)
     def wrapper(*args, **kwargs):
         if len(args) >= 2 or (len(args) == 1 and inspect.isfunction(args[-1])):
-            name = dec_fun.__qualname__
+            name = pretty_name(dec_fun.__qualname__)
             raise RuntimeError(f"The decorator {name} needs to be used with arguments. Add () to it if there are none")
         else:
             return functools.partial(dec_fun, *args, **kwargs)

--- a/modal_utils/decorator_utils.py
+++ b/modal_utils/decorator_utils.py
@@ -3,8 +3,6 @@ import datetime
 import functools
 import inspect
 
-from modal.exception import deprecation_warning
-
 
 def pretty_name(qualname):
     if "." in qualname:
@@ -35,6 +33,8 @@ def decorator_with_options(dec_fun):
             # The decorator is invoked with a function as its first argument
             # Call the decorator function directly
             name = pretty_name(dec_fun.__qualname__)
+            from modal.exception import deprecation_warning
+
             deprecation_warning(
                 datetime.date(2023, 4, 5),
                 f"The decorator {name} without arguments will soon be deprecated. Add empty parens to it, e.g. @{name}() if there are no arguments",

--- a/modal_utils/decorator_utils.py
+++ b/modal_utils/decorator_utils.py
@@ -1,6 +1,9 @@
 # Copyright Modal Labs 2022
+import datetime
 import functools
 import inspect
+
+from modal.exception import deprecation_warning
 
 
 def decorator_with_options(dec_fun):
@@ -22,6 +25,11 @@ def decorator_with_options(dec_fun):
         if len(args) >= 2 or (len(args) == 1 and inspect.isfunction(args[-1])):
             # The decorator is invoked with a function as its first argument
             # Call the decorator function directly
+            name = dec_fun.__qualname__
+            deprecation_warning(
+                datetime.date(2023, 4, 5),
+                f"The decorator {name} without arguments will soon be deprecated. Add () to it if there are no arguments",
+            )
             return dec_fun(*args, **kwargs)
         else:
             # The function is called with arguments
@@ -32,13 +40,13 @@ def decorator_with_options(dec_fun):
     return wrapper
 
 
-def decorator_with_options_deprecated(dec_fun):
+def decorator_with_options_unsupported(dec_fun):
     # Used when we are removing support for decorator_with_options
     @functools.wraps(dec_fun)
     def wrapper(*args, **kwargs):
         if len(args) >= 2 or (len(args) == 1 and inspect.isfunction(args[-1])):
-            name = dec_fun.__name__
-            raise RuntimeError(f"The function {name} needs to be used with arguments. Add () to it if there are none.")
+            name = dec_fun.__qualname__
+            raise RuntimeError(f"The decorator {name} needs to be used with arguments. Add () to it if there are none")
         else:
             return functools.partial(dec_fun, *args, **kwargs)
 

--- a/modal_utils/decorator_utils.py
+++ b/modal_utils/decorator_utils.py
@@ -37,7 +37,7 @@ def decorator_with_options(dec_fun):
             name = pretty_name(dec_fun.__qualname__)
             deprecation_warning(
                 datetime.date(2023, 4, 5),
-                f"The decorator {name} without arguments will soon be deprecated. Add () to it if there are no arguments",
+                f"The decorator {name} without arguments will soon be deprecated. Add empty parens to it, e.g. @{name}() if there are no arguments",
             )
             return dec_fun(*args, **kwargs)
         else:
@@ -55,7 +55,9 @@ def decorator_with_options_unsupported(dec_fun):
     def wrapper(*args, **kwargs):
         if len(args) >= 2 or (len(args) == 1 and inspect.isfunction(args[-1])):
             name = pretty_name(dec_fun.__qualname__)
-            raise RuntimeError(f"The decorator {name} needs to be used with arguments. Add () to it if there are none")
+            raise RuntimeError(
+                f"The decorator {name} needs to be called before decorating a function. Add empty parens to it, e.g. @{name}() if there are no arguments"
+            )
         else:
             return functools.partial(dec_fun, *args, **kwargs)
 


### PR DESCRIPTION
Emits a deprecation warning for now, and we can unsupport the feature in a month or so perhaps (given the very simple migration path)