### PR TITLE
Skip all CI on bot commit

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -116,7 +116,7 @@ jobs:
       - uses: EndBug/add-and-commit@v9
         with:
           add: modal_version/_version_generated.py
-          message: "[auto-commit] Bump the build number"
+          message: "[auto-commit] [skip ci] Bump the build number"
           pull: "--rebase --autostash"
           default_author: github_actions
 


### PR DESCRIPTION
We're running tests and publishing images again now on the bot commits.