### PR TITLE
Make all decorator arguments keyword-only

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1367,6 +1367,7 @@ def _method(
 
 @typechecked
 def _web_endpoint(
+    *,
     method: str = "GET",  # REST method for the created endpoint.
     label: Optional[str] = None,  # Label for created endpoint. Final subdomain will be <workspace>--<label>.modal.run.
     wait_for_response: bool = True,  # Whether requests should wait for and return the function response.
@@ -1428,6 +1429,7 @@ def _web_endpoint(
 
 @typechecked
 def _asgi_app(
+    *,
     label: Optional[str] = None,  # Label for created endpoint. Final subdomain will be <workspace>--<label>.modal.run.
     wait_for_response: bool = True,  # Whether requests should wait for and return the function response.
 ) -> Callable[[Callable[..., Any]], _PartialFunction]:
@@ -1474,6 +1476,7 @@ def _asgi_app(
 
 @typechecked
 def _wsgi_app(
+    *,
     label: Optional[str] = None,  # Label for created endpoint. Final subdomain will be <workspace>--<label>.modal.run.
     wait_for_response: bool = True,  # Whether requests should wait for and return the function response.
 ) -> Callable[[Callable[..., Any]], _PartialFunction]:

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -379,7 +379,7 @@ class _Stub:
         """Names of web endpoint (ie. webhook) functions registered on the stub."""
         return self._web_endpoints
 
-    def local_entrypoint(self, name: Optional[str] = None) -> Callable[[Callable[..., Any]], None]:
+    def local_entrypoint(self, *, name: Optional[str] = None) -> Callable[[Callable[..., Any]], None]:
         """Decorate a function to be used as a CLI entrypoint for a Modal App.
 
         These functions can be used to define code that runs locally to set up the app,
@@ -438,6 +438,7 @@ class _Stub:
     @typechecked
     def function(
         self,
+        *,
         image: Optional[_Image] = None,  # The image to run as the container for the function
         schedule: Optional[Schedule] = None,  # An optional Modal Schedule for the function
         secret: Optional[_Secret] = None,  # An optional Modal Secret with environment variables for the container
@@ -621,6 +622,7 @@ class _Stub:
 
     def cls(
         self,
+        *,
         image: Optional[_Image] = None,  # The image to run as the container for the function
         secret: Optional[_Secret] = None,  # An optional Modal Secret with environment variables for the container
         secrets: Sequence[_Secret] = (),  # Plural version of `secret` when multiple secrets are needed


### PR DESCRIPTION
Currently if you forget the parantheses on `local_entrypoint`, you get this error:

```
erikbern@Eriks-MacBook-Air modal % modal run analytics/container_utilization.py
╭─ Error ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ You need to specify a Modal function or local entrypoint to run, e.g.                                                                                                                            │
│                                                                                                                                                                                                  │
│ modal run app.py::my_function [...args]                                                                                                                                                          │
│                                                                                                                                                                                                  │
│ Registered functions and local entrypoints on the selected stub are:                                                                                                                             │
│ get_top_functions                                                                                                                                                                                │
│ get_usernames                                                                                                                                                                                    │
│                                                                                                                                                                                                  │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

This change sort of catches it, although in an awkward way:

`TypeError: _Stub.local_entrypoint() takes 1 positional argument but 2 were given`

I think that's a very marginal improvement. But we probably should never allow positional arguments in the decorator either way because it makes it easier to make these mistakes. Making everything keyword only makes sense as a step in itself, but we should probably improve the error message when you forget the parantheses too