### PR TITLE
Precreate handles on providers

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -97,7 +97,7 @@ class _App:
 
             for tag, provider in blueprint.items():
                 existing_object_id = self._tag_to_existing_id.get(tag)
-                created_obj = await resolver.load(provider, existing_object_id)
+                created_obj: _Handle = await resolver.load(provider, existing_object_id)
                 self._tag_to_object[tag] = created_obj
 
         # Create the app (and send a list of all tagged obs)

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -142,6 +142,8 @@ class _Dict(_Provider[_DictHandle]):
     def new(data={}) -> "_Dict":
         """Create a new dictionary, optionally filled with initial data."""
 
+        handle: _DictHandle = _DictHandle._new()
+
         async def _load(resolver: Resolver, existing_object_id: Optional[str]) -> _DictHandle:
             serialized = _serialize_dict(data)
             req = api_pb2.DictCreateRequest(
@@ -149,7 +151,8 @@ class _Dict(_Provider[_DictHandle]):
             )
             response = await resolver.client.stub.DictCreate(req)
             logger.debug("Created dict with id %s" % response.dict_id)
-            return _DictHandle._from_id(response.dict_id, resolver.client, None)
+            handle._hydrate(response.dict_id, resolver.client, None)
+            return handle
 
         return _Dict._from_loader(_load, "Dict()")
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -547,7 +547,7 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
             serialized_params=serialized_params,
         )
         response = await self._client.stub.FunctionBindParams(req)
-        new_handle._hydrate(self._client, response.bound_function_id, response.handle_metadata)
+        new_handle._hydrate(response.bound_function_id, self._client, response.handle_metadata)
         new_handle._is_remote_cls_method = True
         return new_handle
 
@@ -976,7 +976,7 @@ class _Function(_Provider[_FunctionHandle]):
             )
             response = await resolver.client.stub.FunctionPrecreate(req)
             # Update the precreated function handle (todo: hack until we merge providers/handles)
-            function_handle._hydrate(resolver.client, response.function_id, response.handle_metadata)
+            function_handle._hydrate(response.function_id, resolver.client, response.handle_metadata)
             return function_handle
 
         async def _load(resolver: Resolver, existing_object_id: Optional[str]) -> _FunctionHandle:
@@ -1165,7 +1165,7 @@ class _Function(_Provider[_FunctionHandle]):
 
             # Instead of returning a new object, just return the precreated one
             # TODO (elias): We should not have to run _hydrate in here since functions are preloaded. Needed for now due to some conflicts with builder_functions
-            function_handle._hydrate(resolver.client, response.function_id, response.handle_metadata)
+            function_handle._hydrate(response.function_id, resolver.client, response.handle_metadata)
             return function_handle
 
         rep = f"Function({tag})"

--- a/modal/image.py
+++ b/modal/image.py
@@ -171,10 +171,13 @@ class _Image(_Provider[_ImageHandle]):
         if build_function and len(base_images) != 1:
             raise InvalidError("Cannot run a build function with multiple base images!")
 
+        handle: _ImageHandle = _ImageHandle._new()
+
         async def _load(resolver: Resolver, existing_object_id: Optional[str]):
             if ref:
                 image_id = (await resolver.load(ref)).object_id
-                return _ImageHandle._from_id(image_id, resolver.client, None)
+                handle._hydrate(image_id, resolver.client, None)
+                return handle
 
             # Recursively build base images
             base_image_ids: List[str] = []
@@ -288,7 +291,8 @@ class _Image(_Provider[_ImageHandle]):
             else:
                 raise RemoteError("Unknown status %s!" % result.status)
 
-            return _ImageHandle._from_id(image_id, resolver.client, None)
+            handle._hydrate(image_id, resolver.client, None)
+            return handle
 
         rep = f"Image({dockerfile_commands})"
         obj = _Image._from_loader(_load, rep)

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -189,6 +189,8 @@ class _NetworkFileSystem(_Provider[_NetworkFileSystemHandle]):
     def new(cloud: Optional[str] = None) -> "_NetworkFileSystem":
         """Construct a new shared volume, which is empty by default."""
 
+        handle: _NetworkFileSystemHandle = _NetworkFileSystemHandle._new()
+
         async def _load(resolver: Resolver, existing_object_id: Optional[str]) -> _NetworkFileSystemHandle:
             status_row = resolver.add_status_row()
             if existing_object_id:
@@ -201,7 +203,8 @@ class _NetworkFileSystem(_Provider[_NetworkFileSystemHandle]):
             req = api_pb2.SharedVolumeCreateRequest(app_id=resolver.app_id, cloud_provider=cloud_provider)
             resp = await retry_transient_errors(resolver.client.stub.SharedVolumeCreate, req)
             status_row.finish("Created shared volume.")
-            return _NetworkFileSystemHandle._from_id(resp.shared_volume_id, resolver.client, None)
+            handle._hydrate(resp.shared_volume_id, resolver.client, None)
+            return handle
 
         return _NetworkFileSystem._from_loader(_load, "NetworkFileSystem()")
 

--- a/modal/object.py
+++ b/modal/object.py
@@ -29,14 +29,17 @@ class _Handle(metaclass=ObjectMeta):
     well as distributed data structures like Queues or Dicts.
     """
 
-    _type_prefix: str
+    _type_prefix: str  # class attribute
+    _object_id: str
+    _client: _Client
+    _is_hydrated: bool
 
     def __init__(self):
         raise Exception("__init__ disallowed, use proper classmethods")
 
     def _init(self):
-        self._client = None
         self._object_id = None
+        self._client = None
         self._is_hydrated = False
 
     @classmethod
@@ -49,9 +52,9 @@ class _Handle(metaclass=ObjectMeta):
     def _initialize_from_empty(self):
         pass  # default implementation
 
-    def _hydrate(self, client: _Client, object_id: str, handle_metadata: Optional[Message]):
-        self._client = client
+    def _hydrate(self, object_id: str, client: _Client, handle_metadata: Optional[Message]):
         self._object_id = object_id
+        self._client = client
         if handle_metadata:
             self._hydrate_metadata(handle_metadata)
         self._is_hydrated = True
@@ -90,7 +93,7 @@ class _Handle(metaclass=ObjectMeta):
 
         # Instantiate object and return
         obj = object_cls._new()
-        obj._hydrate(client, object_id, handle_metadata)
+        obj._hydrate(object_id, client, handle_metadata)
         return obj
 
     @classmethod

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -139,10 +139,13 @@ class _Queue(_Provider[_QueueHandle]):
 
     @staticmethod
     def new():
+        handle: _QueueHandle = _QueueHandle._new()
+
         async def _load(resolver: Resolver, existing_object_id: Optional[str]) -> _QueueHandle:
             request = api_pb2.QueueCreateRequest(app_id=resolver.app_id, existing_queue_id=existing_object_id)
             response = await resolver.client.stub.QueueCreate(request)
-            return _QueueHandle._from_id(response.queue_id, resolver.client, None)
+            handle._hydrate(response.queue_id, resolver.client, None)
+            return handle
 
         return _Queue._from_loader(_load, "Queue()")
 

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -54,6 +54,8 @@ class _Secret(_Provider[_SecretHandle]):
         ):
             raise InvalidError(ENV_DICT_WRONG_TYPE_ERR)
 
+        handle: _SecretHandle = _SecretHandle._new()
+
         async def _load(resolver: Resolver, existing_object_id: Optional[str]) -> _SecretHandle:
             req = api_pb2.SecretCreateRequest(
                 app_id=resolver.app_id,
@@ -62,7 +64,8 @@ class _Secret(_Provider[_SecretHandle]):
                 existing_secret_id=existing_object_id,
             )
             resp = await resolver.client.stub.SecretCreate(req)
-            return _SecretHandle._from_id(resp.secret_id, resolver.client, None)
+            handle._hydrate(resp.secret_id, resolver.client, None)
+            return handle
 
         rep = f"Secret.from_dict([{', '.join(env_dict.keys())}])"
         return _Secret._from_loader(_load, rep)

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -692,7 +692,7 @@ class _Stub:
                     # assigning the app's hydrated function handle ensures it will be used for the later decoration return value
                     self._function_handles[tag] = obj
                 else:
-                    self._function_handles[tag]._hydrate(client, function_id, handle_metadata)
+                    self._function_handles[tag]._hydrate(function_id, client, handle_metadata)
 
     def _get_deduplicated_function_mounts(self, mounts: Dict[str, _Mount]):
         cached_mounts = []

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -103,6 +103,8 @@ class _Volume(_Provider[_VolumeHandle]):
     def new() -> "_Volume":
         """Construct a new volume, which is empty by default."""
 
+        handle: _VolumeHandle = _VolumeHandle._new()
+
         async def _load(resolver: Resolver, existing_object_id: Optional[str]) -> _VolumeHandle:
             status_row = resolver.add_status_row()
             if existing_object_id:
@@ -113,7 +115,8 @@ class _Volume(_Provider[_VolumeHandle]):
             req = api_pb2.VolumeCreateRequest(app_id=resolver.app_id)
             resp = await retry_transient_errors(resolver.client.stub.VolumeCreate, req)
             status_row.finish("Created volume.")
-            return _VolumeHandle._from_id(resp.volume_id, resolver.client, None)
+            handle._hydrate(resp.volume_id, resolver.client, None)
+            return handle
 
         return _Volume._from_loader(_load, "Volume()")
 


### PR DESCRIPTION
This is part of my work to merge providers and handles.

Step 1 is fairly silly which is that each provider just creates a handle in advance and returns it during load, hydrating the handle rather than constructing a new object on the fly.