### PR TITLE
Minor object constructor cleanup

### DIFF
--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -69,7 +69,8 @@ class Resolver:
         return self._client
 
     async def preload(self, obj, existing_object_id: Optional[str] = None):
-        return await obj._preload(self, existing_object_id)
+        if obj._preload is not None:
+            return await obj._preload(self, existing_object_id)
 
     async def load(self, obj, existing_object_id: Optional[str] = None):
         cached_obj = self._local_uuid_to_object.get(obj.local_uuid)

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -1,5 +1,5 @@
 # Copyright Modal Labs 2022
-from typing import Any
+from typing import Any, Optional
 
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronize_apis
@@ -137,7 +137,7 @@ class _Dict(_Provider[_DictHandle]):
     def __init__(self, data={}):
         """Create a new dictionary, optionally filled with initial data."""
 
-        async def _load(resolver: Resolver, existing_object_id: str) -> _DictHandle:
+        async def _load(resolver: Resolver, existing_object_id: Optional[str]) -> _DictHandle:
             serialized = _serialize_dict(data)
             req = api_pb2.DictCreateRequest(
                 app_id=resolver.app_id, data=serialized, existing_dict_id=existing_object_id

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -855,7 +855,7 @@ class _Function(_Provider[_FunctionHandle]):
         self._function_handle = function_handle
 
         rep = f"Function({self._tag})"
-        super().__init__(self._load, rep)
+        super().__init__(self._load, rep, preload=self._preload)
 
     async def _preload(self, resolver: Resolver, existing_object_id: Optional[str]):
         if self._is_generator:

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -875,7 +875,7 @@ class _Function(_Provider[_FunctionHandle]):
         self._function_handle._hydrate(resolver.client, response.function_id, response.handle_metadata)
         return self._function_handle
 
-    async def _load(self, resolver: Resolver, existing_object_id: str):
+    async def _load(self, resolver: Resolver, existing_object_id: Optional[str]):
         status_row = resolver.add_status_row()
         status_row.message(f"Creating {self._tag}...")
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -857,7 +857,7 @@ class _Function(_Provider[_FunctionHandle]):
         rep = f"Function({self._tag})"
         super().__init__(self._load, rep, preload=self._preload)
 
-    async def _preload(self, resolver: Resolver, existing_object_id: Optional[str]):
+    async def _preload(self, resolver: Resolver, existing_object_id: Optional[str]) -> _FunctionHandle:
         if self._is_generator:
             function_type = api_pb2.Function.FUNCTION_TYPE_GENERATOR
         else:
@@ -875,7 +875,7 @@ class _Function(_Provider[_FunctionHandle]):
         self._function_handle._hydrate(resolver.client, response.function_id, response.handle_metadata)
         return self._function_handle
 
-    async def _load(self, resolver: Resolver, existing_object_id: Optional[str]):
+    async def _load(self, resolver: Resolver, existing_object_id: Optional[str]) -> _FunctionHandle:
         status_row = resolver.add_status_row()
         status_row.message(f"Creating {self._tag}...")
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -855,9 +855,11 @@ class _Function(_Provider[_FunctionHandle]):
         self._function_handle = function_handle
 
         rep = f"Function({self._tag})"
-        super().__init__(self._load, rep, preload=self._preload)
+        super().__init__(self._load, rep, preload=self._preload_f)
 
-    async def _preload(self, resolver: Resolver, existing_object_id: Optional[str]) -> _FunctionHandle:
+    async def _preload_f(self, resolver: Resolver, existing_object_id: Optional[str]) -> _FunctionHandle:
+        # TODO(erikbern): this is only called _preload_f to avoid a mypy confusion with the class annotation _preload
+        # We will get rid of this function very soon anyway (will make it an anonymous closure)
         if self._is_generator:
             function_type = api_pb2.Function.FUNCTION_TYPE_GENERATOR
         else:

--- a/modal/image.py
+++ b/modal/image.py
@@ -168,7 +168,7 @@ class _Image(_Provider[_ImageHandle]):
         if build_function and len(base_images) != 1:
             raise InvalidError("Cannot run a build function with multiple base images!")
 
-        async def _load(resolver: Resolver, existing_object_id: str):
+        async def _load(resolver: Resolver, existing_object_id: Optional[str]):
             if ref:
                 image_id = (await resolver.load(ref)).object_id
                 return _ImageHandle._from_id(image_id, resolver.client, None)

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -255,7 +255,7 @@ class _Mount(_Provider[_MountHandle]):
                     # Can happen with temporary files (e.g. emacs will write temp files and delete them quickly)
                     logger.info(f"Ignoring file not found: {exc}")
 
-    async def _load(self, resolver: Resolver, existing_object_id: str):
+    async def _load(self, resolver: Resolver, existing_object_id: Optional[str]):
         # Run a threadpool to compute hash values, and use concurrent coroutines to register files.
         t0 = time.time()
         n_concurrent_uploads = 16

--- a/modal/object.py
+++ b/modal/object.py
@@ -162,6 +162,9 @@ _BLOCKING_P, _ASYNC_P = synchronize_apis(P)
 
 
 class _Provider(Generic[H]):
+    _load: Callable[[Resolver, str], Awaitable[H]]
+    _preload: Optional[Callable[[Resolver, str], Awaitable[H]]]
+
     def _init(
         self,
         load: Callable[[Resolver, str], Awaitable[H]],
@@ -171,9 +174,7 @@ class _Provider(Generic[H]):
     ):
         self._local_uuid = str(uuid.uuid4())
         self._load = load
-        if preload is not None:
-            # only sets _preload if one is provided, otherwise a noop is used
-            self._preload = preload
+        self._preload = preload
         self._rep = rep
         self.is_persisted_ref = is_persisted_ref
 
@@ -294,14 +295,11 @@ class _Provider(Generic[H]):
             handle: H = await handle_cls.from_app(app_name, tag, namespace, client=resolver.client)
             return handle
 
-        async def _no_preload(resolver: Resolver, existing_object_id: str) -> Optional[H]:
-            return None
-
         # Create a class of type cls, but use the base constructor
         # TODO(erikbern): No _Provider subclass should override __init__
         obj = cls.__new__(cls)
         rep = f"Ref({app_name})"
-        _Provider.__init__(obj, _load_remote, rep, preload=_no_preload)
+        _Provider.__init__(obj, _load_remote, rep)
         return obj
 
     @classmethod

--- a/modal/object.py
+++ b/modal/object.py
@@ -349,9 +349,6 @@ class _Provider(Generic[H]):
             else:
                 raise
 
-    async def _preload(self, resolver, existing_object_id):
-        return None
-
 
 # Dumb but needed becauase it's in the hierarchy
 synchronize_apis(Generic, __name__)  # erases base Generic type...

--- a/modal/object.py
+++ b/modal/object.py
@@ -162,15 +162,15 @@ _BLOCKING_P, _ASYNC_P = synchronize_apis(P)
 
 
 class _Provider(Generic[H]):
-    _load: Callable[[Resolver, str], Awaitable[H]]
-    _preload: Optional[Callable[[Resolver, str], Awaitable[H]]]
+    _load: Callable[[Resolver, Optional[str]], Awaitable[H]]
+    _preload: Optional[Callable[[Resolver, Optional[str]], Awaitable[H]]]
 
     def _init(
         self,
-        load: Callable[[Resolver, str], Awaitable[H]],
+        load: Callable[[Resolver, Optional[str]], Awaitable[H]],
         rep: str,
         is_persisted_ref: bool = False,
-        preload: Optional[Callable[[Resolver, str], Awaitable[H]]] = None,
+        preload: Optional[Callable[[Resolver, Optional[str]], Awaitable[H]]] = None,
     ):
         self._local_uuid = str(uuid.uuid4())
         self._load = load
@@ -180,10 +180,10 @@ class _Provider(Generic[H]):
 
     def __init__(
         self,
-        load: Optional[Callable[[Resolver, str], Awaitable[H]]],
+        load: Optional[Callable[[Resolver, Optional[str]], Awaitable[H]]],
         rep: str,
         is_persisted_ref: bool = False,
-        preload: Optional[Callable[[Resolver, str], Awaitable[Optional[H]]]] = None,
+        preload: Optional[Callable[[Resolver, Optional[str]], Awaitable[Optional[H]]]] = None,
     ):
         # TODO(erikbern): this is semi-deprecated - subclasses should use _from_loader
         self._init(load, rep, is_persisted_ref, preload=preload)
@@ -191,10 +191,10 @@ class _Provider(Generic[H]):
     @classmethod
     def _from_loader(
         cls,
-        load: Callable[[Resolver, str], Awaitable[H]],
+        load: Callable[[Resolver, Optional[str]], Awaitable[H]],
         rep: str,
         is_persisted_ref: bool = False,
-        preload: Optional[Callable[[Resolver, str], Awaitable[H]]] = None,
+        preload: Optional[Callable[[Resolver, Optional[str]], Awaitable[H]]] = None,
     ):
         obj = _Handle.__new__(cls)
         obj._init(load, rep, is_persisted_ref, preload)
@@ -259,7 +259,7 @@ class _Provider(Generic[H]):
 
         """
 
-        async def _load_persisted(resolver: Resolver, existing_object_id: str) -> H:
+        async def _load_persisted(resolver: Resolver, existing_object_id: Optional[str]) -> H:
             return await self._deploy(label, namespace, resolver.client)
 
         cls = type(self)
@@ -288,7 +288,7 @@ class _Provider(Generic[H]):
         ```
         """
 
-        async def _load_remote(resolver: Resolver, existing_object_id: str) -> H:
+        async def _load_remote(resolver: Resolver, existing_object_id: Optional[str]) -> H:
             handle_cls = cls._get_handle_cls()
             handle: H = await handle_cls.from_app(app_name, tag, namespace, client=resolver.client)
             return handle

--- a/modal/object.py
+++ b/modal/object.py
@@ -183,7 +183,7 @@ class _Provider(Generic[H]):
         load: Optional[Callable[[Resolver, Optional[str]], Awaitable[H]]],
         rep: str,
         is_persisted_ref: bool = False,
-        preload: Optional[Callable[[Resolver, Optional[str]], Awaitable[Optional[H]]]] = None,
+        preload: Optional[Callable[[Resolver, Optional[str]], Awaitable[H]]] = None,
     ):
         # TODO(erikbern): this is semi-deprecated - subclasses should use _from_loader
         self._init(load, rep, is_persisted_ref, preload=preload)

--- a/modal/object.py
+++ b/modal/object.py
@@ -180,7 +180,7 @@ class _Provider(Generic[H]):
 
     def __init__(
         self,
-        load: Optional[Callable[[Resolver, Optional[str]], Awaitable[H]]],
+        load: Callable[[Resolver, Optional[str]], Awaitable[H]],
         rep: str,
         is_persisted_ref: bool = False,
         preload: Optional[Callable[[Resolver, Optional[str]], Awaitable[H]]] = None,

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -136,7 +136,7 @@ class _Queue(_Provider[_QueueHandle]):
     """
 
     def __init__(self):
-        async def _load(resolver: Resolver, existing_object_id: str) -> _QueueHandle:
+        async def _load(resolver: Resolver, existing_object_id: Optional[str]) -> _QueueHandle:
             request = api_pb2.QueueCreateRequest(app_id=resolver.app_id, existing_queue_id=existing_object_id)
             response = await resolver.client.stub.QueueCreate(request)
             return _QueueHandle._from_id(response.queue_id, resolver.client, None)

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -1,5 +1,5 @@
 # Copyright Modal Labs 2022
-from typing import Dict
+from typing import Dict, Optional
 
 from modal._types import typechecked
 
@@ -44,7 +44,7 @@ class _Secret(_Provider[_SecretHandle]):
         ):
             raise InvalidError(ENV_DICT_WRONG_TYPE_ERR)
 
-        async def _load(resolver: Resolver, existing_object_id: str) -> _SecretHandle:
+        async def _load(resolver: Resolver, existing_object_id: Optional[str]) -> _SecretHandle:
             req = api_pb2.SecretCreateRequest(
                 app_id=resolver.app_id,
                 env_dict=env_dict,

--- a/modal/shared_volume.py
+++ b/modal/shared_volume.py
@@ -183,7 +183,7 @@ class _SharedVolume(_Provider[_SharedVolumeHandle]):
     def __init__(self, cloud_provider: Optional["api_pb2.CloudProvider.ValueType"] = None) -> None:
         """Construct a new shared volume, which is empty by default."""
 
-        async def _load(resolver: Resolver, existing_object_id: str) -> _SharedVolumeHandle:
+        async def _load(resolver: Resolver, existing_object_id: Optional[str]) -> _SharedVolumeHandle:
             status_row = resolver.add_status_row()
             if existing_object_id:
                 # Volume already exists; do nothing.


### PR DESCRIPTION
Was looking at merging Providers and Handles and it's fairly straightforward but will be easier if we simplify the Provider classes first. The main thing is this just turns `_preload` fully into an attribute rather than a base class method (afaict @freider had mostly structured the code that way already)