### PR TITLE
Stub methods: turn deprecation warnings into errors

### DIFF
--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -234,32 +234,6 @@ def test_startup_failure(unix_servicer, event_loop):
 
 
 @skip_windows_unix_socket
-def test_class_scoped_function(unix_servicer, event_loop):
-    with pytest.warns(DeprecationError):
-        client, items = _run_container(unix_servicer, "modal_test_support.functions", "Cube.f")
-    assert len(items) == 1
-    assert items[0].result.status == api_pb2.GenericResult.GENERIC_STATUS_SUCCESS
-    assert items[0].result.data == serialize(42**3)
-
-    Cube = sys.modules["modal_test_support.functions"].Cube  # don't redefine
-
-    assert Cube._events == ["init", "enter", "call", "exit"]
-
-
-@skip_windows_unix_socket
-def test_class_scoped_function_async(unix_servicer, event_loop):
-    with pytest.warns(DeprecationError):
-        client, items = _run_container(unix_servicer, "modal_test_support.functions", "CubeAsync.f")
-    assert len(items) == 1
-    assert items[0].result.status == api_pb2.GenericResult.GENERIC_STATUS_SUCCESS
-    assert items[0].result.data == serialize(42**3)
-
-    CubeAsync = sys.modules["modal_test_support.functions"].CubeAsync
-
-    assert CubeAsync._events == ["init", "enter", "call", "exit"]
-
-
-@skip_windows_unix_socket
 def test_create_package_mounts_inside_container(unix_servicer, event_loop):
     """`create_package_mounts` shouldn't actually run inside the container, because it's possible
     that there are modules that were present locally for the user that didn't get mounted into
@@ -314,25 +288,6 @@ def test_webhook(unix_servicer, event_loop):
     # Check EOF
     assert items[2].result.status == api_pb2.GenericResult.GENERIC_STATUS_SUCCESS
     assert items[2].result.gen_status == api_pb2.GenericResult.GENERATOR_STATUS_COMPLETE
-
-
-@skip_windows_unix_socket
-def test_webhook_lifecycle(unix_servicer, event_loop):
-    inputs = _get_web_inputs()
-    with pytest.warns(DeprecationError):
-        client, items = _run_container(
-            unix_servicer,
-            "modal_test_support.functions",
-            "WebhookLifecycleClass.webhook",
-            inputs=inputs,
-            webhook_type=api_pb2.WEBHOOK_TYPE_FUNCTION,
-        )
-
-    assert len(items) == 3
-    assert items[1].result.status == api_pb2.GenericResult.GENERIC_STATUS_SUCCESS
-    assert items[1].result.gen_status == api_pb2.GenericResult.GENERATOR_STATUS_INCOMPLETE
-    second_message = deserialize(items[1].result.data, client)
-    assert json.loads(second_message["body"]) == {"hello": "space"}
 
 
 @skip_windows_unix_socket

--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -17,7 +17,7 @@ from modal._container_entrypoint import UserException, main
 # from modal_test_support import SLEEP_DELAY
 from modal._serialization import deserialize, serialize
 from modal import Client
-from modal.exception import DeprecationError, InvalidError
+from modal.exception import InvalidError
 from modal.stub import _Stub
 from modal_proto import api_pb2
 from .helpers import deploy_stub_externally

--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -503,26 +503,12 @@ def f(x):
     return x**2
 
 
-with pytest.warns(DeprecationError):
+with pytest.raises(DeprecationError):
 
     class Class:
         @lc_stub.function()
         def f(self, x):
             return x**2
-
-
-def test_raw_call():
-    assert f(111) == 12321
-    instance = Class()
-    with pytest.warns(DeprecationError):
-        assert instance.f(1111) == 1234321
-
-
-def test_method_call(client):
-    instance = Class()
-    with lc_stub.run(client=client):
-        with pytest.warns(DeprecationError):
-            assert instance.f.call(111) == 12321
 
 
 def test_allow_cross_region_volumes(client, servicer):

--- a/client_test/webhook_test.py
+++ b/client_test/webhook_test.py
@@ -18,7 +18,7 @@ async def f(x):
     return {"square": x**2}
 
 
-with pytest.warns(DeprecationError):
+with pytest.raises(DeprecationError):
 
     @stub.function(cpu=42)
     @stub.web_endpoint(method="POST")
@@ -37,11 +37,9 @@ with pytest.raises(DeprecationError):
 async def test_webhook(servicer, client):
     async with stub.run(client=client) as app:
         assert f.web_url
-        assert g.web_url
 
         assert servicer.app_functions["fu-1"].webhook_config.type == api_pb2.WEBHOOK_TYPE_FUNCTION
         assert servicer.app_functions["fu-1"].webhook_config.method == "PATCH"
-        assert servicer.app_functions["fu-2"].webhook_config.method == "POST"
 
         # Make sure we can call the webhooks
         # TODO: reinstate `.call` check when direct webhook fn invocation is fixed.
@@ -51,9 +49,7 @@ async def test_webhook(servicer, client):
         # Make sure the container gets the app id as well
         container_app = await App.init_container.aio(client, app.app_id)
         assert isinstance(container_app.f, FunctionHandle)
-        assert isinstance(container_app.g, FunctionHandle)
         assert container_app.f.web_url
-        assert container_app.g.web_url
 
 
 def test_webhook_cors():

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -23,16 +23,15 @@ from .app import _App, _container_app, is_local
 from .client import _Client
 from .cls import make_remote_cls_constructors
 from .config import logger
-from .exception import InvalidError, deprecation_error, deprecation_warning
+from .exception import InvalidError, deprecation_error
 from .functions import _Function, _FunctionHandle, PartialFunction, _PartialFunction
-from .functions import _asgi_app, _web_endpoint, _wsgi_app
 from .gpu import GPU_T
 from .image import _Image, _ImageHandle
 from .mount import _Mount
 from .object import _Provider
 from .proxy import _Proxy
 from .queue import _Queue
-from .runner import _run_stub, _deploy_stub, _interactive_shell
+from .runner import _run_stub
 from .schedule import Schedule
 from .secret import _Secret
 from .shared_volume import _SharedVolume

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -321,15 +321,14 @@ class _Stub:
         show_progress=None,
         object_entity: str = "ap",
     ) -> _App:
-        """`stub.deploy` is deprecated. Use the `modal deploy` command instead.
+        """`stub.deploy` is deprecated and no longer supported. Use the `modal deploy` command instead.
 
         For programmatic usage, use `modal.runner.deploy_stub`
         """
-        deprecation_warning(
+        deprecation_error(
             date(2023, 5, 9),
             self.deploy.__doc__,
         )
-        return await _deploy_stub(self, name, namespace, client, stdout, show_progress, object_entity)
 
     def _get_default_image(self):
         if "image" in self._blueprint:
@@ -501,10 +500,12 @@ class _Stub:
             raw_f = f
 
         if not _cls and not info.is_serialized() and "." in info.function_name:  # This is a method
-            deprecation_warning(
+            deprecation_error(
                 date(2023, 4, 20),
                 inspect.cleandoc(
-                    """@stub.function on methods is deprecated. Use the @stub.cls and @method decorators. Usage:
+                    """@stub.function on methods is deprecated and no longer supported.
+
+                    Use the @stub.cls and @method decorators. Usage:
 
                     ```
                     @stub.cls(cpu=8)
@@ -592,7 +593,7 @@ class _Stub:
         ] = None,  # Label for created endpoint. Final subdomain will be <workspace>--<label>.modal.run.
         wait_for_response: bool = True,  # Whether requests should wait for and return the function response.
     ):
-        """`stub.web_endpoint` is deprecated. Use `modal.web_endpoint` instead. Usage:
+        """`stub.web_endpoint` is deprecated and no longer supported. Use `modal.web_endpoint` instead. Usage:
 
         ```python
         from modal import Stub, web_endpoint
@@ -603,11 +604,10 @@ class _Stub:
         def my_function():
             ...
         ```"""
-        deprecation_warning(
+        deprecation_error(
             date(2023, 4, 18),
             self.web_endpoint.__doc__,
         )
-        return _web_endpoint(method, label, wait_for_response)
 
     @typechecked
     def asgi_app(
@@ -617,9 +617,8 @@ class _Stub:
         ] = None,  # Label for created endpoint. Final subdomain will be <workspace>--<label>.modal.run.
         wait_for_response: bool = True,  # Whether requests should wait for and return the function response.
     ):
-        """`stub.asgi_app` is deprecated. Use `modal.asgi_app` instead."""
-        deprecation_warning(date(2023, 4, 18), self.asgi_app.__doc__)
-        return _asgi_app(label, wait_for_response)
+        """`stub.asgi_app` is deprecated and no longer supported. Use `modal.asgi_app` instead."""
+        deprecation_error(date(2023, 4, 18), self.asgi_app.__doc__)
 
     @typechecked
     def wsgi_app(
@@ -629,9 +628,8 @@ class _Stub:
         ] = None,  # Label for created endpoint. Final subdomain will be <workspace>--<label>.modal.run.
         wait_for_response: bool = True,  # Whether requests should wait for and return the function response.
     ):
-        """`stub.wsgi_app` is deprecated. Use `modal.wsgi_app` instead."""
-        deprecation_warning(date(2023, 4, 18), self.wsgi_app.__doc__)
-        return _wsgi_app(label, wait_for_response)
+        """`stub.wsgi_app` is deprecated and no longer supported. Use `modal.wsgi_app` instead."""
+        deprecation_error(date(2023, 4, 18), self.wsgi_app.__doc__)
 
     def webhook(
         self,
@@ -688,15 +686,14 @@ class _Stub:
         )
 
     async def interactive_shell(self, cmd=None, image=None, **kwargs):
-        """`stub.interactive_shell` is deprecated. Use the `modal shell` command instead.
+        """`stub.interactive_shell` is deprecated and no longer supported. Use the `modal shell` command instead.
 
         For programmatic usage, use `modal.runner.interactive_shell`
         """
-        deprecation_warning(
+        deprecation_error(
             date(2023, 5, 9),
             self.interactive_shell.__doc__,
         )
-        await _interactive_shell(self, cmd, image, **kwargs)
 
     def cls(
         self,

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -64,76 +64,10 @@ def deprecated_function(x):
     return x**2
 
 
-# TODO(erikbern): once we remove support for the "old" lifecycle method syntax,
-# let's consolidate some tests - Cube, CubeAsync, and Cls pretty much test
-# the same things (but currently only Cls uses the "new" syntax).
-
-
-with pytest.warns(DeprecationError):
-
-    class Cube:
-        _events: list[str] = []
-
-        def __init__(self):
-            self._events.append("init")
-
-        def __enter__(self):
-            self._events.append("enter")
-
-        def __exit__(self, typ, exc, tb):
-            self._events.append("exit")
-
-        @stub.function()  # Will trigger deprecation warning
-        def f(self, x):
-            self._events.append("call")
-            return x**3
-
-
-with pytest.warns(DeprecationError):
-
-    class CubeAsync:
-        _events: list[str] = []
-
-        def __init__(self):
-            self._events.append("init")
-
-        async def __aenter__(self):
-            self._events.append("enter")
-
-        async def __aexit__(self, typ, exc, tb):
-            self._events.append("exit")
-
-        @stub.function()  # Will trigger deprecation warning
-        async def f(self, x):
-            self._events.append("call")
-            return x**3
-
-
 @stub.function()
 @web_endpoint()
 def webhook(arg="world"):
     return {"hello": arg}
-
-
-with pytest.warns(DeprecationError):
-
-    class WebhookLifecycleClass:
-        _events: list[str] = []
-
-        def __init__(self):
-            self._events.append("init")
-
-        async def __aenter__(self):
-            self._events.append("enter")
-
-        async def __aexit__(self, typ, exc, tb):
-            self._events.append("exit")
-
-        @stub.function()  # Will trigger deprecation warning
-        @web_endpoint()
-        def webhook(self, arg="world"):
-            self._events.append("call")
-            return {"hello": arg}
 
 
 def stream():

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -4,10 +4,9 @@ import asyncio
 from datetime import date
 import time
 
-import pytest
 
 from modal import Stub, method, web_endpoint, asgi_app
-from modal.exception import DeprecationError, deprecation_warning
+from modal.exception import deprecation_warning
 
 SLEEP_DELAY = 0.1
 


### PR DESCRIPTION
Also deleted a bunch of tests for these deprecated methods.

This should make it possible to delete a lot of the stub code soon