### PR TITLE
modal shell by not creating functions dynamically

### DIFF
--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -277,7 +277,7 @@ def test_serve(servicer, set_env_client, server_url_env, test_dir):
 
 @pytest.fixture
 def mock_shell_pty():
-    def mock_get_pty_info() -> api_pb2.PTYInfo:
+    def mock_get_pty_info(shell: bool) -> api_pb2.PTYInfo:
         rows, cols = (64, 128)
         return api_pb2.PTYInfo(
             enabled=True,

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -584,7 +584,7 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
             # TODO(erikbern): there is no client test for this branch
             input_stream_unwrapped = synchronizer._translate_in(container_app._pty_input_stream)
             input_stream_blocking = synchronizer._translate_out(input_stream_unwrapped, Interface.BLOCKING)
-            imp_fun.fun = run_in_pty(imp_fun.fun, input_stream_blocking, container_args.function_def.pty_info)
+            imp_fun.fun = run_in_pty(imp_fun.fun, input_stream_blocking, pty_info)
 
         if not imp_fun.is_async:
             call_function_sync(function_io_manager, imp_fun.obj, imp_fun.fun, imp_fun.is_generator)

--- a/modal/_pty.py
+++ b/modal/_pty.py
@@ -142,15 +142,16 @@ def run_in_pty(fn, queue, pty_info: api_pb2.PTYInfo):
     return wrapped_fn
 
 
-def get_pty_info() -> api_pb2.PTYInfo:
+def get_pty_info(shell: bool) -> api_pb2.PTYInfo:
     rows, cols = get_winsz(sys.stdin.fileno())
     return api_pb2.PTYInfo(
-        enabled=True,
+        enabled=True,  # TODO(erikbern): deprecated
         winsz_rows=rows,
         winsz_cols=cols,
         env_term=os.environ.get("TERM"),
         env_colorterm=os.environ.get("COLORTERM"),
         env_term_program=os.environ.get("TERM_PROGRAM"),
+        pty_type=api_pb2.PTYInfo.PTY_TYPE_SHELL if shell else api_pb2.PTYInfo.PTY_TYPE_FUNCTION,
     )
 
 

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -49,7 +49,9 @@ class Resolver:
     _local_uuid_to_future: Dict[str, Future]
     _environment_name: str
 
-    def __init__(self, output_mgr, client, environment_name: str, app_id: Optional[str] = None):
+    def __init__(
+        self, output_mgr, client, environment_name: str, app_id: Optional[str] = None, shell: Optional[bool] = False
+    ):
         from rich.tree import Tree
 
         from ._output import step_progress
@@ -62,6 +64,7 @@ class Resolver:
         self._client = client
         self._app_id = app_id
         self._environment_name = environment_name
+        self._shell = shell
 
     @property
     def app_id(self) -> str:

--- a/modal/app.py
+++ b/modal/app.py
@@ -82,10 +82,10 @@ class _App:
         return self._app_id
 
     async def _create_all_objects(
-        self, blueprint: Dict[str, _Provider], new_app_state: int, environment_name: str
+        self, blueprint: Dict[str, _Provider], new_app_state: int, environment_name: str, shell: bool = False
     ):  # api_pb2.AppState.V
         """Create objects that have been defined but not created on the server."""
-        resolver = Resolver(self._output_mgr, self._client, environment_name, self.app_id)
+        resolver = Resolver(self._output_mgr, self._client, environment_name, self.app_id, shell=shell)
         with resolver.display():
             # Preload all functions to make sure they have ids assigned before they are loaded.
             # This is important to make sure any enclosed function handle references in serialized

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -276,14 +276,8 @@ def shell(
         func_ref, accept_local_entrypoint=False, accept_webhook=True, interactive=True, base_cmd="modal shell"
     )
     assert isinstance(_function_handle, _FunctionHandle)  # ensured by accept_local_entrypoint=False
-    _stub = _function_handle._stub
-    _function = _function_handle._get_function()
-    blocking_stub = synchronizer._translate_out(_stub, Interface.BLOCKING)
-    blocking_function = synchronizer._translate_out(_function, Interface.BLOCKING)
-
     interactive_shell(
-        blocking_stub,
+        _function_handle,
         cmd,
-        blocking_function,
         environment_name=env,
     )

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -319,6 +319,14 @@ class _Stub:
     def _pty_input_stream(self):
         return self._blueprint.get("_pty_input_stream", None)
 
+    def _add_pty_input_stream(self):
+        if self._pty_input_stream:
+            warnings.warn(
+                "Running multiple interactive functions at the same time is not fully supported, and could lead to unexpected behavior."
+            )
+        else:
+            self._blueprint["_pty_input_stream"] = _Queue.new()
+
     def _get_watch_mounts(self):
         all_mounts = [
             *self._mounts,
@@ -501,12 +509,7 @@ class _Stub:
                 is_generator_override = inspect.isgeneratorfunction(raw_f) or inspect.isasyncgenfunction(raw_f)
 
             if interactive:
-                if self._pty_input_stream:
-                    warnings.warn(
-                        "Running multiple interactive functions at the same time is not fully supported, and could lead to unexpected behavior."
-                    )
-                else:
-                    self._blueprint["_pty_input_stream"] = _Queue.new()
+                self._add_pty_input_stream()
 
             function = _Function.from_args(
                 info,


### PR DESCRIPTION
This changes how `modal shell` works. Instead of creating a function dynamically from `exec_cmd`, keep the original function definition, but set a flag on it that tells the container entrypoint to run `exec_cmd` inside the container instead.

Note: broke out a minor part of this change into #674 to be deployed first – should make it easier to test this change against prod.