### PR TITLE
fix: builder fns ignore default cloud setting

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -924,7 +924,7 @@ class _Function(_Provider[_FunctionHandle]):
                 "Setting `keep_warm=True` is deprecated. Pass an explicit warm pool size instead, e.g. `keep_warm=2`.",
             )
 
-        if not cloud:
+        if not cloud and not is_builder_function:
             cloud = config.get("default_cloud")
         if cloud:
             cloud_provider = parse_cloud_provider(cloud)


### PR DESCRIPTION
## Describe your changes

Build functions should run in AWS and not pass through the default cloud specification. Should consider rejecting client requests to run a builder fn in a specific cloud. 

### Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [X] Client+Server: this change is compatible with old servers
- [X] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
