### PR TITLE
Introduce a PTYType enum and handle it in the container

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -578,7 +578,9 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
         with function_io_manager.handle_user_exception():
             imp_fun = import_function(container_args.function_def, ser_cls, ser_fun, container_args.serialized_params)
 
-        if container_args.function_def.pty_info.enabled:
+        pty_info: api_pb2.PTYInfo = container_args.function_def.pty_info
+        if pty_info.pty_type or pty_info.enabled:
+            # TODO(erikbern): the second condition is for legacy compatibility, remove soon
             # TODO(erikbern): there is no client test for this branch
             input_stream_unwrapped = synchronizer._translate_in(container_app._pty_input_stream)
             input_stream_blocking = synchronizer._translate_out(input_stream_unwrapped, Interface.BLOCKING)

--- a/modal/_pty.py
+++ b/modal/_pty.py
@@ -107,6 +107,9 @@ def run_in_pty(fn, queue, pty_info: api_pb2.PTYInfo):
     import pty
     import threading
 
+    if pty_info.pty_type == api_pb2.PTYInfo.PTY_TYPE_SHELL:
+        fn = exec_cmd
+
     @functools.wraps(fn)
     def wrapped_fn(*args, **kwargs):
         write_fd, read_fd = pty.openpty()

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -435,12 +435,18 @@ message DomainCertificateVerifyResponse {
 }
 
 message PTYInfo {
-  bool enabled = 1;
+  bool enabled = 1;  // Soon deprecated
   uint32 winsz_rows = 2;
   uint32 winsz_cols = 3;
   string env_term = 4;
   string env_colorterm = 5;
   string env_term_program = 6;
+  enum PTYType {
+    PTY_TYPE_UNSPECIFIED = 0;  // Nothing
+    PTY_TYPE_FUNCTION = 1;  // Run function in PTY
+    PTY_TYPE_SHELL = 2;  // Replace function with shell
+  }
+  PTYType pty_type = 7;
 }
 
 message Function {


### PR DESCRIPTION
Breaking this out of #672 and deploying it separately. There's some issue where I'm not able to run the changes in that PR against prod and I suspect it's because we're not propagating the new pty_type field properly since it's not a recognized field. I hope that merging the proto changes separately will cause the backend to recognize the field and propagate it.