### PR TITLE
expose all public FunctionHandle methods on Function

### DIFF
--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -37,6 +37,12 @@ def test_run_function(client, servicer):
         assert foo.call(2, 4) == 20
         assert len(servicer.cleared_function_calls) == 1
 
+        # Make sure we can also call the Function object
+        fun = stub.foo
+        assert isinstance(fun, Function)
+        assert fun.call(2, 4) == 20
+        assert len(servicer.cleared_function_calls) == 2
+
 
 @pytest.mark.asyncio
 async def test_call_function_locally(client, servicer):
@@ -65,6 +71,12 @@ def test_map(client, servicer, slow_put_inputs):
         assert len(servicer.cleared_function_calls) == 1
         assert set(dummy_modal.map([5, 2], [4, 3], order_outputs=False)) == {13, 41}
         assert len(servicer.cleared_function_calls) == 2
+
+        # Make sure we can map on the Function object too
+        fun = stub.dummy
+        assert isinstance(fun, Function)
+        assert list(fun.map([5, 2], [4, 3])) == [41, 13]
+        assert len(servicer.cleared_function_calls) == 3
 
 
 _side_effect_count = 0


### PR DESCRIPTION
Continues work in #675 and #685:

* [X] `Queue`
* [X] `Dict`
* [X] `Volume` (`commit`, `reload`, ...)
* [X] `NetworkFileSystem` (`write_file`, `read_file`, ...)
* [X] `Function` (all the function calling)

At this point every handle method is now exposed on the provider classes too. This means that after this PR is merged, we can swap out handle classes for providers, so that the handle classes are internal only. Off the top of my head this is roughly:

* Any function created in global scope
* All objects created on the app object locally
* All objects created on the app object in the container

Once that's done, we should move all docs and implementation from the handle to the provider classes too