### PR TITLE
Client supports concurrent inputs

### DIFF
--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -688,7 +688,7 @@ def verify_concurrent_input_outputs(n_inputs: int, n_parallel: int, output_items
         assert diff == pytest.approx(expected_diff, abs=0.2)
 
     for item in output_items:
-        assert item.output_created_at - item.input_started_at == pytest.approx(1.0, abs=0.05)
+        assert item.output_created_at - item.input_started_at == pytest.approx(1.0, abs=0.1)
         assert item.result.status == api_pb2.GenericResult.GENERIC_STATUS_SUCCESS
         assert item.result.data == serialize(42**2)
 

--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -675,6 +675,7 @@ def test_multistub_is_inside_warning(unix_servicer, caplog, capsys):
         "inside b" in out
     )  # can't determine which of two anonymous stubs is the active one at import time, so both will trigger
 
+
 def verify_concurrent_input_outputs(n_inputs: int, n_parallel: int, output_items: list[api_pb2.FunctionPutOutputsItem]):
     # Ensure that outputs align with expectation of running concurrent inputs
 
@@ -682,7 +683,7 @@ def verify_concurrent_input_outputs(n_inputs: int, n_parallel: int, output_items
     # and different groups should start 1 second apart.
     assert len(output_items) == n_inputs
     for i in range(1, len(output_items)):
-        diff = output_items[i].input_started_at - output_items[i-1].input_started_at
+        diff = output_items[i].input_started_at - output_items[i - 1].input_started_at
         print(diff)
         expected_diff = 1.0 if i % n_parallel == 0 else 0
         assert diff == pytest.approx(expected_diff, abs=0.05)
@@ -691,6 +692,7 @@ def verify_concurrent_input_outputs(n_inputs: int, n_parallel: int, output_items
         assert item.output_created_at - item.input_started_at == pytest.approx(1.0, abs=0.05)
         assert item.result.status == api_pb2.GenericResult.GENERIC_STATUS_SUCCESS
         assert item.result.data == serialize(42**2)
+
 
 @skip_windows_unix_socket
 def test_concurrent_inputs_sync_function(unix_servicer):

--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -698,8 +698,8 @@ def verify_concurrent_input_outputs(n_inputs: int, n_parallel: int, output_items
 
 @skip_windows_unix_socket
 def test_concurrent_inputs_sync_function(unix_servicer):
-    n_inputs = 32
-    n_parallel = 8
+    n_inputs = 18
+    n_parallel = 6
 
     t0 = time.time()
     client, items = _run_container(
@@ -717,8 +717,8 @@ def test_concurrent_inputs_sync_function(unix_servicer):
 
 @skip_windows_unix_socket
 def test_concurrent_inputs_async_function(unix_servicer, event_loop):
-    n_inputs = 32
-    n_parallel = 8
+    n_inputs = 18
+    n_parallel = 6
 
     t0 = time.time()
     client, items = _run_container(

--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -685,7 +685,7 @@ def verify_concurrent_input_outputs(n_inputs: int, n_parallel: int, output_items
     for i in range(1, len(output_items)):
         diff = output_items[i].input_started_at - output_items[i - 1].input_started_at
         expected_diff = 1.0 if i % n_parallel == 0 else 0
-        assert diff == pytest.approx(expected_diff, abs=0.05)
+        assert diff == pytest.approx(expected_diff, abs=0.2)
 
     for item in output_items:
         assert item.output_created_at - item.input_started_at == pytest.approx(1.0, abs=0.05)

--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -30,13 +30,12 @@ FUNCTION_CALL_ID = "fc-123"
 SLEEP_DELAY = 0.1
 
 
-def _get_inputs(args: Tuple[Tuple, Dict] = ((42,), {})) -> list[api_pb2.FunctionGetInputsResponse]:
+def _get_inputs(args: Tuple[Tuple, Dict] = ((42,), {}), n: int = 1) -> list[api_pb2.FunctionGetInputsResponse]:
     input_pb = api_pb2.FunctionInput(args=serialize(args))
 
     return [
-        api_pb2.FunctionGetInputsResponse(inputs=[api_pb2.FunctionGetInputsItem(input_id="in-xyz", input=input_pb)]),
-        api_pb2.FunctionGetInputsResponse(inputs=[api_pb2.FunctionGetInputsItem(kill_switch=True)]),
-    ]
+        api_pb2.FunctionGetInputsResponse(inputs=[api_pb2.FunctionGetInputsItem(input_id="in-xyz", input=input_pb)])
+    ] * n + [api_pb2.FunctionGetInputsResponse(inputs=[api_pb2.FunctionGetInputsItem(kill_switch=True)])]
 
 
 def _run_container(
@@ -50,6 +49,7 @@ def _run_container(
     definition_type=api_pb2.Function.DEFINITION_TYPE_FILE,
     stub_name: str = "",
     is_builder_function: bool = False,
+    allow_concurrent_inputs: Optional[int] = None,
     serialized_params: Optional[bytes] = None,
 ) -> tuple[Client, list[api_pb2.FunctionPutOutputsItem]]:
     with Client(servicer.remote_addr, api_pb2.CLIENT_TYPE_CONTAINER, ("ta-123", "task-secret")) as client:
@@ -76,6 +76,7 @@ def _run_container(
             definition_type=definition_type,
             stub_name=stub_name or "",
             is_builder_function=is_builder_function,
+            allow_concurrent_inputs=allow_concurrent_inputs,
         )
 
         container_args = api_pb2.ContainerArguments(
@@ -672,3 +673,45 @@ def test_multistub_is_inside_warning(unix_servicer, caplog, capsys):
     assert (
         "inside b" in out
     )  # can't determine which of two anonymous stubs is the active one at import time, so both will trigger
+
+
+@skip_windows_unix_socket
+def test_concurrent_inputs_sync_function(unix_servicer):
+    n_inputs = 12
+    n_threads = 6
+    expected_execution = n_inputs / n_threads
+
+    t0 = time.time()
+    client, items = _run_container(
+        unix_servicer,
+        "modal_test_support.functions",
+        "sleep_1_sync",
+        inputs=_get_inputs(n=n_inputs),
+        allow_concurrent_inputs=n_threads,
+    )
+    assert expected_execution <= time.time() - t0 < expected_execution + EXTRA_TOLERANCE_DELAY
+    assert len(items) == n_inputs
+    for item in items:
+        assert item.result.status == api_pb2.GenericResult.GENERIC_STATUS_SUCCESS
+        assert item.result.data == serialize(42**2)
+
+
+@skip_windows_unix_socket
+def test_concurrent_inputs_async_function(unix_servicer, event_loop):
+    n_inputs = 12
+    n_tasks = 6
+    expected_execution = n_inputs / n_tasks
+
+    t0 = time.time()
+    client, items = _run_container(
+        unix_servicer,
+        "modal_test_support.functions",
+        "sleep_1_async",
+        inputs=_get_inputs(n=n_inputs),
+        allow_concurrent_inputs=n_tasks,
+    )
+    assert expected_execution <= time.time() - t0 < expected_execution + EXTRA_TOLERANCE_DELAY
+    assert len(items) == n_inputs
+    for item in items:
+        assert item.result.status == api_pb2.GenericResult.GENERIC_STATUS_SUCCESS
+        assert item.result.data == serialize(42**2)

--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -685,7 +685,7 @@ def verify_concurrent_input_outputs(n_inputs: int, n_parallel: int, output_items
     # Each group of n_parallel inputs should start together of each other
     # and different groups should start SLEEP_TIME apart.
     assert len(output_items) == n_inputs
-    for i in range(1, len(sorted(output_items, key=lambda x: x.input_started_at))):
+    for i in range(1, len(output_items)):
         diff = output_items[i].input_started_at - output_items[i - 1].input_started_at
         expected_diff = SLEEP_TIME if i % n_parallel == 0 else 0
         assert diff == pytest.approx(expected_diff, abs=0.2)

--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -678,6 +678,7 @@ def test_multistub_is_inside_warning(unix_servicer, caplog, capsys):
 
 SLEEP_TIME = 0.7
 
+
 def verify_concurrent_input_outputs(n_inputs: int, n_parallel: int, output_items: list[api_pb2.FunctionPutOutputsItem]):
     # Ensure that outputs align with expectation of running concurrent inputs
 
@@ -697,8 +698,8 @@ def verify_concurrent_input_outputs(n_inputs: int, n_parallel: int, output_items
 
 @skip_windows_unix_socket
 def test_concurrent_inputs_sync_function(unix_servicer):
-    n_inputs = 12
-    n_parallel = 6
+    n_inputs = 30
+    n_parallel = 10
 
     t0 = time.time()
     client, items = _run_container(
@@ -716,8 +717,8 @@ def test_concurrent_inputs_sync_function(unix_servicer):
 
 @skip_windows_unix_socket
 def test_concurrent_inputs_async_function(unix_servicer, event_loop):
-    n_inputs = 12
-    n_parallel = 6
+    n_inputs = 30
+    n_parallel = 10
 
     t0 = time.time()
     client, items = _run_container(

--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -698,8 +698,8 @@ def verify_concurrent_input_outputs(n_inputs: int, n_parallel: int, output_items
 
 @skip_windows_unix_socket
 def test_concurrent_inputs_sync_function(unix_servicer):
-    n_inputs = 30
-    n_parallel = 10
+    n_inputs = 32
+    n_parallel = 8
 
     t0 = time.time()
     client, items = _run_container(
@@ -717,8 +717,8 @@ def test_concurrent_inputs_sync_function(unix_servicer):
 
 @skip_windows_unix_socket
 def test_concurrent_inputs_async_function(unix_servicer, event_loop):
-    n_inputs = 30
-    n_parallel = 10
+    n_inputs = 32
+    n_parallel = 8
 
     t0 = time.time()
     client, items = _run_container(

--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -685,7 +685,7 @@ def verify_concurrent_input_outputs(n_inputs: int, n_parallel: int, output_items
     # Each group of n_parallel inputs should start together of each other
     # and different groups should start SLEEP_TIME apart.
     assert len(output_items) == n_inputs
-    for i in range(1, len(output_items)):
+    for i in range(1, len(sorted(output_items, key=lambda x: x.input_started_at))):
         diff = output_items[i].input_started_at - output_items[i - 1].input_started_at
         expected_diff = SLEEP_TIME if i % n_parallel == 0 else 0
         assert diff == pytest.approx(expected_diff, abs=0.2)

--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -684,7 +684,6 @@ def verify_concurrent_input_outputs(n_inputs: int, n_parallel: int, output_items
     assert len(output_items) == n_inputs
     for i in range(1, len(output_items)):
         diff = output_items[i].input_started_at - output_items[i - 1].input_started_at
-        print(diff)
         expected_diff = 1.0 if i % n_parallel == 0 else 0
         assert diff == pytest.approx(expected_diff, abs=0.05)
 

--- a/modal/_asgi.py
+++ b/modal/_asgi.py
@@ -23,6 +23,8 @@ def asgi_app_wrapper(asgi_app):
 
         # Run the ASGI app, while draining the send message queue at the same time,
         # and yielding results.
+        # TODO(gongy): we currently create one ASGI instance per concurrent input,
+        # but it would be sufficient to share this background ASGI context.
         async with TaskContext(grace=1.0) as tc:
             app_task = tc.create_task(asgi_app(scope, receive, send))
 

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -257,7 +257,7 @@ class _FunctionIOManager:
         # Before trying to fetch an input, acquire the semaphore:
         # - if no input is fetched, release the semaphore.
         # - or, when the output for the fetched input is enqueued, release the semaphore.
-        self.input_concurrency = input_concurrency
+        self._input_concurrency = input_concurrency
         self._semaphore = asyncio.Semaphore(input_concurrency)
 
         async with TaskContext(grace=10) as tc:

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -182,20 +182,23 @@ class _FunctionIOManager:
 
         return math.ceil(RTT_S / max(self.get_average_call_time(), 1e-6))
 
-    async def _generate_inputs(
-        self,
-    ) -> AsyncIterator[tuple[str, api_pb2.FunctionInput]]:
+    async def _generate_inputs(self) -> AsyncIterator[tuple[str, api_pb2.FunctionInput]]:
         request = api_pb2.FunctionGetInputsRequest(function_id=self.function_id)
         eof_received = False
         iteration = 0
         while not eof_received:
             request.average_call_time = self.get_average_call_time()
             request.max_values = self.get_max_inputs_to_fetch()  # Deprecated; remove.
+            request.input_concurrency = self.semaphore.maxsize
 
+            # If number of active inputs is at max queue size, this will block.
+            await self._acquire_semaphore()
             with trace("get_inputs"):
                 set_span_tag("iteration", str(iteration))  # force this to be a tag string
                 iteration += 1
                 response = await retry_transient_errors(self.client.stub.FunctionGetInputs, request)
+
+            yielded = False
 
             if response.rate_limit_sleep_duration:
                 logger.info(
@@ -203,28 +206,29 @@ class _FunctionIOManager:
                     % response.rate_limit_sleep_duration
                 )
                 await asyncio.sleep(response.rate_limit_sleep_duration)
-                continue
+            elif response.inputs:
+                for item in response.inputs:
+                    if item.kill_switch:
+                        logger.debug(f"Task {self.task_id} input received kill signal.")
+                        eof_received = True
+                        break
 
-            if not response.inputs:
-                continue
+                    # If we got a pointer to a blob, download it from S3.
+                    if item.input.WhichOneof("args_oneof") == "args_blob_id":
+                        input_pb = await self.populate_input_blobs(item.input)
+                    else:
+                        input_pb = item.input
 
-            for item in response.inputs:
-                if item.kill_switch:
-                    logger.debug(f"Task {self.task_id} input received kill signal.")
-                    eof_received = True
-                    break
+                    # If yielded, allow semaphore to be released via enqueue_outputs
+                    yield (item.input_id, input_pb)
+                    yielded = True
 
-                # If we got a pointer to a blob, download it from S3.
-                if item.input.WhichOneof("args_oneof") == "args_blob_id":
-                    input_pb = await self.populate_input_blobs(item.input)
-                else:
-                    input_pb = item.input
+                    if item.input.final_input:
+                        eof_received = True
+                        break
 
-                yield (item.input_id, input_pb)
-
-                if item.input.final_input:
-                    eof_received = True
-                    break
+            if not yielded:
+                await self._release_semaphore()
 
     async def _send_outputs(self):
         """Background task that tries to drain output queue until it's empty,
@@ -242,9 +246,18 @@ class _FunctionIOManager:
             # TODO(erikbern): we'll get a RESOURCE_EXCHAUSTED if the buffer is full server-side.
             # It's possible we want to retry "harder" for this particular error.
 
-    async def run_inputs_outputs(self):
+    async def _acquire_semaphore(self):
+        await self.semaphore.put(None)
+
+    async def _release_semaphore(self):
+        await self.semaphore.get()
+        self.semaphore.task_done()
+
+    async def run_inputs_outputs(self, input_concurrency: int = 1):
         # This also makes sure to terminate the outputs
         self.output_queue: asyncio.Queue = asyncio.Queue()
+        # Ensure we do not fetch new inputs when container is too busy
+        self.semaphore: asyncio.Queue[None] = asyncio.Queue(maxsize=input_concurrency)
 
         async with TaskContext(grace=10) as tc:
             tc.create_task(self._send_outputs())
@@ -255,13 +268,14 @@ class _FunctionIOManager:
                     self.current_input_id, self.current_input_started_at = (input_id, time.time())
                     yield input_id, args, kwargs
                     _set_current_input_id(None)
-                    self.total_user_time += time.time() - self.current_input_started_at
                     self.current_input_id, self.current_input_started_at = (None, None)
-                    self.calls_completed += 1
             finally:
+                # wait for all active inputs to place their outputs into the queue
+                await self.semaphore.join()
+                # send the eof to _send_outputs loop
                 await self.output_queue.put(None)
 
-    async def _enqueue_output(self, input_id, gen_index, **kwargs):
+    async def _enqueue_output(self, input_id, started_at: float, gen_index: int, **kwargs):
         # upload data to S3 if too big.
         if "data" in kwargs and kwargs["data"] and len(kwargs["data"]) > MAX_OBJECT_SIZE_BYTES:
             data_blob_id = await blob_upload(kwargs["data"], self.client.stub)
@@ -271,7 +285,7 @@ class _FunctionIOManager:
 
         output = api_pb2.FunctionPutOutputsItem(
             input_id=input_id,
-            input_started_at=self.current_input_started_at,
+            input_started_at=started_at,
             output_created_at=time.time(),
             gen_index=gen_index,
             result=api_pb2.GenericResult(**kwargs),
@@ -330,7 +344,9 @@ class _FunctionIOManager:
             raise UserException()
 
     @contextlib.asynccontextmanager
-    async def handle_input_exception(self, input_id, output_index: SequenceNumber) -> AsyncGenerator[None, None]:
+    async def handle_input_exception(
+        self, input_id, started_at: float, output_index: SequenceNumber
+    ) -> AsyncGenerator[None, None]:
         try:
             with trace("input"):
                 set_span_tag("input_id", input_id)
@@ -349,7 +365,8 @@ class _FunctionIOManager:
             # to unpickle it in some cases). Let's watch out for issues.
             await self._enqueue_output(
                 input_id,
-                output_index.value,
+                started_at=started_at,
+                gen_index=output_index.value,
                 status=api_pb2.GenericResult.GENERIC_STATUS_FAILURE,
                 data=self.serialize_exception(exc),
                 exception=repr(exc),
@@ -357,31 +374,42 @@ class _FunctionIOManager:
                 serialized_tb=serialized_tb,
                 tb_line_cache=tb_line_cache,
             )
+            await self.complete_call(started_at)
 
-    async def enqueue_output(self, input_id, output_index: int, data):
+    async def complete_call(self, started_at):
+        self.total_user_time += time.time() - started_at
+        self.calls_completed += 1
+        await self._release_semaphore()
+
+    async def enqueue_output(self, input_id, started_at: float, output_index: int, data):
         await self._enqueue_output(
             input_id,
+            started_at=started_at,
             gen_index=output_index,
             status=api_pb2.GenericResult.GENERIC_STATUS_SUCCESS,
             data=self.serialize(data),
         )
+        await self.complete_call(started_at)
 
-    async def enqueue_generator_value(self, input_id, output_index: int, data):
+    async def enqueue_generator_value(self, input_id, started_at: float, output_index: int, data):
         await self._enqueue_output(
             input_id,
+            started_at=started_at,
             gen_index=output_index,
             status=api_pb2.GenericResult.GENERIC_STATUS_SUCCESS,
             data=self.serialize(data),
             gen_status=api_pb2.GenericResult.GENERATOR_STATUS_INCOMPLETE,
         )
 
-    async def enqueue_generator_eof(self, input_id, output_index: int):
+    async def enqueue_generator_eof(self, input_id, started_at: float, output_index: int):
         await self._enqueue_output(
             input_id,
+            started_at=started_at,
             gen_index=output_index,
             status=api_pb2.GenericResult.GENERIC_STATUS_SUCCESS,
             gen_status=api_pb2.GenericResult.GENERATOR_STATUS_COMPLETE,
         )
+        await self.complete_call(started_at)
 
 
 # just to mark the class as synchronized, we don't care about the interfaces
@@ -393,6 +421,7 @@ def call_function_sync(
     obj: Optional[Any],
     fun: Callable,
     is_generator: bool,
+    input_concurrency: int,
 ):
     # If this function is on a class, instantiate it and enter it
     if obj is not None:
@@ -404,9 +433,11 @@ def call_function_sync(
             logger.warning("Not running asynchronous enter/exit handlers with a sync function")
 
     try:
-        for input_id, args, kwargs in function_io_manager.run_inputs_outputs():
+        for input_id, args, kwargs in function_io_manager.run_inputs_outputs(input_concurrency):
             output_index = SequenceNumber(0)
-            with function_io_manager.handle_input_exception(input_id, output_index):
+            started_at = time.time()
+            with function_io_manager.handle_input_exception(input_id, started_at, output_index):
+                # TODO(gongy): run this in an executor
                 res = fun(*args, **kwargs)
 
                 # TODO(erikbern): any exception below shouldn't be considered a user exception
@@ -415,17 +446,17 @@ def call_function_sync(
                         raise InvalidError(f"Generator function returned value of type {type(res)}")
 
                     for value in res:
-                        function_io_manager.enqueue_generator_value(input_id, output_index.value, value)
+                        function_io_manager.enqueue_generator_value(input_id, started_at, output_index.value, value)
                         output_index.increase()
 
-                    function_io_manager.enqueue_generator_eof(input_id, output_index.value)
+                    function_io_manager.enqueue_generator_eof(input_id, started_at, output_index.value)
                 else:
                     if inspect.iscoroutine(res) or inspect.isgenerator(res) or inspect.isasyncgen(res):
                         raise InvalidError(
                             f"Sync (non-generator) function return value of type {type(res)}."
                             " You might need to use @stub.function(..., is_generator=True)."
                         )
-                    function_io_manager.enqueue_output(input_id, output_index.value, res)
+                    function_io_manager.enqueue_output(input_id, started_at, output_index.value, res)
     finally:
         if obj is not None and hasattr(obj, "__exit__"):
             with function_io_manager.handle_user_exception():
@@ -438,6 +469,7 @@ async def call_function_async(
     obj: Optional[Any],
     fun: Callable,
     is_generator: bool,
+    input_concurrency: int,
 ):
     # If this function is on a class, instantiate it and enter it
     if obj is not None:
@@ -450,9 +482,11 @@ async def call_function_async(
                 obj.__enter__()
 
     try:
-        async for input_id, args, kwargs in function_io_manager.run_inputs_outputs.aio():
+
+        async def run_input(input_id, args, kwargs):
             output_index = SequenceNumber(0)  # mutable number we can increase from the generator loop
-            async with function_io_manager.handle_input_exception.aio(input_id, output_index):
+            started_at = time.time()
+            async with function_io_manager.handle_input_exception.aio(input_id, started_at, output_index):
                 res = fun(*args, **kwargs)
 
                 # TODO(erikbern): any exception below shouldn't be considered a user exception
@@ -460,9 +494,11 @@ async def call_function_async(
                     if not inspect.isasyncgen(res):
                         raise InvalidError(f"Async generator function returned value of type {type(res)}")
                     async for value in res:
-                        await function_io_manager.enqueue_generator_value.aio(input_id, output_index.value, value)
+                        await function_io_manager.enqueue_generator_value.aio(
+                            input_id, started_at, output_index.value, value
+                        )
                         output_index.increase()
-                    await function_io_manager.enqueue_generator_eof.aio(input_id, output_index.value)
+                    await function_io_manager.enqueue_generator_eof.aio(input_id, started_at, output_index.value)
                 else:
                     if not inspect.iscoroutine(res) or inspect.isgenerator(res) or inspect.isasyncgen(res):
                         raise InvalidError(
@@ -470,7 +506,10 @@ async def call_function_async(
                             " You might need to use @stub.function(..., is_generator=True)."
                         )
                     value = await res
-                    await function_io_manager.enqueue_output.aio(input_id, output_index.value, value)
+                    await function_io_manager.enqueue_output.aio(input_id, started_at, output_index.value, value)
+
+        async for input_id, args, kwargs in function_io_manager.run_inputs_outputs.aio(input_concurrency):
+            asyncio.create_task(run_input(input_id, args, kwargs))
     finally:
         if obj is not None:
             if hasattr(obj, "__aexit__"):
@@ -488,6 +527,7 @@ class ImportedFunction:
     stub: Optional[_Stub]
     is_async: bool
     is_generator: bool
+    input_concurrency: int
 
 
 @wrap()
@@ -527,6 +567,9 @@ def import_function(function_def: api_pb2.Function, ser_cls, ser_fun, ser_params
     # Use the function definition for whether this is a generator (overriden by webhooks)
     is_generator = function_def.function_type == api_pb2.Function.FUNCTION_TYPE_GENERATOR
 
+    # Container can fetch multiple inputs simultaneously
+    input_concurrency = function_def.allow_concurrent_inputs or 1
+
     # Instantiate the class if it's defined
     if cls:
         if ser_params:
@@ -558,7 +601,7 @@ def import_function(function_def: api_pb2.Function, ser_cls, ser_fun, ser_params
         is_async = True
         is_generator = True
 
-    return ImportedFunction(obj, fun, active_stub, is_async, is_generator)
+    return ImportedFunction(obj, fun, active_stub, is_async, is_generator, input_concurrency)
 
 
 def main(container_args: api_pb2.ContainerArguments, client: Client):
@@ -597,10 +640,14 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
             imp_fun.fun = run_in_pty(imp_fun.fun, input_stream_blocking, pty_info)
 
         if not imp_fun.is_async:
-            call_function_sync(function_io_manager, imp_fun.obj, imp_fun.fun, imp_fun.is_generator)
+            call_function_sync(
+                function_io_manager, imp_fun.obj, imp_fun.fun, imp_fun.is_generator, imp_fun.input_concurrency
+            )
         else:
             run_with_signal_handler(
-                call_function_async(function_io_manager, imp_fun.obj, imp_fun.fun, imp_fun.is_generator)
+                call_function_async(
+                    function_io_manager, imp_fun.obj, imp_fun.fun, imp_fun.is_generator, imp_fun.input_concurrency
+                )
             )
 
 

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -434,6 +434,7 @@ def call_function_sync(
             logger.warning("Not running asynchronous enter/exit handlers with a sync function")
 
     try:
+
         def run_inputs(input_id, args, kwargs):
             output_index = SequenceNumber(0)
             started_at = time.time()
@@ -496,6 +497,7 @@ async def call_function_async(
                 obj.__enter__()
 
     try:
+
         async def run_input(input_id, args, kwargs):
             output_index = SequenceNumber(0)  # mutable number we can increase from the generator loop
             started_at = time.time()

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -247,7 +247,6 @@ class _FunctionIOManager:
             # TODO(erikbern): we'll get a RESOURCE_EXCHAUSTED if the buffer is full server-side.
             # It's possible we want to retry "harder" for this particular error.
 
-
     async def run_inputs_outputs(self, input_concurrency: int = 1):
         # This also makes sure to terminate the outputs
         self.output_queue: asyncio.Queue = asyncio.Queue()

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -257,7 +257,7 @@ class _FunctionIOManager:
         # Before trying to fetch an input, acquire the semaphore:
         # - if no input is fetched, release the semaphore.
         # - or, when the output for the fetched input is enqueued, release the semaphore.
-        self._input_concurrency = input_concurrency
+        self.input_concurrency = input_concurrency
         self._semaphore = asyncio.Semaphore(input_concurrency)
 
         async with TaskContext(grace=10) as tc:
@@ -273,7 +273,7 @@ class _FunctionIOManager:
             finally:
                 # collect all active input slots, meaning all outputs of outstanding inputs are enqueued
                 for _ in range(input_concurrency):
-                    await self_semaphore.acquire()
+                    await self._semaphore.acquire()
                 # send the eof to _send_outputs loop
                 await self.output_queue.put(None)
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -838,6 +838,7 @@ class _Function(_Provider, type_prefix="fu"):
         retries: Optional[Union[int, Retries]] = None,
         timeout: Optional[int] = None,
         concurrency_limit: Optional[int] = None,
+        allow_concurrent_inputs: Optional[int] = None,
         container_idle_timeout: Optional[int] = None,
         cpu: Optional[float] = None,
         keep_warm: Optional[int] = None,
@@ -1111,7 +1112,7 @@ class _Function(_Provider, type_prefix="fu"):
                 runtime=config.get("function_runtime"),
                 stub_name=stub_name,
                 is_builder_function=is_builder_function,
-                allow_concurrent_inputs=1,
+                allow_concurrent_inputs=allow_concurrent_inputs,
             )
             request = api_pb2.FunctionCreateRequest(
                 app_id=resolver.app_id,

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -542,6 +542,7 @@ class _Stub:
         proxy: Optional[_Proxy] = None,  # Reference to a Modal Proxy to use in front of this function.
         retries: Optional[Union[int, Retries]] = None,  # Number of times to retry each input in case of failure.
         concurrency_limit: Optional[int] = None,  # Limit for max concurrent containers running the function.
+        allow_concurrent_inputs: Optional[int] = None,  # Number of inputs the container may fetch to run concurrently.
         container_idle_timeout: Optional[int] = None,  # Timeout for idle containers waiting for inputs to shut down.
         timeout: Optional[int] = None,  # Maximum execution time of the function in seconds.
         interactive: bool = False,  # Whether to run the function in interactive mode.
@@ -564,6 +565,7 @@ class _Stub:
             proxy=proxy,
             retries=retries,
             concurrency_limit=concurrency_limit,
+            allow_concurrent_inputs=allow_concurrent_inputs,
             container_idle_timeout=container_idle_timeout,
             timeout=timeout,
             interactive=interactive,

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -433,6 +433,7 @@ class _Stub:
         proxy: Optional[_Proxy] = None,  # Reference to a Modal Proxy to use in front of this function.
         retries: Optional[Union[int, Retries]] = None,  # Number of times to retry each input in case of failure.
         concurrency_limit: Optional[int] = None,  # Limit for max concurrent containers running the function.
+        allow_concurrent_inputs: Optional[int] = None,  # Allow container to handle multiple inputs simultaneously.
         container_idle_timeout: Optional[int] = None,  # Timeout for idle containers waiting for inputs to shut down.
         timeout: Optional[int] = None,  # Maximum execution time of the function in seconds.
         interactive: bool = False,  # Whether to run the function in interactive mode.
@@ -505,6 +506,7 @@ class _Stub:
                 proxy=proxy,
                 retries=retries,
                 concurrency_limit=concurrency_limit,
+                allow_concurrent_inputs=allow_concurrent_inputs,
                 container_idle_timeout=container_idle_timeout,
                 timeout=timeout,
                 cpu=cpu,

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -433,7 +433,7 @@ class _Stub:
         proxy: Optional[_Proxy] = None,  # Reference to a Modal Proxy to use in front of this function.
         retries: Optional[Union[int, Retries]] = None,  # Number of times to retry each input in case of failure.
         concurrency_limit: Optional[int] = None,  # Limit for max concurrent containers running the function.
-        allow_concurrent_inputs: Optional[int] = None,  # Allow container to handle multiple inputs simultaneously.
+        allow_concurrent_inputs: Optional[int] = None,  # Number of inputs the container may fetch to run concurrently.
         container_idle_timeout: Optional[int] = None,  # Timeout for idle containers waiting for inputs to shut down.
         timeout: Optional[int] = None,  # Maximum execution time of the function in seconds.
         interactive: bool = False,  # Whether to run the function in interactive mode.

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -168,3 +168,16 @@ class ParamCls:
     @method()
     def f(self, z: int):
         return f"{self.x} {self.y} {z}"
+
+
+@stub.function(allow_concurrent_inputs=5)
+def sleep_1_sync(x):
+    print("start", time.time())
+    time.sleep(1.0)
+    return x * x
+
+
+@stub.function(allow_concurrent_inputs=5)
+async def sleep_1_async(x):
+    await asyncio.sleep(1.0)
+    return x * x

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -172,7 +172,6 @@ class ParamCls:
 
 @stub.function(allow_concurrent_inputs=5)
 def sleep_1_sync(x):
-    print("start", time.time())
     time.sleep(1.0)
     return x * x
 

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -171,12 +171,12 @@ class ParamCls:
 
 
 @stub.function(allow_concurrent_inputs=5)
-def sleep_1_sync(x):
-    time.sleep(1.0)
+def sleep_700_sync(x):
+    time.sleep(0.7)
     return x * x
 
 
 @stub.function(allow_concurrent_inputs=5)
-async def sleep_1_async(x):
-    await asyncio.sleep(1.0)
+async def sleep_700_async(x):
+    await asyncio.sleep(0.7)
     return x * x


### PR DESCRIPTION
`function_io_manager` should be thread-safe as it executes on the `synchronicity` thread.

This PR contains:
- Unit tests in container_test.py
- An `asyncio.Semaphore` prevents the `n+1`th input from being fetched before in-progress ones are completed
- Spawns calls to sync or async functions in a separate task or thread if `allow_concurrent_inputs` is set