### PR TITLE
Don't build base image for conda 3.7

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -69,6 +69,9 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         image-name: ["debian_slim", "conda", "micromamba"]
+        exclude:
+          - python-version: "3.7"
+            image-name: "conda"
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Not supported