### PR TITLE
Move some stuff from stub.py to runner.py

### DIFF
--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -10,6 +10,7 @@ from synchronicity.exceptions import UserCodeException
 from modal import Proxy, Stub, SharedVolume, web_endpoint, asgi_app, wsgi_app
 from modal.exception import DeprecationError, InvalidError
 from modal.functions import Function, FunctionCall, gather, FunctionHandle
+from modal.runner import deploy_stub
 from modal.stub import AioStub
 
 stub = Stub()
@@ -366,8 +367,7 @@ def test_from_id_internal(client, servicer):
     assert obj.object_id == "fc-123"
 
 
-@pytest.mark.asyncio
-async def test_from_id(client, servicer):
+def test_from_id(client, servicer):
     stub = Stub()
 
     @stub.function(serialized=True)
@@ -375,7 +375,7 @@ async def test_from_id(client, servicer):
     def foo():
         pass
 
-    stub.deploy("dummy", client=client)
+    deploy_stub(stub, "dummy", client=client)
 
     function_id = foo.object_id
     assert function_id

--- a/client_test/lookup_test.py
+++ b/client_test/lookup_test.py
@@ -4,13 +4,14 @@ import pytest
 from modal.aio import AioFunction, AioQueue, AioStub, aio_web_endpoint
 from modal.exception import NotFoundError
 from modal.queue import AioQueueHandle
+from modal.runner import aio_deploy_stub
 
 
 @pytest.mark.asyncio
 async def test_persistent_object(servicer, aio_client):
     stub = AioStub()
     stub["q_1"] = AioQueue()
-    await stub.deploy("my-queue", client=aio_client)
+    await aio_deploy_stub(stub, "my-queue", client=aio_client)
 
     q: AioQueueHandle = await AioQueue.lookup("my-queue", client=aio_client)
     # TODO: remove type annotation here after genstub gets better Generic base class support
@@ -31,7 +32,7 @@ async def test_lookup_function(servicer, aio_client):
     stub = AioStub()
 
     stub.function()(square)
-    await stub.deploy("my-function", client=aio_client)
+    await aio_deploy_stub(stub, "my-function", client=aio_client)
 
     f = await AioFunction.lookup("my-function", client=aio_client)
     assert f.object_id == "fu-1"
@@ -51,7 +52,7 @@ async def test_lookup_function(servicer, aio_client):
 async def test_webhook_lookup(servicer, aio_client):
     stub = AioStub()
     stub.function()(aio_web_endpoint(method="POST")(square))
-    await stub.deploy("my-webhook", client=aio_client)
+    await aio_deploy_stub(stub, "my-webhook", client=aio_client)
 
     f = await AioFunction.lookup("my-webhook", client=aio_client)
     assert f.web_url

--- a/modal/_pty.py
+++ b/modal/_pty.py
@@ -156,7 +156,6 @@ async def write_stdin_to_pty_stream(queue: _QueueHandle):
 
     quit_pipe_read, quit_pipe_write = os.pipe()
 
-    print(f"{sys.stdin=}")
     set_nonblocking(sys.stdin.fileno())
 
     @asyncify

--- a/modal/_pty.py
+++ b/modal/_pty.py
@@ -156,6 +156,7 @@ async def write_stdin_to_pty_stream(queue: _QueueHandle):
 
     quit_pipe_read, quit_pipe_write = os.pipe()
 
+    print(f"{sys.stdin=}")
     set_nonblocking(sys.stdin.fileno())
 
     @asyncify

--- a/modal/serving.py
+++ b/modal/serving.py
@@ -17,14 +17,14 @@ from ._watcher import watch
 from .app import _App
 from .cli.import_refs import import_stub
 from .client import _Client
-from .runner import run_stub
+from .runner import _run_stub, serve_update
 
 
 def _run_serve(stub_ref: str, existing_app_id: str, is_ready: Event):
     # subprocess entrypoint
     _stub = import_stub(stub_ref)
     blocking_stub = synchronizer._translate_out(_stub, Interface.BLOCKING)
-    blocking_stub.serve_update(existing_app_id, is_ready)
+    serve_update(blocking_stub, existing_app_id, is_ready)
 
 
 async def _restart_serve(stub_ref: str, existing_app_id: str, timeout: float = 5.0) -> SpawnProcess:
@@ -109,7 +109,7 @@ async def _serve_stub(
     else:
         watcher = watch(stub._local_mounts, output_mgr)
 
-    async with run_stub(stub, client=client, output_mgr=output_mgr) as app:
+    async with _run_stub(stub, client=client, output_mgr=output_mgr) as app:
         client.set_pre_stop(app.disconnect)
         async with TaskContext(grace=0.1) as tc:
             tc.create_task(_run_watch_loop(stub_ref, app.app_id, output_mgr, watcher))

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -330,7 +330,10 @@ class _Stub:
         show_progress=None,
         object_entity: str = "ap",
     ) -> _App:
-        """`stub.deploy` is deprecated. Use the `modal deploy` command instead."""
+        """`stub.deploy` is deprecated. Use the `modal deploy` command instead.
+
+        For programmatic usage, use `modal.runner.deploy_stub`
+        """
         deprecation_warning(
             date(2023, 5, 9),
             self.deploy.__doc__,
@@ -789,7 +792,10 @@ class _Stub:
         return self.function(web_endpoint, **function_args)
 
     async def interactive_shell(self, cmd=None, image=None, **kwargs):
-        """`stub.interactive_shell` is deprecated. Use the `modal shell` command instead."""
+        """`stub.interactive_shell` is deprecated. Use the `modal shell` command instead.
+
+        For programmatic usage, use `modal.runner.interactive_shell`
+        """
         deprecation_warning(
             date(2023, 5, 9),
             self.interactive_shell.__doc__,


### PR DESCRIPTION
The point is that the `Stub` class is humongous and it's going to be easier to merge `Stub` and `App` if we move a bunch of logic out of those classes. Now that pretty much all usage is through the CLI, we can deprecate the methods on the stub class and move them to `modal.runner` instead.