### PR TITLE
automate releases of alias package

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -132,6 +132,13 @@ jobs:
       - name: Build wheel
         run: python setup.py bdist_wheel
 
+      - name: Create alias package
+        run: inv create-alias-package
+
+      - name: Build alias package
+        working-directory: alias-package
+        run: python setup.py bdist_wheel
+
       - name: Publish client mount
         env:
           MODAL_LOGLEVEL: DEBUG
@@ -143,4 +150,11 @@ jobs:
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+        run: twine upload dist/* --non-interactive
+
+      - name: Upload alias package to PyPI
+        env:
+          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+        working-directory: alias-package
         run: twine upload dist/* --non-interactive

--- a/alias-package/pyproject.toml
+++ b/alias-package/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/alias-package/setup.cfg
+++ b/alias-package/setup.cfg
@@ -1,0 +1,12 @@
+[metadata]
+name = modal
+author = Modal Labs
+author_email = erik@modal.com
+description = Dummy alias that requires modal-client
+long_description = This package is a dummy package that just requires the modal-client package.
+project_urls =
+    Homepage = https://modal.com
+
+[options]
+install_requires =
+    modal-client

--- a/tasks.py
+++ b/tasks.py
@@ -79,7 +79,26 @@ def update_build_number(ctx, new_build_number):
 
     assert new_build_number > current_build_number
     with open("modal_version/_version_generated.py", "w") as f:
-        f.write(f"{copyright_header_full}\nbuild_number = {new_build_number}\n")
+        f.write(
+            f"""\
+{copyright_header_full}
+build_number = {new_build_number}
+"""
+        )
+
+
+@task
+def create_alias_package(ctx):
+    from modal_version import __version__
+
+    with open("alias-package/setup.py", "w") as f:
+        f.write(
+            f"""\
+{copyright_header_full}
+from setuptools import setup
+setup(version={__version__})
+"""
+        )
 
 
 @task


### PR DESCRIPTION
This will create a corresponding package version of `modal` for every release of `modal-client`