### PR TITLE
Add client support for modal.Queue.len()

### DIFF
--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -585,6 +585,10 @@ class MockClientServicer(api_grpc.ModalClientBase):
             values = []
         await stream.send_message(api_pb2.QueueGetResponse(values=values))
 
+    async def QueueLen(self, stream):
+        await stream.recv_message()
+        await stream.send_message(api_pb2.QueueLenResponse(len=len(self.queue)))
+
     ### Sandbox
 
     async def SandboxCreate(self, stream):

--- a/client_test/queue_test.py
+++ b/client_test/queue_test.py
@@ -10,7 +10,10 @@ def test_queue(servicer, client):
     stub.q = Queue.new()
     with stub.run(client=client):
         assert isinstance(stub.q, Queue)
+        assert stub.q.len() == 0
         stub.q.put(42)
+        assert stub.q.len() == 1
         assert stub.q.get() == 42
         with pytest.raises(queue.Empty):
             stub.q.get(timeout=0)
+        assert stub.q.len() == 0

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -159,5 +159,11 @@ class _Queue(_Provider, type_prefix="qu"):
 
         await retry_transient_errors(self._client.stub.QueuePut, request)
 
+    async def len(self) -> int:
+        """Return the number of objects in the queue."""
+        request = api_pb2.QueueLenRequest(queue_id=self.object_id)
+        response = await retry_transient_errors(self._client.stub.QueueLen, request)
+        return response.len
+
 
 Queue = synchronize_api(_Queue)

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -965,6 +965,14 @@ message QueuePutRequest {
   repeated bytes values = 4;
 }
 
+message QueueLenRequest {
+  string queue_id = 1;
+}
+
+message QueueLenResponse {
+  int32 len = 1;
+}
+
 message RateLimit {
   int32 limit = 1;
   RateLimitInterval interval = 2;
@@ -1350,6 +1358,7 @@ service ModalClient {
   rpc QueueCreate(QueueCreateRequest) returns (QueueCreateResponse);
   rpc QueueGet(QueueGetRequest) returns (QueueGetResponse);
   rpc QueuePut(QueuePutRequest) returns (google.protobuf.Empty);
+  rpc QueueLen(QueueLenRequest) returns (QueueLenResponse);
 
   // Sandboxes
   rpc SandboxCreate(SandboxCreateRequest) returns (SandboxCreateResponse);


### PR DESCRIPTION
This returns the number of items in a queue.

Requires server support, which I'll implement separately.