### PR TITLE
Make deprecated `modal env`/MODAL_ENV into errors

### DIFF
--- a/modal/cli/env.py
+++ b/modal/cli/env.py
@@ -3,21 +3,13 @@ import datetime
 
 import typer
 
-from modal.cli import profile as profile_cli
-from modal.exception import deprecation_warning
-
-
-def warn_env_deprecated():
-    pass
-
+from modal.exception import deprecation_error
 
 DEPRECATION_PREFIX = "[Deprecated, use `modal profile` instead] "
 
 
-def print_env_deprecated_warning():
-    deprecation_warning(
-        datetime.date(2023, 5, 24), "`modal env` will soon be deprecated. Use `modal profile` instead", pending=True
-    )
+def print_env_deprecated_error():
+    deprecation_error(datetime.date(2023, 5, 24), "`modal env` has been replaced with `modal profile`")
 
 
 env_cli = typer.Typer(name="env", help=f"{DEPRECATION_PREFIX}Set the current environment.", no_args_is_help=True)
@@ -25,17 +17,14 @@ env_cli = typer.Typer(name="env", help=f"{DEPRECATION_PREFIX}Set the current env
 
 @env_cli.command(help=f"{DEPRECATION_PREFIX}Change the active Modal environment.")
 def activate(env: str = typer.Argument(..., help="Modal environment to activate.")):
-    print_env_deprecated_warning()
-    profile_cli.activate(env)
+    print_env_deprecated_error()
 
 
 @env_cli.command(help=f"{DEPRECATION_PREFIX}Print the active Modal environment.")
 def current():
-    print_env_deprecated_warning()
-    profile_cli.current()
+    print_env_deprecated_error()
 
 
 @env_cli.command(help=f"{DEPRECATION_PREFIX}List all Modal environments that are defined.")
 def list():
-    print_env_deprecated_warning()
-    profile_cli.list()
+    print_env_deprecated_error()

--- a/modal/cli/profile.py
+++ b/modal/cli/profile.py
@@ -3,20 +3,20 @@ import typer
 
 from modal.config import _profile, config_profiles, config_set_active_profile
 
-profile_cli = typer.Typer(name="profile", help="Set the current environment.", no_args_is_help=True)
+profile_cli = typer.Typer(name="profile", help="Set the active Modal profile.", no_args_is_help=True)
 
 
-@profile_cli.command(help="Change the active Modal environment.")
-def activate(profile: str = typer.Argument(..., help="Modal environment to activate.")):
+@profile_cli.command(help="Change the active Modal profile.")
+def activate(profile: str = typer.Argument(..., help="Modal profile to activate.")):
     config_set_active_profile(profile)
 
 
-@profile_cli.command(help="Print the active Modal environment.")
+@profile_cli.command(help="Print the active Modal profile.")
 def current():
     print(_profile)
 
 
-@profile_cli.command(help="List all Modal environments that are defined.")
+@profile_cli.command(help="List all Modal profiles that are defined.")
 def list():
     for env in config_profiles():
         print(f"{env} [active]" if _profile == env else env)

--- a/modal/config.py
+++ b/modal/config.py
@@ -81,7 +81,7 @@ import toml
 
 
 from ._traceback import setup_rich_traceback
-from .exception import deprecation_warning
+from .exception import deprecation_error
 
 # Locate config file and read it
 
@@ -125,9 +125,9 @@ def config_set_active_profile(env: str):
 
 
 if "MODAL_ENV" in os.environ:
-    deprecation_warning(date(2023, 5, 24), "MODAL_ENV will soon be deprecated. Use MODAL_PROFILE instead")
+    deprecation_error(date(2023, 5, 24), "MODAL_ENV has been replaced with MODAL_PROFILE")
 
-_profile = os.environ.get("MODAL_PROFILE", os.environ.get("MODAL_ENV", _config_active_profile()))
+_profile = os.environ.get("MODAL_PROFILE", _config_active_profile())
 
 # Define settings
 


### PR DESCRIPTION
Ahead of the introduction of modal environments, we are quickly removing support for using name `env` or `environment` for what is now known as profiles