### PR TITLE
Move _make_bound_function to the Function class

### DIFF
--- a/modal/object.py
+++ b/modal/object.py
@@ -169,6 +169,7 @@ _BLOCKING_P = synchronize_api(P)
 class _Provider(Generic[H]):
     _load: Callable[[Resolver, Optional[str], H], Awaitable[None]]
     _preload: Optional[Callable[[Resolver, Optional[str], H], Awaitable[None]]]
+    _handle: H
 
     def __init__(self):
         raise Exception("__init__ disallowed, use proper classmethods")


### PR DESCRIPTION
This will make it marginally easier to replace `FunctionHandle` with `Function` in global scope. Tbh it adds a bit of tech debt to some part of the code that's already fairly high debt, but it's a short term thing that I think will let us clean things up a lot soon.