### PR TITLE
Move from_id from handle to provider, turn `FunctionCall` into a `Provider`

### DIFF
--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -515,7 +515,13 @@ def test_from_id(client, servicer):
     function_id = foo.object_id
     assert function_id
     assert foo.web_url
-    rehydrated_function: FunctionHandle = FunctionHandle.from_id(function_id, client=client)
+
+    with pytest.raises(DeprecationError):
+        FunctionHandle.from_id(function_id, client=client)
+
+    rehydrated_function = Function.from_id(function_id, client=client)
+    assert isinstance(rehydrated_function, Function)
+
     assert rehydrated_function.object_id == function_id
     assert rehydrated_function.web_url == foo.web_url
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1238,7 +1238,11 @@ class _Function(_Provider, type_prefix="fu"):
 Function = synchronize_api(_Function)
 
 
-class _FunctionCall(_Handle, type_prefix="fc"):
+class _FunctionCallHandle(_Handle, type_prefix="fc"):
+    pass  # TODO(erikbern): Dumb temp thing, remove soon
+
+
+class _FunctionCall(_Provider, type_prefix="fc"):
     """A reference to an executed function call.
 
     Constructed using `.spawn(...)` on a Modal function with the same

--- a/modal/object.py
+++ b/modal/object.py
@@ -112,18 +112,11 @@ class _Handle:
         return obj
 
     @classmethod
-    async def from_id(cls: Type[H], object_id: str, client: Optional[_Client] = None) -> H:
-        """Get an object of this type from a unique object id (retrieved from `obj.object_id`)"""
-        # This is used in a few examples to construct FunctionCall objects
-        # TODO(erikbern): this should probably be on the provider?
-        if client is None:
-            client = await _Client.from_env()
-        app_lookup_object_response: api_pb2.AppLookupObjectResponse = await retry_transient_errors(
-            client.stub.AppLookupObject, api_pb2.AppLookupObjectRequest(object_id=object_id)
+    async def from_id(cls, object_id: str, client: Optional[_Client] = None):
+        deprecation_error(
+            date(2023, 8, 20),
+            "`Handle.from_id` is no longer supported. Use the method on the object class (e.g. `Function.from_id`)",
         )
-
-        handle_metadata = get_proto_oneof(app_lookup_object_response, "handle_metadata_oneof")
-        return cls._new_hydrated(object_id, client, handle_metadata)
 
     @property
     def object_id(self) -> str:
@@ -241,6 +234,19 @@ class _Provider:
         rep = f"Provider({object_id})"  # TODO(erikbern): dumb
         obj._init(rep, handle=handle)
         return obj
+
+    @classmethod
+    async def from_id(cls: Type[P], object_id: str, client: Optional[_Client] = None) -> P:
+        """Get an object of this type from a unique object id (retrieved from `obj.object_id`)"""
+        # This is used in a few examples to construct FunctionCall objects
+        if client is None:
+            client = await _Client.from_env()
+        app_lookup_object_response: api_pb2.AppLookupObjectResponse = await retry_transient_errors(
+            client.stub.AppLookupObject, api_pb2.AppLookupObjectRequest(object_id=object_id)
+        )
+
+        handle_metadata = get_proto_oneof(app_lookup_object_response, "handle_metadata_oneof")
+        return cls._new_hydrated(object_id, client, handle_metadata)
 
     def __repr__(self):
         return self._rep


### PR DESCRIPTION
Another couple of changes needed to get rid of handles altogether.