### PR TITLE
Allow all pickle-able types for parametrized functions

### DIFF
--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -66,14 +66,12 @@ def test_call_cls_remote_sync(client):
 
 def test_call_cls_remote_invalid_type(client):
     with stub_remote.run(client=client):
-        with pytest.raises(ValueError) as excinfo:
-            FooRemote.remote(object(), "hello")
 
-        exc = excinfo.value
-        assert "x=" in str(exc)
+        def my_function():
+            print("Hello, world!")
 
         with pytest.raises(ValueError) as excinfo:
-            FooRemote.remote(42, {"hello": "world"})
+            FooRemote.remote(42, my_function)
 
         exc = excinfo.value
         assert "y=" in str(exc)

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -1,9 +1,9 @@
 # Copyright Modal Labs 2022
 import inspect
+import pickle
 from typing import Dict, Union, TypeVar, Type
 from modal_utils.async_utils import synchronize_apis
 from .functions import _PartialFunction, PartialFunction, AioPartialFunction, _FunctionHandle
-from datetime import datetime
 
 T = TypeVar("T")
 
@@ -18,9 +18,6 @@ class ClsMixin:
         ...
 
 
-ALLOWED_TYPES = (int, float, bool, str, bytes, type(None), datetime)
-
-
 def make_remote_cls_constructors(
     user_cls: type,
     partial_functions: Dict[str, Union[PartialFunction, AioPartialFunction]],
@@ -29,15 +26,16 @@ def make_remote_cls_constructors(
     original_sig = inspect.signature(user_cls.__init__)  # type: ignore
     new_parameters = [param for name, param in original_sig.parameters.items() if name != "self"]
     sig = inspect.Signature(new_parameters)
-    # TODO: validate signature has only primitive types.
 
     async def _remote(*args, **kwargs):
         params = sig.bind(*args, **kwargs)
 
         for name, param in params.arguments.items():
-            if not isinstance(param, ALLOWED_TYPES):
+            try:
+                pickle.dumps(param)
+            except pickle.PicklingError:
                 raise ValueError(
-                    f"Only primitive types are allowed in remote class constructors. "
+                    f"Only pickle-able types are allowed in remote class constructors. "
                     f"Found {name}={param} of type {type(param)}."
                 )
 

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -33,7 +33,7 @@ def make_remote_cls_constructors(
         for name, param in params.arguments.items():
             try:
                 pickle.dumps(param)
-            except pickle.PicklingError:
+            except Exception:
                 raise ValueError(
                     f"Only pickle-able types are allowed in remote class constructors. "
                     f"Found {name}={param} of type {type(param)}."


### PR DESCRIPTION
Someone tried to pass a pydantic object, which should be supported by us. Relaxing the restriction to be more accurate.