### PR TITLE
Handle failures in generator maps correctly

### DIFF
--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -224,6 +224,85 @@ async def test_generator_future(client, servicer):
         assert later_gen_modal.spawn() is None  # until we have a nice interface for polling generator futures
 
 
+def gen_with_arg(i):
+    yield "foo"
+
+
+@pytest.mark.asyncio
+async def test_generator_map_success(client, servicer):
+    stub = Stub()
+
+    gen_with_arg_modal = stub.function()(gen_with_arg)
+
+    def dummy(i):
+        yield i, "bar"
+        yield i, "baz"
+
+    servicer.function_body(dummy)
+
+    assert len(servicer.cleared_function_calls) == 0
+    with stub.run(client=client):
+        assert gen_with_arg_modal.is_generator
+        res = set(gen_with_arg_modal.map([1, 2, 3]))
+        assert res == {(1, "bar"), (1, "baz"), (2, "bar"), (2, "baz"), (3, "bar"), (3, "baz")}
+
+
+@pytest.mark.asyncio
+async def test_generator_map_exception(client, servicer):
+    stub = Stub()
+
+    gen_with_arg_modal = stub.function()(gen_with_arg)
+
+    def dummy(i):
+        yield i, "bar"
+        if i == 2:
+            raise CustomException("boo!")
+        yield i, "baz"
+
+    servicer.function_body(dummy)
+
+    assert len(servicer.cleared_function_calls) == 0
+    with stub.run(client=client):
+        assert gen_with_arg_modal.is_generator
+
+        with pytest.raises(CustomException) as exc_info:
+            list(gen_with_arg_modal.map([1, 2, 3]))
+        assert exc_info.value.args == ("boo!",)
+
+
+@pytest.mark.asyncio
+async def test_generator_map_return_exceptions(client, servicer):
+    stub = Stub()
+
+    gen_with_arg_modal = stub.function()(gen_with_arg)
+
+    def dummy(i):
+        yield i, "bar"
+        if i == 2:
+            raise CustomException("boo!")
+        yield i, "baz"
+
+    servicer.function_body(dummy)
+
+    assert len(servicer.cleared_function_calls) == 0
+    with stub.run(client=client):
+        assert gen_with_arg_modal.is_generator
+
+        results = set()
+        received_exc = False
+        for result in gen_with_arg_modal.map([1, 2, 3], return_exceptions=True):
+            # TODO: this should just be CustomException directly.
+            if isinstance(result, UserCodeException):
+                assert isinstance(result.exc, CustomException)
+                assert result.exc.args == ("boo!",)
+                received_exc = True
+            else:
+                results.add(result)
+
+        assert received_exc
+        assert results == {(1, "bar"), (1, "baz"), (2, "bar"), (3, "bar"), (3, "baz")}
+
+
 async def slo1(sleep_seconds):
     # need to use async function body in client test to run stuff in parallel
     # but calling interface is still non-asyncio

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -378,13 +378,21 @@ async def _map_invocation(
             last_entry_id = response.last_entry_id
             for item in response.outputs:
                 pending_outputs.setdefault(item.input_id, 0)
-                if item.input_id in completed_outputs or item.gen_index < pending_outputs[item.input_id]:
-                    # this means the output has already been processed and is likely received due
-                    # to a duplicate output enqueue on the server
+                if item.input_id in completed_outputs or (
+                    item.result.gen_status == api_pb2.GenericResult.GENERATOR_STATUS_INCOMPLETE
+                    and item.gen_index < pending_outputs[item.input_id]
+                ):
+                    # If this input is already completed, or if it's a generator output and we've already seen a later
+                    # output, it means the output has already been processed and was received again due
+                    # to a duplicate output enqueue on the server.
                     continue
 
                 if is_generator:
-                    if item.result.gen_status == api_pb2.GenericResult.GENERATOR_STATUS_COMPLETE:
+                    # Mark this input completed if the generator completed successfully, or it crashed (exception, timeout, etc).
+                    if (
+                        item.result.gen_status == api_pb2.GenericResult.GENERATOR_STATUS_COMPLETE
+                        or item.result.status != api_pb2.GenericResult.GENERIC_STATUS_SUCCESS
+                    ):
                         completed_outputs.add(item.input_id)
                         num_outputs += 1
                     else:

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -389,12 +389,13 @@ async def _map_invocation(
 
                 if is_generator:
                     # Mark this input completed if the generator completed successfully, or it crashed (exception, timeout, etc).
-                    if (
-                        item.result.gen_status == api_pb2.GenericResult.GENERATOR_STATUS_COMPLETE
-                        or item.result.status != api_pb2.GenericResult.GENERIC_STATUS_SUCCESS
-                    ):
+                    if item.result.gen_status == api_pb2.GenericResult.GENERATOR_STATUS_COMPLETE:
                         completed_outputs.add(item.input_id)
                         num_outputs += 1
+                    elif item.result.status != api_pb2.GenericResult.GENERIC_STATUS_SUCCESS:
+                        completed_outputs.add(item.input_id)
+                        num_outputs += 1
+                        yield item
                     else:
                         assert pending_outputs[item.input_id] == item.gen_index
                         pending_outputs[item.input_id] += 1

--- a/modal/image.py
+++ b/modal/image.py
@@ -272,7 +272,7 @@ class _Image(_Provider[_ImageHandle]):
                         raise exc
 
             if result.status == api_pb2.GenericResult.GENERIC_STATUS_FAILURE:
-                raise RemoteError(f"Image build for {image_id} failed wtih the exception:\n{result.exception}")
+                raise RemoteError(f"Image build for {image_id} failed with the exception:\n{result.exception}")
             elif result.status == api_pb2.GenericResult.GENERIC_STATUS_TERMINATED:
                 raise RemoteError(f"Image build for {image_id} terminated due to external shut-down. Please try again.")
             elif result.status == api_pb2.GenericResult.GENERIC_STATUS_TIMEOUT:


### PR DESCRIPTION
Previously timeout errors when mapping over generators would cause the map to get stuck forever. Exceptions raised would also result in the same behavior if `return_exceptions=True`.

We didn't have any tests for generator maps, so added a few.


---
Resolves MOD-1268