### PR TITLE
tracing_hostname setting

### DIFF
--- a/modal/_tracing.py
+++ b/modal/_tracing.py
@@ -18,7 +18,7 @@ else:
 
 if TRACING_ENABLED:
     logging.getLogger("ddtrace").setLevel(logging.CRITICAL)
-    tracer.configure(hostname="172.19.0.1")
+    tracer.configure(hostname=config.get("tracing_hostname"))
 
 if config.get("profiling_enabled"):
     try:

--- a/modal/config.py
+++ b/modal/config.py
@@ -147,6 +147,7 @@ _SETTINGS = {
     "image_id": _Setting(),
     "automount": _Setting(True, transform=lambda x: x not in ("", "0")),
     "tracing_enabled": _Setting(False, transform=lambda x: x not in ("", "0")),
+    "tracing_hostname": _Setting("172.19.0.1"),
     "profiling_enabled": _Setting(False, transform=lambda x: x not in ("", "0")),
     "heartbeat_interval": _Setting(15, float),
     "function_runtime": _Setting(),


### PR DESCRIPTION
Allow configuring the dd tracer hostname, e.g. by setting the env var `MODAL_TRACING_HOSTNAME=localhost`.