### PR TITLE
`Resolver.load` returns `Provider`

### DIFF
--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -89,9 +89,9 @@ class Resolver:
     def shell(self):
         return self._shell
 
-    async def preload(self, obj, existing_object_id: Optional[str], handle):
+    async def preload(self, obj, existing_object_id: Optional[str]):
         if obj._preload is not None:
-            return await obj._preload(self, existing_object_id, handle)
+            return await obj._preload(self, existing_object_id, obj._handle)
 
     async def load(self, obj, existing_object_id: Optional[str] = None):
         cached_future = self._local_uuid_to_future.get(obj.local_uuid)

--- a/modal/app.py
+++ b/modal/app.py
@@ -104,7 +104,7 @@ class _App:
                 # Note: preload only currently implemented for Functions, returns None otherwise
                 # this is to ensure that directly referenced functions from the global scope has
                 # ids associated with them when they are serialized into other functions
-                precreated_object = await resolver.preload(provider, existing_object_id, provider._handle)
+                precreated_object = await resolver.preload(provider, existing_object_id)
                 if precreated_object is not None:
                     self._tag_to_existing_id[tag] = precreated_object.object_id
                     self._tag_to_object[tag] = precreated_object


### PR DESCRIPTION
Fairly inconsequential prep work for some changes I'm working on – I broke it out of a separate PR just to keep things clean and small