### PR TITLE
Add custom `ParamType` for `Any`

### DIFF
--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -236,9 +236,10 @@ def test_run_parse_args(servicer, set_env_client, test_dir):
             "the day is 31",
         ),
         (["run", f"{stub_file.as_posix()}::dt_arg", "--dt=2022-10-31"], "the day is 31"),
-        (["run", f"{stub_file.as_posix()}::int_arg", "--i=200"], "200"),
-        (["run", f"{stub_file.as_posix()}::default_arg"], "10"),
-        (["run", f"{stub_file.as_posix()}::unannotated_arg", "--i=2022-10-31"], "'2022-10-31'"),
+        (["run", f"{stub_file.as_posix()}::int_arg", "--i=200"], "200 <class 'int'>"),
+        (["run", f"{stub_file.as_posix()}::default_arg"], "10 <class 'int'>"),
+        (["run", f"{stub_file.as_posix()}::unannotated_arg", "--i=2022-10-31"], "'2022-10-31' <class 'str'>"),
+        (["run", f"{stub_file.as_posix()}::unannotated_default_arg"], "10 <class 'int'>"),
         # TODO: fix class references
         # (["run", f"{stub_file.as_posix()}::ALifecycle.some_method", "--i=hello"], "'hello'"),
     ]

--- a/client_test/supports/app_run_tests/cli_args.py
+++ b/client_test/supports/app_run_tests/cli_args.py
@@ -13,17 +13,22 @@ def dt_arg(dt: datetime):
 
 @stub.local_entrypoint()
 def int_arg(i: int):
-    print(repr(i))
+    print(repr(i), type(i))
 
 
 @stub.local_entrypoint()
 def default_arg(i: int = 10):
-    print(repr(i))
+    print(repr(i), type(i))
 
 
 @stub.local_entrypoint()
 def unannotated_arg(i):
-    print(repr(i))
+    print(repr(i), type(i))
+
+
+@stub.local_entrypoint()
+def unannotated_default_arg(i=10):
+    print(repr(i), type(i))
 
 
 @stub.cls()

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -5,7 +5,7 @@ import inspect
 import sys
 import time
 import warnings
-from typing import Optional
+from typing import Any, Optional
 
 import click
 import typer
@@ -24,6 +24,14 @@ from ..functions import _FunctionHandle
 from .import_refs import import_function, import_stub
 from .utils import ENV_OPTION, ENV_OPTION_HELP
 
+
+class AnyParamType(click.ParamType):
+    name = "any"
+
+    def convert(self, value, param, ctx):
+        return value
+
+
 # Why do we need to support both types and the strings? Because something weird with
 # how __annotations__ works in Python (which inspect.signature uses). See #220.
 option_parsers = {
@@ -37,6 +45,7 @@ option_parsers = {
     "bool": bool,
     datetime.datetime: click.DateTime(),
     "datetime.datetime": click.DateTime(),
+    Any: AnyParamType(),
 }
 
 
@@ -50,7 +59,7 @@ def _add_click_options(func, signature: inspect.Signature):
     Kind of like typer, but using options instead of positional arguments
     """
     for param in signature.parameters.values():
-        param_type = str if param.annotation is inspect.Signature.empty else param.annotation
+        param_type = Any if param.annotation is inspect.Signature.empty else param.annotation
         param_name = param.name.replace("_", "-")
         cli_name = "--" + param_name
         if param_type in (bool, "bool"):


### PR DESCRIPTION
Earlier, the default click param type was `str`. This would also cast any default values provided to strings, which caused some very hard to debug errors. 

For example, in this case:

```python
@stub.local_entrypoint()
def f(x: int = [1,2,3]):
    print(type(x))
```

`modal run` would print `<class 'str'>`. 

Adding a custom `ParamType` that doesn't do any type conversion, since [click](https://click.palletsprojects.com/en/8.1.x/parameters/#parameter-types) doesn't have something like that.

---

Resolves MOD-1217