### PR TITLE
Fixes missing deprecation warning after merge

### DIFF
--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -142,11 +142,14 @@ class FunctionInfo:
                     "Modal can only import functions defined in global scope unless they are `serialized=True`"
                 )
 
+    def is_serialized(self) -> bool:
+        return self.definition_type == api_pb2.Function.DEFINITION_TYPE_SERIALIZED
+
     def serialized_function(self) -> bytes:
         # Note: this should only be called from .load() and not at function decoration time
         #       otherwise the serialized function won't have access to variables/side effect
         #        defined after it in the same file
-        assert self.definition_type == api_pb2.Function.DEFINITION_TYPE_SERIALIZED
+        assert self.is_serialized()
         serialized_bytes = serialize(self.raw_f)
         logger.debug(f"Serializing {self.raw_f.__qualname__}, size is {len(serialized_bytes)}")
         return serialized_bytes

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -960,7 +960,7 @@ class _Function(_Provider[_FunctionHandle]):
         else:
             warm_pool_size = self._keep_warm or 0
 
-        if self._info.definition_type == api_pb2.Function.DEFINITION_TYPE_SERIALIZED:
+        if self._info.is_serialized():
             # Use cloudpickle. Used when working w/ Jupyter notebooks.
             # serialize at _load time, not function decoration time
             # otherwise we can't capture a surrounding class for lifetime methods etc.

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -594,7 +594,7 @@ class _Stub:
             webhook_config = None
             raw_f = f
 
-        if not _cls and not info.serialized_function and "." in info.function_name:  # This is a method
+        if not _cls and not info.is_serialized() and "." in info.function_name:  # This is a method
             deprecation_warning(
                 date(2023, 4, 20),
                 inspect.cleandoc(


### PR DESCRIPTION
Broke a test due to an undetected merge conflict (serialized_function was made into a method instead of an attribute)