### PR TITLE
Enable sending utm_source as a part of the token flow too

### DIFF
--- a/modal/cli/token.py
+++ b/modal/cli/token.py
@@ -43,11 +43,11 @@ def set(
 
 
 @token_cli.command(help="Creates a new token by using an authenticated web session.")
-def new(profile: Optional[str] = profile_option, no_verify: bool = False):
+def new(profile: Optional[str] = profile_option, no_verify: bool = False, source: Optional[str] = None):
     server_url = config.get("server_url", profile=profile)
 
     with Client.unauthenticated_client(server_url) as client:
-        token_flow_id, web_url = client.start_token_flow()
+        token_flow_id, web_url = client.start_token_flow(source)
         console = Console()
         with console.status("Waiting for authentication in the web browser...", spinner="dots"):
             # Open the web url in the browser

--- a/modal/client.py
+++ b/modal/client.py
@@ -168,12 +168,13 @@ class _Client:
         # To be used with the token flow
         return _Client(server_url, api_pb2.CLIENT_TYPE_CLIENT, None, no_verify=True)
 
-    async def start_token_flow(self) -> Tuple[str, str]:
+    async def start_token_flow(self, utm_source: Optional[str] = None) -> Tuple[str, str]:
         # Create token creation request
         # Send some strings identifying the computer (these are shown to the user for security reasons)
         req = api_pb2.TokenFlowCreateRequest(
             node_name=platform.node(),
             platform_name=platform.platform(),
+            utm_source=utm_source,
         )
         resp = await self.stub.TokenFlowCreate(req)
         return (resp.token_flow_id, resp.web_url)

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1045,6 +1045,7 @@ message TaskResultRequest {
 message TokenFlowCreateRequest {
   string node_name = 1;
   string platform_name = 2;
+  string utm_source = 3;
 }
 
 message TokenFlowCreateResponse {


### PR DESCRIPTION
Makes it possible to (optionally) track the source of a signup through the token flow