### PR TITLE
Clean up CLI

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -507,7 +507,7 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
     def _initialize_from_empty(self):
         self._progress = None
         self._is_generator = None
-        self._info = None
+        self._info = None  # TODO(erikbern): remove
         self._web_url = None
         self._output_mgr: Optional[OutputManager] = None
         self._mute_cancellation = (
@@ -518,6 +518,7 @@ class _FunctionHandle(_Handle, type_prefix="fu"):
 
     def _initialize_from_local(self, info: FunctionInfo):
         # note that this is not a full hydration of the function, as it doesn't yet get an object_id etc.
+        # TODO(erikbern): remove this
         self._info = info
 
     def _hydrate_metadata(self, metadata: Message):
@@ -977,6 +978,14 @@ class _Function(_Provider, type_prefix="fu"):
     def tag(self):
         """mdmd:hidden"""
         return self._tag
+
+    @property
+    def stub(self) -> "modal.stub._Stub":
+        return self._stub
+
+    @property
+    def info(self) -> FunctionInfo:
+        return self._info
 
     def get_build_def(self) -> str:
         """mdmd:hidden"""

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -51,6 +51,10 @@ class _LocalEntrypoint:
     def raw_f(self) -> Callable:
         return self._raw_f
 
+    @property
+    def stub(self) -> "_Stub":
+        return self._stub
+
 
 LocalEntrypoint = synchronize_api(_LocalEntrypoint)
 


### PR DESCRIPTION
This gets rid of a bunch of CLI code that handles synchronization - there's no need to do it. This is mostly a leftover from when we had different types of interfaces, but it also took a few PRs (#748, #749, and #750) to prep for it.

