### PR TITLE
Send globals along with `run_function` step definition

### DIFF
--- a/client_test/image_test.py
+++ b/client_test/image_test.py
@@ -277,8 +277,6 @@ def run_f():
 
 
 def test_image_run_function(client, servicer):
-    global X
-
     stub = Stub()
     volume = NetworkFileSystem.persisted("test-vol")
     stub["image"] = (

--- a/client_test/image_test.py
+++ b/client_test/image_test.py
@@ -277,6 +277,8 @@ def run_f():
 
 
 def test_image_run_function(client, servicer):
+    global X
+
     stub = Stub()
     volume = NetworkFileSystem.persisted("test-vol")
     stub["image"] = (
@@ -290,11 +292,42 @@ def test_image_run_function(client, servicer):
         assert "foo!" in layers[0].build_function_def
         assert "Secret.from_dict([xyz])" in layers[0].build_function_def
         assert "Ref<NetworkFileSystem()>(test-vol)" in layers[0].build_function_def
+        # globals is none when no globals are referenced
+        assert layers[0].build_function_globals == b""
 
     function_id = servicer.image_build_function_ids[2]
     assert function_id
     assert servicer.app_functions[function_id].function_name == "run_f"
     assert len(servicer.app_functions[function_id].secret_ids) == 1
+
+
+X = 1
+
+
+def run_f_globals():
+    print("foo!", X)
+
+
+def test_image_run_function_globals(client, servicer):
+    global X
+
+    stub = Stub()
+    stub["image"] = Image.debian_slim().run_function(run_f_globals)
+
+    with stub.run(client=client):
+        layers = get_image_layers(stub["image"].object_id, servicer)
+        old_globals = layers[0].build_function_globals
+        assert old_globals is not None
+
+    X = 3
+    with stub.run(client=client):
+        layers = get_image_layers(stub["image"].object_id, servicer)
+        assert layers[0].build_function_globals != old_globals
+
+    X = 1
+    with stub.run(client=client):
+        layers = get_image_layers(stub["image"].object_id, servicer)
+        assert layers[0].build_function_globals == old_globals
 
 
 def test_poetry(client, servicer):

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -153,6 +153,14 @@ class FunctionInfo:
         logger.debug(f"Serializing {self.raw_f.__qualname__}, size is {len(serialized_bytes)}")
         return serialized_bytes
 
+    def get_globals(self):
+        from cloudpickle.cloudpickle import _extract_code_globals
+
+        func = self.raw_f
+        f_globals_ref = _extract_code_globals(func.__code__)
+        f_globals = {k: func.__globals__[k] for k in f_globals_ref if k in func.__globals__}
+        return f_globals
+
     def get_mounts(self) -> Dict[str, _Mount]:
         """
         Includes:

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -960,14 +960,6 @@ class _Function(_Provider, type_prefix="fu"):
         """mdmd:hidden"""
         return f"{inspect.getsource(self._raw_f)}\n{repr(self._build_args)}"
 
-    def get_globals(self):
-        from cloudpickle.cloudpickle import _extract_code_globals
-
-        func = self._raw_f
-        f_globals_ref = _extract_code_globals(func.__code__)
-        f_globals = {k: func.__globals__[k] for k in f_globals_ref if k in func.__globals__}
-        return f_globals
-
     def _bind_obj(self, obj, objtype):
         # This is needed to bind "self" to methods for direct __call__
         # TODO(erikbern): we're mutating self directly here, as opposed to returning a different _FunctionHandle

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -960,6 +960,14 @@ class _Function(_Provider, type_prefix="fu"):
         """mdmd:hidden"""
         return f"{inspect.getsource(self._raw_f)}\n{repr(self._build_args)}"
 
+    def get_globals(self):
+        from cloudpickle.cloudpickle import _extract_code_globals
+
+        func = self._raw_f
+        f_globals_ref = _extract_code_globals(func.__code__)
+        f_globals = {k: func.__globals__[k] for k in f_globals_ref if k in func.__globals__}
+        return f_globals
+
     def _bind_obj(self, obj, objtype):
         # This is needed to bind "self" to methods for direct __call__
         # TODO(erikbern): we're mutating self directly here, as opposed to returning a different _FunctionHandle

--- a/modal/image.py
+++ b/modal/image.py
@@ -197,7 +197,7 @@ class _Image(_Provider, type_prefix="im"):
                 build_function_def = build_function.get_build_def()
                 build_function_id = (await resolver.load(build_function)).object_id
 
-                globals = build_function.get_globals()
+                globals = build_function._get_info().get_globals()
                 # Cloudpickle function serialization produces unstable values.
                 # TODO: better way to filter out types that don't have a stable hash?
                 globals = {k: v for k, v in globals.items() if not isfunction(v)}

--- a/modal/image.py
+++ b/modal/image.py
@@ -201,7 +201,7 @@ class _Image(_Provider, type_prefix="im"):
                 # Cloudpickle function serialization produces unstable values.
                 # TODO: better way to filter out types that don't have a stable hash?
                 globals = {k: v for k, v in globals.items() if not isfunction(v)}
-                build_function_globals = serialize(globals)
+                build_function_globals = serialize(globals) if globals else None
             else:
                 build_function_def = None
                 build_function_id = None

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -855,10 +855,12 @@ message Image {
   // Note: field 13 is getting replaced field 16. The client now sends both fields,
   // but the server still only reads field 13.
   bool gpu = 13;
-  string build_function_def = 14;
   string context_mount_id = 15;
   GPUConfig gpu_config = 16;
   ImageRegistryConfig image_registry_config = 17;
+
+  string build_function_def = 14;
+  bytes build_function_globals = 18;
 }
 
 message ImageContextFile {


### PR DESCRIPTION
Allows us to fix the issue where changing a global variable referenced in a function doesn't rebuild the function:

```python
BASE_MODEL = "foo"

def download_models():
    from transformers import LlamaForCausalLM, LlamaTokenizer

    LlamaForCausalLM.from_pretrained(BASE_MODEL)
    LlamaTokenizer.from_pretrained(BASE_MODEL)
```

We're filtering out any functions referenced here because they can't be serialized in a "stable" way, but there might be other types we should filter out. 

An alternative would be letting users specify parameters explicitly:

```python
def download_models(model):
    from transformers import LlamaForCausalLM, LlamaTokenizer

    LlamaForCausalLM.from_pretrained(model)
    LlamaTokenizer.from_pretrained(model)

image = modal.Image.debian_slim().run_function(download_models, "foo")
```

This isn't great because it's easy for users to miss, and then leads to the same confusion as now when changing a variable doesn't change the image. 