### PR TITLE
make _run_serve_loop a context manager

### DIFF
--- a/client_test/live_reload_test.py
+++ b/client_test/live_reload_test.py
@@ -4,14 +4,14 @@ import pytest
 import threading
 from unittest import mock
 
-from modal._live_reload import aio_run_serve_loop, run_serve_loop
+from modal.serving import aio_serve_stub, serve_stub
 from .supports.skip import skip_old_py, skip_windows
 
 
 @pytest.mark.asyncio
 async def test_live_reload(test_dir, server_url_env, servicer):
     stub_file = str(test_dir / "supports" / "app_run_tests" / "webhook.py")
-    async with aio_run_serve_loop(stub_file):
+    async with aio_serve_stub(stub_file):
         await asyncio.sleep(3.0)
     assert servicer.app_set_objects_count == 1
     assert servicer.app_client_disconnect_count == 1
@@ -29,7 +29,7 @@ def test_file_changes_trigger_reloads(test_dir, server_url_env, servicer):
         watcher_done.set()
 
     stub_file = str(test_dir / "supports" / "app_run_tests" / "webhook.py")
-    with run_serve_loop(stub_file, _watcher=fake_watch()) as app:
+    with serve_stub(stub_file, _watcher=fake_watch()) as app:
         watcher_done.wait()  # wait until watcher loop is done
 
     assert servicer.app_set_objects_count == 4  # 1 + number of file changes
@@ -46,7 +46,7 @@ async def test_no_change(test_dir, server_url_env, servicer):
             yield
 
     stub_file = str(test_dir / "supports" / "app_run_tests" / "webhook.py")
-    async with aio_run_serve_loop(stub_file, _watcher=fake_watch()):
+    async with aio_serve_stub(stub_file, _watcher=fake_watch()):
         pass
 
     assert servicer.app_set_objects_count == 1  # Should create the initial app once
@@ -58,7 +58,7 @@ async def test_no_change(test_dir, server_url_env, servicer):
 async def test_heartbeats(test_dir, server_url_env, servicer):
     with mock.patch("modal.runner.HEARTBEAT_INTERVAL", 1):
         stub_file = str(test_dir / "supports" / "app_run_tests" / "webhook.py")
-        async with aio_run_serve_loop(stub_file):
+        async with aio_serve_stub(stub_file):
             await asyncio.sleep(3.5)
 
     apps = list(servicer.app_heartbeats.keys())

--- a/client_test/live_reload_test.py
+++ b/client_test/live_reload_test.py
@@ -1,5 +1,7 @@
 # Copyright Modal Labs 2023
+import asyncio
 import pytest
+import threading
 from unittest import mock
 
 from modal._live_reload import aio_run_serve_loop, run_serve_loop
@@ -9,8 +11,8 @@ from .supports.skip import skip_old_py, skip_windows
 @pytest.mark.asyncio
 async def test_live_reload(test_dir, server_url_env, servicer):
     stub_file = str(test_dir / "supports" / "app_run_tests" / "webhook.py")
-    async with aio_run_serve_loop(stub_file, timeout=3.0):
-        pass
+    async with aio_run_serve_loop(stub_file):
+        await asyncio.sleep(3.0)
     assert servicer.app_set_objects_count == 1
     assert servicer.app_client_disconnect_count == 1
     assert servicer.app_get_logs_initial_count == 1
@@ -19,13 +21,16 @@ async def test_live_reload(test_dir, server_url_env, servicer):
 @skip_old_py("live-reload requires python3.8 or higher", (3, 8))
 @skip_windows("live-reload not supported on windows")
 def test_file_changes_trigger_reloads(test_dir, server_url_env, servicer):
+    watcher_done = threading.Event()
+
     async def fake_watch():
         for i in range(3):
             yield
+        watcher_done.set()
 
     stub_file = str(test_dir / "supports" / "app_run_tests" / "webhook.py")
     with run_serve_loop(stub_file, _watcher=fake_watch()) as app:
-        pass
+        watcher_done.wait()  # wait until watcher loop is done
 
     assert servicer.app_set_objects_count == 4  # 1 + number of file changes
     assert servicer.app_client_disconnect_count == 1
@@ -53,8 +58,8 @@ async def test_no_change(test_dir, server_url_env, servicer):
 async def test_heartbeats(test_dir, server_url_env, servicer):
     with mock.patch("modal.runner.HEARTBEAT_INTERVAL", 1):
         stub_file = str(test_dir / "supports" / "app_run_tests" / "webhook.py")
-        async with aio_run_serve_loop(stub_file, timeout=3.5):
-            pass
+        async with aio_run_serve_loop(stub_file):
+            await asyncio.sleep(3.5)
 
     apps = list(servicer.app_heartbeats.keys())
     assert len(apps) == 1

--- a/modal/_live_reload.py
+++ b/modal/_live_reload.py
@@ -1,5 +1,6 @@
 # Copyright Modal Labs 2023
 import asyncio
+import contextlib
 import io
 import multiprocessing
 from multiprocessing.context import SpawnProcess
@@ -14,6 +15,7 @@ from modal_utils.async_utils import asyncify, synchronize_apis, synchronizer
 
 from ._output import OutputManager
 from ._watcher import watch
+from .app import _App
 from .cli.import_refs import import_stub
 from .client import _Client
 from .config import config
@@ -54,31 +56,7 @@ async def _terminate(proc: Optional[SpawnProcess], output_mgr: OutputManager, ti
         pass  # Child process already finished
 
 
-def _get_clean_stub_description(stub_ref: str) -> str:
-    # If possible, consider the 'ref' argument the start of the app's args. Everything
-    # before it Modal CLI cruft (eg. `modal serve --timeout 1.0`).
-    try:
-        func_ref_arg_idx = sys.argv.index(stub_ref)
-        return " ".join(sys.argv[func_ref_arg_idx:])
-    except ValueError:
-        return " ".join(sys.argv)
-
-
-async def _run_serve_loop(
-    stub_ref: str,
-    timeout: Optional[float] = None,
-    stdout: Optional[io.TextIOWrapper] = None,
-    show_progress: bool = True,
-    _watcher: Optional[AsyncGenerator[None, None]] = None,  # for testing
-    _app_q: Optional[asyncio.Queue] = None,  # for testing
-):
-    stub = import_stub(stub_ref)
-    if stub._description is None:
-        stub._description = _get_clean_stub_description(stub_ref)
-
-    if timeout is None:
-        timeout = config["serve_timeout"]
-
+async def _run_watch_loop(stub_ref: str, app_id: str, output_mgr: OutputManager, watcher: AsyncGenerator[None, None]):
     unsupported_msg = None
     if platform.system() == "Windows":
         unsupported_msg = "Live-reload skipped. This feature is currently unsupported on Windows"
@@ -89,6 +67,44 @@ async def _run_serve_loop(
             " Upgrade to Python 3.8+ to enable live-reloading."
         )
 
+    if unsupported_msg:
+        async for _ in watcher:
+            output_mgr.print_if_visible(unsupported_msg)
+    else:
+        curr_proc = None
+        try:
+            async for _ in watcher:
+                await _terminate(curr_proc, output_mgr)
+                curr_proc = await _restart_serve(stub_ref, existing_app_id=app_id)
+        finally:
+            await _terminate(curr_proc, output_mgr)
+
+
+def _get_clean_stub_description(stub_ref: str) -> str:
+    # If possible, consider the 'ref' argument the start of the app's args. Everything
+    # before it Modal CLI cruft (eg. `modal serve --timeout 1.0`).
+    try:
+        func_ref_arg_idx = sys.argv.index(stub_ref)
+        return " ".join(sys.argv[func_ref_arg_idx:])
+    except ValueError:
+        return " ".join(sys.argv)
+
+
+@contextlib.asynccontextmanager
+async def _run_serve_loop(
+    stub_ref: str,
+    timeout: Optional[float] = None,
+    stdout: Optional[io.TextIOWrapper] = None,
+    show_progress: bool = True,
+    _watcher: Optional[AsyncGenerator[None, None]] = None,  # for testing
+) -> AsyncGenerator[_App, None]:
+    stub = import_stub(stub_ref)
+    if stub._description is None:
+        stub._description = _get_clean_stub_description(stub_ref)
+
+    if timeout is None:
+        timeout = config["serve_timeout"]
+
     client = await _Client.from_env()
 
     output_mgr = OutputManager(stdout, show_progress, "Running app...")
@@ -98,26 +114,13 @@ async def _run_serve_loop(
     else:
         watcher = watch(stub._local_mounts, output_mgr, timeout)
 
-    if unsupported_msg:
-        async with stub.run(client=client, output_mgr=output_mgr) as app:
-            client.set_pre_stop(app.disconnect)
-            async for _ in watcher:
-                output_mgr.print_if_visible(unsupported_msg)
-    else:
-        # Run the object creation loop one time first, to make sure all images etc get built
-        # This also handles the logs and the heartbeats
-        async with stub.run(client=client, output_mgr=output_mgr) as app:
-            if _app_q:
-                await _app_q.put(app)
-            client.set_pre_stop(app.disconnect)
-            existing_app_id = app.app_id
-            curr_proc = None
-            try:
-                async for _ in watcher:
-                    await _terminate(curr_proc, output_mgr)
-                    curr_proc = await _restart_serve(stub_ref, existing_app_id=existing_app_id)
-            finally:
-                await _terminate(curr_proc, output_mgr)
+    async with stub.run(client=client, output_mgr=output_mgr) as app:
+        client.set_pre_stop(app.disconnect)
+        watcher_task = asyncio.create_task(_run_watch_loop(stub_ref, app.app_id, output_mgr, watcher))
+        try:
+            yield app
+        finally:
+            await watcher_task
 
 
 run_serve_loop, aio_run_serve_loop = synchronize_apis(_run_serve_loop)

--- a/modal/_live_reload.py
+++ b/modal/_live_reload.py
@@ -17,6 +17,7 @@ from ._watcher import watch
 from .app import _App
 from .cli.import_refs import import_stub
 from .client import _Client
+from .runner import run_stub
 
 
 def _run_serve(stub_ref: str, existing_app_id: str, is_ready: Event):
@@ -108,7 +109,7 @@ async def _run_serve_loop(
     else:
         watcher = watch(stub._local_mounts, output_mgr)
 
-    async with stub.run(client=client, output_mgr=output_mgr) as app:
+    async with run_stub(stub, client=client, output_mgr=output_mgr) as app:
         client.set_pre_stop(app.disconnect)
         async with TaskContext(grace=0.1) as tc:
             tc.create_task(_run_watch_loop(stub_ref, app.app_id, output_mgr, watcher))

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -201,11 +201,12 @@ def serve(
     modal serve hello_world.py
     ```
     """
-    with run_serve_loop(stub_ref, timeout):
+    with run_serve_loop(stub_ref):
         if timeout is None:
-            time.sleep(1e9)
-        else:
-            time.sleep(config["serve_timeout"])
+            timeout = config["serve_timeout"]
+        if timeout is None:
+            timeout = 1e9
+        time.sleep(timeout)
 
 
 def shell(

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -3,6 +3,7 @@ import asyncio
 import datetime
 import inspect
 import sys
+import time
 from typing import Optional
 
 import click
@@ -11,6 +12,7 @@ from rich.console import Console
 from synchronicity import Interface
 
 from modal._live_reload import run_serve_loop
+from modal.config import config
 from modal.exception import InvalidError
 from modal.stub import LocalEntrypoint
 from modal_utils.async_utils import synchronizer
@@ -200,7 +202,10 @@ def serve(
     ```
     """
     with run_serve_loop(stub_ref, timeout):
-        pass  # Nothing to do in parallel
+        if timeout is None:
+            time.sleep(1e9)
+        else:
+            time.sleep(config["serve_timeout"])
 
 
 def shell(

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -11,9 +11,9 @@ import typer
 from rich.console import Console
 from synchronicity import Interface
 
-from modal._live_reload import run_serve_loop
 from modal.config import config
 from modal.exception import InvalidError
+from modal.serving import serve_stub
 from modal.stub import LocalEntrypoint
 from modal_utils.async_utils import synchronizer
 
@@ -201,7 +201,7 @@ def serve(
     modal serve hello_world.py
     ```
     """
-    with run_serve_loop(stub_ref):
+    with serve_stub(stub_ref):
         if timeout is None:
             timeout = config["serve_timeout"]
         if timeout is None:

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -199,7 +199,8 @@ def serve(
     modal serve hello_world.py
     ```
     """
-    run_serve_loop(stub_ref, timeout)
+    with run_serve_loop(stub_ref, timeout):
+        pass  # Nothing to do in parallel
 
 
 def shell(

--- a/modal/serving.py
+++ b/modal/serving.py
@@ -90,7 +90,7 @@ def _get_clean_stub_description(stub_ref: str) -> str:
 
 
 @contextlib.asynccontextmanager
-async def _run_serve_loop(
+async def _serve_stub(
     stub_ref: str,
     stdout: Optional[io.TextIOWrapper] = None,
     show_progress: bool = True,
@@ -116,4 +116,4 @@ async def _run_serve_loop(
             yield app
 
 
-run_serve_loop, aio_run_serve_loop = synchronize_apis(_run_serve_loop)
+serve_stub, aio_serve_stub = synchronize_apis(_serve_stub)


### PR DESCRIPTION
A user was asking for something that essentially requires running modal serve in a more programmatic way, and also get app info back.

I realize it's pretty tricky given the current client code, but with some minor refactoring it shouldn't be too hard. This also lets us unify the interface between running and serving to some extent.