### PR TITLE
Unify all provider constructors

### DIFF
--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -457,8 +457,8 @@ def test_closure_valued_serialized_function(client, servicer):
     assert functions["ret_bar"]() == "bar"
 
 
-def test_from_id_internal(client, servicer):
-    obj = FunctionCall._from_id("fc-123", client, None)
+def test_new_hydrated_internal(client, servicer):
+    obj = FunctionCall._new_hydrated("fc-123", client, None)
     assert obj.object_id == "fc-123"
 
 

--- a/client_test/object_test.py
+++ b/client_test/object_test.py
@@ -24,19 +24,19 @@ async def test_use_object(client):
         assert running_app["my_q"].object_id == "qu-foo"
 
 
-def test_from_id(client):
+def test_new_hydrated(client):
     from modal.dict import _DictHandle
     from modal.object import _Handle
     from modal.queue import _QueueHandle
 
-    assert isinstance(_DictHandle._from_id("di-123", client, None), _DictHandle)
-    assert isinstance(_QueueHandle._from_id("qu-123", client, None), _QueueHandle)
+    assert isinstance(_DictHandle._new_hydrated("di-123", client, None), _DictHandle)
+    assert isinstance(_QueueHandle._new_hydrated("qu-123", client, None), _QueueHandle)
 
     with pytest.raises(InvalidError):
-        _QueueHandle._from_id("di-123", client, None)  # Wrong prefix for type
+        _QueueHandle._new_hydrated("di-123", client, None)  # Wrong prefix for type
 
-    assert isinstance(_Handle._from_id("qu-123", client, None), _QueueHandle)
-    assert isinstance(_Handle._from_id("di-123", client, None), _DictHandle)
+    assert isinstance(_Handle._new_hydrated("qu-123", client, None), _QueueHandle)
+    assert isinstance(_Handle._new_hydrated("di-123", client, None), _DictHandle)
 
     with pytest.raises(InvalidError):
-        _Handle._from_id("xy-123", client, None)
+        _Handle._new_hydrated("xy-123", client, None)

--- a/modal/_serialization.py
+++ b/modal/_serialization.py
@@ -44,7 +44,7 @@ class Unpickler(pickle.Unpickler):
 
     def persistent_load(self, pid):
         (object_id, target_interface, handle_proto) = pid
-        raw_obj = _Handle._from_id(object_id, self.client, handle_proto)
+        raw_obj = _Handle._new_hydrated(object_id, self.client, handle_proto)
         return restore_synchronicity_interface(raw_obj, target_interface)
 
 

--- a/modal/_serialization.py
+++ b/modal/_serialization.py
@@ -34,7 +34,7 @@ class Pickler(cloudpickle.Pickler):
             return
         if not obj.object_id:
             raise InvalidError(f"Can't serialize object {obj} which hasn't been created.")
-        return (obj.object_id, get_synchronicity_interface(obj), obj._get_handle_metadata())
+        return (obj.object_id, get_synchronicity_interface(obj), obj._get_metadata())
 
 
 class Unpickler(pickle.Unpickler):

--- a/modal/app.py
+++ b/modal/app.py
@@ -169,7 +169,7 @@ class _App:
             # TODO(erikbern): we shouldn't create new handles here if there are existing objects
             # FunctionHandle objects already exist in the global scope so let's grab those and hydrate
             handle_metadata = get_proto_oneof(item, "handle_metadata_oneof")
-            obj = _Handle._from_id(item.object_id, self._client, handle_metadata)
+            obj = _Handle._new_hydrated(item.object_id, self._client, handle_metadata)
             self._tag_to_object[item.tag] = obj
 
     @staticmethod

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -524,12 +524,12 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
         self._stub = stub  # TODO(erikbern): remove
         self._info = info
 
-    def _hydrate_metadata(self, handle_metadata: Message):
+    def _hydrate_metadata(self, metadata: Message):
         # makes function usable
-        assert isinstance(handle_metadata, (api_pb2.Function, api_pb2.FunctionHandleMetadata))
-        self._is_generator = handle_metadata.function_type == api_pb2.Function.FUNCTION_TYPE_GENERATOR
-        self._web_url = handle_metadata.web_url
-        self._function_name = handle_metadata.function_name
+        assert isinstance(metadata, (api_pb2.Function, api_pb2.FunctionHandleMetadata))
+        self._is_generator = metadata.function_type == api_pb2.Function.FUNCTION_TYPE_GENERATOR
+        self._web_url = metadata.web_url
+        self._function_name = metadata.function_name
 
     async def _make_bound_function_handle(self, *args: Iterable[Any], **kwargs: Dict[str, Any]) -> "_FunctionHandle":
         assert self.is_hydrated(), "Cannot make bound function handle from unhydrated handle."
@@ -560,7 +560,7 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
     def _get_self_obj(self):
         return self._self_obj
 
-    def _get_handle_metadata(self):
+    def _get_metadata(self):
         return api_pb2.FunctionHandleMetadata(
             function_name=self._function_name,
             function_type=api_pb2.Function.FUNCTION_TYPE_GENERATOR
@@ -886,9 +886,7 @@ class _Function(_Provider[_FunctionHandle]):
             # and there should be no need to "steal" ids
             running_handle = stub.app._tag_to_object.get(tag)
             if running_handle is not None:
-                function_id = running_handle.object_id
-                handle_metadata = running_handle._get_handle_metadata()
-                handle._hydrate(function_id, stub.app.client, handle_metadata)
+                handle._hydrate_from_other(running_handle)
 
         raw_f = info.raw_f
         assert callable(raw_f)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -782,7 +782,7 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
             return None
 
         invocation = await self._call_function_nowait(args, kwargs)
-        return _FunctionCall._from_id(invocation.function_call_id, invocation.client, None)
+        return _FunctionCall._new_hydrated(invocation.function_call_id, invocation.client, None)
 
     def get_raw_f(self) -> Callable[..., Any]:
         """Return the inner Python object wrapped by this Modal Function."""

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -195,7 +195,8 @@ class _NetworkFileSystem(_Provider[_NetworkFileSystemHandle]):
             status_row = resolver.add_status_row()
             if existing_object_id:
                 # Volume already exists; do nothing.
-                return _NetworkFileSystemHandle._from_id(existing_object_id, resolver.client, None)
+                handle._hydrate(existing_object_id, resolver.client, None)
+                return handle
 
             cloud_provider = parse_cloud_provider(cloud) if cloud else None
 

--- a/modal/object.py
+++ b/modal/object.py
@@ -265,7 +265,7 @@ class _Provider(Generic[H]):
 
         handle_cls = self._get_handle_cls()
         handle: H = handle_cls._new()
-            
+
         async def _load_persisted(resolver: Resolver, existing_object_id: Optional[str]) -> H:
             await self._deploy(label, namespace, resolver.client, environment_name=environment_name, handle=handle)
             return handle
@@ -299,7 +299,7 @@ class _Provider(Generic[H]):
 
         handle_cls = cls._get_handle_cls()
         handle: H = handle_cls._new()
-        
+
         async def _load_remote(resolver: Resolver, existing_object_id: Optional[str]) -> H:
             nonlocal environment_name
             if environment_name is None:
@@ -338,7 +338,7 @@ class _Provider(Generic[H]):
         """
         handle_cls = cls._get_handle_cls()
         handle: H = handle_cls._new()
-        handle._hydrate_from_app(app_name, tag, namespace, client, environment_name=environment_name)
+        await handle._hydrate_from_app(app_name, tag, namespace, client, environment_name=environment_name)
         return handle
 
     @classmethod

--- a/modal/object.py
+++ b/modal/object.py
@@ -75,7 +75,9 @@ class _Handle(metaclass=ObjectMeta):
         return None
 
     @classmethod
-    def _from_id(cls: Type[H], object_id: str, client: _Client, handle_metadata: Optional[Message]) -> H:
+    def _new_hydrated(cls: Type[H], object_id: str, client: _Client, handle_metadata: Optional[Message]) -> H:
+        """Similar to `_new` and `_hydrate` but does both at the same time."""
+
         if cls._type_prefix is not None:
             # This is called directly on a subclass, e.g. Secret.from_id
             if not object_id.startswith(cls._type_prefix + "-"):
@@ -108,7 +110,7 @@ class _Handle(metaclass=ObjectMeta):
         )
 
         handle_metadata = get_proto_oneof(app_lookup_object_response, "handle_metadata_oneof")
-        return cls._from_id(object_id, client, handle_metadata)
+        return cls._new_hydrated(object_id, client, handle_metadata)
 
     @property
     def object_id(self) -> str:
@@ -149,7 +151,7 @@ class _Handle(metaclass=ObjectMeta):
                 raise
 
         handle_metadata = get_proto_oneof(response, "handle_metadata_oneof")
-        return cls._from_id(response.object_id, client, handle_metadata)
+        return cls._new_hydrated(response.object_id, client, handle_metadata)
 
 
 Handle = synchronize_api(_Handle)

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -93,6 +93,7 @@ class _Secret(_Provider[_SecretHandle]):
         This will use the location of the script calling `modal.Secret.from_dotenv` as a
         starting point for finding the `.env` file.
         """
+        handle: _SecretHandle = _SecretHandle._new()
 
         async def _load(resolver: Resolver, existing_object_id: Optional[str]) -> _SecretHandle:
             try:
@@ -126,7 +127,9 @@ class _Secret(_Provider[_SecretHandle]):
                 existing_secret_id=existing_object_id,
             )
             resp = await resolver.client.stub.SecretCreate(req)
-            return _SecretHandle._from_id(resp.secret_id, resolver.client, None)
+
+            handle._hydrate(resp.secret_id, resolver.client, None)
+            return handle
 
         return _Secret._from_loader(_load, "Secret.from_dotenv()")
 

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -130,7 +130,8 @@ class _Volume(_Provider[_VolumeHandle]):
             status_row = resolver.add_status_row()
             if existing_object_id:
                 # Volume already exists; do nothing.
-                return _VolumeHandle._from_id(existing_object_id, resolver.client, None)
+                handle._hydrate(existing_object_id, resolver.client, None)
+                return handle
 
             status_row.message("Creating volume...")
             req = api_pb2.VolumeCreateRequest(app_id=resolver.app_id)


### PR DESCRIPTION
One step towards merging handles and providers is we want to construct "unhydrated" handle objects early on – at the point of the provider constructor. I already made this change for a lot of subclasses in #660 but not for some special constructors on the base class. This finishes the work.

The unhydrated handle objects are just scoped inside constructors for now – but the next PR will make it a core property of the base provider class, which will let us unify even more constructor logic. (The step after that is to move pretty much all handle logic to the providers instead, which will make the handles pointless)

A lot of the existing constructor code is quite messy and unfortunately this change makes it slightly _more_ messy in the short term, which is regrettable. But I think there's some short-term pain for long-term gain.

This PR also renames some internal constructors to have more consistent names. So for instance `_from_id` is now called `_new_hydrated` since it basically combines `_new` and `_hydrate`. Generally trying to use the verb "hydrate" throughout the code base to make it clear.