### PR TITLE
Make the `_Function` constructor a factory function

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -1099,10 +1099,10 @@ class _Image(_Provider[_ImageHandle]):
 
         function_handle = _FunctionHandle._new()
 
-        function = _Function(
+        function = _Function.from_args(
             function_handle,
             info,
-            _stub=None,
+            stub=None,
             image=self,
             secret=secret,
             secrets=secrets,

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -656,10 +656,10 @@ class _Stub:
             else:
                 self._blueprint["_pty_input_stream"] = _Queue()
 
-        function = _Function(
+        function = _Function.from_args(
             function_handle,
             info,
-            _stub=self,
+            stub=self,
             image=image,
             secret=secret,
             secrets=secrets,
@@ -682,7 +682,7 @@ class _Stub:
             name=name,
             cloud=cloud,
             webhook_config=webhook_config,
-            _cls=_cls,
+            cls=_cls,
         )
 
         self._add_function(function, [*base_mounts, *mounts])


### PR DESCRIPTION
This is one step towards merging `Provider` and `Handle` classes. The reason this makes it a lot easier is that if all construction happens through factory functions, then it doesn't really matter where those are located – which means we can rename `_FunctionHandle` to `_Function` and move the factory function to the other class.

There is way too much state still left on the `_Function` object. Something like 90% of it is needed because of `interactive_shell`, and about 30% is needed for builder functions (there's some overlap). I think we can clean that up but it seems easier to do that in a subsequent PR.