### PR TITLE
Deprecate SharedVolume constructor

### DIFF
--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -513,7 +513,7 @@ with pytest.raises(DeprecationError):
 
 def test_allow_cross_region_volumes(client, servicer):
     stub = Stub()
-    vol1, vol2 = SharedVolume(), SharedVolume()
+    vol1, vol2 = SharedVolume.new(), SharedVolume.new()
     # Should pass flag for all the function's SharedVolumeMounts
     stub.function(shared_volumes={"/sv-1": vol1, "/sv-2": vol2}, allow_cross_region_volumes=True)(dummy)
 
@@ -528,7 +528,7 @@ def test_allow_cross_region_volumes(client, servicer):
 def test_allow_cross_region_volumes_webhook(client, servicer):
     # TODO(erikbern): this stest seems a bit redundant
     stub = Stub()
-    vol1, vol2 = SharedVolume(), SharedVolume()
+    vol1, vol2 = SharedVolume.new(), SharedVolume.new()
     # Should pass flag for all the function's SharedVolumeMounts
     stub.function(shared_volumes={"/sv-1": vol1, "/sv-2": vol2}, allow_cross_region_volumes=True)(web_endpoint()(dummy))
 

--- a/client_test/image_test.py
+++ b/client_test/image_test.py
@@ -278,7 +278,7 @@ def run_f():
 
 def test_image_run_function(client, servicer):
     stub = Stub()
-    volume = SharedVolume().persist("test-vol")
+    volume = SharedVolume.persisted("test-vol")
     stub["image"] = (
         Image.debian_slim()
         .pip_install("pandas")

--- a/client_test/resolver_test.py
+++ b/client_test/resolver_test.py
@@ -18,15 +18,14 @@ async def test_multi_resolve_sequential_loads_once():
     load_count = 0
 
     class DumbObject(_Provider):
-        def __init__(self):
-            async def _load(resolver: Resolver, existing_object_id: Optional[str]):
-                nonlocal load_count
-                load_count += 1
-                await asyncio.sleep(0.1)
+        pass
 
-            super().__init__(_load, "DumbObject()")
+    async def _load(resolver: Resolver, existing_object_id: Optional[str]):
+        nonlocal load_count
+        load_count += 1
+        await asyncio.sleep(0.1)
 
-    obj = DumbObject()
+    obj = DumbObject._from_loader(_load, "DumbObject()")
 
     t0 = time.monotonic()
     await resolver.load(obj)
@@ -44,15 +43,14 @@ async def test_multi_resolve_concurrent_loads_once():
     load_count = 0
 
     class DumbObject(_Provider):
-        def __init__(self):
-            async def _load(resolver: Resolver, existing_object_id: Optional[str]):
-                nonlocal load_count
-                load_count += 1
-                await asyncio.sleep(0.1)
+        pass
 
-            super().__init__(_load, "DumbObject()")
+    async def _load(resolver: Resolver, existing_object_id: Optional[str]):
+        nonlocal load_count
+        load_count += 1
+        await asyncio.sleep(0.1)
 
-    obj = DumbObject()
+    obj = DumbObject._from_loader(_load, "DumbObject()")
     t0 = time.monotonic()
     await asyncio.gather(resolver.load(obj), resolver.load(obj))
     assert 0.1 < time.monotonic() - t0 < 0.15

--- a/client_test/stub_test.py
+++ b/client_test/stub_test.py
@@ -255,7 +255,7 @@ async def test_redeploy_persist(servicer, client):
     assert app.app_id == "ap-1"
     assert servicer.app_objects["ap-1"]["d"] == "di-0"
 
-    stub.d = Dict.new().persist("my-dict")
+    stub.d = Dict.persisted("my-dict")
     # Redeploy, make sure all ids are the same
     app = await deploy_stub.aio(stub, "my-app", client=client)
     assert app.app_id == "ap-1"

--- a/client_test/volume_test.py
+++ b/client_test/volume_test.py
@@ -17,7 +17,7 @@ def test_volume_mount(client, servicer):
     stub = modal.Stub()
 
     _ = stub.function(
-        volumes={"/root/foo": modal.Volume()},
+        volumes={"/root/foo": modal.Volume.new()},
     )(dummy)
 
     with stub.run(client=client):
@@ -28,17 +28,17 @@ def test_volume_mount(client, servicer):
 def test_volume_bad_paths(client, servicer):
     stub = modal.Stub()
 
-    _ = stub.function(volumes={"/root/../../foo": modal.Volume()})(dummy)
+    _ = stub.function(volumes={"/root/../../foo": modal.Volume.new()})(dummy)
     with pytest.raises(InvalidError):
         with stub.run(client=client):
             pass
 
-    _ = stub.function(volumes={"/": modal.Volume()})(dummy)
+    _ = stub.function(volumes={"/": modal.Volume.new()})(dummy)
     with pytest.raises(InvalidError):
         with stub.run(client=client):
             pass
 
-    _ = stub.function(volumes={"/tmp/": modal.Volume()})(dummy)
+    _ = stub.function(volumes={"/tmp/": modal.Volume.new()})(dummy)
     with pytest.raises(InvalidError):
         with stub.run(client=client):
             pass
@@ -47,7 +47,7 @@ def test_volume_bad_paths(client, servicer):
 def test_volume_duplicate_mount(client, servicer):
     stub = modal.Stub()
 
-    volume = modal.Volume()
+    volume = modal.Volume.new()
     _ = stub.function(volumes={"/foo": volume, "/bar": volume})(dummy)
     with pytest.raises(InvalidError):
         with stub.run(client=client):
@@ -56,7 +56,7 @@ def test_volume_duplicate_mount(client, servicer):
 
 def test_volume_commit(client, servicer):
     stub = modal.Stub()
-    stub.vol = modal.Volume()
+    stub.vol = modal.Volume.new()
 
     with stub.run(client=client) as app:
         handle = app.vol
@@ -71,7 +71,7 @@ def test_volume_commit(client, servicer):
 
 def test_volume_reload(client, servicer):
     stub = modal.Stub()
-    stub.vol = modal.Volume()
+    stub.vol = modal.Volume.new()
 
     with stub.run(client=client) as app:
         handle = app.vol

--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -75,7 +75,7 @@ def create(
     env: Optional[str] = typer.Option(None, help=ENV_OPTION_HELP, hidden=True),
 ):
     ensure_env(env)
-    volume = modal.SharedVolume(cloud=cloud)
+    volume = modal.SharedVolume.new(cloud=cloud)
     volume._deploy(name, environment_name=env)
     console = Console()
     console.print(f"Created volume '{name}' in {cloud.upper()}. \n\nCode example:\n")

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -139,7 +139,7 @@ class _Dict(_Provider[_DictHandle]):
 
     @typechecked
     @staticmethod
-    def new(data={}):
+    def new(data={}) -> "_Dict":
         """Create a new dictionary, optionally filled with initial data."""
 
         async def _load(resolver: Resolver, existing_object_id: Optional[str]) -> _DictHandle:
@@ -158,6 +158,19 @@ class _Dict(_Provider[_DictHandle]):
         deprecation_warning(date(2023, 6, 27), self.__init__.__doc__)
         obj = _Dict.new(data)
         self._init_from_other(obj)
+
+    @staticmethod
+    def persisted(
+        label: str, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, environment_name: Optional[str] = None
+    ) -> "_Dict":
+        return _Dict.new()._persist(label, namespace, environment_name)
+
+    def persist(
+        self, label: str, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, environment_name: Optional[str] = None
+    ) -> "_Dict":
+        """`Dict().persist("my-dict")` is deprecated. Use `Dict.persisted("my-dict")` instead."""
+        deprecation_warning(date(2023, 6, 30), self.persist.__doc__)
+        return self.persisted(label, namespace, environment_name)
 
 
 Dict = synchronize_api(_Dict)

--- a/modal/object.py
+++ b/modal/object.py
@@ -1,4 +1,5 @@
 # Copyright Modal Labs 2022
+from datetime import date
 import uuid
 from typing import Awaitable, Callable, Generic, Optional, Type, TypeVar
 
@@ -14,7 +15,7 @@ from ._object_meta import ObjectMeta
 from ._resolver import Resolver
 from .client import _Client
 from .config import config
-from .exception import InvalidError, NotFoundError
+from .exception import InvalidError, NotFoundError, deprecation_error
 
 H = TypeVar("H", bound="_Handle")
 
@@ -184,7 +185,7 @@ class _Provider(Generic[H]):
         self._init(load, rep, is_persisted_ref, preload=preload)
 
     def _init_from_other(self, other: "_Provider"):
-        # Transient use case, see Queue.__init__ and Dict.__init__
+        # Transient use case, see Dict, Queue, and SharedVolume
         self._init(other._load, other._rep, other._is_persisted_ref, other._preload)
 
     @classmethod
@@ -239,8 +240,18 @@ class _Provider(Generic[H]):
         await app.deploy(label, namespace, object_entity)  # TODO(erikbern): not needed if the app already existed
         return handle
 
-    @typechecked
     def persist(
+        self, label: str, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, environment_name: Optional[str] = None
+    ):
+        """`Provider.persist` is deprecated for generic objects. See `SharedVolume.persisted` or `Dict.persisted`."""
+        # Note: this method is overridden in SharedVolume in Dict to print a warning
+        deprecation_error(
+            date(2023, 6, 30),
+            self.persist.__doc__,
+        )
+
+    @typechecked
+    def _persist(
         self, label: str, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, environment_name: Optional[str] = None
     ):
         """Deploy a Modal app containing this object. This object can then be imported from other apps using

--- a/modal/object.py
+++ b/modal/object.py
@@ -161,6 +161,9 @@ class _Provider(Generic[H]):
     _load: Callable[[Resolver, Optional[str]], Awaitable[H]]
     _preload: Optional[Callable[[Resolver, Optional[str]], Awaitable[H]]]
 
+    def __init__(self):
+        raise Exception("__init__ disallowed, use proper classmethods")
+
     def _init(
         self,
         load: Callable[[Resolver, Optional[str]], Awaitable[H]],
@@ -173,16 +176,6 @@ class _Provider(Generic[H]):
         self._preload = preload
         self._rep = rep
         self._is_persisted_ref = is_persisted_ref
-
-    def __init__(
-        self,
-        load: Callable[[Resolver, Optional[str]], Awaitable[H]],
-        rep: str,
-        is_persisted_ref: bool = False,
-        preload: Optional[Callable[[Resolver, Optional[str]], Awaitable[H]]] = None,
-    ):
-        # TODO(erikbern): this is semi-deprecated - subclasses should use _from_loader
-        self._init(load, rep, is_persisted_ref, preload=preload)
 
     def _init_from_other(self, other: "_Provider"):
         # Transient use case, see Dict, Queue, and SharedVolume

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -83,7 +83,7 @@ class _Volume(_Provider[_VolumeHandle]):
     import modal
 
     stub = modal.Stub()
-    stub.volume = modal.Volume()
+    stub.volume = modal.Volume.new()
 
     @stub.function(volumes={"/root/foo": stub.volume})
     def f():
@@ -99,7 +99,8 @@ class _Volume(_Provider[_VolumeHandle]):
     ```
     """
 
-    def __init__(self) -> None:
+    @staticmethod
+    def new() -> "_Volume":
         """Construct a new volume, which is empty by default."""
 
         async def _load(resolver: Resolver, existing_object_id: Optional[str]) -> _VolumeHandle:
@@ -114,8 +115,7 @@ class _Volume(_Provider[_VolumeHandle]):
             status_row.finish("Created volume.")
             return _VolumeHandle._from_id(resp.volume_id, resolver.client, None)
 
-        rep = "Volume()"
-        super().__init__(_load, rep)
+        return _Volume._from_loader(_load, "Volume()")
 
 
 Volume = synchronize_api(_Volume)


### PR DESCRIPTION
This deprecates the constructor of `SharedVolume` in favor of `SharedVolume.new()` – this was the last remaining use of the constructor since #608 (EDIT: updated `Volume` as well, which is not used atm)

In order to avoid the awkward `SharedVolume.new().persist("my-volume")` I added a classemethod `.persisted` instead. So going forward it's going to be `SharedVolume.persisted("my-volume")`. I updated the `Dict` code to have a similar syntax, but otherwise got rid of support for persisting generic objects – it's only used for those two at this point (and will potentially be deprecated later).

All of this (with the exception of removing `.persist` for generic objects) is backwards compatible but will start to print deprecation warnings for now. We can delete a bunch of code once everything has been fully unsupported – probably a few months down the road.

If we want to rename `SharedVolume`, it's probably good to do that very soon. Doesn't have to be the same PR, but the longer we wait, the more users will have to do two different migrations to their code. Vs if we do it in quick succession then most users can change both things at once.