### PR TITLE
Type annotations for decorator stuff

### DIFF
--- a/.github/actions/setup-cached-python/action.yml
+++ b/.github/actions/setup-cached-python/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: Which Python version to install
     required: true
-    default: "3.9"
+    default: "3.10"
 
 runs:
   using: composite

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -14,7 +14,7 @@ from modal._types import typechecked
 
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronize_apis
-from modal_utils.decorator_utils import decorator_with_options_unsupported, decorator_with_options
+from modal_utils.decorator_utils import decorator_simplify, decorator_with_options_unsupported, decorator_with_options
 from .retries import Retries
 
 from ._function_utils import FunctionInfo
@@ -434,8 +434,8 @@ class _Stub:
         """Names of web endpoint (ie. webhook) functions registered on the stub."""
         return self._web_endpoints
 
-    @decorator_with_options
-    def local_entrypoint(self, raw_f=None, name: Optional[str] = None):
+    @decorator_simplify
+    def local_entrypoint(self, raw_f: Callable[[], None], name: Optional[str] = None) -> LocalEntrypoint:
         """Decorate a function to be used as a CLI entrypoint for a Modal App.
 
         These functions can be used to define code that runs locally to set up the app,
@@ -647,17 +647,17 @@ class _Stub:
         self._add_function(function, [*base_mounts, *mounts])
         return function_handle
 
-    @decorator_with_options_unsupported
+    @decorator_simplify
     @typechecked
     def web_endpoint(
         self,
-        raw_f: Optional[Callable[..., Any]] = None,
+        raw_f: Callable[..., Any],
         method: str = "GET",  # REST method for the created endpoint.
         label: Optional[
             str
         ] = None,  # Label for created endpoint. Final subdomain will be <workspace>--<label>.modal.run.
         wait_for_response: bool = True,  # Whether requests should wait for and return the function response.
-    ):
+    ) -> WebhookConfig:
         """Register a basic web endpoint with this application.
 
         This is the simple way to create a web endpoint on Modal. The function

--- a/modal_utils/decorator_utils.py
+++ b/modal_utils/decorator_utils.py
@@ -3,7 +3,13 @@
 import datetime
 import functools
 import inspect
-from typing import Any, Callable, Concatenate, ParamSpec, TypeVar
+import sys
+from typing import Any, Callable, TypeVar
+
+if sys.version_info >= (3, 10):
+    from typing import Concatenate, ParamSpec
+else:
+    from typing_extensions import Concatenate, ParamSpec
 
 
 def pretty_name(qualname):

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     typer>=0.6.1
     types-certifi
     types-toml
+    typing-extensions;python_version<'3.10'
     watchfiles
 
 [options.entry_points]


### PR DESCRIPTION
We have a lot of decorators on the `Stub` class that themselves rely on another decorator to inject the function-to-be-decorated as the first argument. This is nice because we don't have to write nested functions. However the drawback is that mypy doesn't understand this properly, so our typing annotations end up having to hack around that (like making the function-to-be-decorated optional, even though it should always be provided).

Thanks to [PEP 612](https://peps.python.org/pep-0612/), we can support it without relying on those hacks.