### PR TITLE
Make "modal" the official client package

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ are currently in private beta**, and you can get a beta testing invite at
 This requires Python 3.7 or later. Install the package with:
 
 ```bash
-pip install modal-client
+pip install modal
 ```
 
 ## Support

--- a/client_test/version_test.py
+++ b/client_test/version_test.py
@@ -6,7 +6,7 @@ import modal
 
 def test_version():
     mod_version = modal.__version__
-    pkg_version = pkg_resources.require("modal-client")[0].version
+    pkg_version = pkg_resources.require("modal")[0].version
 
     assert pkg_resources.parse_version(mod_version) > pkg_resources.parse_version("0.0.0")
     assert pkg_resources.parse_version(pkg_version) > pkg_resources.parse_version("0.0.0")

--- a/modal/client.py
+++ b/modal/client.py
@@ -138,7 +138,7 @@ class _Client:
         except GRPCError as exc:
             if exc.status == Status.FAILED_PRECONDITION:
                 raise VersionError(
-                    f"The client version {self.version} is too old. Please update to the latest package on PyPi: https://pypi.org/project/modal-client"
+                    f"The client version {self.version} is too old. Please update to the latest package on PyPi: https://pypi.org/project/modal"
                 )
             elif exc.status == Status.UNAUTHENTICATED:
                 raise AuthError(exc.message)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
-name = modal-client
+name = modal
 author = Modal Labs
-author_email = erik@modal.com
+author_email = support@modal.com
 description = Python client library for Modal
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tasks.py
+++ b/tasks.py
@@ -104,20 +104,20 @@ setup(version="{__version__}")
         f.write(
             f"""\
 [metadata]
-name = modal
+name = modal-client
 author = Modal Labs
-author_email = erik@modal.com
-description = Dummy alias that requires modal-client
-long_description = This package is a dummy package that just requires the modal-client package.
-            If you're looking for the active learning framework [modAL](https://modal-python.readthedocs.io/en/latest/),
-            it's now available using the package name `modAL-python`.
+author_email = support@modal.com
+description = Legacy name for the Modal client
+long_description = This is a legacy compatibility package that just requires the `modal` client library.
+            In versions before 0.51, the official name of the client library was called `modal-client`.
+            We have renamed it to `modal`, but this library is kept updated for compatibility.
 long_description_content_type = text/markdown
 project_urls =
     Homepage = https://modal.com
 
 [options]
 install_requires =
-    modal-client=={__version__}
+    modal=={__version__}
 """
         )
     with open("alias-package/pyproject.toml", "w") as f:


### PR DESCRIPTION
Currently, the official client package is named "modal-client" with "modal" as a thin wrapper or alias. This change makes it so that "modal" is the official package on PyPI, and we leave "modal-client" as the name of the legacy compatibility package.

This also updates the README and other references to use the new name.
