### PR TITLE
[MOD-1159] Fix problem with volume get on some OSes and setups

### DIFF
--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -324,11 +324,13 @@ def test_logs(servicer, server_url_env):
 def test_volume_get(set_env_client):
     volume_name = "my-shared-volume"
     _run(["volume", "create", volume_name])
-    with tempfile.NamedTemporaryFile(mode="w+") as fp:
-        fp.write("foo bar baz")
-        fp.flush()
-        _run(["volume", "put", volume_name, fp.name, "test.txt"])
     with tempfile.TemporaryDirectory() as tmpdir:
+        upload_path = os.path.join(tmpdir, "upload.txt")
+        with open(upload_path, "w") as f:
+            f.write("foo bar baz")
+            f.flush()
+        _run(["volume", "put", volume_name, upload_path, "test.txt"])
+
         _run(["volume", "get", volume_name, "test.txt", tmpdir])
         with open(os.path.join(tmpdir, "test.txt"), "r") as f:
             assert f.read() == "foo bar baz"

--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -519,6 +519,16 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.shared_volume_files[req.shared_volume_id][req.path] = req
         await stream.send_message(api_pb2.SharedVolumePutFileResponse(exists=True))
 
+    async def SharedVolumeGetFile(self, stream):
+        req = await stream.recv_message()
+        put_req = self.shared_volume_files.get(req.shared_volume_id, {}).get(req.path)
+        if not put_req:
+            raise GRPCError(Status.NOT_FOUND, f"No such file: {req.path}")
+        if put_req.data_blob_id:
+            await stream.send_message(api_pb2.SharedVolumeGetFileResponse(data_blob_id=put_req.data_blob_id))
+        else:
+            await stream.send_message(api_pb2.SharedVolumeGetFileResponse(data=put_req.data))
+
     ### Task
 
     async def TaskResult(self, stream):

--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -244,7 +244,7 @@ async def get(volume_name: str, remote_path: str, local_destination: str = typer
         else:
             with NamedTemporaryFile(delete=False) as fp:
                 yield fp
-            Path(fp.name).rename(destination)
+            shutil.move(fp.name, destination)
 
     b = 0
     try:


### PR DESCRIPTION
`pathlib.rename()` uses `os.rename()`. `os.rename()` fails on certin UNIX flavours if the source and target destinations are on different devices/filesystems. In this case if the users temp dir and the target directory are on different devices.

For example, before this change here's what happens on a recent Linux when `/tmp` is on a different device than cwd:

```
$ modal volume get some-volume some-file.txt
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ <...>/synchronizer.py:362 in f_wrapped                                                           │
│                                                                                                  │
│ <...>/volume.py:256 in get                                                                       │
│                                                                                                  │
│   255 │   │   │   │   fp.write(chunk)                                                            │
│ ❱ 256 │   │   │   │   b += len(chunk)                                                            │
│   257 │   except GRPCError as exc:                                                               │
│                                                                                                  │
│ <...>/contextlib.py:126 in __exit__                                                              │
│                                                                                                  │
│   125 │   │   │   try:                                                                           │
│ ❱ 126 │   │   │   │   next(self.gen)                                                             │
│   127 │   │   │   except StopIteration:                                                          │
│                                                                                                  │
│ <...>/client/modal/cli/volume.py:249 in _destination_stream                                      │
│                                                                                                  │
│   248 │   │   │   │   yield fp                                                                   │
│ ❱ 249 │   │   │   Path(fp.name).rename(destination)                                              │
│   250                                                                                            │
│                                                                                                  │
│ <...>/pathlib.py:1382 in rename                                                                  │
│                                                                                                  │
│   1381 │   │   """                                                                               │
│ ❱ 1382 │   │   self._accessor.rename(self, target)                                               │
│   1383 │   │   return self.__class__(target)                                                     │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
OSError: [Errno 18] Invalid cross-device link: '/tmp/tmpm6wlhqcl' -> 'some-file.txt'
```