### PR TITLE
[MOD-979] Stop rooting relative Mount remote_path values at '/'

### DIFF
--- a/modal/mount.py
+++ b/modal/mount.py
@@ -219,7 +219,7 @@ class _Mount(_Provider[_MountHandle]):
         local_path = Path(local_path)
         if remote_path is None:
             remote_path = local_path.name
-        remote_path = PurePosixPath("/", remote_path)
+        remote_path = PurePosixPath("/", remote_path)  # TODO(Jonathon): don't make filepath absolute client-side
         return self.extend(
             _MountFile(
                 local_file=local_path,
@@ -319,6 +319,8 @@ class _Mount(_Provider[_MountHandle]):
 
         # Build mounts
         status_row.message(f"Creating mount {message_label}: Building mount")
+        print("MOUNT BUILD DETAILS")
+        print(files)
         req = api_pb2.MountBuildRequest(app_id=resolver.app_id, existing_mount_id=existing_object_id, files=files)
         resp = await retry_transient_errors(resolver.client.stub.MountBuild, req, base_delay=1)
         status_row.finish(f"Created mount {message_label}")

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -1,4 +1,5 @@
 # Copyright Modal Labs 2022
+import _strptime  # nopycln: import # noqa: F401
 import abc
 import asyncio
 import concurrent.futures
@@ -182,7 +183,7 @@ class _Mount(_Provider[_MountHandle]):
         local_path = Path(local_path)
         if remote_path is None:
             remote_path = local_path.name
-        remote_path = PurePosixPath("/", remote_path)
+        remote_path = PurePosixPath(remote_path)
         if condition is None:
 
             def include_all(path):
@@ -219,7 +220,7 @@ class _Mount(_Provider[_MountHandle]):
         local_path = Path(local_path)
         if remote_path is None:
             remote_path = local_path.name
-        remote_path = PurePosixPath("/", remote_path)  # TODO(Jonathon): don't make filepath absolute client-side
+        remote_path = PurePosixPath(remote_path)
         return self.extend(
             _MountFile(
                 local_file=local_path,
@@ -319,8 +320,6 @@ class _Mount(_Provider[_MountHandle]):
 
         # Build mounts
         status_row.message(f"Creating mount {message_label}: Building mount")
-        print("MOUNT BUILD DETAILS")
-        print(files)
         req = api_pb2.MountBuildRequest(app_id=resolver.app_id, existing_mount_id=existing_object_id, files=files)
         resp = await retry_transient_errors(resolver.client.stub.MountBuild, req, base_delay=1)
         status_row.finish(f"Created mount {message_label}")


### PR DESCRIPTION
This is addressing a UX issue where relative `remote_path` values don't put files in the current working directory as users expect. (see Linear card)

⚠️  The server is already configured to handle relative paths, but this is a backwards incompatible, breaking client change. Any user code that currently expects `remote_path="foo.txt"` to be placed at `/foo.txt` will break.

Not sure yet how best to manage this incompatibility.