### PR TITLE
Remove the custom repr stuff from objects

### DIFF
--- a/client_test/resolver_test.py
+++ b/client_test/resolver_test.py
@@ -24,7 +24,7 @@ async def test_multi_resolve_sequential_loads_once():
         load_count += 1
         await asyncio.sleep(0.1)
 
-    obj = _DumbObject._from_loader(_load, "DumbObject()")
+    obj = _DumbObject._from_loader(_load)
 
     t0 = time.monotonic()
     await resolver.load(obj)
@@ -49,7 +49,7 @@ async def test_multi_resolve_concurrent_loads_once():
         load_count += 1
         await asyncio.sleep(0.1)
 
-    obj = _DumbObject._from_loader(_load, "DumbObject()")
+    obj = _DumbObject._from_loader(_load)
     t0 = time.monotonic()
     await asyncio.gather(resolver.load(obj), resolver.load(obj))
     assert 0.08 < time.monotonic() - t0 < 0.15

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -66,7 +66,7 @@ class _Dict(_Object, type_prefix="di"):
             logger.debug("Created dict with id %s" % response.dict_id)
             provider._hydrate(response.dict_id, resolver.client, None)
 
-        return _Dict._from_loader(_load, "Dict()")
+        return _Dict._from_loader(_load)
 
     def __init__(self, data={}):
         """mdmd:hidden"""

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -801,8 +801,7 @@ class _Function(_Object, type_prefix="fu"):
 
             provider._hydrate(response.function_id, resolver.client, response.handle_metadata)
 
-        rep = f"Function({tag})"
-        obj = _Function._from_loader(_load, rep, preload=_preload)
+        obj = _Function._from_loader(_load, preload=_preload)
 
         obj._raw_f = raw_f
         obj._info = info

--- a/modal/image.py
+++ b/modal/image.py
@@ -305,8 +305,7 @@ class _Image(_Object, type_prefix="im"):
 
             provider._hydrate(image_id, resolver.client, None)
 
-        rep = f"Image({dockerfile_commands})"
-        obj = _Image._from_loader(_load, rep)
+        obj = _Image._from_loader(_load)
         obj.force_build = force_build
         return obj
 

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -158,9 +158,8 @@ class _Mount(_Object, type_prefix="mo"):
 
     @staticmethod
     def _from_entries(*entries: _MountEntry) -> "_Mount":
-        rep = f"Mount({entries})"
         load = functools.partial(_Mount._load_mount, entries)
-        obj = _Mount._from_loader(load, rep)
+        obj = _Mount._from_loader(load)
         obj._entries = entries
         obj._is_local = True
         return obj

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -112,7 +112,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
             status_row.finish("Created network file system.")
             provider._hydrate(resp.shared_volume_id, resolver.client, None)
 
-        return _NetworkFileSystem._from_loader(_load, "NetworkFileSystem()")
+        return _NetworkFileSystem._from_loader(_load)
 
     @staticmethod
     def persisted(

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -51,7 +51,7 @@ class _Queue(_Object, type_prefix="qu"):
             response = await resolver.client.stub.QueueCreate(request)
             provider._hydrate(response.queue_id, resolver.client, None)
 
-        return _Queue._from_loader(_load, "Queue()")
+        return _Queue._from_loader(_load)
 
     def __init__(self):
         """mdmd:hidden"""

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -163,7 +163,7 @@ class _Sandbox(_Object, type_prefix="sb"):
             provider._stdout = LogsReader(api_pb2.FILE_DESCRIPTOR_STDOUT, sandbox_id, resolver.client)
             provider._stderr = LogsReader(api_pb2.FILE_DESCRIPTOR_STDERR, sandbox_id, resolver.client)
 
-        return _Sandbox._from_loader(_load, "Sandbox()")
+        return _Sandbox._from_loader(_load)
 
     # Live handle methods
 

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -64,8 +64,7 @@ class _Secret(_Object, type_prefix="st"):
                 raise
             provider._hydrate(resp.secret_id, resolver.client, None)
 
-        rep = f"Secret.from_dict([{', '.join(env_dict.keys())}])"
-        return _Secret._from_loader(_load, rep)
+        return _Secret._from_loader(_load)
 
     @staticmethod
     def from_dotenv(path=None):
@@ -122,7 +121,7 @@ class _Secret(_Object, type_prefix="st"):
 
             provider._hydrate(resp.secret_id, resolver.client, None)
 
-        return _Secret._from_loader(_load, "Secret.from_dotenv()")
+        return _Secret._from_loader(_load)
 
 
 Secret = synchronize_api(_Secret)

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -79,7 +79,7 @@ class _Volume(_Object, type_prefix="vo"):
             status_row.finish("Created volume.")
             provider._hydrate(resp.volume_id, resolver.client, None)
 
-        return _Volume._from_loader(_load, "Volume()")
+        return _Volume._from_loader(_load)
 
     @staticmethod
     def persisted(


### PR DESCRIPTION
I personally find custom reprs pretty annoying and I'm not sure why it was there – I think maybe from a long time ago when we hadn't figured out the object hierarchy properly.