### PR TITLE
Don't warn about not finding stub when using an image builder function

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -506,7 +506,7 @@ def import_function(function_def: api_pb2.Function, ser_cls, ser_fun) -> Importe
         _function_proxy = synchronizer._translate_in(fun)
         fun = _function_proxy.get_raw_f()
         active_stub = _function_proxy._stub
-    elif module is not None:
+    elif module is not None and not function_def.is_builder_function:
         # This branch is reached in the special case that the imported function is 1) not serialized, and 2) isn't a FunctionHandle - i.e, not decorated at definition time
         # Look for stubs in the same module as the function
         # This is not necessarily enough, and the active stub might not even be loaded, but it's a best effort

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -749,6 +749,7 @@ class _Function(_Provider[_FunctionHandle]):
     _cloud: Optional[str]
     _function_handle: _FunctionHandle
     _stub: "modal.stub._Stub"
+    _is_builder_function: bool
 
     def __init__(
         self,
@@ -778,11 +779,13 @@ class _Function(_Provider[_FunctionHandle]):
         interactive: bool = False,
         name: Optional[str] = None,
         cloud: Optional[str] = None,
+        is_builder_function: bool = False,
         _cls: Optional[type] = None,
     ) -> None:
         """mdmd:hidden"""
         raw_f = function_info.raw_f
         self._stub = _stub
+        self._is_builder_function = is_builder_function
         assert callable(raw_f)
         self._info = function_info
         if schedule is not None:
@@ -1018,6 +1021,7 @@ class _Function(_Provider[_FunctionHandle]):
             warm_pool_size=warm_pool_size,
             runtime=config.get("function_runtime"),
             stub_name=stub_name,
+            is_builder_function=self._is_builder_function,
         )
         request = api_pb2.FunctionCreateRequest(
             app_id=resolver.app_id,

--- a/modal/image.py
+++ b/modal/image.py
@@ -1114,6 +1114,7 @@ class _Image(_Provider[_ImageHandle]):
             timeout=timeout,
             cpu=cpu,
             cloud=cloud,
+            is_builder_function=True,
         )
         return self.extend(build_function=function, force_build=self.force_build or force_build)
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -408,6 +408,8 @@ message Function {
   string runtime = 30;
 
   string stub_name = 31;
+
+  bool is_builder_function = 32;
 }
 
 message FunctionHandleMetadata {

--- a/modal_test_support/image_run_function.py
+++ b/modal_test_support/image_run_function.py
@@ -1,0 +1,17 @@
+# Copyright Modal Labs 2022
+import modal
+
+stub = modal.Stub("a")
+other = modal.Stub("b")
+
+
+def builder_function():
+    print("ran builder function")
+
+
+image = modal.Image.debian_slim().run_function(builder_function)
+
+
+@stub.function(image=image)
+def foo():
+    pass


### PR DESCRIPTION
Followup to #502 

image builder functions aren't strictly linked to stubs, and the apps wouldn't necessarily be loadable anyways, so we shouldn't warn if we can't hydrate the stub when running one