### PR TITLE
Link to app page URL from status spinner

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -41,6 +41,7 @@ class _App:
     _tag_to_existing_id: Dict[str, str]
     _client: _Client
     _app_id: str
+    _app_page_url: str
     _resolver: Optional[Resolver]
 
     def __init__(

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -59,6 +59,7 @@ async def run_stub(
         with output_mgr.ctx_if_visible(output_mgr.make_live(step_progress("Initializing..."))):
             initialized_msg = f"Initialized. [grey70]View app at [underline]{app._app_page_url}[/underline][/grey70]"
             output_mgr.print_if_visible(step_completed(initialized_msg))
+            output_mgr.update_app_page_url(app._app_page_url)
 
         # Start logs loop
         logs_loop = tc.create_task(get_app_logs_loop(app.app_id, client, output_mgr))


### PR DESCRIPTION
I find myself having to go to the apps page to look up a running app's URL too often. It is a bit hard to ctrl+click on it sometimes since it refreshes so often, but still better than nothing.

<img width="762" alt="image" src="https://user-images.githubusercontent.com/5786378/232246372-f8858cb2-62b1-44a1-907e-0fd501c5b6e6.png">
