### PR TITLE
Make it possible to set a default cloud from config or an env var

### DIFF
--- a/modal/config.py
+++ b/modal/config.py
@@ -156,6 +156,7 @@ _SETTINGS = {
     "heartbeat_interval": _Setting(15, float),
     "function_runtime": _Setting(),
     "environment": _Setting(),
+    "default_cloud": _Setting(None, transform=lambda x: x if x else None),
 }
 
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -924,6 +924,8 @@ class _Function(_Provider[_FunctionHandle]):
                 "Setting `keep_warm=True` is deprecated. Pass an explicit warm pool size instead, e.g. `keep_warm=2`.",
             )
 
+        if not cloud:
+            cloud = config.get("default_cloud")
         if cloud:
             cloud_provider = parse_cloud_provider(cloud)
         else:


### PR DESCRIPTION
Primarily planning to use this for internal synthetic monitors, but this can also be useful for cases where people only want to use a particular cloud (and more importantly, a particular region in the future)