### PR TITLE
Fix serve watching logic for directories

### DIFF
--- a/client_test/watcher_test.py
+++ b/client_test/watcher_test.py
@@ -16,13 +16,15 @@ async def test__watch_args_from_mounts(monkeypatch, test_dir):
         mounts=[
             _Mount.from_local_file("/x/foo.py", remote_path="/foo.py"),
             _Mount.from_local_dir("/one/two/bucklemyshoe", remote_path="/"),
+            _Mount.from_local_dir("/x/z", remote_path="/z"),
         ]
     )
 
-    assert paths == {Path("/x"), Path("/one/two/bucklemyshoe")}
+    assert paths == {Path("/x"), Path("/one/two/bucklemyshoe"), Path("/x/z")}
     assert watch_filter(Change.modified, "/x/foo.py")
     assert not watch_filter(Change.modified, "/x/notwatched.py")
     assert not watch_filter(Change.modified, "/x/y/foo.py")
+    assert watch_filter(Change.modified, "/x/z/bar.py")
     random_filename = "".join(random.choices(string.ascii_uppercase + string.digits, k=10))
     assert watch_filter(Change.modified, f"/one/two/bucklemyshoe/{random_filename}")
     assert not watch_filter(Change.modified, "/one/two/bucklemyshoe/.DS_Store")

--- a/modal/_watcher.py
+++ b/modal/_watcher.py
@@ -37,9 +37,23 @@ class StubFilesFilter(DefaultFilter):
         # into a target directory.
         elif p.name == "4913":
             return False
+
+        allowlists = set()
+
         for root, allowlist in self.dir_filters.items():
-            if allowlist is not None and root in p.parents and path not in allowlist:
-                return False
+            # For every filter path that's a parent of the current path...
+            if root in p.parents:
+                # If allowlist is None, we're watching the directory and we have a match.
+                if allowlist is None:
+                    return super().__call__(change, path)
+
+                # If not, it's specific files, and we could have a match.
+                else:
+                    allowlists |= allowlist
+
+        if allowlists and path not in allowlists:
+            return False
+
         return super().__call__(change, path)
 
 


### PR DESCRIPTION
This code is a little complicated. Mostly this is because watching individual files doesn't work (https://github.com/notify-rs/notify/issues/394) so we need to use directories + filtering to achieve the same effect.