### PR TITLE
Bump synchronicity to v0.4.4

### DIFF
--- a/modal/requirements.txt
+++ b/modal/requirements.txt
@@ -14,7 +14,7 @@ ipython>=7.34.0
 protobuf>=3.19.0
 python-multipart>=0.0.5
 rich==12.3.0
-synchronicity==0.4.2
+synchronicity~=0.4.4
 tblib==1.7.0
 toml==0.10.2
 typer==0.6.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     importlib_metadata>=3.6.0
     protobuf>=3.19,<5.0
     rich>=12.0.0
-    synchronicity==0.4.2
+    synchronicity~=0.4.4
     tblib>=1.7.0
     toml
     typer>=0.6.1


### PR DESCRIPTION
Also, use latest patch version if possible using ~ specification, so any bug fix release of synchronicity will be picked up automatically