### PR TITLE
Turn deprecation_warning into deprecation_error

### DIFF
--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -317,20 +317,6 @@ def test_webhook(unix_servicer, event_loop):
 
 
 @skip_windows_unix_socket
-def test_webhook_old(unix_servicer, event_loop):
-    inputs = _get_web_inputs()
-    client, items = _run_container(
-        unix_servicer,
-        "modal_test_support.functions",
-        "webhook_old",
-        inputs=inputs,
-        webhook_type=api_pb2.WEBHOOK_TYPE_FUNCTION,
-    )
-
-    assert len(items) == 3
-
-
-@skip_windows_unix_socket
 def test_webhook_lifecycle(unix_servicer, event_loop):
     inputs = _get_web_inputs()
     with pytest.warns(DeprecationError):

--- a/client_test/webhook_test.py
+++ b/client_test/webhook_test.py
@@ -22,14 +22,13 @@ with pytest.warns(DeprecationError):
 
     @stub.function(cpu=42)
     @stub.web_endpoint(method="POST")
-    async def h(x):
+    async def g(x):
         return {"square": x**2}
 
 
-with pytest.warns(DeprecationError):
-
+with pytest.raises(DeprecationError):
     @stub.webhook(method="PUT", cpu=42)
-    async def g(x):
+    async def h(x):
         return {"square": x**2}
 
 

--- a/client_test/webhook_test.py
+++ b/client_test/webhook_test.py
@@ -27,6 +27,7 @@ with pytest.warns(DeprecationError):
 
 
 with pytest.raises(DeprecationError):
+
     @stub.webhook(method="PUT", cpu=42)
     async def h(x):
         return {"square": x**2}

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -117,13 +117,6 @@ def webhook(arg="world"):
 
 with pytest.warns(DeprecationError):
 
-    @stub.webhook()
-    def webhook_old(arg="world"):
-        return {"hello": arg}
-
-
-with pytest.warns(DeprecationError):
-
     class WebhookLifecycleClass:
         _events: list[str] = []
 


### PR DESCRIPTION
We had a few warnings since April 4, it's almost two months now.

I'll merge this next week probably.

Slowly reducing the complexity of the `Stub` class, which will make it a lot easier to merge it with `App`