### PR TITLE
Fix bug where app deployments don't delete prior objects

### DIFF
--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -313,8 +313,12 @@ class MockClientServicer(api_grpc.ModalClientBase):
     ### Dict
 
     async def DictCreate(self, stream):
-        dict_id = f"di-{len(self.dicts)}"
-        self.dicts[dict_id] = {}
+        request: api_pb2.DictCreateRequest = await stream.recv_message()
+        if request.existing_dict_id:
+            dict_id = request.existing_dict_id
+        else:
+            dict_id = f"di-{len(self.dicts)}"
+            self.dicts[dict_id] = {}
         await stream.send_message(api_pb2.DictCreateResponse(dict_id=dict_id))
 
     async def DictGet(self, stream):

--- a/client_test/stub_test.py
+++ b/client_test/stub_test.py
@@ -259,3 +259,23 @@ async def test_redeploy_persist(servicer, client):
     app = await deploy_stub.aio(stub, "my-app", client=client)
     assert app.app_id == "ap-1"
     assert servicer.app_objects["ap-1"]["d"] == "di-1"
+
+
+def test_redeploy_delete_objects(servicer, client):
+    # Deploy an app with objects d1 and d2
+    stub = Stub()
+    stub.d1 = Dict.new()
+    stub.d2 = Dict.new()
+    app = deploy_stub(stub, "xyz", client=client)
+
+    # Check objects
+    assert set(servicer.app_objects[app.app_id].keys()) == set(["d1", "d2"])
+
+    # Deploy an app with objects d2 and d3
+    stub = Stub()
+    stub.d2 = Dict.new()
+    stub.d3 = Dict.new()
+    app = deploy_stub(stub, "xyz", client=client)
+
+    # Make sure d1 is deleted
+    assert set(servicer.app_objects[app.app_id].keys()) == set(["d2", "d3"])

--- a/modal/app.py
+++ b/modal/app.py
@@ -126,6 +126,10 @@ class _App:
             shell=shell,
         )
         with resolver.display():
+            # Get current objects, and reset all objects
+            tag_to_object_id = self._tag_to_object_id
+            self._tag_to_object_id = {}
+
             # Assign all objects
             for tag, provider in blueprint.items():
                 self._tag_to_object[tag] = provider
@@ -140,7 +144,7 @@ class _App:
             # Note: when handles/providers are merged, all objects will need to get ids pre-assigned
             # like this in order to be referrable within serialized functions
             for tag, provider in blueprint.items():
-                existing_object_id = self._tag_to_object_id.get(tag)
+                existing_object_id = tag_to_object_id.get(tag)
                 # Note: preload only currently implemented for Functions, returns None otherwise
                 # this is to ensure that directly referenced functions from the global scope has
                 # ids associated with them when they are serialized into other functions
@@ -149,7 +153,7 @@ class _App:
                     self._tag_to_object_id[tag] = provider.object_id
 
             for tag, provider in blueprint.items():
-                existing_object_id = self._tag_to_object_id.get(tag)
+                existing_object_id = tag_to_object_id.get(tag)
                 await resolver.load(provider, existing_object_id)
                 self._tag_to_object_id[tag] = provider.object_id
 

--- a/modal/app.py
+++ b/modal/app.py
@@ -150,7 +150,7 @@ class _App:
                 # ids associated with them when they are serialized into other functions
                 await resolver.preload(provider, existing_object_id)
                 if provider.object_id is not None:
-                    self._tag_to_object_id[tag] = provider.object_id
+                    tag_to_object_id[tag] = provider.object_id
 
             for tag, provider in blueprint.items():
                 existing_object_id = tag_to_object_id.get(tag)


### PR DESCRIPTION
This currently unbreaks integration tests

I would like to add a client test to this so we can catch this issue sooner. But I'll put this PR up here for now in case we need to unbreak CI sooner.