### PR TITLE
Warning when no functions ran remotely with `local_entrypoint`

### DIFF
--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -134,6 +134,16 @@ def test_run(servicer, set_env_client, test_dir):
     _run(["run", file_with_entrypoint.as_posix() + "::stub.main"])
 
 
+def test_local_entrypoint_no_remote_calls(servicer, set_env_client, test_dir):
+    file = test_dir / "supports" / "app_run_tests" / "local_entrypoint.py"
+    res = _run(["run", file.as_posix()])
+    assert "Warning: no remote function calls were made" not in res.stdout
+
+    file = test_dir / "supports" / "app_run_tests" / "local_entrypoint_no_remote.py"
+    res = _run(["run", file.as_posix()])
+    assert "Warning: no remote function calls were made" in res.stdout
+
+
 def test_help_message_unspecified_function(servicer, set_env_client, test_dir):
     stub_file = test_dir / "supports" / "app_run_tests" / "stub_with_multiple_functions.py"
     result = _run(["run", stub_file.as_posix()], expected_exit_code=2, expected_stderr=None)

--- a/client_test/supports/app_run_tests/local_entrypoint_no_remote.py
+++ b/client_test/supports/app_run_tests/local_entrypoint_no_remote.py
@@ -1,0 +1,16 @@
+# Copyright Modal Labs 2022
+
+import modal
+
+stub = modal.Stub()
+
+
+@stub.function()
+def foo():
+    pass
+
+
+@stub.local_entrypoint()
+def main():
+    foo()
+    foo()

--- a/modal/app.py
+++ b/modal/app.py
@@ -44,6 +44,7 @@ class _App:
     _app_id: str
     _app_page_url: str
     _resolver: Optional[Resolver]
+    _function_invocations: int  # Number of function invocations made by this app.
 
     def __init__(
         self,
@@ -59,6 +60,7 @@ class _App:
         self._client = client
         self._tag_to_object = tag_to_object or {}
         self._tag_to_existing_id = tag_to_existing_id or {}
+        self._function_invocations = 0
 
     @property
     def client(self) -> _Client:
@@ -137,6 +139,13 @@ class _App:
 
     def __getattr__(self, tag: str) -> _Handle:
         return self._tag_to_object[tag]
+
+    def track_function_invocation(self):
+        self._function_invocations += 1
+
+    @property
+    def function_invocations(self):
+        return self._function_invocations
 
     async def _init_container(self, client: _Client, app_id: str):
         self._client = client

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -107,11 +107,17 @@ def _get_click_command_for_local_entrypoint(_stub, entrypoint: LocalEntrypoint):
                 "Note that running a local entrypoint in detached mode only keeps the last triggered Modal function alive after the parent process has been killed or disconnected."
             )
 
-        with blocking_stub.run(detach=ctx.obj["detach"], show_progress=ctx.obj["show_progress"]):
+        with blocking_stub.run(detach=ctx.obj["detach"], show_progress=ctx.obj["show_progress"]) as app:
             if isasync:
                 asyncio.run(func(*args, **kwargs))
             else:
                 func(*args, **kwargs)
+            if app.function_invocations == 0:
+                print(
+                    "Warning: no remote function calls were made.\n"
+                    "Note that Modal functions run locally when called directly (e.g. `f()`).\n"
+                    "In order to run a function remotely, you may use `f.call()`. (See https://modal.com/docs/reference/modal.Function for other options)."
+                )
 
     with_click_options = _add_click_options(f, inspect.signature(func))
     return click.command(with_click_options)

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -113,6 +113,7 @@ def _get_click_command_for_local_entrypoint(_stub, entrypoint: LocalEntrypoint):
             else:
                 func(*args, **kwargs)
             if app.function_invocations == 0:
+                # TODO: better formatting for the warning message
                 print(
                     "Warning: no remote function calls were made.\n"
                     "Note that Modal functions run locally when called directly (e.g. `f()`).\n"

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -535,6 +535,7 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
             self._output_mgr.function_progress_callback(self._function_name) if self._output_mgr else None
         )
 
+        self._stub.app.track_function_invocation()
         async for item in _map_invocation(
             self._object_id,
             input_stream,
@@ -629,6 +630,7 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
             yield item
 
     async def _call_function(self, args, kwargs):
+        self._stub.app.track_function_invocation()
         invocation = await _Invocation.create(self._object_id, args, kwargs, self._client)
         try:
             return await invocation.run_function()
@@ -638,15 +640,18 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
                 raise
 
     async def _call_function_nowait(self, args, kwargs):
+        self._stub.app.track_function_invocation()
         return await _Invocation.create(self._object_id, args, kwargs, self._client)
 
     @warn_if_generator_is_not_consumed
     async def _call_generator(self, args, kwargs):
+        self._stub.app.track_function_invocation()
         invocation = await _Invocation.create(self._object_id, args, kwargs, self._client)
         async for res in invocation.run_generator():
             yield res
 
     async def _call_generator_nowait(self, args, kwargs):
+        self._stub.app.track_function_invocation()
         return await _Invocation.create(self._object_id, args, kwargs, self._client)
 
     def call(self, *args, **kwargs) -> Any:  # TODO: Generics/TypeVars

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -521,6 +521,10 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
     def is_generator(self) -> bool:
         return self._is_generator
 
+    def _track_function_invocation(self):
+        if self._stub and self._stub.app:
+            self._stub.app.track_function_invocation()
+
     async def _map(self, input_stream: AsyncIterable[Any], order_outputs: bool, return_exceptions: bool, kwargs={}):
         if self._web_url:
             raise InvalidError(
@@ -535,7 +539,7 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
             self._output_mgr.function_progress_callback(self._function_name) if self._output_mgr else None
         )
 
-        self._stub.app.track_function_invocation()
+        self._track_function_invocation()
         async for item in _map_invocation(
             self._object_id,
             input_stream,
@@ -630,7 +634,7 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
             yield item
 
     async def _call_function(self, args, kwargs):
-        self._stub.app.track_function_invocation()
+        self._track_function_invocation()
         invocation = await _Invocation.create(self._object_id, args, kwargs, self._client)
         try:
             return await invocation.run_function()
@@ -640,18 +644,18 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
                 raise
 
     async def _call_function_nowait(self, args, kwargs):
-        self._stub.app.track_function_invocation()
+        self._track_function_invocation()
         return await _Invocation.create(self._object_id, args, kwargs, self._client)
 
     @warn_if_generator_is_not_consumed
     async def _call_generator(self, args, kwargs):
-        self._stub.app.track_function_invocation()
+        self._track_function_invocation()
         invocation = await _Invocation.create(self._object_id, args, kwargs, self._client)
         async for res in invocation.run_generator():
             yield res
 
     async def _call_generator_nowait(self, args, kwargs):
-        self._stub.app.track_function_invocation()
+        self._track_function_invocation()
         return await _Invocation.create(self._object_id, args, kwargs, self._client)
 
     def call(self, *args, **kwargs) -> Any:  # TODO: Generics/TypeVars


### PR DESCRIPTION
Resolves a super common issue that first-time users run into.