### PR TITLE
Enable Ruff's isort rules

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,4 +1,0 @@
-[settings]
-known_first_party=modal,modal_base_images,modal_proto,modal_utils,modal_version
-extra_standard_library=pytest
-profile=black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,12 @@
 repos:
-  - repo: https://github.com/hadialqattan/pycln
-    rev: v1.1.0
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: "v0.0.277"
     hooks:
-      - id: pycln
-        args: ["-a"]
+      - id: ruff
+        # Autofix, and respect `exclude` and `extend-exclude` settings.
+        args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/ambv/black
     rev: 22.3.0
     hooks:
       - id: black
         language_version: python3
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.239"
-    hooks:
-      - id: ruff

--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -1,19 +1,19 @@
 # Copyright Modal Labs 2022-2023
 import os
+import pytest
 import sys
 import tempfile
 import traceback
 import unittest.mock
-from unittest import mock
 from typing import List, Optional
+from unittest import mock
 
 import click
 import click.testing
-import pytest
 import pytest_asyncio
 
-from modal.cli.entry_point import entrypoint_cli
 from modal import Client
+from modal.cli.entry_point import entrypoint_cli
 from modal_proto import api_pb2
 from modal_utils.async_utils import asyncnullcontext
 

--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -3,10 +3,10 @@ import inspect
 import pytest
 
 from modal import Stub, method
-from modal.functions import FunctionHandle
-from modal_proto import api_pb2
 from modal._serialization import deserialize
 from modal.cls import ClsMixin
+from modal.functions import FunctionHandle
+from modal_proto import api_pb2
 
 stub = Stub()
 

--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -6,6 +6,7 @@ import contextlib
 import hashlib
 import inspect
 import os
+import pytest
 import shutil
 import sys
 import tempfile
@@ -19,7 +20,6 @@ import aiohttp.web_runner
 import cloudpickle
 import grpclib.server
 import pkg_resources
-import pytest
 import pytest_asyncio
 from google.protobuf.empty_pb2 import Empty
 from grpclib import GRPCError, Status
@@ -31,8 +31,8 @@ from modal.image import _dockerhub_python_version
 from modal.mount import client_mount_name
 from modal_proto import api_grpc, api_pb2
 from modal_utils.async_utils import synchronize_api
-from modal_utils.grpc_utils import find_free_port
 from modal_utils.grpc_testing import patch_mock_servicer
+from modal_utils.grpc_utils import find_free_port
 from modal_utils.http_utils import run_temporary_http_server
 
 

--- a/client_test/container_app_test.py
+++ b/client_test/container_app_test.py
@@ -4,11 +4,11 @@ import os
 import pytest
 from unittest import mock
 
+import modal.secret
 from modal import App, FunctionHandle, Image, Stub
 from modal.exception import InvalidError
 
 from .supports.skip import skip_windows_unix_socket
-import modal.secret
 
 
 def my_f_1(x):

--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -1,27 +1,28 @@
 # Copyright Modal Labs 2022
 from __future__ import annotations
-import pickle
+
 import base64
 import json
 import pathlib
+import pickle
 import pytest
 import subprocess
 import sys
 import time
-from typing import List, Tuple, Dict, Optional
+from typing import Dict, List, Optional, Tuple
 
 from grpclib.exceptions import GRPCError
 
+from modal import Client
 from modal._container_entrypoint import UserException, main
 
 # from modal_test_support import SLEEP_DELAY
 from modal._serialization import deserialize, serialize
-from modal import Client
 from modal.exception import InvalidError
 from modal.stub import _Stub
 from modal_proto import api_pb2
-from .helpers import deploy_stub_externally
 
+from .helpers import deploy_stub_externally
 from .supports.skip import skip_windows_unix_socket
 
 EXTRA_TOLERANCE_DELAY = 1.0

--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -1,20 +1,18 @@
 # Copyright Modal Labs 2022
 import asyncio
 import inspect
-import typing
 import pytest
 import time
+import typing
 
 import cloudpickle
-
 from synchronicity.exceptions import UserCodeException
 
-from modal_proto import api_pb2
-
-from modal import Proxy, Stub, NetworkFileSystem, web_endpoint, asgi_app, wsgi_app
+from modal import NetworkFileSystem, Proxy, Stub, asgi_app, web_endpoint, wsgi_app
 from modal.exception import DeprecationError, InvalidError
-from modal.functions import Function, FunctionCall, gather, FunctionHandle
+from modal.functions import Function, FunctionCall, FunctionHandle, gather
 from modal.runner import deploy_stub
+from modal_proto import api_pb2
 
 stub = Stub()
 
@@ -555,7 +553,7 @@ def test_shared_volumes(client, servicer):
 
 
 def test_serialize_deserialize_function_handle(servicer, client):
-    from modal._serialization import serialize, deserialize
+    from modal._serialization import deserialize, serialize
 
     stub = Stub()
 

--- a/client_test/image_test.py
+++ b/client_test/image_test.py
@@ -5,7 +5,7 @@ import sys
 from tempfile import NamedTemporaryFile
 from typing import List
 
-from modal import Image, Mount, Secret, NetworkFileSystem, Stub, gpu
+from modal import Image, Mount, NetworkFileSystem, Secret, Stub, gpu
 from modal.exception import InvalidError, NotFoundError
 from modal.image import _dockerhub_python_version
 from modal_proto import api_pb2

--- a/client_test/live_reload_test.py
+++ b/client_test/live_reload_test.py
@@ -5,6 +5,7 @@ import threading
 from unittest import mock
 
 from modal.serving import serve_stub
+
 from .supports.skip import skip_old_py, skip_windows
 
 

--- a/client_test/mount_test.py
+++ b/client_test/mount_test.py
@@ -1,10 +1,9 @@
 # Copyright Modal Labs 2022
 import hashlib
 import os
+import pytest
 import sys
 from pathlib import Path
-
-import pytest
 
 from modal import App, Stub
 from modal._blob_utils import LARGE_FILE_LIMIT

--- a/client_test/mounted_files_test.py
+++ b/client_test/mounted_files_test.py
@@ -1,14 +1,15 @@
 # Copyright Modal Labs 2022
 import os
 import pytest
-import pytest_asyncio
 import subprocess
 import sys
 from pathlib import Path
 
-from modal._function_utils import FunctionInfo
-from . import helpers
+import pytest_asyncio
 
+from modal._function_utils import FunctionInfo
+
+from . import helpers
 from .supports.skip import skip_windows, skip_windows_unix_socket
 
 

--- a/client_test/network_file_system_test.py
+++ b/client_test/network_file_system_test.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2022
-from unittest import mock
-
 import pytest
+from unittest import mock
 
 import modal
 from modal.exception import DeprecationError, InvalidError

--- a/client_test/notebook_test.py
+++ b/client_test/notebook_test.py
@@ -1,9 +1,9 @@
 # Copyright Modal Labs 2022
+import pytest
+import warnings
 from pathlib import Path
 
 import jupytext
-import pytest
-import warnings
 
 try:
     from nbclient.exceptions import CellExecutionError

--- a/client_test/object_test.py
+++ b/client_test/object_test.py
@@ -25,8 +25,8 @@ async def test_use_object(client):
 
 
 def test_from_id(client):
-    from modal.object import _Handle
     from modal.dict import _DictHandle
+    from modal.object import _Handle
     from modal.queue import _QueueHandle
 
     assert isinstance(_DictHandle._from_id("di-123", client, None), _DictHandle)

--- a/client_test/resolver_test.py
+++ b/client_test/resolver_test.py
@@ -1,9 +1,8 @@
 # Copyright Modal Labs 2023
 import asyncio
+import pytest
 import time
 from typing import Optional
-
-import pytest
 
 from modal._output import OutputManager
 from modal._resolver import Resolver

--- a/client_test/runner_test.py
+++ b/client_test/runner_test.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2023
-import typing
-
 import pytest
+import typing
 
 import modal
 from modal.runner import run_stub

--- a/client_test/serialization_test.py
+++ b/client_test/serialization_test.py
@@ -1,8 +1,8 @@
 # Copyright Modal Labs 2022
 import pytest
 
-from modal._serialization import deserialize, serialize
 from modal import Queue, Stub
+from modal._serialization import deserialize, serialize
 
 stub = Stub()
 

--- a/client_test/stub_test.py
+++ b/client_test/stub_test.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2022
 import asyncio
 import logging
-
 import pytest
 
 from google.protobuf.empty_pb2 import Empty

--- a/client_test/supports/skip.py
+++ b/client_test/supports/skip.py
@@ -1,9 +1,8 @@
 # Copyright Modal Labs 2022
 
 import platform
-import sys
-
 import pytest
+import sys
 
 
 def skip_windows(msg: str):

--- a/client_test/utils_test.py
+++ b/client_test/utils_test.py
@@ -2,7 +2,6 @@
 import asyncio
 import hashlib
 import io
-
 import pytest
 
 from modal._blob_utils import BytesIOSegmentPayload

--- a/client_test/webhook_test.py
+++ b/client_test/webhook_test.py
@@ -3,14 +3,14 @@ import pathlib
 import pytest
 import subprocess
 import sys
+
 from fastapi.testclient import TestClient
 
-from modal_proto import api_pb2
-from modal import App, Stub, web_endpoint, asgi_app, wsgi_app
-from modal.functions import FunctionHandle
-from modal.exception import DeprecationError, InvalidError
+from modal import App, Stub, asgi_app, web_endpoint, wsgi_app
 from modal._asgi import webhook_asgi_app
-
+from modal.exception import DeprecationError, InvalidError
+from modal.functions import FunctionHandle
+from modal_proto import api_pb2
 
 stub = Stub()
 

--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -5,16 +5,16 @@ from .app import App, container_app, is_local
 from .client import Client
 from .dict import Dict
 from .exception import Error
-from .functions import Function, FunctionHandle, current_input_id, method, asgi_app, wsgi_app, web_endpoint
+from .functions import Function, FunctionHandle, asgi_app, current_input_id, method, web_endpoint, wsgi_app
 from .image import Image
 from .mount import Mount, create_package_mounts
-from .object import Handle, _BLOCKING_H  # noqa
+from .network_file_system import NetworkFileSystem
+from .object import _BLOCKING_H, Handle  # noqa
 from .proxy import Proxy
 from .queue import Queue
 from .retries import Retries
 from .schedule import Cron, Period
 from .secret import Secret
-from .network_file_system import NetworkFileSystem
 from .shared_volume import SharedVolume
 from .stub import Stub
 from .volume import Volume

--- a/modal/_blob_utils.py
+++ b/modal/_blob_utils.py
@@ -4,9 +4,9 @@ import dataclasses
 import hashlib
 import io
 import os
-from pathlib import Path
 from contextlib import contextmanager
-from typing import AsyncIterator, BinaryIO, Optional, Union, List
+from pathlib import Path
+from typing import AsyncIterator, BinaryIO, List, Optional, Union
 from urllib.parse import urlparse
 
 from aiohttp import BytesIOPayload
@@ -16,7 +16,7 @@ from modal.exception import ExecutionError
 from modal_proto import api_pb2
 from modal_utils.async_utils import retry
 from modal_utils.grpc_utils import retry_transient_errors
-from modal_utils.hash_utils import get_sha256_hex, get_upload_hashes, UploadHashes
+from modal_utils.hash_utils import UploadHashes, get_sha256_hex, get_upload_hashes
 from modal_utils.http_utils import http_client_with_tls
 from modal_utils.logger import logger
 

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -5,9 +5,9 @@ import asyncio
 import base64
 import contextlib
 import importlib
-import pickle
 import inspect
 import math
+import pickle
 import signal
 import sys
 import time
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from typing import Any, AsyncGenerator, AsyncIterator, Callable, Optional
 
 from grpclib import Status
+from synchronicity.interface import Interface
 
 from modal.stub import _Stub
 from modal_proto import api_pb2
@@ -26,7 +27,7 @@ from modal_utils.async_utils import (
     synchronizer,
 )
 from modal_utils.grpc_utils import retry_transient_errors
-from synchronicity.interface import Interface
+
 from ._asgi import asgi_app_wrapper, webhook_asgi_app, wsgi_app_wrapper
 from ._blob_utils import MAX_OBJECT_SIZE_BYTES, blob_download, blob_upload
 from ._function_utils import load_function_from_module

--- a/modal/_output.py
+++ b/modal/_output.py
@@ -1,5 +1,6 @@
 # Copyright Modal Labs 2022
 from __future__ import annotations
+
 import asyncio
 import contextlib
 import functools

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -20,7 +20,7 @@ class StatusRow:
     def __init__(self, progress: Optional[Tree]):
         from ._output import (
             step_progress,
-        )  # Lazy import to only import `rich` when necessary.
+        )
 
         self._spinner = None
         self._step_node = None
@@ -35,7 +35,7 @@ class StatusRow:
             step_progress_update(self._spinner, message)
 
     def finish(self, message):
-        from ._output import step_progress_update, step_completed
+        from ._output import step_completed, step_progress_update
 
         if self._step_node is not None:
             step_progress_update(self._spinner, message)
@@ -50,8 +50,9 @@ class Resolver:
     _environment_name: str
 
     def __init__(self, output_mgr, client, environment_name: str, app_id: Optional[str] = None):
-        from ._output import step_progress
         from rich.tree import Tree
+
+        from ._output import step_progress
 
         self._output_mgr = output_mgr
         self._local_uuid_to_future = {}

--- a/modal/_serialization.py
+++ b/modal/_serialization.py
@@ -4,12 +4,13 @@ import pickle
 from typing import Optional
 
 import cloudpickle
-
-from modal_utils import async_utils
 from synchronicity import Interface
 from synchronicity.synchronizer import TARGET_INTERFACE_ATTR
+
+from modal_utils import async_utils
+
 from .exception import InvalidError
-from .object import _Handle, Handle
+from .object import Handle, _Handle
 
 PICKLE_PROTOCOL = 4  # Support older Python versions.
 

--- a/modal/_watcher.py
+++ b/modal/_watcher.py
@@ -10,7 +10,6 @@ from modal.mount import _Mount
 
 from ._output import OutputManager
 
-
 _TIMEOUT_SENTINEL = object()
 
 

--- a/modal/aio.py
+++ b/modal/aio.py
@@ -3,7 +3,6 @@ import datetime
 
 from modal.exception import deprecation_error
 
-
 deprecation_error(
     datetime.date(2023, 5, 12),
     "The `modal.aio` module and `Aio*` classes have been deprecated.\n"

--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -1,6 +1,6 @@
 # Copyright Modal Labs 2022
 import asyncio
-from typing import Optional, List, Union
+from typing import List, Optional, Union
 
 import typer
 from click import UsageError
@@ -8,9 +8,9 @@ from grpclib import GRPCError, Status
 from rich.text import Text
 
 from modal._output import OutputManager, get_app_logs_loop
-from modal.environments import ensure_env
-from modal.cli.utils import timestamp_to_local, display_table, ENV_OPTION
+from modal.cli.utils import ENV_OPTION, display_table, timestamp_to_local
 from modal.client import _Client
+from modal.environments import ensure_env
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronizer
 

--- a/modal/cli/config.py
+++ b/modal/cli/config.py
@@ -3,7 +3,7 @@ import pprint
 
 import typer
 
-from modal.config import config, _store_user_config, _config_active_profile
+from modal.config import _config_active_profile, _store_user_config, config
 
 config_cli = typer.Typer(
     name="config",

--- a/modal/cli/entry_point.py
+++ b/modal/cli/entry_point.py
@@ -7,9 +7,9 @@ from modal.cli.environment import environment_cli
 from .app import app_cli
 from .config import config_cli
 from .network_file_system import nfs_cli, vol_cli
+from .profile import profile_cli
 from .secret import secret_cli
 from .token import token_cli
-from .profile import profile_cli
 
 
 def version_callback(value: bool):

--- a/modal/cli/network_file_system.py
+++ b/modal/cli/network_file_system.py
@@ -20,11 +20,11 @@ from typer import Typer
 
 import modal
 from modal._location import display_location
-from modal._output import step_progress, step_completed
-from modal.environments import ensure_env
-from modal.cli.utils import display_table, ENV_OPTION
+from modal._output import step_completed, step_progress
+from modal.cli.utils import ENV_OPTION, display_table
 from modal.client import _Client
-from modal.network_file_system import _NetworkFileSystemHandle, _NetworkFileSystem
+from modal.environments import ensure_env
+from modal.network_file_system import _NetworkFileSystem, _NetworkFileSystemHandle
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronizer
 from modal_utils.grpc_utils import retry_transient_errors

--- a/modal/cli/profile.py
+++ b/modal/cli/profile.py
@@ -1,10 +1,11 @@
 # Copyright Modal Labs 2022
 
+from typing import Optional
+
 import typer
 
-from typing import Optional
-from modal.config import _profile, config_profiles, config_set_active_profile
 from modal.cli.utils import display_selection
+from modal.config import _profile, config_profiles, config_set_active_profile
 
 profile_cli = typer.Typer(name="profile", help="Set the active Modal profile.", no_args_is_help=True)
 

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -14,14 +14,15 @@ from synchronicity import Interface
 
 from modal.config import config
 from modal.exception import InvalidError
-from modal.runner import run_stub, deploy_stub, interactive_shell
+from modal.runner import deploy_stub, interactive_shell, run_stub
 from modal.serving import serve_stub
 from modal.stub import LocalEntrypoint
 from modal_utils.async_utils import synchronizer
+
 from ..environments import ensure_env
+from ..functions import _FunctionHandle
 from .import_refs import import_function, import_stub
 from .utils import ENV_OPTION, ENV_OPTION_HELP
-from ..functions import _FunctionHandle
 
 # Why do we need to support both types and the strings? Because something weird with
 # how __annotations__ works in Python (which inspect.signature uses). See #220.

--- a/modal/cli/secret.py
+++ b/modal/cli/secret.py
@@ -11,9 +11,9 @@ from rich.console import Console
 from rich.syntax import Syntax
 
 import modal
-from modal.environments import ensure_env
-from modal.cli.utils import timestamp_to_local, display_table, ENV_OPTION
+from modal.cli.utils import ENV_OPTION, display_table, timestamp_to_local
 from modal.client import Client, _Client
+from modal.environments import ensure_env
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronizer
 from modal_utils.grpc_utils import retry_transient_errors

--- a/modal/cli/token.py
+++ b/modal/cli/token.py
@@ -1,11 +1,11 @@
 # Copyright Modal Labs 2022
 import getpass
-from typing import Optional
 import webbrowser
+from typing import Optional
 
 import rich
-from rich.console import Console
 import typer
+from rich.console import Console
 
 from modal.client import Client
 from modal.config import _store_user_config, config, user_config_path

--- a/modal/cli/utils.py
+++ b/modal/cli/utils.py
@@ -1,12 +1,12 @@
 # Copyright Modal Labs 2022
 from datetime import datetime
-from typing import Union, List
+from typing import List, Union
 
 import typer
 from rich.console import Console
+from rich.json import JSON
 from rich.table import Table
 from rich.text import Text
-from rich.json import JSON
 
 
 def timestamp_to_local(ts: float) -> str:

--- a/modal/client.py
+++ b/modal/client.py
@@ -2,7 +2,7 @@
 import asyncio
 import platform
 import warnings
-from typing import Awaitable, Callable, Optional, Tuple, Dict
+from typing import Awaitable, Callable, Dict, Optional, Tuple
 
 from aiohttp import ClientConnectorError, ClientResponseError
 from google.protobuf import empty_pb2

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -1,9 +1,11 @@
 # Copyright Modal Labs 2022
 import inspect
 import pickle
-from typing import Dict, TypeVar, Type
+from typing import Dict, Type, TypeVar
+
 from modal_utils.async_utils import synchronize_api
-from .functions import _PartialFunction, PartialFunction, _FunctionHandle
+
+from .functions import PartialFunction, _FunctionHandle, _PartialFunction
 
 T = TypeVar("T")
 

--- a/modal/config.py
+++ b/modal/config.py
@@ -79,7 +79,6 @@ from datetime import date
 
 import toml
 
-
 from ._traceback import setup_rich_traceback
 from .exception import deprecation_error
 

--- a/modal/environments.py
+++ b/modal/environments.py
@@ -1,5 +1,5 @@
 # Copyright Modal Labs 2023
-from typing import Optional, List
+from typing import List, Optional
 
 from google.protobuf.empty_pb2 import Empty
 from google.protobuf.wrappers_pb2 import StringValue

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1,13 +1,14 @@
 # Copyright Modal Labs 2022
-import pickle
-import os
 import asyncio
 import inspect
+import os
+import pickle
 import posixpath
 import time
 import typing
 import warnings
 from dataclasses import dataclass
+from datetime import date
 from pathlib import PurePath
 from typing import (
     Any,
@@ -17,28 +18,27 @@ from typing import (
     Callable,
     Collection,
     Dict,
+    Iterable,
     List,
     Optional,
     Set,
     Tuple,
     Union,
-    Iterable,
 )
 
-from datetime import date
 from aiostream import pipe, stream
 from google.protobuf.message import Message
 from grpclib import GRPCError, Status
 from synchronicity.exceptions import UserCodeException
 
 from modal import _pty
-from modal_proto import api_pb2
 from modal._types import typechecked
+from modal_proto import api_pb2
 from modal_utils.async_utils import (
     queue_batch_iterator,
     synchronize_api,
-    warn_if_generator_is_not_consumed,
     synchronizer,
+    warn_if_generator_is_not_consumed,
 )
 from modal_utils.grpc_utils import retry_transient_errors
 
@@ -55,19 +55,25 @@ from ._resolver import Resolver
 from ._serialization import deserialize, serialize
 from ._traceback import append_modal_tb
 from .call_graph import InputInfo, _reconstruct_call_graph
-from .config import config, logger
 from .client import _Client
-from .exception import ExecutionError, InvalidError, RemoteError, deprecation_error, deprecation_warning
-from .exception import TimeoutError as _TimeoutError
-from .gpu import GPU_T, parse_gpu_config, display_gpu_config
+from .config import config, logger
+from .exception import (
+    ExecutionError,
+    InvalidError,
+    RemoteError,
+    TimeoutError as _TimeoutError,
+    deprecation_error,
+    deprecation_warning,
+)
+from .gpu import GPU_T, display_gpu_config, parse_gpu_config
 from .image import _Image
-from .mount import _Mount, _get_client_mount
+from .mount import _get_client_mount, _Mount
+from .network_file_system import _NetworkFileSystem
 from .object import _Handle, _Provider
 from .proxy import _Proxy
 from .retries import Retries
 from .schedule import Schedule
 from .secret import _Secret
-from .network_file_system import _NetworkFileSystem
 from .volume import _Volume
 
 ATTEMPT_TIMEOUT_GRACE_PERIOD = 5  # seconds

--- a/modal/gpu.py
+++ b/modal/gpu.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 from dataclasses import dataclass
 from datetime import date
-from typing import Union, Optional
+from typing import Optional, Union
 
 from modal_proto import api_pb2
 

--- a/modal/image.py
+++ b/modal/image.py
@@ -5,7 +5,7 @@ import sys
 import typing
 from datetime import date
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import toml
 from grpclib.exceptions import GRPCError, StreamTerminatedError
@@ -14,6 +14,7 @@ from modal._types import typechecked
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronize_api
 from modal_utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES, unary_stream
+
 from ._function_utils import FunctionInfo
 from ._resolver import Resolver
 from .app import is_local
@@ -21,9 +22,9 @@ from .config import config, logger
 from .exception import InvalidError, NotFoundError, RemoteError, deprecation_warning
 from .gpu import GPU_T, parse_gpu_config
 from .mount import _Mount
+from .network_file_system import _NetworkFileSystem
 from .object import _Handle, _Provider
 from .secret import _Secret
-from .network_file_system import _NetworkFileSystem
 
 
 def _validate_python_version(version: str) -> None:

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -9,18 +9,19 @@ import time
 import typing
 from datetime import date
 from pathlib import Path, PurePosixPath
-from typing import AsyncGenerator, Callable, List, Optional, Union, Tuple, Sequence
+from typing import AsyncGenerator, Callable, List, Optional, Sequence, Tuple, Union
 
 import aiostream
 from google.protobuf.message import Message
-from modal._types import typechecked
 
 import modal.exception
+from modal._types import typechecked
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronize_api
 from modal_utils.grpc_utils import retry_transient_errors
 from modal_utils.package_utils import get_module_mount_info, module_mount_condition
 from modal_version import __version__
+
 from ._blob_utils import FileUploadSpec, blob_upload_file, get_file_upload_spec
 from ._resolver import Resolver
 from .config import config, logger
@@ -381,8 +382,9 @@ Mount = synchronize_api(_Mount)
 
 def _create_client_mount():
     # TODO(erikbern): make this a static method on the Mount class
-    import modal
     import synchronicity
+
+    import modal
 
     # Get the base_path because it also contains `modal_utils` and `modal_proto`.
     base_path, _ = os.path.split(modal.__path__[0])

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -1,16 +1,16 @@
 # Copyright Modal Labs 2023
 import os
-from datetime import date
 import time
+from datetime import date
 from pathlib import Path, PurePosixPath
 from typing import AsyncIterator, BinaryIO, List, Optional, Union
 
 import modal
+from modal._location import parse_cloud_provider
 from modal_proto import api_pb2
-from modal_utils.async_utils import synchronize_api, ConcurrencyPool
+from modal_utils.async_utils import ConcurrencyPool, synchronize_api
 from modal_utils.grpc_utils import retry_transient_errors, unary_stream
 from modal_utils.hash_utils import get_sha256_hex
-from modal._location import parse_cloud_provider
 
 from ._blob_utils import LARGE_FILE_LIMIT, blob_iter, blob_upload_file
 from ._resolver import Resolver

--- a/modal/object.py
+++ b/modal/object.py
@@ -1,15 +1,15 @@
 # Copyright Modal Labs 2022
-from datetime import date
 import uuid
+from datetime import date
 from typing import Awaitable, Callable, Generic, Optional, Type, TypeVar
 
 from google.protobuf.message import Message
 from grpclib import GRPCError, Status
-from modal._types import typechecked
 
+from modal._types import typechecked
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronize_api
-from modal_utils.grpc_utils import retry_transient_errors, get_proto_oneof
+from modal_utils.grpc_utils import get_proto_oneof, retry_transient_errors
 
 from ._object_meta import ObjectMeta
 from ._resolver import Resolver

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -1,8 +1,8 @@
 # Copyright Modal Labs 2022
 import queue  # The system library
-from datetime import date
 import time
 import warnings
+from datetime import date
 from typing import Any, List, Optional
 
 from modal_proto import api_pb2

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -10,7 +10,7 @@ from modal_utils.async_utils import TaskContext, synchronize_api
 from modal_utils.grpc_utils import retry_transient_errors
 
 from . import _pty
-from ._output import OutputManager, step_completed, step_progress, get_app_logs_loop
+from ._output import OutputManager, get_app_logs_loop, step_completed, step_progress
 from .app import _App, is_local
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, _Client
 from .config import config

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -1,10 +1,9 @@
 # Copyright Modal Labs 2022
 import os
-from typing import Dict, Optional
 from datetime import date
+from typing import Dict, Optional
 
 from modal._types import typechecked
-
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronize_api
 
@@ -94,7 +93,7 @@ class _Secret(_Provider[_SecretHandle]):
 
         async def _load(resolver: Resolver, existing_object_id: Optional[str]) -> _SecretHandle:
             try:
-                from dotenv import find_dotenv, dotenv_values
+                from dotenv import dotenv_values, find_dotenv
                 from dotenv.main import _walk_to_root
             except ImportError:
                 raise ImportError(

--- a/modal/serving.py
+++ b/modal/serving.py
@@ -2,10 +2,10 @@
 import contextlib
 import io
 import multiprocessing
-from multiprocessing.context import SpawnProcess
-from multiprocessing.synchronize import Event
 import platform
 import sys
+from multiprocessing.context import SpawnProcess
+from multiprocessing.synchronize import Event
 from typing import AsyncGenerator, Optional
 
 from synchronicity import Interface

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -1,19 +1,17 @@
 # Copyright Modal Labs 2022
-import typing
-from datetime import date
 import inspect
 import os
 import sys
+import typing
 import warnings
-from typing import AsyncGenerator, Callable, Dict, List, Optional, Union, Any, Sequence
+from datetime import date
+from typing import Any, AsyncGenerator, Callable, Dict, List, Optional, Sequence, Union
 
 from synchronicity.async_wrap import asynccontextmanager
+
 from modal._types import typechecked
-
 from modal_proto import api_pb2
-
 from modal_utils.async_utils import synchronize_api, synchronizer
-from .retries import Retries
 
 from ._function_utils import FunctionInfo
 from ._ipython import is_notebook
@@ -23,17 +21,18 @@ from .client import _Client
 from .cls import make_remote_cls_constructors
 from .config import logger
 from .exception import InvalidError, deprecation_error, deprecation_warning
-from .functions import _Function, _FunctionHandle, PartialFunction, _PartialFunction
+from .functions import PartialFunction, _Function, _FunctionHandle, _PartialFunction
 from .gpu import GPU_T
 from .image import _Image, _ImageHandle
 from .mount import _Mount
+from .network_file_system import _NetworkFileSystem
 from .object import _Provider
 from .proxy import _Proxy
 from .queue import _Queue
+from .retries import Retries
 from .runner import _run_stub
 from .schedule import Schedule
 from .secret import _Secret
-from .network_file_system import _NetworkFileSystem
 from .volume import _Volume
 
 _default_image: _Image = _Image.debian_slim()

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -3,7 +3,7 @@ import asyncio
 from typing import Optional
 
 from modal_proto import api_pb2
-from modal_utils.async_utils import synchronize_api, asyncnullcontext
+from modal_utils.async_utils import asyncnullcontext, synchronize_api
 from modal_utils.grpc_utils import retry_transient_errors
 
 from ._resolver import Resolver

--- a/modal_base_images/client_mount.py
+++ b/modal_base_images/client_mount.py
@@ -2,7 +2,7 @@
 import asyncio
 
 from modal.config import config
-from modal.mount import create_client_mount, client_mount_name
+from modal.mount import client_mount_name, create_client_mount
 from modal_proto import api_pb2
 
 

--- a/modal_base_images/conda.py
+++ b/modal_base_images/conda.py
@@ -1,6 +1,6 @@
 # Copyright Modal Labs 2022
-import sys
 import asyncio
+import sys
 
 from modal import Image, Stub
 

--- a/modal_base_images/micromamba.py
+++ b/modal_base_images/micromamba.py
@@ -1,6 +1,6 @@
 # Copyright Modal Labs 2022
-import sys
 import asyncio
+import sys
 
 from modal import Image, Stub
 

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -1,11 +1,11 @@
 # Copyright Modal Labs 2022
 from __future__ import annotations
+
 import asyncio
-from datetime import date
 import time
+from datetime import date
 
-
-from modal import Stub, method, web_endpoint, asgi_app
+from modal import Stub, asgi_app, method, web_endpoint
 from modal.exception import deprecation_warning
 
 SLEEP_DELAY = 0.1

--- a/modal_test_support/multistub.py
+++ b/modal_test_support/multistub.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2023
 import modal
 
-
 a = modal.Stub()
 
 

--- a/modal_test_support/multistub_privately_decorated.py
+++ b/modal_test_support/multistub_privately_decorated.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2023
 import modal
 
-
 stub = modal.Stub()
 
 

--- a/modal_test_support/multistub_privately_decorated_named_stub.py
+++ b/modal_test_support/multistub_privately_decorated_named_stub.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2023
 import modal
 
-
 stub = modal.Stub("dummy")
 
 

--- a/modal_test_support/multistub_same_name.py
+++ b/modal_test_support/multistub_same_name.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2023
 import modal
 
-
 stub = modal.Stub("dummy")
 
 

--- a/modal_test_support/multistub_serialized_func.py
+++ b/modal_test_support/multistub_serialized_func.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2023
 import modal
 
-
 stub = modal.Stub()
 
 

--- a/modal_test_support/package_mount.py
+++ b/modal_test_support/package_mount.py
@@ -1,5 +1,5 @@
 # Copyright Modal Labs 2022
-from modal import Stub, Mount
+from modal import Mount, Stub
 
 stub = Stub()
 

--- a/modal_utils/async_utils.py
+++ b/modal_utils/async_utils.py
@@ -7,9 +7,9 @@ import time
 import typing
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, Awaitable, Callable, Iterator, List, Optional, Set, TypeVar
-from typing_extensions import ParamSpec
 
 import synchronicity
+from typing_extensions import ParamSpec
 
 from .logger import logger
 

--- a/modal_utils/grpc_testing.py
+++ b/modal_utils/grpc_testing.py
@@ -2,8 +2,8 @@
 import contextlib
 import inspect
 import logging
-from collections import defaultdict, Counter
-from typing import Any, List, Tuple, Callable, Dict
+from collections import Counter, defaultdict
+from typing import Any, Callable, Dict, List, Tuple
 
 from grpclib import GRPCError, Status
 

--- a/modal_utils/grpc_utils.py
+++ b/modal_utils/grpc_utils.py
@@ -1,9 +1,9 @@
 # Copyright Modal Labs 2022
 import asyncio
 import contextlib
+import platform
 import socket
 import time
-import platform
 import urllib.parse
 import uuid
 from typing import (
@@ -18,8 +18,8 @@ from typing import (
     cast,
 )
 
-import grpclib.events
 import grpclib.client
+import grpclib.events
 from google.protobuf.message import Message
 from grpclib import GRPCError, Status
 from grpclib.exceptions import StreamTerminatedError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,7 @@ no_strict_optional = true
 namespace_packages = true
 
 [[tool.mypy.overrides]]
-module = [
-    "ddtrace.*",
-]
+module = ["ddtrace.*"]
 check_untyped_defs = false
 follow_imports = "skip"
 
@@ -33,28 +31,22 @@ filterwarnings = [
 ]
 
 [tool.ruff]
-exclude = [
-    '.venv',
-    '.git',
-    '__pycache__',
-    'proto',
-    'build',
-    'modal_proto',
-
-]
-ignore = [
-    'E501',
-    'E741',
-]
-# Enable these Pyflakes codes by default.
-select = [
-    'E',
-    'F',
-    'W',
-]
-
+exclude = ['.venv', '.git', '__pycache__', 'proto', 'build', 'modal_proto']
+ignore = ['E501', 'E741']
+select = ['E', 'F', 'W', 'I']
 line-length = 120
 
 [tool.ruff.per-file-ignores]
 "*_test.py" = ['E712']
 "client_test/supports/notebooks/*.py" = ['E402']
+
+[tool.ruff.isort]
+combine-as-imports = true
+known-first-party = [
+    "modal",
+    "modal_base_images",
+    "modal_proto",
+    "modal_utils",
+    "modal_version",
+]
+extra-standard-library = ["pytest"]


### PR DESCRIPTION
When we removed isort and switched to Ruff, we didn't actually enable Ruff's isort rules, so our imports weren't being sorted.
