### PR TITLE
Fix async local entrypoints

### DIFF
--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -123,6 +123,16 @@ def test_run(servicer, set_env_client, test_dir):
     _run(["run", file_with_entrypoint.as_posix() + "::stub.main"])
 
 
+def test_run_async(servicer, set_env_client, test_dir):
+    sync_fn = test_dir / "supports" / "app_run_tests" / "local_entrypoint.py"
+    res = _run(["run", sync_fn.as_posix()])
+    assert "called locally" in res.stdout
+
+    async_fn = test_dir / "supports" / "app_run_tests" / "local_entrypoint_async.py"
+    res = _run(["run", async_fn.as_posix()])
+    assert "called locally (async)" in res.stdout
+
+
 def test_help_message_unspecified_function(servicer, set_env_client, test_dir):
     stub_file = test_dir / "supports" / "app_run_tests" / "stub_with_multiple_functions.py"
     result = _run(["run", stub_file.as_posix()], expected_exit_code=2, expected_stderr=None)

--- a/client_test/supports/app_run_tests/local_entrypoint_async.py
+++ b/client_test/supports/app_run_tests/local_entrypoint_async.py
@@ -1,0 +1,17 @@
+# Copyright Modal Labs 2022
+
+import modal
+
+stub = modal.Stub()
+
+
+@stub.function()
+def foo():
+    pass
+
+
+@stub.local_entrypoint()
+async def main():
+    print("called locally (async)")
+    await foo.remote.aio()
+    await foo.remote.aio()

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -111,7 +111,7 @@ def _get_click_command_for_function(stub: Stub, function_tag):
 
 
 def _get_click_command_for_local_entrypoint(stub: Stub, entrypoint: LocalEntrypoint):
-    func = entrypoint.raw_f
+    func = entrypoint.info.raw_f
     isasync = inspect.iscoroutinefunction(func)
 
     @click.pass_context

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -37,19 +37,19 @@ _default_image: _Image = _Image.debian_slim()
 
 
 class _LocalEntrypoint:
-    _raw_f: Callable[..., Any]
+    _info: FunctionInfo
     _stub: "_Stub"
 
-    def __init__(self, raw_f, stub):
-        self._raw_f = raw_f  # type: ignore
+    def __init__(self, info, stub):
+        self._info = info  # type: ignore
         self._stub = stub
 
     def __call__(self, *args, **kwargs):
-        return self._raw_f(*args, **kwargs)
+        return self._info.raw_f(*args, **kwargs)
 
     @property
-    def raw_f(self) -> Callable:
-        return self._raw_f
+    def info(self) -> FunctionInfo:
+        return self._info
 
     @property
     def stub(self) -> "_Stub":
@@ -398,8 +398,9 @@ class _Stub:
         """
 
         def wrapped(raw_f: Callable[..., Any]) -> None:
+            info = FunctionInfo(raw_f)
             tag = name if name is not None else raw_f.__qualname__
-            entrypoint = self._local_entrypoints[tag] = _LocalEntrypoint(raw_f, self)
+            entrypoint = self._local_entrypoints[tag] = _LocalEntrypoint(info, self)
             return entrypoint
 
         return wrapped


### PR DESCRIPTION
This was broken because of an annoying quirk with synchronicity. If a synchronized function returns a callable, synchronicity tries to wrap the return value as well. The point of this is to handle decorators.

However in the case of `LocalEntrypoint.raw_f`, we just want to return a `Callable` but not have it wrapped (because it's just a function). I solved it in a stupid way by returning a `FunctionInfo` object instead. But I'm not super happy with it.

