### PR TITLE
Retry RESOURCE_EXHAUSTED for pumping inputs with max delay 10s

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -359,6 +359,8 @@ async def _map_invocation(
                 client.stub.FunctionPutInputs,
                 request,
                 max_retries=None,
+                max_delay=10,
+                additional_status_codes=[Status.RESOURCE_EXHAUSTED],
             )
             for item in resp.inputs:
                 pending_outputs.setdefault(item.input_id, 0)


### PR DESCRIPTION
Retry `RESOURCE_EXHAUSTED` when pumping inputs.

Bump max delay between retries to 10 seconds.