### PR TITLE
Do not allow large serialized functions

### DIFF
--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -651,3 +651,27 @@ def test_default_cloud_provider(client, servicer, monkeypatch):
 def test_not_hydrated():
     with pytest.raises(ExecutionError):
         assert foo.remote(2, 4) == 20
+
+
+def test_invalid_large_serialization(client):
+    big_data = b"1" * 500000
+
+    def f():
+        return big_data
+
+    with pytest.warns(UserWarning, match="larger than the recommended limit"):
+        stub = Stub()
+        stub.function(serialized=True)(f)
+        with stub.run(client=client):
+            pass
+
+    bigger_data = b"1" * 50000000
+
+    def g():
+        return bigger_data
+
+    with pytest.raises(InvalidError):
+        stub = Stub()
+        stub.function(serialized=True)(g)
+        with stub.run(client=client):
+            pass

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -758,13 +758,13 @@ class _Function(_Object, type_prefix="fu"):
                     raise InvalidError(
                         f"Function {info.raw_f} has size {len(function_serialized)} bytes when packaged. "
                         "This is larger than the maximum limit of 16 MiB. "
-                        "Try reducing the size of the closure by passing data as arguments, not large global variables."
+                        "Try reducing the size of the closure by using parameters or mounts, not large global variables."
                     )
                 elif len(function_serialized) > 256 << 10:  # 256 KiB
                     warnings.warn(
                         f"Function {info.raw_f} has size {len(function_serialized)} bytes when packaged. "
                         "This is larger than the recommended limit of 256 KiB. "
-                        "Try reducing the size of the closure by passing data as arguments, not large global variables."
+                        "Try reducing the size of the closure by using parameters or mounts, not large global variables."
                     )
             else:
                 function_serialized = None


### PR DESCRIPTION
Modal breaks with a cryptic "unknown 413" gRPC error message when a function in a Jupyter Notebook closes over a global variable in scope that is over 100 MiB when serialized. This PR warns users if their function closes over 256 KiB of data (a conservative limit), then emits a full error if the size is over 16 MiB.

Also added a test for this behavior in the client.
