### PR TITLE
Simplify object._deploy

### DIFF
--- a/client_test/container_app_test.py
+++ b/client_test/container_app_test.py
@@ -104,8 +104,8 @@ async def test_is_inside_default_image(servicer, unix_servicer, client, containe
 
     app = await App._init_new.aio(client)
     app_id = app.app_id
-    default_image_handle = await app.create_one_object.aio(_default_image, "")
-    default_image_id = default_image_handle.object_id
+    await app.create_one_object.aio(_default_image, "")
+    default_image_id = _default_image.object_id
 
     # Copy the app objects to the container servicer
     unix_servicer.app_objects[app_id] = servicer.app_objects[app_id]

--- a/client_test/lookup_test.py
+++ b/client_test/lookup_test.py
@@ -61,14 +61,17 @@ async def test_webhook_lookup(servicer, client):
 @pytest.mark.asyncio
 async def test_deploy_exists(servicer, client):
     assert not await Queue._exists.aio("my-queue", client=client)  # type: ignore
-    h1: QueueHandle = await Queue.new()._deploy.aio("my-queue", client=client)
+    q1: Queue = Queue.new()
+    await q1._deploy.aio("my-queue", client=client)
     assert await Queue._exists.aio("my-queue", client=client)  # type: ignore
-    h2: QueueHandle = await Queue.lookup.aio("my-queue", client=client)  # type: ignore
-    assert h1.object_id == h2.object_id
+    q2: QueueHandle = await Queue.lookup.aio("my-queue", client=client)  # type: ignore
+    assert q1.object_id == q2.object_id
 
 
 @pytest.mark.asyncio
 async def test_deploy_retain_id(servicer, client):
-    h1: QueueHandle = await Queue.new()._deploy.aio("my-queue", client=client)
-    h2: QueueHandle = await Queue.new()._deploy.aio("my-queue", client=client)
-    assert h1.object_id == h2.object_id
+    q1: Queue = Queue.new()
+    q2: Queue = Queue.new()
+    await q1._deploy.aio("my-queue", client=client)
+    await q2._deploy.aio("my-queue", client=client)
+    assert q1.object_id == q2.object_id

--- a/client_test/mount_test.py
+++ b/client_test/mount_test.py
@@ -58,9 +58,9 @@ def test_create_mount(servicer, client):
     m = Mount.from_local_dir(local_dir, remote_path="/foo", condition=condition)
 
     app = App._init_new(client)
-    obj = app.create_one_object(m, "")
+    app.create_one_object(m, "")
 
-    assert obj.object_id == "mo-123"
+    assert m.object_id == "mo-123"
     assert f"/foo/{cur_filename}" in servicer.files_name2sha
     sha256_hex = servicer.files_name2sha[f"/foo/{cur_filename}"]
     assert sha256_hex in servicer.files_sha2data

--- a/modal/app.py
+++ b/modal/app.py
@@ -246,7 +246,7 @@ class _App:
                 client, name, detach=False, deploying=True, environment_name=environment_name, output_mgr=output_mgr
             )
 
-    async def create_one_object(self, provider: _Provider, environment_name: str) -> _Handle:
+    async def create_one_object(self, provider: _Provider, environment_name: str) -> None:
         existing_object_id: Optional[str] = self._tag_to_existing_id.get("_object")
         resolver = Resolver(self._client, environment_name=environment_name, app_id=self.app_id)
         await resolver.load(provider, existing_object_id)
@@ -259,7 +259,6 @@ class _App:
             new_app_state=api_pb2.APP_STATE_UNSPECIFIED,  # app is either already deployed or will be set to deployed after this call
         )
         await retry_transient_errors(self._client.stub.AppSetObjects, req_set)
-        return provider._handle
 
     async def deploy(self, name: str, namespace, object_entity: str) -> str:
         deploy_req = api_pb2.AppDeployRequest(


### PR DESCRIPTION
I believe this is the last thing I need before I can make the change that causes handles to be internal (not user facing). But that's in a separate PR (should be small though).