### PR TITLE
Move handle methods to providers: Queue and Dict

### DIFF
--- a/modal/object.py
+++ b/modal/object.py
@@ -258,6 +258,10 @@ class _Provider:
     def is_hydrated(self) -> bool:
         return self._handle.is_hydrated()
 
+    @property
+    def _client(self) -> _Client:
+        return self._handle._client
+
     async def _deploy(
         self,
         label: str,

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -16,16 +16,48 @@ from .object import _Handle, _Provider
 
 
 class _QueueHandle(_Handle, type_prefix="qu"):
-    """Handle for interacting with the contents of a `Queue`
+    pass
+
+
+QueueHandle = synchronize_api(_QueueHandle)
+
+
+class _Queue(_Provider, type_prefix="qu"):
+    """A distributed, FIFO Queue available to Modal apps.
+
+    The queue can contain any object serializable by `cloudpickle`.
 
     ```python
-    stub.some_dict = modal.Queue.new()
+    stub.some_queue = modal.Queue.new()
 
     if __name__ == "__main__":
-        with stub.run() as app:
-            app.some_dict.put({"some": "object"})
+        with stub.run():
+            stub.some_queue.put({"some": "object"})
     ```
     """
+
+    @staticmethod
+    def new():
+        async def _load(resolver: Resolver, existing_object_id: Optional[str], handle: _QueueHandle):
+            request = api_pb2.QueueCreateRequest(app_id=resolver.app_id, existing_queue_id=existing_object_id)
+            response = await resolver.client.stub.QueueCreate(request)
+            handle._hydrate(response.queue_id, resolver.client, None)
+
+        return _Queue._from_loader(_load, "Queue()")
+
+    def __init__(self):
+        """`Queue({...})` is deprecated. Please use `Queue.new({...})` instead."""
+        deprecation_warning(date(2023, 6, 27), self.__init__.__doc__)
+        obj = _Queue.new()
+        self._init_from_other(obj)
+
+    @staticmethod
+    def persisted(
+        label: str, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, environment_name: Optional[str] = None
+    ) -> "_Queue":
+        return _Queue.new()._persist(label, namespace, environment_name)
+
+    # Live handle methods
 
     async def _get_nonblocking(self, n_values: int) -> List[Any]:
         request = api_pb2.QueueGetRequest(
@@ -126,50 +158,6 @@ class _QueueHandle(_Handle, type_prefix="qu"):
         )
 
         await retry_transient_errors(self._client.stub.QueuePut, request)
-
-
-QueueHandle = synchronize_api(_QueueHandle)
-
-
-class _Queue(_Provider, type_prefix="qu"):
-    """A distributed, FIFO Queue available to Modal apps.
-
-    The queue can contain any object serializable by `cloudpickle`.
-    """
-
-    @staticmethod
-    def new():
-        async def _load(resolver: Resolver, existing_object_id: Optional[str], handle: _QueueHandle):
-            request = api_pb2.QueueCreateRequest(app_id=resolver.app_id, existing_queue_id=existing_object_id)
-            response = await resolver.client.stub.QueueCreate(request)
-            handle._hydrate(response.queue_id, resolver.client, None)
-
-        return _Queue._from_loader(_load, "Queue()")
-
-    def __init__(self):
-        """`Queue({...})` is deprecated. Please use `Queue.new({...})` instead."""
-        deprecation_warning(date(2023, 6, 27), self.__init__.__doc__)
-        obj = _Queue.new()
-        self._init_from_other(obj)
-
-    @staticmethod
-    def persisted(
-        label: str, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, environment_name: Optional[str] = None
-    ) -> "_Queue":
-        return _Queue.new()._persist(label, namespace, environment_name)
-
-    # Live handle methods
-    async def get(self, block: bool = True, timeout: Optional[float] = None) -> Optional[Any]:
-        return await self._handle.get(block, timeout)
-
-    async def get_many(self, n_values: int, block: bool = True, timeout: Optional[float] = None) -> List[Any]:
-        return await self._handle.get_many(n_values, block, timeout)
-
-    async def put(self, v: Any) -> None:
-        return await self._handle.put(v)
-
-    async def put_many(self, vs: List[Any]) -> None:
-        return await self._handle.put_many(vs)
 
 
 Queue = synchronize_api(_Queue)


### PR DESCRIPTION
This moves all "live methods" of `Dict` and `Queue` to the providers (which has already proxied them for a few weeks)

I'm starting with the less frequently used objects to minimize risk (will do `Function` last)