### PR TITLE
Fix flaky test in resolver_test on Windows

### DIFF
--- a/client_test/resolver_test.py
+++ b/client_test/resolver_test.py
@@ -29,7 +29,7 @@ async def test_multi_resolve_sequential_loads_once():
     t0 = time.monotonic()
     await resolver.load(obj)
     await resolver.load(obj)
-    assert 0.1 < time.monotonic() - t0 < 0.15
+    assert 0.08 < time.monotonic() - t0 < 0.15
 
     assert load_count == 1
 


### PR DESCRIPTION
Apparently on Windows, in GitHub Actions, `sleep()` can actually be inaccurate by 10 milliseconds… see https://github.com/modal-labs/modal-client/actions/runs/6027036204/job/16351311934
