### PR TITLE
Use the same GPU type for multi-GPU

### DIFF
--- a/client_test/gpu_test.py
+++ b/client_test/gpu_test.py
@@ -106,7 +106,7 @@ def test_memory_selection_gpu_variant(client, servicer, memory, gpu_type):
     assert func_def.resources.gpu_config.memory == memory
 
 
-A100_GPU_COUNT_MAPPING = {1: api_pb2.GPU_TYPE_A100, **{i: api_pb2.GPU_TYPE_A100_40GB_MANY for i in range(2, 5)}}
+A100_GPU_COUNT_MAPPING = {1: api_pb2.GPU_TYPE_A100, **{i: api_pb2.GPU_TYPE_A100 for i in range(2, 5)}}
 
 
 @pytest.mark.parametrize("count,gpu_type", A100_GPU_COUNT_MAPPING.items())

--- a/modal/gpu.py
+++ b/modal/gpu.py
@@ -49,10 +49,7 @@ class A100(_GPUConfig):
         if memory not in allowed_memory_values:
             raise ValueError(f"A100s can only have memory values of {allowed_memory_values} => memory={memory}")
 
-        # Multi-GPU workloads require a different GPU type.
         gpu_type = api_pb2.GPU_TYPE_A100
-        if count > 1:
-            gpu_type = api_pb2.GPU_TYPE_A100_40GB_MANY
 
         if memory == 20:
             if count != 1:

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -899,7 +899,7 @@ enum GPUType {
   GPU_TYPE_A10G = 3;
   GPU_TYPE_ANY = 4;
   GPU_TYPE_A100_20G = 5;
-  GPU_TYPE_A100_40GB_MANY = 6;
+  GPU_TYPE_A100_40GB_MANY = 6 [deprecated=true];
   GPU_TYPE_INFERENTIA2 = 7;
 }
 


### PR DESCRIPTION
We are unifying the worker pools on the server side, so there's no point sending a separate value here