### PR TITLE
fix bug where profile-default environment wasn't used for `modal run`

### DIFF
--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -159,7 +159,7 @@ class RunGroup(click.Group):
 )
 @click.option("-q", "--quiet", is_flag=True, help="Don't show Modal progress indicators.")
 @click.option("-d", "--detach", is_flag=True, help="Don't stop the app if the local process dies or disconnects.")
-@click.option("-e", "--env", help=ENV_OPTION_HELP, default="", hidden=True)
+@click.option("-e", "--env", help=ENV_OPTION_HELP, default=None, hidden=True)
 @click.pass_context
 def run(ctx, detach, quiet, env):
     """Run a Modal function or local entrypoint


### PR DESCRIPTION
The environment set by environment variable or `.modal.toml` wasn't being used by `modal run` since it had the empty string as the default instead of None (empty string is a valid value used to communiate "use the only existing one", for compatibility with old clients)