### PR TITLE
Use an empty environment name by default

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -8,7 +8,7 @@ from modal_utils.grpc_utils import get_proto_oneof, retry_transient_errors
 from ._resolver import Resolver
 from .client import _Client
 from .config import logger
-from .object import _Handle, _Provider, DEFAULT_ENVIRONMENT_NAME
+from .object import _Handle, _Provider
 
 if TYPE_CHECKING:
     from rich.tree import Tree
@@ -184,7 +184,7 @@ class _App:
         description: Optional[str] = None,
         detach: bool = False,
         deploying: bool = False,
-        environment_name: str = DEFAULT_ENVIRONMENT_NAME,
+        environment_name: str = "",
     ) -> "_App":
         # Start app
         # TODO(erikbern): maybe this should happen outside of this method?
@@ -200,7 +200,7 @@ class _App:
         return _App(client, app_resp.app_id, app_page_url)
 
     @staticmethod
-    async def _init_from_name(client: _Client, name: str, namespace, environment_name: str):
+    async def _init_from_name(client: _Client, name: str, namespace, environment_name: str = ""):
         # Look up any existing deployment
         app_req = api_pb2.AppGetByDeploymentNameRequest(
             name=name, namespace=namespace, environment_name=environment_name

--- a/modal/object.py
+++ b/modal/object.py
@@ -19,8 +19,6 @@ H = TypeVar("H", bound="_Handle")
 
 _BLOCKING_H, _ASYNC_H = synchronize_apis(H)
 
-DEFAULT_ENVIRONMENT_NAME: str = "default"
-
 
 class _Handle(metaclass=ObjectMeta):
     """mdmd:hidden The shared base class of any synced/distributed object in Modal.
@@ -128,7 +126,6 @@ class _Handle(metaclass=ObjectMeta):
             object_tag=tag,
             namespace=namespace,
             object_entity=cls._type_prefix,
-            environment_name=DEFAULT_ENVIRONMENT_NAME,
         )
         try:
             response = await retry_transient_errors(client.stub.AppLookupObject, request)
@@ -227,7 +224,7 @@ class _Provider(Generic[H]):
 
         handle_cls = self._get_handle_cls()
         object_entity = handle_cls._type_prefix
-        app = await _App._init_from_name(client, label, namespace, environment_name=DEFAULT_ENVIRONMENT_NAME)
+        app = await _App._init_from_name(client, label, namespace)
         handle = await app.create_one_object(self)
         await app.deploy(label, namespace, object_entity)  # TODO(erikbern): not needed if the app already existed
         return handle

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -15,7 +15,6 @@ from .app import _App, is_local
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, _Client
 from .config import config
 from .exception import InvalidError
-from .object import DEFAULT_ENVIRONMENT_NAME
 from .queue import _QueueHandle
 
 
@@ -35,7 +34,7 @@ async def _run_stub(
     show_progress: Optional[bool] = None,
     detach: bool = False,
     output_mgr: Optional[OutputManager] = None,
-    environment: str = DEFAULT_ENVIRONMENT_NAME,
+    environment: str = "",
 ) -> AsyncGenerator[_App, None]:
     if not is_local():
         raise InvalidError(
@@ -175,7 +174,7 @@ async def _deploy_stub(
     if client is None:
         client = await _Client.from_env()
 
-    app = await _App._init_from_name(client, name, namespace, environment_name=DEFAULT_ENVIRONMENT_NAME)
+    app = await _App._init_from_name(client, name, namespace, environment_name="")
 
     output_mgr = OutputManager(stdout, show_progress)
 


### PR DESCRIPTION
Instead, we'll treat an unspecified environment (empty string) on the backend by assuming there is only one environment and using that one, or error if there are multiple ones.

This lets the users have any name on their 'single' environments, and legacy clients will use that one. When a workspace has multiple environments, the profile (or cli command) should always explicitly state which one to use, to avoid mishaps.
