### PR TITLE
Move web_endpoint, asgi_app, and wsgi_app out of the stub

### DIFF
--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -6,7 +6,7 @@ import time
 import cloudpickle
 from synchronicity.exceptions import UserCodeException
 
-from modal import Proxy, Stub, SharedVolume
+from modal import Proxy, Stub, SharedVolume, web_endpoint
 from modal.exception import InvalidError
 from modal.functions import Function, FunctionCall, gather
 from modal.stub import AioStub
@@ -423,9 +423,7 @@ def test_allow_cross_region_volumes_webhook(client, servicer):
     stub = Stub()
     vol1, vol2 = SharedVolume(), SharedVolume()
     # Should pass flag for all the function's SharedVolumeMounts
-    stub.function(shared_volumes={"/sv-1": vol1, "/sv-2": vol2}, allow_cross_region_volumes=True)(
-        stub.web_endpoint()(dummy)
-    )
+    stub.function(shared_volumes={"/sv-1": vol1, "/sv-2": vol2}, allow_cross_region_volumes=True)(web_endpoint()(dummy))
 
     with stub.run(client=client):
         assert len(servicer.app_functions) == 1

--- a/client_test/lookup_test.py
+++ b/client_test/lookup_test.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2023
 import pytest
 
-from modal.aio import AioFunction, AioQueue, AioStub, aio_lookup
+from modal.aio import AioFunction, AioQueue, AioStub, aio_lookup, aio_web_endpoint
 from modal.exception import DeprecationError, NotFoundError
 from modal.queue import AioQueueHandle
 
@@ -50,7 +50,7 @@ async def test_lookup_function(servicer, aio_client):
 @pytest.mark.asyncio
 async def test_webhook_lookup(servicer, aio_client):
     stub = AioStub()
-    stub.function()(stub.web_endpoint(method="POST")(square))
+    stub.function()(aio_web_endpoint(method="POST")(square))
     await stub.deploy("my-webhook", client=aio_client)
 
     f = await AioFunction.lookup("my-webhook", client=aio_client)

--- a/client_test/stub_test.py
+++ b/client_test/stub_test.py
@@ -9,7 +9,7 @@ from google.protobuf.empty_pb2 import Empty
 from grpclib import GRPCError, Status
 
 import modal.app
-from modal import Client, Stub
+from modal import Client, Stub, web_endpoint, wsgi_app
 from modal.aio import AioDict, AioQueue, AioStub
 from modal.exception import DeprecationError, InvalidError
 from modal_proto import api_pb2
@@ -172,7 +172,7 @@ skip_in_github = pytest.mark.skipif(
 def test_serve(client):
     stub = Stub()
 
-    stub.function()(stub.wsgi_app()(dummy))
+    stub.function()(wsgi_app()(dummy))
     with pytest.warns(DeprecationError):
         stub.serve(client=client, timeout=1)
 
@@ -181,7 +181,7 @@ def test_serve(client):
 def test_serve_teardown(client, servicer):
     stub = Stub()
     with Client(servicer.remote_addr, api_pb2.CLIENT_TYPE_CLIENT, ("foo-id", "foo-secret")) as client:
-        stub.function()(stub.wsgi_app()(dummy))
+        stub.function()(wsgi_app()(dummy))
         with pytest.warns(DeprecationError):
             stub.serve(client=client, timeout=1)
 
@@ -195,7 +195,7 @@ def test_serve_teardown(client, servicer):
 def test_nested_serve_invocation(client):
     stub = Stub()
 
-    stub.function()(stub.wsgi_app()(dummy))
+    stub.function()(wsgi_app()(dummy))
     with pytest.raises(InvalidError) as excinfo:
         with stub.run(client=client):
             # This nested call creates a second web endpoint!
@@ -247,7 +247,7 @@ def test_registered_web_endpoints(client, servicer):
     stub.function()(square)
     with pytest.warns(DeprecationError):
         stub.webhook(web1)
-    stub.function()(stub.web_endpoint()(web2))
+    stub.function()(web_endpoint()(web2))
 
     assert stub.registered_web_endpoints == ["web1", "web2"]
 

--- a/client_test/supports/app_run_tests/webhook.py
+++ b/client_test/supports/app_run_tests/webhook.py
@@ -1,10 +1,10 @@
 # Copyright Modal Labs 2022
-import modal
+from modal import Stub, web_endpoint
 
-stub = modal.Stub()
+stub = Stub()
 
 
 @stub.function()
-@stub.web_endpoint()
+@web_endpoint()
 def foo():
     return {"bar": "baz"}

--- a/client_test/webhook_test.py
+++ b/client_test/webhook_test.py
@@ -7,7 +7,7 @@ import sys
 from modal_proto import api_pb2
 from modal.aio import AioApp, AioStub, aio_web_endpoint, aio_asgi_app, aio_wsgi_app
 from modal.functions import AioFunctionHandle
-from modal.exception import DeprecationError, InvalidError
+from modal.exception import DeprecationError, PendingDeprecationError, InvalidError
 
 stub = AioStub()
 
@@ -18,7 +18,7 @@ async def f(x):
     return {"square": x**2}
 
 
-with pytest.warns(DeprecationError):
+with pytest.warns(PendingDeprecationError):
 
     @stub.function(cpu=42)
     @stub.web_endpoint(method="POST")

--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -5,7 +5,7 @@ from .app import App, container_app, is_local
 from .client import Client
 from .dict import Dict
 from .exception import Error
-from .functions import Function, current_input_id, method
+from .functions import Function, current_input_id, method, asgi_app, wsgi_app, web_endpoint
 from .image import Image
 from .mount import Mount, create_package_mounts
 from .object import lookup
@@ -35,10 +35,13 @@ __all__ = [
     "Secret",
     "SharedVolume",
     "Stub",
+    "asgi_app",
     "container_app",
     "create_package_mounts",
+    "current_input_id",
     "is_local",
     "lookup",
     "method",
-    "current_input_id",
+    "web_endpoint",
+    "wsgi_app",
 ]

--- a/modal/aio.py
+++ b/modal/aio.py
@@ -7,7 +7,15 @@ The async interfaces are mostly mirrors of the blocking ones, with the `Aio` or 
 from .app import AioApp, aio_container_app
 from .client import AioClient
 from .dict import AioDict
-from .functions import AioFunction, AioFunctionHandle, AioFunctionCall, aio_method
+from .functions import (
+    AioFunction,
+    AioFunctionHandle,
+    AioFunctionCall,
+    aio_method,
+    aio_asgi_app,
+    aio_wsgi_app,
+    aio_web_endpoint,
+)
 from .image import AioImage
 from .mount import AioMount
 from .object import aio_lookup
@@ -34,4 +42,7 @@ __all__ = [
     "aio_container_app",
     "aio_lookup",
     "aio_method",
+    "aio_asgi_app",
+    "aio_web_endpoint",
+    "aio_wsgi_app",
 ]

--- a/modal/exception.py
+++ b/modal/exception.py
@@ -61,6 +61,10 @@ class DeprecationError(UserWarning):
     # Overloading it to evade the default filter, which excludes __main__.
 
 
+class PendingDeprecationError(UserWarning):
+    """Soon to be deprecated feature. Only used intermittently because of multi-repo concerns."""
+
+
 _INTERNAL_MODULES = ["modal", "synchronicity"]
 
 
@@ -73,7 +77,7 @@ def deprecation_error(deprecated_on: date, msg: str):
     raise DeprecationError(f"Deprecated on {deprecated_on}: {msg}")
 
 
-def deprecation_warning(deprecated_on: date, msg: str):
+def deprecation_warning(deprecated_on: date, msg: str, pending=False):
     """Utility for getting the proper stack entry.
 
     See the implementation of the built-in [warnings.warn](https://docs.python.org/3/library/warnings.html#available-functions).
@@ -89,5 +93,7 @@ def deprecation_warning(deprecated_on: date, msg: str):
         filename = "<unknown>"
         lineno = 0
 
+    warning_cls: type = PendingDeprecationError if pending else DeprecationError
+
     # This is a lower-level function that warnings.warn uses
-    warnings.warn_explicit(f"{deprecated_on}: {msg}", DeprecationError, filename, lineno)
+    warnings.warn_explicit(f"{deprecated_on}: {msg}", warning_cls, filename, lineno)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1149,7 +1149,7 @@ class _PartialFunction:
 
     def __del__(self):
         if self.wrapped is False:
-            warnings.warn(
+            logger.warning(
                 f"Method or web function {self.raw_f} was never turned into a function."
                 " Did you forget a @stub.function or @stub.cls decorator?"
             )

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -35,11 +35,6 @@ async def run_stub(
     detach: bool = False,
     output_mgr: Optional[OutputManager] = None,
 ) -> AsyncGenerator[_App, None]:
-    if stub._loose_webhook_configs:
-        raise InvalidError(
-            f"Web endpoints {stub._loose_webhook_configs} need to be decorated with @stub.function() too.\nUsage:\n\n"
-            "@stub.function()\n@stub.web_endpoint()\ndef my_webhook():\n    ..."
-        )
     if not is_local():
         raise InvalidError(
             "Can not run an app from within a container."
@@ -135,11 +130,6 @@ async def deploy_stub(
     show_progress=None,
     object_entity="ap",
 ) -> _App:
-    if stub._loose_webhook_configs:
-        raise InvalidError(
-            f"Web endpoints {stub._loose_webhook_configs} need to be decorated with @stub.function() too. Usage:\n\n"
-            "@stub.function()\n@stub.web_endpoint()\ndef my_webhook():\n    ..."
-        )
     if not is_local():
         raise InvalidError("Cannot run a deploy from within a container.")
     if name is None:

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -666,6 +666,7 @@ stub = Stub()
 def my_function():
     ...
 """,
+            pending=True,
         )
         return _web_endpoint(method, label, wait_for_response)
 
@@ -677,7 +678,7 @@ def my_function():
         ] = None,  # Label for created endpoint. Final subdomain will be <workspace>--<label>.modal.run.
         wait_for_response: bool = True,  # Whether requests should wait for and return the function response.
     ):
-        deprecation_warning(date(2023, 4, 18), "stub.asgi_app is deprecated. Use modal.asgi_app instead.")
+        deprecation_warning(date(2023, 4, 18), "stub.asgi_app is deprecated. Use modal.asgi_app instead.", pending=True)
         return _asgi_app(label, wait_for_response)
 
     @typechecked
@@ -688,7 +689,7 @@ def my_function():
         ] = None,  # Label for created endpoint. Final subdomain will be <workspace>--<label>.modal.run.
         wait_for_response: bool = True,  # Whether requests should wait for and return the function response.
     ):
-        deprecation_warning(date(2023, 4, 18), "stub.wsgi_app is deprecated. Use modal.wsgi_app instead.")
+        deprecation_warning(date(2023, 4, 18), "stub.wsgi_app is deprecated. Use modal.wsgi_app instead.", pending=True)
         return _wsgi_app(label, wait_for_response)
 
     @decorator_with_options

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -7,7 +7,7 @@ from multiprocessing.synchronize import Event
 import os
 import sys
 import warnings
-from typing import AsyncGenerator, Callable, Dict, List, Optional, Union, Any, Sequence, Set
+from typing import AsyncGenerator, Callable, Dict, List, Optional, Union, Any, Sequence
 
 from synchronicity.async_wrap import asynccontextmanager
 from modal._types import typechecked
@@ -108,7 +108,6 @@ class _Stub:
     _local_entrypoints: Dict[str, LocalEntrypoint]
     _local_mounts: List[_Mount]
     _app: Optional[_App]
-    _loose_webhook_configs: Set[Callable[..., Any]]  # Used to warn users if they forget to decorate a webhook
 
     @typechecked
     def __init__(
@@ -155,7 +154,6 @@ class _Stub:
         self._local_entrypoints = {}
         self._local_mounts = []
         self._web_endpoints = []
-        self._loose_webhook_configs = set()
 
         self._app = None
         if not is_local():
@@ -577,12 +575,12 @@ class _Stub:
             image = self._get_default_image()
 
         if isinstance(f, _PartialFunction):
+            f.wrapped = True
             info = FunctionInfo(f.raw_f, serialized=serialized, name_override=name)
             raw_f = f.raw_f
             webhook_config = f.webhook_config
             if webhook_config:
                 self._web_endpoints.append(info.get_tag())
-                # self._loose_webhook_configs.remove(raw_f)
 
                 if is_generator or (inspect.isgeneratorfunction(raw_f) or inspect.isasyncgenfunction(raw_f)):
                     if webhook_config.type == api_pb2.WEBHOOK_TYPE_FUNCTION:

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -6,7 +6,7 @@ import time
 
 import pytest
 
-from modal import Stub, method
+from modal import Stub, method, web_endpoint, asgi_app
 from modal.exception import DeprecationError, deprecation_warning
 
 SLEEP_DELAY = 0.1
@@ -101,7 +101,7 @@ class CubeAsync:
 
 
 @stub.function()
-@stub.web_endpoint()
+@web_endpoint()
 def webhook(arg="world"):
     return {"hello": arg}
 
@@ -126,7 +126,7 @@ class WebhookLifecycleClass:
         self._events.append("exit")
 
     @stub.function()
-    @stub.web_endpoint()
+    @web_endpoint()
     def webhook(self, arg="world"):
         self._events.append("call")
         return {"hello": arg}
@@ -139,7 +139,7 @@ def stream():
 
 
 @stub.function()
-@stub.web_endpoint()
+@web_endpoint()
 def webhook_streaming():
     from fastapi.responses import StreamingResponse
 
@@ -153,7 +153,7 @@ async def stream_async():
 
 
 @stub.function()
-@stub.web_endpoint()
+@web_endpoint()
 async def webhook_streaming_async():
     from fastapi.responses import StreamingResponse
 
@@ -175,7 +175,7 @@ def fun_returning_gen(n):
 
 
 @stub.function()
-@stub.asgi_app()
+@asgi_app()
 def fastapi_app():
     from fastapi import FastAPI
 
@@ -197,6 +197,6 @@ class Cls:
     def f(self, x):
         return self._k * x
 
-    @stub.web_endpoint()
+    @web_endpoint()
     def web(self, arg):
         return {"ret": arg * self._k}

--- a/modal_test_support/webhook_forgot_function.py
+++ b/modal_test_support/webhook_forgot_function.py
@@ -1,0 +1,7 @@
+# Copyright Modal Labs 2023
+from modal import web_endpoint
+
+
+@web_endpoint()
+async def absent_minded_function(x):
+    pass


### PR DESCRIPTION
I'm trying to simplify the `Stub` class since it's very complex – it makes it harder to perform other refactorings (merging stubs and apps) and fundamentally makes it harder for users to understand what a stub "is". I want to make it a "carrier of other objects" but it's currently doing all kinds of other stuff.

This PR changes

```python
from modal import Stub

stub = Stub()

@stub.function(cpu=12)
@stub.web_endpoint(method="POST")
def my_f():
    ...
```

to

```python
from modal import Stub, web_endpoint

stub = Stub()

@stub.function(cpu=12)
@web_endpoint(method="POST")
def my_f():
    ...
```

Note that this is a temporary increase in LOC but that's just because there's a ton of deprecation warnings – those will go away in a few months.

~Currently failing on a unit test that detects web endpoints that were never decorated by a function. I'm going to rewrite that logic slightly.~ EDIT: done
