### PR TITLE
Deprecate old lifecycle syntax

### DIFF
--- a/client_test/cli_imports_test.py
+++ b/client_test/cli_imports_test.py
@@ -29,8 +29,9 @@ other_stub = modal.Stub("BAR")
 @other_stub.function()
 def func():
     pass
+@stub.cls()
 class Parent:
-    @stub.function()
+    @modal.method()
     def meth(self):
         pass
 

--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -7,7 +7,7 @@ import cloudpickle
 from synchronicity.exceptions import UserCodeException
 
 from modal import Proxy, Stub, SharedVolume, web_endpoint
-from modal.exception import InvalidError
+from modal.exception import DeprecationError, InvalidError
 from modal.functions import Function, FunctionCall, gather, FunctionHandle
 from modal.stub import AioStub
 
@@ -386,10 +386,12 @@ def f(x):
     return x**2
 
 
-class Class:
-    @lc_stub.function()
-    def f(self, x):
-        return x**2
+with pytest.warns(DeprecationError):
+
+    class Class:
+        @lc_stub.function()
+        def f(self, x):
+            return x**2
 
 
 def test_raw_call():

--- a/client_test/supports/app_run_tests/cli_args.py
+++ b/client_test/supports/app_run_tests/cli_args.py
@@ -1,9 +1,9 @@
 # Copyright Modal Labs 2022
 from datetime import datetime
 
-import modal
+from modal import Stub, method
 
-stub = modal.Stub()
+stub = Stub()
 
 
 @stub.local_entrypoint()
@@ -26,7 +26,8 @@ def unannotated_arg(i):
     print(repr(i))
 
 
+@stub.cls()
 class ALifecycle:
-    @stub.function()
+    @method()
     def some_method(self, i):
         print(repr(i))

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -87,6 +87,7 @@ class FunctionInfo:
     # TODO: if the function is declared in a local scope, this function still "works": we should throw an exception
     def __init__(self, f, serialized=False, name_override: Optional[str] = None):
         self.raw_f = f
+        # TODO(erikbern): if f.__qualname__ != f.__name__,  we should infer the class name instead
         self.function_name = name_override if name_override is not None else f.__qualname__
         self.signature = inspect.signature(f)
         module = inspect.getmodule(f)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1183,6 +1183,7 @@ PartialFunction, AioPartialFunction = synchronize_apis(_PartialFunction)
 
 
 def _method(
+    *,
     is_generator: Optional[
         bool
     ] = None,  # Set this to True if it's a non-generator function returning a [sync/async] generator object

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -64,40 +64,49 @@ def deprecated_function(x):
     return x**2
 
 
-class Cube:
-    _events: list[str] = []
-
-    def __init__(self):
-        self._events.append("init")
-
-    def __enter__(self):
-        self._events.append("enter")
-
-    def __exit__(self, typ, exc, tb):
-        self._events.append("exit")
-
-    @stub.function()
-    def f(self, x):
-        self._events.append("call")
-        return x**3
+# TODO(erikbern): once we remove support for the "old" lifecycle method syntax,
+# let's consolidate some tests - Cube, CubeAsync, and Cls pretty much test
+# the same things (but currently only Cls uses the "new" syntax).
 
 
-class CubeAsync:
-    _events: list[str] = []
+with pytest.warns(DeprecationError):
 
-    def __init__(self):
-        self._events.append("init")
+    class Cube:
+        _events: list[str] = []
 
-    async def __aenter__(self):
-        self._events.append("enter")
+        def __init__(self):
+            self._events.append("init")
 
-    async def __aexit__(self, typ, exc, tb):
-        self._events.append("exit")
+        def __enter__(self):
+            self._events.append("enter")
 
-    @stub.function()
-    async def f(self, x):
-        self._events.append("call")
-        return x**3
+        def __exit__(self, typ, exc, tb):
+            self._events.append("exit")
+
+        @stub.function()  # Will trigger deprecation warning
+        def f(self, x):
+            self._events.append("call")
+            return x**3
+
+
+with pytest.warns(DeprecationError):
+
+    class CubeAsync:
+        _events: list[str] = []
+
+        def __init__(self):
+            self._events.append("init")
+
+        async def __aenter__(self):
+            self._events.append("enter")
+
+        async def __aexit__(self, typ, exc, tb):
+            self._events.append("exit")
+
+        @stub.function()  # Will trigger deprecation warning
+        async def f(self, x):
+            self._events.append("call")
+            return x**3
 
 
 @stub.function()
@@ -113,23 +122,25 @@ with pytest.warns(DeprecationError):
         return {"hello": arg}
 
 
-class WebhookLifecycleClass:
-    _events: list[str] = []
+with pytest.warns(DeprecationError):
 
-    def __init__(self):
-        self._events.append("init")
+    class WebhookLifecycleClass:
+        _events: list[str] = []
 
-    async def __aenter__(self):
-        self._events.append("enter")
+        def __init__(self):
+            self._events.append("init")
 
-    async def __aexit__(self, typ, exc, tb):
-        self._events.append("exit")
+        async def __aenter__(self):
+            self._events.append("enter")
 
-    @stub.function()
-    @web_endpoint()
-    def webhook(self, arg="world"):
-        self._events.append("call")
-        return {"hello": arg}
+        async def __aexit__(self, typ, exc, tb):
+            self._events.append("exit")
+
+        @stub.function()  # Will trigger deprecation warning
+        @web_endpoint()
+        def webhook(self, arg="world"):
+            self._events.append("call")
+            return {"hello": arg}
 
 
 def stream():


### PR DESCRIPTION
Throws a warning that looks like this:

````
modal.exception.DeprecationError: 2023-04-20: @stub.function on methods is deprecated. Use the @stub.cls and @method decorators. Usage:

```
@stub.cls(cpu=8)
class MyCls:
    @method()
    def f(self):
        ...
```
````

There's a slightly more correct implementation that changes this in the backend so that we pass the class name as a part of the `Function` definition. But this is a bit more work to implement and it gets easier once remove support for deprecate the old syntax. So I'd rather do that first.