### PR TITLE
Remove usage of the deprecated web_url* fields

### DIFF
--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -120,7 +120,6 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
         self.cleared_function_calls = set()
 
-        self.enforce_object_entity = True
         self.cancelled_calls = []
 
         self.app_client_disconnect_count = 0
@@ -226,7 +225,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         else:
             object_id = request.object_id
 
-        if request.app_name and self.enforce_object_entity:
+        if request.app_name:
             assert request.object_entity
             if object_id:
                 assert object_id.startswith(request.object_entity)

--- a/modal/client.py
+++ b/modal/client.py
@@ -213,30 +213,30 @@ class _Client:
             client_type = api_pb2.CLIENT_TYPE_CLIENT
             credentials = None
 
-        if cls._client_from_env:
-            return cls._client_from_env
-
         if cls._client_from_env_lock is None:
             cls._client_from_env_lock = asyncio.Lock()
 
         async with cls._client_from_env_lock:
-            client = _Client(server_url, client_type, credentials)
-            await client._open()
-            async_utils.on_shutdown(client._close())
-            try:
-                await client._verify()
-            except AuthError:
-                if not credentials:
-                    creds_missing_msg = (
-                        "Token missing. Could not authenticate client. "
-                        "If you have token credentials, see modal.com/docs/reference/modal.config for setup help. "
-                        "If you are a new user, register an account at modal.com, then run `modal token new`."
-                    )
-                    raise AuthError(creds_missing_msg)
-                else:
-                    raise
-            cls._client_from_env = client
-            return client
+            if cls._client_from_env:
+                return cls._client_from_env
+            else:
+                client = _Client(server_url, client_type, credentials)
+                await client._open()
+                async_utils.on_shutdown(client._close())
+                try:
+                    await client._verify()
+                except AuthError:
+                    if not credentials:
+                        creds_missing_msg = (
+                            "Token missing. Could not authenticate client. "
+                            "If you have token credentials, see modal.com/docs/reference/modal.config for setup help. "
+                            "If you are a new user, register an account at modal.com, then run `modal token new`."
+                        )
+                        raise AuthError(creds_missing_msg)
+                    else:
+                        raise
+                cls._client_from_env = client
+                return client
 
     @classmethod
     def set_env_client(cls, client):

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1142,13 +1142,13 @@ class _Function(_Provider[_FunctionHandle]):
                     raise InvalidError(exc.message)
                 raise
 
-            if response.web_url:
+            if response.function.web_url:
                 # Ensure terms used here match terms used in modal.com/docs/guide/webhook-urls doc.
-                if response.web_url_info.truncated:
+                if response.function.web_url_info.truncated:
                     suffix = " [grey70](label truncated)[/grey70]"
-                elif response.web_url_info.has_unique_hash:
+                elif response.function.web_url_info.has_unique_hash:
                     suffix = " [grey70](label includes conflict-avoidance hash)[/grey70]"
-                elif response.web_url_info.label_stolen:
+                elif response.function.web_url_info.label_stolen:
                     suffix = " [grey70](label stolen)[/grey70]"
                 else:
                     suffix = ""

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -493,8 +493,8 @@ message FunctionBindParamsResponse {
 
 message FunctionCreateResponse {
   string function_id = 1;
-  string web_url = 2;  // Deprecated - needed until 0.46 is the minimum version
-  WebUrlInfo web_url_info = 3;  // Deprecated - needed until 0.46 is the minimum version
+  string web_url = 2;  // Deprecated - needed until 0.51 is the minimum version
+  WebUrlInfo web_url_info = 3;  // Deprecated - needed until 0.51 is the minimum version
   Function function = 4;
   FunctionHandleMetadata handle_metadata = 5;
 }


### PR DESCRIPTION
Main change here is that `FunctionCreateResponse.web_url` and `FunctionCreateResponse.web_url_info` have been deprecated for a while, but I noticed we were actually still using them, so I'm removing their usage and moving up the deprecation comment to version 0.51.