### PR TITLE
Add deprecation docstring to lookup

### DIFF
--- a/modal/object.py
+++ b/modal/object.py
@@ -137,9 +137,10 @@ async def _lookup(
     namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
     client: Optional[_Client] = None,
 ) -> _Handle:
+    """Deprecated. Use corresponding class methods instead," " e.g. modal.Secret.lookup, etc."""
     deprecation_warning(
         date(2023, 2, 11),
-        "modal.lookup is deprecated. Use corresponding class methods instead," " e.g. modal.Secret.lookup, etc.",
+        _lookup.__doc__,
     )
     return await _Handle.from_app(app_name, tag, namespace, client)
 


### PR DESCRIPTION
Should have done this in #482 

Adds a docstring to https://modal.com/docs/reference/modal.lookup – it's currently empty

<img width="1261" alt="image" src="https://user-images.githubusercontent.com/1027979/232912778-1841fbe7-b708-4fb3-aa68-0b9c5d2a0b61.png">
