### PR TITLE
Separate method for generators

### DIFF
--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -231,7 +231,7 @@ async def test_generator(client, servicer):
     assert len(servicer.cleared_function_calls) == 0
     with stub.run(client=client):
         assert later_gen_modal.is_generator
-        res: typing.Generator = later_gen_modal.remote()  # type: ignore
+        res: typing.Generator = later_gen_modal.remote_gen()  # type: ignore
         # Generators fulfil the *iterator protocol*, which requires both these methods.
         # https://docs.python.org/3/library/stdtypes.html#typeiter
         assert hasattr(res, "__iter__")  # strangely inspect.isgenerator returns false
@@ -239,6 +239,11 @@ async def test_generator(client, servicer):
         assert next(res) == "bar"
         assert list(res) == ["baz", "boo"]
         assert len(servicer.cleared_function_calls) == 1
+
+        # Check deprecated interface
+        with pytest.warns(DeprecationError):
+            res = later_gen_modal.call()
+            assert next(res) == "bar"
 
 
 @pytest.mark.asyncio
@@ -256,7 +261,7 @@ async def test_generator_async(client, servicer):
     assert len(servicer.cleared_function_calls) == 0
     async with stub.run(client=client):
         assert later_gen_modal.is_generator
-        res = later_gen_modal.remote.aio()
+        res = later_gen_modal.remote_gen.aio()
         # Async generators fulfil the *asynchronous iterator protocol*, which requires both these methods.
         # https://peps.python.org/pep-0525/#support-for-asynchronous-iteration-protocol
         assert hasattr(res, "__aiter__")

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1141,11 +1141,12 @@ class _Function(_Object, type_prefix="fu"):
             )
             return self.remote(*args, **kwargs)
 
-    async def shell(self, *args, **kwargs):
+    async def shell(self, *args, **kwargs) -> None:
         if self._is_generator:
-            # TOOD(erikbern): would be easy to add support, but it seems like a niche case tbh
-            raise InvalidError("`.shell` is not supported for generators right now")
-        return await self._call_function(args, kwargs)
+            async for item in self._call_generator(args, kwargs):
+                pass
+        else:
+            await self._call_function(args, kwargs)
 
     def _get_is_remote_cls_method(self):
         return self._is_remote_cls_method

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1132,12 +1132,12 @@ class _Function(_Object, type_prefix="fu"):
     def call(self, *args, **kwargs) -> Awaitable[Any]:  # TODO: Generics/TypeVars
         if self._is_generator:
             deprecation_warning(
-                date(2018, 8, 16), "`f.call(...)` is deprecated. It has been renamed to `f.remote(...)`"
+                date(2023, 8, 16), "`f.call(...)` is deprecated. It has been renamed to `f.remote(...)`"
             )
             return self.remote_gen(*args, **kwargs)
         else:
             deprecation_warning(
-                date(2018, 8, 16), "`f.call(...)` is deprecated. It has been renamed to `f.remote_gen(...)`"
+                date(2023, 8, 16), "`f.call(...)` is deprecated. It has been renamed to `f.remote_gen(...)`"
             )
             return self.remote(*args, **kwargs)
 
@@ -1184,7 +1184,7 @@ class _Function(_Object, type_prefix="fu"):
             return self.remote(*args, **kwargs)
 
         deprecation_warning(
-            date(2018, 8, 16),
+            date(2023, 8, 16),
             "Calling Modal functions like `f(...)` is deprecated. Use `f.local(...)` if you want to call the"
             " function in the same Python process. Use `f.remote(...)` if you want to call the function in"
             " a Modal container in the cloud",


### PR DESCRIPTION
This breaks out `.remote` into `.remote_gen` for generators. The reason is it makes it easier to define the function signature, which will make it easier to support decorators for live methods, which is required for lazy loading functions later.