### PR TITLE
Print custom domain URL in terminal when using custom domains

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1162,6 +1162,11 @@ class _Function(_Provider[_FunctionHandle]):
                     suffix = ""
                 # TODO: this is only printed when we're showing progress. Maybe move this somewhere else.
                 status_row.finish(f"Created {tag} => [magenta underline]{response.web_url}[/magenta underline]{suffix}")
+                
+                # Print custom domain in terminal
+                for custom_domain in response.function.custom_domain_info:
+                    status_row.finish(f"Created {tag} => [magenta underline]{custom_domain.url}[/magenta underline]{suffix}")
+
             else:
                 status_row.finish(f"Created {tag}.")
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1162,10 +1162,12 @@ class _Function(_Provider[_FunctionHandle]):
                     suffix = ""
                 # TODO: this is only printed when we're showing progress. Maybe move this somewhere else.
                 status_row.finish(f"Created {tag} => [magenta underline]{response.web_url}[/magenta underline]{suffix}")
-                
+
                 # Print custom domain in terminal
                 for custom_domain in response.function.custom_domain_info:
-                    status_row.finish(f"Created {tag} => [magenta underline]{custom_domain.url}[/magenta underline]{suffix}")
+                    status_row.finish(
+                        f"Created {tag} => [magenta underline]{custom_domain.url}[/magenta underline]{suffix}"
+                    )
 
             else:
                 status_row.finish(f"Created {tag}.")

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1142,7 +1142,7 @@ class _Function(_Provider[_FunctionHandle]):
                 existing_function_id=existing_object_id,
             )
             try:
-                response = await resolver.client.stub.FunctionCreate(request)
+                response: api_pb2.FunctionCreateResponse = await resolver.client.stub.FunctionCreate(request)
             except GRPCError as exc:
                 if exc.status == Status.INVALID_ARGUMENT:
                     raise InvalidError(exc.message)
@@ -1165,8 +1165,9 @@ class _Function(_Provider[_FunctionHandle]):
 
                 # Print custom domain in terminal
                 for custom_domain in response.function.custom_domain_info:
-                    status_row.finish(
-                        f"Created {tag} => [magenta underline]{custom_domain.url}[/magenta underline]{suffix}"
+                    custom_domain_status_row = resolver.add_status_row()
+                    custom_domain_status_row.finish(
+                        f"Custom domain for {tag} => [magenta underline]{custom_domain.url}[/magenta underline]{suffix}"
                     )
 
             else:

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -510,6 +510,8 @@ message Function {
   repeated VolumeMount volume_mounts = 33;
 
   uint32 allow_concurrent_inputs = 34;
+
+  repeated CustomDomainInfo custom_domain_info = 35;
 }
 
 message FunctionHandleMetadata {
@@ -1253,6 +1255,10 @@ message VolumeMount {
 
 message CustomDomainConfig {
   string name = 1;
+}
+
+message CustomDomainInfo {
+  string url = 1;
 }
 
 message WebhookConfig {


### PR DESCRIPTION
When creating an endpoint with a custom domain definition we send back the custom domain URL. This print that URL in the terminal like we do with webhook URLs today.


```shell
$ modal serve custom_domains.py
✓ Initialized. View app at https://modal.com/apps/ap-00000000000
✓ Created objects.
├── 🔨 Created call => https://luiscape--custom-domains-test-call-dev.modal.run
├── 🔨 Created mount /home/ubuntu/modal/.local/custom_domains.py
└── 🔨 Custom domain for call => https://t.music.schule
...
```