### PR TITLE
Rename cli "envs" to "profiles"

### DIFF
--- a/client_test/config_test.py
+++ b/client_test/config_test.py
@@ -61,7 +61,7 @@ def test_config_store_user(servicer):
     _cli(["token", "set", "--token-id", "foo", "--token-secret", "bar1", "--env", "prof_1"], env=env)
 
     # Set creds to foo / bar2 for the prof_2 profile (given as an env var)
-    _cli(["token", "set", "--token-id", "foo", "--token-secret", "bar2"], env={"MODAL_ENV": "prof_2", **env})
+    _cli(["token", "set", "--token-id", "foo", "--token-secret", "bar2"], env={"MODAL_PROFILE": "prof_2", **env})
 
     # Now these should be stored in the user's home directory
     config = _get_config(env=env)
@@ -74,12 +74,12 @@ def test_config_store_user(servicer):
     assert config["token_secret"] == "xyz"
 
     # Check that we can get the prof_1 env creds too
-    config = _get_config(env={"MODAL_ENV": "prof_1", **env})
+    config = _get_config(env={"MODAL_PROFILE": "prof_1", **env})
     assert config["token_id"] == "foo"
     assert config["token_secret"] == "bar1"
 
     # Check that we can get the prof_1 env creds too
-    config = _get_config(env={"MODAL_ENV": "prof_2", **env})
+    config = _get_config(env={"MODAL_PROFILE": "prof_2", **env})
     assert config["token_id"] == "foo"
     assert config["token_secret"] == "bar2"
 

--- a/modal/cli/entry_point.py
+++ b/modal/cli/entry_point.py
@@ -9,6 +9,7 @@ from .env import env_cli
 from .secret import secret_cli
 from .token import token_cli
 from .volume import volume_cli
+from .profile import profile_cli
 
 
 def version_callback(value: bool):
@@ -43,6 +44,7 @@ def modal(
 entrypoint_cli_typer.add_typer(app_cli)
 entrypoint_cli_typer.add_typer(config_cli)
 entrypoint_cli_typer.add_typer(env_cli)
+entrypoint_cli_typer.add_typer(profile_cli)
 entrypoint_cli_typer.add_typer(secret_cli)
 entrypoint_cli_typer.add_typer(token_cli)
 entrypoint_cli_typer.add_typer(volume_cli)

--- a/modal/cli/env.py
+++ b/modal/cli/env.py
@@ -1,22 +1,41 @@
 # Copyright Modal Labs 2022
+import datetime
+
 import typer
 
-from modal.config import _env, config_envs, config_set_active_env
+from modal.cli import profile as profile_cli
+from modal.exception import deprecation_warning
 
-env_cli = typer.Typer(name="env", help="Set the current environment.", no_args_is_help=True)
+
+def warn_env_deprecated():
+    pass
 
 
-@env_cli.command(help="Change the active Modal environment.")
+DEPRECATION_PREFIX = "[Deprecated, use `modal profile` instead] "
+
+
+def print_env_deprecated_warning():
+    deprecation_warning(
+        datetime.date(2023, 5, 24), "`modal env` will soon be deprecated. Use `modal profile` instead", pending=True
+    )
+
+
+env_cli = typer.Typer(name="env", help=f"{DEPRECATION_PREFIX}Set the current environment.", no_args_is_help=True)
+
+
+@env_cli.command(help=f"{DEPRECATION_PREFIX}Change the active Modal environment.")
 def activate(env: str = typer.Argument(..., help="Modal environment to activate.")):
-    config_set_active_env(env)
+    print_env_deprecated_warning()
+    profile_cli.activate(env)
 
 
-@env_cli.command(help="Print the active Modal environment.")
+@env_cli.command(help=f"{DEPRECATION_PREFIX}Print the active Modal environment.")
 def current():
-    print(_env)
+    print_env_deprecated_warning()
+    profile_cli.current()
 
 
-@env_cli.command(help="List all Modal environments that are defined.")
+@env_cli.command(help=f"{DEPRECATION_PREFIX}List all Modal environments that are defined.")
 def list():
-    for env in config_envs():
-        print(f"{env} [active]" if _env == env else env)
+    print_env_deprecated_warning()
+    profile_cli.list()

--- a/modal/cli/profile.py
+++ b/modal/cli/profile.py
@@ -1,0 +1,22 @@
+# Copyright Modal Labs 2022
+import typer
+
+from modal.config import _env, config_envs, config_set_active_profile
+
+profile_cli = typer.Typer(name="profile", help="Set the current environment.", no_args_is_help=True)
+
+
+@profile_cli.command(help="Change the active Modal environment.")
+def activate(profile: str = typer.Argument(..., help="Modal environment to activate.")):
+    config_set_active_profile(profile)
+
+
+@profile_cli.command(help="Print the active Modal environment.")
+def current():
+    print(_env)
+
+
+@profile_cli.command(help="List all Modal environments that are defined.")
+def list():
+    for env in config_envs():
+        print(f"{env} [active]" if _env == env else env)

--- a/modal/cli/profile.py
+++ b/modal/cli/profile.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 import typer
 
-from modal.config import _env, config_envs, config_set_active_profile
+from modal.config import _profile, config_profiles, config_set_active_profile
 
 profile_cli = typer.Typer(name="profile", help="Set the current environment.", no_args_is_help=True)
 
@@ -13,10 +13,10 @@ def activate(profile: str = typer.Argument(..., help="Modal environment to activ
 
 @profile_cli.command(help="Print the active Modal environment.")
 def current():
-    print(_env)
+    print(_profile)
 
 
 @profile_cli.command(help="List all Modal environments that are defined.")
 def list():
-    for env in config_envs():
-        print(f"{env} [active]" if _env == env else env)
+    for env in config_profiles():
+        print(f"{env} [active]" if _profile == env else env)

--- a/modal/config.py
+++ b/modal/config.py
@@ -67,7 +67,7 @@ Some "meta-options" are set using environment variables only:
 
 * ``MODAL_CONFIG_PATH`` lets you override the location of the .toml file,
   by default ``~/.modal.toml``.
-* ``MODAL_ENV`` lets you use multiple sections in the .toml file
+* ``MODAL_PROFILE`` lets you use multiple sections in the .toml file
   and switch between them. It defaults to "default".
 """
 
@@ -75,11 +75,13 @@ import logging
 import os
 import typing
 import warnings
+from datetime import date
 
 import toml
 
 
 from ._traceback import setup_rich_traceback
+from .exception import deprecation_warning
 
 # Locate config file and read it
 
@@ -97,12 +99,12 @@ def _read_user_config():
 _user_config = _read_user_config()
 
 
-def config_envs():
-    """List the available modal envs in the .modal.toml file."""
+def config_profiles():
+    """List the available modal profiles in the .modal.toml file."""
     return _user_config.keys()
 
 
-def _config_active_env():
+def _config_active_profile():
     for key, values in _user_config.items():
         if values.get("active", False) is True:
             return key
@@ -111,7 +113,7 @@ def _config_active_env():
 
 
 def config_set_active_profile(env: str):
-    """Set the user's active modal env by writing it to the `.modal.toml` file."""
+    """Set the user's active modal profile by writing it to the `.modal.toml` file."""
     if env not in _user_config:
         raise KeyError(env)
 
@@ -122,7 +124,10 @@ def config_set_active_profile(env: str):
     _write_user_config(_user_config)
 
 
-_env = os.environ.get("MODAL_ENV", _config_active_env())
+if "MODAL_ENV" in os.environ:
+    deprecation_warning(date(2023, 5, 24), "MODAL_ENV will soon be deprecated. Use MODAL_PROFILE instead")
+
+_profile = os.environ.get("MODAL_PROFILE", os.environ.get("MODAL_ENV", _config_active_profile()))
 
 # Define settings
 
@@ -168,7 +173,7 @@ class Config:
         3. The default value of the setting
         """
         if env is None:
-            env = _env
+            env = _profile
         s = _SETTINGS[key]
         env_var_key = "MODAL_" + key.upper()
         if env_var_key in os.environ:
@@ -203,7 +208,7 @@ logger.addHandler(ch)
 def _store_user_config(new_settings, env=None):
     """Internal method, used by the CLI to set tokens."""
     if env is None:
-        env = _env
+        env = _profile
     user_config = _read_user_config()
     user_config.setdefault(env, {}).update(**new_settings)
     _write_user_config(user_config)

--- a/modal/config.py
+++ b/modal/config.py
@@ -110,7 +110,7 @@ def _config_active_env():
         return "default"
 
 
-def config_set_active_env(env: str):
+def config_set_active_profile(env: str):
     """Set the user's active modal env by writing it to the `.modal.toml` file."""
     if env not in _user_config:
         raise KeyError(env)


### PR DESCRIPTION
Some quick fixes ahead of introducing a new concept of Environments which is different from the "env" we have been using for the CLI profiles