### PR TITLE
Show progress by default

### DIFF
--- a/modal/_output.py
+++ b/modal/_output.py
@@ -31,7 +31,6 @@ from rich.text import Text
 from modal_proto import api_pb2
 from modal_utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES, unary_stream
 
-from ._ipython import is_notebook
 from .client import _Client
 from .config import logger
 
@@ -130,15 +129,10 @@ class OutputManager:
     _status_spinner: Spinner
     _app_page_url: Optional[str]
 
-    def __init__(
-        self, stdout: io.TextIOWrapper, show_progress: Optional[bool], status_spinner_text: str = "Running app..."
-    ):
+    def __init__(self, stdout: io.TextIOWrapper, show_progress: bool, status_spinner_text: str = "Running app..."):
         self.stdout = stdout or sys.stdout
-        if show_progress is None:
-            self._visible_progress = self.stdout.isatty() or is_notebook(self.stdout)
-        else:
-            self._visible_progress = show_progress
 
+        self._visible_progress = show_progress
         self._console = Console(file=stdout, highlight=False)
         self._task_states = {}
         self._task_progress_items = {}

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -31,7 +31,7 @@ async def _run_stub(
     stub,
     client: Optional[_Client] = None,
     stdout=None,
-    show_progress: Optional[bool] = None,
+    show_progress: bool = True,
     detach: bool = False,
     output_mgr: Optional[OutputManager] = None,
     environment_name: Optional[str] = None,
@@ -121,7 +121,7 @@ async def _serve_update(
     # Used by child process to reinitialize a served app
     client = await _Client.from_env()
     try:
-        output_mgr = OutputManager(None, None)
+        output_mgr = OutputManager(None, True)
         app = await _App._init_existing(client, existing_app_id)
 
         # Create objects
@@ -140,7 +140,7 @@ async def _deploy_stub(
     namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
     client=None,
     stdout=None,
-    show_progress=None,
+    show_progress=True,
     object_entity="ap",
     environment_name: Optional[str] = None,
 ) -> _App:


### PR DESCRIPTION
We don't need the manual `isatty()` detection anymore, since `rich` is smart enough to not print progress bars when the output is a TTY. 