### PR TITLE
[MOD-1371] Add experimental volumes API

### DIFF
--- a/client_test/volume_test.py
+++ b/client_test/volume_test.py
@@ -1,0 +1,82 @@
+# Copyright Modal Labs 2023
+
+import pytest
+
+import modal
+from modal.exception import InvalidError
+from modal.volume import VolumeHandle
+
+from .supports.skip import skip_windows
+
+
+def dummy():
+    pass
+
+
+def test_volume_mount(client, servicer):
+    stub = modal.Stub()
+
+    dummy_modal = stub.function(
+        volumes={"/root/foo": modal.Volume()},
+    )(dummy)
+
+    with stub.run(client=client):
+        dummy_modal.call()
+
+
+@skip_windows("TODO: implement client-side path check on Windows.")
+def test_volume_bad_paths(client, servicer):
+    stub = modal.Stub()
+
+    dummy_modal = stub.function(volumes={"/root/../../foo": modal.Volume()})(dummy)
+    with pytest.raises(InvalidError):
+        with stub.run(client=client):
+            dummy_modal.call()
+
+    dummy_modal = stub.function(volumes={"/": modal.Volume()})(dummy)
+    with pytest.raises(InvalidError):
+        with stub.run(client=client):
+            dummy_modal.call()
+
+    dummy_modal = stub.function(volumes={"/tmp/": modal.Volume()})(dummy)
+    with pytest.raises(InvalidError):
+        with stub.run(client=client):
+            dummy_modal.call()
+
+
+def test_volume_duplicate_mount(client, servicer):
+    stub = modal.Stub()
+
+    volume = modal.Volume()
+    dummy_modal = stub.function(volumes={"/foo": volume, "/bar": volume})(dummy)
+    with pytest.raises(InvalidError):
+        with stub.run(client=client):
+            dummy_modal.call()
+
+
+def test_volume_commit(client, servicer):
+    stub = modal.Stub()
+    stub.vol = modal.Volume()
+
+    with stub.run(client=client) as app:
+        handle = app.vol
+        assert isinstance(handle, VolumeHandle)
+        # Note that in practice this will not work unless run in a task.
+        handle.commit()
+
+    assert servicer.volume_commits[handle.object_id] == 1
+    # commit should implicitly reload on successful commit
+    assert servicer.volume_reloads[handle.object_id] == 1
+
+
+def test_volume_reload(client, servicer):
+    stub = modal.Stub()
+    stub.vol = modal.Volume()
+
+    with stub.run(client=client) as app:
+        handle = app.vol
+        assert isinstance(handle, VolumeHandle)
+        # Note that in practice this will not work unless run in a task.
+        handle.reload()
+
+    assert servicer.volume_reloads[handle.object_id] == 1

--- a/client_test/volume_test.py
+++ b/client_test/volume_test.py
@@ -15,43 +15,44 @@ def dummy():
 
 def test_volume_mount(client, servicer):
     stub = modal.Stub()
+    stub.vol = modal.Volume()
 
-    dummy_modal = stub.function(
+    _ = stub.function(
         volumes={"/root/foo": modal.Volume()},
     )(dummy)
 
     with stub.run(client=client):
-        dummy_modal.call()
+        pass
 
 
 @skip_windows("TODO: implement client-side path check on Windows.")
 def test_volume_bad_paths(client, servicer):
     stub = modal.Stub()
 
-    dummy_modal = stub.function(volumes={"/root/../../foo": modal.Volume()})(dummy)
+    _ = stub.function(volumes={"/root/../../foo": modal.Volume()})(dummy)
     with pytest.raises(InvalidError):
         with stub.run(client=client):
-            dummy_modal.call()
+            pass
 
-    dummy_modal = stub.function(volumes={"/": modal.Volume()})(dummy)
+    _ = stub.function(volumes={"/": modal.Volume()})(dummy)
     with pytest.raises(InvalidError):
         with stub.run(client=client):
-            dummy_modal.call()
+            pass
 
-    dummy_modal = stub.function(volumes={"/tmp/": modal.Volume()})(dummy)
+    _ = stub.function(volumes={"/tmp/": modal.Volume()})(dummy)
     with pytest.raises(InvalidError):
         with stub.run(client=client):
-            dummy_modal.call()
+            pass
 
 
 def test_volume_duplicate_mount(client, servicer):
     stub = modal.Stub()
 
     volume = modal.Volume()
-    dummy_modal = stub.function(volumes={"/foo": volume, "/bar": volume})(dummy)
+    _ = stub.function(volumes={"/foo": volume, "/bar": volume})(dummy)
     with pytest.raises(InvalidError):
         with stub.run(client=client):
-            dummy_modal.call()
+            pass
 
 
 def test_volume_commit(client, servicer):

--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -16,6 +16,7 @@ from .schedule import Cron, Period
 from .secret import Secret
 from .shared_volume import SharedVolume
 from .stub import Stub
+from .volume import Volume
 
 __all__ = [
     "__version__",
@@ -35,6 +36,7 @@ __all__ = [
     "Secret",
     "SharedVolume",
     "Stub",
+    "Volume",
     "asgi_app",
     "container_app",
     "create_package_mounts",

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -983,8 +983,8 @@ class _Function(_Provider[_FunctionHandle]):
 
             # Mount point path validation for volumes and shared volumes
             def _validate_mount_points(
-                display_name: str, volume_likes: Dict[Union[str, os.PathLike], Any]
-            ) -> List[Tuple[str, Any]]:
+                display_name: str, volume_likes: Dict[Union[str, os.PathLike], Union[_Volume, _SharedVolume]]
+            ) -> List[Tuple[str, Union[_Volume, _SharedVolume]]]:
                 validated = []
                 for path, vol in volume_likes.items():
                     path = PurePath(path).as_posix()

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -991,13 +991,13 @@ class _Function(_Provider[_FunctionHandle]):
                     abs_path = posixpath.abspath(path)
 
                     if path != abs_path:
-                        raise InvalidError(f"{display_name} {abs_path} must be a canonical, absolute path.")
+                        raise InvalidError(f"{display_name} {path} must be a canonical, absolute path.")
                     elif abs_path == "/":
-                        raise InvalidError(f"{display_name} {abs_path} cannot be mounted into root directory.")
+                        raise InvalidError(f"{display_name} {path} cannot be mounted into root directory.")
                     elif abs_path == "/root":
-                        raise InvalidError(f"{display_name} {abs_path} cannot be mounted at '/root'.")
+                        raise InvalidError(f"{display_name} {path} cannot be mounted at '/root'.")
                     elif abs_path == "/tmp":
-                        raise InvalidError(f"{display_name} {abs_path} cannot be mounted at '/tmp'.")
+                        raise InvalidError(f"{display_name} {path} cannot be mounted at '/tmp'.")
                     validated.append((path, vol))
                 return validated
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -20,6 +20,7 @@ from typing import (
     List,
     Optional,
     Set,
+    Tuple,
     Union,
     Iterable,
 )
@@ -982,8 +983,8 @@ class _Function(_Provider[_FunctionHandle]):
 
             # Mount point path validation for volumes and shared volumes
             def _validate_mount_points(
-                display_name: str, volume_likes: typing.Dict[str, typing.Union[_Volume, _SharedVolume]]
-            ) -> typing.List[typing.Tuple[str, typing.Union[_Volume, _SharedVolume]]]:
+                display_name: str, volume_likes: Dict[Union[str, os.PathLike], Any]
+            ) -> List[Tuple[str, Any]]:
                 validated = []
                 for path, vol in volume_likes.items():
                     path = PurePath(path).as_posix()
@@ -1036,7 +1037,7 @@ class _Function(_Provider[_FunctionHandle]):
                 raise InvalidError("volumes must be a dict[str, Volume] where the keys are paths")
             validated_volumes = _validate_mount_points("Volume", volumes)
             # We don't support mounting a volume in more than one location
-            volume_to_paths = {}
+            volume_to_paths: Dict[_Volume, List[str]] = {}
             for (path, volume) in validated_volumes:
                 volume_to_paths.setdefault(volume, []).append(path)
             for paths in volume_to_paths.values():

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1035,6 +1035,16 @@ class _Function(_Provider[_FunctionHandle]):
             if not isinstance(volumes, dict):
                 raise InvalidError("volumes must be a dict[str, Volume] where the keys are paths")
             validated_volumes = _validate_mount_points("Volume", volumes)
+            # We don't support mounting a volume in more than one location
+            volume_to_paths = {}
+            for (path, volume) in validated_volumes:
+                volume_to_paths.setdefault(volume, []).append(path)
+            for paths in volume_to_paths.values():
+                if len(paths) > 1:
+                    conflicting = ", ".join(paths)
+                    raise InvalidError(
+                        f"The same Volume cannot be mounted in multiple locations for the same function: {conflicting}"
+                    )
 
             async def volume_loader():
                 volume_mounts = []

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -34,6 +34,7 @@ from .runner import _run_stub
 from .schedule import Schedule
 from .secret import _Secret
 from .shared_volume import _SharedVolume
+from .volume import _Volume
 
 _default_image: _Image = _Image.debian_slim()
 
@@ -462,6 +463,7 @@ class _Stub:
         mounts: Sequence[_Mount] = (),
         shared_volumes: Dict[Union[str, os.PathLike], _SharedVolume] = {},
         allow_cross_region_volumes: bool = False,  # Whether using shared volumes from other regions is allowed.
+        volumes: Dict[Union[str, os.PathLike], _Volume] = {},  # Experimental. Do not use!
         cpu: Optional[float] = None,  # How many CPU cores to request. This is a soft limit.
         memory: Optional[int] = None,  # How much memory to request, in MiB. This is a soft limit.
         proxy: Optional[_Proxy] = None,  # Reference to a Modal Proxy to use in front of this function.
@@ -545,6 +547,7 @@ class _Stub:
                 mounts=[*self._mounts, *mounts],
                 shared_volumes=shared_volumes,
                 allow_cross_region_volumes=allow_cross_region_volumes,
+                volumes=volumes,
                 memory=memory,
                 proxy=proxy,
                 retries=retries,
@@ -686,6 +689,7 @@ class _Stub:
         mounts: Sequence[_Mount] = (),
         shared_volumes: Dict[Union[str, os.PathLike], _SharedVolume] = {},
         allow_cross_region_volumes: bool = False,  # Whether using shared volumes from other regions is allowed.
+        volumes: Dict[Union[str, os.PathLike], _Volume] = {},  # Experimental. Do not use!
         cpu: Optional[float] = None,  # How many CPU cores to request. This is a soft limit.
         memory: Optional[int] = None,  # How much memory to request, in MiB. This is a soft limit.
         proxy: Optional[_Proxy] = None,  # Reference to a Modal Proxy to use in front of this function.
@@ -715,6 +719,7 @@ class _Stub:
                         mounts=mounts,
                         shared_volumes=shared_volumes,
                         allow_cross_region_volumes=allow_cross_region_volumes,
+                        volumes=volumes,
                         cpu=cpu,
                         memory=memory,
                         proxy=proxy,

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -1,0 +1,106 @@
+# Copyright Modal Labs 2023
+from typing import Optional
+
+from modal_proto import api_pb2
+from modal_utils.async_utils import synchronize_api
+from modal_utils.grpc_utils import retry_transient_errors
+
+from ._resolver import Resolver
+from .object import _Handle, _Provider
+
+
+class _VolumeHandle(_Handle, type_prefix="vo"):
+    """mdmd:hidden Handle to a `Volume` object."""
+
+    async def commit(self):
+        """Commit changes to the volume and fetch any other changes made to the volume by other tasks.
+
+        Committing always triggers a reload after saving changes.
+
+        If successful, the changes made are now persisted in durable storage and available for other functions/tasks.
+
+        Committing will fail if there are open files for the volume.
+        """
+        req = api_pb2.VolumeCommitRequest(volume_id=self.object_id)
+        _ = await retry_transient_errors(self._client.stub.VolumeCommit, req)
+        # Reload changes on successful commit.
+        await self.reload()
+
+    async def reload(self):
+        """Make changes made by other tasks/functions visible in the volume.
+
+        Uncommitted changes to the volume, such as new or modified files, will be preserved during reload. Uncommitted
+        changes will shadow any changes made by other tasks - e.g. if you have an uncommitted modified a file that was
+        also updated by another task/function you will not see the changes made by the other function/task.
+
+        Reloading will fail if there are open files for the volume.
+        """
+        req = api_pb2.VolumeReloadRequest(volume_id=self.object_id)
+        _ = await retry_transient_errors(self._client.stub.VolumeReload, req)
+
+
+VolumeHandle = synchronize_api(_VolumeHandle)
+
+
+class _Volume(_Provider[_VolumeHandle]):
+    """mdmd:hidden A writeable volume that can be used to share files between one or more Modal functions.
+
+    The contents of a volume is exposed as a filesystem. You can use it to share data between different functions, or
+    to persist durable state across several instances of the same function.
+
+    Unlike a networked filesystem, you need to explicitly reload the volume to see changes made since it was mounted.
+    Similarly, you need to explicitly commit any changes you make to the volume for the changes to become visible
+    outside the current task.
+
+    Concurrent modification is supported, but concurrent modifications of the same files should be avoided! Last write
+    wins in case of concurrent modification of the same file - any data the last writer didn't have when committing
+    changes will be lost!
+
+    As a result, volumes are typically not a good fit for use cases where you need to make concurrent modifications to
+    the same file (nor is distributed file locking supported).
+
+    Volumes can only be committed and reloaded if there are no open files for the volume - attempting to reload or
+    commit with open files will result in an error.
+
+    **Usage**
+
+    ```python
+    import modal
+
+    stub = modal.Stub()
+    stub.volume = modal.Volume()
+
+    @stub.function(volumes={"/root/foo": stub.volume})
+    def f():
+        with open("/root/foo/bar.txt", "w") as f:
+            f.write("hello")
+        stub.app.volume.commit()  # Persist changes
+
+    @stub.function(volumes={"/root/foo": stub.volume})
+    def g():
+        stub.app.volume.reload()  # Fetch latest changes
+        with open("/root/foo/bar.txt", "r") as f:
+            print(f.read())
+    ```
+    """
+
+    def __init__(self) -> None:
+        """Construct a new volume, which is empty by default."""
+
+        async def _load(resolver: Resolver, existing_object_id: Optional[str]) -> _VolumeHandle:
+            status_row = resolver.add_status_row()
+            if existing_object_id:
+                # Volume already exists; do nothing.
+                return _VolumeHandle._from_id(existing_object_id, resolver.client, None)
+
+            status_row.message("Creating volume...")
+            req = api_pb2.VolumeCreateRequest(app_id=resolver.app_id)
+            resp = await retry_transient_errors(resolver.client.stub.VolumeCreate, req)
+            status_row.finish("Created volume.")
+            return _VolumeHandle._from_id(resp.volume_id, resolver.client, None)
+
+        rep = "Volume()"
+        super().__init__(_load, rep)
+
+
+Volume = synchronize_api(_Volume)

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -446,6 +446,8 @@ message Function {
   string stub_name = 31;
 
   bool is_builder_function = 32;
+
+  repeated VolumeMount volume_mounts = 33;
 }
 
 message FunctionHandleMetadata {
@@ -1060,6 +1062,31 @@ message TokenFlowWaitResponse {
   bool timeout = 3;
 }
 
+message VolumeCreateRequest {
+  string app_id = 1;
+}
+
+message VolumeCreateResponse {
+  string volume_id = 1;
+}
+
+message VolumeCommitRequest {
+  // NOTE(staffan): Mounting a volume in multiple locations is not supported, so volume_id alone uniquely identifies
+  // a volume mount.
+  string volume_id = 1;
+}
+
+message VolumeReloadRequest {
+  // NOTE(staffan): Mounting a volume in multiple locations is not supported, so volume_id alone uniquely identifies
+  // a volume mount.
+  string volume_id = 1;
+}
+
+message VolumeMount {
+  string volume_id = 1;
+  string mount_path = 2;
+}
+
 message WebhookConfig {
   WebhookType type = 1;
   string method = 2;
@@ -1162,4 +1189,9 @@ service ModalClient {
   // Tokens (web auth flow)
   rpc TokenFlowCreate(TokenFlowCreateRequest) returns (TokenFlowCreateResponse);
   rpc TokenFlowWait(TokenFlowWaitRequest) returns (TokenFlowWaitResponse);
+
+  // Volumes
+  rpc VolumeCreate(VolumeCreateRequest) returns (VolumeCreateResponse);
+  rpc VolumeCommit(VolumeCommitRequest) returns (google.protobuf.Empty);
+  rpc VolumeReload(VolumeReloadRequest) returns (google.protobuf.Empty);
 }

--- a/tasks.py
+++ b/tasks.py
@@ -146,5 +146,6 @@ def type_stubs(ctx):
         "modal.secret",
         "modal.shared_volume",
         "modal.stub",
+        "modal.volume",
     ]
     subprocess.check_call(["python", "-m", "synchronicity.type_stubs", *modules])


### PR DESCRIPTION
This is API for working with volumes, which are durable storage units exposed via the file system. Unlike a networked file system changes to the volumes are only made visible when explcitly committed. Similarly, to get updates to the volume you need to explicitly reload.

Note that the backend support for volumes is not yet in place, so they are non-functional as is.