### PR TITLE
Lower minimum protobuf version in client requirements

### DIFF
--- a/modal/requirements.txt
+++ b/modal/requirements.txt
@@ -11,7 +11,7 @@ fastprogress==1.0.0
 grpclib==0.4.3
 importlib_metadata==4.8.1
 ipython>=7.34.0
-protobuf>=4.21.0
+protobuf>=3.19.0
 python-multipart>=0.0.5
 rich==12.3.0
 synchronicity==0.4.2


### PR DESCRIPTION
The minimum we test against is 3.19.0. The stricter requirement causes users to have to manually override it later, which is annoying and doesn't work with Dockerfiles.