### PR TITLE
Prevent concurrent operations on a single volume

### DIFF
--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -1,10 +1,9 @@
-# Copyright Modal Labs 2022
+# Copyright Modal Labs 2022-2023
 import os
 import sys
 import tempfile
 import traceback
 import unittest.mock
-from contextlib import asynccontextmanager
 from unittest import mock
 from typing import List, Optional
 
@@ -16,6 +15,7 @@ import pytest_asyncio
 from modal.cli.entry_point import entrypoint_cli
 from modal import Client
 from modal_proto import api_pb2
+from modal_utils.async_utils import asyncnullcontext
 
 dummy_app_file = """
 import modal
@@ -285,13 +285,9 @@ def mock_shell_pty():
             env_term_program=os.environ.get("TERM_PROGRAM"),
         )
 
-    @asynccontextmanager
-    async def noop_async_context_manager(*args, **kwargs):
-        yield
-
     with mock.patch("rich.console.Console.is_terminal", True), mock.patch(
         "modal._pty.get_pty_info", mock_get_pty_info
-    ), mock.patch("modal._pty.write_stdin_to_pty_stream", noop_async_context_manager):
+    ), mock.patch("modal._pty.write_stdin_to_pty_stream", asyncnullcontext):
         yield
 
 

--- a/client_test/volume_test.py
+++ b/client_test/volume_test.py
@@ -15,7 +15,6 @@ def dummy():
 
 def test_volume_mount(client, servicer):
     stub = modal.Stub()
-    stub.vol = modal.Volume()
 
     _ = stub.function(
         volumes={"/root/foo": modal.Volume()},

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -1,4 +1,5 @@
 # Copyright Modal Labs 2023
+import asyncio
 from typing import Optional
 
 from modal_proto import api_pb2
@@ -12,6 +13,12 @@ from .object import _Handle, _Provider
 class _VolumeHandle(_Handle, type_prefix="vo"):
     """mdmd:hidden Handle to a `Volume` object."""
 
+    _lock: asyncio.Lock
+
+    def _initialize_from_empty(self):
+        # To prevent multiple concurrent operations on the same volume.
+        self._lock = asyncio.Lock()
+
     async def commit(self):
         """Commit changes to the volume and fetch any other changes made to the volume by other tasks.
 
@@ -21,10 +28,11 @@ class _VolumeHandle(_Handle, type_prefix="vo"):
 
         Committing will fail if there are open files for the volume.
         """
-        req = api_pb2.VolumeCommitRequest(volume_id=self.object_id)
-        _ = await retry_transient_errors(self._client.stub.VolumeCommit, req)
-        # Reload changes on successful commit.
-        await self.reload()
+        async with self._lock:
+            req = api_pb2.VolumeCommitRequest(volume_id=self.object_id)
+            _ = await retry_transient_errors(self._client.stub.VolumeCommit, req)
+            # Reload changes on successful commit.
+            await self._do_reload(lock=False)
 
     async def reload(self):
         """Make changes made by other tasks/functions visible in the volume.
@@ -35,8 +43,17 @@ class _VolumeHandle(_Handle, type_prefix="vo"):
 
         Reloading will fail if there are open files for the volume.
         """
-        req = api_pb2.VolumeReloadRequest(volume_id=self.object_id)
-        _ = await retry_transient_errors(self._client.stub.VolumeReload, req)
+        await self._do_reload()
+
+    async def _do_reload(self, lock=True):
+        if lock:
+            await self._lock.acquire()
+        try:
+            req = api_pb2.VolumeReloadRequest(volume_id=self.object_id)
+            _ = await retry_transient_errors(self._client.stub.VolumeReload, req)
+        finally:
+            if lock:
+                self._lock.release()
 
 
 VolumeHandle = synchronize_api(_VolumeHandle)

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -16,7 +16,10 @@ class _VolumeHandle(_Handle, type_prefix="vo"):
     _lock: asyncio.Lock
 
     def _initialize_from_empty(self):
-        # To prevent multiple concurrent operations on the same volume.
+        # To (mostly*) prevent multiple concurrent operations on the same volume, which can cause problems under
+        # some unlikely circumstances.
+        # *: You can bypass this by creating multiple handles to the same volume, e.g. via lookup. But this
+        # covers the typical case = good enough.
         self._lock = asyncio.Lock()
 
     async def commit(self):

--- a/modal_utils/async_utils.py
+++ b/modal_utils/async_utils.py
@@ -5,6 +5,7 @@ import functools
 import inspect
 import time
 import typing
+from contextlib import asynccontextmanager
 from typing import Any, Awaitable, Callable, List, Optional, Set, TypeVar
 from typing_extensions import ParamSpec
 
@@ -328,3 +329,16 @@ class ConcurrencyPool:
                 return await coro
 
         return await asyncio.gather(*coros, return_exceptions=return_exceptions)
+
+
+@asynccontextmanager
+async def asyncnullcontext(*args, **kwargs):
+    """Async noop context manager.
+
+    Note that for Python 3.10+ you can use contextlib.nullcontext() instead.
+
+    Usage:
+    async with asyncnullcontext():
+        pass
+    """
+    yield


### PR DESCRIPTION
We don't support concurrent reload/commit requests for the same volume. Most of the time this will just result in an error but under certain (unlikely) circumstances this will cause problems.

Use a lock on the volume handle to prevent this. You can still create concurrent operations by instantiating several handles (e.g. via `Volume.lookup()`), but this should prevent the most common case. Good enough?