### PR TITLE
Deprecate old syntax for parametrized functions

### DIFF
--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -8,6 +8,7 @@ from typing_extensions import assert_type
 from modal import Function, Stub, method
 from modal._serialization import deserialize
 from modal.cls import ClsMixin
+from modal.exception import DeprecationError
 from modal_proto import api_pb2
 
 stub = Stub()
@@ -59,11 +60,14 @@ class FooRemote(ClsMixin):
 
 def test_call_cls_remote_sync(client):
     with stub_remote.run(client=client):
-        foo_remote: FooRemote = FooRemote.remote(3, "hello")
+        foo_remote: FooRemote
+        with pytest.warns(DeprecationError):
+            foo_remote = FooRemote.remote(3, "hello")
         # Mock servicer just squares the argument
         # This means remote function call is taking place.
         assert foo_remote.bar.remote(8) == 64
-        assert foo_remote.bar(8) == 64
+        with pytest.warns(DeprecationError):
+            assert foo_remote.bar(8) == 64
 
         # Check new syntax
         foo_remote_2: FooRemote = FooRemote(3, "hello")
@@ -80,7 +84,7 @@ def test_call_cls_remote_invalid_type(client):
             print("Hello, world!")
 
         with pytest.raises(ValueError) as excinfo:
-            FooRemote.remote(42, my_function)
+            FooRemote(42, my_function)
 
         exc = excinfo.value
         assert "function" in str(exc)
@@ -99,6 +103,8 @@ class Bar:
 @pytest.mark.asyncio
 async def test_call_class_async(client, servicer):
     async with stub_2.run(client=client):
+        with pytest.warns(DeprecationError):
+            bar = await Bar.remote.aio()
         bar = Bar()
         assert await bar.baz.remote.aio(42) == 1764
 
@@ -151,11 +157,13 @@ async def test_call_cls_remote_async(client):
     async with stub_remote_2.run(client=client):
         coro = BarRemote.remote.aio(3, "hello")  # type: ignore
         assert inspect.iscoroutine(coro)
-        bar_remote = await coro
+        with pytest.warns(DeprecationError):
+            bar_remote = await coro
         # Mock servicer just squares the argument
         # This means remote function call is taking place.
         assert await bar_remote.baz.remote.aio(8) == 64
-        assert bar_remote.baz(8) == 64
+        with pytest.warns(DeprecationError):
+            assert bar_remote.baz(8) == 64
 
 
 stub_local = Stub()
@@ -202,10 +210,16 @@ class NoArgRemote(ClsMixin):
 
 def test_call_cls_remote_no_args(client):
     with stub_remote_3.run(client=client):
-        foo_remote = NoArgRemote.remote()
+        with pytest.warns(DeprecationError):
+            foo_remote = NoArgRemote.remote()
         # Mock servicer just squares the argument
         # This means remote function call is taking place.
         assert foo_remote.baz(8) == 64
+        with pytest.warns(DeprecationError):
+            assert foo_remote.baz(8) == 64
+
+        foo_remote = NoArgRemote()
+        assert foo_remote.baz.remote(8) == 64
 
 
 if TYPE_CHECKING:

--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -62,7 +62,7 @@ def test_call_cls_remote_sync(client):
     with stub_remote.run(client=client):
         foo_remote: FooRemote
         with pytest.warns(DeprecationError):
-            foo_remote = FooRemote.remote(3, "hello")
+            foo_remote = FooRemote.remote(3, "hello")  # type: ignore
         # Mock servicer just squares the argument
         # This means remote function call is taking place.
         assert foo_remote.bar.remote(8) == 64
@@ -82,7 +82,7 @@ def test_call_cls_remote_invalid_type(client):
             print("Hello, world!")
 
         with pytest.raises(ValueError) as excinfo:
-            FooRemote(42, my_function)
+            FooRemote(42, my_function)  # type: ignore
 
         exc = excinfo.value
         assert "function" in str(exc)
@@ -102,7 +102,7 @@ class Bar:
 async def test_call_class_async(client, servicer):
     async with stub_2.run(client=client):
         with pytest.warns(DeprecationError):
-            bar = await Bar.remote.aio()
+            bar = await Bar.remote.aio()  # type: ignore
         bar = Bar()
         assert await bar.baz.remote.aio(42) == 1764
 
@@ -209,7 +209,7 @@ class NoArgRemote:
 def test_call_cls_remote_no_args(client):
     with stub_remote_3.run(client=client):
         with pytest.warns(DeprecationError):
-            foo_remote = NoArgRemote.remote()
+            foo_remote = NoArgRemote.remote()  # type: ignore
         # Mock servicer just squares the argument
         # This means remote function call is taking place.
         with pytest.warns(DeprecationError):

--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -48,7 +48,7 @@ stub_remote = Stub()
 
 
 @stub_remote.cls(cpu=42)
-class FooRemote(ClsMixin):
+class FooRemote:
     def __init__(self, x: int, y: str) -> None:
         self.x = x
         self.y = y
@@ -142,7 +142,7 @@ stub_remote_2 = Stub()
 
 
 @stub_remote_2.cls(cpu=42)
-class BarRemote(ClsMixin):
+class BarRemote:
     def __init__(self, x: int, y: str) -> None:
         self.x = x
         self.y = y
@@ -199,7 +199,7 @@ stub_remote_3 = Stub()
 
 
 @stub_remote_3.cls(cpu=42)
-class NoArgRemote(ClsMixin):
+class NoArgRemote:
     def __init__(self) -> None:
         pass
 
@@ -220,6 +220,12 @@ def test_call_cls_remote_no_args(client):
 
         foo_remote = NoArgRemote()
         assert foo_remote.baz.remote(8) == 64
+
+
+def test_deprecated_mixin():
+    with pytest.warns(DeprecationError):
+        class FooRemote(ClsMixin):
+            pass
 
 
 if TYPE_CHECKING:

--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -221,6 +221,7 @@ def test_call_cls_remote_no_args(client):
 
 def test_deprecated_mixin():
     with pytest.warns(DeprecationError):
+
         class FooRemote(ClsMixin):
             pass
 

--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -73,8 +73,6 @@ def test_call_cls_remote_sync(client):
         foo_remote_2: FooRemote = FooRemote(3, "hello")
         ret: float = foo_remote_2.bar.remote(8)
         assert ret == 64
-        ret_2: float = foo_remote_2.bar(8)
-        assert ret_2 == 64
 
 
 def test_call_cls_remote_invalid_type(client):
@@ -214,7 +212,6 @@ def test_call_cls_remote_no_args(client):
             foo_remote = NoArgRemote.remote()
         # Mock servicer just squares the argument
         # This means remote function call is taking place.
-        assert foo_remote.baz(8) == 64
         with pytest.warns(DeprecationError):
             assert foo_remote.baz(8) == 64
 

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -1,9 +1,11 @@
 # Copyright Modal Labs 2022
 import pickle
+from datetime import date
 from typing import Any, Callable, Dict, Type, TypeVar
 
 from modal_utils.async_utils import synchronize_api
 
+from .exception import deprecation_warning
 from .functions import _Function
 
 T = TypeVar("T")
@@ -91,7 +93,9 @@ class _Cls:
         return _Obj(self._user_cls, self._base_functions, args, kwargs)
 
     async def remote(self, *args, **kwargs) -> _Obj:
-        # Deprecated
+        deprecation_warning(
+            date(2023, 9, 1), "`Cls.remote(...)` on classes is deprecated. Use the constructor: `Cls(...)`."
+        )
         return self(*args, **kwargs)
 
     def __getattr__(self, k):

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -12,6 +12,11 @@ T = TypeVar("T")
 
 
 class ClsMixin:
+    def __init_subclass__(cls):
+        deprecation_warning(
+            date(2023, 9, 1), "`ClsMixin` is deprecated and can be safely removed."
+       )
+
     @classmethod
     def remote(cls: Type[T], *args, **kwargs) -> T:
         ...

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -13,9 +13,7 @@ T = TypeVar("T")
 
 class ClsMixin:
     def __init_subclass__(cls):
-        deprecation_warning(
-            date(2023, 9, 1), "`ClsMixin` is deprecated and can be safely removed."
-       )
+        deprecation_warning(date(2023, 9, 1), "`ClsMixin` is deprecated and can be safely removed.")
 
     @classmethod
     def remote(cls: Type[T], *args, **kwargs) -> T:

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -853,7 +853,7 @@ class _Function(_Object, type_prefix="fu"):
         if len(args) + len(kwargs) == 0:
             # Edge case that lets us hydrate all objects right away
             provider._hydrate_from_other(self)
-        provider._is_remote_cls_method = True
+        provider._is_remote_cls_method = True  # TODO(erikbern): deprecated
         provider._info = self._info
         provider._obj = obj
         return provider
@@ -1151,8 +1151,12 @@ class _Function(_Object, type_prefix="fu"):
 
     @synchronizer.nowrap
     def __call__(self, *args, **kwargs) -> Any:  # TODO: Generics/TypeVars
-        if self._get_is_remote_cls_method():  # TODO(elias): change parametrization so this is isn't needed
-            # TODO(erikbern): deprecate this soon too
+        if self._get_is_remote_cls_method():
+            deprecation_warning(
+                date(2023, 9, 1),
+                "Calling remote class methods like `obj.f(...)` is deprecated. Use `obj.f.remote(...)` for remote calls"
+                " and `obj.f.local(...)` for local calls",
+            )
             return self.remote(*args, **kwargs)
 
         deprecation_warning(

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1158,29 +1158,29 @@ class _Function(_Object, type_prefix="fu"):
                 " and `obj.f.local(...)` for local calls",
             )
             return self.remote(*args, **kwargs)
-
-        deprecation_warning(
-            date(2023, 8, 16),
-            "Calling Modal functions like `f(...)` is deprecated. Use `f.local(...)` if you want to call the"
-            " function in the same Python process. Use `f.remote(...)` if you want to call the function in"
-            " a Modal container in the cloud",
-        )
-
-        info = self._get_info()
-        if not info:
-            msg = (
-                "The definition for this function is missing so it is not possible to invoke it locally. "
-                "If this function was retrieved via `Function.lookup` you need to use `.remote()`."
-            )
-            raise AttributeError(msg)
-
-        self_obj = self._get_self_obj()
-        if self_obj:
-            # This is a method on a class, so bind the self to the function
-            fun = info.raw_f.__get__(self_obj)
         else:
-            fun = info.raw_f
-        return fun(*args, **kwargs)
+            deprecation_warning(
+                date(2023, 8, 16),
+                "Calling Modal functions like `f(...)` is deprecated. Use `f.local(...)` if you want to call the"
+                " function in the same Python process. Use `f.remote(...)` if you want to call the function in"
+                " a Modal container in the cloud",
+            )
+
+            info = self._get_info()
+            if not info:
+                msg = (
+                    "The definition for this function is missing so it is not possible to invoke it locally. "
+                    "If this function was retrieved via `Function.lookup` you need to use `.remote()`."
+                )
+                raise AttributeError(msg)
+
+            self_obj = self._get_self_obj()
+            if self_obj:
+                # This is a method on a class, so bind the self to the function
+                fun = info.raw_f.__get__(self_obj)
+            else:
+                fun = info.raw_f
+            return fun(*args, **kwargs)
 
     async def spawn(self, *args, **kwargs) -> Optional["_FunctionCall"]:
         """Calls the function with the given arguments, without waiting for the results.


### PR DESCRIPTION
This adds deprecation warnings for the old syntax (using `.remote` on the class, NOT using `.remote` on the method) as well as deprecating the mixin (since it's no longer needed)