### PR TITLE
Raise an error if someone tries to start an app from a stub that is already starting or running

### DIFF
--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -208,6 +208,15 @@ def test_run_local_entrypoint(servicer, set_env_client, test_dir):
     assert len(servicer.client_calls) == 4
 
 
+def test_run_local_entrypoint_invalid_with_stub_run(servicer, set_env_client, test_dir):
+    stub_file = test_dir / "supports" / "app_run_tests" / "local_entrypoint_invalid.py"
+
+    res = _run(["run", stub_file.as_posix()], expected_exit_code=1)
+    assert "app is already running" in str(res.exception).lower()
+    assert "unreachable" not in res.stdout
+    assert len(servicer.client_calls) == 0
+
+
 def test_run_parse_args(servicer, set_env_client, test_dir):
     stub_file = test_dir / "supports" / "app_run_tests" / "cli_args.py"
     res = _run(["run", stub_file.as_posix()], expected_exit_code=2, expected_stderr=None)

--- a/client_test/supports/app_run_tests/local_entrypoint_invalid.py
+++ b/client_test/supports/app_run_tests/local_entrypoint_invalid.py
@@ -1,3 +1,4 @@
+# Copyright Modal Labs 2023
 import modal
 
 stub = modal.Stub()

--- a/client_test/supports/app_run_tests/local_entrypoint_invalid.py
+++ b/client_test/supports/app_run_tests/local_entrypoint_invalid.py
@@ -1,0 +1,15 @@
+import modal
+
+stub = modal.Stub()
+
+
+@stub.function()
+def foo():
+    pass
+
+
+@stub.local_entrypoint()
+def main():
+    with stub.run():  # should error here
+        print("unreachable")
+        foo.call()  # should not get here

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -43,6 +43,13 @@ async def _run_stub(
             " Are you calling stub.run() directly?"
             " Consider using the `modal run` shell command."
         )
+    if stub._is_running():
+        raise InvalidError(
+            "App is already running and can't be started again.\n"
+            "You should not use `stub.run` or `run_stub` within a Modal local_entrypoint"
+        )
+    stub._set_running(True)
+
     if client is None:
         client = await _Client.from_env()
     if output_mgr is None:
@@ -98,6 +105,7 @@ async def _run_stub(
                 )
         finally:
             await app.disconnect()
+            stub._set_running(False)
 
     output_mgr.print_if_visible(step_completed("App completed."))
 

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -43,12 +43,11 @@ async def _run_stub(
             " Are you calling stub.run() directly?"
             " Consider using the `modal run` shell command."
         )
-    if stub._is_running():
+    if stub.app:
         raise InvalidError(
             "App is already running and can't be started again.\n"
             "You should not use `stub.run` or `run_stub` within a Modal local_entrypoint"
         )
-    stub._set_running(True)
 
     if client is None:
         client = await _Client.from_env()
@@ -105,7 +104,6 @@ async def _run_stub(
                 )
         finally:
             await app.disconnect()
-            stub._set_running(False)
 
     output_mgr.print_if_visible(step_completed("App completed."))
 

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -108,6 +108,7 @@ class _Stub:
     _local_entrypoints: Dict[str, LocalEntrypoint]
     _app: Optional[_App]
     _all_stubs: typing.ClassVar[Dict[str, List["_Stub"]]] = {}
+    _is_running_flag: bool = False  # used to prevent double runs locally, do not use container-side
 
     @typechecked
     def __init__(
@@ -271,6 +272,14 @@ class _Stub:
             yield
         finally:
             self._app = None
+
+    def _set_running(self, is_running: bool):
+        # mdmd:hidden
+        self._is_running_flag = is_running
+
+    def _is_running(self) -> bool:
+        # mdmd:hidden
+        return self._is_running_flag
 
     @asynccontextmanager
     async def run(

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -108,7 +108,6 @@ class _Stub:
     _local_entrypoints: Dict[str, LocalEntrypoint]
     _app: Optional[_App]
     _all_stubs: typing.ClassVar[Dict[str, List["_Stub"]]] = {}
-    _is_running_flag: bool = False  # used to prevent double runs locally, do not use container-side
 
     @typechecked
     def __init__(
@@ -272,14 +271,6 @@ class _Stub:
             yield
         finally:
             self._app = None
-
-    def _set_running(self, is_running: bool):
-        # mdmd:hidden
-        self._is_running_flag = is_running
-
-    def _is_running(self) -> bool:
-        # mdmd:hidden
-        return self._is_running_flag
 
     @asynccontextmanager
     async def run(


### PR DESCRIPTION
## Describe your changes

Previously, it could lead to unexpected behavior in case a user accidentally put a `stub.run()` block within their local entrypoint and then called the script using `modal run`. The second call would take over the output management and overwrite the original app run's output, making it look like the app hangs during setup. User ran into this in beta-testing slack

I don't love adding this extra stuff the already large stub class, but I don't see an easy way around that in this case?