### PR TITLE
super minor fix for deprecation warnings

### DIFF
--- a/modal/exception.py
+++ b/modal/exception.py
@@ -65,7 +65,8 @@ class PendingDeprecationError(UserWarning):
     """Soon to be deprecated feature. Only used intermittently because of multi-repo concerns."""
 
 
-_INTERNAL_MODULES = ["modal", "synchronicity"]
+# TODO(erikbern): we have something similready in _function_utils.py
+_INTERNAL_MODULES = ["modal", "modal_utils", "synchronicity"]
 
 
 def _is_internal_frame(frame):


### PR DESCRIPTION
Was running a script that had outdated syntax and it printed

`/Users/erikbern/modal-client/modal_utils/decorator_utils.py:38: DeprecationError: 2023-04-05: The decorator stub.local_entrypoint without arguments will soon be deprecated. Add empty parens to it, e.g. @stub.local_entrypoint() if there are no arguments`

Note that the file and line number isn't helpful here because it's an internal Modal package. After this fix, it now prints the user file and line number:

`/Users/erikbern/modal/analytics/paying_users.py:154: DeprecationError: 2023-04-05: The decorator stub.local_entrypoint without arguments will soon be deprecated. Add empty parens to it, e.g. @stub.local_entrypoint() if there are no arguments`