### PR TITLE
new parametrized method syntax

### DIFF
--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -1,5 +1,4 @@
 # Copyright Modal Labs 2022
-import inspect
 import pytest
 
 from modal import Stub, method

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -35,7 +35,7 @@ def make_remote_cls_constructors(
 ):
     cls = type(f"Remote{user_cls.__name__}", (), partial_functions)
 
-    async def _remote(*args, **kwargs):
+    def _remote(*args, **kwargs):
         for i, arg in enumerate(args):
             check_picklability(i + 1, arg)
         for key, kwarg in kwargs.items():

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -1,12 +1,12 @@
 # Copyright Modal Labs 2022
-from datetime import date
 import pickle
+from datetime import date
 from typing import Dict, Type, TypeVar
 
 from modal_utils.async_utils import synchronize_api
 
-from .functions import PartialFunction, _Function, _PartialFunction
 from .exception import deprecation_warning
+from .functions import PartialFunction, _Function, _PartialFunction
 
 T = TypeVar("T")
 
@@ -54,8 +54,7 @@ def wrap_cls(
 
     async def _remote(*args, **kwargs):
         deprecation_warning(
-            date(2023, 8, 29),
-            "`Cls.remote(...)` on classes is deprecated. Use the constructor: `Cls(...)`."
+            date(2023, 8, 29), "`Cls.remote(...)` on classes is deprecated. Use the constructor: `Cls(...)`."
         )
         return _new(None, *args, **kwargs)
 

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -1,10 +1,12 @@
 # Copyright Modal Labs 2022
+from datetime import date
 import pickle
 from typing import Dict, Type, TypeVar
 
 from modal_utils.async_utils import synchronize_api
 
 from .functions import PartialFunction, _Function, _PartialFunction
+from .exception import deprecation_warning
 
 T = TypeVar("T")
 
@@ -51,7 +53,10 @@ def wrap_cls(
         return obj
 
     async def _remote(*args, **kwargs):
-        # TODO(erikbern): deprecate
+        deprecation_warning(
+            date(2023, 8, 29),
+            "`Cls.remote(...)` on classes is deprecated. Use the constructor: `Cls(...)`."
+        )
         return _new(None, *args, **kwargs)
 
     user_cls.__new__ = _new

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -35,7 +35,7 @@ def make_remote_cls_constructors(
 ):
     cls = type(f"Remote{user_cls.__name__}", (), partial_functions)
 
-    def _remote(*args, **kwargs):
+    async def _remote(*args, **kwargs):
         for i, arg in enumerate(args):
             check_picklability(i + 1, arg)
         for key, kwarg in kwargs.items():

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -41,11 +41,11 @@ def wrap_cls(
 
         new_functions: Dict[str, _Function] = {}
 
-        for k, v in partial_functions.items():
-            new_functions[k] = functions[k].from_parametrized(args, kwargs)
-
         obj = super(user_cls, user_cls).__new__(user_cls)
         obj.__init__(*args, **kwargs)
+
+        for k, v in partial_functions.items():
+            new_functions[k] = functions[k].from_parametrized(obj, args, kwargs)
 
         _PartialFunction.initialize_obj(obj, new_functions)
         return obj

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -862,9 +862,8 @@ class _Function(_Object, type_prefix="fu"):
         return obj
 
     def from_parametrized(self, args: Iterable[Any], kwargs: Dict[str, Any]) -> "_Function":
-        assert self._is_hydrated, "Cannot make bound function handle from unhydrated handle."
-
         async def _load(provider: _Function, resolver: Resolver, existing_object_id: Optional[str]):
+            assert self._is_hydrated, "Cannot make bound function handle from unhydrated handle."
             serialized_params = pickle.dumps((args, kwargs))  # TODO(erikbern): use modal._serialization?
             req = api_pb2.FunctionBindParamsRequest(
                 function_id=self._object_id,
@@ -873,9 +872,9 @@ class _Function(_Object, type_prefix="fu"):
             response = await retry_transient_errors(self._client.stub.FunctionBindParams, req)
             provider._hydrate(response.bound_function_id, self._client, response.handle_metadata)
 
-        provider = _Function._from_loader(_load, "Function(parametrized)", hydrate_lazily=True)
-        provider._is_remote_cls_method = True
-        return provider
+        obj = _Function._from_loader(_load, "Function(parametrized)", hydrate_lazily=True)
+        obj._is_remote_cls_method = True
+        return obj
 
     def get_panel_items(self) -> List[str]:
         """mdmd:hidden"""

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1174,7 +1174,7 @@ class _Function(_Object, type_prefix="fu"):
             deprecation_warning(
                 date(2023, 8, 29),
                 "Calling remove class methods like `obj.f(...)` is deprecated. Use `obj.f.remote(...)` for remote calls"
-                " and `obj.f.local(...)` for local calls"
+                " and `obj.f.local(...)` for local calls",
             )
             return self.remote(*args, **kwargs)
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1171,7 +1171,11 @@ class _Function(_Object, type_prefix="fu"):
     @synchronizer.nowrap
     def __call__(self, *args, **kwargs) -> Any:  # TODO: Generics/TypeVars
         if self._get_is_remote_cls_method():  # TODO(elias): change parametrization so this is isn't needed
-            # TODO(erikbern): deprecate this soon too
+            deprecation_warning(
+                date(2023, 8, 29),
+                "Calling remove class methods like `obj.f(...)` is deprecated. Use `obj.f.remote(...)` for remote calls"
+                " and `obj.f.local(...)` for local calls"
+            )
             return self.remote(*args, **kwargs)
 
         deprecation_warning(

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -16,7 +16,7 @@ from ._ipython import is_notebook
 from ._output import OutputManager
 from .app import _App, _container_app, is_local
 from .client import _Client
-from .cls import make_remote_cls_constructors
+from .cls import wrap_cls
 from .config import logger
 from .exception import InvalidError, deprecation_warning
 from .functions import PartialFunction, _Function, _PartialFunction
@@ -580,9 +580,7 @@ class _Stub:
                     partial_function = synchronizer._translate_in(v)  # TODO: remove need for?
                     functions[k] = decorator(partial_function, user_cls)
 
-            _PartialFunction.initialize_cls(user_cls, functions)
-            remote = make_remote_cls_constructors(user_cls, partial_functions, functions)
-            user_cls.remote = remote
+            wrap_cls(user_cls, partial_functions, functions)
             return user_cls
 
         return wrapper


### PR DESCRIPTION
This deprecates
```python
obj = Cls.remote(1, 2, 3)
```
and
```python
obj.f("foo", "bar")
```
in favor of
```python
obj = Cls(1, 2, 3)
```
and
```python
obj.f.remote("foo", "bar")
```

Almost works (local calling is broken)