### PR TITLE
Fix sandbox wait

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -171,7 +171,7 @@ class _Sandbox(_Provider, type_prefix="sb"):
         while True:
             req = api_pb2.SandboxWaitRequest(sandbox_id=self.object_id, timeout=50)
             resp = await retry_transient_errors(self._client.stub.SandboxWait, req)
-            if resp.result:
+            if resp.result.status:
                 self._result = resp.result
                 break
 


### PR DESCRIPTION
🤦 will add tests for it in a follow-up. Maybe should send an explicit "still waiting" flag from the server too, instead of the empty response.