### PR TITLE
Refactor some of the init/hydration code to have a bit more clear names

### DIFF
--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -349,7 +349,6 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.precreated_functions.add(function_id)
 
         web_url = "http://xyz.internal" if req.HasField("webhook_config") and req.webhook_config.type else None
-
         await stream.send_message(
             api_pb2.FunctionPrecreateResponse(
                 function_id=function_id,
@@ -378,7 +377,17 @@ class MockClientServicer(api_grpc.ModalClientBase):
             function.web_url = "http://xyz.internal"
 
         self.app_functions[function_id] = function
-        await stream.send_message(api_pb2.FunctionCreateResponse(function_id=function_id, function=function))
+        await stream.send_message(
+            api_pb2.FunctionCreateResponse(
+                function_id=function_id,
+                function=function,
+                handle_metadata=api_pb2.FunctionHandleMetadata(
+                    function_name=function.function_name,
+                    function_type=function.function_type,
+                    web_url=function.web_url,
+                ),
+            )
+        )
 
     async def FunctionMap(self, stream):
         self.fcidx += 1

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -68,7 +68,7 @@ class Resolver:
     def client(self):
         return self._client
 
-    async def preload(self, obj, existing_object_id: Optional[str] = None) -> Optional[str]:
+    async def preload(self, obj, existing_object_id: Optional[str] = None):
         return await obj._preload(self, existing_object_id)
 
     async def load(self, obj, existing_object_id: Optional[str] = None):

--- a/modal/app.py
+++ b/modal/app.py
@@ -86,15 +86,14 @@ class _App:
                 # Note: preload only currently implemented for Functions, returns None otherwise
                 # this is to ensure that directly referenced functions from the global scope has
                 # ids associated with them when they are serialized into other functions
-                object_id = await resolver.preload(provider, existing_object_id)
-                if object_id is not None:
-                    self._tag_to_existing_id[tag] = object_id
+                precreated_object = await resolver.preload(provider, existing_object_id)
+                if precreated_object is not None:
+                    self._tag_to_existing_id[tag] = precreated_object.object_id
+                    self._tag_to_object[tag] = precreated_object
 
             for tag, provider in blueprint.items():
                 existing_object_id = self._tag_to_existing_id.get(tag)
                 created_obj = await resolver.load(provider, existing_object_id)
-                if not created_obj.object_id:
-                    breakpoint()
                 self._tag_to_object[tag] = created_obj
 
         # Create the app (and send a list of all tagged obs)

--- a/modal/app.py
+++ b/modal/app.py
@@ -93,6 +93,8 @@ class _App:
             for tag, provider in blueprint.items():
                 existing_object_id = self._tag_to_existing_id.get(tag)
                 created_obj = await resolver.load(provider, existing_object_id)
+                if not created_obj.object_id:
+                    breakpoint()
                 self._tag_to_object[tag] = created_obj
 
         # Create the app (and send a list of all tagged obs)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1025,6 +1025,8 @@ class _Function(_Provider[_FunctionHandle]):
             status_row.finish(f"Created {self._tag}.")
 
         # Instead of returning a new object, just return the precreated one
+        # TODO (elias): We should not have to run _hydrate in here since functions are preloaded. Needed for now due to some conflicts with builder_functions
+        self._function_handle._hydrate(resolver.client, response.function_id, response.handle_metadata)
         return self._function_handle
 
     def get_panel_items(self) -> List[str]:

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -482,6 +482,18 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
         self._stub = None
         self._self_obj = None
 
+    def _initialize_from_local(self, stub, info: FunctionInfo):
+        # note that this is not a full hydration of the function, as it doesn't yet get an object_id etc.
+        self._stub = stub
+        self._info = info
+
+    def _hydrate_metadata(self, handle_metadata: Message):
+        # makes function usable
+        assert isinstance(handle_metadata, (api_pb2.Function, api_pb2.FunctionHandleMetadata))
+        self._is_generator = handle_metadata.function_type == api_pb2.Function.FUNCTION_TYPE_GENERATOR
+        self._web_url = handle_metadata.web_url
+        self._function_name = handle_metadata.function_name
+
     def _get_handle_metadata(self):
         return api_pb2.FunctionHandleMetadata(
             function_name=self._function_name,
@@ -490,16 +502,6 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
             else api_pb2.Function.FUNCTION_TYPE_FUNCTION,
             web_url=self._web_url,
         )
-
-    def _initialize_from_handle_metadata(self, proto: Message):
-        assert isinstance(proto, (api_pb2.Function, api_pb2.FunctionHandleMetadata))
-        self._is_generator = proto.function_type == api_pb2.Function.FUNCTION_TYPE_GENERATOR
-        self._web_url = proto.web_url
-        self._function_name = proto.function_name
-
-    def _initialize_from_local(self, stub, info: FunctionInfo):
-        self._stub = stub
-        self._info = info
 
     def _set_mute_cancellation(self, value: bool = True):
         self._mute_cancellation = value
@@ -869,8 +871,8 @@ class _Function(_Provider[_FunctionHandle]):
             existing_function_id=existing_object_id,
         )
         response = await resolver.client.stub.FunctionPrecreate(req)
-        self._function_handle._initialize_handle(resolver.client, response.function_id)
-        self._function_handle._initialize_from_handle_metadata(response.handle_metadata)
+        # Update the precreated function handle (todo: hack until we merge providers/handles)
+        self._function_handle._hydrate(resolver.client, response.function_id, response.handle_metadata)
         return response.function_id
 
     async def _load(self, resolver: Resolver, existing_object_id: str):
@@ -1021,19 +1023,6 @@ class _Function(_Provider[_FunctionHandle]):
             )
         else:
             status_row.finish(f"Created {self._tag}.")
-
-        # Update the precreated function handle (todo: hack until we merge providers/handles)
-        self._function_handle._initialize_handle(resolver.client, response.function_id)
-        if response.HasField("handle_metadata"):
-            self._function_handle._initialize_from_handle_metadata(response.handle_metadata)
-        else:
-            # TODO: remove this branch as soon as backend with handle_metadata is live
-            handle_metadata = api_pb2.FunctionHandleMetadata(
-                function_name=response.function.function_name,
-                function_type=response.function.function_type,
-                web_url=response.function.web_url,
-            )
-            self._function_handle._initialize_from_handle_metadata(handle_metadata)
 
         # Instead of returning a new object, just return the precreated one
         return self._function_handle

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -873,7 +873,7 @@ class _Function(_Provider[_FunctionHandle]):
         response = await resolver.client.stub.FunctionPrecreate(req)
         # Update the precreated function handle (todo: hack until we merge providers/handles)
         self._function_handle._hydrate(resolver.client, response.function_id, response.handle_metadata)
-        return response.function_id
+        return self._function_handle
 
     async def _load(self, resolver: Resolver, existing_object_id: str):
         status_row = resolver.add_status_row()

--- a/modal/image.py
+++ b/modal/image.py
@@ -175,6 +175,7 @@ class _Image(_Provider[_ImageHandle]):
             if build_function:
                 # preloading function, to set the handle
                 await resolver.preload(build_function)
+            return None
 
         async def _load(resolver: Resolver, existing_object_id: str):
             if ref:

--- a/modal/image.py
+++ b/modal/image.py
@@ -168,15 +168,6 @@ class _Image(_Provider[_ImageHandle]):
         if build_function and len(base_images) != 1:
             raise InvalidError("Cannot run a build function with multiple base images!")
 
-        async def _preload(resolver: Resolver, existing_object_id: str):
-            for image in base_images.values():
-                await resolver.preload(image)
-
-            if build_function:
-                # preloading function, to set the handle
-                await resolver.preload(build_function)
-            return None
-
         async def _load(resolver: Resolver, existing_object_id: str):
             if ref:
                 image_id = (await resolver.load(ref)).object_id
@@ -294,7 +285,7 @@ class _Image(_Provider[_ImageHandle]):
             return _ImageHandle._from_id(image_id, resolver.client, None)
 
         rep = f"Image({dockerfile_commands})"
-        obj = _Image._from_loader(_load, rep, preload=_preload)
+        obj = _Image._from_loader(_load, rep)
         obj.force_build = force_build
         return obj
 

--- a/modal/image.py
+++ b/modal/image.py
@@ -121,7 +121,7 @@ class _ImageRegistryConfig:
 
 
 if typing.TYPE_CHECKING:
-    from .functions import _Function
+    import modal.functions
 
 
 class _Image(_Provider[_ImageHandle]):
@@ -142,7 +142,7 @@ class _Image(_Provider[_ImageHandle]):
         secrets: Sequence[_Secret] = [],
         ref=None,
         gpu_config: Optional[api_pb2.GPUConfig] = None,
-        build_function: "_Function" = None,
+        build_function: "modal.functions._Function" = None,
         context_mount: Optional[_Mount] = None,
         image_registry_config: Optional[_ImageRegistryConfig] = None,
         force_build: bool = False,

--- a/modal/image.py
+++ b/modal/image.py
@@ -174,7 +174,6 @@ class _Image(_Provider[_ImageHandle]):
 
             if build_function:
                 # preloading function, to set the handle
-                breakpoint()
                 await resolver.preload(build_function)
 
         async def _load(resolver: Resolver, existing_object_id: str):

--- a/modal/object.py
+++ b/modal/object.py
@@ -161,8 +161,19 @@ _BLOCKING_P, _ASYNC_P = synchronize_apis(P)
 
 
 class _Provider(Generic[H]):
-    def _init(self, load: Callable[[Resolver, str], Awaitable[H]], rep: str, is_persisted_ref: bool = False):
+    def _init(
+        self,
+        load: Callable[[Resolver, str], Awaitable[H]],
+        rep: str,
+        is_persisted_ref: bool = False,
+        preload: Optional[Callable[[Resolver, str], Awaitable[H]]] = None,
+    ):
         self._local_uuid = str(uuid.uuid4())
+
+        async def default_preload(resolver, existing_object_id=None):
+            pass
+
+        self._preload = preload if preload is not None else default_preload
         self._load = load
         self._rep = rep
         self.is_persisted_ref = is_persisted_ref
@@ -172,14 +183,20 @@ class _Provider(Generic[H]):
         load: Callable[[Resolver, str], Awaitable[H]],
         rep: str,
         is_persisted_ref: bool = False,
+        preload: Optional[Callable[[Resolver, str], Awaitable[H]]] = None,
     ):
         # TODO(erikbern): this is semi-deprecated - subclasses should use _from_loader
-        self._init(load, rep, is_persisted_ref)
+        self._init(load, rep, is_persisted_ref, preload=preload)
 
     @classmethod
-    def _from_loader(cls, load: Callable[[Resolver, str], Awaitable[H]], rep: str):
+    def _from_loader(
+        cls,
+        load: Callable[[Resolver, str], Awaitable[H]],
+        rep: str,
+        preload: Optional[Callable[[Resolver, str], Awaitable[H]]] = None,
+    ):
         obj = _Handle.__new__(cls)
-        obj._init(load, rep)
+        obj._init(load, rep, preload=preload)
         return obj
 
     @classmethod

--- a/modal/object.py
+++ b/modal/object.py
@@ -58,8 +58,9 @@ class _Handle(metaclass=ObjectMeta):
         pass
 
     def _get_handle_metadata(self) -> Optional[Message]:
-        # get the necessary metadata from this handle to be able to re-hydrate in another context
-        # inverse of _hydrate_metadata
+        # return the necessary metadata from this handle to be able to re-hydrate in another context if one is needed
+        # used to provide a handle's handle_metadata for serializing/pickling a live handle
+        # the object_id is already provided by other means
         return None
 
     @classmethod
@@ -171,7 +172,7 @@ class _Provider(Generic[H]):
         self._local_uuid = str(uuid.uuid4())
         self._load = load
         if preload is not None:
-            # overwrite preload, needed for refs to Functions to work
+            # only sets _preload if one is provided, otherwise a noop is used
             self._preload = preload
         self._rep = rep
         self.is_persisted_ref = is_persisted_ref

--- a/modal/object.py
+++ b/modal/object.py
@@ -44,17 +44,22 @@ class _Handle(metaclass=ObjectMeta):
         obj._initialize_from_empty()
         return obj
 
-    def _initialize_handle(self, client: _Client, object_id: str):
-        self._client = client
-        self._object_id = object_id
-
     def _initialize_from_empty(self):
         pass  # default implementation
 
-    def _initialize_from_handle_metadata(self, proto: Message):
-        pass  # default implementation
+    def _hydrate(self, client: _Client, object_id: str, handle_metadata: Optional[Message]):
+        self._client = client
+        self._object_id = object_id
+        if handle_metadata:
+            self._hydrate_metadata(handle_metadata)
+
+    def _hydrate_metadata(self, handle_metadata: Message):
+        # override this is subclasses that need additional data (other than an object_id) for a functioning Handle
+        pass
 
     def _get_handle_metadata(self) -> Optional[Message]:
+        # get the necessary metadata from this handle to be able to re-hydrate in another context
+        # inverse of _hydrate_from_handle_metadata
         return None
 
     @classmethod
@@ -76,8 +81,7 @@ class _Handle(metaclass=ObjectMeta):
 
         # Instantiate object and return
         obj = object_cls._new()
-        obj._initialize_handle(client, object_id)
-        obj._initialize_from_handle_metadata(handle_metadata)
+        obj._hydrate(client, object_id, handle_metadata)
         return obj
 
     @classmethod

--- a/modal/object.py
+++ b/modal/object.py
@@ -59,7 +59,7 @@ class _Handle(metaclass=ObjectMeta):
 
     def _get_handle_metadata(self) -> Optional[Message]:
         # get the necessary metadata from this handle to be able to re-hydrate in another context
-        # inverse of _hydrate_from_handle_metadata
+        # inverse of _hydrate_metadata
         return None
 
     @classmethod

--- a/modal/object.py
+++ b/modal/object.py
@@ -169,12 +169,9 @@ class _Provider(Generic[H]):
         preload: Optional[Callable[[Resolver, str], Awaitable[H]]] = None,
     ):
         self._local_uuid = str(uuid.uuid4())
-
-        async def default_preload(resolver, existing_object_id=None):
-            pass
-
-        self._preload = preload if preload is not None else default_preload
         self._load = load
+        if preload is not None:
+            self._preload = preload
         self._rep = rep
         self.is_persisted_ref = is_persisted_ref
 
@@ -355,7 +352,7 @@ class _Provider(Generic[H]):
             else:
                 raise
 
-    async def _preload(self, resolver, existing_object_id) -> Optional[str]:
+    async def _preload(self, resolver, existing_object_id):
         return None
 
 


### PR DESCRIPTION
Functionality same as before, we now only have one code path for hydrating handles regardless if they have metadata or not.

`._hydrate(object_id, handle_metadata: Optional[Message])` now hydrates the object.
An object that uses handle_metadata (currently only functions) can implement their own `_hydrate_metadata()` function that is called by _hydrate with metadata if it's present, in order to bootstrap the handle