### PR TITLE
Bump synchronicity to 0.5.x

### DIFF
--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -34,9 +34,9 @@ dummy_other_module_file = "x = 42"
 
 
 @pytest_asyncio.fixture
-async def set_env_client(aio_client):
+async def set_env_client(client):
     try:
-        Client.set_env_client(aio_client)
+        Client.set_env_client(client)
         yield
     finally:
         Client.set_env_client(None)
@@ -75,20 +75,6 @@ def test_app_deploy_with_name(servicer, mock_dir, set_env_client):
         _run(["deploy", "myapp.py", "--name", "my_app_foo"])
 
     assert "my_app_foo" in servicer.deployed_apps
-
-
-dummy_aio_app_file = """
-from modal.aio import AioStub
-
-stub = AioStub("my_aio_app")
-"""
-
-
-def test_aio_app_deploy_success(servicer, mock_dir, set_env_client):
-    with mock_dir({"myaioapp.py": dummy_aio_app_file}):
-        _run(["deploy", "myaioapp.py"])
-
-    assert "my_aio_app" in servicer.deployed_apps
 
 
 def test_app_deploy_no_such_module():
@@ -203,7 +189,7 @@ def test_run_custom_stub(servicer, set_env_client, test_dir):
     _run(["run", stub_file.as_posix() + "::foo"])
 
 
-def test_run_aiostub(servicer, set_env_client, test_dir):
+def test_run_aiofunc(servicer, set_env_client, test_dir):
     stub_file = test_dir / "supports" / "app_run_tests" / "async_stub.py"
     _run(["run", stub_file.as_posix()])
     assert len(servicer.client_calls) == 1

--- a/client_test/lookup_test.py
+++ b/client_test/lookup_test.py
@@ -13,13 +13,13 @@ async def test_persistent_object(servicer, aio_client):
     stub["q_1"] = AioQueue()
     await aio_deploy_stub(stub, "my-queue", client=aio_client)
 
-    q: AioQueueHandle = await AioQueue.lookup("my-queue", client=aio_client)
+    q: AioQueueHandle = await AioQueue.lookup("my-queue", client=aio_client)  # type: ignore
     # TODO: remove type annotation here after genstub gets better Generic base class support
     assert isinstance(q, AioQueueHandle)  # TODO(erikbern): it's a AioQueueHandler
     assert q.object_id == "qu-1"
 
     with pytest.raises(NotFoundError):
-        await AioQueue.lookup("bazbazbaz", client=aio_client)
+        await AioQueue.lookup("bazbazbaz", client=aio_client)  # type: ignore
 
 
 def square(x):
@@ -34,14 +34,14 @@ async def test_lookup_function(servicer, aio_client):
     stub.function()(square)
     await aio_deploy_stub(stub, "my-function", client=aio_client)
 
-    f = await AioFunction.lookup("my-function", client=aio_client)
+    f = await AioFunction.lookup("my-function", client=aio_client)  # type: ignore
     assert f.object_id == "fu-1"
 
     # Call it using two arguments
-    f = await AioFunction.lookup("my-function", "square", client=aio_client)
+    f = await AioFunction.lookup("my-function", "square", client=aio_client)  # type: ignore
     assert f.object_id == "fu-1"
     with pytest.raises(NotFoundError):
-        f = await AioFunction.lookup("my-function", "cube", client=aio_client)
+        f = await AioFunction.lookup("my-function", "cube", client=aio_client)  # type: ignore
 
     # Make sure we can call this function
     assert await f.call(2, 4) == 20
@@ -54,16 +54,16 @@ async def test_webhook_lookup(servicer, aio_client):
     stub.function()(aio_web_endpoint(method="POST")(square))
     await aio_deploy_stub(stub, "my-webhook", client=aio_client)
 
-    f = await AioFunction.lookup("my-webhook", client=aio_client)
+    f = await AioFunction.lookup("my-webhook", client=aio_client)  # type: ignore
     assert f.web_url
 
 
 @pytest.mark.asyncio
 async def test_deploy_exists(servicer, aio_client):
-    assert not await AioQueue._exists("my-queue", client=aio_client)
+    assert not await AioQueue._exists("my-queue", client=aio_client)  # type: ignore
     h1 = await AioQueue()._deploy("my-queue", client=aio_client)
-    assert await AioQueue._exists("my-queue", client=aio_client)
-    h2 = await AioQueue().lookup("my-queue", client=aio_client)
+    assert await AioQueue._exists("my-queue", client=aio_client)  # type: ignore
+    h2 = await AioQueue().lookup("my-queue", client=aio_client)  # type: ignore
     assert h1.object_id == h2.object_id
 
 

--- a/client_test/supports/app_run_tests/async_stub.py
+++ b/client_test/supports/app_run_tests/async_stub.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
-import modal.aio
+import modal
 
-stub = modal.aio.AioStub()
+stub = modal.Stub()
 
 
 @stub.function()

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -292,7 +292,7 @@ class _FunctionIOManager:
         return serialized_tb, tb_line_cache
 
     @contextlib.asynccontextmanager
-    async def handle_user_exception(self):
+    async def handle_user_exception(self) -> AsyncGenerator[None, None]:
         """Sets the task as failed in a way where it's not retried
 
         Only used for importing user code atm

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -13,7 +13,7 @@ import sys
 import time
 import traceback
 from dataclasses import dataclass
-from typing import Any, AsyncIterator, Callable, Optional
+from typing import Any, AsyncGenerator, AsyncIterator, Callable, Optional
 
 from grpclib import Status
 
@@ -323,7 +323,7 @@ class _FunctionIOManager:
             raise UserException()
 
     @contextlib.asynccontextmanager
-    async def handle_input_exception(self, input_id, output_index: SequenceNumber):
+    async def handle_input_exception(self, input_id, output_index: SequenceNumber) -> AsyncGenerator[None, None]:
         try:
             with trace("input"):
                 set_span_tag("input_id", input_id)
@@ -378,7 +378,7 @@ class _FunctionIOManager:
 
 
 # just to mark the class as synchronized, we don't care about the interfaces
-FunctionIOManager, AioFunctionIOManager = synchronize_apis(_FunctionIOManager)
+FunctionIOManager, _ = synchronize_apis(_FunctionIOManager)
 
 
 def call_function_sync(
@@ -427,7 +427,7 @@ def call_function_sync(
 
 @wrap()
 async def call_function_async(
-    aio_function_io_manager,  #: AioFunctionIOManager,  # TODO: this one too
+    function_io_manager,  #: FunctionIOManager,  # TODO: this one too
     obj: Optional[Any],
     fun: Callable,
     is_generator: bool,
@@ -436,16 +436,16 @@ async def call_function_async(
     if obj is not None:
         if hasattr(obj, "__aenter__"):
             # Call a user-defined method
-            async with aio_function_io_manager.handle_user_exception():
+            async with function_io_manager.handle_user_exception.aio():
                 await obj.__aenter__()
         elif hasattr(obj, "__enter__"):
-            async with aio_function_io_manager.handle_user_exception():
+            async with function_io_manager.handle_user_exception.aio():
                 obj.__enter__()
 
     try:
-        async for input_id, args, kwargs in aio_function_io_manager.run_inputs_outputs():
+        async for input_id, args, kwargs in function_io_manager.run_inputs_outputs.aio():
             output_index = SequenceNumber(0)  # mutable number we can increase from the generator loop
-            async with aio_function_io_manager.handle_input_exception(input_id, output_index):
+            async with function_io_manager.handle_input_exception.aio(input_id, output_index):
                 res = fun(*args, **kwargs)
 
                 # TODO(erikbern): any exception below shouldn't be considered a user exception
@@ -453,9 +453,9 @@ async def call_function_async(
                     if not inspect.isasyncgen(res):
                         raise InvalidError(f"Async generator function returned value of type {type(res)}")
                     async for value in res:
-                        await aio_function_io_manager.enqueue_generator_value(input_id, output_index.value, value)
+                        await function_io_manager.enqueue_generator_value.aio(input_id, output_index.value, value)
                         output_index.increase()
-                    await aio_function_io_manager.enqueue_generator_eof(input_id, output_index.value)
+                    await function_io_manager.enqueue_generator_eof.aio(input_id, output_index.value)
                 else:
                     if not inspect.iscoroutine(res) or inspect.isgenerator(res) or inspect.isasyncgen(res):
                         raise InvalidError(
@@ -463,14 +463,14 @@ async def call_function_async(
                             " You might need to use @stub.function(..., is_generator=True)."
                         )
                     value = await res
-                    await aio_function_io_manager.enqueue_output(input_id, output_index.value, value)
+                    await function_io_manager.enqueue_output.aio(input_id, output_index.value, value)
     finally:
         if obj is not None:
             if hasattr(obj, "__aexit__"):
-                async with aio_function_io_manager.handle_user_exception():
+                async with function_io_manager.handle_user_exception.aio():
                     await obj.__aexit__(*sys.exc_info())
             elif hasattr(obj, "__exit__"):
-                async with aio_function_io_manager.handle_user_exception():
+                async with function_io_manager.handle_user_exception.aio():
                     obj.__exit__(*sys.exc_info())
 
 
@@ -562,7 +562,7 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
     # This is a bit weird but we need both the blocking and async versions of FunctionIOManager.
     # At some point, we should fix that by having built-in support for running "user code"
     _function_io_manager = _FunctionIOManager(container_args, client)
-    function_io_manager, aio_function_io_manager = synchronize_apis(_function_io_manager)
+    function_io_manager, _ = synchronize_apis(_function_io_manager)
 
     container_app = function_io_manager.initialize_app()
 
@@ -591,7 +591,7 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
             call_function_sync(function_io_manager, imp_fun.obj, imp_fun.fun, imp_fun.is_generator)
         else:
             run_with_signal_handler(
-                call_function_async(aio_function_io_manager, imp_fun.obj, imp_fun.fun, imp_fun.is_generator)
+                call_function_async(function_io_manager, imp_fun.obj, imp_fun.fun, imp_fun.is_generator)
             )
 
 

--- a/modal/_serialization.py
+++ b/modal/_serialization.py
@@ -19,6 +19,7 @@ def get_synchronicity_interface(obj) -> Optional[Interface]:
 
 
 def restore_synchronicity_interface(raw_obj, target_interface: Optional[Interface]):
+    print("Unpickling", raw_obj.object_id, "as", target_interface)
     if target_interface:
         return async_utils.synchronizer._translate_out(raw_obj, target_interface)
     return raw_obj
@@ -33,6 +34,7 @@ class Pickler(cloudpickle.Pickler):
             return
         if not obj.object_id:
             raise InvalidError(f"Can't serialize object {obj} which hasn't been created.")
+        print("Pickling", obj.object_id, "as", get_synchronicity_interface(obj))
         return (obj.object_id, get_synchronicity_interface(obj), obj._get_handle_metadata())
 
 

--- a/modal/_serialization.py
+++ b/modal/_serialization.py
@@ -19,7 +19,6 @@ def get_synchronicity_interface(obj) -> Optional[Interface]:
 
 
 def restore_synchronicity_interface(raw_obj, target_interface: Optional[Interface]):
-    print("Unpickling", raw_obj.object_id, "as", target_interface)
     if target_interface:
         return async_utils.synchronizer._translate_out(raw_obj, target_interface)
     return raw_obj
@@ -34,7 +33,6 @@ class Pickler(cloudpickle.Pickler):
             return
         if not obj.object_id:
             raise InvalidError(f"Can't serialize object {obj} which hasn't been created.")
-        print("Pickling", obj.object_id, "as", get_synchronicity_interface(obj))
         return (obj.object_id, get_synchronicity_interface(obj), obj._get_handle_metadata())
 
 

--- a/modal/aio.py
+++ b/modal/aio.py
@@ -4,6 +4,7 @@
 The async interfaces are mostly mirrors of the blocking ones, with the `Aio` or `aio_` prefixes.
 """
 
+from modal.exception import deprecation_warning
 from .app import AioApp, aio_container_app
 from .client import AioClient
 from .dict import AioDict
@@ -23,6 +24,7 @@ from .secret import AioSecret
 from .shared_volume import AioSharedVolume
 from .stub import AioStub
 from .proxy import AioProxy
+import datetime
 
 __all__ = [
     "AioApp",
@@ -44,3 +46,9 @@ __all__ = [
     "aio_web_endpoint",
     "aio_wsgi_app",
 ]
+
+deprecation_warning(
+    datetime.date(2023, 5, 12),
+    "The modal.aio module and Aio* classes will soon be deprecated. Use `await some_function.aio(...)` instead.",
+    pending=True,
+)

--- a/modal/aio.py
+++ b/modal/aio.py
@@ -49,9 +49,9 @@ __all__ = [
 
 deprecation_warning(
     datetime.date(2023, 5, 12),
-    "The modal.aio module and Aio* classes will soon be deprecated.\n"
-    "For calling functions asyncronousy, use `await some_function.aio(...)`\n"
-    "Instead of separate classes for Async usage, the interface now only changes how to call the methods."
+    "The `modal.aio` module and `Aio*` classes will soon be deprecated.\n"
+    "For calling functions asyncronously, use `await some_function.aio(...)`\n"
+    "Instead of separate classes for async usage, the interface now only changes how to call the methods."
     "Where you would have previously used `await AioDict.lookup(...)` you now use "
     "`await Dict.lookup.aio(...)` instead.\nObjects that are themselves generators or context managers "
     "now conform to both the blocking and async interfaces, and returned objects of all functions/methods",

--- a/modal/aio.py
+++ b/modal/aio.py
@@ -49,6 +49,11 @@ __all__ = [
 
 deprecation_warning(
     datetime.date(2023, 5, 12),
-    "The modal.aio module and Aio* classes will soon be deprecated. Use `await some_function.aio(...)` instead.",
+    "The modal.aio module and Aio* classes will soon be deprecated.\n"
+    "For calling functions asyncronousy, use `await some_function.aio(...)`\n"
+    "Instead of separate classes for Async usage, the interface now only changes how to call the methods."
+    "Where you would have previously used `await AioDict.lookup(...)` you now use "
+    "`await Dict.lookup.aio(...)` instead.\nObjects that are themselves generators or context managers "
+    "now conform to both the blocking and async interfaces, and returned objects of all functions/methods",
     pending=True,
 )

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -9,7 +9,7 @@ import typing
 import warnings
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Any, AsyncIterable, Callable, Collection, Dict, List, Optional, Set, Union
+from typing import Any, AsyncGenerator, AsyncIterable, Awaitable, Callable, Collection, Dict, List, Optional, Set, Union
 
 from datetime import date
 from aiostream import pipe, stream
@@ -583,7 +583,7 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
         kwargs={},  # any extra keyword arguments for the function
         order_outputs=None,  # defaults to True for regular functions, False for generators
         return_exceptions=False,  # whether to propogate exceptions (False) or aggregate them in the results list (True)
-    ):
+    ) -> AsyncGenerator[Any, None]:
         """Parallel map over a set of inputs.
 
         Takes one iterator argument per argument in the function being mapped over.
@@ -682,7 +682,7 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
         self._track_function_invocation()
         return await _Invocation.create(self._object_id, args, kwargs, self._client)
 
-    def call(self, *args, **kwargs) -> Any:  # TODO: Generics/TypeVars
+    def call(self, *args, **kwargs) -> Union[Awaitable[Any], AsyncGenerator[Any, Any]]:  # TODO: Generics/TypeVars
         """
         Calls the function remotely, executing it with the given arguments and returning the execution's result.
         """

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -682,7 +682,7 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
         self._track_function_invocation()
         return await _Invocation.create(self._object_id, args, kwargs, self._client)
 
-    def call(self, *args, **kwargs) -> Union[Awaitable[Any], AsyncGenerator[Any, Any]]:  # TODO: Generics/TypeVars
+    def call(self, *args, **kwargs) -> Awaitable[Any]:  # TODO: Generics/TypeVars
         """
         Calls the function remotely, executing it with the given arguments and returning the execution's result.
         """
@@ -692,7 +692,7 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
                 f"Invoke this function via its web url '{self._web_url}' or call it locally: {self._function_name}()."
             )
         if self._is_generator:
-            return self._call_generator(args, kwargs)
+            return self._call_generator(args, kwargs)  # type: ignore
         else:
             return self._call_function(args, kwargs)
 

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -351,7 +351,7 @@ def _create_client_mount():
     )
 
 
-_, aio_create_client_mount = synchronize_apis(_create_client_mount)
+create_client_mount, aio_create_client_mount = synchronize_apis(_create_client_mount)
 
 
 def _get_client_mount():

--- a/modal_base_images/client_mount.py
+++ b/modal_base_images/client_mount.py
@@ -1,14 +1,14 @@
 # Copyright Modal Labs 2022
 import asyncio
 
-from modal.mount import aio_create_client_mount, client_mount_name
+from modal.mount import create_client_mount, client_mount_name
 from modal_proto import api_pb2
 
 
 async def main(client=None):
-    mount = aio_create_client_mount()
+    mount = create_client_mount()
     name = client_mount_name()
-    await mount._deploy(client_mount_name(), api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL, client=client)
+    await mount._deploy.aio(client_mount_name(), api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL, client=client)
     print(f"✅ Deployed client mount {name} to global namespace.")
 
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -15,7 +15,6 @@ pytest-markdown-docs==0.4.3
 pytest-timeout~=2.1.0
 python-dotenv~=1.0.0;python_version>='3.8'
 ruff~=0.0.239
-synchronicity~=0.5.0
 types-croniter~=1.0.8
 types-python-dateutil~=2.8.10
 types-setuptools~=57.4.11

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -15,7 +15,7 @@ pytest-markdown-docs==0.4.3
 pytest-timeout~=2.1.0
 python-dotenv~=1.0.0;python_version>='3.8'
 ruff~=0.0.239
-synchronicity==0.4.1
+synchronicity~=0.5.0
 types-croniter~=1.0.8
 types-python-dateutil~=2.8.10
 types-setuptools~=57.4.11

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     importlib_metadata>=3.6.0
     protobuf>=3.19,<5.0
     rich>=12.0.0
-    synchronicity~=0.5.1
+    synchronicity~=0.5.2
     tblib>=1.7.0
     toml
     typer>=0.6.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     importlib_metadata>=3.6.0
     protobuf>=3.19,<5.0
     rich>=12.0.0
-    synchronicity~=0.4.4
+    synchronicity~=0.5.0
     tblib>=1.7.0
     toml
     typer>=0.6.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ install_requires =
     aiostream
     asgiref
     certifi
-    # These are pinned to be protocol-compatible with the version of 
+    # These are pinned to be protocol-compatible with the version of
     # cloudpickle inside the container (defined in requirements.txt).
     cloudpickle>=2.0.0,<2.1.0;python_version<'3.11'
     cloudpickle>=2.2.0,<2.3.0;python_version>='3.11'
@@ -32,7 +32,7 @@ install_requires =
     importlib_metadata>=3.6.0
     protobuf>=3.19,<5.0
     rich>=12.0.0
-    synchronicity~=0.5.0
+    synchronicity~=0.5.1
     tblib>=1.7.0
     toml
     typer>=0.6.1


### PR DESCRIPTION
Followups:
1. Remove all internal/external usages of old modal.aio module
2. Add deprecation warning to modal.aio import
3. (later) Remove aio module and old async interfaces
4. Drop old async interface from synchronicity itself