### PR TITLE
gen wrapper fix pt2

### DIFF
--- a/modal_utils/async_utils.py
+++ b/modal_utils/async_utils.py
@@ -265,9 +265,9 @@ class _WarnIfGeneratorIsNotConsumed:
         self.iterated = True
         return self.gen
 
-    def __anext__(self):
+    async def __anext__(self):
         self.iterated = True
-        return self.gen.__anext__()
+        return await self.gen.__anext__()
 
     def __repr__(self):
         return repr(self.gen)


### PR DESCRIPTION
Follow up to #456, correcting mistake. Helps if you actually implement the interface.

I tried yesterday implementing a test in `container_test.py`, but because this involves a modal function calling a modal function the existing test machinery doesn't work (it only supports a single modal function).