### PR TITLE
Don't enforce object ID stability for persisted objects

### DIFF
--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -16,7 +16,9 @@ from modal.exception import ExecutionError
 
 class StatusRow:
     def __init__(self, progress: Optional[Tree]):
-        from ._output import step_progress  # Lazy import to only import `rich` when necessary.
+        from ._output import (
+            step_progress,
+        )  # Lazy import to only import `rich` when necessary.
 
         self._spinner = None
         self._step_node = None
@@ -75,12 +77,15 @@ class Resolver:
         created_obj = await obj._load(self, existing_object_id)
 
         if existing_object_id is not None and created_obj.object_id != existing_object_id:
-            # TODO(erikbern): this is a very ugly fix to a problem that's on the server side.
+            # TODO(erikbern): ignoring images is an ugly fix to a problem that's on the server.
             # Unlike every other object, images are not assigned random ids, but rather an
             # id given by the hash of its contents. This means we can't _force_ an image to
             # have a particular id. The better solution is probably to separate "images"
             # from "image definitions" or something like that, but that's a big project.
-            if not existing_object_id.startswith("im-"):
+            #
+            # Persisted refs are ignored because their life cycle is managed independently.
+            # The same tag on an app can be pointed at different objects.
+            if not obj.is_persisted_ref and not existing_object_id.startswith("im-"):
                 raise Exception(
                     f"Tried creating an object using existing id {existing_object_id}"
                     f" but it has id {created_obj.object_id}"

--- a/modal/object.py
+++ b/modal/object.py
@@ -157,9 +157,15 @@ class _Provider(Generic[H]):
         self._load = load
         self._rep = rep
 
-    def __init__(self, load: Callable[[Resolver, str], Awaitable[H]], rep: str):
+    def __init__(
+        self,
+        load: Callable[[Resolver, str], Awaitable[H]],
+        rep: str,
+        is_persisted_ref: bool = False,
+    ):
         # TODO(erikbern): this is semi-deprecated - subclasses should use _from_loader
         self._init(load, rep)
+        self.is_persisted_ref = is_persisted_ref
 
     @classmethod
     def _from_loader(cls, load: Callable[[Resolver, str], Awaitable[H]], rep: str):
@@ -182,7 +188,10 @@ class _Provider(Generic[H]):
         return self._local_uuid
 
     async def _deploy(
-        self, label: str, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, client: Optional[_Client] = None
+        self,
+        label: str,
+        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        client: Optional[_Client] = None,
     ) -> H:
         """mdmd:hidden
 
@@ -231,12 +240,15 @@ class _Provider(Generic[H]):
         cls = type(self)
         obj = cls.__new__(cls)
         rep = f"PersistedRef<{self}>({label})"
-        _Provider.__init__(obj, _load_persisted, rep)
+        _Provider.__init__(obj, _load_persisted, rep, is_persisted_ref=True)
         return obj
 
     @classmethod
     def from_name(
-        cls: Type[P], app_name: str, tag: Optional[str] = None, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE
+        cls: Type[P],
+        app_name: str,
+        tag: Optional[str] = None,
+        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
     ) -> P:
         """Returns a reference to an Modal object of any type
 


### PR DESCRIPTION
Persisted objects have an independent lifecycle that's not managed by the app. This means for example that the user can create/delete them (and the ID can change). 
