### PR TITLE
Remove old usage of aio from tests, make deprecation non-pending

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -52,8 +52,8 @@ jobs:
         run: pytest -v -s client_test
 
       - name: Run docstring tests
-        run: pytest -s --markdown-docs -m markdown-docs modal
-       
+        run: pytest -s --markdown-docs -m markdown-docs modal --ignore modal/aio.py
+
 
   publish-base-images:
     name: |

--- a/client_test/aio_test.py
+++ b/client_test/aio_test.py
@@ -1,0 +1,24 @@
+import pytest
+
+from modal.exception import DeprecationError, InvalidError
+
+
+@pytest.mark.asyncio
+async def test_deprecated(servicer, client):
+    with pytest.warns(DeprecationError):
+        from modal.aio import AioStub
+
+    stub = AioStub()
+
+    async with stub.run(client=client) as app:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_new(servicer, client):
+    from modal import Stub
+
+    stub = Stub()
+
+    async with stub.run(client=client) as app:
+        pass

--- a/client_test/aio_test.py
+++ b/client_test/aio_test.py
@@ -1,6 +1,7 @@
+# Copyright Modal Labs 2023
 import pytest
 
-from modal.exception import DeprecationError, InvalidError
+from modal.exception import DeprecationError
 
 
 @pytest.mark.asyncio
@@ -10,7 +11,7 @@ async def test_deprecated(servicer, client):
 
     stub = AioStub()
 
-    async with stub.run(client=client) as app:
+    async with stub.run(client=client):
         pass
 
 
@@ -20,5 +21,5 @@ async def test_new(servicer, client):
 
     stub = Stub()
 
-    async with stub.run(client=client) as app:
+    async with stub.run(client=client):
         pass

--- a/client_test/blob_test.py
+++ b/client_test/blob_test.py
@@ -1,12 +1,12 @@
 # Copyright Modal Labs 2022
 import pytest
 
-from modal._blob_utils import blob_download, blob_upload
+from modal._blob_utils import blob_download as _blob_download, blob_upload as _blob_upload
 from modal.exception import ExecutionError
 from modal_utils.async_utils import synchronize_apis
 
-blob_upload, _ = synchronize_apis(blob_upload)
-blob_download, _ = synchronize_apis(blob_download)
+blob_upload, _ = synchronize_apis(_blob_upload)
+blob_download, _ = synchronize_apis(_blob_download)
 
 
 @pytest.mark.asyncio

--- a/client_test/blob_test.py
+++ b/client_test/blob_test.py
@@ -5,42 +5,42 @@ from modal._blob_utils import blob_download, blob_upload
 from modal.exception import ExecutionError
 from modal_utils.async_utils import synchronize_apis
 
-_, aio_blob_upload = synchronize_apis(blob_upload)
-_, aio_blob_download = synchronize_apis(blob_download)
+blob_upload, _ = synchronize_apis(blob_upload)
+blob_download, _ = synchronize_apis(blob_download)
 
 
 @pytest.mark.asyncio
-async def test_blob_put_get(servicer, blob_server, aio_client):
+async def test_blob_put_get(servicer, blob_server, client):
     # Upload
-    blob_id = await aio_blob_upload(b"Hello, world", aio_client.stub)
+    blob_id = await blob_upload.aio(b"Hello, world", client.stub)
 
     # Download
-    data = await aio_blob_download(blob_id, aio_client.stub)
+    data = await blob_download.aio(blob_id, client.stub)
     assert data == b"Hello, world"
 
 
 @pytest.mark.asyncio
-async def test_blob_put_failure(servicer, blob_server, aio_client):
+async def test_blob_put_failure(servicer, blob_server, client):
     with pytest.raises(ExecutionError):
-        await aio_blob_upload(b"FAILURE", aio_client.stub)
+        await blob_upload.aio(b"FAILURE", client.stub)
 
 
 @pytest.mark.asyncio
-async def test_blob_get_failure(servicer, blob_server, aio_client):
+async def test_blob_get_failure(servicer, blob_server, client):
     with pytest.raises(ExecutionError):
-        await aio_blob_download("bl-failure", aio_client.stub)
+        await blob_download.aio("bl-failure", client.stub)
 
 
 @pytest.mark.asyncio
-async def test_blob_large(servicer, blob_server, aio_client):
+async def test_blob_large(servicer, blob_server, client):
     data = b"*" * 10_000_000
-    blob_id = await aio_blob_upload(data, aio_client.stub)
-    assert await aio_blob_download(blob_id, aio_client.stub) == data
+    blob_id = await blob_upload.aio(data, client.stub)
+    assert await blob_download.aio(blob_id, client.stub) == data
 
 
 @pytest.mark.asyncio
-async def test_blob_multipart(servicer, blob_server, aio_client):
+async def test_blob_multipart(servicer, blob_server, client):
     servicer.blob_multipart_threshold = 2_000_000
     data = b"*" * 10_000_020
-    blob_id = await aio_blob_upload(data, aio_client.stub)
-    assert await aio_blob_download(blob_id, aio_client.stub) == data
+    blob_id = await blob_upload.aio(data, client.stub)
+    assert await blob_download.aio(blob_id, client.stub) == data

--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -140,7 +140,7 @@ class BarRemote(ClsMixin):
 @pytest.mark.asyncio
 async def test_call_cls_remote_async(client):
     async with stub_remote_2.run(client=client):
-        coro = BarRemote.remote.aio(3, "hello")
+        coro = BarRemote.remote.aio(3, "hello")  # type: ignore
         assert inspect.iscoroutine(coro)
         bar_remote = await coro
         # Mock servicer just squares the argument

--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -26,7 +26,7 @@ from grpclib import GRPCError, Status
 
 from modal import __version__
 from modal.app import _App
-from modal.client import AioClient, Client
+from modal.client import Client
 from modal.image import _dockerhub_python_version
 from modal.mount import client_mount_name
 from modal_proto import api_grpc, api_pb2
@@ -722,20 +722,14 @@ async def unix_servicer(servicer_factory):
 
 
 @pytest_asyncio.fixture(scope="function")
-async def aio_client(servicer):
-    async with AioClient(servicer.remote_addr, api_pb2.CLIENT_TYPE_CLIENT, ("foo-id", "foo-secret")) as client:
-        yield client
-
-
-@pytest_asyncio.fixture(scope="function")
 async def client(servicer):
     with Client(servicer.remote_addr, api_pb2.CLIENT_TYPE_CLIENT, ("foo-id", "foo-secret")) as client:
         yield client
 
 
 @pytest_asyncio.fixture(scope="function")
-async def aio_container_client(unix_servicer):
-    async with AioClient(unix_servicer.remote_addr, api_pb2.CLIENT_TYPE_CONTAINER, ("ta-123", "task-secret")) as client:
+async def container_client(unix_servicer):
+    async with Client(unix_servicer.remote_addr, api_pb2.CLIENT_TYPE_CONTAINER, ("ta-123", "task-secret")) as client:
         yield client
 
 
@@ -747,7 +741,7 @@ async def server_url_env(servicer, monkeypatch):
 
 @pytest_asyncio.fixture(scope="function", autouse=True)
 async def reset_default_client():
-    AioClient.set_env_client(None)
+    Client.set_env_client(None)
 
 
 @pytest.fixture(name="mock_dir", scope="session")

--- a/client_test/container_app_test.py
+++ b/client_test/container_app_test.py
@@ -4,7 +4,7 @@ import os
 import pytest
 from unittest import mock
 
-from modal import App, FunctionHandle, Image, Stub, container_app
+from modal import App, FunctionHandle, Image, Stub
 from modal.exception import InvalidError
 
 from .supports.skip import skip_windows_unix_socket
@@ -48,7 +48,7 @@ async def test_container_function_initialization(unix_servicer, container_client
     # Now, let's create my_f_2 after the app started running
     # This might happen if some local module is imported lazily
     my_f_2_container = stub.function()(my_f_2)
-    assert await my_f_2_container.call(42) == 1764  # type: ignore
+    assert await my_f_2_container.call.aio(42) == 1764  # type: ignore
 
 
 @skip_windows_unix_socket
@@ -109,9 +109,9 @@ async def test_is_inside_default_image(servicer, unix_servicer, client, containe
 
     from modal.stub import _default_image
 
-    app = await App._init_new(client)
+    app = await App._init_new.aio(client)
     app_id = app.app_id
-    default_image_handle = await app.create_one_object(_default_image)
+    default_image_handle = await app.create_one_object.aio(_default_image)
     default_image_id = default_image_handle.object_id
 
     # Copy the app objects to the container servicer

--- a/client_test/container_app_test.py
+++ b/client_test/container_app_test.py
@@ -4,7 +4,7 @@ import os
 import pytest
 from unittest import mock
 
-from modal.aio import AioApp, AioFunctionHandle, AioImage, AioStub, aio_container_app
+from modal import App, FunctionHandle, Image, Stub, container_app
 from modal.exception import InvalidError
 
 from .supports.skip import skip_windows_unix_socket
@@ -21,23 +21,23 @@ def my_f_2(x):
 
 @skip_windows_unix_socket
 @pytest.mark.asyncio
-async def test_container_function_initialization(unix_servicer, aio_container_client):
+async def test_container_function_initialization(unix_servicer, container_client):
     unix_servicer.app_objects["ap-123"] = {
         "my_f_1": "fu-123",
         "my_f_2": "fu-456",
     }
 
-    container_app = await AioApp.init_container(aio_container_client, "ap-123")
+    container_app = await App.init_container.aio(container_client, "ap-123")
 
-    stub = AioStub()
-    stub._hydrate_function_handles(aio_container_client, container_app)
+    stub = Stub()
+    stub._hydrate_function_handles(container_client, container_app)
     # my_f_1_container = stub.function()(my_f_1)
 
     # Make sure these functions exist and have the right type
-    my_f_1_app = aio_container_app["my_f_1"]
-    my_f_2_app = aio_container_app["my_f_1"]
-    assert isinstance(my_f_1_app, AioFunctionHandle)
-    assert isinstance(my_f_2_app, AioFunctionHandle)
+    my_f_1_app = container_app["my_f_1"]
+    my_f_2_app = container_app["my_f_1"]
+    assert isinstance(my_f_1_app, FunctionHandle)
+    assert isinstance(my_f_2_app, FunctionHandle)
 
     # Make sure we can call my_f_1 inside the container
     # assert await my_f_1_container.call(42) == 1764
@@ -53,17 +53,17 @@ async def test_container_function_initialization(unix_servicer, aio_container_cl
 
 @skip_windows_unix_socket
 @pytest.mark.asyncio
-async def test_is_inside(servicer, unix_servicer, aio_client, aio_container_client):
-    image_1 = AioImage.debian_slim().pip_install(["abc"])
-    image_2 = AioImage.debian_slim().pip_install(["def"])
+async def test_is_inside(servicer, unix_servicer, client, container_client):
+    image_1 = Image.debian_slim().pip_install(["abc"])
+    image_2 = Image.debian_slim().pip_install(["def"])
 
     def get_stub():
-        return AioStub(image=image_1, image_2=image_2)
+        return Stub(image=image_1, image_2=image_2)
 
     stub = get_stub()
 
     # Run container
-    async with stub.run(client=aio_client) as app:
+    async with stub.run(client=client) as app:
         # We're not inside the container (yet)
         assert not stub.is_inside()
         assert not stub.is_inside(image_1)
@@ -77,7 +77,7 @@ async def test_is_inside(servicer, unix_servicer, aio_client, aio_container_clie
         unix_servicer.app_objects[app_id] = servicer.app_objects[app_id]
 
         # Pretend that we're inside the container
-        await AioApp.init_container(aio_container_client, app_id)
+        await App.init_container.aio(container_client, app_id)
 
         # Create a new stub (TODO: tie it to the previous stub through name or similar)
         stub = get_stub()
@@ -101,15 +101,15 @@ def f():
 
 @skip_windows_unix_socket
 @pytest.mark.asyncio
-async def test_is_inside_default_image(servicer, unix_servicer, aio_client, aio_container_client):
-    stub = AioStub()
+async def test_is_inside_default_image(servicer, unix_servicer, client, container_client):
+    stub = Stub()
     stub.function()(f)
 
     assert not stub.is_inside()
 
     from modal.stub import _default_image
 
-    app = await AioApp._init_new(aio_client)
+    app = await App._init_new(client)
     app_id = app.app_id
     default_image_handle = await app.create_one_object(_default_image)
     default_image_id = default_image_handle.object_id
@@ -117,10 +117,10 @@ async def test_is_inside_default_image(servicer, unix_servicer, aio_client, aio_
     # Copy the app objects to the container servicer
     unix_servicer.app_objects[app_id] = servicer.app_objects[app_id]
 
-    await AioApp.init_container(aio_container_client, app_id)
+    await App.init_container.aio(container_client, app_id)
 
     # Create a new stub (TODO: tie it to the previous stub through name or similar)
-    stub = AioStub()
+    stub = Stub()
 
     with mock.patch.dict(os.environ, {"MODAL_IMAGE_ID": default_image_id}):
         assert stub.is_inside()

--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -203,7 +203,7 @@ async def test_generator(client, servicer):
 
 
 @pytest.mark.asyncio
-async def test_generator_async(aio_client, servicer):
+async def test_generator_async(client, servicer):
     stub = AioStub()
 
     later_gen_modal = stub.function()(async_later_gen)
@@ -215,7 +215,7 @@ async def test_generator_async(aio_client, servicer):
     servicer.function_body(async_dummy)
 
     assert len(servicer.cleared_function_calls) == 0
-    async with stub.run(client=aio_client):
+    async with stub.run(client=client):
         assert later_gen_modal.is_generator
         res = later_gen_modal.call()
         # Async generators fulfil the *asynchronous iterator protocol*, which requires both these methods.
@@ -363,11 +363,11 @@ def test_function_exception(client, servicer):
 
 
 @pytest.mark.asyncio
-async def test_function_exception_async(aio_client, servicer):
+async def test_function_exception_async(client, servicer):
     stub = AioStub()
 
     failure_modal = stub.function()(servicer.function_body(failure))
-    async with stub.run(client=aio_client):
+    async with stub.run(client=client):
         with pytest.raises(CustomException) as excinfo:
             coro = failure_modal.call()
             assert inspect.isawaitable(

--- a/client_test/lookup_test.py
+++ b/client_test/lookup_test.py
@@ -61,14 +61,14 @@ async def test_webhook_lookup(servicer, client):
 @pytest.mark.asyncio
 async def test_deploy_exists(servicer, client):
     assert not await Queue._exists.aio("my-queue", client=client)  # type: ignore
-    h1 = await Queue()._deploy.aio("my-queue", client=client)
+    h1: QueueHandle = await Queue()._deploy.aio("my-queue", client=client)
     assert await Queue._exists.aio("my-queue", client=client)  # type: ignore
-    h2 = await Queue().lookup.aio("my-queue", client=client)  # type: ignore
+    h2: QueueHandle = await Queue().lookup.aio("my-queue", client=client)  # type: ignore
     assert h1.object_id == h2.object_id
 
 
 @pytest.mark.asyncio
 async def test_deploy_retain_id(servicer, client):
-    h1 = await Queue()._deploy.aio("my-queue", client=client)
-    h2 = await Queue()._deploy.aio("my-queue", client=client)
+    h1: QueueHandle = await Queue()._deploy.aio("my-queue", client=client)
+    h2: QueueHandle = await Queue()._deploy.aio("my-queue", client=client)
     assert h1.object_id == h2.object_id

--- a/client_test/lookup_test.py
+++ b/client_test/lookup_test.py
@@ -1,25 +1,25 @@
 # Copyright Modal Labs 2023
 import pytest
 
-from modal.aio import AioFunction, AioQueue, AioStub, aio_web_endpoint
+from modal import Function, Queue, Stub, web_endpoint
 from modal.exception import NotFoundError
-from modal.queue import AioQueueHandle
-from modal.runner import aio_deploy_stub
+from modal.queue import QueueHandle
+from modal.runner import deploy_stub
 
 
 @pytest.mark.asyncio
-async def test_persistent_object(servicer, aio_client):
-    stub = AioStub()
-    stub["q_1"] = AioQueue()
-    await aio_deploy_stub(stub, "my-queue", client=aio_client)
+async def test_persistent_object(servicer, client):
+    stub = Stub()
+    stub["q_1"] = Queue()
+    await deploy_stub.aio(stub, "my-queue", client=client)
 
-    q: AioQueueHandle = await AioQueue.lookup("my-queue", client=aio_client)  # type: ignore
+    q: QueueHandle = await Queue.lookup.aio("my-queue", client=client)  # type: ignore
     # TODO: remove type annotation here after genstub gets better Generic base class support
-    assert isinstance(q, AioQueueHandle)  # TODO(erikbern): it's a AioQueueHandler
+    assert isinstance(q, QueueHandle)  # TODO(erikbern): it's a QueueHandler
     assert q.object_id == "qu-1"
 
     with pytest.raises(NotFoundError):
-        await AioQueue.lookup("bazbazbaz", client=aio_client)  # type: ignore
+        await Queue.lookup.aio("bazbazbaz", client=client)  # type: ignore
 
 
 def square(x):
@@ -28,47 +28,47 @@ def square(x):
 
 
 @pytest.mark.asyncio
-async def test_lookup_function(servicer, aio_client):
-    stub = AioStub()
+async def test_lookup_function(servicer, client):
+    stub = Stub()
 
     stub.function()(square)
-    await aio_deploy_stub(stub, "my-function", client=aio_client)
+    await deploy_stub.aio(stub, "my-function", client=client)
 
-    f = await AioFunction.lookup("my-function", client=aio_client)  # type: ignore
+    f = await Function.lookup.aio("my-function", client=client)  # type: ignore
     assert f.object_id == "fu-1"
 
     # Call it using two arguments
-    f = await AioFunction.lookup("my-function", "square", client=aio_client)  # type: ignore
+    f = await Function.lookup.aio("my-function", "square", client=client)  # type: ignore
     assert f.object_id == "fu-1"
     with pytest.raises(NotFoundError):
-        f = await AioFunction.lookup("my-function", "cube", client=aio_client)  # type: ignore
+        f = await Function.lookup.aio("my-function", "cube", client=client)  # type: ignore
 
     # Make sure we can call this function
-    assert await f.call(2, 4) == 20
+    assert await f.call.aio(2, 4) == 20
     assert [r async for r in f.map([5, 2], [4, 3])] == [41, 13]
 
 
 @pytest.mark.asyncio
-async def test_webhook_lookup(servicer, aio_client):
-    stub = AioStub()
-    stub.function()(aio_web_endpoint(method="POST")(square))
-    await aio_deploy_stub(stub, "my-webhook", client=aio_client)
+async def test_webhook_lookup(servicer, client):
+    stub = Stub()
+    stub.function()(web_endpoint(method="POST")(square))
+    await deploy_stub.aio(stub, "my-webhook", client=client)
 
-    f = await AioFunction.lookup("my-webhook", client=aio_client)  # type: ignore
+    f = await Function.lookup.aio("my-webhook", client=client)  # type: ignore
     assert f.web_url
 
 
 @pytest.mark.asyncio
-async def test_deploy_exists(servicer, aio_client):
-    assert not await AioQueue._exists("my-queue", client=aio_client)  # type: ignore
-    h1 = await AioQueue()._deploy("my-queue", client=aio_client)
-    assert await AioQueue._exists("my-queue", client=aio_client)  # type: ignore
-    h2 = await AioQueue().lookup("my-queue", client=aio_client)  # type: ignore
+async def test_deploy_exists(servicer, client):
+    assert not await Queue._exists.aio("my-queue", client=client)  # type: ignore
+    h1 = await Queue()._deploy.aio("my-queue", client=client)
+    assert await Queue._exists.aio("my-queue", client=client)  # type: ignore
+    h2 = await Queue().lookup.aio("my-queue", client=client)  # type: ignore
     assert h1.object_id == h2.object_id
 
 
 @pytest.mark.asyncio
-async def test_deploy_retain_id(servicer, aio_client):
-    h1 = await AioQueue()._deploy("my-queue", client=aio_client)
-    h2 = await AioQueue()._deploy("my-queue", client=aio_client)
+async def test_deploy_retain_id(servicer, client):
+    h1 = await Queue()._deploy.aio("my-queue", client=client)
+    h2 = await Queue()._deploy.aio("my-queue", client=client)
     assert h1.object_id == h2.object_id

--- a/client_test/object_test.py
+++ b/client_test/object_test.py
@@ -1,26 +1,26 @@
 # Copyright Modal Labs 2022
 import pytest
 
-from modal.aio import AioQueue, AioStub
+from modal import Queue, Stub
 from modal.exception import InvalidError
 
 
 @pytest.mark.asyncio
-async def test_async_factory(aio_client):
-    stub = AioStub()
-    stub["my_factory"] = AioQueue()
-    async with stub.run(client=aio_client) as running_app:
-        # assert isinstance(running_app["my_factory"], AioQueue)  # TODO(erikbern(): is a handle now
+async def test_async_factory(client):
+    stub = Stub()
+    stub["my_factory"] = Queue()
+    async with stub.run(client=client) as running_app:
+        # assert isinstance(running_app["my_factory"], Queue)  # TODO(erikbern(): is a handle now
         assert running_app["my_factory"].object_id == "qu-1"
 
 
 @pytest.mark.asyncio
-async def test_use_object(aio_client):
-    stub = AioStub()
-    q = AioQueue.from_name("foo-queue")
-    assert isinstance(q, AioQueue)
+async def test_use_object(client):
+    stub = Stub()
+    q = Queue.from_name("foo-queue")
+    assert isinstance(q, Queue)
     stub["my_q"] = q
-    async with stub.run(client=aio_client) as running_app:
+    async with stub.run(client=client) as running_app:
         assert running_app["my_q"].object_id == "qu-foo"
 
 

--- a/client_test/serialization_test.py
+++ b/client_test/serialization_test.py
@@ -2,11 +2,11 @@
 import pytest
 
 from modal._serialization import deserialize, serialize
-from modal.aio import AioQueue, AioStub
+from modal import Queue, Stub
 
-stub = AioStub()
+stub = Stub()
 
-stub.q = AioQueue()
+stub.q = Queue()
 
 
 @pytest.mark.asyncio

--- a/client_test/shared_volume_test.py
+++ b/client_test/shared_volume_test.py
@@ -4,9 +4,8 @@ from unittest import mock
 import pytest
 
 import modal
-import modal.aio
 from modal.exception import InvalidError
-from modal.shared_volume import SharedVolumeHandle, AioSharedVolumeHandle
+from modal.shared_volume import SharedVolumeHandle
 
 from .supports.skip import skip_windows
 
@@ -97,15 +96,15 @@ async def test_shared_volume_handle_dir(client, tmp_path, servicer):
 @pytest.mark.asyncio
 async def test_shared_volume_handle_big_file(client, tmp_path, servicer, blob_server, *args):
     with mock.patch("modal.shared_volume.LARGE_FILE_LIMIT", 10):
-        stub = modal.aio.AioStub()
-        stub.vol = modal.aio.AioSharedVolume()
+        stub = modal.Stub()
+        stub.vol = modal.SharedVolume()
         local_file_path = tmp_path / "bigfile"
         local_file_path.write_text("hello world, this is a lot of text")
 
         async with stub.run(client=client) as app:
             handle = app.vol
-            assert isinstance(handle, AioSharedVolumeHandle)
-            await handle.add_local_file(local_file_path)
+            assert isinstance(handle, SharedVolumeHandle)
+            await handle.add_local_file.aio(local_file_path)
 
         assert servicer.shared_volume_files[handle.object_id].keys() == {"/bigfile"}
         assert servicer.shared_volume_files[handle.object_id]["/bigfile"].data == b""

--- a/client_test/stub_test.py
+++ b/client_test/stub_test.py
@@ -8,8 +8,8 @@ from google.protobuf.empty_pb2 import Empty
 from grpclib import GRPCError, Status
 
 import modal.app
-from modal import Client, Dict, Image, Queue, Stub, web_endpoint, wsgi_app
-from modal.exception import DeprecationError, InvalidError
+from modal import Dict, Image, Queue, Stub, web_endpoint
+from modal.exception import InvalidError
 from modal.runner import deploy_stub
 from modal_proto import api_pb2
 from modal_test_support import module_1, module_2

--- a/client_test/stub_test.py
+++ b/client_test/stub_test.py
@@ -8,8 +8,7 @@ from google.protobuf.empty_pb2 import Empty
 from grpclib import GRPCError, Status
 
 import modal.app
-from modal import Client, Stub, web_endpoint, wsgi_app
-from modal import Dict, Queue, Stub, Image
+from modal import Client, Dict, Image, Queue, Stub, web_endpoint, wsgi_app
 from modal.exception import DeprecationError, InvalidError
 from modal.runner import deploy_stub
 from modal_proto import api_pb2

--- a/client_test/stub_test.py
+++ b/client_test/stub_test.py
@@ -8,48 +8,48 @@ from google.protobuf.empty_pb2 import Empty
 from grpclib import GRPCError, Status
 
 import modal.app
-from modal import Stub, web_endpoint
-from modal.aio import AioDict, AioQueue, AioStub, AioImage
-from modal.exception import InvalidError
-from modal.runner import aio_deploy_stub, deploy_stub
+from modal import Client, Stub, web_endpoint, wsgi_app
+from modal import Dict, Queue, Stub, Image
+from modal.exception import DeprecationError, InvalidError
+from modal.runner import deploy_stub
 from modal_proto import api_pb2
 from modal_test_support import module_1, module_2
 
 
 @pytest.mark.asyncio
-async def test_kwargs(servicer, aio_client):
-    stub = AioStub(
-        d=AioDict(),
-        q=AioQueue(),
+async def test_kwargs(servicer, client):
+    stub = Stub(
+        d=Dict(),
+        q=Queue(),
     )
-    async with stub.run(client=aio_client) as app:
+    async with stub.run(client=client) as app:
         # TODO: interface to get type safe objects from live apps
-        await app["d"].put("foo", "bar")  # type: ignore
-        await app["q"].put("baz")  # type: ignore
-        assert await app["d"].get("foo") == "bar"  # type: ignore
-        assert await app["q"].get() == "baz"  # type: ignore
+        await app["d"].put.aio("foo", "bar")  # type: ignore
+        await app["q"].put.aio("baz")  # type: ignore
+        assert await app["d"].get.aio("foo") == "bar"  # type: ignore
+        assert await app["q"].get.aio() == "baz"  # type: ignore
 
 
 @pytest.mark.asyncio
-async def test_attrs(servicer, aio_client):
-    stub = AioStub()
-    stub.d = AioDict()
-    stub.q = AioQueue()
-    async with stub.run(client=aio_client) as app:
-        await app.d.put("foo", "bar")  # type: ignore
-        await app.q.put("baz")  # type: ignore
-        assert await app.d.get("foo") == "bar"  # type: ignore
-        assert await app.q.get() == "baz"  # type: ignore
+async def test_attrs(servicer, client):
+    stub = Stub()
+    stub.d = Dict()
+    stub.q = Queue()
+    async with stub.run(client=client) as app:
+        await app.d.put.aio("foo", "bar")  # type: ignore
+        await app.q.put.aio("baz")  # type: ignore
+        assert await app.d.get.aio("foo") == "bar"  # type: ignore
+        assert await app.q.get.aio() == "baz"  # type: ignore
 
 
 @pytest.mark.asyncio
-async def test_stub_type_validation(servicer, aio_client):
+async def test_stub_type_validation(servicer, client):
     with pytest.raises(InvalidError):
-        stub = AioStub(
+        stub = Stub(
             foo=4242,  # type: ignore
         )
 
-    stub = AioStub()
+    stub = Stub()
 
     with pytest.raises(InvalidError) as excinfo:
         stub.bar = 4242  # type: ignore
@@ -62,19 +62,19 @@ def square(x):
 
 
 @pytest.mark.asyncio
-async def test_redeploy(servicer, aio_client):
-    stub = AioStub()
+async def test_redeploy(servicer, client):
+    stub = Stub()
     stub.function()(square)
-    stub.image = AioImage.debian_slim().pip_install("pandas")
+    stub.image = Image.debian_slim().pip_install("pandas")
 
     # Deploy app
-    app = await aio_deploy_stub(stub, "my-app", client=aio_client)
+    app = await deploy_stub.aio(stub, "my-app", client=client)
     assert app.app_id == "ap-1"
     assert servicer.app_objects["ap-1"]["square"] == "fu-1"
     assert servicer.app_state_history[app.app_id] == [api_pb2.APP_STATE_INITIALIZING, api_pb2.APP_STATE_DEPLOYED]
 
     # Redeploy, make sure all ids are the same
-    app = await aio_deploy_stub(stub, "my-app", client=aio_client)
+    app = await deploy_stub.aio(stub, "my-app", client=client)
     assert app.app_id == "ap-1"
     assert servicer.app_objects["ap-1"]["square"] == "fu-1"
     assert servicer.app_state_history[app.app_id] == [
@@ -84,7 +84,7 @@ async def test_redeploy(servicer, aio_client):
     ]
 
     # Deploy to a different name, ids should change
-    app = await aio_deploy_stub(stub, "my-app-xyz", client=aio_client)
+    app = await deploy_stub.aio(stub, "my-app-xyz", client=client)
     assert app.app_id == "ap-2"
     assert servicer.app_objects["ap-2"]["square"] == "fu-2"
     assert servicer.app_state_history[app.app_id] == [api_pb2.APP_STATE_INITIALIZING, api_pb2.APP_STATE_DEPLOYED]
@@ -182,9 +182,9 @@ def test_detach_state(client, servicer):
 
 
 @pytest.mark.asyncio
-async def test_grpc_protocol(aio_client, servicer):
-    stub = AioStub()
-    async with stub.run(client=aio_client):
+async def test_grpc_protocol(client, servicer):
+    stub = Stub()
+    async with stub.run(client=client):
         await asyncio.sleep(0.01)  # wait for heartbeat
     assert len(servicer.requests) == 4
     assert isinstance(servicer.requests[0], Empty)  # ClientHello
@@ -244,20 +244,20 @@ def test_set_image_on_stub_as_attribute():
 
 
 @pytest.mark.asyncio
-async def test_redeploy_persist(servicer, aio_client):
-    stub = AioStub()
+async def test_redeploy_persist(servicer, client):
+    stub = Stub()
     stub.function()(square)
-    stub.image = AioImage.debian_slim().pip_install("pandas")
+    stub.image = Image.debian_slim().pip_install("pandas")
 
-    stub.d = AioDict()
+    stub.d = Dict()
 
     # Deploy app
-    app = await aio_deploy_stub(stub, "my-app", client=aio_client)
+    app = await deploy_stub.aio(stub, "my-app", client=client)
     assert app.app_id == "ap-1"
     assert servicer.app_objects["ap-1"]["d"] == "di-0"
 
-    stub.d = AioDict().persist("my-dict")
+    stub.d = Dict().persist("my-dict")
     # Redeploy, make sure all ids are the same
-    app = await aio_deploy_stub(stub, "my-app", client=aio_client)
+    app = await deploy_stub.aio(stub, "my-app", client=client)
     assert app.app_id == "ap-1"
     assert servicer.app_objects["ap-1"]["d"] == "di-1"

--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -5,7 +5,7 @@ from .app import App, container_app, is_local
 from .client import Client
 from .dict import Dict
 from .exception import Error
-from .functions import Function, current_input_id, method, asgi_app, wsgi_app, web_endpoint
+from .functions import Function, FunctionHandle, current_input_id, method, asgi_app, wsgi_app, web_endpoint
 from .image import Image
 from .mount import Mount, create_package_mounts
 from .object import Handle, _BLOCKING_H  # noqa
@@ -25,6 +25,7 @@ __all__ = [
     "Dict",
     "Error",
     "Function",
+    "FunctionHandle",
     "Image",
     "Mount",
     "Period",

--- a/modal/aio.py
+++ b/modal/aio.py
@@ -55,5 +55,4 @@ deprecation_warning(
     "Where you would have previously used `await AioDict.lookup(...)` you now use "
     "`await Dict.lookup.aio(...)` instead.\nObjects that are themselves generators or context managers "
     "now conform to both the blocking and async interfaces, and returned objects of all functions/methods",
-    pending=True,
 )

--- a/modal/extensions/ipython.py
+++ b/modal/extensions/ipython.py
@@ -4,7 +4,7 @@ import logging
 import sys
 from typing import Any
 
-from modal.aio import AioStub
+from modal import Stub
 from modal.config import config, logger
 from modal_utils.async_utils import run_coro_blocking
 
@@ -19,7 +19,7 @@ def load_ipython_extension(ipython):
     logger.setLevel(config["loglevel"])
 
     # Create a app and provide it in the IPython app
-    stub = AioStub()
+    stub = Stub()
     ipython.push({"stub": stub})
 
     app_ctx = stub.run()

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     importlib_metadata>=3.6.0
     protobuf>=3.19,<5.0
     rich>=12.0.0
-    synchronicity~=0.5.2
+    synchronicity~=0.5.3
     tblib>=1.7.0
     toml
     typer>=0.6.1


### PR DESCRIPTION
This basically just gets rid of all old usage of `modal.aio` from tests, and changes the deprecation warning so it's no longer pending.