### PR TITLE
v0 parametrized function support

### DIFF
--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -1,4 +1,5 @@
 # Copyright Modal Labs 2022
+import inspect
 import pytest
 
 from modal import Stub, method
@@ -6,6 +7,7 @@ from modal.aio import AioStub, aio_method
 from modal.functions import FunctionHandle
 from modal_proto import api_pb2
 from modal._serialization import deserialize
+from modal.cls import ClsMixin
 
 stub = Stub()
 
@@ -34,6 +36,30 @@ def test_call_class_sync(client, servicer):
     with stub.run(client=client):
         foo = Foo()
         assert foo.bar.call(42) == 1764
+
+
+# Reusing the stub runs into an issue with stale function handles.
+# TODO (akshat): have all the client tests use separate stubs, and throw
+# an exception if the user tries to reuse a stub.
+stub_remote = Stub()
+
+
+@stub_remote.cls(cpu=42)
+class FooRemote(ClsMixin):
+    def __init__(self, x: int, y: str) -> None:
+        self.x = x
+        self.y = y
+
+    @method()
+    def bar(self, z: int):
+        pass  # Servicer doesn't use function body
+
+
+def test_call_cls_remote_sync(client):
+    with stub_remote.run(client=client):
+        foo_remote = FooRemote.remote(3, "hello")
+        assert foo_remote.bar.call(8) == 64
+        assert foo_remote.bar(8) == 64
 
 
 aio_stub = AioStub()
@@ -81,6 +107,30 @@ def test_run_class_serialized(client, servicer):
     assert isinstance(obj.bar, FunctionHandle)
     # Make sure it's callable
     assert meth(100) == 1000000
+
+
+aio_stub_remote = AioStub()
+
+
+@aio_stub_remote.cls(cpu=42)
+class BarRemote(ClsMixin):
+    def __init__(self, x: int, y: str) -> None:
+        self.x = x
+        self.y = y
+
+    @aio_method()
+    def baz(self, z: int):
+        pass  # Servicer doesn't use function body
+
+
+@pytest.mark.asyncio
+async def test_call_cls_remote_async(client):
+    async with aio_stub_remote.run(client=client):
+        coro = BarRemote.aio_remote(3, "hello")
+        assert inspect.iscoroutine(coro)
+        bar_remote = await coro
+        assert await bar_remote.baz.call(8) == 64
+        assert await bar_remote.baz(8) == 64
 
 
 stub_local = Stub()

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -3,6 +3,7 @@ import inspect
 from typing import Dict, Union
 from modal_utils.async_utils import synchronize_apis
 from .functions import _PartialFunction, PartialFunction, AioPartialFunction, _FunctionHandle
+from datetime import datetime
 
 
 class ClsMixin:
@@ -13,6 +14,9 @@ class ClsMixin:
     @staticmethod
     async def aio_remote(*args, **kwargs):
         ...
+
+
+ALLOWED_TYPES = (int, float, bool, str, bytes, type(None), datetime)
 
 
 def make_remote_cls_constructors(
@@ -27,6 +31,13 @@ def make_remote_cls_constructors(
 
     async def _remote(*args, **kwargs):
         params = sig.bind(*args, **kwargs)
+
+        for name, param in params.arguments.items():
+            if not isinstance(param, ALLOWED_TYPES):
+                raise ValueError(
+                    f"Only primitive types are allowed in remote class constructors. "
+                    f"Found {name}={param} of type {type(param)}."
+                )
 
         cls_dict = {}
         new_function_handles: Dict[str, _FunctionHandle] = {}

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -1,0 +1,33 @@
+# Copyright Modal Labs 2022
+import inspect
+from typing import Dict, Union
+from modal_utils.async_utils import synchronize_apis
+from .functions import _PartialFunction, PartialFunction, AioPartialFunction, _FunctionHandle
+
+
+def make_remote_cls_constructors(
+    user_cls: type,
+    partial_functions: Dict[str, Union[PartialFunction, AioPartialFunction]],
+    function_handles: Dict[str, _FunctionHandle],
+):
+    original_sig = inspect.signature(user_cls.__init__)  # type: ignore
+    new_parameters = [param for name, param in original_sig.parameters.items() if name != "self"]
+    sig = inspect.Signature(new_parameters)
+    # TODO: validate signature has only primitive types.
+
+    async def _remote(*args, **kwargs):
+        params = sig.bind(*args, **kwargs)
+        params.apply_defaults()
+
+        cls_dict = {}
+        new_function_handles: Dict[str, _FunctionHandle] = {}
+
+        for k, v in partial_functions.items():
+            new_function_handles[k] = await function_handles[k].make_bound_function_handle(params)
+            cls_dict[k] = v
+
+        cls = type(f"Remote{user_cls.__name__}", (), cls_dict)
+        _PartialFunction.initialize_cls(cls, new_function_handles)
+        return cls()
+
+    return synchronize_apis(_remote)

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -1,18 +1,20 @@
 # Copyright Modal Labs 2022
 import inspect
-from typing import Dict, Union
+from typing import Dict, Union, TypeVar, Type
 from modal_utils.async_utils import synchronize_apis
 from .functions import _PartialFunction, PartialFunction, AioPartialFunction, _FunctionHandle
 from datetime import datetime
 
+T = TypeVar("T")
+
 
 class ClsMixin:
-    @staticmethod
-    def remote(*args, **kwargs):
+    @classmethod
+    def remote(cls: Type[T], *args, **kwargs) -> T:
         ...
 
-    @staticmethod
-    async def aio_remote(*args, **kwargs):
+    @classmethod
+    async def aio_remote(cls: Type[T], *args, **kwargs) -> T:
         ...
 
 

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -17,7 +17,6 @@ def make_remote_cls_constructors(
 
     async def _remote(*args, **kwargs):
         params = sig.bind(*args, **kwargs)
-        params.apply_defaults()
 
         cls_dict = {}
         new_function_handles: Dict[str, _FunctionHandle] = {}

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -32,7 +32,6 @@ def make_remote_cls_constructors(
         new_function_handles: Dict[str, _FunctionHandle] = {}
 
         for k, v in partial_functions.items():
-            print("HYDRAITNGJklli", k, function_handles[k])
             new_function_handles[k] = await function_handles[k].make_bound_function_handle(params)
             cls_dict[k] = v
 

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -5,6 +5,16 @@ from modal_utils.async_utils import synchronize_apis
 from .functions import _PartialFunction, PartialFunction, AioPartialFunction, _FunctionHandle
 
 
+class ClsMixin:
+    @staticmethod
+    def remote(*args, **kwargs):
+        ...
+
+    @staticmethod
+    async def aio_remote(*args, **kwargs):
+        ...
+
+
 def make_remote_cls_constructors(
     user_cls: type,
     partial_functions: Dict[str, Union[PartialFunction, AioPartialFunction]],
@@ -22,6 +32,7 @@ def make_remote_cls_constructors(
         new_function_handles: Dict[str, _FunctionHandle] = {}
 
         for k, v in partial_functions.items():
+            print("HYDRAITNGJklli", k, function_handles[k])
             new_function_handles[k] = await function_handles[k].make_bound_function_handle(params)
             cls_dict[k] = v
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -470,6 +470,7 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
     _web_url: Optional[str]
     _info: Optional[FunctionInfo]
     _stub: Optional["modal.stub._Stub"]
+    _is_remote_cls_method: bool = False
 
     def _initialize_from_empty(self):
         self._progress = None
@@ -513,6 +514,7 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
         )
         response = await self._client.stub.FunctionBindParams(req)
         new_handle._hydrate(self._client, response.bound_function_id, response.handle_metadata)
+        new_handle._is_remote_cls_method = True
         return new_handle
 
     def _get_handle_metadata(self):
@@ -694,6 +696,9 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
             return self._call_function(args, kwargs)
 
     def __call__(self, *args, **kwargs) -> Any:  # TODO: Generics/TypeVars
+        if self._is_remote_cls_method:
+            return self.call(*args, **kwargs)
+
         if not self._info:
             msg = (
                 "The definition for this function is missing so it is not possible to invoke it locally. "

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -62,6 +62,9 @@ def check_sequence(items: typing.Sequence[typing.Any], item_type: typing.Type[ty
         raise InvalidError(error_msg)
 
 
+CLS_T = typing.TypeVar("CLS_T", bound=typing.Type)
+
+
 class _Stub:
     """A `Stub` is a description of how to create a Modal application.
 
@@ -867,8 +870,8 @@ class _Stub:
         interactive: bool = False,  # Whether to run the function in interactive mode.
         keep_warm: Optional[int] = None,  # An optional number of containers to always keep warm.
         cloud: Optional[str] = None,  # Cloud provider to run the function on. Possible values are aws, gcp, auto.
-    ) -> Callable[[type], type]:
-        def wrapper(user_cls: type) -> type:
+    ) -> Callable[[CLS_T], CLS_T]:
+        def wrapper(user_cls: CLS_T) -> CLS_T:
             partial_functions: Dict[str, Union[PartialFunction, AioPartialFunction]] = {}
             function_handles: Dict[str, _FunctionHandle] = {}
 

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -231,3 +231,14 @@ def check_sibling_hydration(x):
     assert fastapi_app.is_hydrated()
     assert fun_returning_gen.is_hydrated()
     assert fun_returning_gen.is_generator
+
+
+@stub.cls()
+class ParamCls:
+    def __init__(self, x: int, y: str) -> None:
+        self.x = x
+        self.y = y
+
+    @method()
+    def f(self, z: int):
+        return f"{self.x} {self.y} {z}"


### PR DESCRIPTION
`@stub.cls`-decorated objects now have a `.remote()` function that forwards its arguments to the class constructor. This works by creating a "bound function" from the base that has these parameters registered:

```python
@stub.cls()
class Model:
    def __init__(self, x: str, y: int) -> None:
        self.x = x
        self.y = y

    @method()
    def f(self):
        print(self.x)
        return y**2


@stub.local_entrypoint()
def main():
    model = Model.remote("hello", y=42)
    model.f.call()
```

The pool of functions for each set of parameters scales independently. Also, a set of parameters uniquely determines the pools by value. So calling `Model.remote("hello")` from two different processes will still refer to the same "bound function ID".

### TODO

- [x] Validate that only primitive types are sent
- [x] Tests
- [x] Remove the need for `.call()`
- [x] Type hints?