### PR TITLE
Change the signature of load and preload to operate on Provider not Handle

### DIFF
--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -91,7 +91,7 @@ class Resolver:
 
     async def preload(self, obj, existing_object_id: Optional[str]):
         if obj._preload is not None:
-            await obj._preload(self, existing_object_id, obj._handle)
+            await obj._preload(obj, self, existing_object_id)
 
     async def load(self, obj, existing_object_id: Optional[str] = None):
         cached_future = self._local_uuid_to_future.get(obj.local_uuid)
@@ -99,9 +99,8 @@ class Resolver:
         if not cached_future:
             # don't run any awaits within this if-block to prevent race conditions
             async def loader():
-                handle = obj._handle
-                await obj._load(self, existing_object_id, handle)
-                if existing_object_id is not None and handle.object_id != existing_object_id:
+                await obj._load(obj, self, existing_object_id)
+                if existing_object_id is not None and obj.object_id != existing_object_id:
                     # TODO(erikbern): ignoring images is an ugly fix to a problem that's on the server.
                     # Unlike every other object, images are not assigned random ids, but rather an
                     # id given by the hash of its contents. This means we can't _force_ an image to
@@ -113,7 +112,7 @@ class Resolver:
                     if not obj._is_persisted_ref and not existing_object_id.startswith("im-"):
                         raise Exception(
                             f"Tried creating an object using existing id {existing_object_id}"
-                            f" but it has id {handle.object_id}"
+                            f" but it has id {obj.object_id}"
                         )
 
                 return obj

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -62,14 +62,14 @@ class _Dict(_Provider, type_prefix="di"):
     def new(data={}) -> "_Dict":
         """Create a new dictionary, optionally filled with initial data."""
 
-        async def _load(resolver: Resolver, existing_object_id: Optional[str], handle: _DictHandle):
+        async def _load(provider: _Dict, resolver: Resolver, existing_object_id: Optional[str]):
             serialized = _serialize_dict(data)
             req = api_pb2.DictCreateRequest(
                 app_id=resolver.app_id, data=serialized, existing_dict_id=existing_object_id
             )
             response = await resolver.client.stub.DictCreate(req)
             logger.debug("Created dict with id %s" % response.dict_id)
-            handle._hydrate(response.dict_id, resolver.client, None)
+            provider._handle._hydrate(response.dict_id, resolver.client, None)
 
         return _Dict._from_loader(_load, "Dict()")
 

--- a/modal/image.py
+++ b/modal/image.py
@@ -166,10 +166,10 @@ class _Image(_Provider, type_prefix="im"):
         if build_function and len(base_images) != 1:
             raise InvalidError("Cannot run a build function with multiple base images!")
 
-        async def _load(resolver: Resolver, existing_object_id: Optional[str], handle: _ImageHandle):
+        async def _load(provider: _Image, resolver: Resolver, existing_object_id: Optional[str]):
             if ref:
                 image_id = (await resolver.load(ref)).object_id
-                handle._hydrate(image_id, resolver.client, None)
+                provider._handle._hydrate(image_id, resolver.client, None)
 
             # Recursively build base images
             base_image_ids: List[str] = []
@@ -291,7 +291,7 @@ class _Image(_Provider, type_prefix="im"):
             else:
                 raise RemoteError("Unknown status %s!" % result.status)
 
-            handle._hydrate(image_id, resolver.client, None)
+            provider._handle._hydrate(image_id, resolver.client, None)
 
         rep = f"Image({dockerfile_commands})"
         obj = _Image._from_loader(_load, rep)

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -256,9 +256,9 @@ class _Mount(_Provider, type_prefix="mo"):
     @staticmethod
     async def _load_mount(
         entries: List[_MountEntry],
+        provider: "_Mount",
         resolver: Resolver,
         existing_object_id: Optional[str],
-        handle: _MountHandle,
     ):
         # Run a threadpool to compute hash values, and use concurrent coroutines to register files.
         t0 = time.time()
@@ -328,8 +328,7 @@ class _Mount(_Provider, type_prefix="mo"):
         status_row.finish(f"Created mount {message_label}")
 
         logger.debug(f"Uploaded {len(uploaded_hashes)}/{n_files} files and {total_bytes} bytes in {time.time() - t0}s")
-        handle._hydrate(resp.mount_id, resolver.client, resp.handle_metadata)
-        return handle
+        provider._handle._hydrate(resp.mount_id, resolver.client, resp.handle_metadata)
 
     @staticmethod
     def from_local_python_packages(*module_names: str) -> "_Mount":

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -78,11 +78,11 @@ class _NetworkFileSystem(_Provider, type_prefix="sv"):
     def new(cloud: Optional[str] = None) -> "_NetworkFileSystem":
         """Construct a new network file system, which is empty by default."""
 
-        async def _load(resolver: Resolver, existing_object_id: Optional[str], handle: _NetworkFileSystemHandle):
+        async def _load(provider: _NetworkFileSystem, resolver: Resolver, existing_object_id: Optional[str]):
             status_row = resolver.add_status_row()
             if existing_object_id:
                 # Volume already exists; do nothing.
-                handle._hydrate(existing_object_id, resolver.client, None)
+                provider._handle._hydrate(existing_object_id, resolver.client, None)
                 return
 
             cloud_provider = parse_cloud_provider(cloud) if cloud else None
@@ -91,7 +91,7 @@ class _NetworkFileSystem(_Provider, type_prefix="sv"):
             req = api_pb2.SharedVolumeCreateRequest(app_id=resolver.app_id, cloud_provider=cloud_provider)
             resp = await retry_transient_errors(resolver.client.stub.SharedVolumeCreate, req)
             status_row.finish("Created network file system.")
-            handle._hydrate(resp.shared_volume_id, resolver.client, None)
+            provider._handle._hydrate(resp.shared_volume_id, resolver.client, None)
 
         return _NetworkFileSystem._from_loader(_load, "NetworkFileSystem()")
 

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -38,10 +38,10 @@ class _Queue(_Provider, type_prefix="qu"):
 
     @staticmethod
     def new():
-        async def _load(resolver: Resolver, existing_object_id: Optional[str], handle: _QueueHandle):
+        async def _load(provider: _Queue, resolver: Resolver, existing_object_id: Optional[str]):
             request = api_pb2.QueueCreateRequest(app_id=resolver.app_id, existing_queue_id=existing_object_id)
             response = await resolver.client.stub.QueueCreate(request)
-            handle._hydrate(response.queue_id, resolver.client, None)
+            provider._handle._hydrate(response.queue_id, resolver.client, None)
 
         return _Queue._from_loader(_load, "Queue()")
 

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -154,7 +154,7 @@ class _Sandbox(_Provider, type_prefix="sb"):
         if len(entrypoint_args) == 0:
             raise InvalidError("entrypoint_args must not be empty")
 
-        async def _load(resolver: Resolver, _existing_object_id: Optional[str], handle: _SandboxHandle):
+        async def _load(provider: _Sandbox, resolver: Resolver, _existing_object_id: Optional[str]):
             async def _load_ids(objs: Sequence[_Provider]) -> List[str]:
                 handles = await asyncio.gather(*[resolver.load(obj) for obj in objs])
                 return [handle.object_id for handle in handles]
@@ -187,10 +187,9 @@ class _Sandbox(_Provider, type_prefix="sb"):
             create_resp = await retry_transient_errors(resolver.client.stub.SandboxCreate, create_req)
 
             sandbox_id = create_resp.sandbox_id
-            handle._hydrate(sandbox_id, resolver.client, None)
-
-            handle._stdout = LogsReader(api_pb2.FILE_DESCRIPTOR_STDOUT, sandbox_id, resolver.client)
-            handle._stderr = LogsReader(api_pb2.FILE_DESCRIPTOR_STDERR, sandbox_id, resolver.client)
+            provider._handle._hydrate(sandbox_id, resolver.client, None)
+            provider._handle._stdout = LogsReader(api_pb2.FILE_DESCRIPTOR_STDOUT, sandbox_id, resolver.client)
+            provider._handle._stderr = LogsReader(api_pb2.FILE_DESCRIPTOR_STDERR, sandbox_id, resolver.client)
 
         return _Sandbox._from_loader(_load, "Sandbox()")
 

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -53,7 +53,7 @@ class _Secret(_Provider, type_prefix="st"):
         ):
             raise InvalidError(ENV_DICT_WRONG_TYPE_ERR)
 
-        async def _load(resolver: Resolver, existing_object_id: Optional[str], handle: _SecretHandle):
+        async def _load(provider: _Secret, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.SecretCreateRequest(
                 app_id=resolver.app_id,
                 env_dict=env_dict,
@@ -61,7 +61,7 @@ class _Secret(_Provider, type_prefix="st"):
                 existing_secret_id=existing_object_id,
             )
             resp = await resolver.client.stub.SecretCreate(req)
-            handle._hydrate(resp.secret_id, resolver.client, None)
+            provider._handle._hydrate(resp.secret_id, resolver.client, None)
 
         rep = f"Secret.from_dict([{', '.join(env_dict.keys())}])"
         return _Secret._from_loader(_load, rep)
@@ -86,7 +86,7 @@ class _Secret(_Provider, type_prefix="st"):
         starting point for finding the `.env` file.
         """
 
-        async def _load(resolver: Resolver, existing_object_id: Optional[str], handle: _SecretHandle):
+        async def _load(provider: _Secret, resolver: Resolver, existing_object_id: Optional[str]):
             try:
                 from dotenv import dotenv_values, find_dotenv
                 from dotenv.main import _walk_to_root
@@ -119,7 +119,7 @@ class _Secret(_Provider, type_prefix="st"):
             )
             resp = await resolver.client.stub.SecretCreate(req)
 
-            handle._hydrate(resp.secret_id, resolver.client, None)
+            provider._handle._hydrate(resp.secret_id, resolver.client, None)
 
         return _Secret._from_loader(_load, "Secret.from_dotenv()")
 

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -72,18 +72,18 @@ class _Volume(_Provider, type_prefix="vo"):
     def new() -> "_Volume":
         """Construct a new volume, which is empty by default."""
 
-        async def _load(resolver: Resolver, existing_object_id: Optional[str], handle: _VolumeHandle):
+        async def _load(provider: _Volume, resolver: Resolver, existing_object_id: Optional[str]):
             status_row = resolver.add_status_row()
             if existing_object_id:
                 # Volume already exists; do nothing.
-                handle._hydrate(existing_object_id, resolver.client, None)
+                provider._handle._hydrate(existing_object_id, resolver.client, None)
                 return
 
             status_row.message("Creating volume...")
             req = api_pb2.VolumeCreateRequest(app_id=resolver.app_id)
             resp = await retry_transient_errors(resolver.client.stub.VolumeCreate, req)
             status_row.finish("Created volume.")
-            handle._hydrate(resp.volume_id, resolver.client, None)
+            provider._handle._hydrate(resp.volume_id, resolver.client, None)
 
         return _Volume._from_loader(_load, "Volume()")
 


### PR DESCRIPTION
Doing this in order to move more functionality out of the `Handle` class.

This has the additional benefit of making it possible to use normal methods as loaders (i.e. we don't need anonymous closure necessarily) but that's a separate change.