### PR TITLE
Make 'no remote calls' into a real python warning, written to stderr

### DIFF
--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -123,14 +123,15 @@ def test_run(servicer, set_env_client, test_dir):
     _run(["run", file_with_entrypoint.as_posix() + "::stub.main"])
 
 
+@pytest.mark.filterwarnings("error")  # any warnings that aren't caught will fail this test
 def test_local_entrypoint_no_remote_calls(servicer, set_env_client, test_dir):
     file = test_dir / "supports" / "app_run_tests" / "local_entrypoint.py"
     res = _run(["run", file.as_posix()])
-    assert "Warning: no remote function calls were made" not in res.stdout
+    assert "Warning: no remote function calls were made" not in res.stderr
 
     file = test_dir / "supports" / "app_run_tests" / "local_entrypoint_no_remote.py"
-    res = _run(["run", file.as_posix()])
-    assert "Warning: no remote function calls were made" in res.stdout
+    with pytest.warns(UserWarning, match="Warning: no remote function calls were made"):
+        _run(["run", file.as_posix()])
 
 
 def test_help_message_unspecified_function(servicer, set_env_client, test_dir):

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -4,6 +4,7 @@ import datetime
 import inspect
 import sys
 import time
+import warnings
 from typing import Optional
 
 import click
@@ -115,7 +116,7 @@ def _get_click_command_for_local_entrypoint(_stub, entrypoint: LocalEntrypoint):
                 func(*args, **kwargs)
             if app.function_invocations == 0:
                 # TODO: better formatting for the warning message
-                print(
+                warnings.warn(
                     "Warning: no remote function calls were made.\n"
                     "Note that Modal functions run locally when called directly (e.g. `f()`).\n"
                     "In order to run a function remotely, you may use `f.call()`. (See https://modal.com/docs/reference/modal.Function for other options)."


### PR DESCRIPTION
Had some issues when writing tests examining stdout due to this warning appearing there instead of stderr