### PR TITLE
Don't overwrite internal _description property

### DIFF
--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -155,8 +155,8 @@ class RunGroup(click.Group):
             func_ref, accept_local_entrypoint=True, interactive=False, base_cmd="modal run"
         )
         _stub = _function_or_entrypoint._stub
-        if _stub._description is None:
-            _stub._description = _get_clean_stub_description(func_ref)
+        if _stub.description is None:
+            _stub.set_description(_get_clean_stub_description(func_ref))
         if isinstance(_function_or_entrypoint, LocalEntrypoint):
             click_command = _get_click_command_for_local_entrypoint(_stub, _function_or_entrypoint)
         else:

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2022
 import inspect
 import os
-import sys
 import typing
 import warnings
 from datetime import date
@@ -94,7 +93,7 @@ class _Stub:
     """
 
     _name: Optional[str]
-    _description: str
+    _description: Optional[str]
     _app_id: str
     _blueprint: Dict[str, _Provider]
     _function_mounts: Dict[str, _Mount]
@@ -170,28 +169,16 @@ class _Stub:
         return self._app
 
     @property
-    def description(self) -> str:
+    def description(self) -> Optional[str]:
         """The Stub's `name`, if available, or a fallback descriptive identifier."""
-        return self._description or self._infer_app_desc()
+        return self._description
+
+    def set_description(self, description: str):
+        self._description = description
 
     def _validate_blueprint_value(self, key: str, value: Any):
         if not isinstance(value, _Provider):
             raise InvalidError(f"Stub attribute {key} with value {value} is not a valid Modal object")
-
-    def _infer_app_desc(self):
-        if is_notebook():
-            # when running from a notebook the sys.argv for the kernel will
-            # be really long and not very helpful
-            return "Notebook"  # TODO: use actual name of notebook
-
-        if is_local():
-            script_filename = os.path.split(sys.argv[0])[-1]
-            args = [script_filename] + sys.argv[1:]
-            return " ".join(args)
-        else:
-            # in a container we rarely use the description, but nice to have a fallback
-            # instead of displaying "_container_entrypoint.py [base64 garbage]"
-            return "[unnamed app]"
 
     def _add_object(self, tag, obj):
         if self._app:


### PR DESCRIPTION
Was cleaning up some CLI code and ran into this thin where we mutate internal variables.

I don't think we need _infer_app_description given that we mostly set the description from the `modal run` command itself. 