### PR TITLE
Fix remote() for constructors with no args

### DIFF
--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -176,3 +176,24 @@ def test_can_call_remotely_from_local(client):
         # which just squares the arguments
         assert foo.bar.call(8) == 64
         assert foo.baz.call(9) == 81
+
+
+stub_remote_3 = Stub()
+
+
+@stub_remote_3.cls(cpu=42)
+class NoArgRemote(ClsMixin):
+    def __init__(self) -> None:
+        pass
+
+    @method()
+    def baz(self, z: int):
+        return z**3
+
+
+def test_call_cls_remote_no_args(client):
+    with stub_remote_3.run(client=client):
+        foo_remote = NoArgRemote.remote()
+        # Mock servicer just squares the argument
+        # This means remote function call is taking place.
+        assert foo_remote.baz(8) == 64

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1185,12 +1185,6 @@ class _Function(_Provider, type_prefix="fu"):
 
         async def _load(resolver: Resolver, existing_object_id: Optional[str], handle: _FunctionHandle):
             handle._initialize_from_local(base_handle._stub, base_handle._info)
-            handle._is_remote_cls_method = True
-
-            if len(args) + len(kwargs) == 0:
-                # if no args, don't need a separate object.
-                handle._hydrate(base_handle.object_id, resolver.client, base_handle._get_metadata())
-                return
 
             serialized_params = pickle.dumps((args, kwargs))  # TODO(erikbern): use modal._serialization?
             req = api_pb2.FunctionBindParamsRequest(
@@ -1199,6 +1193,7 @@ class _Function(_Provider, type_prefix="fu"):
             )
             response = await retry_transient_errors(resolver.client.stub.FunctionBindParams, req)
             handle._hydrate(response.bound_function_id, resolver.client, response.handle_metadata)
+            handle._is_remote_cls_method = True
 
         return _Function._from_loader(_load, "Function(parametrized)")
 


### PR DESCRIPTION
We had a short-circuit for `.remote()` without arguments, which isn't really needed.