### PR TITLE
synchronize LocalEntrypoint

### DIFF
--- a/client_test/cli_imports_test.py
+++ b/client_test/cli_imports_test.py
@@ -10,7 +10,7 @@ from modal.cli.import_refs import (
     parse_import_ref,
 )
 from modal.functions import _Function
-from modal.stub import LocalEntrypoint, _Stub
+from modal.stub import _LocalEntrypoint, _Stub
 from modal_utils.async_utils import synchronizer
 
 # Some helper vars for import_stub tests:
@@ -90,7 +90,7 @@ dir_containing_python_package = {
         (empty_dir_with_python_file, "mod::other_stub", _Stub),
         (dir_containing_python_package, "pack.mod", _Stub),
         (dir_containing_python_package, "pack.mod::other_stub", _Stub),
-        (dir_containing_python_package, "pack/local.py::stub.main", LocalEntrypoint),
+        (dir_containing_python_package, "pack/local.py::stub.main", _LocalEntrypoint),
     ],
 )
 def test_import_object(dir_structure, ref, expected_object_type, mock_dir):

--- a/modal/cli/import_refs.py
+++ b/modal/cli/import_refs.py
@@ -20,7 +20,7 @@ from rich.prompt import Prompt
 
 import modal
 from modal.functions import _Function
-from modal.stub import LocalEntrypoint, Stub, _Stub
+from modal.stub import Stub, _LocalEntrypoint, _Stub
 from modal_utils.async_utils import synchronizer
 
 
@@ -140,7 +140,7 @@ def choose_function_interactive(stub: _Stub, console: Console) -> str:
 
 def infer_function_or_help(
     _stub: _Stub, interactive: bool, accept_local_entrypoint: bool, accept_webhook: bool
-) -> Union[_Function, LocalEntrypoint]:
+) -> Union[_Function, _LocalEntrypoint]:
     function_choices = set(_stub.registered_functions.keys())
     if not accept_webhook:
         function_choices -= set(_stub.registered_web_endpoints)
@@ -249,7 +249,7 @@ You would run foo as [bold green]{base_cmd} app.py::foo[/bold green]"""
 
 def import_function(
     func_ref: str, base_cmd: str, accept_local_entrypoint=True, accept_webhook=False, interactive=False
-) -> Union[_Function, LocalEntrypoint]:
+) -> Union[_Function, _LocalEntrypoint]:
     import_ref = parse_import_ref(func_ref)
     try:
         module = import_file_or_module(import_ref.file_or_module)
@@ -272,7 +272,7 @@ def import_function(
         return _function_handle
     elif isinstance(stub_or_function, _Function):
         return stub_or_function
-    elif isinstance(stub_or_function, LocalEntrypoint):
+    elif isinstance(stub_or_function, _LocalEntrypoint):
         if not accept_local_entrypoint:
             raise click.UsageError(
                 f"{func_ref} is not a Modal Function (a Modal local_entrypoint can't be used in this context)"

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -17,7 +17,7 @@ from modal.config import config
 from modal.exception import InvalidError
 from modal.runner import deploy_stub, interactive_shell, run_stub
 from modal.serving import serve_stub
-from modal.stub import LocalEntrypoint
+from modal.stub import _LocalEntrypoint
 from modal_utils.async_utils import synchronizer
 
 from ..environments import ensure_env
@@ -115,7 +115,7 @@ def _get_click_command_for_function(_stub, function_tag):
     return click.command(with_click_options)
 
 
-def _get_click_command_for_local_entrypoint(_stub, entrypoint: LocalEntrypoint):
+def _get_click_command_for_local_entrypoint(_stub, entrypoint: _LocalEntrypoint):
     blocking_stub = synchronizer._translate_out(_stub, Interface.BLOCKING)
     func = entrypoint.raw_f
     isasync = inspect.iscoroutinefunction(func)
@@ -157,7 +157,7 @@ class RunGroup(click.Group):
         _stub = _function_or_entrypoint._stub
         if _stub.description is None:
             _stub.set_description(_get_clean_stub_description(func_ref))
-        if isinstance(_function_or_entrypoint, LocalEntrypoint):
+        if isinstance(_function_or_entrypoint, _LocalEntrypoint):
             click_command = _get_click_command_for_local_entrypoint(_stub, _function_or_entrypoint)
         else:
             tag = _function_or_entrypoint._info.get_tag()


### PR DESCRIPTION
Doing this since it lets me simplify a lot of CLI code so none of it has to deal with synchronization etc. The problem is the `LocalEntrypoint` carries a `_Stub` class but it's actually better if it returns a `Stub` class.

Needed because I want to change the signature of import_stub in a subsequent PR similar to #749 (both PRs were broken out of a PR that was too big)
