### PR TITLE
stub.function now returns a Function

### DIFF
--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -5,7 +5,7 @@ import pytest
 from modal import Stub, method
 from modal._serialization import deserialize
 from modal.cls import ClsMixin
-from modal.functions import FunctionHandle
+from modal.functions import Function
 from modal_proto import api_pb2
 
 stub = Stub()
@@ -118,7 +118,7 @@ def test_run_class_serialized(client, servicer):
     obj = cls()
     meth = fun.__get__(obj, cls)
 
-    assert isinstance(obj.bar, FunctionHandle)
+    assert isinstance(obj.bar, Function)
     # Make sure it's callable
     assert meth(100) == 1000000
 

--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -586,7 +586,7 @@ def test_serialize_deserialize_function_handle(servicer, client):
 
     rehydrated_function_handle = deserialize(blob, client)
     assert rehydrated_function_handle.object_id == my_handle.object_id
-    assert isinstance(rehydrated_function_handle, FunctionHandle)
+    assert isinstance(rehydrated_function_handle, Function)
     assert rehydrated_function_handle.web_url == "http://xyz.internal"
 
 

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -501,7 +501,7 @@ def import_function(function_def: api_pb2.Function, ser_cls, ser_fun, ser_params
     active_stub = None
     if isinstance(fun, Function):
         _function_proxy = synchronizer._translate_in(fun)
-        fun = _function_proxy._handle.get_raw_f()
+        fun = _function_proxy.get_raw_f()
         active_stub = _function_proxy._handle._stub
     elif module is not None and not function_def.is_builder_function:
         # This branch is reached in the special case that the imported function is 1) not serialized, and 2) isn't a FunctionHandle - i.e, not decorated at definition time

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -40,7 +40,7 @@ from .app import _App
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, Client, _Client
 from .config import logger
 from .exception import InvalidError
-from .functions import FunctionHandle, _set_current_input_id  # type: ignore
+from .functions import Function, _set_current_input_id  # type: ignore
 
 MAX_OUTPUT_BATCH_SIZE = 100
 
@@ -499,10 +499,10 @@ def import_function(function_def: api_pb2.Function, ser_cls, ser_fun, ser_params
 
     # The decorator is typically in global scope, but may have been applied independently
     active_stub = None
-    if isinstance(fun, FunctionHandle):
+    if isinstance(fun, Function):
         _function_proxy = synchronizer._translate_in(fun)
-        fun = _function_proxy.get_raw_f()
-        active_stub = _function_proxy._stub
+        fun = _function_proxy._handle.get_raw_f()
+        active_stub = _function_proxy._handle._stub
     elif module is not None and not function_def.is_builder_function:
         # This branch is reached in the special case that the imported function is 1) not serialized, and 2) isn't a FunctionHandle - i.e, not decorated at definition time
         # Look at all instantiated stubs - if there is only one with the indicated name, use that one

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1280,6 +1280,9 @@ class _Function(_Provider, type_prefix="fu"):
     async def get_current_stats(self) -> FunctionStats:
         return await self._handle.get_current_stats()
 
+    def get_raw_f(self) -> Callable[..., Any]:
+        return self._handle.get_raw_f()
+
 
 Function = synchronize_api(_Function)
 

--- a/modal/object.py
+++ b/modal/object.py
@@ -255,6 +255,9 @@ class _Provider:
     def _get_metadata(self) -> Optional[Message]:
         return self._handle._get_metadata()
 
+    def is_hydrated(self) -> bool:
+        return self._handle.is_hydrated()
+
     async def _deploy(
         self,
         label: str,

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -506,7 +506,7 @@ class _Stub:
             )
 
             self._add_function(function)
-            return function._handle
+            return function
 
         return wrapped
 
@@ -560,16 +560,16 @@ class _Stub:
 
         def wrapper(user_cls: CLS_T) -> CLS_T:
             partial_functions: Dict[str, PartialFunction] = {}
-            function_handles: Dict[str, _FunctionHandle] = {}
+            functions: Dict[str, _Function] = {}
 
             for k, v in user_cls.__dict__.items():
                 if isinstance(v, PartialFunction):
                     partial_functions[k] = v
                     partial_function = synchronizer._translate_in(v)  # TODO: remove need for?
-                    function_handles[k] = decorator(partial_function, user_cls)
+                    functions[k] = decorator(partial_function, user_cls)
 
-            _PartialFunction.initialize_cls(user_cls, function_handles)
-            remote = make_remote_cls_constructors(user_cls, partial_functions, function_handles)
+            _PartialFunction.initialize_cls(user_cls, functions)
+            remote = make_remote_cls_constructors(user_cls, partial_functions, functions)
             user_cls.remote = remote
             return user_cls
 


### PR DESCRIPTION
This is a fairly consequential change and finally brings us a big step towards merging providers and handles.

`@stub.function` now returns a `Function` rather than a `FunctionHandle`. This means all functions in global scope will be `Function`, and it means that most methods on `FunctionHandle` are no longer used.

This PR relies on duck typing which is a bit ugly but seems fine since this is just an interim solution.

Next step is to move all the code from the handle class to the provider class.

Notes:
* I've had this change ready for several days but there was a handful small unit tests that were failing – it put me on a wild goose chase and it turned out I needed some fairly substantive changes, eg #708 and #709
* Have run this against all integration tests and they are passing. Wanted to sanity check since this is a big change.
* In what places are we still exposing handles? Off the top of my head (1) lookups (2) looking up objects from the app (3) `_deploy` and maybe some other esoteric things. I'll change those in subsequent PRs.