### PR TITLE
parametrized functions: misc cleanup

### DIFF
--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -73,7 +73,7 @@ def test_call_cls_remote_invalid_type(client):
             FooRemote.remote(42, my_function)
 
         exc = excinfo.value
-        assert "y=" in str(exc)
+        assert "function" in str(exc)
 
 
 stub_2 = Stub()

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -36,6 +36,8 @@ def make_remote_cls_constructors(
     partial_functions: Dict[str, PartialFunction],
     functions: Dict[str, _Function],
 ):
+    cls = type(f"Remote{user_cls.__name__}", (), partial_functions)
+
     async def _remote(*args, **kwargs):
         for i, arg in enumerate(args):
             check_picklability(i+1, arg)
@@ -52,8 +54,8 @@ def make_remote_cls_constructors(
             await resolver.load(new_function)
             new_functions[k] = new_function
 
-        cls = type(f"Remote{user_cls.__name__}", (), partial_functions)
-        _PartialFunction.initialize_cls(cls, new_functions)
-        return cls()
+        obj = cls()
+        _PartialFunction.initialize_obj(obj, new_functions)
+        return obj
 
     return synchronize_api(_remote)

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -42,7 +42,6 @@ def make_remote_cls_constructors(
         for key, kwarg in kwargs.items():
             check_picklability(key, kwarg)
 
-        cls_dict = {}
         new_functions: Dict[str, _Function] = {}
 
         for k, v in partial_functions.items():
@@ -52,9 +51,8 @@ def make_remote_cls_constructors(
             resolver = Resolver(client)
             await resolver.load(new_function)
             new_functions[k] = new_function
-            cls_dict[k] = v
 
-        cls = type(f"Remote{user_cls.__name__}", (), cls_dict)
+        cls = type(f"Remote{user_cls.__name__}", (), partial_functions)
         _PartialFunction.initialize_cls(cls, new_functions)
         return cls()
 

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -26,8 +26,7 @@ def check_picklability(key, arg):
         pickle.dumps(arg)
     except Exception:
         raise ValueError(
-            f"Only pickle-able types are allowed in remote class constructors. "
-            f"Argument {key} of type {type(arg)}."
+            f"Only pickle-able types are allowed in remote class constructors: argument {key} of type {type(arg)}."
         )
 
 
@@ -40,7 +39,7 @@ def make_remote_cls_constructors(
 
     async def _remote(*args, **kwargs):
         for i, arg in enumerate(args):
-            check_picklability(i+1, arg)
+            check_picklability(i + 1, arg)
         for key, kwarg in kwargs.items():
             check_picklability(key, kwarg)
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1331,6 +1331,10 @@ class _PartialFunction:
     def initialize_cls(user_cls: type, functions: Dict[str, _Function]):
         user_cls._modal_functions = functions
 
+    @staticmethod
+    def initialize_obj(user_obj, functions: Dict[str, _Function]):
+        user_obj._modal_functions = functions
+
     def __init__(
         self,
         raw_f: Callable[..., Any],


### PR DESCRIPTION
A couple of changes:

1. No need to inspect the signature of the constructor, since it's only used for type errors messages (rare?) and we can do almost the same thing without
2. Instead of constructing a new class _per parametrized function_, we construct one class, and then use that for all parameters. This is conceptually more aligned since it means `cls` creates a new class (rather than a family of classes)

Should be a noop other than error messages