### PR TITLE
Fix outdated image API in error message

### DIFF
--- a/modal/stub.py
+++ b/modal/stub.py
@@ -251,7 +251,7 @@ class _Stub:
             raise InvalidError(
                 inspect.cleandoc(
                     """`is_inside` only works for an image associated with an App. For instance:
-                    stub.image = DebianSlim()
+                    stub.image = Image.debian_slim()
                     if stub.is_inside(stub.image):
                         print("I'm inside!")
                     """


### PR DESCRIPTION
## Describe your changes

- _Provide Linear issue reference (e.g. MOD-1234) if available._


## Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.
