### PR TITLE
Fix copy_local_file

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -344,19 +344,26 @@ class _Image(_Provider[_ImageHandle]):
         )
         return self.copy_mount(mount, remote_path)
 
-    def copy_local_file(self, local_path: Union[str, Path], remote_path: Union[str, Path] = ".") -> "_Image":
+    def copy_local_file(self, local_path: Union[str, Path], remote_path: Union[str, Path] = "./") -> "_Image":
         """Copy a file into the image as a part of building it.
 
         This works in a similar way to `COPY` in a `Dockerfile`."""
-        mount = _Mount.from_local_file(local_path, remote_path="/")
-        return self.copy_mount(mount, remote_path)
+        basename = str(Path(local_path).name)
+        mount = _Mount.from_local_file(local_path, remote_path=f"/{basename}")
+        return self.extend(
+            dockerfile_commands=["FROM base", f"COPY {basename} {remote_path}"],
+            context_mount=mount,
+        )
 
     def copy_local_dir(self, local_path: Union[str, Path], remote_path: Union[str, Path] = ".") -> "_Image":
         """Copy a directory into the image as a part of building the image.
 
         This works in a similar way to `COPY` in a `Dockerfile`."""
         mount = _Mount.from_local_dir(local_path, remote_path="/")
-        return self.copy_mount(mount, remote_path)
+        return self.extend(
+            dockerfile_commands=["FROM base", f"COPY . {remote_path}"],
+            context_mount=mount,
+        )
 
     @typechecked
     def pip_install(


### PR DESCRIPTION
This doesn't change the behavior of `copy_local_dir`, but I changed it so it also inlines the `.extend` call – so there's more symmetry with `copy_local_file`