### PR TITLE
Add separate TimeoutError subclasses

### DIFF
--- a/modal/exception.py
+++ b/modal/exception.py
@@ -28,7 +28,15 @@ class RemoteError(Error):
 
 
 class TimeoutError(Error):
+    """Base class for Modal timeouts."""
+
+
+class FunctionTimeoutError(TimeoutError):
     """Raised when a Function exceeds its execution duration limit and times out."""
+
+
+class MountUploadTimeoutError(TimeoutError):
+    """Raised when a Mount upload times out."""
 
 
 class AuthError(Error):

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -59,9 +59,9 @@ from .client import _Client
 from .config import config, logger
 from .exception import (
     ExecutionError,
+    FunctionTimeoutError,
     InvalidError,
     RemoteError,
-    TimeoutError as _TimeoutError,
     deprecation_warning,
 )
 from .gpu import GPU_T, display_gpu_config, parse_gpu_config
@@ -114,7 +114,7 @@ async def _process_result(result, stub, client=None):
         data = result.data
 
     if result.status == api_pb2.GenericResult.GENERIC_STATUS_TIMEOUT:
-        raise _TimeoutError(result.exception)
+        raise FunctionTimeoutError(result.exception)
     elif result.status != api_pb2.GenericResult.GENERIC_STATUS_SUCCESS:
         if data:
             try:

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -301,7 +301,7 @@ class _Mount(_Object, type_prefix="mo"):
                 if response.exists:
                     return mount_file
 
-            raise modal.exception.TimeoutError(f"Mounting of {file_spec.filename} timed out")
+            raise modal.exception.MountUploadTimeoutError(f"Mounting of {file_spec.filename} timed out")
 
         logger.debug(f"Uploading mount using {n_concurrent_uploads} uploads")
 


### PR DESCRIPTION
Originally wanted to deprecate `TimeoutError` entirely, but there does't seem to be a nice way to print a deprecation warning while still supporting it (tried some wacky stuff with `__instancecheck__` and `__subclasscheck__` that could have worked in theory) 