### PR TITLE
Show logs from dynamically created images

### DIFF
--- a/modal/_output.py
+++ b/modal/_output.py
@@ -129,7 +129,7 @@ class OutputManager:
     _line_buffers: dict[int, LineBufferedOutput]
     _status_spinner: Spinner
     _app_page_url: Optional[str]
-    is_app_running: bool
+    _show_image_logs: bool
 
     def __init__(self, stdout: io.TextIOWrapper, show_progress: bool, status_spinner_text: str = "Running app..."):
         self.stdout = stdout or sys.stdout
@@ -145,7 +145,7 @@ class OutputManager:
         self._line_buffers = {}
         self._status_spinner = step_progress(status_spinner_text)
         self._app_page_url = None
-        self.is_app_running = False
+        self._show_image_logs = False
 
     def print_if_visible(self, renderable) -> None:
         if self._visible_progress:
@@ -163,8 +163,8 @@ class OutputManager:
         self._current_render_group = Group(renderable)
         return Live(self._current_render_group, console=self._console, transient=True, refresh_per_second=4)
 
-    def set_app_running(self):
-        self.is_app_running = True
+    def enable_image_logs(self):
+        self._show_image_logs = True
 
     @property
     def function_progress(self) -> Progress:
@@ -392,7 +392,7 @@ async def get_app_logs_loop(app_id: str, client: _Client, output_mgr: OutputMana
                 logger.debug("App logs are done")
                 last_log_batch_entry_id = None
                 break
-            elif log_batch.image_id and not output_mgr.is_app_running:
+            elif log_batch.image_id and not output_mgr._show_image_logs:
                 # Ignore image logs while app is creating objects.
                 # These logs are fetched through ImageJoinStreaming instead.
                 # Logs from images built "dynamically" (after the app has started)

--- a/modal/_output.py
+++ b/modal/_output.py
@@ -129,6 +129,7 @@ class OutputManager:
     _line_buffers: dict[int, LineBufferedOutput]
     _status_spinner: Spinner
     _app_page_url: Optional[str]
+    is_app_running: bool
 
     def __init__(self, stdout: io.TextIOWrapper, show_progress: bool, status_spinner_text: str = "Running app..."):
         self.stdout = stdout or sys.stdout
@@ -144,6 +145,7 @@ class OutputManager:
         self._line_buffers = {}
         self._status_spinner = step_progress(status_spinner_text)
         self._app_page_url = None
+        self.is_app_running = False
 
     def print_if_visible(self, renderable) -> None:
         if self._visible_progress:
@@ -160,6 +162,9 @@ class OutputManager:
         self._function_progress = None
         self._current_render_group = Group(renderable)
         return Live(self._current_render_group, console=self._console, transient=True, refresh_per_second=4)
+
+    def set_app_running(self):
+        self.is_app_running = True
 
     @property
     def function_progress(self) -> Progress:
@@ -387,9 +392,13 @@ async def get_app_logs_loop(app_id: str, client: _Client, output_mgr: OutputMana
                 logger.debug("App logs are done")
                 last_log_batch_entry_id = None
                 break
-            elif log_batch.image_id:
-                # Ignore image logs - these still exist for old clients
-                # New clients get them through ImageJoinStreaming (see image.py)
+            elif log_batch.image_id and not output_mgr.is_app_running:
+                # Ignore image logs while app is creating objects.
+                # These logs are fetched through ImageJoinStreaming instead.
+                # Logs from images built "dynamically" (after the app has started)
+                # are printed through this loop.
+                # TODO (akshat): have a better way of differentiating between
+                # statically and dynamically built images.
                 pass
             else:
                 for log in log_batch.items:

--- a/modal/app.py
+++ b/modal/app.py
@@ -272,7 +272,7 @@ class _App:
 
         self._client.track_function_invocation()
 
-        resolver = Resolver(self._output_mgr, self._client, self._environment_name, self.app_id)
+        resolver = Resolver(None, self._client, self._environment_name, self.app_id)
         provider = _Sandbox._new(entrypoint_args, image or _default_image, mounts, timeout)
         return await resolver.load(provider)
 

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -86,7 +86,9 @@ async def _run_stub(
             for tag, obj in stub.registered_functions.items():
                 obj._handle._set_output_mgr(output_mgr)
 
-            output_mgr.set_app_running()
+            # Show logs from dynamically created images.
+            # TODO: better way to do this
+            output_mgr.enable_image_logs()
 
             # Yield to context
             if stub._pty_input_stream:

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -86,6 +86,8 @@ async def _run_stub(
             for tag, obj in stub.registered_functions.items():
                 obj._handle._set_output_mgr(output_mgr)
 
+            output_mgr.set_app_running()
+
             # Yield to context
             if stub._pty_input_stream:
                 output_mgr._visible_progress = False


### PR DESCRIPTION
Simple fix for now, for log output from "dynamically created" images not showing up in the terminal. Medium term we might want to either tag the logs themselves with this value, or filter out specific image IDs that we know are being built statically?

---

Resolves MOD-1483