### PR TITLE
Support `modal shell` with no arguments

### DIFF
--- a/modal/cli/entry_point.py
+++ b/modal/cli/entry_point.py
@@ -89,8 +89,8 @@ entrypoint_cli_typer.add_typer(volume_cli)
 
 entrypoint_cli_typer.command("deploy", help="Deploy a Modal stub as an application.", no_args_is_help=True)(run.deploy)
 entrypoint_cli_typer.command("serve", no_args_is_help=True)(run.serve)
-entrypoint_cli_typer.command("shell", no_args_is_help=True)(run.shell)
 entrypoint_cli_typer.command("setup", help="Bootstrap Modal's configuration.")(setup)
+entrypoint_cli_typer.command("shell")(run.shell)
 
 entrypoint_cli = typer.main.get_command(entrypoint_cli_typer)
 entrypoint_cli.add_command(run.run, name="run")  # type: ignore

--- a/modal/cli/import_refs.py
+++ b/modal/cli/import_refs.py
@@ -181,7 +181,7 @@ def import_stub(stub_ref: str) -> Stub:
     return stub
 
 
-def _show_function_ref_help(stub_ref: ImportRef, base_cmd) -> None:
+def _show_function_ref_help(stub_ref: ImportRef, base_cmd: str) -> None:
     object_path = stub_ref.object_path
     import_path = stub_ref.file_or_module
     error_console = Console(stderr=True)

--- a/modal/cli/utils.py
+++ b/modal/cli/utils.py
@@ -45,9 +45,9 @@ def display_selection(choices: List[str], active: str, json: bool):
             console.print(text)
 
 
-ENV_OPTION_HELP = """Environment to interact with
+ENV_OPTION_HELP = """Environment to interact with.
 
-If none is specified, Modal will use the default environment of your current profile (can also be specified via the environment variable MODAL_ENVIRONMENT).
-If neither is set, Modal will assume there is only one environment in the active workspace and use that one, or raise an error if there are multiple environments.
+If not specified, Modal will use the default environment of your current profile, or the `MODAL_ENVIRONMENT` variable.
+Otherwise, raises an error if the workspace has multiple environments.
 """
 ENV_OPTION = typer.Option(default=None, help=ENV_OPTION_HELP)


### PR DESCRIPTION
Let me know if this is within scope, but I wanted to suggest that

```bash
modal shell
```

could create a new shell in the base Debian image by default. It seems like a more basic behavior that lets people interactively try out a shell in Modal without first having to create a file just to do so. Defaults matter here I think, and this just working the first time could be nice.

It's a quick utility and an example to show what Modal can do.

```bash
modal shell

modal shell --image python:3.11 --cpu 24 --memory 65536

modal shell --image pytorch/pytorch:2.0.1-cuda11.7-cudnn8-devel --gpu a10g:4
```

Resolves MOD-1426.