### PR TITLE
Don't mount the origin package for each function more than once

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -859,7 +859,7 @@ class _Function(_Provider[_FunctionHandle]):
 
         all_mounts = [
             _get_client_mount(),  # client
-            *info.get_mounts().values(),  # implicit mounts
+            *stub._get_function_mounts_cached(info.get_mounts()),  # implicit mounts
             *mounts,  # explicit mounts
         ]
 

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -857,5 +857,13 @@ class _Stub:
                 else:
                     self._function_handles[tag]._hydrate(client, function_id, handle_metadata)
 
+    def _get_function_mounts_cached(self, mounts: Dict[str, _Mount]):
+        cached_mounts = []
+        for root_path, mount in mounts.items():
+            if root_path not in self._function_mounts:
+                self._function_mounts[root_path] = mount
+            cached_mounts.append(self._function_mounts[root_path])
+        return cached_mounts
+
 
 Stub, AioStub = synchronize_apis(_Stub)

--- a/modal_test_support/hello.py
+++ b/modal_test_support/hello.py
@@ -8,3 +8,8 @@ stub = modal.Stub()
 def hello():
     print("hello")
     return "hello"
+
+
+@stub.function()
+def other():
+    return "other"


### PR DESCRIPTION
Regardless if there are multiple functions in the stub. This patch simply reintroduces the _function_mounts stub-level mount cache that we had until last week.

It's a bit janky, but we should refactor this mount logic soon and get rid of a bunch of this. Preferably in a way that lets us upload all mount files in one common thread pool instead of using one for each mount sequentially
