### PR TITLE
@live_method decorator

### DIFF
--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -9,7 +9,7 @@ import cloudpickle
 from synchronicity.exceptions import UserCodeException
 
 from modal import NetworkFileSystem, Proxy, Stub, asgi_app, web_endpoint, wsgi_app
-from modal.exception import DeprecationError, InvalidError
+from modal.exception import DeprecationError, ExecutionError, InvalidError
 from modal.functions import Function, FunctionCall, gather
 from modal.runner import deploy_stub
 from modal_proto import api_pb2
@@ -646,3 +646,8 @@ def test_default_cloud_provider(client, servicer, monkeypatch):
         f = servicer.app_functions[app._get_object("dummy").object_id]
 
     assert f.cloud_provider == api_pb2.CLOUD_PROVIDER_OCI
+
+
+def test_not_hydrated():
+    with pytest.raises(ExecutionError):
+        assert foo.remote(2, 4) == 20

--- a/client_test/stub_test.py
+++ b/client_test/stub_test.py
@@ -8,7 +8,7 @@ from grpclib import GRPCError, Status
 
 import modal.app
 from modal import Dict, Image, Queue, Stub, web_endpoint
-from modal.exception import DeprecationError, InvalidError
+from modal.exception import DeprecationError, ExecutionError, InvalidError
 from modal.runner import deploy_stub
 from modal_proto import api_pb2
 from modal_test_support import module_1, module_2
@@ -134,10 +134,11 @@ def test_run_function_without_app_error():
     stub = Stub()
     dummy_modal = stub.function()(dummy)
 
-    with pytest.raises(InvalidError) as excinfo:
+    with pytest.raises(ExecutionError) as excinfo:
         dummy_modal.remote()
 
-    assert "stub.run" in str(excinfo.value)
+    assert "hydrated" in str(excinfo.value)
+    assert "remote" in str(excinfo.value)
 
 
 def test_is_inside_basic():

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -187,16 +187,7 @@ class _Invocation:
         self.function_call_id = function_call_id  # TODO: remove and use only input_id
 
     @staticmethod
-    async def create(function_id, args, kwargs, client):
-        if not function_id:
-            raise InvalidError(
-                "The function has not been initialized.\n"
-                "\n"
-                "Modal functions can only be called within an app. "
-                "Try calling it from another running modal function or from an app run context:\n\n"
-                "with stub.run():\n"
-                "    my_modal_function.remote()\n"
-            )
+    async def create(function_id: str, args, kwargs, client: _Client):
         request = api_pb2.FunctionMapRequest(
             function_id=function_id,
             parent_input_id=current_input_id(),

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -68,7 +68,7 @@ from .gpu import GPU_T, display_gpu_config, parse_gpu_config
 from .image import _Image
 from .mount import _get_client_mount, _Mount
 from .network_file_system import _NetworkFileSystem
-from .object import _Object
+from .object import _Object, live_method, live_method_gen
 from .proxy import _Proxy
 from .retries import Retries
 from .schedule import Schedule
@@ -997,6 +997,7 @@ class _Function(_Object, type_prefix="fu"):
         return await _Invocation.create(self.object_id, args, kwargs, self._client)
 
     @warn_if_generator_is_not_consumed
+    @live_method_gen
     async def _call_generator(self, args, kwargs):
         invocation = await _Invocation.create(self.object_id, args, kwargs, self._client)
         async for res in invocation.run_generator():
@@ -1006,6 +1007,7 @@ class _Function(_Object, type_prefix="fu"):
         return await _Invocation.create(self.object_id, args, kwargs, self._client)
 
     @warn_if_generator_is_not_consumed
+    @live_method_gen
     async def map(
         self,
         *input_iterators,  # one input iterator per argument in the mapped-over function/generator
@@ -1071,6 +1073,7 @@ class _Function(_Object, type_prefix="fu"):
             pass
 
     @warn_if_generator_is_not_consumed
+    @live_method_gen
     async def starmap(
         self, input_iterator, kwargs={}, order_outputs=None, return_exceptions=False
     ) -> AsyncGenerator[Any, None]:
@@ -1096,6 +1099,7 @@ class _Function(_Object, type_prefix="fu"):
         async for item in self._map(input_stream, order_outputs, return_exceptions, kwargs):
             yield item
 
+    @live_method
     async def remote(self, *args, **kwargs) -> Awaitable[Any]:  # TODO: Generics/TypeVars
         """
         Calls the function remotely, executing it with the given arguments and returning the execution's result.
@@ -1112,6 +1116,7 @@ class _Function(_Object, type_prefix="fu"):
 
         return await self._call_function(args, kwargs)
 
+    @live_method_gen
     async def remote_gen(self, *args, **kwargs) -> AsyncGenerator[Any, None]:  # TODO: Generics/TypeVars
         """
         Calls the generator remotely, executing it with the given arguments and returning the execution's result.
@@ -1141,6 +1146,7 @@ class _Function(_Object, type_prefix="fu"):
             )
             return self.remote(*args, **kwargs)
 
+    @live_method
     async def shell(self, *args, **kwargs) -> None:
         if self._is_generator:
             async for item in self._call_generator(args, kwargs):
@@ -1229,6 +1235,7 @@ class _Function(_Object, type_prefix="fu"):
 
         return self._info.raw_f
 
+    @live_method
     async def get_current_stats(self) -> FunctionStats:
         """Return a `FunctionStats` object describing the current function's queue and runner counts."""
 

--- a/modal/object.py
+++ b/modal/object.py
@@ -200,10 +200,6 @@ class _Object:
         """mdmd:hidden"""
         return self._is_hydrated
 
-    def check_hydration(self):
-        if not self._is_hydrated:
-            raise ExecutionError("Method `{method.__name__}` requires object to be hydrated.")
-
     async def _deploy(
         self,
         label: str,
@@ -355,7 +351,8 @@ Object = synchronize_api(_Object, target_module=__name__)
 def live_method(method):
     @wraps(method)
     async def wrapped(self, *args, **kwargs):
-        self.check_hydration()
+        if not self._is_hydrated:
+            raise ExecutionError(f"Calling method `{method.__name__}` requires the object to be hydrated.")
         return await method(self, *args, **kwargs)
 
     return wrapped
@@ -364,7 +361,8 @@ def live_method(method):
 def live_method_gen(method):
     @wraps(method)
     async def wrapped(self, *args, **kwargs):
-        self.check_hydration()
+        if not self._is_hydrated:
+            raise ExecutionError(f"Calling method `{method.__name__}` requires the object to be hydrated.")
         async for item in method(self, *args, **kwargs):
             yield item
 


### PR DESCRIPTION
This annotates all "live" methods with a decorator. Only used for functions so far. Currently all the decorator does is to check that the object is hydrated, but a later point I'm planning to use it for "lazy" hydration of certain objects, in particular parametrized functions.

There's a failing test right now because we don't "unhydrate" when an app finishes running – will add that and rebase before merging this.

I'll also add this decorator to all other object types at a later point – images, volumes etc.