### PR TITLE
tag `get_inputs` span with `iteration`

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -186,7 +186,8 @@ class _FunctionIOManager:
 
             with trace("get_inputs"):
                 span = tracer.current_span()
-                span.set_tag("iteration", str(iteration))  # force this to be a tag string
+                if span:
+                    span.set_tag("iteration", str(iteration))  # force this to be a tag string
                 iteration += 1
                 response = await retry_transient_errors(self.client.stub.FunctionGetInputs, request)
 

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -14,7 +14,6 @@ import time
 import traceback
 from typing import Any, AsyncIterator, Callable, Optional
 
-from ddtrace import tracer
 from grpclib import Status
 from synchronicity.interface import Interface
 
@@ -185,9 +184,7 @@ class _FunctionIOManager:
             request.max_values = self.get_max_inputs_to_fetch()  # Deprecated; remove.
 
             with trace("get_inputs"):
-                span = tracer.current_span()
-                if span:
-                    span.set_tag("iteration", str(iteration))  # force this to be a tag string
+                set_span_tag("iteration", str(iteration))  # force this to be a tag string
                 iteration += 1
                 response = await retry_transient_errors(self.client.stub.FunctionGetInputs, request)
 


### PR DESCRIPTION
Add `iteration` tag to `get_inputs` span so we can search for slow initial `get_inputs` spans in cold-start traces