### PR TITLE
Remove __init__ from Dict & Queue

### DIFF
--- a/client_test/lookup_test.py
+++ b/client_test/lookup_test.py
@@ -10,7 +10,7 @@ from modal.runner import deploy_stub
 @pytest.mark.asyncio
 async def test_persistent_object(servicer, client):
     stub = Stub()
-    stub["q_1"] = Queue()
+    stub["q_1"] = Queue.new()
     await deploy_stub.aio(stub, "my-queue", client=client)
 
     q: QueueHandle = await Queue.lookup.aio("my-queue", client=client)  # type: ignore
@@ -61,14 +61,14 @@ async def test_webhook_lookup(servicer, client):
 @pytest.mark.asyncio
 async def test_deploy_exists(servicer, client):
     assert not await Queue._exists.aio("my-queue", client=client)  # type: ignore
-    h1: QueueHandle = await Queue()._deploy.aio("my-queue", client=client)
+    h1: QueueHandle = await Queue.new()._deploy.aio("my-queue", client=client)
     assert await Queue._exists.aio("my-queue", client=client)  # type: ignore
-    h2: QueueHandle = await Queue().lookup.aio("my-queue", client=client)  # type: ignore
+    h2: QueueHandle = await Queue.lookup.aio("my-queue", client=client)  # type: ignore
     assert h1.object_id == h2.object_id
 
 
 @pytest.mark.asyncio
 async def test_deploy_retain_id(servicer, client):
-    h1: QueueHandle = await Queue()._deploy.aio("my-queue", client=client)
-    h2: QueueHandle = await Queue()._deploy.aio("my-queue", client=client)
+    h1: QueueHandle = await Queue.new()._deploy.aio("my-queue", client=client)
+    h2: QueueHandle = await Queue.new()._deploy.aio("my-queue", client=client)
     assert h1.object_id == h2.object_id

--- a/client_test/object_test.py
+++ b/client_test/object_test.py
@@ -8,7 +8,7 @@ from modal.exception import InvalidError
 @pytest.mark.asyncio
 async def test_async_factory(client):
     stub = Stub()
-    stub["my_factory"] = Queue()
+    stub["my_factory"] = Queue.new()
     async with stub.run(client=client) as running_app:
         # assert isinstance(running_app["my_factory"], Queue)  # TODO(erikbern(): is a handle now
         assert running_app["my_factory"].object_id == "qu-1"

--- a/client_test/secret_test.py
+++ b/client_test/secret_test.py
@@ -4,21 +4,9 @@ import pytest
 import tempfile
 
 from modal import Secret, Stub
-from modal.exception import DeprecationError, InvalidError
+from modal.exception import InvalidError
 
 from .supports.skip import skip_old_py
-
-
-def test_old_secret(servicer, client):
-    stub = Stub()
-    with pytest.warns(DeprecationError):
-        stub.secret1 = Secret({"FOO": "BAR"})
-        stub.secret2 = Secret({"BAZ": "XYZ"})
-    with stub.run(client=client) as running_app:
-        assert running_app.secret1.object_id == "st-0"
-        assert servicer.secrets["st-0"].env_dict == {"FOO": "BAR"}
-        assert running_app.secret2.object_id == "st-1"
-        assert servicer.secrets["st-1"].env_dict == {"BAZ": "XYZ"}
 
 
 def test_secret_from_dict(servicer, client):

--- a/client_test/serialization_test.py
+++ b/client_test/serialization_test.py
@@ -6,7 +6,7 @@ from modal import Queue, Stub
 
 stub = Stub()
 
-stub.q = Queue()
+stub.q = Queue.new()
 
 
 @pytest.mark.asyncio

--- a/client_test/stub_test.py
+++ b/client_test/stub_test.py
@@ -18,8 +18,8 @@ from modal_test_support import module_1, module_2
 @pytest.mark.asyncio
 async def test_kwargs(servicer, client):
     stub = Stub(
-        d=Dict(),
-        q=Queue(),
+        d=Dict.new(),
+        q=Queue.new(),
     )
     async with stub.run(client=client) as app:
         # TODO: interface to get type safe objects from live apps
@@ -32,8 +32,8 @@ async def test_kwargs(servicer, client):
 @pytest.mark.asyncio
 async def test_attrs(servicer, client):
     stub = Stub()
-    stub.d = Dict()
-    stub.q = Queue()
+    stub.d = Dict.new()
+    stub.q = Queue.new()
     async with stub.run(client=client) as app:
         await app.d.put.aio("foo", "bar")  # type: ignore
         await app.q.put.aio("baz")  # type: ignore
@@ -227,8 +227,8 @@ def test_init_types():
         image=modal.Image.debian_slim().pip_install("pandas"),
         secrets=[modal.Secret.from_dict()],
         mounts=[modal.Mount.from_local_file(__file__)],
-        some_dict=modal.Dict(),
-        some_queue=modal.Queue(),
+        some_dict=modal.Dict.new(),
+        some_queue=modal.Queue.new(),
     )
 
 
@@ -248,14 +248,14 @@ async def test_redeploy_persist(servicer, client):
     stub.function()(square)
     stub.image = Image.debian_slim().pip_install("pandas")
 
-    stub.d = Dict()
+    stub.d = Dict.new()
 
     # Deploy app
     app = await deploy_stub.aio(stub, "my-app", client=client)
     assert app.app_id == "ap-1"
     assert servicer.app_objects["ap-1"]["d"] == "di-0"
 
-    stub.d = Dict().persist("my-dict")
+    stub.d = Dict.new().persist("my-dict")
     # Redeploy, make sure all ids are the same
     app = await deploy_stub.aio(stub, "my-app", client=client)
     assert app.app_id == "ap-1"

--- a/modal/object.py
+++ b/modal/object.py
@@ -184,7 +184,7 @@ class _Provider(Generic[H]):
         self._init(load, rep, is_persisted_ref, preload=preload)
 
     def _init_from_other(self, other: "_Provider"):
-        # Transient use case, see Secret.__inint__
+        # Transient use case, see Queue.__init__ and Dict.__init__
         self._init(other._load, other._rep, other._is_persisted_ref, other._preload)
 
     @classmethod

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -1,5 +1,6 @@
 # Copyright Modal Labs 2022
 import queue  # The system library
+from datetime import date
 import time
 import warnings
 from typing import Any, List, Optional
@@ -10,6 +11,8 @@ from modal_utils.grpc_utils import retry_transient_errors
 
 from ._resolver import Resolver
 from ._serialization import deserialize, serialize
+from ._types import typechecked
+from .exception import deprecation_warning
 from .object import _Handle, _Provider
 
 
@@ -17,7 +20,7 @@ class _QueueHandle(_Handle, type_prefix="qu"):
     """Handle for interacting with the contents of a `Queue`
 
     ```python
-    stub.some_dict = modal.Queue()
+    stub.some_dict = modal.Queue.new()
 
     if __name__ == "__main__":
         with stub.run() as app:
@@ -135,13 +138,21 @@ class _Queue(_Provider[_QueueHandle]):
     The queue can contain any object serializable by `cloudpickle`.
     """
 
-    def __init__(self):
+    @typechecked
+    @staticmethod
+    def new():
         async def _load(resolver: Resolver, existing_object_id: Optional[str]) -> _QueueHandle:
             request = api_pb2.QueueCreateRequest(app_id=resolver.app_id, existing_queue_id=existing_object_id)
             response = await resolver.client.stub.QueueCreate(request)
             return _QueueHandle._from_id(response.queue_id, resolver.client, None)
 
-        super().__init__(_load, "Queue()")
+        return _Queue._from_loader(_load, "Queue()")
+
+    def __init__(self):
+        """`Queue({...})` is deprecated. Please use `Queue.new({...})` instead."""
+        deprecation_warning(date(2023, 6, 27), self.__init__.__doc__)
+        obj = _Queue.new()
+        self._init_from_other(obj)
 
 
 Queue = synchronize_api(_Queue)

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -9,7 +9,7 @@ from modal_proto import api_pb2
 from modal_utils.async_utils import synchronize_api
 
 from ._resolver import Resolver
-from .exception import InvalidError, deprecation_warning
+from .exception import InvalidError, deprecation_error
 from .object import _Handle, _Provider
 
 
@@ -70,9 +70,7 @@ class _Secret(_Provider[_SecretHandle]):
 
     def __init__(self, env_dict: Dict[str, str]):
         """`Secret({...})` is deprecated. Please use `Secret.from_dict({...})` instead."""
-        deprecation_warning(date(2023, 5, 1), self.__init__.__doc__)
-        obj = _Secret.from_dict(env_dict)
-        self._init_from_other(obj)
+        deprecation_error(date(2023, 5, 1), self.__init__.__doc__)
 
     @staticmethod
     def from_dotenv(path=None):

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -530,7 +530,7 @@ class _Stub:
                         "Running multiple interactive functions at the same time is not fully supported, and could lead to unexpected behavior."
                     )
                 else:
-                    self._blueprint["_pty_input_stream"] = _Queue()
+                    self._blueprint["_pty_input_stream"] = _Queue.new()
 
             function = _Function.from_args(
                 function_handle,


### PR DESCRIPTION
This replaces `__init__` with a static factory method.

This will make it a bit easier to merge providers and handles, and it makes these constructors consistent with all other objects.

These objects aren't widely used so hopefully it won't make a big user impact.