### PR TITLE
Add size to MountFile

### DIFF
--- a/modal/mount.py
+++ b/modal/mount.py
@@ -267,7 +267,9 @@ class _Mount(_Provider[_MountHandle]):
             )
 
             remote_filename = file_spec.mount_filename
-            mount_file = api_pb2.MountFile(filename=remote_filename, sha256_hex=file_spec.sha256_hex)
+            mount_file = api_pb2.MountFile(
+                filename=remote_filename, sha256_hex=file_spec.sha256_hex, size=file_spec.size
+            )
 
             if file_spec.sha256_hex in uploaded_hashes:
                 return mount_file

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -747,6 +747,7 @@ message MountBuildResponse {
 message MountFile {
   string filename = 1;
   string sha256_hex = 3;
+  optional uint64 size = 4;
 }
 
 message MountPutFileRequest {


### PR DESCRIPTION
Having size in MountFile helps reduce RPCs on the backend size. See MOD-1302 for context.


## Backward/forward compatibility checks

- [x] Client+Server: this change is compatible with old servers
