### PR TITLE
Replicate handle methods on the provider

### DIFF
--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -575,7 +575,11 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def QueueGet(self, stream):
         await stream.recv_message()
-        await stream.send_message(api_pb2.QueueGetResponse(values=[self.queue.pop(0)]))
+        if len(self.queue) > 0:
+            values = [self.queue.pop(0)]
+        else:
+            values = []
+        await stream.send_message(api_pb2.QueueGetResponse(values=values))
 
     ### Sandbox
 

--- a/client_test/dict_test.py
+++ b/client_test/dict_test.py
@@ -15,7 +15,7 @@ def test_dict(servicer, client):
 def test_dict_use_provider(servicer, client):
     stub = Stub()
     stub.d = Dict.new()
-    with stub.run(client=client) as app:
+    with stub.run(client=client):
         stub.d["foo"] = 42
         stub.d["foo"] += 5
         assert stub.d["foo"] == 47

--- a/client_test/dict_test.py
+++ b/client_test/dict_test.py
@@ -1,0 +1,21 @@
+# Copyright Modal Labs 2022
+
+from modal import Dict, Stub
+
+
+def test_dict(servicer, client):
+    stub = Stub()
+    stub.d = Dict.new()
+    with stub.run(client=client) as app:
+        app.d["foo"] = 42
+        app.d["foo"] += 5
+        assert app.d["foo"] == 47
+
+
+def test_dict_use_provider(servicer, client):
+    stub = Stub()
+    stub.d = Dict.new()
+    with stub.run(client=client) as app:
+        stub.d["foo"] = 42
+        stub.d["foo"] += 5
+        assert stub.d["foo"] == 47

--- a/client_test/queue_test.py
+++ b/client_test/queue_test.py
@@ -19,4 +19,5 @@ def test_queue_use_provider(servicer, client):
     stub = Stub()
     stub.q = Queue.new()
     with stub.run(client=client):
+        assert isinstance(stub.q, Queue)
         stub.q.put("xyz")

--- a/client_test/queue_test.py
+++ b/client_test/queue_test.py
@@ -1,0 +1,22 @@
+# Copyright Modal Labs 2022
+import queue
+import pytest
+
+from modal import Queue, Stub
+
+
+def test_queue(servicer, client):
+    stub = Stub()
+    stub.q = Queue.new()
+    with stub.run(client=client) as app:
+        app.q.put(42)
+        assert app.q.get() == 42
+        with pytest.raises(queue.Empty):
+            app.q.get(timeout=0)
+
+
+def test_queue_use_provider(servicer, client):
+    stub = Stub()
+    stub.q = Queue.new()
+    with stub.run(client=client) as app:
+        stub.q.put("xyz")

--- a/client_test/queue_test.py
+++ b/client_test/queue_test.py
@@ -1,6 +1,6 @@
 # Copyright Modal Labs 2022
-import queue
 import pytest
+import queue
 
 from modal import Queue, Stub
 
@@ -18,5 +18,5 @@ def test_queue(servicer, client):
 def test_queue_use_provider(servicer, client):
     stub = Stub()
     stub.q = Queue.new()
-    with stub.run(client=client) as app:
+    with stub.run(client=client):
         stub.q.put("xyz")

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -173,5 +173,36 @@ class _Dict(_Provider[_DictHandle]):
         deprecation_warning(date(2023, 6, 30), self.persist.__doc__)
         return self.persisted(label, namespace, environment_name)
 
+    # Handle methods - temporary until we get rid of all user-facing handles
+    async def get(self, key: Any) -> Any:
+        return await self._handle.get(key)
+
+    async def contains(self, key: Any) -> bool:
+        return await self._handle.contains(key)
+
+    async def len(self) -> int:
+        return await self._handle.len()
+
+    async def __getitem__(self, key: Any) -> Any:
+        return await self._handle.__getitem__(key)
+
+    async def update(self, **kwargs) -> None:
+        return await self._handle.update(**kwargs)
+
+    async def put(self, key: Any, value: Any) -> None:
+        return await self._handle.put(key, value)
+
+    async def __setitem__(self, key: Any, value: Any) -> None:
+        return await self._handle.__setitem__(key, value)
+
+    async def pop(self, key: Any) -> Any:
+        return await self._handle.pop(key)
+
+    async def __delitem__(self, key: Any) -> Any:
+        return await self._handle.__delitem__(key)
+
+    async def __contains__(self, key: Any) -> bool:
+        return await self._handle.__contains(key)
+
 
 Dict = synchronize_api(_Dict)

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -158,5 +158,18 @@ class _Queue(_Provider[_QueueHandle]):
     ) -> "_Queue":
         return _Queue.new()._persist(label, namespace, environment_name)
 
+    # Live handle methods
+    async def get(self, block: bool = True, timeout: Optional[float] = None) -> Optional[Any]:
+        return await self._handle.get(block, timeout)
+
+    async def get_many(self, n_values: int, block: bool = True, timeout: Optional[float] = None) -> List[Any]:
+        return await self._handle.get_many(n_values, block, timeout)
+
+    async def put(self, v: Any) -> None:
+        return await self._handle.put(v)
+
+    async def put_many(self, vs: List[Any]) -> None:
+        return await self._handle.put_many(vs)
+
 
 Queue = synchronize_api(_Queue)


### PR DESCRIPTION
This lets you call "live" handle methods on the `Provider` class instead, which basically works by routing every method call to the underlying handle.

Only doing it for 2/5 handles in this PR:

* [X] `Queue`
* [X] `Dict`
* [ ] `Volume` (`commit`, `reload`, ...)
* [ ] `NetworkFileSystem` (`write_file`, `read_file`, ...)
* [ ] `Function` (all the function calling)

Replicating all methods is a fairly dumb workaround for now. But the idea is that once all methods are wrapped, we can return a `Provider` class instead of a `Handle` class in a bunch of places without breaking user code, thanks to the magic of duck typing. Once we return providers everywhere, we can move the biz logic from the handle classes the provider classes and get rid of the handle classes 🎉 
