### PR TITLE
wait for inputs to be finished to avoid server errors

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -303,6 +303,7 @@ MAP_INVOCATION_CHUNK_SIZE = 100
 # Maximum number of unfinished inputs for maps
 MAP_INVOCATION_CONCURRENCY = 20000
 
+
 async def _map_invocation(
     function_id: str,
     input_stream: AsyncIterable[Any],


### PR DESCRIPTION
The server rejects inputs if there are already 25000 inputs waiting to be finished.

This client change reduces the number of unnecessary API calls trying to append inputs, when it must wait for more inputs to be finished in order to continue uploading inputs.