### PR TITLE
Turn deprecation warnings into errors

### DIFF
--- a/client_test/lookup_test.py
+++ b/client_test/lookup_test.py
@@ -1,8 +1,8 @@
 # Copyright Modal Labs 2023
 import pytest
 
-from modal.aio import AioFunction, AioQueue, AioStub, aio_lookup, aio_web_endpoint
-from modal.exception import DeprecationError, NotFoundError
+from modal.aio import AioFunction, AioQueue, AioStub, aio_web_endpoint
+from modal.exception import NotFoundError
 from modal.queue import AioQueueHandle
 
 
@@ -55,18 +55,6 @@ async def test_webhook_lookup(servicer, aio_client):
 
     f = await AioFunction.lookup("my-webhook", client=aio_client)
     assert f.web_url
-
-
-@pytest.mark.asyncio
-async def test_deprecated(servicer, aio_client):
-    stub = AioStub()
-    stub["q_1"] = AioQueue()
-    await stub.deploy("my-queue", client=aio_client)
-
-    servicer.enforce_object_entity = False
-    with pytest.warns(DeprecationError):
-        q = await aio_lookup("my-queue", client=aio_client)
-    assert q.object_id == "qu-1"
 
 
 @pytest.mark.asyncio

--- a/client_test/mount_test.py
+++ b/client_test/mount_test.py
@@ -9,7 +9,7 @@ import pytest
 from modal import App, Stub, create_package_mounts
 from modal._blob_utils import LARGE_FILE_LIMIT
 from modal.aio import AioApp
-from modal.exception import DeprecationError, NotFoundError
+from modal.exception import NotFoundError
 from modal.mount import AioMount, Mount
 
 
@@ -49,26 +49,6 @@ async def test_get_files(servicer, aio_client, tmpdir):
         "data": small_content,
         "data_blob_id": "",
     }
-
-
-def test_create_mount_legacy_constructor(servicer, client):
-    local_dir, cur_filename = os.path.split(__file__)
-    remote_dir = "/foo"
-
-    def condition(fn):
-        return fn.endswith(".py")
-
-    with pytest.warns(DeprecationError):
-        m = Mount(local_dir=local_dir, remote_dir=remote_dir, condition=condition)
-
-    app = App._init_new(client)
-    obj = app.create_one_object(m)
-
-    assert obj.object_id == "mo-123"
-    assert f"/foo/{cur_filename}" in servicer.files_name2sha
-    sha256_hex = servicer.files_name2sha[f"/foo/{cur_filename}"]
-    assert sha256_hex in servicer.files_sha2data
-    assert servicer.files_sha2data[sha256_hex]["data"] == open(__file__, "rb").read()
 
 
 def test_create_mount(servicer, client):

--- a/conftest.py
+++ b/conftest.py
@@ -4,4 +4,12 @@ def pytest_markdown_docs_globals():
 
     import modal
 
-    return {"modal": modal, "stub": modal.Stub(), "math": math, "__name__": "runtest"}
+    return {
+        "modal": modal,
+        "stub": modal.Stub(),
+        "math": math,
+        "__name__": "runtest",
+        "web_endpoint": modal.web_endpoint,
+        "asgi_app": modal.asgi_app,
+        "wsgi_app": modal.wsgi_app,
+    }

--- a/modal/object.py
+++ b/modal/object.py
@@ -15,7 +15,7 @@ from modal_utils.grpc_utils import retry_transient_errors
 from ._object_meta import ObjectMeta
 from ._resolver import Resolver
 from .client import _Client
-from .exception import InvalidError, NotFoundError, deprecation_warning
+from .exception import InvalidError, NotFoundError, deprecation_error
 
 H = TypeVar("H", bound="_Handle")
 
@@ -136,13 +136,12 @@ async def _lookup(
     tag: Optional[str] = None,
     namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
     client: Optional[_Client] = None,
-) -> _Handle:
+):
     """Deprecated. Use corresponding class methods instead," " e.g. modal.Secret.lookup, etc."""
-    deprecation_warning(
+    deprecation_error(
         date(2023, 2, 11),
         _lookup.__doc__,
     )
-    return await _Handle.from_app(app_name, tag, namespace, client)
 
 
 lookup, aio_lookup = synchronize_apis(_lookup)

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -653,9 +653,9 @@ class _Stub:
         ] = None,  # Label for created endpoint. Final subdomain will be <workspace>--<label>.modal.run.
         wait_for_response: bool = True,  # Whether requests should wait for and return the function response.
     ):
-        """stub.web_endpoint is deprecated. Use modal.web_endpoint instead. Usage:
+        """`stub.web_endpoint` is deprecated. Use `modal.web_endpoint` instead. Usage:
 
-        ```
+        ```python
         from modal import Stub, web_endpoint
 
         stub = Stub()
@@ -678,7 +678,7 @@ class _Stub:
         ] = None,  # Label for created endpoint. Final subdomain will be <workspace>--<label>.modal.run.
         wait_for_response: bool = True,  # Whether requests should wait for and return the function response.
     ):
-        """stub.asgi_app is deprecated. Use modal.asgi_app instead."""
+        """`stub.asgi_app` is deprecated. Use `modal.asgi_app` instead."""
         deprecation_warning(date(2023, 4, 18), self.asgi_app.__doc__)
         return _asgi_app(label, wait_for_response)
 
@@ -690,7 +690,7 @@ class _Stub:
         ] = None,  # Label for created endpoint. Final subdomain will be <workspace>--<label>.modal.run.
         wait_for_response: bool = True,  # Whether requests should wait for and return the function response.
     ):
-        """stub.wsgi_app is deprecated. Use modal.wsgi_app instead."""
+        """`stub.wsgi_app` is deprecated. Use `modal.wsgi_app` instead."""
         deprecation_warning(date(2023, 4, 18), self.wsgi_app.__doc__)
         return _wsgi_app(label, wait_for_response)
 
@@ -705,9 +705,9 @@ class _Stub:
         wait_for_response: bool = True,
         **function_args,
     ) -> _FunctionHandle:
-        """stub.webhook() is deprecated. Use stub.function in combination with stub.web_endpoint instead. Usage:
+        """`stub.webhook` is deprecated. Use `stub.function` in combination with `modal.web_endpoint` instead. Usage:
 
-        ```
+        ```python
         @stub.function(cpu=42)
         @web_endpoint(method="POST")
         def my_function():
@@ -730,9 +730,9 @@ class _Stub:
         wait_for_response: bool = True,
         **function_args,
     ) -> _FunctionHandle:
-        """stub.asgi() is deprecated. Use stub.function in combination with modal.asgi_app instead. Usage:
+        """`stub.asgi` is deprecated. Use `stub.function` in combination with `modal.asgi_app` instead. Usage:
 
-        ```
+        ```python
         @stub.function(cpu=42)
         @asgi_app()
         def my_asgi_app():
@@ -753,7 +753,7 @@ class _Stub:
         wait_for_response: bool = True,
         **function_args,
     ) -> _FunctionHandle:
-        """stub.wsgi() is deprecated. Use stub.function in combination with modal.wsgi_app instead. Usage:
+        """`stub.wsgi` is deprecated. Use stub.function in combination with `modal.wsgi_app` instead. Usage:
 
         ```
         @stub.function(cpu=42)


### PR DESCRIPTION
Mostly for the `Mount` constructor.

There's some more stuff to clean up there but I'll leave it for later.