### PR TITLE
Add gpu and secrets options to remaining Image builder functions

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -521,7 +521,7 @@ class _Image(_Provider[_ImageHandle]):
             dockerfile_commands=dockerfile_commands,
             context_files=context_files,
             force_build=self.force_build or force_build,
-            gpu=parse_gpu_config(gpu),
+            gpu_config=parse_gpu_config(gpu),
             secrets=secrets,
         )
 
@@ -635,7 +635,7 @@ class _Image(_Provider[_ImageHandle]):
             context_files=context_files,
             force_build=self.force_build or force_build,
             secrets=secrets,
-            gpu=parse_gpu_config(gpu),
+            gpu_config=parse_gpu_config(gpu),
         )
 
     @typechecked
@@ -808,7 +808,7 @@ class _Image(_Provider[_ImageHandle]):
             context_files=context_files,
             force_build=self.force_build or force_build,
             secrets=secrets,
-            gpu=parse_gpu_config(gpu),
+            gpu_config=parse_gpu_config(gpu),
         )
 
     @staticmethod
@@ -857,7 +857,7 @@ class _Image(_Provider[_ImageHandle]):
             dockerfile_commands=dockerfile_commands,
             force_build=self.force_build or force_build,
             secrets=secrets,
-            gpu=parse_gpu_config(gpu),
+            gpu_config=parse_gpu_config(gpu),
         )
 
     @staticmethod
@@ -1130,7 +1130,7 @@ class _Image(_Provider[_ImageHandle]):
         return self.extend(
             dockerfile_commands=dockerfile_commands,
             force_build=self.force_build or force_build,
-            gpu=parse_gpu_config(gpu),
+            gpu_config=parse_gpu_config(gpu),
             secrets=secrets,
         )
 


### PR DESCRIPTION
The `gpu` and/or `secrets` options were missing from:
* `pip_install`
* `conda_install`
* `from_dockerfile`
* `pip_install_private_repos`
* `pip_install_from_requirements`
* `pip_install_from_pyproject`
* `poetry_install_from_file`
* `micromamba_install`
* `conda_update_from_environment`
* `apt_install`

While it's quite unusual to need them, there are apparently pypi packages that require a GPU at install time, so it's not unreasonable to add the options to the method signatures :man_shrugging: 