### PR TITLE
fix: 'modal shell' should work on web endpoints

### DIFF
--- a/modal/cli/import_refs.py
+++ b/modal/cli/import_refs.py
@@ -139,9 +139,11 @@ def choose_function_interactive(stub: _Stub, console: Console) -> str:
 
 
 def infer_function_or_help(
-    _stub: _Stub, interactive: bool, accept_local_entrypoint: bool
+    _stub: _Stub, interactive: bool, accept_local_entrypoint: bool, accept_webhook: bool
 ) -> Union[_FunctionHandle, LocalEntrypoint]:
-    function_choices = set(_stub.registered_functions.keys()) - set(_stub.registered_web_endpoints)
+    function_choices = set(_stub.registered_functions.keys())
+    if not accept_webhook:
+        function_choices -= set(_stub.registered_web_endpoints)
     if accept_local_entrypoint:
         function_choices |= set(_stub.registered_entrypoints.keys())
 
@@ -246,7 +248,7 @@ You would run foo as [bold green]{base_cmd} app.py::foo[/bold green]"""
 
 
 def import_function(
-    func_ref: str, base_cmd: str, accept_local_entrypoint=True, interactive=False
+    func_ref: str, base_cmd: str, accept_local_entrypoint=True, accept_webhook=False, interactive=False
 ) -> Union[_FunctionHandle, LocalEntrypoint]:
     import_ref = parse_import_ref(func_ref)
     try:
@@ -266,7 +268,7 @@ def import_function(
     if isinstance(stub_or_function, _Stub):
         # infer function or display help for how to select one
         _stub = stub_or_function
-        _function_handle = infer_function_or_help(_stub, interactive, accept_local_entrypoint)
+        _function_handle = infer_function_or_help(_stub, interactive, accept_local_entrypoint, accept_webhook)
         return _function_handle
     if isinstance(stub_or_function, _FunctionHandle):
         return stub_or_function

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -248,7 +248,7 @@ def shell(
         raise click.UsageError("`modal shell` can only be run from a terminal.")
 
     _function_handle = import_function(
-        func_ref, accept_local_entrypoint=False, interactive=True, base_cmd="modal shell"
+        func_ref, accept_local_entrypoint=False, accept_webhook=True, interactive=True, base_cmd="modal shell"
     )
     assert isinstance(_function_handle, _FunctionHandle)  # ensured by accept_local_entrypoint=False
     _stub = _function_handle._stub


### PR DESCRIPTION
Issue a user hit on Thursday: https://modalbetatesters.slack.com/archives/C031Z7DBQFL/p1683236640997479?thread_ts=1683234820.662439&cid=C031Z7DBQFL