### PR TITLE
modal serve: sleep inf

### DIFF
--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -205,8 +205,11 @@ def serve(
         if timeout is None:
             timeout = config["serve_timeout"]
         if timeout is None:
-            timeout = 1e9
-        time.sleep(timeout)
+            timeout = float("inf")
+        while timeout > 0:
+            t = min(timeout, 3600)
+            time.sleep(t)
+            timeout -= t
 
 
 def shell(


### PR DESCRIPTION
I think some platforms reject `time.sleep(1e9)`

Not sure if it's worth adding a test for this even though it's maybe doable.