### PR TITLE
App holds providers

### DIFF
--- a/client_test/container_app_test.py
+++ b/client_test/container_app_test.py
@@ -5,7 +5,7 @@ import pytest
 from unittest import mock
 
 import modal.secret
-from modal import App, FunctionHandle, Image, Stub
+from modal import App, Function, Image, Stub
 from modal.exception import InvalidError
 
 from .supports.skip import skip_windows_unix_socket
@@ -34,8 +34,8 @@ async def test_container_function_lazily_imported(unix_servicer, container_clien
     # Make sure these functions exist and have the right type
     my_f_1_app = container_app["my_f_1"]
     my_f_2_app = container_app["my_f_2"]
-    assert isinstance(my_f_1_app, FunctionHandle)
-    assert isinstance(my_f_2_app, FunctionHandle)
+    assert isinstance(my_f_1_app, Function)
+    assert isinstance(my_f_2_app, Function)
 
     # Now, let's create my_f_2 after the app started running
     # This might happen if some local module is imported lazily

--- a/client_test/network_file_system_test.py
+++ b/client_test/network_file_system_test.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import modal
 from modal.exception import DeprecationError, InvalidError
-from modal.network_file_system import NetworkFileSystemHandle
+from modal.network_file_system import NetworkFileSystem
 from modal.runner import deploy_stub
 
 from .supports.skip import skip_windows
@@ -56,7 +56,7 @@ def test_network_file_system_handle_single_file(client, tmp_path, servicer):
 
     with stub.run(client=client) as app:
         handle = app.vol
-        assert isinstance(handle, NetworkFileSystemHandle)
+        assert isinstance(handle, NetworkFileSystem)
         handle.add_local_file(local_file_path)
         handle.add_local_file(local_file_path.as_posix(), remote_path="/foo/other_destination")
 
@@ -82,7 +82,7 @@ async def test_network_file_system_handle_dir(client, tmp_path, servicer):
 
     with stub.run(client=client) as app:
         handle = app.vol
-        assert isinstance(handle, NetworkFileSystemHandle)
+        assert isinstance(handle, NetworkFileSystem)
         handle.add_local_dir(local_dir)
 
     assert servicer.nfs_files[handle.object_id].keys() == {
@@ -103,7 +103,7 @@ async def test_network_file_system_handle_big_file(client, tmp_path, servicer, b
 
         async with stub.run(client=client) as app:
             handle = app.vol
-            assert isinstance(handle, NetworkFileSystemHandle)
+            assert isinstance(handle, NetworkFileSystem)
             await handle.add_local_file.aio(local_file_path)
 
         assert servicer.nfs_files[handle.object_id].keys() == {"/bigfile"}
@@ -122,9 +122,9 @@ def test_old_syntax(client, servicer):
         stub.vol2 = modal.SharedVolume.new()
     stub.vol3 = modal.NetworkFileSystem.new()
     with stub.run(client=client) as app:
-        assert isinstance(app.vol1, NetworkFileSystemHandle)
-        assert isinstance(app.vol2, NetworkFileSystemHandle)
-        assert isinstance(app.vol3, NetworkFileSystemHandle)
+        assert isinstance(app.vol1, NetworkFileSystem)
+        assert isinstance(app.vol2, NetworkFileSystem)
+        assert isinstance(app.vol3, NetworkFileSystem)
 
 
 def test_redeploy(servicer, client):
@@ -165,7 +165,7 @@ def test_write_file(client, tmp_path, servicer):
 
     with stub.run(client=client) as app:
         handle = app.vol
-        assert isinstance(handle, NetworkFileSystemHandle)
+        assert isinstance(handle, NetworkFileSystem)
         handle.write_file("remote_path.txt", open(local_file_path, "rb"))
 
         # Make sure we can write through the provider too

--- a/client_test/serialization_test.py
+++ b/client_test/serialization_test.py
@@ -3,7 +3,6 @@ import pytest
 
 from modal import Queue, Stub
 from modal._serialization import deserialize, serialize
-from modal.queue import QueueHandle
 
 stub = Stub()
 
@@ -11,7 +10,7 @@ stub.q = Queue.new()
 
 
 @pytest.mark.asyncio
-async def test_handle(servicer, client):
+async def test_roundtrip(servicer, client):
     async with stub.run(client=client) as running_app:
         q = running_app.q
         data = serialize(q)
@@ -24,17 +23,6 @@ async def test_handle(servicer, client):
         # is most likely because the name doesn't match. To fix this, make
         # sure that cls.__name__ (which is something synchronicity sets)
         # is the same as the symbol defined in the global scope.
-        q_roundtrip = deserialize(data, running_app)
-        assert isinstance(q_roundtrip, QueueHandle)
-        assert q.object_id == q_roundtrip.object_id
-
-
-@pytest.mark.asyncio
-async def test_provider(servicer, client):
-    async with stub.run(client=client) as running_app:
-        q = stub.q
-        data = serialize(q)
-        assert len(data) < 350
         q_roundtrip = deserialize(data, running_app)
         assert isinstance(q_roundtrip, Queue)
         assert q.object_id == q_roundtrip.object_id

--- a/client_test/volume_test.py
+++ b/client_test/volume_test.py
@@ -5,7 +5,7 @@ import pytest
 import modal
 from modal.exception import InvalidError
 from modal.runner import deploy_stub
-from modal.volume import VolumeHandle
+from modal.volume import Volume
 
 from .supports.skip import skip_windows
 
@@ -61,7 +61,7 @@ def test_volume_commit(client, servicer):
 
     with stub.run(client=client) as app:
         handle = app.vol
-        assert isinstance(handle, VolumeHandle)
+        assert isinstance(handle, Volume)
         # Note that in practice this will not work unless run in a task.
         handle.commit()
 
@@ -79,7 +79,7 @@ def test_volume_reload(client, servicer):
 
     with stub.run(client=client) as app:
         handle = app.vol
-        assert isinstance(handle, VolumeHandle)
+        assert isinstance(handle, Volume)
         # Note that in practice this will not work unless run in a task.
         handle.reload()
 

--- a/client_test/webhook_test.py
+++ b/client_test/webhook_test.py
@@ -9,7 +9,7 @@ from fastapi.testclient import TestClient
 from modal import App, Stub, asgi_app, web_endpoint, wsgi_app
 from modal._asgi import webhook_asgi_app
 from modal.exception import InvalidError
-from modal.functions import FunctionHandle
+from modal.functions import Function
 from modal_proto import api_pb2
 
 stub = Stub()
@@ -37,7 +37,7 @@ async def test_webhook(servicer, client):
         # Make sure the container gets the app id as well
         container_app = await App.init_container.aio(client, app.app_id)
         await container_app._init_container_objects.aio(stub)
-        assert isinstance(container_app.f, FunctionHandle)
+        assert isinstance(container_app.f, Function)
         assert container_app.f.web_url
 
 

--- a/modal/_pty.py
+++ b/modal/_pty.py
@@ -11,7 +11,7 @@ from typing import Optional, Tuple, no_type_check
 
 import rich
 
-from modal.queue import _QueueHandle
+from modal.queue import _Queue
 from modal_proto import api_pb2
 from modal_utils.async_utils import TaskContext, asyncify
 
@@ -156,7 +156,7 @@ def get_pty_info(shell: bool) -> api_pb2.PTYInfo:
 
 
 @contextlib.asynccontextmanager
-async def write_stdin_to_pty_stream(queue: _QueueHandle):
+async def write_stdin_to_pty_stream(queue: _Queue):
     if platform.system() == "Windows":
         raise InvalidError("Interactive mode is not currently supported on Windows.")
 

--- a/modal/image.py
+++ b/modal/image.py
@@ -1233,6 +1233,11 @@ class _Image(_Provider, type_prefix="im"):
         """
         return self.extend(dockerfile_commands=["FROM base"] + [f"WORKDIR {shlex.quote(path)}"])
 
+    # Live handle methods
+
+    def _is_inside(self) -> bool:
+        return self._handle._is_inside()
+
 
 ImageHandle = synchronize_api(_ImageHandle)
 Image = synchronize_api(_Image)

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -16,7 +16,7 @@ from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, _Client
 from .config import config
 from .exception import InvalidError
 from .functions import _FunctionHandle
-from .queue import _QueueHandle
+from .queue import _Queue
 
 
 async def _heartbeat(client, app_id):
@@ -94,7 +94,7 @@ async def _run_stub(
             if stub._pty_input_stream:
                 output_mgr._visible_progress = False
                 handle = app._pty_input_stream
-                assert isinstance(handle, _QueueHandle)
+                assert isinstance(handle, _Queue)
                 async with _pty.write_stdin_to_pty_stream(handle):
                     yield app
                 output_mgr._visible_progress = True

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -22,7 +22,7 @@ from .config import logger
 from .exception import InvalidError, deprecation_warning
 from .functions import PartialFunction, _Function, _FunctionHandle, _PartialFunction
 from .gpu import GPU_T
-from .image import _Image, _ImageHandle
+from .image import _Image
 from .mount import _Mount
 from .network_file_system import _NetworkFileSystem
 from .object import _Provider
@@ -246,7 +246,6 @@ class _Stub:
         assert isinstance(image, _Image)
         for tag, provider in self._blueprint.items():
             if provider == image:
-                image_handle = self._app[tag]
                 break
         else:
             raise InvalidError(
@@ -259,8 +258,8 @@ class _Stub:
                 )
             )
 
-        assert isinstance(image_handle, _ImageHandle)
-        return image_handle._is_inside()
+        assert isinstance(image, _Image)
+        return image._is_inside()
 
     @asynccontextmanager
     async def _set_app(self, app: _App) -> AsyncGenerator[None, None]:

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -337,8 +337,8 @@ class _Stub:
             # If this is inside a container, and some module is loaded lazily, then a function may be
             # defined later than the container initialization. If this happens then lets hydrate the
             # function at this point
-            handle = self._app[function.tag]
-            function._handle._hydrate_from_other(handle)
+            other_function = self._app[function.tag]
+            function._handle._hydrate_from_other(other_function._handle)
 
         self._blueprint[function.tag] = function
 


### PR DESCRIPTION
This should be the last place we expose handles to users. Any access of objects on the app now returns the provider instead.

For some reason we had a ton of `isinstance` in tests, so most of the delta is just changing those.