### PR TITLE
[mod-1323] modal shell platform-specific fixes

### DIFF
--- a/modal/_pty.py
+++ b/modal/_pty.py
@@ -7,7 +7,6 @@ import platform
 import select
 import signal
 import sys
-import termios
 import traceback
 from typing import Optional, Tuple, no_type_check
 
@@ -76,6 +75,7 @@ def _pty_spawn(pty_info: api_pb2.PTYInfo, fn, args, kwargs):
     and run a custom function in the forked child process."""
 
     import pty
+    import termios
     import tty
 
     # https://github.com/google/gvisor/issues/9333

--- a/modal/_pty.py
+++ b/modal/_pty.py
@@ -6,6 +6,7 @@ import os
 import platform
 import select
 import sys
+import termios
 import traceback
 from typing import Optional, Tuple, no_type_check
 
@@ -89,7 +90,7 @@ def _pty_spawn(pty_info: api_pb2.PTYInfo, fn, args, kwargs):
 
     try:
         mode = tty.tcgetattr(pty.STDIN_FILENO)
-        tty.setraw(pty.STDIN_FILENO)
+        tty.setraw(pty.STDIN_FILENO, when=termios.TCSANOW)
         restore = 1
     except tty.error:  # This is the same as termios.error
         restore = 0
@@ -97,7 +98,7 @@ def _pty_spawn(pty_info: api_pb2.PTYInfo, fn, args, kwargs):
         pty._copy(master_fd, pty._read, pty._read)
     except OSError:
         if restore:
-            tty.tcsetattr(pty.STDIN_FILENO, tty.TCSAFLUSH, mode)
+            tty.tcsetattr(pty.STDIN_FILENO, tty.TCSANOW, mode)
 
     os.close(master_fd)
     return os.waitpid(pid, 0)[1]


### PR DESCRIPTION
I've identified at least 3 issues with gvisor's terminal handling

1. The exit of the replica/slave side (e.g. the `sh` or `bash` session) does not exit the parent process.
2. Issuing <kbd>CTRL</kbd> + <kbd>d</kbd> (EOF) on an empty buffer does not send EOF to slave, so session doesn't exit
3. Can't set raw mode with `pty.setraw(pty.STDIN_FILENO)` so echo doesn't work.

These PR has workarounds for 1 and 3. Fixing 2 will require a fix to gvisor as I can't think of a simple workaround. 

These changes are also compatible with `runc`.
