### PR TITLE
Lookup returns providers not handles

### DIFF
--- a/client_test/lookup_test.py
+++ b/client_test/lookup_test.py
@@ -15,7 +15,7 @@ async def test_persistent_object(servicer, client):
 
     q: QueueHandle = await Queue.lookup.aio("my-queue", client=client)  # type: ignore
     # TODO: remove type annotation here after genstub gets better Generic base class support
-    assert isinstance(q, QueueHandle)  # TODO(erikbern): it's a QueueHandler
+    assert isinstance(q, Queue)
     assert q.object_id == "qu-1"
 
     with pytest.raises(NotFoundError):

--- a/modal/cli/network_file_system.py
+++ b/modal/cli/network_file_system.py
@@ -24,7 +24,7 @@ from modal._output import step_completed, step_progress
 from modal.cli.utils import ENV_OPTION, display_table
 from modal.client import _Client
 from modal.environments import ensure_env
-from modal.network_file_system import _NetworkFileSystem, _NetworkFileSystemHandle
+from modal.network_file_system import _NetworkFileSystem
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronizer
 from modal_utils.grpc_utils import retry_transient_errors
@@ -82,11 +82,11 @@ def create(
     console.print(usage)
 
 
-async def _volume_from_name(deployment_name: str) -> _NetworkFileSystemHandle:
+async def _volume_from_name(deployment_name: str) -> _NetworkFileSystem:
     network_file_system = await _NetworkFileSystem.lookup(
         deployment_name, environment_name=None
     )  # environment None will take value from config
-    if not isinstance(network_file_system, _NetworkFileSystemHandle):
+    if not isinstance(network_file_system, _NetworkFileSystem):
         raise Exception("The specified app entity is not a network file system")
     return network_file_system
 
@@ -171,9 +171,7 @@ class CliError(Exception):
         self.message = message
 
 
-async def _glob_download(
-    volume: _NetworkFileSystemHandle, remote_glob_path: str, local_destination: Path, overwrite: bool
-):
+async def _glob_download(volume: _NetworkFileSystem, remote_glob_path: str, local_destination: Path, overwrite: bool):
     q: asyncio.Queue[Tuple[Optional[Path], Optional[api_pb2.SharedVolumeListFilesEntry]]] = asyncio.Queue()
 
     async def producer():

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -262,7 +262,7 @@ class _NetworkFileSystem(_Provider, type_prefix="sv"):
     async def add_local_file(
         self, local_path: Union[Path, str], remote_path: Optional[Union[str, PurePosixPath, None]] = None
     ):
-        return await self._handle.write_file(local_path, remote_path)
+        return await self._handle.add_local_file(local_path, remote_path)
 
     async def add_local_dir(
         self,

--- a/modal/object.py
+++ b/modal/object.py
@@ -360,7 +360,7 @@ class _Provider:
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
-    ) -> _Handle:
+    ) -> P:
         """
         General purpose method to retrieve Modal objects such as functions, network file systems, and secrets.
         ```python notest
@@ -372,10 +372,14 @@ class _Provider:
             ...
         ```
         """
+        # TODO(erikbern): this code is very duplicated. Clean up once handles are gone.
         handle_cls = cls._get_handle_cls()
         handle: _Handle = handle_cls._new()
         await handle._hydrate_from_app(app_name, tag, namespace, client, environment_name=environment_name)
-        return handle
+        obj = _Provider.__new__(cls)
+        rep = f"Provider({app_name})"  # TODO(erikbern): dumb
+        obj._init(rep, handle=handle)
+        return obj
 
     @classmethod
     async def _exists(


### PR DESCRIPTION
~Tiny commit on top of #712, will rebase once it's merged.~ EDIT: done

This makes lookup return provider, e.g. `modal.Function.lookup` would previously return a `FunctionHandle` but now it returns a `Function`. Relies on the magic of duck typing. Another place where handle objects are exposed to users. After this, there are almost no remaining ones (just app objects and `_deploy`), so I can remove handles soon.

For some reason this caused a lot of issues with NetworkFileSystem but nothing else