### PR TITLE
tracing: respect datadog endpoint env vars

### DIFF
--- a/modal/_tracing.py
+++ b/modal/_tracing.py
@@ -55,18 +55,21 @@ def inject_tracing_context(metadata: Dict[str, str]):
         logger.exception("Failed to inject tracing context")
 
 
+TRACING_SERVICE = None if os.environ.get("DD_SERVICE") else "modal-runtime-client"
+
+
 def wrap(*args, **kwargs):
     if not TRACING_ENABLED:
         return lambda f: f
 
-    return tracer.wrap(*args, **kwargs, service="modal-runtime-client")
+    return tracer.wrap(*args, **kwargs, service=TRACING_SERVICE)
 
 
 def trace(*args, **kwargs):
     if not TRACING_ENABLED:
         return contextlib.nullcontext()
 
-    return tracer.trace(*args, **kwargs, service="modal-runtime-client")
+    return tracer.trace(*args, **kwargs, service=TRACING_SERVICE)
 
 
 def set_span_tag(key, value):

--- a/modal/_tracing.py
+++ b/modal/_tracing.py
@@ -6,8 +6,7 @@ from typing import Dict
 
 from .config import config, logger
 
-dd_trace_enabled = os.environ.get("DD_TRACE_ENABLED", "") in ("true", "1")
-if config.get("tracing_enabled") or dd_trace_enabled:
+if config.get("tracing_enabled") or os.environ.get("DD_TRACE_ENABLED") == "true":
     try:
         from ddtrace import tracer
         from ddtrace.propagation.http import HTTPPropagator

--- a/modal/_tracing.py
+++ b/modal/_tracing.py
@@ -6,7 +6,8 @@ from typing import Dict
 
 from .config import config, logger
 
-if config.get("tracing_enabled"):
+dd_trace_enabled = os.environ.get("DD_TRACE_ENABLED", "") in ("true", "1")
+if config.get("tracing_enabled") or dd_trace_enabled:
     try:
         from ddtrace import tracer
         from ddtrace.propagation.http import HTTPPropagator

--- a/modal/_tracing.py
+++ b/modal/_tracing.py
@@ -54,21 +54,21 @@ def inject_tracing_context(metadata: Dict[str, str]):
         logger.exception("Failed to inject tracing context")
 
 
-TRACING_SERVICE = None if os.environ.get("DD_SERVICE") else "modal-runtime-client"
+TRACING_KWARGS = {} if os.environ.get("DD_SERVICE") else {"service": "modal-runtime-client"}
 
 
 def wrap(*args, **kwargs):
     if not TRACING_ENABLED:
         return lambda f: f
 
-    return tracer.wrap(*args, **kwargs, service=TRACING_SERVICE)
+    return tracer.wrap(*args, **kwargs, **TRACING_KWARGS)
 
 
 def trace(*args, **kwargs):
     if not TRACING_ENABLED:
         return contextlib.nullcontext()
 
-    return tracer.trace(*args, **kwargs, service=TRACING_SERVICE)
+    return tracer.trace(*args, **kwargs, **TRACING_KWARGS)
 
 
 def set_span_tag(key, value):

--- a/modal/_tracing.py
+++ b/modal/_tracing.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
 import contextlib
 import logging
+import os
 from typing import Dict
 
 from .config import config, logger
@@ -18,7 +19,10 @@ else:
 
 if TRACING_ENABLED:
     logging.getLogger("ddtrace").setLevel(logging.CRITICAL)
-    tracer.configure(hostname="172.19.0.1")
+    if any(os.environ.get(k) for k in ("DD_TRACE_AGENT_URL", "DD_AGENT_HOST")):
+        tracer.configure()
+    else:
+        tracer.configure(hostname="172.19.0.1")
 
 if config.get("profiling_enabled"):
     try:


### PR DESCRIPTION
Allow configuring datadog agent endpoint using the `DD_TRACE_AGENT_URL` and `DD_AGENT_HOST` env vars.

Alternative to https://github.com/modal-labs/modal-client/pull/474.

With this we should be able to enable dd tracing for the client in tasks:

```
"DD_TRACE_ENABLED": "true",
"DD_AGENT_HOST": "127.0.0.1",
```

We could instead introduce `MODAL_TRACING_URL` and/or `MODAL_TRACING_HOSTNAME` but this seems like additional work for little gain.

Also respect `DD_SERVICE` if set.