### PR TITLE
move function_invocations to the client

### DIFF
--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -124,11 +124,14 @@ def test_run(servicer, set_env_client, test_dir):
 
 
 @pytest.mark.filterwarnings("error")  # any warnings that aren't caught will fail this test
-def test_local_entrypoint_no_remote_calls(servicer, set_env_client, test_dir):
+def test_local_entrypoint_yes_remote_calls(servicer, set_env_client, test_dir):
     file = test_dir / "supports" / "app_run_tests" / "local_entrypoint.py"
     res = _run(["run", file.as_posix()])
     assert "Warning: no remote function calls were made" not in res.stderr
 
+
+@pytest.mark.filterwarnings("error")  # any warnings that aren't caught will fail this test
+def test_local_entrypoint_no_remote_calls(servicer, set_env_client, test_dir):
     file = test_dir / "supports" / "app_run_tests" / "local_entrypoint_no_remote.py"
     with pytest.warns(UserWarning, match="Warning: no remote function calls were made"):
         _run(["run", file.as_posix()])

--- a/modal/app.py
+++ b/modal/app.py
@@ -47,7 +47,6 @@ class _App:
     _app_id: str
     _app_page_url: str
     _resolver: Optional[Resolver]
-    _function_invocations: int  # Number of function invocations made by this app.
     _environment_name: str
     _output_mgr: Optional[OutputManager]
 
@@ -68,7 +67,6 @@ class _App:
         self._client = client
         self._tag_to_object = tag_to_object or {}
         self._tag_to_existing_id = tag_to_existing_id or {}
-        self._function_invocations = 0
         self._stub_name = stub_name
         self._environment_name = environment_name
         self._output_mgr = output_mgr
@@ -150,13 +148,6 @@ class _App:
 
     def __getattr__(self, tag: str) -> _Handle:
         return self._tag_to_object[tag]
-
-    def track_function_invocation(self):
-        self._function_invocations += 1
-
-    @property
-    def function_invocations(self):
-        return self._function_invocations
 
     async def _init_container(self, client: _Client, app_id: str, stub_name: str):
         self._client = client
@@ -265,8 +256,6 @@ class _App:
     async def spawn_sandbox(self, *entrypoint_args: str, image=None, mounts=[]) -> "modal.sandbox._SandboxHandle":
         from .sandbox import _Sandbox
         from .stub import _default_image
-
-        self.track_function_invocation()
 
         resolver = Resolver(self._output_mgr, self._client, self._environment_name, self.app_id)
         provider = _Sandbox._new(list(entrypoint_args), image or _default_image, mounts)

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -124,7 +124,7 @@ def _get_click_command_for_local_entrypoint(_stub, entrypoint: LocalEntrypoint):
                 asyncio.run(func(*args, **kwargs))
             else:
                 func(*args, **kwargs)
-            if app.function_invocations == 0:
+            if app.client.function_invocations == 0:
                 # TODO: better formatting for the warning message
                 warnings.warn(
                     "Warning: no remote function calls were made.\n"

--- a/modal/client.py
+++ b/modal/client.py
@@ -89,6 +89,7 @@ class _Client:
         self._pre_stop: Optional[Callable[[], Awaitable[None]]] = None
         self._channel = None
         self._stub = None
+        self._function_invocations = 0
 
     @property
     def stub(self):
@@ -242,6 +243,13 @@ class _Client:
     def set_env_client(cls, client):
         """Just used from tests."""
         cls._client_from_env = client
+
+    def track_function_invocation(self):
+        self._function_invocations += 1
+
+    @property
+    def function_invocations(self):
+        return self._function_invocations
 
 
 Client = synchronize_api(_Client)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -589,7 +589,8 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
         return self._is_generator
 
     def _track_function_invocation(self):
-        self._client.track_function_invocation()
+        if self._client is not None:  # Note that if it is None, then it will fail later anyway
+            self._client.track_function_invocation()
 
     async def _map(self, input_stream: AsyncIterable[Any], order_outputs: bool, return_exceptions: bool, kwargs={}):
         if self._web_url:

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -589,8 +589,7 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
         return self._is_generator
 
     def _track_function_invocation(self):
-        if self._stub and self._stub.app:
-            self._stub.app.track_function_invocation()
+        self._client.track_function_invocation()
 
     async def _map(self, input_stream: AsyncIterable[Any], order_outputs: bool, return_exceptions: bool, kwargs={}):
         if self._web_url:


### PR DESCRIPTION
Minor thing but the fact that the `_FunctionHandle` has a reference to the stub gets in the way of some refactoring I want to do. And this is one out of two reasons it refers to it. The other once can be fixed pretty easily once #669 is merged.

Don't think there's an obvious place to track the number of function invocations, so client vs app seems fairly irrelevant to me – and all handles already carry references to clients.

I think changing to `.remote(...)` and `.local(...)` would also obviate the need for this, since the user mistake we're trying to assist with is people forgetting to use `.call(...)` and calling a function locally. So at that point we can remove this altogether.