### PR TITLE
Determine stub to hydrate via imported function handle if possible

### DIFF
--- a/client_test/container_app_test.py
+++ b/client_test/container_app_test.py
@@ -27,9 +27,10 @@ async def test_container_function_initialization(unix_servicer, aio_container_cl
         "my_f_2": "fu-456",
     }
 
-    await AioApp.init_container(aio_container_client, "ap-123")
+    container_app = await AioApp.init_container(aio_container_client, "ap-123")
 
     stub = AioStub()
+    stub._hydrate_function_handles(aio_container_client, container_app)
     # my_f_1_container = stub.function()(my_f_1)
 
     # Make sure these functions exist and have the right type

--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -593,33 +593,33 @@ def _run_e2e_function(
     assert items[0].result.status == assert_result
 
 
-def test_function_hydration(unix_servicer):
-    _run_e2e_function(unix_servicer, "modal_test_support.functions", "stub", "check_sibling_hydration")
+def test_function_hydration(servicer):
+    _run_e2e_function(servicer, "modal_test_support.functions", "stub", "check_sibling_hydration")
 
 
-def test_multistub(unix_servicer, caplog):
-    _run_e2e_function(unix_servicer, "modal_test_support.multistub", "a", "a_func")
+def test_multistub(servicer, caplog):
+    _run_e2e_function(servicer, "modal_test_support.multistub", "a", "a_func")
     assert len(caplog.messages) == 0  # no need for a warning about double stubs here
 
 
-def test_multistub_privately_decorated(unix_servicer, caplog):
+def test_multistub_privately_decorated(servicer, caplog):
     # function handle does not override the original function, so we can't find the stub
     # and the two stubs are not named
-    _run_e2e_function(unix_servicer, "modal_test_support.multistub_privately_decorated", "stub", "foo")
+    _run_e2e_function(servicer, "modal_test_support.multistub_privately_decorated", "stub", "foo")
     assert "Could not determine the active stub" in caplog.text
 
 
-def test_multistub_privately_decorated_named_stub(unix_servicer, caplog):
+def test_multistub_privately_decorated_named_stub(servicer, caplog):
     # function handle does not override the original function, so we can't find the stub
     # but we can use the names of the stubs to determine the active stub
     _run_e2e_function(
-        unix_servicer, "modal_test_support.multistub_privately_decorated_named_stub", "stub", "foo", stub_name="dummy"
+        servicer, "modal_test_support.multistub_privately_decorated_named_stub", "stub", "foo", stub_name="dummy"
     )
     assert len(caplog.messages) == 0  # no warnings, since target stub is named
 
 
-def test_multistub_same_name_warning(unix_servicer, caplog):
+def test_multistub_same_name_warning(servicer, caplog):
     # function handle does not override the original function, so we can't find the stub
     # two stubs with the same name - warn since we won't know which one to hydrate
-    _run_e2e_function(unix_servicer, "modal_test_support.multistub_same_name", "stub", "foo", stub_name="dummy")
+    _run_e2e_function(servicer, "modal_test_support.multistub_same_name", "stub", "foo", stub_name="dummy")
     assert "You have more than one Stub with the same name" in caplog.text

--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -580,7 +580,7 @@ def test_cli(unix_servicer, event_loop):
         raise Exception(f"Failed with {ret.returncode} stdout: {stdout} stderr: {stderr}")
 
     assert stdout == ""
-    # assert stderr == ""  # TODO(erikbern): this doesn't work right now:
+    assert stderr == ""
 
 
 def _run_e2e_function(

--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -7,7 +7,7 @@ import pytest
 import subprocess
 import sys
 import time
-from typing import List, Optional, Tuple, Dict
+from typing import List, Tuple, Dict
 
 from grpclib.exceptions import GRPCError
 
@@ -17,6 +17,7 @@ from modal._container_entrypoint import UserException, main
 from modal._serialization import deserialize, serialize
 from modal import Client
 from modal.exception import InvalidError
+from modal.stub import _Stub
 from modal_proto import api_pb2
 
 from .supports.skip import skip_windows_unix_socket
@@ -56,7 +57,7 @@ def _run_container(
     function_type=api_pb2.Function.FUNCTION_TYPE_FUNCTION,
     webhook_type=api_pb2.WEBHOOK_TYPE_UNSPECIFIED,
     definition_type=api_pb2.Function.DEFINITION_TYPE_FILE,
-    stub_name: Optional[str] = None,
+    stub_name: str = "",
     is_builder_function: bool = False,
 ) -> tuple[Client, list[api_pb2.FunctionPutOutputsItem]]:
     with Client(servicer.remote_addr, api_pb2.CLIENT_TYPE_CONTAINER, ("ta-123", "task-secret")) as client:
@@ -285,7 +286,7 @@ def _get_web_inputs(path="/"):
         "http_version": "2",
     }
     body = b""
-    return _get_inputs(([scope, body], {}))
+    return _get_inputs(((scope, body), {}))
 
 
 @skip_windows_unix_socket
@@ -588,13 +589,14 @@ def _run_e2e_function(
     stub_var_name,
     function_name,
     *,
-    stub_name=None,
+    stub_name="",
     assert_result=api_pb2.GenericResult.GENERIC_STATUS_SUCCESS,
     function_definition_type=api_pb2.Function.DEFINITION_TYPE_FILE,
     inputs=None,
     is_builder_function: bool = False,
 ):
     # TODO(elias): make this a bit more prod-like in how it connects the load and run parts by returning function definitions from _load_stub so we don't have to double specifiy things like definition type
+    _Stub._all_stubs = {}  # reset _Stub tracking state between runs
     _load_stub(servicer, module_name, stub_var_name)
     client, items = _run_container(
         servicer,
@@ -608,46 +610,55 @@ def _run_e2e_function(
     assert items[0].result.status == assert_result
 
 
-def test_function_hydration(servicer):
-    _run_e2e_function(servicer, "modal_test_support.functions", "stub", "check_sibling_hydration")
+@skip_windows_unix_socket
+def test_function_hydration(unix_servicer):
+    _run_e2e_function(unix_servicer, "modal_test_support.functions", "stub", "check_sibling_hydration")
 
 
-def test_multistub(servicer, caplog):
-    _run_e2e_function(servicer, "modal_test_support.multistub", "a", "a_func")
-    assert len(caplog.messages) == 0  # no need for a warning about double stubs here
+@skip_windows_unix_socket
+def test_multistub(unix_servicer, caplog):
+    _run_e2e_function(unix_servicer, "modal_test_support.multistub", "a", "a_func")
+    assert (
+        len(caplog.messages) == 1
+    )  # warns in case the user would use is_inside checks... Hydration should work regardless
+    assert "You have more than one unnamed stub" in caplog.text
 
 
-def test_multistub_privately_decorated(servicer, caplog):
+@skip_windows_unix_socket
+def test_multistub_privately_decorated(unix_servicer, caplog):
     # function handle does not override the original function, so we can't find the stub
     # and the two stubs are not named
-    _run_e2e_function(servicer, "modal_test_support.multistub_privately_decorated", "stub", "foo")
-    assert "Could not determine the active stub" in caplog.text
+    _run_e2e_function(unix_servicer, "modal_test_support.multistub_privately_decorated", "stub", "foo")
+    assert "You have more than one unnamed stub." in caplog.text
 
 
-def test_multistub_privately_decorated_named_stub(servicer, caplog):
+@skip_windows_unix_socket
+def test_multistub_privately_decorated_named_stub(unix_servicer, caplog):
     # function handle does not override the original function, so we can't find the stub
     # but we can use the names of the stubs to determine the active stub
     _run_e2e_function(
-        servicer, "modal_test_support.multistub_privately_decorated_named_stub", "stub", "foo", stub_name="dummy"
+        unix_servicer, "modal_test_support.multistub_privately_decorated_named_stub", "stub", "foo", stub_name="dummy"
     )
     assert len(caplog.messages) == 0  # no warnings, since target stub is named
 
 
-def test_multistub_same_name_warning(servicer, caplog):
+@skip_windows_unix_socket
+def test_multistub_same_name_warning(unix_servicer, caplog):
     # function handle does not override the original function, so we can't find the stub
     # two stubs with the same name - warn since we won't know which one to hydrate
-    _run_e2e_function(servicer, "modal_test_support.multistub_same_name", "stub", "foo", stub_name="dummy")
-    assert "You have more than one Stub with the same name" in caplog.text
+    _run_e2e_function(unix_servicer, "modal_test_support.multistub_same_name", "stub", "foo", stub_name="dummy")
+    assert "You have more than one stub with the same name ('dummy')" in caplog.text
 
 
-def test_multistub_serialized_func(servicer, caplog):
+@skip_windows_unix_socket
+def test_multistub_serialized_func(unix_servicer, caplog):
     # serialized functions shouldn't warn about multiple/not finding stubs, since they shouldn't load the module to begin with
     def dummy(x):
         return x
 
-    servicer.function_serialized = serialize(dummy)
+    unix_servicer.function_serialized = serialize(dummy)
     _run_e2e_function(
-        servicer,
+        unix_servicer,
         "modal_test_support.multistub_serialized_func",
         "stub",
         "foo",
@@ -656,10 +667,11 @@ def test_multistub_serialized_func(servicer, caplog):
     assert len(caplog.messages) == 0
 
 
-def test_image_run_function_no_warn(servicer, caplog):
+@skip_windows_unix_socket
+def test_image_run_function_no_warn(unix_servicer, caplog):
     # builder functions currently aren't tied to any modal stub, so they shouldn't need to warn if they can't determine a stub to use
     _run_e2e_function(
-        servicer,
+        unix_servicer,
         "modal_test_support.image_run_function",
         "stub",
         "builder_function",
@@ -667,3 +679,43 @@ def test_image_run_function_no_warn(servicer, caplog):
         is_builder_function=True,
     )
     assert len(caplog.messages) == 0
+
+
+@skip_windows_unix_socket
+def test_is_inside(unix_servicer, caplog, capsys):
+    _run_e2e_function(
+        unix_servicer,
+        "modal_test_support.is_inside",
+        "stub",
+        "foo",
+    )
+    assert len(caplog.messages) == 0
+    out, err = capsys.readouterr()
+    assert "in container!" in out
+    assert "in local" not in out
+
+
+@skip_windows_unix_socket
+def test_multistub_is_inside(unix_servicer, caplog, capsys):
+    _run_e2e_function(unix_servicer, "modal_test_support.multistub_is_inside", "a_stub", "foo", stub_name="a")
+    assert len(caplog.messages) == 0
+    out, err = capsys.readouterr()
+    assert "inside a" in out
+    assert "inside b" not in out
+
+
+@skip_windows_unix_socket
+def test_multistub_is_inside_warning(unix_servicer, caplog, capsys):
+    _run_e2e_function(
+        unix_servicer,
+        "modal_test_support.multistub_is_inside_warning",
+        "a_stub",
+        "foo",
+    )
+    assert len(caplog.messages) == 1
+    assert "You have more than one unnamed stub" in caplog.text
+    out, err = capsys.readouterr()
+    assert "inside a" in out
+    assert (
+        "inside b" in out
+    )  # can't determine which of two anonymous stubs is the active one at import time, so both will trigger

--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -595,7 +595,7 @@ def _run_e2e_function(
     inputs=None,
     is_builder_function: bool = False,
 ):
-    # TODO(elias): make this a bit more prod-like in how it connects the load and run parts by returning function definitions from _load_stub so we don't have to double specifiy things like definition type
+    # TODO(elias): make this a bit more prod-like in how it connects the load and run parts by returning function definitions from _load_stub so we don't have to double specify things like definition type
     _Stub._all_stubs = {}  # reset _Stub tracking state between runs
     _load_stub(servicer, module_name, stub_var_name)
     client, items = _run_container(

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -506,7 +506,7 @@ def import_function(function_def: api_pb2.Function, ser_cls, ser_fun) -> Importe
         _function_proxy = synchronizer._translate_in(fun)
         fun = _function_proxy.get_raw_f()
         active_stub = _function_proxy._stub
-    elif module is not None:
+    elif module is not None and not function_def.is_builder_function:
         # This branch is reached in the special case that the imported function is 1) not serialized, and 2) isn't a FunctionHandle - i.e, not decorated at definition time
         # Look for stubs in the same module as the function
         # This is not necessarily enough, and the active stub might not even be loaded, but it's a best effort

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -507,9 +507,10 @@ def import_function(function_def: api_pb2.Function, ser_cls, ser_fun) -> Importe
         fun = _function_proxy.get_raw_f()
         active_stub = _function_proxy._stub
     elif module is not None:
+        # This branch is reached in the special case that the imported function is 1) not serialized, and 2) isn't a FunctionHandle - i.e, not decorated at definition time
         # Look for stubs in the same module as the function
         # This is not necessarily enough, and the active stub might not even be loaded, but it's a best effort
-        # TODO(elias): Use some kind of global "Stub registry" instead of looking at stubs in global scope of the module, or store which module the stub is declared in?
+        # TODO(elias): Use some kind of global automatic "Stub registry" instead of looking at stubs in global scope of the module?
         stubs: typing.List[_Stub] = []
         for module_item in module.__dict__.values():
             if isinstance(module_item, (Stub, AioStub)):
@@ -522,13 +523,13 @@ def import_function(function_def: api_pb2.Function, ser_cls, ser_fun) -> Importe
                     if active_stub is not None:
                         # already matched with a stub - i.e. there are more than one with the name we look for
                         logger.warning(
-                            "You have more than one Stub with the same name. It's highly recommended to name all your Stubs uniquely."
+                            "You have more than one Stub with the same name. It's recommended to name all your Stubs uniquely."
                         )
                     active_stub = stub
 
             if not active_stub:
                 logger.warning(
-                    "Could not determine the active stub, which may prevent you from calling into other functions. It's highly recommended to name all your Stubs uniquely and expose your stub as a variable in the module that declares your function."
+                    "Could not determine the active stub, which may prevent you from calling into other functions. It's recommended to name all your Stubs uniquely and expose your stub as a global variable in the module that declares your function."
                 )
 
     # Check this property before we turn it into a method (overriden by webhooks)

--- a/modal/app.py
+++ b/modal/app.py
@@ -149,7 +149,7 @@ class _App:
     def function_invocations(self):
         return self._function_invocations
 
-    async def _init_container(self, client: _Client, app_id: str, stub_name: Optional[str]):
+    async def _init_container(self, client: _Client, app_id: str, stub_name: str):
         self._client = client
         self._app_id = app_id
         self._stub_name = stub_name
@@ -161,7 +161,7 @@ class _App:
             self._tag_to_object[item.tag] = obj
 
     @staticmethod
-    async def init_container(client: _Client, app_id: str, stub_name: Optional[str] = None) -> "_App":
+    async def init_container(client: _Client, app_id: str, stub_name: str = "") -> "_App":
         """Used by the container to bootstrap the app and all its objects. Not intended to be called by Modal users."""
         global _container_app, _is_container_app
         _is_container_app = True

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -749,6 +749,7 @@ class _Function(_Provider[_FunctionHandle]):
     _cloud: Optional[str]
     _function_handle: _FunctionHandle
     _stub: "modal.stub._Stub"
+    _is_builder_function: bool
 
     def __init__(
         self,
@@ -778,11 +779,13 @@ class _Function(_Provider[_FunctionHandle]):
         interactive: bool = False,
         name: Optional[str] = None,
         cloud: Optional[str] = None,
+        is_builder_function: bool = False,
         _cls: Optional[type] = None,
     ) -> None:
         """mdmd:hidden"""
         raw_f = function_info.raw_f
         self._stub = _stub
+        self._is_builder_function = is_builder_function
         assert callable(raw_f)
         self._info = function_info
         if schedule is not None:
@@ -1018,6 +1021,7 @@ class _Function(_Provider[_FunctionHandle]):
             warm_pool_size=warm_pool_size,
             runtime=config.get("function_runtime"),
             stub_name=stub_name,
+            is_builder_function=self._is_builder_function,
         )
         request = api_pb2.FunctionCreateRequest(
             app_id=resolver.app_id,

--- a/modal/image.py
+++ b/modal/image.py
@@ -1114,6 +1114,7 @@ class _Image(_Provider[_ImageHandle]):
             timeout=timeout,
             cpu=cpu,
             cloud=cloud,
+            is_builder_function=True,
         )
         return self.extend(build_function=function, force_build=self.force_build or force_build)
 

--- a/modal/object.py
+++ b/modal/object.py
@@ -36,6 +36,7 @@ class _Handle(metaclass=ObjectMeta):
     def _init(self):
         self._client = None
         self._object_id = None
+        self._is_hydrated = False
 
     @classmethod
     def _new(cls: Type[H]) -> H:
@@ -52,6 +53,12 @@ class _Handle(metaclass=ObjectMeta):
         self._object_id = object_id
         if handle_metadata:
             self._hydrate_metadata(handle_metadata)
+        self._is_hydrated = True
+
+    def is_hydrated(self) -> bool:
+        # A hydrated Handle is fully functional and linked to a live object in an app
+        # To hydrate Handles, run an app using stub.run() or look up the object from a running app using <HandleClass>.lookup()
+        return self._is_hydrated
 
     def _hydrate_metadata(self, handle_metadata: Message):
         # override this is subclasses that need additional data (other than an object_id) for a functioning Handle

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -890,7 +890,12 @@ class _Stub:
             if isinstance(obj, _FunctionHandle):
                 function_id = obj.object_id
                 handle_metadata = obj._get_handle_metadata()
-                self._function_handles[tag]._hydrate(client, function_id, handle_metadata)
+                if tag not in self._function_handles:
+                    # this could happen if a sibling function decoration is lazy loaded at a later than function import
+                    # assigning the app's hydrated function handle ensures it will be used for the later decoration return value
+                    self._function_handles[tag] = obj
+                else:
+                    self._function_handles[tag]._hydrate(client, function_id, handle_metadata)
 
 
 Stub, AioStub = synchronize_apis(_Stub)

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -159,7 +159,7 @@ class _Stub:
         self._app = None
 
         string_name = self._name or ""
-        existing_stubs = self._all_stubs.setdefault(string_name, [])
+        existing_stubs = _Stub._all_stubs.setdefault(string_name, [])
 
         if not is_local() and _container_app._stub_name == string_name:
             if len(existing_stubs) == 1:  # warn the first time we reach a duplicate stub name for the active stub
@@ -173,7 +173,7 @@ class _Stub:
             # note that all stubs with the correct name will get the container app assigned
             self._app = _container_app
 
-        self._all_stubs[string_name].append(self)
+        _Stub._all_stubs[string_name].append(self)
 
     @property
     def name(self) -> Optional[str]:

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -108,6 +108,7 @@ class _Stub:
     _local_entrypoints: Dict[str, LocalEntrypoint]
     _local_mounts: List[_Mount]
     _app: Optional[_App]
+    _all_stubs: typing.ClassVar[Dict[str, List["_Stub"]]] = {}
 
     @typechecked
     def __init__(
@@ -156,11 +157,23 @@ class _Stub:
         self._web_endpoints = []
 
         self._app = None
-        if not is_local():
-            # TODO(erikbern): in theory there could be multiple stubs defined.
-            # We should try to determine whether this is in fact the "right" one.
-            # We could probably do this by looking at the app's name.
+
+        string_name = self._name or ""
+        existing_stubs = self._all_stubs.setdefault(string_name, [])
+
+        if not is_local() and _container_app._stub_name == string_name:
+            if len(existing_stubs) == 1:  # warn the first time we reach a duplicate stub name for the active stub
+                if self._name is None:
+                    warning_sub_message = "unnamed stub"
+                else:
+                    warning_sub_message = f"stub with the same name ('{self._name}')"
+                logger.warning(
+                    f"You have more than one {warning_sub_message}. It's recommended to name all your Stubs uniquely when using multiple stubs"
+                )
+            # note that all stubs with the correct name will get the container app assigned
             self._app = _container_app
+
+        self._all_stubs[string_name].append(self)
 
     @property
     def name(self) -> Optional[str]:

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -408,6 +408,8 @@ message Function {
   string runtime = 30;
 
   string stub_name = 31;
+
+  bool is_builder_function = 32;
 }
 
 message FunctionHandleMetadata {

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -218,3 +218,16 @@ class Cls:
     @method(is_generator=True)
     def generator(self, x):
         return self._generator(x)
+
+
+@stub.function()
+def check_sibling_hydration(x):
+    assert square.is_hydrated()
+    assert Cls().f.is_hydrated()
+    assert Cls().web.is_hydrated()
+    assert Cls().web.web_url
+    assert Cls().generator.is_hydrated()
+    assert Cls().generator.is_generator
+    assert fastapi_app.is_hydrated()
+    assert fun_returning_gen.is_hydrated()
+    assert fun_returning_gen.is_generator

--- a/modal_test_support/image_run_function.py
+++ b/modal_test_support/image_run_function.py
@@ -1,0 +1,17 @@
+# Copyright Modal Labs 2022
+import modal
+
+stub = modal.Stub("a")
+other = modal.Stub("b")
+
+
+def builder_function():
+    print("ran builder function")
+
+
+image = modal.Image.debian_slim().run_function(builder_function)
+
+
+@stub.function(image=image)
+def foo():
+    pass

--- a/modal_test_support/is_inside.py
+++ b/modal_test_support/is_inside.py
@@ -1,0 +1,14 @@
+# Copyright Modal Labs 2023
+import modal
+
+stub = modal.Stub()
+
+if stub.is_inside():
+    print("in container!")
+else:
+    print("in local!")
+
+
+@stub.function()
+def foo(i):
+    pass

--- a/modal_test_support/multistub.py
+++ b/modal_test_support/multistub.py
@@ -1,0 +1,19 @@
+import modal
+
+
+a = modal.Stub()
+
+
+@a.function()
+def a_func(i):
+    assert a_func.is_hydrated()
+    assert not b_func.is_hydrated()
+
+
+b = modal.Stub()
+
+
+@b.function()
+def b_func(i):
+    assert b_func.is_hydrated()
+    assert not a_func.is_hydrated()

--- a/modal_test_support/multistub.py
+++ b/modal_test_support/multistub.py
@@ -1,3 +1,4 @@
+# Copyright Modal Labs 2023
 import modal
 
 

--- a/modal_test_support/multistub_is_inside.py
+++ b/modal_test_support/multistub_is_inside.py
@@ -1,0 +1,18 @@
+# Copyright Modal Labs 2023
+import modal
+
+a_stub = modal.Stub("a")
+b_stub = modal.Stub("b")
+
+
+if a_stub.is_inside():
+    print("inside a")
+
+
+if b_stub.is_inside():
+    print("inside b")
+
+
+@a_stub.function()
+def foo(i):
+    pass

--- a/modal_test_support/multistub_is_inside_warning.py
+++ b/modal_test_support/multistub_is_inside_warning.py
@@ -1,0 +1,18 @@
+# Copyright Modal Labs 2023
+import modal
+
+a_stub = modal.Stub()
+b_stub = modal.Stub()
+
+
+if a_stub.is_inside():
+    print("inside a")
+
+
+if b_stub.is_inside():
+    print("inside b")
+
+
+@a_stub.function()
+def foo(i):
+    pass

--- a/modal_test_support/multistub_privately_decorated.py
+++ b/modal_test_support/multistub_privately_decorated.py
@@ -1,0 +1,19 @@
+import modal
+
+
+stub = modal.Stub()
+
+
+def foo(i):
+    return 1
+
+
+foo_handle = stub.function()(foo)  #  "privately" decorated, by not override the original function
+
+
+other_stub = modal.Stub()
+
+
+@other_stub.function()
+def bar(i):
+    return 2

--- a/modal_test_support/multistub_privately_decorated.py
+++ b/modal_test_support/multistub_privately_decorated.py
@@ -1,3 +1,4 @@
+# Copyright Modal Labs 2023
 import modal
 
 

--- a/modal_test_support/multistub_privately_decorated_named_stub.py
+++ b/modal_test_support/multistub_privately_decorated_named_stub.py
@@ -1,0 +1,19 @@
+import modal
+
+
+stub = modal.Stub("dummy")
+
+
+def foo(i):
+    return 1
+
+
+foo_handle = stub.function()(foo)
+
+
+other_stub = modal.Stub()
+
+
+@other_stub.function()
+def bar(i):
+    return 2

--- a/modal_test_support/multistub_privately_decorated_named_stub.py
+++ b/modal_test_support/multistub_privately_decorated_named_stub.py
@@ -1,3 +1,4 @@
+# Copyright Modal Labs 2023
 import modal
 
 

--- a/modal_test_support/multistub_same_name.py
+++ b/modal_test_support/multistub_same_name.py
@@ -1,0 +1,19 @@
+import modal
+
+
+stub = modal.Stub("dummy")
+
+
+def foo(i):
+    return 1
+
+
+foo_handle = stub.function()(foo)
+
+
+other_stub = modal.Stub("dummy")
+
+
+@other_stub.function()
+def bar(i):
+    return 2

--- a/modal_test_support/multistub_serialized_func.py
+++ b/modal_test_support/multistub_serialized_func.py
@@ -2,17 +2,17 @@
 import modal
 
 
-stub = modal.Stub("dummy")
+stub = modal.Stub()
 
 
 def foo(i):
     return 1
 
 
-foo_handle = stub.function()(foo)
+foo_handle = stub.function(serialized=True)(foo)
 
 
-other_stub = modal.Stub("dummy")
+other_stub = modal.Stub()
 
 
 @other_stub.function()


### PR DESCRIPTION
Use the imported function to infer the relevant stub to hydrate then use the container app to hydrate all functions of that stub.

Notable exceptions:
* Serialized functions are not imported from modules, so they don't have attached stubs. However, they don't need their global references to be hydrated in their module scope, since the serialized references are automatically hydrated on unpickling.
* Functions that are 'privately' decorated such that the imported function isn't a FunctionHandle but a regular python function will not have a linked stub. In those cases we try to pick up a single stub from the function's module scope if there is one. If there is more than one we use explicit stub names to try to determine the stub, and if that fails we print some warnings and don't hydrate any stub.

TODO:
* Run integration tests to see that nothing breaks outside of what is tested in the client

Followup PR:
* Refactor `stub.is_inside()` logic to also use the stub name (right now all the stubs pass the condition when they are not local...)

