### PR TITLE
Include stub name in function definition

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -991,6 +991,7 @@ class _Function(_Provider[_FunctionHandle]):
             cloud_provider=self._cloud_provider,
             warm_pool_size=warm_pool_size,
             runtime=config.get("function_runtime"),
+            stub_name=self._stub.name or "",
         )
         request = api_pb2.FunctionCreateRequest(
             app_id=resolver.app_id,

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -968,6 +968,10 @@ class _Function(_Provider[_FunctionHandle]):
             function_serialized = None
             class_serialized = None
 
+        stub_name = ""
+        if self._stub and self._stub.name:
+            stub_name = self._stub.name
+
         # Create function remotely
         function_definition = api_pb2.Function(
             module_name=self._info.module_name,
@@ -991,7 +995,7 @@ class _Function(_Provider[_FunctionHandle]):
             cloud_provider=self._cloud_provider,
             warm_pool_size=warm_pool_size,
             runtime=config.get("function_runtime"),
-            stub_name=self._stub.name or "",
+            stub_name=stub_name,
         )
         request = api_pb2.FunctionCreateRequest(
             app_id=resolver.app_id,

--- a/modal/image.py
+++ b/modal/image.py
@@ -1102,7 +1102,7 @@ class _Image(_Provider[_ImageHandle]):
         function = _Function(
             function_handle,
             info,
-            _stub=self,
+            _stub=None,
             image=self,
             secret=secret,
             secrets=secrets,

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -95,7 +95,7 @@ class _Stub:
     In this example, the secret and schedule are registered with the app.
     """
 
-    _name: str
+    _name: Optional[str]
     _description: str
     _app_id: str
     _blueprint: Dict[str, _Provider]
@@ -163,7 +163,7 @@ class _Stub:
             self._app = _container_app
 
     @property
-    def name(self) -> str:
+    def name(self) -> Optional[str]:
         """The user-provided name of the Stub."""
         return self._name
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -406,6 +406,8 @@ message Function {
 
   // If set, overrides the runtime used by the function, either "runc" or "gvisor".
   string runtime = 30;
+
+  string stub_name = 31;
 }
 
 message FunctionHandleMetadata {


### PR DESCRIPTION
When provided, this can be used to distinguish mutiple stubs from one another when executing a function in a container. Useful for improving `is_inside()` checks and function rehydration in some special cases