### PR TITLE
Fix the _strptime issue

### DIFF
--- a/modal/_ipython.py
+++ b/modal/_ipython.py
@@ -1,13 +1,21 @@
 # Copyright Modal Labs 2022
 import sys
+import warnings
+
+ipy_outstream = None
+try:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        import ipykernel.iostream
+
+    ipy_outstream = ipykernel.iostream.OutStream
+except ImportError:
+    pass
 
 
 def is_notebook(stdout=None):
+    if ipy_outstream is None:
+        return False
     if stdout is None:
         stdout = sys.stdout
-    try:
-        import ipykernel.iostream
-
-        return isinstance(stdout, ipykernel.iostream.OutStream)
-    except ImportError:
-        return False
+    return isinstance(stdout, ipy_outstream)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ filterwarnings = [
     "ignore::DeprecationWarning:pytest.*:",
     "ignore::DeprecationWarning:pkg_resources.*:",
     "ignore::DeprecationWarning:google.rpc.*:",
-    "module:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning",
     "ignore:.*pkg_resources.*:DeprecationWarning::",
 ]
 


### PR DESCRIPTION
This fixes a bunch of tests failing with weird ass `_strptime` failures.

Btw the way to reproduce this is to run: `pytest -v client_test/mount_test.py `

The absurd thing is that
1. Running the failing test in isolation works: `pytest -v client_test/mount_test.py -k test_create_package_mounts`
2. Running ALL client tests also works.

I think the problem might be that you can't `import ipykernel.iostream` in non-global scope or similar – it's very strange.
