### PR TITLE
Aio interface adjustments

### DIFF
--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -23,6 +23,11 @@ def foo(p, q):
     return p + q + 11  # not actually used in test (servicer returns sum of square of all args)
 
 
+@stub.function()
+async def async_foo(p, q):
+    return p + q + 12
+
+
 def dummy():
     pass  # not actually used in test (servicer returns sum of square of all args)
 
@@ -34,11 +39,17 @@ def test_run_function(client, servicer):
         assert len(servicer.cleared_function_calls) == 1
 
 
-def test_call_function_locally(client, servicer):
+@pytest.mark.asyncio
+async def test_call_function_locally(client, servicer):
     assert foo(22, 44) == 77  # call it locally
+    assert await async_foo(22, 44) == 78
+
     with stub.run(client=client):
         assert foo.call(2, 4) == 20
         assert foo(22, 55) == 88
+        assert await async_foo(22, 44) == 78
+        assert async_foo.call(2, 4) == 20
+        assert await async_foo.call.aio(2, 4) == 20
 
 
 @pytest.mark.parametrize("slow_put_inputs", [False, True])

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -45,7 +45,7 @@ def make_remote_cls_constructors(
         new_function_handles: Dict[str, _FunctionHandle] = {}
 
         for k, v in partial_functions.items():
-            new_function_handles[k] = await function_handles[k].make_bound_function_handle(params)
+            new_function_handles[k] = await function_handles[k]._make_bound_function_handle(params)
             cls_dict[k] = v
 
         cls = type(f"Remote{user_cls.__name__}", (), cls_dict)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -508,7 +508,7 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
         self._web_url = handle_metadata.web_url
         self._function_name = handle_metadata.function_name
 
-    async def make_bound_function_handle(self, params: inspect.BoundArguments) -> "_FunctionHandle":
+    async def _make_bound_function_handle(self, params: inspect.BoundArguments) -> "_FunctionHandle":
         assert self.is_hydrated(), "Cannot make bound function handle from unhydrated handle."
 
         if len(params.args) + len(params.kwargs) == 0:
@@ -715,10 +715,11 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
             return self._call_function(args, kwargs)
 
     @synchronizer.nowrap
-    def __call__(self, *args, **kwargs) -> Any:  # TODO: Generics/TypeVars
-        unwrapped_self = synchronizer._translate_in(self)
+    def __call__(wrapped_self, *args, **kwargs) -> Any:  # TODO: Generics/TypeVars
+        unwrapped_self = synchronizer._translate_in(wrapped_self)
         if unwrapped_self._is_remote_cls_method:
-            return unwrapped_self.call(*args, **kwargs)
+            # note this uses the wrapped self instead, since this is a remote version of the function
+            return wrapped_self.call(*args, **kwargs)
 
         if not unwrapped_self._info:
             msg = (

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -649,7 +649,9 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
             pass
 
     @warn_if_generator_is_not_consumed
-    async def starmap(self, input_iterator, kwargs={}, order_outputs=None, return_exceptions=False):
+    async def starmap(
+        self, input_iterator, kwargs={}, order_outputs=None, return_exceptions=False
+    ) -> AsyncGenerator[typing.Any, None]:
         """Like `map` but spreads arguments over multiple function arguments
 
         Assumes every input is a sequence (e.g. a tuple).


### PR DESCRIPTION
* Fix for not getting an .aio-interface on `starmap`
* Fix for `FunctionHandle.__call__` being synchronicity-wrapped, and therefor running end-user code in the synchronizer thread

Notable weirdnesses:
* There is no `function_handle.aio(...)`, but I think this makes sense as the `__call__` is simply a passthrough (so the function handle of an async function would return a coroutine when called locally now). The user controls asyncness of local usage of their functions as they would with any Python function.
* The remote parameterized version using `.remote()` is a bit janky and get no .aio version since we don't currently support .aio versions of `.__call__`