### PR TITLE
broken: add type hints for decorated function arguments

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1325,12 +1325,12 @@ def _set_current_input_id(input_id: Optional[str]):
     _current_input_id = input_id
 
 
-class _PartialFunction:
+class _PartialFunction(Generic[P]):
     """Intermediate function, produced by @method or @web_endpoint"""
 
     def __init__(
         self,
-        raw_f: Callable[..., Any],
+        raw_f: Callable[P, Any],
         webhook_config: Optional[api_pb2.WebhookConfig] = None,
         is_generator: Optional[bool] = None,
     ):

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -16,9 +16,11 @@ from typing import (
     Callable,
     Collection,
     Dict,
+    Generic,
     Iterable,
     List,
     Optional,
+    ParamSpec,
     Set,
     Union,
 )
@@ -484,7 +486,10 @@ class FunctionStats:
     num_total_runners: int
 
 
-class _Function(_Object, type_prefix="fu"):
+P = ParamSpec("P")
+
+
+class _Function(_Object, Generic[P], type_prefix="fu"):
     """Functions are the basic units of serverless execution on Modal.
 
     Generally, you will not construct a `Function` directly. Instead, use the
@@ -1066,7 +1071,7 @@ class _Function(_Object, type_prefix="fu"):
             yield item
 
     @live_method
-    async def remote(self, *args, **kwargs) -> Awaitable[Any]:  # TODO: Generics/TypeVars
+    async def remote(self, *args: P.args, **kwargs: P.kwargs) -> Awaitable[Any]:  # TODO: Generics/TypeVars
         """
         Calls the function remotely, executing it with the given arguments and returning the execution's result.
         """
@@ -1217,6 +1222,7 @@ class _Function(_Object, type_prefix="fu"):
         )
 
 
+synchronize_api(Generic)  # dumb, needed or synchronicity
 Function = synchronize_api(_Function)
 
 

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -4,7 +4,7 @@ import os
 import typing
 import warnings
 from datetime import date
-from typing import Any, AsyncGenerator, Callable, ClassVar, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, AsyncGenerator, Callable, ClassVar, Dict, Generic, List, Optional, Protocol, Sequence, Tuple, Union
 
 from synchronicity.async_wrap import asynccontextmanager
 
@@ -67,6 +67,16 @@ def check_sequence(items: typing.Sequence[typing.Any], item_type: typing.Type[ty
 
 
 CLS_T = typing.TypeVar("CLS_T", bound=typing.Type)
+
+
+class _FunctionDecorator(Protocol):
+    def __call__(self, function: Union[_PartialFunction, Callable[..., Any]], _cls: Optional[CLS_T] = None) -> _Function:
+        ...
+
+
+synchronize_api(Generic)  # dumb, needed or synchronicity
+synchronize_api(Protocol)  # same
+FunctionDecorator = synchronize_api(_FunctionDecorator)  # think needed for type stubs?
 
 
 class _Stub:
@@ -440,7 +450,7 @@ class _Stub:
             bool
         ] = None,  # Set this to True if it's a non-generator function returning a [sync/async] generator object
         cloud: Optional[str] = None,  # Cloud provider to run the function on. Possible values are aws, gcp, oci, auto.
-    ) -> Callable[..., _Function]:
+    ) -> FunctionDecorator:
         """Decorator to register a new Modal function with this stub."""
         if image is None:
             image = self._get_default_image()

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -70,7 +70,7 @@ CLS_T = typing.TypeVar("CLS_T", bound=typing.Type)
 
 
 class _FunctionDecorator(Protocol):
-    def __call__(self, function: Union[_PartialFunction, Callable[P, Any]], _cls: Optional[CLS_T] = None) -> _Function[P]:
+    def __call__(self, function: Union[_PartialFunction[P], Callable[P, Any]], _cls: Optional[CLS_T] = None) -> _Function[P]:
         ...
 
 
@@ -463,7 +463,7 @@ class _Stub:
             )
 
         def wrapped(
-            f: Union[_PartialFunction, Callable[..., Any]],
+            f: Union[_PartialFunction[P], Callable[P, Any]],
             _cls: Optional[type] = None,  # Used for methods only
         ) -> _Function[P]:
             is_generator_override: Optional[bool] = is_generator

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -19,7 +19,7 @@ from .client import _Client
 from .cls import _Cls
 from .config import logger
 from .exception import InvalidError, deprecation_error
-from .functions import PartialFunction, _Function, _PartialFunction
+from .functions import P, PartialFunction, _Function, _PartialFunction
 from .gpu import GPU_T
 from .image import _Image
 from .mount import _Mount
@@ -70,12 +70,11 @@ CLS_T = typing.TypeVar("CLS_T", bound=typing.Type)
 
 
 class _FunctionDecorator(Protocol):
-    def __call__(self, function: Union[_PartialFunction, Callable[..., Any]], _cls: Optional[CLS_T] = None) -> _Function:
+    def __call__(self, function: Union[_PartialFunction, Callable[P, Any]], _cls: Optional[CLS_T] = None) -> _Function[P]:
         ...
 
 
-synchronize_api(Generic)  # dumb, needed or synchronicity
-synchronize_api(Protocol)  # same
+synchronize_api(Protocol)  # dumb, needed or synchronicity
 FunctionDecorator = synchronize_api(_FunctionDecorator)  # think needed for type stubs?
 
 
@@ -466,7 +465,7 @@ class _Stub:
         def wrapped(
             f: Union[_PartialFunction, Callable[..., Any]],
             _cls: Optional[type] = None,  # Used for methods only
-        ) -> _Function:
+        ) -> _Function[P]:
             is_generator_override: Optional[bool] = is_generator
 
             if isinstance(f, _PartialFunction):


### PR DESCRIPTION
This should in theory work, in that the type arguments of a modalized function should carry through so that you can call it using `.remote` with the same parameter types, and it will know what those are.

But I believe synchronicity mangles ParamSpec right now. Looks like `Callable[P, Any]` gets translated into `Callable[[P], Any]` or something similar. Not sure what's up.