### PR TITLE
Unit test for the KeyboardInterrupt (`modal serve`) fix

### DIFF
--- a/client_test/stub_test.py
+++ b/client_test/stub_test.py
@@ -301,3 +301,11 @@ async def test_unhydrate(servicer, client):
 
     # After app finishes, it should unhydrate
     assert not stub.d.is_hydrated()
+
+
+def test_keyboard_interrupt(servicer, client):
+    stub = Stub()
+    stub.function()(square)
+    with stub.run(client=client):
+        # The exit handler should catch this interrupt and exit gracefully
+        raise KeyboardInterrupt()


### PR DESCRIPTION
This test fails when I remove the commit in #795 

```
FAILED client_test/stub_test.py::test_keyboard_interrupt - KeyError: '_function_handles'
```