### PR TITLE
Fix bump build number

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -117,6 +117,9 @@ jobs:
           add: modal_version/_version_generated.py
           message: "[auto-commit] Bump the build number"
           pull: "--rebase --autostash"
+          default_author: github_actions
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
       - name: Build protobuf
         run: inv protoc


### PR DESCRIPTION
PR bot still runs into branch protection rules. Using `GITHUB_TOKEN` on the step itself seems unnecessary according to the docs, but trying it.