### PR TITLE
`modal run`: raise exception if the function is a generator

### DIFF
--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -133,6 +133,12 @@ def test_run_async(servicer, set_env_client, test_dir):
     assert "called locally (async)" in res.stdout
 
 
+def test_run_generator(servicer, set_env_client, test_dir):
+    stub_file = test_dir / "supports" / "app_run_tests" / "generator.py"
+    result = _run(["run", stub_file.as_posix()], expected_exit_code=1)
+    assert "generator functions" in str(result.exception)
+
+
 def test_help_message_unspecified_function(servicer, set_env_client, test_dir):
     stub_file = test_dir / "supports" / "app_run_tests" / "stub_with_multiple_functions.py"
     result = _run(["run", stub_file.as_posix()], expected_exit_code=2, expected_stderr=None)

--- a/client_test/supports/app_run_tests/generator.py
+++ b/client_test/supports/app_run_tests/generator.py
@@ -1,0 +1,9 @@
+# Copyright Modal Labs 2022
+import modal
+
+stub = modal.Stub()
+
+
+@stub.function()
+def foo():
+    yield "xyz"

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -89,6 +89,10 @@ def _get_clean_stub_description(func_ref: str) -> str:
 
 def _get_click_command_for_function(stub: Stub, function_tag):
     function = stub[function_tag]
+
+    if function.is_generator:
+        raise InvalidError("`modal run` is not supported for generator functions")
+
     if function.info.cls is not None:
         obj = function.info.cls()
         raw_func = functools.partial(function.info.raw_f, obj)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -865,6 +865,7 @@ class _Function(_Provider, type_prefix="fu"):
         obj._panel_items = panel_items
         obj._stub = stub  # Needed for CLI right now
         obj._self_obj = None
+        obj._is_generator = is_generator
 
         # Used to check whether we should rebuild an image using run_function
         # Plaintext source and arg definition for the function, so it's part of the image


### PR DESCRIPTION
This currently succeeds but with a warning:

```
erikbern@Eriks-MacBook-Air modal-client % modal run generator_thing.py
✓ Initialized. View app at https://modal.com/apps/ap-tjAkKycsOHiJBi43qJVjZM
✓ Created objects.
├── 🔨 Created foo.
└── 🔨 Created mount /Users/erikbern/modal-client/generator_thing.py
✓ App completed.
Warning: the results of a call to _call_generator was not consumed, so the call will never be executed. Consider a for-loop like `for x in _call_generator(...)` or unpacking the generator using `list(...)`
```

After this change, it fails:

```
InvalidError: `modal run` is not supported for generator functions
```