### PR TITLE
mount handle hydrate checksum

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -199,8 +199,8 @@ class _Image(_Provider[_ImageHandle]):
                 build_function_def = build_function.get_build_def()
                 build_function_id = (await resolver.load(build_function)).object_id
             else:
-                build_function_id = None
                 build_function_def = None
+                build_function_id = None
 
             dockerfile_commands_list: List[str]
             if callable(dockerfile_commands):

--- a/modal/image.py
+++ b/modal/image.py
@@ -199,8 +199,8 @@ class _Image(_Provider[_ImageHandle]):
                 build_function_def = build_function.get_build_def()
                 build_function_id = (await resolver.load(build_function)).object_id
             else:
-                build_function_def = None
                 build_function_id = None
+                build_function_def = None
 
             dockerfile_commands_list: List[str]
             if callable(dockerfile_commands):

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -188,6 +188,7 @@ message AppLookupObjectResponse {
   string error_message = 2;
   oneof handle_metadata_oneof {
     FunctionHandleMetadata function = 3;
+    MountHandleMetadata mount_handle_metadata = 4;
   }
 }
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -758,6 +758,11 @@ message MountBuildRequest {
 
 message MountBuildResponse {
   string mount_id = 1;
+  MountHandleMetadata handle_metadata = 2;
+}
+
+message MountHandleMetadata {
+  string content_checksum_sha256_hex = 1;
 }
 
 message MountFile {


### PR DESCRIPTION
`_MountHandle` should contain a content checksum so that we can add it to the description of build functions.

`_MountHandle` should hydrate itself from `handle_metadata` produced from `MountBuildResponse` and 
`mount_handle_metadata` `AppLookupObjectResponse`.