### PR TITLE
Support `modal run` for `cls` functions

### DIFF
--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -220,7 +220,7 @@ def test_run_local_entrypoint_invalid_with_stub_run(servicer, set_env_client, te
     assert len(servicer.client_calls) == 0
 
 
-def test_run_parse_args(servicer, set_env_client, test_dir):
+def test_run_parse_args_entrypoint(servicer, set_env_client, test_dir):
     stub_file = test_dir / "supports" / "app_run_tests" / "cli_args.py"
     res = _run(["run", stub_file.as_posix()], expected_exit_code=2, expected_stderr=None)
     assert "You need to specify a Modal function or local entrypoint to run" in res.stderr
@@ -239,13 +239,31 @@ def test_run_parse_args(servicer, set_env_client, test_dir):
         (["run", f"{stub_file.as_posix()}::int_arg", "--i=200"], "200"),
         (["run", f"{stub_file.as_posix()}::default_arg"], "10"),
         (["run", f"{stub_file.as_posix()}::unannotated_arg", "--i=2022-10-31"], "'2022-10-31'"),
-        # TODO: fix class references
-        # (["run", f"{stub_file.as_posix()}::ALifecycle.some_method", "--i=hello"], "'hello'"),
     ]
     for args, expected in valid_call_args:
         res = _run(args)
         assert expected in res.stdout
         assert len(servicer.client_calls) == 0
+
+
+def test_run_parse_args_function(servicer, set_env_client, test_dir):
+    stub_file = test_dir / "supports" / "app_run_tests" / "cli_args.py"
+    res = _run(["run", stub_file.as_posix()], expected_exit_code=2, expected_stderr=None)
+    assert "You need to specify a Modal function or local entrypoint to run" in res.stderr
+
+    # HACK: all the tests use the same arg, i.
+    @servicer.function_body
+    def print_type(i):
+        print(repr(i), type(i))
+
+    valid_call_args = [
+        (["run", f"{stub_file.as_posix()}::int_arg_fn", "--i=200"], "200 <class 'int'>"),
+        (["run", f"{stub_file.as_posix()}::ALifecycle.some_method", "--i=hello"], "'hello' <class 'str'>"),
+        (["run", f"{stub_file.as_posix()}::ALifecycle.some_method_int", "--i=42"], "42 <class 'int'>"),
+    ]
+    for args, expected in valid_call_args:
+        res = _run(args)
+        assert expected in res.stdout
 
 
 @pytest.fixture

--- a/client_test/supports/app_run_tests/cli_args.py
+++ b/client_test/supports/app_run_tests/cli_args.py
@@ -26,8 +26,17 @@ def unannotated_arg(i):
     print(repr(i))
 
 
+@stub.function()
+def int_arg_fn(i: int):
+    print(repr(i), type(i))
+
+
 @stub.cls()
 class ALifecycle:
     @method()
     def some_method(self, i):
-        print(repr(i))
+        print(repr(i), type(i))
+
+    @method()
+    def some_method_int(self, i: int):
+        print(repr(i), type(i))

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -83,8 +83,9 @@ class FunctionInfo:
 
     # TODO: we should have a bunch of unit tests for this
     # TODO: if the function is declared in a local scope, this function still "works": we should throw an exception
-    def __init__(self, f, serialized=False, name_override: Optional[str] = None):
+    def __init__(self, f, serialized=False, name_override: Optional[str] = None, cls: Optional[Type] = None):
         self.raw_f = f
+        self.cls = cls
         # TODO(erikbern): if f.__qualname__ != f.__name__,  we should infer the class name instead
         self.function_name = name_override if name_override is not None else f.__qualname__
         self.signature = inspect.signature(f)

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
 import asyncio
 import datetime
+import functools
 import inspect
 import sys
 import time
@@ -84,7 +85,11 @@ def _get_click_command_for_function(_stub, function_tag):
     blocking_stub = synchronizer._translate_out(_stub, Interface.BLOCKING)
 
     _function = _stub[function_tag]
-    raw_func = _function._info.raw_f
+    if _function._info.cls is not None:
+        obj = _function._info.cls()
+        raw_func = functools.partial(_function._info.raw_f, obj)
+    else:
+        raw_func = _function._info.raw_f
 
     @click.pass_context
     def f(ctx, *args, **kwargs):

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -464,14 +464,14 @@ class _Stub:
 
             if isinstance(f, _PartialFunction):
                 f.wrapped = True
-                info = FunctionInfo(f.raw_f, serialized=serialized, name_override=name)
+                info = FunctionInfo(f.raw_f, serialized=serialized, name_override=name, cls=_cls)
                 raw_f = f.raw_f
                 webhook_config = f.webhook_config
                 is_generator_override = f.is_generator
                 if webhook_config:
                     self._web_endpoints.append(info.get_tag())
             else:
-                info = FunctionInfo(f, serialized=serialized, name_override=name)
+                info = FunctionInfo(f, serialized=serialized, name_override=name, cls=_cls)
                 webhook_config = None
                 raw_f = f
 


### PR DESCRIPTION
Went on a wild goose chase fixing the tests—forgot we had a fixed `function_body` defined in the servicer 🤦 

Actual solution is pretty simple, just storing the `cls` and partially applying it before passing it to click.

---

Resolves MOD-1117