### PR TITLE
remove _track_function_invocation

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -44,7 +44,6 @@ class _App:
     _app_id: str
     _app_page_url: str
     _resolver: Optional[Resolver]
-    _function_invocations: int  # Number of function invocations made by this app.
 
     def __init__(
         self,
@@ -61,7 +60,6 @@ class _App:
         self._client = client
         self._tag_to_object = tag_to_object or {}
         self._tag_to_existing_id = tag_to_existing_id or {}
-        self._function_invocations = 0
         self._stub_name = stub_name
 
     @property
@@ -141,13 +139,6 @@ class _App:
 
     def __getattr__(self, tag: str) -> _Handle:
         return self._tag_to_object[tag]
-
-    def track_function_invocation(self):
-        self._function_invocations += 1
-
-    @property
-    def function_invocations(self):
-        return self._function_invocations
 
     async def _init_container(self, client: _Client, app_id: str, stub_name: str):
         self._client = client

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -587,10 +587,6 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
     def is_generator(self) -> bool:
         return self._is_generator
 
-    def _track_function_invocation(self):
-        if self._stub and self._stub.app:
-            self._stub.app.track_function_invocation()
-
     async def _map(self, input_stream: AsyncIterable[Any], order_outputs: bool, return_exceptions: bool, kwargs={}):
         if self._web_url:
             raise InvalidError(
@@ -605,7 +601,6 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
             self._output_mgr.function_progress_callback(self._function_name, total=None) if self._output_mgr else None
         )
 
-        self._track_function_invocation()
         async for item in _map_invocation(
             self._object_id,
             input_stream,
@@ -708,7 +703,6 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
             yield item
 
     async def _call_function(self, args, kwargs):
-        self._track_function_invocation()
         invocation = await _Invocation.create(self._object_id, args, kwargs, self._client)
         try:
             return await invocation.run_function()
@@ -718,18 +712,15 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
                 raise
 
     async def _call_function_nowait(self, args, kwargs):
-        self._track_function_invocation()
         return await _Invocation.create(self._object_id, args, kwargs, self._client)
 
     @warn_if_generator_is_not_consumed
     async def _call_generator(self, args, kwargs):
-        self._track_function_invocation()
         invocation = await _Invocation.create(self._object_id, args, kwargs, self._client)
         async for res in invocation.run_generator():
             yield res
 
     async def _call_generator_nowait(self, args, kwargs):
-        self._track_function_invocation()
         return await _Invocation.create(self._object_id, args, kwargs, self._client)
 
     def call(self, *args, **kwargs) -> Awaitable[Any]:  # TODO: Generics/TypeVars


### PR DESCRIPTION
Afaict this is never used by the client library. It does get in the way of a later refactoring I want to make (removing the stub from the FunctionHandle class).