### PR TITLE
Adds proto field to display custom URLs in CLI

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -510,6 +510,8 @@ message Function {
   repeated VolumeMount volume_mounts = 33;
 
   uint32 allow_concurrent_inputs = 34;
+
+  repeated CustomDomainInfo custom_domain_info = 35;
 }
 
 message FunctionHandleMetadata {
@@ -1253,6 +1255,10 @@ message VolumeMount {
 
 message CustomDomainConfig {
   string name = 1;
+}
+
+message CustomDomainInfo {
+  string url = 1;
 }
 
 message WebhookConfig {


### PR DESCRIPTION
Adds the definition `CustomDomainInfo` now part of `Function`. This will contain the URL used to create new custom domains. 

This PR only contains the definition so we can deploy backend changes before adding functionality to print the resulting URL in the terminal. 