### PR TITLE
Allow skipping modal client setup in registry images

### DIFF
--- a/client_test/image_test.py
+++ b/client_test/image_test.py
@@ -253,6 +253,22 @@ def test_dockerhub_install(servicer, client):
 
         assert any("FROM gisops/valhalla:latest" in cmd for cmd in layers[0].dockerfile_commands)
         assert any("RUN apt-get update" in cmd for cmd in layers[0].dockerfile_commands)
+        assert any("modal_requirements.txt" in cmd for cmd in layers[0].dockerfile_commands)
+
+
+def test_dockerhub_no_client_install(servicer, client):
+    stub = Stub(
+        image=Image.from_dockerhub(
+            "gisops/valhalla:latest", setup_dockerfile_commands=["RUN apt-get update"], setup_modal_client=False
+        )
+    )
+
+    with stub.run(client=client) as running_app:
+        layers = get_image_layers(running_app["image"].object_id, servicer)
+
+        assert any("FROM gisops/valhalla:latest" in cmd for cmd in layers[0].dockerfile_commands)
+        assert any("RUN apt-get update" in cmd for cmd in layers[0].dockerfile_commands)
+        assert not any("modal_requirements.txt" in cmd for cmd in layers[0].dockerfile_commands)
 
 
 def test_ecr_install(servicer, client):

--- a/modal/image.py
+++ b/modal/image.py
@@ -874,7 +874,7 @@ class _Image(_Provider[_ImageHandle]):
         )
 
     @staticmethod
-    def _registry_setup_commands(tag: str, setup_dockerfile_commands: List[str], setup_modal_client: bool) -> List[str]:
+    def _registry_setup_commands(tag: str, setup_dockerfile_commands: List[str], no_python: bool) -> List[str]:
         commands = [
             f"FROM {tag}",
             *setup_dockerfile_commands,
@@ -882,7 +882,7 @@ class _Image(_Provider[_ImageHandle]):
 
         # Install requirements to allow the Modal client to be mounted.
         # This is needed for function images, but not for sandbox images.
-        if setup_modal_client:
+        if not no_python:
             commands.extend(
                 [
                     "COPY /modal_requirements.txt /modal_requirements.txt",
@@ -898,7 +898,7 @@ class _Image(_Provider[_ImageHandle]):
         tag: str,
         setup_dockerfile_commands: List[str] = [],
         force_build: bool = False,
-        setup_modal_client: bool = True,  # Can be set to False for sandbox images, where the client is not needed.
+        no_python: bool = False,  # Can be set to True for sandbox images, where the Python client is not needed.
         **kwargs,
     ) -> "_Image":
         """
@@ -924,7 +924,7 @@ class _Image(_Provider[_ImageHandle]):
         ```
         """
         requirements_path = _get_client_requirements_path()
-        dockerfile_commands = _Image._registry_setup_commands(tag, setup_dockerfile_commands, setup_modal_client)
+        dockerfile_commands = _Image._registry_setup_commands(tag, setup_dockerfile_commands, no_python)
 
         return _Image._from_args(
             dockerfile_commands=dockerfile_commands,
@@ -940,7 +940,7 @@ class _Image(_Provider[_ImageHandle]):
         secret: Optional[_Secret] = None,
         setup_dockerfile_commands: List[str] = [],
         force_build: bool = False,
-        setup_modal_client: bool = True,  # Can be set to False for sandbox images, where the client is not needed.
+        no_python: bool = False,  # Can be set to True for sandbox images, where the Python client is not needed.
         **kwargs,
     ) -> "_Image":
         """
@@ -971,7 +971,7 @@ class _Image(_Provider[_ImageHandle]):
         """
         requirements_path = _get_client_requirements_path()
 
-        dockerfile_commands = _Image._registry_setup_commands(tag, setup_dockerfile_commands, setup_modal_client)
+        dockerfile_commands = _Image._registry_setup_commands(tag, setup_dockerfile_commands, no_python)
 
         return _Image._from_args(
             dockerfile_commands=dockerfile_commands,
@@ -988,7 +988,7 @@ class _Image(_Provider[_ImageHandle]):
         secret: Optional[_Secret] = None,
         setup_dockerfile_commands: List[str] = [],
         force_build: bool = False,
-        setup_modal_client: bool = True,  # Can be set to False for sandbox images, where the client is not needed.
+        no_python: bool = False,  # Can be set to True for sandbox images, where the Python client is not needed.
         **kwargs,
     ) -> "_Image":
         """
@@ -1020,7 +1020,7 @@ class _Image(_Provider[_ImageHandle]):
         ```
         """
         requirements_path = _get_client_requirements_path()
-        dockerfile_commands = _Image._registry_setup_commands(tag, setup_dockerfile_commands, setup_modal_client)
+        dockerfile_commands = _Image._registry_setup_commands(tag, setup_dockerfile_commands, no_python)
 
         return _Image._from_args(
             dockerfile_commands=dockerfile_commands,

--- a/modal/image.py
+++ b/modal/image.py
@@ -874,14 +874,23 @@ class _Image(_Provider[_ImageHandle]):
         )
 
     @staticmethod
-    def _registry_setup_commands(tag: str, setup_dockerfile_commands: List[str]) -> List[str]:
-        return [
+    def _registry_setup_commands(tag: str, setup_dockerfile_commands: List[str], setup_modal_client: bool) -> List[str]:
+        commands = [
             f"FROM {tag}",
             *setup_dockerfile_commands,
-            "COPY /modal_requirements.txt /modal_requirements.txt",
-            "RUN python -m pip install --upgrade pip",
-            "RUN python -m pip install -r /modal_requirements.txt",
         ]
+
+        # Install requirements to allow the Modal client to be mounted.
+        # This is needed for function images, but not for sandbox images.
+        if setup_modal_client:
+            commands.extend(
+                [
+                    "COPY /modal_requirements.txt /modal_requirements.txt",
+                    "RUN python -m pip install --upgrade pip",
+                    "RUN python -m pip install -r /modal_requirements.txt",
+                ]
+            )
+        return commands
 
     @staticmethod
     @typechecked
@@ -889,6 +898,7 @@ class _Image(_Provider[_ImageHandle]):
         tag: str,
         setup_dockerfile_commands: List[str] = [],
         force_build: bool = False,
+        setup_modal_client: bool = True,  # Can be set to False for sandbox images, where the client is not needed.
         **kwargs,
     ) -> "_Image":
         """
@@ -914,7 +924,7 @@ class _Image(_Provider[_ImageHandle]):
         ```
         """
         requirements_path = _get_client_requirements_path()
-        dockerfile_commands = _Image._registry_setup_commands(tag, setup_dockerfile_commands)
+        dockerfile_commands = _Image._registry_setup_commands(tag, setup_dockerfile_commands, setup_modal_client)
 
         return _Image._from_args(
             dockerfile_commands=dockerfile_commands,
@@ -930,6 +940,7 @@ class _Image(_Provider[_ImageHandle]):
         secret: Optional[_Secret] = None,
         setup_dockerfile_commands: List[str] = [],
         force_build: bool = False,
+        setup_modal_client: bool = True,  # Can be set to False for sandbox images, where the client is not needed.
         **kwargs,
     ) -> "_Image":
         """
@@ -960,7 +971,7 @@ class _Image(_Provider[_ImageHandle]):
         """
         requirements_path = _get_client_requirements_path()
 
-        dockerfile_commands = _Image._registry_setup_commands(tag, setup_dockerfile_commands)
+        dockerfile_commands = _Image._registry_setup_commands(tag, setup_dockerfile_commands, setup_modal_client)
 
         return _Image._from_args(
             dockerfile_commands=dockerfile_commands,
@@ -977,6 +988,7 @@ class _Image(_Provider[_ImageHandle]):
         secret: Optional[_Secret] = None,
         setup_dockerfile_commands: List[str] = [],
         force_build: bool = False,
+        setup_modal_client: bool = True,  # Can be set to False for sandbox images, where the client is not needed.
         **kwargs,
     ) -> "_Image":
         """
@@ -1008,7 +1020,7 @@ class _Image(_Provider[_ImageHandle]):
         ```
         """
         requirements_path = _get_client_requirements_path()
-        dockerfile_commands = _Image._registry_setup_commands(tag, setup_dockerfile_commands)
+        dockerfile_commands = _Image._registry_setup_commands(tag, setup_dockerfile_commands, setup_modal_client)
 
         return _Image._from_args(
             dockerfile_commands=dockerfile_commands,


### PR DESCRIPTION
Adds a flag, `setup_modal_client` to Image static methods that load from a registry. This is so that images that don't need the Modal client (for `Sandbox` tasks) don't need Python installed.

```python
modal.Image.from_dockerhub("node:slim", setup_modal_client=False)
```

Honestly don't love this, open to ideas for a better name. Some other options:

```python
modal.Image.from_dockerhub("node:slim", for_sandbox=True)
```


```python
modal.Image.from_dockerhub("node:slim", install_modal_client_reqs=False)
```


```python
modal.Image.from_dockerhub("node:slim", no_python=True)
```


```python
modal.Image.from_dockerhub("node:slim", skip_modal_client=True)
```