### PR TITLE
Move _stub from FunctionHandle to Function

### DIFF
--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -691,7 +691,7 @@ def verify_concurrent_input_outputs(n_inputs: int, n_parallel: int, output_items
         assert diff == pytest.approx(expected_diff, abs=0.2)
 
     for item in output_items:
-        assert item.output_created_at - item.input_started_at == pytest.approx(SLEEP_TIME, abs=0.1)
+        assert item.output_created_at - item.input_started_at == pytest.approx(SLEEP_TIME, abs=0.2)
         assert item.result.status == api_pb2.GenericResult.GENERIC_STATUS_SUCCESS
         assert item.result.data == serialize(42**2)
 

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -556,7 +556,7 @@ def import_function(function_def: api_pb2.Function, ser_cls, ser_fun, ser_params
     if isinstance(fun, Function):
         _function_proxy = synchronizer._translate_in(fun)
         fun = _function_proxy.get_raw_f()
-        active_stub = _function_proxy._handle._stub
+        active_stub = _function_proxy._stub
     elif module is not None and not function_def.is_builder_function:
         # This branch is reached in the special case that the imported function is 1) not serialized, and 2) isn't a FunctionHandle - i.e, not decorated at definition time
         # Look at all instantiated stubs - if there is only one with the indicated name, use that one

--- a/modal/cli/import_refs.py
+++ b/modal/cli/import_refs.py
@@ -19,7 +19,7 @@ from rich.panel import Panel
 from rich.prompt import Prompt
 
 import modal
-from modal.functions import _Function, _FunctionHandle
+from modal.functions import _Function
 from modal.stub import LocalEntrypoint, Stub, _Stub
 from modal_utils.async_utils import synchronizer
 
@@ -140,7 +140,7 @@ def choose_function_interactive(stub: _Stub, console: Console) -> str:
 
 def infer_function_or_help(
     _stub: _Stub, interactive: bool, accept_local_entrypoint: bool, accept_webhook: bool
-) -> Union[_FunctionHandle, LocalEntrypoint]:
+) -> Union[_Function, LocalEntrypoint]:
     function_choices = set(_stub.registered_functions.keys())
     if not accept_webhook:
         function_choices -= set(_stub.registered_web_endpoints)
@@ -178,7 +178,7 @@ Registered functions and local entrypoints on the selected stub are:
         # entrypoint is in entrypoint registry, for now
         return _stub.registered_entrypoints[function_name]
 
-    return _stub[function_name]._handle  # functions are in blueprint
+    return _stub[function_name]  # functions are in blueprint
 
 
 def _show_no_auto_detectable_stub(stub_ref: ImportRef) -> None:
@@ -249,7 +249,7 @@ You would run foo as [bold green]{base_cmd} app.py::foo[/bold green]"""
 
 def import_function(
     func_ref: str, base_cmd: str, accept_local_entrypoint=True, accept_webhook=False, interactive=False
-) -> Union[_FunctionHandle, LocalEntrypoint]:
+) -> Union[_Function, LocalEntrypoint]:
     import_ref = parse_import_ref(func_ref)
     try:
         module = import_file_or_module(import_ref.file_or_module)
@@ -270,10 +270,8 @@ def import_function(
         _stub = stub_or_function
         _function_handle = infer_function_or_help(_stub, interactive, accept_local_entrypoint, accept_webhook)
         return _function_handle
-    if isinstance(stub_or_function, _FunctionHandle):
-        return stub_or_function
     elif isinstance(stub_or_function, _Function):
-        return stub_or_function._handle
+        return stub_or_function
     elif isinstance(stub_or_function, LocalEntrypoint):
         if not accept_local_entrypoint:
             raise click.UsageError(

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -21,7 +21,7 @@ from modal.stub import LocalEntrypoint
 from modal_utils.async_utils import synchronizer
 
 from ..environments import ensure_env
-from ..functions import _FunctionHandle
+from ..functions import _Function
 from .import_refs import import_function, import_stub
 from .utils import ENV_OPTION, ENV_OPTION_HELP
 
@@ -151,16 +151,16 @@ def _get_click_command_for_local_entrypoint(_stub, entrypoint: LocalEntrypoint):
 
 class RunGroup(click.Group):
     def get_command(self, ctx, func_ref):
-        _function_handle_or_entrypoint = import_function(
+        _function_or_entrypoint = import_function(
             func_ref, accept_local_entrypoint=True, interactive=False, base_cmd="modal run"
         )
-        _stub = _function_handle_or_entrypoint._stub
+        _stub = _function_or_entrypoint._stub
         if _stub._description is None:
             _stub._description = _get_clean_stub_description(func_ref)
-        if isinstance(_function_handle_or_entrypoint, LocalEntrypoint):
-            click_command = _get_click_command_for_local_entrypoint(_stub, _function_handle_or_entrypoint)
+        if isinstance(_function_or_entrypoint, LocalEntrypoint):
+            click_command = _get_click_command_for_local_entrypoint(_stub, _function_or_entrypoint)
         else:
-            tag = _function_handle_or_entrypoint._info.get_tag()
+            tag = _function_or_entrypoint._info.get_tag()
             click_command = _get_click_command_for_function(_stub, tag)
 
         return click_command
@@ -285,12 +285,12 @@ def shell(
     if not console.is_terminal:
         raise click.UsageError("`modal shell` can only be run from a terminal.")
 
-    _function_handle = import_function(
+    _function = import_function(
         func_ref, accept_local_entrypoint=False, accept_webhook=True, interactive=True, base_cmd="modal shell"
     )
-    assert isinstance(_function_handle, _FunctionHandle)  # ensured by accept_local_entrypoint=False
+    assert isinstance(_function, _Function)  # ensured by accept_local_entrypoint=False
     interactive_shell(
-        _function_handle,
+        _function,
         cmd,
         environment_name=env,
     )

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -15,7 +15,7 @@ from .app import _App, is_local
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, _Client
 from .config import config
 from .exception import InvalidError
-from .functions import _FunctionHandle
+from .functions import _Function
 
 
 async def _heartbeat(client, app_id):
@@ -221,7 +221,7 @@ async def _deploy_stub(
     return app
 
 
-async def _interactive_shell(_function_handle: _FunctionHandle, cmd: str, environment_name: str = ""):
+async def _interactive_shell(_function: _Function, cmd: str, environment_name: str = ""):
     """Run an interactive shell (like `bash`) within the image for this app.
 
     This is useful for online debugging and interactive exploration of the
@@ -242,10 +242,10 @@ async def _interactive_shell(_function_handle: _FunctionHandle, cmd: str, enviro
     modal shell script.py --cmd /bin/bash
     ```
     """
-    _stub = _function_handle._stub
+    _stub = _function._stub
     _stub._add_pty_input_stream()  # TOOD(erikbern): slightly hacky
     async with _run_stub(_stub, environment_name=environment_name, shell=True):
-        await _function_handle.shell(cmd)
+        await _function.shell(cmd)
 
 
 run_stub = synchronize_api(_run_stub)


### PR DESCRIPTION
I have a big change that moves all the methods from `_FunctionHandle` to `Function`, but it felt a bit big and sprawling and there's some unit test failures still. Breaking it up into multiple changes instead. Here's the first!