### PR TITLE
use _tag_to_object less

### DIFF
--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -91,7 +91,7 @@ class Resolver:
 
     async def preload(self, obj, existing_object_id: Optional[str]):
         if obj._preload is not None:
-            return await obj._preload(self, existing_object_id, obj._handle)
+            await obj._preload(self, existing_object_id, obj._handle)
 
     async def load(self, obj, existing_object_id: Optional[str] = None):
         cached_future = self._local_uuid_to_future.get(obj.local_uuid)

--- a/modal/app.py
+++ b/modal/app.py
@@ -151,11 +151,13 @@ class _App:
             for tag, provider in blueprint.items():
                 existing_object_id = self._tag_to_object_id.get(tag)
                 await resolver.load(provider, existing_object_id)
+                self._tag_to_object_id[tag] = provider.object_id
 
         # Create the app (and send a list of all tagged obs)
         # TODO(erikbern): we should delete objects from a previous version that are no longer needed
         # We just delete them from the app, but the actual objects will stay around
-        indexed_object_ids = {tag: obj.object_id for tag, obj in self._tag_to_object.items()}
+        indexed_object_ids = self._tag_to_object_id
+        assert indexed_object_ids == self._tag_to_object_id
         all_objects = resolver.objects()
 
         unindexed_object_ids = list(

--- a/modal/app.py
+++ b/modal/app.py
@@ -140,9 +140,9 @@ class _App:
                 # Note: preload only currently implemented for Functions, returns None otherwise
                 # this is to ensure that directly referenced functions from the global scope has
                 # ids associated with them when they are serialized into other functions
-                precreated_object = await resolver.preload(provider, existing_object_id)
-                if precreated_object is not None:
-                    self._tag_to_object_id[tag] = precreated_object.object_id
+                await resolver.preload(provider, existing_object_id)
+                if provider.object_id is not None:
+                    self._tag_to_object_id[tag] = provider.object_id
 
             for tag, provider in blueprint.items():
                 existing_object_id = self._tag_to_object_id.get(tag)

--- a/modal/app.py
+++ b/modal/app.py
@@ -126,6 +126,10 @@ class _App:
             shell=shell,
         )
         with resolver.display():
+            # Assign all objects
+            for tag, provider in blueprint.items():
+                self._tag_to_object[tag] = provider
+
             # Preload all functions to make sure they have ids assigned before they are loaded.
             # This is important to make sure any enclosed function handle references in serialized
             # functions have ids assigned to them when the function is serialized.
@@ -139,12 +143,10 @@ class _App:
                 precreated_object = await resolver.preload(provider, existing_object_id)
                 if precreated_object is not None:
                     self._tag_to_object_id[tag] = precreated_object.object_id
-                    self._tag_to_object[tag] = precreated_object
 
             for tag, provider in blueprint.items():
                 existing_object_id = self._tag_to_object_id.get(tag)
                 await resolver.load(provider, existing_object_id)
-                self._tag_to_object[tag] = provider
 
         # Create the app (and send a list of all tagged obs)
         # TODO(erikbern): we should delete objects from a previous version that are no longer needed

--- a/modal/app.py
+++ b/modal/app.py
@@ -130,6 +130,10 @@ class _App:
             for tag, provider in blueprint.items():
                 self._tag_to_object[tag] = provider
 
+                # Reset object_id in case the app runs twice
+                # TODO(erikbern): clean up the interface
+                provider._handle._init()
+
             # Preload all functions to make sure they have ids assigned before they are loaded.
             # This is important to make sure any enclosed function handle references in serialized
             # functions have ids assigned to them when the function is serialized.


### PR DESCRIPTION
More prep work for removing apps holding objects. This just avoids using `self._tag_to_object` in a few places.