### PR TITLE
Fix docstring in config.py

### DIFF
--- a/modal/config.py
+++ b/modal/config.py
@@ -1,5 +1,5 @@
 # Copyright Modal Labs 2022
-"""Modal intentionally keeps configurability to a minimum.
+r"""Modal intentionally keeps configurability to a minimum.
 
 The main configuration options are the API tokens: the token id and the token secret.
 These can be configured in two ways:


### PR DESCRIPTION
It wasn't a raw string, so the backslashes were treated as escape sequences and not showing up in the docs.