### PR TITLE
Remove legacy GPU field

### DIFF
--- a/client_test/gpu_test.py
+++ b/client_test/gpu_test.py
@@ -26,7 +26,6 @@ def test_gpu_any_function(client, servicer):
 
     assert len(servicer.app_functions) == 1
     func_def = next(iter(servicer.app_functions.values()))
-    assert func_def.resources.gpu == 0
     assert func_def.resources.gpu_config.count == 1
     assert func_def.resources.gpu_config.type == api_pb2.GPU_TYPE_ANY
 
@@ -44,7 +43,6 @@ def test_gpu_string_config(client, servicer):
 
     assert len(servicer.app_functions) == 1
     func_def = next(iter(servicer.app_functions.values()))
-    assert func_def.resources.gpu == 0
     assert func_def.resources.gpu_config.count == 1
     assert func_def.resources.gpu_config.type == api_pb2.GPU_TYPE_A100
 
@@ -60,7 +58,6 @@ def test_gpu_config_function(client, servicer):
 
     assert len(servicer.app_functions) == 1
     func_def = next(iter(servicer.app_functions.values()))
-    assert func_def.resources.gpu == 0
     assert func_def.resources.gpu_config.count == 1
     assert func_def.resources.gpu_config.type == api_pb2.GPU_TYPE_A100
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -996,7 +996,6 @@ message GPUConfig {
 }
 
 message Resources {
-  reserved 1; // Legacy boolean "gpu" field
   uint32 memory_mb = 2;
   uint32 milli_cpu = 3;
   GPUConfig gpu_config = 4;

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -996,7 +996,7 @@ message GPUConfig {
 }
 
 message Resources {
-  reserved 1; // Legacy integer "gpu" field
+  reserved 1; // Legacy boolean "gpu" field
   uint32 memory_mb = 2;
   uint32 milli_cpu = 3;
   GPUConfig gpu_config = 4;

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -996,7 +996,7 @@ message GPUConfig {
 }
 
 message Resources {
-  bool gpu = 1; // Legacy GPU toggle.
+  reserved 1; // Legacy integer "gpu" field
   uint32 memory_mb = 2;
   uint32 milli_cpu = 3;
   GPUConfig gpu_config = 4;


### PR DESCRIPTION
Was deprecated in #122, time to remove.

Server changes to make this not break tests are in PR 7204 of our monorepo