### PR TITLE
Construct a handle on the base provider constructor

### DIFF
--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -25,7 +25,7 @@ from modal_proto import api_pb2
 from .helpers import deploy_stub_externally
 from .supports.skip import skip_windows_unix_socket
 
-EXTRA_TOLERANCE_DELAY = 1.0
+EXTRA_TOLERANCE_DELAY = 3.0
 FUNCTION_CALL_ID = "fc-123"
 SLEEP_DELAY = 0.1
 

--- a/client_test/resolver_test.py
+++ b/client_test/resolver_test.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from modal._output import OutputManager
 from modal._resolver import Resolver
-from modal.object import _Provider
+from modal.object import _Handle, _Provider
 
 
 @pytest.mark.asyncio
@@ -16,15 +16,18 @@ async def test_multi_resolve_sequential_loads_once():
 
     load_count = 0
 
-    class DumbObject(_Provider):
+    class _DumbHandle(_Handle):
         pass
 
-    async def _load(resolver: Resolver, existing_object_id: Optional[str]):
+    class _DumbProvider(_Provider[_DumbHandle]):
+        pass
+
+    async def _load(resolver: Resolver, existing_object_id: Optional[str], handle: _DumbHandle):
         nonlocal load_count
         load_count += 1
         await asyncio.sleep(0.1)
 
-    obj = DumbObject._from_loader(_load, "DumbObject()")
+    obj = _DumbProvider._from_loader(_load, "DumbProvider()")
 
     t0 = time.monotonic()
     await resolver.load(obj)
@@ -41,15 +44,18 @@ async def test_multi_resolve_concurrent_loads_once():
 
     load_count = 0
 
-    class DumbObject(_Provider):
+    class _DumbHandle(_Handle):
         pass
 
-    async def _load(resolver: Resolver, existing_object_id: Optional[str]):
+    class _DumbProvider(_Provider[_DumbHandle]):
+        pass
+
+    async def _load(resolver: Resolver, existing_object_id: Optional[str], handle: _DumbHandle):
         nonlocal load_count
         load_count += 1
         await asyncio.sleep(0.1)
 
-    obj = DumbObject._from_loader(_load, "DumbObject()")
+    obj = _DumbProvider._from_loader(_load, "DumbProvider()")
     t0 = time.monotonic()
     await asyncio.gather(resolver.load(obj), resolver.load(obj))
     assert 0.1 < time.monotonic() - t0 < 0.15

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -73,9 +73,9 @@ class Resolver:
     def client(self):
         return self._client
 
-    async def preload(self, obj, existing_object_id: Optional[str] = None):
+    async def preload(self, obj, existing_object_id: Optional[str], handle):
         if obj._preload is not None:
-            return await obj._preload(self, existing_object_id)
+            return await obj._preload(self, existing_object_id, handle)
 
     async def load(self, obj, existing_object_id: Optional[str] = None):
         cached_future = self._local_uuid_to_future.get(obj.local_uuid)
@@ -83,8 +83,9 @@ class Resolver:
         if not cached_future:
             # don't run any awaits within this if-block to prevent race conditions
             async def loader():
-                created_obj = await obj._load(self, existing_object_id)
-                if existing_object_id is not None and created_obj.object_id != existing_object_id:
+                handle = obj._handle
+                await obj._load(self, existing_object_id, handle)
+                if existing_object_id is not None and handle.object_id != existing_object_id:
                     # TODO(erikbern): ignoring images is an ugly fix to a problem that's on the server.
                     # Unlike every other object, images are not assigned random ids, but rather an
                     # id given by the hash of its contents. This means we can't _force_ an image to
@@ -96,10 +97,10 @@ class Resolver:
                     if not obj._is_persisted_ref and not existing_object_id.startswith("im-"):
                         raise Exception(
                             f"Tried creating an object using existing id {existing_object_id}"
-                            f" but it has id {created_obj.object_id}"
+                            f" but it has id {handle.object_id}"
                         )
 
-                return created_obj
+                return handle
 
             cached_future = asyncio.create_task(loader())
             self._local_uuid_to_future[obj.local_uuid] = cached_future

--- a/modal/app.py
+++ b/modal/app.py
@@ -97,7 +97,7 @@ class _App:
                 # Note: preload only currently implemented for Functions, returns None otherwise
                 # this is to ensure that directly referenced functions from the global scope has
                 # ids associated with them when they are serialized into other functions
-                precreated_object = await resolver.preload(provider, existing_object_id)
+                precreated_object = await resolver.preload(provider, existing_object_id, provider._handle)
                 if precreated_object is not None:
                     self._tag_to_existing_id[tag] = precreated_object.object_id
                     self._tag_to_object[tag] = precreated_object

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -142,9 +142,7 @@ class _Dict(_Provider[_DictHandle]):
     def new(data={}) -> "_Dict":
         """Create a new dictionary, optionally filled with initial data."""
 
-        handle: _DictHandle = _DictHandle._new()
-
-        async def _load(resolver: Resolver, existing_object_id: Optional[str]) -> _DictHandle:
+        async def _load(resolver: Resolver, existing_object_id: Optional[str], handle: _DictHandle):
             serialized = _serialize_dict(data)
             req = api_pb2.DictCreateRequest(
                 app_id=resolver.app_id, data=serialized, existing_dict_id=existing_object_id
@@ -152,7 +150,6 @@ class _Dict(_Provider[_DictHandle]):
             response = await resolver.client.stub.DictCreate(req)
             logger.debug("Created dict with id %s" % response.dict_id)
             handle._hydrate(response.dict_id, resolver.client, None)
-            return handle
 
         return _Dict._from_loader(_load, "Dict()")
 

--- a/modal/image.py
+++ b/modal/image.py
@@ -171,13 +171,10 @@ class _Image(_Provider[_ImageHandle]):
         if build_function and len(base_images) != 1:
             raise InvalidError("Cannot run a build function with multiple base images!")
 
-        handle: _ImageHandle = _ImageHandle._new()
-
-        async def _load(resolver: Resolver, existing_object_id: Optional[str]):
+        async def _load(resolver: Resolver, existing_object_id: Optional[str], handle: _ImageHandle):
             if ref:
                 image_id = (await resolver.load(ref)).object_id
                 handle._hydrate(image_id, resolver.client, None)
-                return handle
 
             # Recursively build base images
             base_image_ids: List[str] = []
@@ -292,7 +289,6 @@ class _Image(_Provider[_ImageHandle]):
                 raise RemoteError("Unknown status %s!" % result.status)
 
             handle._hydrate(image_id, resolver.client, None)
-            return handle
 
         rep = f"Image({dockerfile_commands})"
         obj = _Image._from_loader(_load, rep)

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -142,8 +142,7 @@ class _Mount(_Provider[_MountHandle]):
     @staticmethod
     def _from_entries(*entries: _MountEntry) -> "_Mount":
         rep = f"Mount({entries})"
-        handle: _MountHandle = _MountHandle._new()
-        load = functools.partial(_Mount._load_mount, entries, handle)
+        load = functools.partial(_Mount._load_mount, entries)
         obj = _Mount._from_loader(load, rep)
         obj._entries = entries
         obj._is_local = True
@@ -256,7 +255,10 @@ class _Mount(_Provider[_MountHandle]):
 
     @staticmethod
     async def _load_mount(
-        entries: List[_MountEntry], handle: _MountHandle, resolver: Resolver, existing_object_id: Optional[str]
+        entries: List[_MountEntry],
+        resolver: Resolver,
+        existing_object_id: Optional[str],
+        handle: _MountHandle,
     ):
         # Run a threadpool to compute hash values, and use concurrent coroutines to register files.
         t0 = time.time()

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -189,14 +189,11 @@ class _NetworkFileSystem(_Provider[_NetworkFileSystemHandle]):
     def new(cloud: Optional[str] = None) -> "_NetworkFileSystem":
         """Construct a new shared volume, which is empty by default."""
 
-        handle: _NetworkFileSystemHandle = _NetworkFileSystemHandle._new()
-
-        async def _load(resolver: Resolver, existing_object_id: Optional[str]) -> _NetworkFileSystemHandle:
+        async def _load(resolver: Resolver, existing_object_id: Optional[str], handle: _NetworkFileSystemHandle):
             status_row = resolver.add_status_row()
             if existing_object_id:
                 # Volume already exists; do nothing.
                 handle._hydrate(existing_object_id, resolver.client, None)
-                return handle
 
             cloud_provider = parse_cloud_provider(cloud) if cloud else None
 
@@ -205,7 +202,6 @@ class _NetworkFileSystem(_Provider[_NetworkFileSystemHandle]):
             resp = await retry_transient_errors(resolver.client.stub.SharedVolumeCreate, req)
             status_row.finish("Created shared volume.")
             handle._hydrate(resp.shared_volume_id, resolver.client, None)
-            return handle
 
         return _NetworkFileSystem._from_loader(_load, "NetworkFileSystem()")
 

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -139,13 +139,10 @@ class _Queue(_Provider[_QueueHandle]):
 
     @staticmethod
     def new():
-        handle: _QueueHandle = _QueueHandle._new()
-
-        async def _load(resolver: Resolver, existing_object_id: Optional[str]) -> _QueueHandle:
+        async def _load(resolver: Resolver, existing_object_id: Optional[str], handle: _QueueHandle):
             request = api_pb2.QueueCreateRequest(app_id=resolver.app_id, existing_queue_id=existing_object_id)
             response = await resolver.client.stub.QueueCreate(request)
             handle._hydrate(response.queue_id, resolver.client, None)
-            return handle
 
         return _Queue._from_loader(_load, "Queue()")
 

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -105,9 +105,7 @@ class _Sandbox(_Provider[_SandboxHandle]):
         if len(entrypoint_args) == 0:
             raise InvalidError("entrypoint_args must not be empty")
 
-        async def _load(resolver: Resolver, _existing_object_id: Optional[str]) -> _SandboxHandle:
-            handle: _SandboxHandle = _SandboxHandle._new()
-
+        async def _load(resolver: Resolver, _existing_object_id: Optional[str], handle: _SandboxHandle):
             async def _load_mounts():
                 handles = await asyncio.gather(*[resolver.load(mount) for mount in mounts])
                 return [handle.object_id for handle in handles]
@@ -131,7 +129,6 @@ class _Sandbox(_Provider[_SandboxHandle]):
 
             handle._stdout = LogsReader(api_pb2.FILE_DESCRIPTOR_STDOUT, sandbox_id, resolver.client)
             handle._stderr = LogsReader(api_pb2.FILE_DESCRIPTOR_STDERR, sandbox_id, resolver.client)
-            return handle
 
         return _Sandbox._from_loader(_load, "Sandbox()")
 

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -54,9 +54,7 @@ class _Secret(_Provider[_SecretHandle]):
         ):
             raise InvalidError(ENV_DICT_WRONG_TYPE_ERR)
 
-        handle: _SecretHandle = _SecretHandle._new()
-
-        async def _load(resolver: Resolver, existing_object_id: Optional[str]) -> _SecretHandle:
+        async def _load(resolver: Resolver, existing_object_id: Optional[str], handle: _SecretHandle):
             req = api_pb2.SecretCreateRequest(
                 app_id=resolver.app_id,
                 env_dict=env_dict,
@@ -65,7 +63,6 @@ class _Secret(_Provider[_SecretHandle]):
             )
             resp = await resolver.client.stub.SecretCreate(req)
             handle._hydrate(resp.secret_id, resolver.client, None)
-            return handle
 
         rep = f"Secret.from_dict([{', '.join(env_dict.keys())}])"
         return _Secret._from_loader(_load, rep)
@@ -93,9 +90,8 @@ class _Secret(_Provider[_SecretHandle]):
         This will use the location of the script calling `modal.Secret.from_dotenv` as a
         starting point for finding the `.env` file.
         """
-        handle: _SecretHandle = _SecretHandle._new()
 
-        async def _load(resolver: Resolver, existing_object_id: Optional[str]) -> _SecretHandle:
+        async def _load(resolver: Resolver, existing_object_id: Optional[str], handle: _SecretHandle):
             try:
                 from dotenv import dotenv_values, find_dotenv
                 from dotenv.main import _walk_to_root
@@ -129,7 +125,6 @@ class _Secret(_Provider[_SecretHandle]):
             resp = await resolver.client.stub.SecretCreate(req)
 
             handle._hydrate(resp.secret_id, resolver.client, None)
-            return handle
 
         return _Secret._from_loader(_load, "Secret.from_dotenv()")
 

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -124,21 +124,17 @@ class _Volume(_Provider[_VolumeHandle]):
     def new() -> "_Volume":
         """Construct a new volume, which is empty by default."""
 
-        handle: _VolumeHandle = _VolumeHandle._new()
-
-        async def _load(resolver: Resolver, existing_object_id: Optional[str]) -> _VolumeHandle:
+        async def _load(resolver: Resolver, existing_object_id: Optional[str], handle: _VolumeHandle):
             status_row = resolver.add_status_row()
             if existing_object_id:
                 # Volume already exists; do nothing.
                 handle._hydrate(existing_object_id, resolver.client, None)
-                return handle
 
             status_row.message("Creating volume...")
             req = api_pb2.VolumeCreateRequest(app_id=resolver.app_id)
             resp = await retry_transient_errors(resolver.client.stub.VolumeCreate, req)
             status_row.finish("Created volume.")
             handle._hydrate(resp.volume_id, resolver.client, None)
-            return handle
 
         return _Volume._from_loader(_load, "Volume()")
 


### PR DESCRIPTION
This makes the `Provider` base class constructor an unhydrated `Handle` object as a part of it, which means every `Provider` always carries a handle (hydrated or not).

This ties the two classes even tighter together. Next step is to move a lot of logic from the handles to the providers, turning handles into a useless object eventually (that can be removed). 