### PR TITLE
make 'modal config set-environment' visible

### DIFF
--- a/modal/cli/config.py
+++ b/modal/cli/config.py
@@ -32,7 +32,7 @@ when running a command that requires an environment.
 """
 
 
-@config_cli.command(help=SET_DEFAULT_ENV_HELP, hidden=True)
+@config_cli.command(help=SET_DEFAULT_ENV_HELP)
 def set_environment(environment_name: str):
     _store_user_config({"environment": environment_name})
     active_profile = _config_active_profile()


### PR DESCRIPTION
### Describe your changes

I think this may have been intended to be only hidden initially? 


### Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
