### PR TITLE
Fix issue with existing volume ID

### DIFF
--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -194,6 +194,7 @@ class _NetworkFileSystem(_Provider[_NetworkFileSystemHandle]):
             if existing_object_id:
                 # Volume already exists; do nothing.
                 handle._hydrate(existing_object_id, resolver.client, None)
+                return
 
             cloud_provider = parse_cloud_provider(cloud) if cloud else None
 

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -129,6 +129,7 @@ class _Volume(_Provider[_VolumeHandle]):
             if existing_object_id:
                 # Volume already exists; do nothing.
                 handle._hydrate(existing_object_id, resolver.client, None)
+                return
 
             status_row.message("Creating volume...")
             req = api_pb2.VolumeCreateRequest(app_id=resolver.app_id)


### PR DESCRIPTION
We removed some code in [this PR](https://github.com/modal-labs/modal-client/pull/669) that caused us to not exit early when an object ID already existed. This was causing us to create a new shared volume when already existed (etc)