### PR TITLE
NFS support for sandboxes

### DIFF
--- a/client_test/sandbox_test.py
+++ b/client_test/sandbox_test.py
@@ -6,7 +6,8 @@ import pytest
 import time
 from pathlib import Path
 
-from modal import Image, Mount, Secret, Stub
+from modal import Image, Mount, NetworkFileSystem, Secret, Stub
+from modal.exception import InvalidError
 
 stub = Stub()
 
@@ -67,3 +68,16 @@ def test_sandbox_secret(client, servicer, tmpdir):
         sb.wait()
 
     assert len(servicer.sandbox_defs[0].secret_ids) == 1
+
+
+@skip_non_linux
+def test_sandbox_nfs(client, servicer, tmpdir):
+    with stub.run(client=client) as app:
+        nfs = NetworkFileSystem.new()
+
+        with pytest.raises(InvalidError):
+            app.spawn_sandbox("echo", "foo > /cache/a.txt", network_file_systems={"/": nfs})
+
+        app.spawn_sandbox("echo", "foo > /cache/a.txt", network_file_systems={"/cache": nfs})
+
+    assert len(servicer.sandbox_defs[0].nfs_mounts) == 1

--- a/modal/_mount_utils.py
+++ b/modal/_mount_utils.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 def validate_mount_points(
     display_name: str, volume_likes: Dict[Union[str, os.PathLike], Union["_Volume", "_NetworkFileSystem"]]
-) -> List[Tuple[str, Union[_Volume, _NetworkFileSystem]]]:
+) -> List[Tuple[str, Union["_Volume", "_NetworkFileSystem"]]]:
     """Mount point path validation for volumes and network file systems."""
 
     validated = []

--- a/modal/_mount_utils.py
+++ b/modal/_mount_utils.py
@@ -1,0 +1,33 @@
+# Copyright Modal Labs 2022
+import os
+import posixpath
+from pathlib import PurePath
+from typing import TYPE_CHECKING, Dict, List, Tuple, Union
+
+from .exception import InvalidError
+
+if TYPE_CHECKING:
+    from .network_file_system import _NetworkFileSystem
+    from .volume import _Volume
+
+
+def validate_mount_points(
+    display_name: str, volume_likes: Dict[Union[str, os.PathLike], Union["_Volume", "_NetworkFileSystem"]]
+) -> List[Tuple[str, Union[_Volume, _NetworkFileSystem]]]:
+    """Mount point path validation for volumes and network file systems."""
+
+    validated = []
+    for path, vol in volume_likes.items():
+        path = PurePath(path).as_posix()
+        abs_path = posixpath.abspath(path)
+
+        if path != abs_path:
+            raise InvalidError(f"{display_name} {path} must be a canonical, absolute path.")
+        elif abs_path == "/":
+            raise InvalidError(f"{display_name} {path} cannot be mounted into root directory.")
+        elif abs_path == "/root":
+            raise InvalidError(f"{display_name} {path} cannot be mounted at '/root'.")
+        elif abs_path == "/tmp":
+            raise InvalidError(f"{display_name} {path} cannot be mounted at '/tmp'.")
+        validated.append((path, vol))
+    return validated

--- a/modal/app.py
+++ b/modal/app.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
+import os
 from datetime import date
-from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, TypeVar
+from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, TypeVar, Union
 
 from google.protobuf.message import Message
 
@@ -14,6 +15,7 @@ from .client import _Client
 from .config import logger
 from .exception import deprecation_warning
 from .gpu import GPU_T
+from .network_file_system import _NetworkFileSystem
 from .object import _Object
 
 if TYPE_CHECKING:
@@ -326,6 +328,7 @@ class _App:
         image: Optional["modal.image._Image"] = None,  # The image to run as the container for the sandbox.
         mounts: Sequence["modal.mount._Mount"] = (),  # Mounts to attach to the sandbox.
         secrets: Sequence["modal.secret._Secret"] = (),  # Environment variables to inject into the sandbox.
+        network_file_systems: Dict[Union[str, os.PathLike], _NetworkFileSystem] = {},
         timeout: Optional[int] = None,  # Maximum execution time of the sandbox in seconds.
         workdir: Optional[str] = None,  # Working directory of the sandbox.
         gpu: GPU_T = None,
@@ -354,6 +357,7 @@ class _App:
             cloud=cloud,
             cpu=cpu,
             memory=memory,
+            network_file_systems=network_file_systems,
         )
         await resolver.load(obj)
         return obj

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -1,9 +1,10 @@
 # Copyright Modal Labs 2023
+import asyncio
 import os
 import time
 from datetime import date
 from pathlib import Path, PurePosixPath
-from typing import AsyncIterator, BinaryIO, List, Optional, Union
+from typing import AsyncIterator, BinaryIO, Dict, List, Optional, Union
 
 import modal
 from modal._location import parse_cloud_provider
@@ -13,14 +14,40 @@ from modal_utils.grpc_utils import retry_transient_errors, unary_stream
 from modal_utils.hash_utils import get_sha256_hex
 
 from ._blob_utils import LARGE_FILE_LIMIT, blob_iter, blob_upload_file
+from ._mount_utils import validate_mount_points
 from ._resolver import Resolver
 from ._types import typechecked
-from .exception import deprecation_warning
+from .exception import InvalidError, deprecation_warning
 from .object import _Object
 
 NETWORK_FILE_SYSTEM_PUT_FILE_CLIENT_TIMEOUT = (
     10 * 60
 )  # 10 min max for transferring files (does not include upload time to s3)
+
+
+async def load_network_file_systems(
+    network_file_systems: Dict[Union[str, os.PathLike], "_NetworkFileSystem"],
+    allow_cross_region_volumes: bool,
+    resolver: Resolver,
+) -> List[api_pb2.SharedVolumeMount]:
+    if not isinstance(network_file_systems, dict):
+        raise InvalidError("network_file_systems must be a dict[str, NetworkFileSystem] where the keys are paths")
+
+    validated_network_file_systems = validate_mount_points("Network file system", network_file_systems)
+    loaded_handles = await asyncio.gather(*[resolver.load(vol) for _, vol in validated_network_file_systems])
+    volume_ids = [handle.object_id for handle in loaded_handles]
+
+    network_file_system_mounts = []
+    # Relies on dicts being ordered (true as of Python 3.6).
+    for (path, _), volume_id in zip(validated_network_file_systems, volume_ids):
+        network_file_system_mounts.append(
+            api_pb2.SharedVolumeMount(
+                mount_path=path,
+                shared_volume_id=volume_id,
+                allow_cross_region=allow_cross_region_volumes,
+            )
+        )
+    return network_file_system_mounts
 
 
 class _NetworkFileSystem(_Object, type_prefix="sv"):


### PR DESCRIPTION
Can use both "ephemeral" and persisted sandboxes. For example:

```python
@stub.local_entrypoint()
def main():
    nfs = modal.NetworkFileSystem.new()
    sb = stub.app.spawn_sandbox(
        "bash",
        "-c",
        "echo foo > /cache/a.txt",
        network_file_systems={"/cache": nfs},
    )
    sb.wait()
    for x in nfs.read_file("/a.txt"):
        print(x)

```