### PR TITLE
Introduce "handle metadata" for functions

### DIFF
--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -213,7 +213,11 @@ class MockClientServicer(api_grpc.ModalClientBase):
             assert request.object_entity
             if object_id is not None:
                 assert object_id.startswith(request.object_entity)
-        function = function_definition_to_handle_metadata(self.app_functions.get(object_id))
+
+        if object_id in self.app_functions:
+            function = function_definition_to_handle_metadata(self.app_functions.get(object_id))
+        else:
+            function = None
         await stream.send_message(api_pb2.AppLookupObjectResponse(object_id=object_id, function=function))
 
     async def AppHeartbeat(self, stream):

--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -8,7 +8,7 @@ from synchronicity.exceptions import UserCodeException
 
 from modal import Proxy, Stub, SharedVolume
 from modal.exception import InvalidError
-from modal.functions import Function, FunctionCall, gather
+from modal.functions import Function, FunctionCall, gather, FunctionHandle
 from modal.stub import AioStub
 from modal_proto import api_pb2
 
@@ -458,3 +458,23 @@ def test_allow_cross_region_volumes_webhook(client, servicer):
             assert len(func.shared_volume_mounts) == 2
             for svm in func.shared_volume_mounts:
                 assert svm.allow_cross_region
+
+
+def test_serialize_deserialize_function_handle(servicer, client):
+    from modal._serialization import serialize, deserialize
+
+    stub = Stub()
+
+    @stub.function(serialized=True)
+    def my_handle():
+        pass
+
+    with pytest.raises(InvalidError, match="hasn't been created"):
+        serialize(my_handle)  # handle is not "live" yet! should not be serializable yet
+
+    with stub.run(client=client):
+        blob = serialize(my_handle)
+
+    rehydrated_function_handle = deserialize(blob, client)
+    assert rehydrated_function_handle.object_id == my_handle.object_id
+    assert isinstance(rehydrated_function_handle, FunctionHandle)

--- a/modal/_serialization.py
+++ b/modal/_serialization.py
@@ -4,8 +4,10 @@ import pickle
 
 import cloudpickle
 
+from modal_utils import async_utils
+from synchronicity.synchronizer import TARGET_INTERFACE_ATTR
 from .exception import InvalidError
-from .object import _Handle
+from .object import _Handle, Handle, AioHandle
 
 PICKLE_PROTOCOL = 4  # Support older Python versions.
 
@@ -15,11 +17,11 @@ class Pickler(cloudpickle.Pickler):
         super().__init__(buf, protocol=PICKLE_PROTOCOL)
 
     def persistent_id(self, obj):
-        if not isinstance(obj, _Handle):
+        if not isinstance(obj, (_Handle, Handle, AioHandle)):
             return
         if not obj.object_id:
             raise InvalidError(f"Can't serialize object {obj} which hasn't been created.")
-        return obj.object_id
+        return (obj.object_id, getattr(obj, TARGET_INTERFACE_ATTR, None), obj._handle_proto())
 
 
 class Unpickler(pickle.Unpickler):
@@ -28,10 +30,11 @@ class Unpickler(pickle.Unpickler):
         super().__init__(buf)
 
     def persistent_load(self, pid):
-        object_id = pid
-        # TODO(erikbern): we should get the proto somehow,
-        # for functions
-        return _Handle._from_id(object_id, self.client, None)
+        (object_id, target_interface, handle_proto) = pid
+        raw_obj = _Handle._from_id(object_id, self.client, handle_proto)
+        if target_interface:
+            return async_utils.synchronizer._translate_out(raw_obj, target_interface)
+        return raw_obj
 
 
 def serialize(obj):

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -484,7 +484,7 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
         self._self_obj = None
 
     def _initialize_from_proto(self, proto: Message):
-        assert isinstance(proto, api_pb2.Function)
+        assert isinstance(proto, (api_pb2.Function, api_pb2.FunctionHandleMetadata))
         self._is_generator = proto.function_type == api_pb2.Function.FUNCTION_TYPE_GENERATOR
         self._web_url = proto.web_url
         self._function_name = proto.function_name
@@ -1010,7 +1010,7 @@ class _Function(_Provider[_FunctionHandle]):
 
         # Update the precreated function handle (todo: hack until we merge providers/handles)
         self._function_handle._initialize_handle(resolver.client, response.function_id)
-        self._function_handle._initialize_from_proto(response.function)
+        self._function_handle._initialize_from_proto(response.handle_metadata)
 
         # Instead of returning a new object, just return the precreated one
         return self._function_handle

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -483,6 +483,15 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
         self._stub = None
         self._self_obj = None
 
+    def _handle_proto(self):
+        return api_pb2.FunctionHandleMetadata(
+            function_name=self._function_name,
+            function_type=api_pb2.Function.FUNCTION_TYPE_GENERATOR
+            if self._is_generator
+            else api_pb2.Function.FUNCTION_TYPE_FUNCTION,
+            web_url=self._web_url,
+        )
+
     def _initialize_from_proto(self, proto: Message):
         assert isinstance(proto, (api_pb2.Function, api_pb2.FunctionHandleMetadata))
         self._is_generator = proto.function_type == api_pb2.Function.FUNCTION_TYPE_GENERATOR
@@ -1010,7 +1019,16 @@ class _Function(_Provider[_FunctionHandle]):
 
         # Update the precreated function handle (todo: hack until we merge providers/handles)
         self._function_handle._initialize_handle(resolver.client, response.function_id)
-        self._function_handle._initialize_from_proto(response.handle_metadata)
+        if response.HasField("handle_metadata"):
+            self._function_handle._initialize_from_proto(response.handle_metadata)
+        else:
+            # TODO: remove this branch as soon as backend with handle_metadata is live
+            handle_metadata = api_pb2.FunctionHandleMetadata(
+                function_name=response.function.function_name,
+                function_type=response.function.function_type,
+                web_url=response.function.web_url,
+            )
+            self._function_handle._initialize_from_proto(handle_metadata)
 
         # Instead of returning a new object, just return the precreated one
         return self._function_handle

--- a/modal/object.py
+++ b/modal/object.py
@@ -56,6 +56,9 @@ class _Handle(metaclass=ObjectMeta):
     def _initialize_from_proto(self, proto: Message):
         pass  # default implementation
 
+    def _handle_proto(self) -> Optional[Message]:
+        return None
+
     @classmethod
     def _from_id(cls: Type[H], object_id: str, client: _Client, proto: Optional[Message]) -> H:
         if cls._type_prefix is not None:

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -148,7 +148,7 @@ message AppGetObjectsItem {
   string tag = 1;
   string object_id = 2;
   oneof object_oneof {
-    Function function = 3;
+    FunctionHandleMetadata function = 3;
   }
 }
 
@@ -183,7 +183,7 @@ message AppLookupObjectResponse {
   string object_id = 1;
   string error_message = 2;
   oneof object_oneof {
-    Function function = 3;
+    FunctionHandleMetadata function = 3;
   }
 }
 
@@ -408,6 +408,17 @@ message Function {
   string runtime = 30;
 }
 
+message FunctionHandleMetadata {
+  // contains all the info about a function that is needed to trigger the right
+  // behaviour when using a FunctionHandler. Notably excludes things purely
+  // used for *executing* the function in a container entrypoint
+
+  // Should be a subset and use IDs/types from `Function` above
+  string function_name = 2;
+  Function.FunctionType function_type = 8;
+  string web_url = 28;
+}
+
 message FunctionCreateRequest {
   Function function = 1;
   string app_id = 2;
@@ -420,6 +431,7 @@ message FunctionCreateResponse {
   string web_url = 2;  // Deprecated - needed until 0.46 is the minimum version
   WebUrlInfo web_url_info = 3;  // Deprecated - needed until 0.46 is the minimum version
   Function function = 4;
+  FunctionHandleMetadata handle_metadata = 5;
 }
 
 message FunctionGetInputsItem {


### PR DESCRIPTION
Replaces the full function proto in the context of `_initialize_from_proto`. This lets us have a much lighter weight proto with only the fields necessary for users of the handle, rather than all the info needed to execute the function. It has two advantages:
* We can use it in serialization/deserialization of individual objects to get functioning Handles on deserialization, without any RPC calls or similar.
* We can "hydrate" an app (AppGetObjects) without having to get a bunch of backend data
* in #466 we can let the "preload" phase of functions return a handle proto, letting serialized functions encode references to other function handles, or even to themselves.

The concept is general for all `_Handle`s but only needed for FunctionHandles at this time. Will be used in a new version of #466 to avoid having to load an entire app to rehydrate a serialized handle.

As a followup backend PR, we'll add rpc support for returning FunctionHandles in AppGetObjects, AppLookupObject and FunctionCreate. Since the protos share data types and indices, we should be able to do this in a backwards compatible way