### PR TITLE
Mount synchronicity instead of installing inside image

### DIFF
--- a/modal/mount.py
+++ b/modal/mount.py
@@ -327,6 +327,7 @@ Mount, AioMount = synchronize_apis(_Mount)
 def _create_client_mount():
     # TODO(erikbern): make this a static method on the Mount class
     import modal
+    import synchronicity
 
     # Get the base_path because it also contains `modal_utils` and `modal_proto`.
     base_path, _ = os.path.split(modal.__path__[0])
@@ -338,7 +339,9 @@ def _create_client_mount():
     def condition(arg):
         return module_mount_condition(arg) and arg.startswith(prefix)
 
-    return _Mount.from_local_dir(base_path, remote_path="/pkg/", condition=condition, recursive=True)
+    return _Mount.from_local_dir(base_path, remote_path="/pkg/", condition=condition, recursive=True).add_local_dir(
+        synchronicity.__path__[0], remote_path="/pkg/synchronicity", condition=module_mount_condition, recursive=True
+    )
 
 
 _, aio_create_client_mount = synchronize_apis(_create_client_mount)

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -339,8 +339,15 @@ def _create_client_mount():
     def condition(arg):
         return module_mount_condition(arg) and arg.startswith(prefix)
 
-    return _Mount.from_local_dir(base_path, remote_path="/pkg/", condition=condition, recursive=True).add_local_dir(
-        synchronicity.__path__[0], remote_path="/pkg/synchronicity", condition=module_mount_condition, recursive=True
+    return (
+        _Mount.from_local_dir(base_path, remote_path="/pkg/", condition=condition, recursive=True)
+        # Mount synchronicity, so version changes don't trigger image rebuilds for users.
+        .add_local_dir(
+            synchronicity.__path__[0],
+            remote_path="/pkg/synchronicity",
+            condition=module_mount_condition,
+            recursive=True,
+        )
     )
 
 

--- a/modal/requirements.txt
+++ b/modal/requirements.txt
@@ -14,7 +14,6 @@ ipython>=7.34.0
 protobuf>=3.19.0
 python-multipart>=0.0.5
 rich==12.3.0
-synchronicity~=0.4.4
 tblib==1.7.0
 toml==0.10.2
 typer==0.6.1


### PR DESCRIPTION
Makes it so bumping synchronicity versions does not trigger image rebuilds for users. The `publish-client` job installs modal through pip, so the version defined in `setup.cfg` will be what's mounted.