### PR TITLE
Remove app object ownership: prep work

### DIFF
--- a/client_test/container_app_test.py
+++ b/client_test/container_app_test.py
@@ -29,7 +29,6 @@ async def test_container_function_lazily_imported(unix_servicer, container_clien
 
     container_app = await App.init_container.aio(container_client, "ap-123")
     stub = Stub()
-    await container_app._init_container_objects.aio(stub)
 
     # Make sure these functions exist and have the right type
     my_f_1_app = container_app["my_f_1"]
@@ -69,8 +68,7 @@ async def test_is_inside(servicer, unix_servicer, client, container_client):
         unix_servicer.app_objects[app_id] = servicer.app_objects[app_id]
 
         # Pretend that we're inside the container
-        container_app = await App.init_container.aio(container_client, app_id)
-        await container_app._init_container_objects.aio(None)
+        await App.init_container.aio(container_client, app_id)
 
         # Create a new stub (TODO: tie it to the previous stub through name or similar)
         stub = get_stub()

--- a/client_test/webhook_test.py
+++ b/client_test/webhook_test.py
@@ -36,7 +36,7 @@ async def test_webhook(servicer, client):
 
         # Make sure the container gets the app id as well
         container_app = await App.init_container.aio(client, app.app_id)
-        await container_app._init_container_objects.aio(stub)
+        container_app._associate_stub(stub)
         assert isinstance(container_app.f, Function)
         assert container_app.f.web_url
 

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -125,10 +125,6 @@ class _FunctionIOManager:
         self._container_app = await _App.init_container(self._client, self.app_id, self._stub_name)
         return self._container_app
 
-    @wrap()
-    async def initialize_app_objects(self, stub: Optional[_Stub]):
-        await self._container_app._init_container_objects(stub)
-
     async def _heartbeat(self):
         request = api_pb2.ContainerHeartbeatRequest()
         if self.current_input_id is not None:
@@ -637,11 +633,9 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
             ser_cls, ser_fun = None, None
 
         # Initialize the function
+        # Note: detecting the stub causes all objects to be associated with the app and hydrated
         with function_io_manager.handle_user_exception():
             imp_fun = import_function(container_args.function_def, ser_cls, ser_fun, container_args.serialized_params)
-
-        # Hydrate all app objects
-        function_io_manager.initialize_app_objects(imp_fun.stub)
 
         pty_info: api_pb2.PTYInfo = container_args.function_def.pty_info
         if pty_info.pty_type or pty_info.enabled:

--- a/modal/app.py
+++ b/modal/app.py
@@ -1,5 +1,5 @@
 # Copyright Modal Labs 2022
-from typing import TYPE_CHECKING, Dict, Optional, Sequence, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, TypeVar
 
 from google.protobuf.message import Message
 
@@ -53,7 +53,7 @@ class _App:
     _resolver: Optional[Resolver]
     _environment_name: str
     _output_mgr: Optional[OutputManager]
-    _associated_stub: Optional["_Stub"]
+    _associated_stub: Optional[Any]  # TODO(erikbern): type
 
     def __init__(
         self,
@@ -88,7 +88,7 @@ class _App:
         """A unique identifier for this running App."""
         return self._app_id
 
-    def _associate_stub(self, stub: "_Stub"):
+    def _associate_stub(self, stub):
         if self._associated_stub:
             if self._stub_name:
                 warning_sub_message = f"stub with the same name ('{self._stub_name}')"

--- a/modal/app.py
+++ b/modal/app.py
@@ -50,6 +50,7 @@ class _App:
     _resolver: Optional[Resolver]
     _environment_name: str
     _output_mgr: Optional[OutputManager]
+    _associated_stub: Optional["_Stub"]
 
     def __init__(
         self,
@@ -71,6 +72,7 @@ class _App:
         self._stub_name = stub_name
         self._environment_name = environment_name
         self._output_mgr = output_mgr
+        self._associated_stub = None
 
     @property
     def client(self) -> _Client:
@@ -81,6 +83,17 @@ class _App:
     def app_id(self) -> str:
         """A unique identifier for this running App."""
         return self._app_id
+
+    def _associate_stub(self, stub: "_Stub"):
+        if self._associated_stub:
+            if self._stub_name:
+                warning_sub_message = f"stub with the same name ('{self._stub_name}')"
+            else:
+                warning_sub_message = "unnamed stub"
+            logger.warning(
+                f"You have more than one {warning_sub_message}. It's recommended to name all your Stubs uniquely when using multiple stubs"
+            )
+        self._associated_stub = stub
 
     async def _create_all_objects(
         self, blueprint: Dict[str, _Provider], new_app_state: int, environment_name: str, shell: bool = False

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -151,21 +151,13 @@ class _Stub:
         self._app = None
 
         string_name = self._name or ""
-        existing_stubs = _Stub._all_stubs.setdefault(string_name, [])
 
         if not is_local() and _container_app._stub_name == string_name:
-            if len(existing_stubs) == 1:  # warn the first time we reach a duplicate stub name for the active stub
-                if self._name is None:
-                    warning_sub_message = "unnamed stub"
-                else:
-                    warning_sub_message = f"stub with the same name ('{self._name}')"
-                logger.warning(
-                    f"You have more than one {warning_sub_message}. It's recommended to name all your Stubs uniquely when using multiple stubs"
-                )
+            _container_app._associate_stub(self)
             # note that all stubs with the correct name will get the container app assigned
             self._app = _container_app
 
-        _Stub._all_stubs[string_name].append(self)
+        _Stub._all_stubs.setdefault(string_name, []).append(self)
 
     @property
     def name(self) -> Optional[str]:


### PR DESCRIPTION
As a part of the provider/handle merge, I've realized it makes no sense that both the stub and the app holds objects. It's better if only the stub holds objects and the app just refers to those. Fixing this should also fix the `is_inside` problem.

This PR doesn't accomplish this! However, it contains a bunch of prep work for removing this ownership. I just wanted to roll a bunch of low-risk changes into a prequel PR so that the actual change itself is tinier.