### PR TITLE
Make .remote non-async

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -4,7 +4,6 @@ from typing import Dict, Type, TypeVar
 
 from modal_utils.async_utils import synchronize_api
 
-from ._resolver import Resolver
 from .functions import PartialFunction, _Function, _PartialFunction
 
 T = TypeVar("T")
@@ -36,7 +35,7 @@ def make_remote_cls_constructors(
 ):
     cls = type(f"Remote{user_cls.__name__}", (), partial_functions)
 
-    async def _remote(*args, **kwargs):
+    def _remote(*args, **kwargs):
         for i, arg in enumerate(args):
             check_picklability(i + 1, arg)
         for key, kwarg in kwargs.items():
@@ -45,11 +44,7 @@ def make_remote_cls_constructors(
         new_functions: Dict[str, _Function] = {}
 
         for k, v in partial_functions.items():
-            base_function: _Function = functions[k]
-            new_function: _Function = base_function.from_parametrized(args, kwargs)
-            resolver = Resolver()
-            await resolver.load(new_function)
-            new_functions[k] = new_function
+            new_functions[k] = functions[k].from_parametrized(args, kwargs)
 
         obj = cls()
         _PartialFunction.initialize_obj(obj, new_functions)

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -35,7 +35,7 @@ def make_remote_cls_constructors(
 ):
     cls = type(f"Remote{user_cls.__name__}", (), partial_functions)
 
-    def _remote(*args, **kwargs):
+    async def _remote(*args, **kwargs):
         for i, arg in enumerate(args):
             check_picklability(i + 1, arg)
         for key, kwarg in kwargs.items():

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -872,9 +872,10 @@ class _Function(_Object, type_prefix="fu"):
             )
             response = await retry_transient_errors(self._client.stub.FunctionBindParams, req)
             provider._hydrate(response.bound_function_id, self._client, response.handle_metadata)
-            provider._is_remote_cls_method = True
 
-        return _Function._from_loader(_load, "Function(parametrized)")
+        provider = _Function._from_loader(_load, "Function(parametrized)", hydrate_lazily=True)
+        provider._is_remote_cls_method = True
+        return provider
 
     def get_panel_items(self) -> List[str]:
         """mdmd:hidden"""


### PR DESCRIPTION
This uses lazy initialization for the methods, which means `.remote` no longer has to be async, which will make it easier to turn it into an `__init__` constructor in the next step.

Edit: realized we have to keep the signature async (even though it does nothing async) in order for `.remote.aio` not to break. This doesn't really matter – the point is that we can break out the implementation and use it separately from a non-async method