### PR TITLE
Prevent double mount of "main" file

### DIFF
--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -81,6 +81,8 @@ class MockClientServicer(api_grpc.ModalClientBase):
         }
         self.n_inputs = 0
         self.n_queues = 0
+        self.n_mounts = 0
+        self.n_mount_files = 0
         self.files_name2sha = {}
         self.files_sha2data = {}
         self.function_id_for_function_call = {}
@@ -520,6 +522,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         request: api_pb2.MountPutFileRequest = await stream.recv_message()
         if request.WhichOneof("data_oneof") is not None:
             self.files_sha2data[request.sha256_hex] = {"data": request.data, "data_blob_id": request.data_blob_id}
+            self.n_mount_files += 1
             await stream.send_message(api_pb2.MountPutFileResponse(exists=True))
         else:
             await stream.send_message(api_pb2.MountPutFileResponse(exists=False))
@@ -528,6 +531,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         request: api_pb2.MountBuildRequest = await stream.recv_message()
         for file in request.files:
             self.files_name2sha[file.filename] = file.sha256_hex
+        self.n_mounts += 1
         await stream.send_message(api_pb2.MountBuildResponse(mount_id="mo-123"))
 
     ### Queue

--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -12,8 +12,6 @@ from modal.exception import DeprecationError, InvalidError
 from modal.functions import Function, FunctionCall, gather, FunctionHandle
 from modal.stub import AioStub
 
-from . import helpers
-
 stub = Stub()
 
 
@@ -502,17 +500,3 @@ def test_invalid_web_decorator_usage():
         @wsgi_app  # type: ignore
         def my_handle_wsgi():
             pass
-
-
-def test_e2e_modal_run_py_file_mounts(servicer, test_dir):
-    helpers.deploy_stub_externally(servicer, "hello.py", cwd=test_dir.parent / "modal_test_support")
-    assert servicer.n_mounts == 1  # there should be a single mount
-    assert servicer.n_mount_files == 1
-    assert "/root/hello.py" in servicer.files_name2sha
-
-
-def test_e2e_modal_run_py_module_mounts(servicer, test_dir):
-    helpers.deploy_stub_externally(servicer, "hello", cwd=test_dir.parent / "modal_test_support")
-    assert servicer.n_mounts == 1  # there should be a single mount
-    assert servicer.n_mount_files == 1
-    assert "/root/hello.py" in servicer.files_name2sha

--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -12,6 +12,8 @@ from modal.exception import DeprecationError, InvalidError
 from modal.functions import Function, FunctionCall, gather, FunctionHandle
 from modal.stub import AioStub
 
+from . import helpers
+
 stub = Stub()
 
 
@@ -500,3 +502,17 @@ def test_invalid_web_decorator_usage():
         @wsgi_app  # type: ignore
         def my_handle_wsgi():
             pass
+
+
+def test_e2e_modal_run_py_file_mounts(servicer, test_dir):
+    helpers.deploy_stub_externally(servicer, "hello.py", cwd=test_dir.parent / "modal_test_support")
+    assert servicer.n_mounts == 1  # there should be a single mount
+    assert servicer.n_mount_files == 1
+    assert "/root/hello.py" in servicer.files_name2sha
+
+
+def test_e2e_modal_run_py_module_mounts(servicer, test_dir):
+    helpers.deploy_stub_externally(servicer, "hello", cwd=test_dir.parent / "modal_test_support")
+    assert servicer.n_mounts == 1  # there should be a single mount
+    assert servicer.n_mount_files == 1
+    assert "/root/hello.py" in servicer.files_name2sha

--- a/client_test/helpers.py
+++ b/client_test/helpers.py
@@ -1,0 +1,21 @@
+import pathlib
+import subprocess
+import sys
+from typing import Optional
+
+
+def deploy_stub_externally(
+    servicer, file_or_module: str, stub_variable: Optional[str] = None, deployment_name="Deployment", cwd=None
+):
+    # deploys a stub from another interpreter to prevent leaking state from client into a container process (apart from what goes through the servicer)
+    env = {"MODAL_SERVER_URL": servicer.remote_addr}
+    if cwd is None:
+        cwd = pathlib.Path(__file__).parent.parent
+
+    stub_ref = file_or_module if stub_variable is None else f"{file_or_module}::{stub_variable}"
+
+    subprocess.check_call(
+        [sys.executable, "-m", "modal.cli.entry_point", "deploy", stub_ref, "--name", deployment_name],
+        cwd=cwd,
+        env=env,
+    )

--- a/client_test/helpers.py
+++ b/client_test/helpers.py
@@ -1,3 +1,4 @@
+# Copyright Modal Labs 2023
 import pathlib
 import subprocess
 import sys
@@ -8,6 +9,7 @@ def deploy_stub_externally(
     servicer, file_or_module: str, stub_variable: Optional[str] = None, deployment_name="Deployment", cwd=None
 ):
     # deploys a stub from another interpreter to prevent leaking state from client into a container process (apart from what goes through the servicer)
+    # also has the advantage that no modules imported by the test files themselves will be added to sys.modules and included in mounts etc.
     env = {"MODAL_SERVER_URL": servicer.remote_addr}
     if cwd is None:
         cwd = pathlib.Path(__file__).parent.parent

--- a/client_test/mounted_files_test.py
+++ b/client_test/mounted_files_test.py
@@ -7,8 +7,9 @@ import sys
 from pathlib import Path
 
 from modal._function_utils import FunctionInfo
+from . import helpers
 
-from .supports.skip import skip_windows
+from .supports.skip import skip_windows, skip_windows_unix_socket
 
 
 @pytest.fixture
@@ -173,3 +174,21 @@ def test_mounted_files_config(supports_dir, env_mount_files):
 
     # Assert just the script is there
     assert files == {"/root/script.py"}
+
+
+@skip_windows_unix_socket
+def test_e2e_modal_run_py_file_mounts(unix_servicer, test_dir):
+    helpers.deploy_stub_externally(unix_servicer, "hello.py", cwd=test_dir.parent / "modal_test_support")
+    assert len(unix_servicer.files_name2sha) == 1
+    assert unix_servicer.n_mounts == 1  # there should be a single mount
+    assert unix_servicer.n_mount_files == 1
+    assert "/root/hello.py" in unix_servicer.files_name2sha
+
+
+@skip_windows_unix_socket
+def test_e2e_modal_run_py_module_mounts(unix_servicer, test_dir):
+    helpers.deploy_stub_externally(unix_servicer, "hello", cwd=test_dir.parent / "modal_test_support")
+    assert len(unix_servicer.files_name2sha) == 1
+    assert unix_servicer.n_mounts == 1  # there should be a single mount
+    assert unix_servicer.n_mount_files == 1
+    assert "/root/hello.py" in unix_servicer.files_name2sha

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -120,7 +120,7 @@ class FunctionInfo:
         elif hasattr(module, "__file__") and not serialized:
             # This generally covers the case where it's invoked with
             # python foo/bar/baz.py
-            self.file = inspect.getfile(f)
+            self.file = os.path.abspath(inspect.getfile(f))
             self.module_name = inspect.getmodulename(self.file)
             self.base_dir = os.path.dirname(self.file)
             self.definition_type = api_pb2.Function.DEFINITION_TYPE_FILE
@@ -155,34 +155,37 @@ class FunctionInfo:
         return serialized_bytes
 
     def get_mounts(self) -> Dict[str, _Mount]:
-        if self.type == FunctionInfoType.PACKAGE:
-            mounts = {
-                self.base_dir: _Mount.from_local_dir(
-                    self.base_dir,
-                    remote_path=self.remote_dir,
-                    recursive=True,
-                    condition=package_mount_condition,
-                )
-            }
-        elif self.type == FunctionInfoType.FILE:
-            remote_path = ROOT_DIR / Path(self.file).name
-            mounts = {
-                self.file: _Mount.from_local_file(
-                    self.file,
-                    remote_path=remote_path,
-                )
-            }
-        elif self.type == FunctionInfoType.NOTEBOOK:
+        if self.type == FunctionInfoType.NOTEBOOK:
             # Don't auto-mount anything for notebooks.
             return {}
+
+        if config.get("automount"):
+            mounts = self._get_auto_mounts()
         else:
             mounts = {}
 
-        if not config.get("automount"):
-            return filter_safe_mounts(mounts)
+        # make sure the function's own entrypoint is included:
+        if self.type == FunctionInfoType.PACKAGE:
+            mounts[self.base_dir] = _Mount.from_local_dir(
+                self.base_dir,
+                remote_path=self.remote_dir,
+                recursive=True,
+                condition=package_mount_condition,
+            )
+        elif self.type == FunctionInfoType.FILE:
+            remote_path = ROOT_DIR / Path(self.file).name
+            mounts[self.file] = _Mount.from_local_file(
+                self.file,
+                remote_path=remote_path,
+            )
 
+        return filter_safe_mounts(mounts)
+
+    def _get_auto_mounts(self):
         # Auto-mount local modules that have been imported in global scope.
+        # This may or may not include the "entrypoint" of the function as well, depending on how modal is invoked
         # Note: sys.modules may change during the iteration
+        mounts = {}
         modules = []
         skip_prefixes = set()
         for name, module in sorted(sys.modules.items(), key=lambda kv: len(kv[0])):
@@ -234,11 +237,13 @@ class FunctionInfo:
                     remote_path = ROOT_DIR / relpath / Path(path).name
                 else:
                     remote_path = ROOT_DIR / Path(path).name
+
+                print("Automatically mounting", path, m)
                 mounts[path] = _Mount.from_local_file(
                     path,
                     remote_path=remote_path,
                 )
-        return filter_safe_mounts(mounts)
+        return mounts
 
     def get_tag(self):
         return self.function_name

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -238,7 +238,6 @@ class FunctionInfo:
                 else:
                     remote_path = ROOT_DIR / Path(path).name
 
-                print("Automatically mounting", path, m)
                 mounts[path] = _Mount.from_local_file(
                     path,
                     remote_path=remote_path,

--- a/modal_test_support/hello.py
+++ b/modal_test_support/hello.py
@@ -1,0 +1,9 @@
+import modal
+
+stub = modal.Stub()
+
+
+@stub.function()
+def hello():
+    print("hello")
+    return "hello"

--- a/modal_test_support/hello.py
+++ b/modal_test_support/hello.py
@@ -1,3 +1,4 @@
+# Copyright Modal Labs 2023
 import modal
 
 stub = modal.Stub()


### PR DESCRIPTION
When `modal run`:ing a `.py` file, not using module syntax, the file was previously mounted twice due to FunctionInfo assigning the relative path instead of the absolute path to the file as the `file` attribute.

This fixes this, adds an "end to end" test for the number of mounts/files attached to a deployed stub, and and rearranges the automount code to be somewhat more readable.