### PR TITLE
Fix deprecation warning in modal shell

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -641,7 +641,7 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
         if pty_info.pty_type or pty_info.enabled:
             # TODO(erikbern): the second condition is for legacy compatibility, remove soon
             # TODO(erikbern): there is no client test for this branch
-            input_stream_unwrapped = synchronizer._translate_in(container_app._pty_input_stream)
+            input_stream_unwrapped = synchronizer._translate_in(container_app._get_object("_pty_input_stream"))
             input_stream_blocking = synchronizer._translate_out(input_stream_unwrapped, Interface.BLOCKING)
             imp_fun.fun = run_in_pty(imp_fun.fun, input_stream_blocking, pty_info)
 


### PR DESCRIPTION
It's pretty unfortunate that this code path is untested, but it's a bit annoying to fix and I think this needs to be rewritten anyway.