### PR TITLE
Fix is_persisted_ref for some Handlers

### DIFF
--- a/client_test/image_test.py
+++ b/client_test/image_test.py
@@ -334,7 +334,7 @@ def test_image_build_with_context_mount(client, servicer, tmp_path):
     stub["dockerfile_commands"] = Image.debian_slim().from_dockerfile(dockerfile.name, context_mount=data_mount)
 
     with stub.run(client=client) as running_app:
-        for (image_name, expected_layer) in [("copy", 0), ("dockerfile_commands", 1), ("from_dockerfile", 0)]:
+        for image_name, expected_layer in [("copy", 0), ("dockerfile_commands", 1), ("from_dockerfile", 0)]:
             layers = get_image_layers(running_app[image_name].object_id, servicer)
             assert layers[expected_layer].context_mount_id == "mo-123", f"error in {image_name}"
             assert "COPY . /dummy" in layers[expected_layer].dockerfile_commands
@@ -380,7 +380,7 @@ def test_image_force_build(client, servicer):
 
     stub["image"] = (
         Image.from_gcp_artifact_registry("foo", force_build=True)
-        .run_commands("echo 1")
+        .run_commands("python_packagesecho 1")
         .pip_install("foo", force_build=True)
         .run_commands("echo 2")
     )

--- a/client_test/stub_test.py
+++ b/client_test/stub_test.py
@@ -10,7 +10,7 @@ from grpclib import GRPCError, Status
 
 import modal.app
 from modal import Client, Stub, web_endpoint, wsgi_app
-from modal.aio import AioDict, AioQueue, AioStub
+from modal.aio import AioDict, AioQueue, AioStub, AioImage
 from modal.exception import DeprecationError, InvalidError
 from modal_proto import api_pb2
 from modal_test_support import module_1, module_2
@@ -65,6 +65,7 @@ def square(x):
 async def test_redeploy(servicer, aio_client):
     stub = AioStub()
     stub.function()(square)
+    stub.image = AioImage.debian_slim().pip_install("pandas")
 
     # Deploy app
     app = await stub.deploy("my-app", client=aio_client)

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -85,6 +85,7 @@ class Resolver:
             #
             # Persisted refs are ignored because their life cycle is managed independently.
             # The same tag on an app can be pointed at different objects.
+            print(obj, type(obj))
             if not obj.is_persisted_ref and not existing_object_id.startswith("im-"):
                 raise Exception(
                     f"Tried creating an object using existing id {existing_object_id}"

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -85,7 +85,6 @@ class Resolver:
             #
             # Persisted refs are ignored because their life cycle is managed independently.
             # The same tag on an app can be pointed at different objects.
-            print(obj, type(obj))
             if not obj.is_persisted_ref and not existing_object_id.startswith("im-"):
                 raise Exception(
                     f"Tried creating an object using existing id {existing_object_id}"

--- a/modal/object.py
+++ b/modal/object.py
@@ -152,11 +152,10 @@ _BLOCKING_P, _ASYNC_P = synchronize_apis(P)
 
 
 class _Provider(Generic[H]):
-    def _init(self, load: Callable[[Resolver, str], Awaitable[H]], rep: str, is_persisted_ref: bool = False):
+    def _init(self, load: Callable[[Resolver, str], Awaitable[H]], rep: str):
         self._local_uuid = str(uuid.uuid4())
         self._load = load
         self._rep = rep
-        self.is_persisted_ref = is_persisted_ref
 
     def __init__(
         self,
@@ -165,7 +164,8 @@ class _Provider(Generic[H]):
         is_persisted_ref: bool = False,
     ):
         # TODO(erikbern): this is semi-deprecated - subclasses should use _from_loader
-        self._init(load, rep, is_persisted_ref)
+        self._init(load, rep)
+        self.is_persisted_ref = is_persisted_ref
 
     @classmethod
     def _from_loader(cls, load: Callable[[Resolver, str], Awaitable[H]], rep: str):

--- a/modal/object.py
+++ b/modal/object.py
@@ -152,10 +152,11 @@ _BLOCKING_P, _ASYNC_P = synchronize_apis(P)
 
 
 class _Provider(Generic[H]):
-    def _init(self, load: Callable[[Resolver, str], Awaitable[H]], rep: str):
+    def _init(self, load: Callable[[Resolver, str], Awaitable[H]], rep: str, is_persisted_ref: bool = False):
         self._local_uuid = str(uuid.uuid4())
         self._load = load
         self._rep = rep
+        self.is_persisted_ref = is_persisted_ref
 
     def __init__(
         self,
@@ -164,8 +165,7 @@ class _Provider(Generic[H]):
         is_persisted_ref: bool = False,
     ):
         # TODO(erikbern): this is semi-deprecated - subclasses should use _from_loader
-        self._init(load, rep)
-        self.is_persisted_ref = is_persisted_ref
+        self._init(load, rep, is_persisted_ref)
 
     @classmethod
     def _from_loader(cls, load: Callable[[Resolver, str], Awaitable[H]], rep: str):


### PR DESCRIPTION
Didn't realize there's another code path where `Handlers` can be initialized. Added a test for this + one for the original issue with persisted refs changing.