### PR TITLE
Remove some methods from Mount

### DIFF
--- a/client_test/image_test.py
+++ b/client_test/image_test.py
@@ -339,7 +339,7 @@ def test_image_build_with_context_mount(client, servicer, tmp_path):
             assert layers[expected_layer].context_mount_id == "mo-123", f"error in {image_name}"
             assert "COPY . /dummy" in layers[expected_layer].dockerfile_commands
 
-        files = {f.mount_filename: f.content for f in data_mount._get_files()}
+        files = {f.mount_filename: f.content for f in Mount._get_files(data_mount.entries)}
         assert files == {"/data.txt": b"hello", "/data/sub": b"world"}
 
 

--- a/client_test/mount_test.py
+++ b/client_test/mount_test.py
@@ -24,7 +24,7 @@ async def test_get_files(servicer, aio_client, tmpdir):
 
     files = {}
     m = AioMount.from_local_dir(Path(tmpdir), remote_path="/", condition=lambda fn: fn.endswith(".py"), recursive=True)
-    async for upload_spec in m._get_files():
+    async for upload_spec in AioMount._get_files(m.entries):
         files[upload_spec.mount_filename] = upload_spec
 
     assert "/small.py" in files

--- a/client_test/mounted_files_test.py
+++ b/client_test/mounted_files_test.py
@@ -41,7 +41,7 @@ async def env_mount_files():
 
     filenames = []
     for _, mount in fn_info.get_mounts().items():
-        async for file_info in mount._get_files():
+        async for file_info in mount._get_files(mount.entries):
             filenames.append(file_info.mount_filename)
 
     return filenames

--- a/client_test/supports/pkg_a/package.py
+++ b/client_test/supports/pkg_a/package.py
@@ -19,7 +19,7 @@ async def get_files():
     fn_info = FunctionInfo(f)
 
     for _, mount in fn_info.get_mounts().items():
-        async for file_info in mount._get_files():
+        async for file_info in mount._get_files(mount.entries):
             print(file_info.mount_filename)
 
 

--- a/client_test/supports/pkg_a/script.py
+++ b/client_test/supports/pkg_a/script.py
@@ -19,7 +19,7 @@ async def get_files():
     fn_info = FunctionInfo(f)
 
     for _, mount in fn_info.get_mounts().items():
-        async for file_info in mount._get_files():
+        async for file_info in mount._get_files(mount.entries):
             print(file_info.mount_filename)
 
 

--- a/client_test/supports/pkg_a/serialized_fn.py
+++ b/client_test/supports/pkg_a/serialized_fn.py
@@ -19,7 +19,7 @@ async def get_files():
     fn_info = FunctionInfo(f, serialized=True)
 
     for _, mount in fn_info.get_mounts().items():
-        async for file_info in mount._get_files():
+        async for file_info in mount._get_files(mount.entries):
             print(file_info.mount_filename)
 
 


### PR DESCRIPTION
* Getting rid of the constructor and using a factory function internally
* Making the `load` method more closure like by making it static and binding arguments to it

This is in preparation of merging `Provider` and `Handle` classes