### PR TITLE
modal shell: hacky workaround for old workers and newest client

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1088,6 +1088,11 @@ class _Function(_Provider[_FunctionHandle]):
             if resolver._shell:
                 timeout_secs = 86400
                 pty_info = _pty.get_pty_info(shell=True)
+
+                # TODO(erikbern): super hacky workaround for old workers 2023-07-24
+                from ._pty import exec_cmd
+
+                info = FunctionInfo(exec_cmd)
             elif interactive:
                 pty_info = _pty.get_pty_info(shell=False)
             else:


### PR DESCRIPTION
It does look like #672 breaks with old workers (who don't know the `pty_type` field) and the newest client.

This is an incredibly dumb workaround that we might need for a few days. 