### PR TITLE
container test for function that isn't associated with a stub

### DIFF
--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -732,3 +732,12 @@ def test_concurrent_inputs_async_function(unix_servicer, event_loop):
     expected_execution = n_inputs / n_parallel * SLEEP_TIME
     assert expected_execution <= time.time() - t0 < expected_execution + EXTRA_TOLERANCE_DELAY
     verify_concurrent_input_outputs(n_inputs, n_parallel, items)
+
+
+@skip_windows_unix_socket
+def test_unassociated_function(unix_servicer, event_loop):
+    client, items = _run_container(unix_servicer, "modal_test_support.functions", "unassociated_function")
+    assert len(items) == 1
+    assert items[0].result.status == api_pb2.GenericResult.GENERIC_STATUS_SUCCESS
+    assert items[0].result.data
+    assert deserialize(items[0].result.data, client) == 58

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -180,3 +180,7 @@ def sleep_700_sync(x):
 async def sleep_700_async(x):
     await asyncio.sleep(0.7)
     return x * x
+
+
+def unassociated_function(x):
+    return 100 - x


### PR DESCRIPTION
We didn't have any test coverage for [this branch](https://github.com/modal-labs/modal-client/blob/main/modal/_container_entrypoint.py#L564) and it caused me to break some stuff in #736 (which was luckily caught by another test, but only because I changed some other stuff in subsequent commits). This test would have caught the issue much earlier, not after like 7 commits.