### PR TITLE
Fix error for deprecated local calls of looked up functions

### DIFF
--- a/client_test/lookup_test.py
+++ b/client_test/lookup_test.py
@@ -2,7 +2,7 @@
 import pytest
 
 from modal import Function, Queue, Stub, web_endpoint
-from modal.exception import NotFoundError
+from modal.exception import DeprecationError, ExecutionError, NotFoundError
 from modal.runner import deploy_stub
 
 
@@ -45,6 +45,16 @@ async def test_lookup_function(servicer, client):
     # Make sure we can call this function
     assert await f.remote.aio(2, 4) == 20
     assert [r async for r in f.map([5, 2], [4, 3])] == [41, 13]
+
+    # Make sure the new-style local calls raise an error
+    with pytest.raises(ExecutionError):
+        assert f.local(2, 4) == 20
+
+    # Make sure the old-style local calls raise an error
+    with pytest.raises(ExecutionError):
+        # It also throws a deprecation warning, so let's ignore that
+        with pytest.warns(DeprecationError):
+            assert f(2, 4) == 20
 
 
 @pytest.mark.asyncio

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -891,6 +891,7 @@ class _Function(_Object, type_prefix="fu"):
             False  # set when a user terminates the app intentionally, to prevent useless traceback spam
         )
         self._function_name = None
+        self._info = None
 
     def _hydrate_metadata(self, metadata: Message):
         # Overridden concrete implementation of base class method
@@ -1139,7 +1140,7 @@ class _Function(_Object, type_prefix="fu"):
                 "The definition for this function is missing so it is not possible to invoke it locally. "
                 "If this function was retrieved via `Function.lookup` you need to use `.remote()`."
             )
-            raise AttributeError(msg)
+            raise ExecutionError(msg)
 
         self_obj = self._get_self_obj()
         if self_obj:
@@ -1172,7 +1173,7 @@ class _Function(_Object, type_prefix="fu"):
                     "The definition for this function is missing so it is not possible to invoke it locally. "
                     "If this function was retrieved via `Function.lookup` you need to use `.remote()`."
                 )
-                raise AttributeError(msg)
+                raise ExecutionError(msg)
 
             self_obj = self._get_self_obj()
             if self_obj:


### PR DESCRIPTION
Minor thing I ran into. If you used `.lookup` and called the function using the old-style local syntax, you would get a weird error:

```
>>> f = modal.Function.lookup("deployed", "square")
>>> f(42)
<stdin>:1: DeprecationError: 2023-08-16: Calling Modal functions like `f(...)` is deprecated. Use `f.local(...)` if you want to call the function in the same Python process. Use `f.remote(...)` if you want to call the function in a Modal container in the cloud
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ <stdin>:1 in <module>                                                                            │
│                                                                                                  │
│                                                                                                  │
│ /Users/erikbern/modal-client/modal/functions.py:1169 in __call__                                 │
│                                                                                                  │
│   1168 │   │   │                                                                                 │
│ ❱ 1169 │   │   │   info = self._get_info()                                                       │
│   1170 │   │   │   if not info:                                                                  │
│                                                                                                  │
│ /Users/erikbern/python3.10-env/lib/python3.10/site-packages/synchronicity/synchronizer.py:497 in │
│ proxy_method                                                                                     │
│                                                                                                  │
│ /Users/erikbern/python3.10-env/lib/python3.10/site-packages/synchronicity/synchronizer.py:398 in │
│ f_wrapped                                                                                        │
│                                                                                                  │
│ /Users/erikbern/modal-client/modal/functions.py:1127 in _get_info                                │
│                                                                                                  │
│   1126 │   def _get_info(self):                                                                  │
│ ❱ 1127 │   │   return self._info                                                                 │
│   1128                                                                                           │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
AttributeError: '_Function' object has no attribute '_info'
>>> f.remote(42)
```

This now makes it a bit nicer:
```
>>> f = modal.Function.lookup("deployed", "square")
>>> f(42)
<stdin>:1: DeprecationError: 2023-08-16: Calling Modal functions like `f(...)` is deprecated. Use `f.local(...)` if you want to call the function in the same Python process. Use `f.remote(...)` if you want to call the function in a Modal container in the cloud
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ <stdin>:1 in <module>                                                                            │
│                                                                                                  │
│                                                                                                  │
│ /Users/erikbern/modal-client/modal/functions.py:1176 in __call__                                 │
│                                                                                                  │
│   1175 │   │   │   │   )                                                                         │
│ ❱ 1176 │   │   │   │   raise ExecutionError(msg)                                                 │
│   1177                                                                                           │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
ExecutionError: The definition for this function is missing so it is not possible to invoke it locally. If this function was retrieved via `Function.lookup` you need to use `.remote()`.
>>> f.remote(42)
1764
>>> 
```