### PR TITLE
Adds protos for updating name/web_suffix of environments

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package modal.client;
 
 import "google/protobuf/empty.proto";
+import "google/protobuf/wrappers.proto";
 
 enum AppState {
   APP_STATE_UNSPECIFIED = 0;
@@ -223,10 +224,17 @@ message EnvironmentDeleteRequest {
 
 message EnvironmentListItem {
   string name = 1;
+  string webhook_suffix = 2;
 }
 
 message EnvironmentListResponse {
   repeated EnvironmentListItem items = 2;
+}
+
+message EnvironmentUpdateRequest {
+  string current_name = 1;
+  google.protobuf.StringValue name = 2;
+  google.protobuf.StringValue web_suffix = 3;
 }
 
 enum RegistryType {
@@ -1104,6 +1112,7 @@ service ModalClient {
   rpc EnvironmentCreate(EnvironmentCreateRequest) returns (google.protobuf.Empty);
   rpc EnvironmentList(google.protobuf.Empty) returns (EnvironmentListResponse);
   rpc EnvironmentDelete(EnvironmentDeleteRequest) returns (google.protobuf.Empty);
+  rpc EnvironmentUpdate(EnvironmentUpdateRequest) returns (EnvironmentListItem);
 
   // Functions
   rpc FunctionBindParams(FunctionBindParamsRequest) returns (FunctionBindParamsResponse);


### PR DESCRIPTION
There is currently no way of changing the name of an existing environment, or adjusting the `web_suffix` applied to apps within one