### PR TITLE
Use plain objects for Modal classes

### DIFF
--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -48,6 +48,7 @@ def _run(args: List[str], expected_exit_code: int = 0, expected_stderr: Optional
         res = runner.invoke(entrypoint_cli, args)
     if res.exit_code != expected_exit_code:
         print("stdout:", repr(res.stdout))
+        print("stderr:", repr(res.stderr))
         traceback.print_tb(res.exc_info[2])
         print(res.exception, file=sys.stderr)
         assert res.exit_code == expected_exit_code

--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -5,7 +5,6 @@ import pytest
 from modal import Stub, method
 from modal._serialization import deserialize
 from modal.cls import ClsMixin
-from modal.functions import Function
 from modal_proto import api_pb2
 
 stub = Stub()
@@ -59,6 +58,11 @@ def test_call_cls_remote_sync(client):
         foo_remote = FooRemote.remote(3, "hello")
         # Mock servicer just squares the argument
         # This means remote function call is taking place.
+        assert foo_remote.bar.remote(8) == 64
+        assert foo_remote.bar(8) == 64
+
+        # Check new syntax
+        foo_remote = FooRemote(3, "hello")
         assert foo_remote.bar.remote(8) == 64
         assert foo_remote.bar(8) == 64
 
@@ -118,7 +122,6 @@ def test_run_class_serialized(client, servicer):
     obj = cls()
     meth = fun.__get__(obj, cls)
 
-    assert isinstance(obj.bar, Function)
     # Make sure it's callable
     assert meth(100) == 1000000
 

--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -1,8 +1,11 @@
 # Copyright Modal Labs 2022
 import inspect
 import pytest
+from typing import TYPE_CHECKING
 
-from modal import Stub, method
+from typing_extensions import assert_type
+
+from modal import Function, Stub, method
 from modal._serialization import deserialize
 from modal.cls import ClsMixin
 from modal_proto import api_pb2
@@ -13,8 +16,8 @@ stub = Stub()
 @stub.cls(cpu=42)
 class Foo:
     @method()
-    def bar(self, x):
-        return x**3
+    def bar(self, x: int) -> float:
+        return x**3.5
 
 
 def test_run_class(client, servicer):
@@ -32,8 +35,9 @@ def test_run_class(client, servicer):
 
 def test_call_class_sync(client, servicer):
     with stub.run(client=client):
-        foo = Foo()
-        assert foo.bar.remote(42) == 1764
+        foo: Foo = Foo()
+        ret: float = foo.bar.remote(42)
+        assert ret == 1764
 
 
 # Reusing the stub runs into an issue with stale function handles.
@@ -55,16 +59,18 @@ class FooRemote(ClsMixin):
 
 def test_call_cls_remote_sync(client):
     with stub_remote.run(client=client):
-        foo_remote = FooRemote.remote(3, "hello")
+        foo_remote: FooRemote = FooRemote.remote(3, "hello")
         # Mock servicer just squares the argument
         # This means remote function call is taking place.
         assert foo_remote.bar.remote(8) == 64
         assert foo_remote.bar(8) == 64
 
         # Check new syntax
-        foo_remote = FooRemote(3, "hello")
-        assert foo_remote.bar.remote(8) == 64
-        assert foo_remote.bar(8) == 64
+        foo_remote_2: FooRemote = FooRemote(3, "hello")
+        ret: float = foo_remote_2.bar.remote(8)
+        assert ret == 64
+        ret_2: float = foo_remote_2.bar(8)
+        assert ret_2 == 64
 
 
 def test_call_cls_remote_invalid_type(client):
@@ -200,3 +206,9 @@ def test_call_cls_remote_no_args(client):
         # Mock servicer just squares the argument
         # This means remote function call is taking place.
         assert foo_remote.baz(8) == 64
+
+
+if TYPE_CHECKING:
+    # Check that type annotations carry through to the decorated classes
+    assert_type(Foo(), Foo)
+    assert_type(Foo().bar, Function)

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -39,6 +39,7 @@ from ._traceback import extract_traceback
 from ._tracing import extract_tracing_context, set_span_tag, trace, wrap
 from .app import _App
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, Client, _Client
+from .cls import Cls
 from .config import logger
 from .exception import InvalidError
 from .functions import Function, _set_current_input_id  # type: ignore
@@ -580,6 +581,8 @@ def import_function(function_def: api_pb2.Function, ser_cls, ser_fun, ser_params
 
     # Instantiate the class if it's defined
     if cls:
+        if isinstance(cls, Cls):
+            cls = cls.get_user_cls()
         if ser_params:
             args, kwargs = pickle.loads(ser_params)
             obj = cls(*args, **kwargs)

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -1,10 +1,10 @@
 # Copyright Modal Labs 2022
 import pickle
-from typing import Dict, Type, TypeVar
+from typing import Any, Callable, Dict, Type, TypeVar
 
 from modal_utils.async_utils import synchronize_api
 
-from .functions import PartialFunction, _Function, _PartialFunction
+from .functions import _Function
 
 T = TypeVar("T")
 
@@ -28,26 +28,75 @@ def check_picklability(key, arg):
         )
 
 
-def make_remote_cls_constructors(
-    user_cls: type,
-    partial_functions: Dict[str, PartialFunction],
-    functions: Dict[str, _Function],
-):
-    cls = type(f"Remote{user_cls.__name__}", (), partial_functions)
+class _Obj:
+    """An instance of a `Cls`, i.e. `Cls("foo", 42)` returns an `Obj`.
 
-    async def _remote(*args, **kwargs):
+    All this class does is to return `Function` objects."""
+
+    _functions: Dict[str, _Function]
+    _has_local_obj: bool
+    _local_obj: Any
+    _local_obj_constr: Callable[[], Any]
+
+    def __init__(self, user_cls: type, base_functions: Dict[str, _Function], args, kwargs):
         for i, arg in enumerate(args):
             check_picklability(i + 1, arg)
         for key, kwarg in kwargs.items():
             check_picklability(key, kwarg)
 
-        new_functions: Dict[str, _Function] = {}
+        self._functions = {}
+        for k, fun in base_functions.items():
+            self._functions[k] = fun.from_parametrized(self, args, kwargs)
 
-        for k, v in partial_functions.items():
-            new_functions[k] = functions[k].from_parametrized(args, kwargs)
+        # Used for construction local object lazily
+        self._has_local_obj = False
+        self._local_obj = None
+        self._local_obj_constr = lambda: user_cls(*args, **kwargs)
 
-        obj = cls()
-        _PartialFunction.initialize_obj(obj, new_functions)
-        return obj
+    def get_local_obj(self):
+        # Construct local object lazily. Used for .local() calls
+        if not self._has_local_obj:
+            self._local_obj = self._local_obj_constr()
+            setattr(self._local_obj, "_modal_functions", self._functions)  # Needed for PartialFunction.__get__
+            self._has_local_obj = True
 
-    return synchronize_api(_remote)
+        return self._local_obj
+
+    def __getattr__(self, k):
+        return self._functions[k]
+
+
+Obj = synchronize_api(_Obj)
+
+
+class _Cls:
+    # TODO(erikbern): Make this inherit from Object (needs backend support for this)
+    _user_cls: type
+    _functions: Dict[str, _Function]
+
+    def __init__(self, user_cls, base_functions: Dict[str, _Function]):
+        self._user_cls = user_cls
+        self._base_functions = base_functions
+        setattr(self._user_cls, "_modal_functions", base_functions)  # Needed for PartialFunction.__get__
+
+    def get_user_cls(self):
+        # Used by the container entrypoint
+        return self._user_cls
+
+    def get_base_function(self, k: str) -> _Function:
+        return self._base_functions[k]
+
+    def __call__(self, *args, **kwargs) -> _Obj:
+        """This acts as the class constructor."""
+        return _Obj(self._user_cls, self._base_functions, args, kwargs)
+
+    async def remote(self, *args, **kwargs) -> _Obj:
+        # Deprecated
+        return self(*args, **kwargs)
+
+    def __getattr__(self, k):
+        # Used by CLI and container entrypoint
+        return self._base_functions[k]
+
+
+Cls = synchronize_api(_Cls)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -497,7 +497,7 @@ class _Function(_Object, type_prefix="fu"):
     _info: FunctionInfo
     _all_mounts: Collection[_Mount]
     _stub: "modal.stub._Stub"
-    _self_obj: Any
+    _obj: Any
     _web_url: Optional[str]
     _is_remote_cls_method: bool = False
     _function_name: Optional[str]
@@ -846,7 +846,7 @@ class _Function(_Object, type_prefix="fu"):
         obj._all_mounts = all_mounts  # needed for modal.serve file watching
         obj._panel_items = panel_items
         obj._stub = stub  # Needed for CLI right now
-        obj._self_obj = None
+        obj._obj = None
         obj._is_generator = is_generator
 
         # Used to check whether we should rebuild an image using run_function
@@ -861,10 +861,9 @@ class _Function(_Object, type_prefix="fu"):
 
         return obj
 
-    def from_parametrized(self, args: Iterable[Any], kwargs: Dict[str, Any]) -> "_Function":
-        assert self._is_hydrated, "Cannot make bound function handle from unhydrated handle."
-
+    def from_parametrized(self, obj, args: Iterable[Any], kwargs: Dict[str, Any]) -> "_Function":
         async def _load(provider: _Function, resolver: Resolver, existing_object_id: Optional[str]):
+            assert self._is_hydrated, "Cannot make bound function handle from unhydrated handle."
             serialized_params = pickle.dumps((args, kwargs))  # TODO(erikbern): use modal._serialization?
             req = api_pb2.FunctionBindParamsRequest(
                 function_id=self._object_id,
@@ -874,7 +873,12 @@ class _Function(_Object, type_prefix="fu"):
             provider._hydrate(response.bound_function_id, self._client, response.handle_metadata)
 
         provider = _Function._from_loader(_load, "Function(parametrized)", hydrate_lazily=True)
+        if len(args) + len(kwargs) == 0:
+            # Edge case that lets us hydrate all objects right away
+            provider._hydrate_from_other(self)
         provider._is_remote_cls_method = True
+        provider._info = self._info
+        provider._obj = obj
         return provider
 
     def get_panel_items(self) -> List[str]:
@@ -897,12 +901,6 @@ class _Function(_Object, type_prefix="fu"):
     def get_build_def(self) -> str:
         """mdmd:hidden"""
         return f"{inspect.getsource(self._raw_f)}\n{repr(self._build_args)}"
-
-    def _bind_obj(self, obj, objtype):
-        # This is needed to bind "self" to methods for direct __call__
-        # TODO(erikbern): we're mutating self directly here, as opposed to returning a different _FunctionHandle
-        # We should fix this in the future since it probably precludes using classmethods/staticmethods
-        self._self_obj = obj
 
     # Live handle methods
 
@@ -1152,7 +1150,7 @@ class _Function(_Object, type_prefix="fu"):
         return self._info
 
     def _get_self_obj(self):
-        return self._self_obj
+        return self._obj.get_local_obj() if self._obj else None
 
     @synchronizer.nowrap
     def local(self, *args, **kwargs) -> Any:
@@ -1343,14 +1341,6 @@ def _set_current_input_id(input_id: Optional[str]):
 class _PartialFunction:
     """Intermediate function, produced by @method or @web_endpoint"""
 
-    @staticmethod
-    def initialize_cls(user_cls: type, functions: Dict[str, _Function]):
-        user_cls._modal_functions = functions
-
-    @staticmethod
-    def initialize_obj(user_obj, functions: Dict[str, _Function]):
-        user_obj._modal_functions = functions
-
     def __init__(
         self,
         raw_f: Callable[..., Any],
@@ -1363,12 +1353,12 @@ class _PartialFunction:
         self.wrapped = False  # Make sure that this was converted into a FunctionHandle
 
     def __get__(self, obj, objtype=None) -> _Function:
+        # This only happens inside user methods when they refer to other methods
         k = self.raw_f.__name__
         if obj:  # Cls().fun
-            function = obj._modal_functions[k]
+            function = getattr(obj, "_modal_functions")[k]
         else:  # Cls.fun
-            function = objtype._modal_functions[k]
-        function._bind_obj(obj, objtype)  # TODO(erikbern): don't mutate
+            function = getattr(objtype, "_modal_functions")[k]
         return function
 
     def __del__(self):

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -16,7 +16,7 @@ from ._ipython import is_notebook
 from ._output import OutputManager
 from .app import _App, _container_app, is_local
 from .client import _Client
-from .cls import make_remote_cls_constructors
+from .cls import _Cls
 from .config import logger
 from .exception import InvalidError, deprecation_warning
 from .functions import PartialFunction, _Function, _PartialFunction
@@ -545,7 +545,7 @@ class _Stub:
         interactive: bool = False,  # Whether to run the function in interactive mode.
         keep_warm: Optional[int] = None,  # An optional number of containers to always keep warm.
         cloud: Optional[str] = None,  # Cloud provider to run the function on. Possible values are aws, gcp, oci, auto.
-    ) -> Callable[[CLS_T], CLS_T]:
+    ) -> Callable[[CLS_T], _Cls]:
         decorator: Callable[[PartialFunction, type], _Function] = self.function(
             image=image,
             secret=secret,
@@ -570,7 +570,7 @@ class _Stub:
             cloud=cloud,
         )
 
-        def wrapper(user_cls: CLS_T) -> CLS_T:
+        def wrapper(user_cls: CLS_T) -> _Cls:
             partial_functions: Dict[str, PartialFunction] = {}
             functions: Dict[str, _Function] = {}
 
@@ -580,10 +580,7 @@ class _Stub:
                     partial_function = synchronizer._translate_in(v)  # TODO: remove need for?
                     functions[k] = decorator(partial_function, user_cls)
 
-            _PartialFunction.initialize_cls(user_cls, functions)
-            remote = make_remote_cls_constructors(user_cls, partial_functions, functions)
-            user_cls.remote = remote
-            return user_cls
+            return _Cls(user_cls, functions)
 
         return wrapper
 

--- a/tasks.py
+++ b/tasks.py
@@ -133,9 +133,11 @@ build-backend = "setuptools.build_meta"
 @task
 def type_stubs(ctx):
     # we only generate type stubs for modules that contain synchronicity wrapped types
+    # TODO(erikbern): can we automate this list?
     modules = [
         "modal.app",
         "modal.client",
+        "modal.cls",
         "modal.dict",
         "modal.environments",
         "modal.functions",


### PR DESCRIPTION
The rough idea is that `@stub.cls` doesn't create a new Python class, it returns an instance of `modal.Cls` instead. That in turn has a `__call__` method which creates a `modal.Obj` class. That in turn implements `__getattr__` which returns `Function` objects. So for instance to support `FooCls(1, 2, 3).method("xyz")` then

* `FooCls` is an _object_ (not a class) of type `Cls`
* `FooCls(1, 2, 3)` returns an object of type `Obj`
* `FooCls(1, 2, 3).method` is a `Function` which comes from `Obj.__getattr__`

The main benefit of this is that we can support `modal.Cls.lookup("my-object")` quite easily, since `modal.Cls` will be a Modal object (with an object id etc) later – I haven't implemented the backend part of this, but this should be quite doable.

This PR is not big but somewhat complex mostly because of a lot of subtleties (for instance – _inside_ function methods, you need `self` to refer to the original class instance, but you need `self.method` to still return `Function` objects). I think there's some room to simplify things over time.

This supersedes #805 since it's a completely different approach. It does add the constructor as an alternative to `.remote` but I haven't implemented the deprecations etc. Will do that in a separate PR.