### PR TITLE
Fix MODAL_PROFILE bug in set-environment CLI

### DIFF
--- a/modal/cli/config.py
+++ b/modal/cli/config.py
@@ -3,7 +3,7 @@ import pprint
 
 import typer
 
-from modal.config import _config_active_profile, _store_user_config, config
+from modal.config import _profile, _store_user_config, config
 
 config_cli = typer.Typer(
     name="config",
@@ -35,8 +35,7 @@ when running a command that requires an environment.
 @config_cli.command(help=SET_DEFAULT_ENV_HELP)
 def set_environment(environment_name: str):
     _store_user_config({"environment": environment_name})
-    active_profile = _config_active_profile()
-    typer.echo(f"New default environment for profile {active_profile}: {environment_name}")
+    typer.echo(f"New default environment for profile {_profile}: {environment_name}")
 
 
 @config_cli.command(hidden=True)


### PR DESCRIPTION
If you set the profile via `MODAL_PROFILE`, this would display `default` instead of the currently-passed profile.

For example:
```sh-session
$ MODAL_PROFILE=modal_labs modal config set-environment prod
New default environment for profile default: prod
```

Even though it updates the `modal_labs` profile