### PR TITLE
Add st_mode to MountFile and unify internal_api

### DIFF
--- a/client_test/mount_test.py
+++ b/client_test/mount_test.py
@@ -31,10 +31,12 @@ async def test_get_files(servicer, client, tmpdir):
     assert files["/small.py"].use_blob is False
     assert files["/small.py"].content == small_content
     assert files["/small.py"].sha256_hex == hashlib.sha256(small_content).hexdigest()
+    assert files["/small.py"].mode == 0o644
 
     assert files["/large.py"].use_blob is True
     assert files["/large.py"].content is None
     assert files["/large.py"].sha256_hex == hashlib.sha256(large_content).hexdigest()
+    assert files["/large.py"].mode == 0o644
 
     app = await App._init_new.aio(client)
     await app.create_one_object.aio(m, "")

--- a/modal/_blob_utils.py
+++ b/modal/_blob_utils.py
@@ -322,13 +322,14 @@ class FileUploadSpec:
     use_blob: bool
     content: Optional[bytes]  # typically None if using blob, required otherwise
     sha256_hex: str
+    mode: int  # file permission bits (last 12 bits of st_mode)
     size: int
 
 
 def get_file_upload_spec(filename: Path, mount_filename: str) -> FileUploadSpec:
     # Somewhat CPU intensive, so we run it in a thread/process
-    size = os.path.getsize(filename)
-    if size >= LARGE_FILE_LIMIT:
+    stat = os.stat(filename)
+    if stat.st_size >= LARGE_FILE_LIMIT:
         use_blob = True
         content = None
         with open(filename, "rb") as fp:
@@ -339,7 +340,13 @@ def get_file_upload_spec(filename: Path, mount_filename: str) -> FileUploadSpec:
             content = fp.read()
         sha256_hex = get_sha256_hex(content)
     return FileUploadSpec(
-        filename, mount_filename, use_blob=use_blob, content=content, sha256_hex=sha256_hex, size=size
+        filename,
+        mount_filename,
+        use_blob=use_blob,
+        content=content,
+        sha256_hex=sha256_hex,
+        mode=stat.st_mode & 0o7777,
+        size=stat.st_size,
     )
 
 

--- a/modal/_blob_utils.py
+++ b/modal/_blob_utils.py
@@ -4,6 +4,7 @@ import dataclasses
 import hashlib
 import io
 import os
+import platform
 from contextlib import contextmanager
 from pathlib import Path
 from typing import AsyncIterator, BinaryIO, List, Optional, Union
@@ -345,7 +346,9 @@ def get_file_upload_spec(filename: Path, mount_filename: str) -> FileUploadSpec:
         use_blob=use_blob,
         content=content,
         sha256_hex=sha256_hex,
-        mode=stat.st_mode & 0o7777,
+        # Python appears to give files 0o666 bits on Windows, so we mask those to 0o644 for
+        # compatibility with POSIX-based permissions.
+        mode=stat.st_mode & (0o7777 if platform.system() != "Windows" else 0o644),
         size=stat.st_size,
     )
 

--- a/modal/_blob_utils.py
+++ b/modal/_blob_utils.py
@@ -346,9 +346,9 @@ def get_file_upload_spec(filename: Path, mount_filename: str) -> FileUploadSpec:
         use_blob=use_blob,
         content=content,
         sha256_hex=sha256_hex,
-        # Python appears to give files 0o666 bits on Windows, so we mask those to 0o644 for
-        # compatibility with POSIX-based permissions.
-        mode=stat.st_mode & (0o7777 if platform.system() != "Windows" else 0o644),
+        # Python appears to give files 0o666 bits on Windows (equal for user, group, and global),
+        # so we mask those out to 0o755 for compatibility with POSIX-based permissions.
+        mode=stat.st_mode & (0o7777 if platform.system() != "Windows" else 0o7755),
         size=stat.st_size,
     )
 

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -239,7 +239,7 @@ class _Mount(_Object, type_prefix="mo"):
                 futs.append(loop.run_in_executor(exe, get_file_upload_spec, local_filename, remote_filename))
 
             logger.debug(f"Computing checksums for {len(futs)} files using {exe._max_workers} workers")
-            for i, fut in enumerate(asyncio.as_completed(futs)):
+            for fut in asyncio.as_completed(futs):
                 try:
                     yield await fut
                 except FileNotFoundError as exc:
@@ -270,7 +270,11 @@ class _Mount(_Object, type_prefix="mo"):
             )
 
             remote_filename = file_spec.mount_filename
-            mount_file = api_pb2.MountFile(filename=remote_filename, sha256_hex=file_spec.sha256_hex)
+            mount_file = api_pb2.MountFile(
+                filename=remote_filename,
+                sha256_hex=file_spec.sha256_hex,
+                mode=file_spec.mode,
+            )
 
             if file_spec.sha256_hex in uploaded_hashes:
                 return mount_file

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -920,7 +920,9 @@ message MountHandleMetadata {
 
 message MountFile {
   string filename = 1;
-  string sha256_hex = 3;
+  string sha256_hex = 3; // SHA-256 checksum of the file.
+  optional uint64 size = 4; // Size of the file in bytes — ignored in MountBuild().
+  optional uint32 mode = 5; // Unix file permission bits `st_mode`.
 }
 
 message MountPutFileRequest {


### PR DESCRIPTION
Adding a mode flag to the `MountFile` message, but not handling it in the server yet.

This change is fully backwards-compatible, just adding more information to the client MountBuild message protobuf.