### PR TITLE
Only setup Rich tracebacks when running CLI

### DIFF
--- a/modal/__main__.py
+++ b/modal/__main__.py
@@ -1,10 +1,13 @@
 # Copyright Modal Labs 2022
+from ._traceback import setup_rich_traceback
 from .cli.entry_point import entrypoint_cli
 
 
 def main():
+    # Setup rich tracebacks, but only on user's end, when using the Modal CLI.
+    setup_rich_traceback()
     entrypoint_cli()
 
 
 if __name__ == "__main__":
-    entrypoint_cli()
+    main()

--- a/modal/cli/entry_point.py
+++ b/modal/cli/entry_point.py
@@ -70,5 +70,5 @@ entrypoint_cli.add_command(run.run, name="run")  # type: ignore
 entrypoint_cli.list_commands(None)  # type: ignore
 
 if __name__ == "__main__":
-    # this module is only called from tests, otherwise the parent package __init__.py is used as the entrypoint
+    # this module is only called from tests, otherwise the parent package __main__.py is used as the entrypoint
     entrypoint_cli()

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -11,14 +11,13 @@ import click
 import typer
 from rich.console import Console
 
-from modal.config import config
-from modal.exception import InvalidError
-from modal.runner import deploy_stub, interactive_shell, run_stub
-from modal.serving import serve_stub
-from modal.stub import LocalEntrypoint, Stub
-
+from ..config import config
 from ..environments import ensure_env
+from ..exception import InvalidError
 from ..functions import Function
+from ..runner import deploy_stub, interactive_shell, run_stub
+from ..serving import serve_stub
+from ..stub import LocalEntrypoint, Stub
 from .import_refs import import_function, import_stub
 from .utils import ENV_OPTION, ENV_OPTION_HELP
 
@@ -206,9 +205,8 @@ def deploy(
     name: str = typer.Option(None, help="Name of the deployment."),
     env: str = ENV_OPTION,
 ):
-    env = ensure_env(
-        env
-    )  # this ensures that `modal.lookup()` without environment specification uses the same env as specified
+    # this ensures that `modal.lookup()` without environment specification uses the same env as specified
+    env = ensure_env(env)
 
     stub = import_stub(stub_ref)
 

--- a/modal/config.py
+++ b/modal/config.py
@@ -79,7 +79,6 @@ from datetime import date
 
 import toml
 
-from ._traceback import setup_rich_traceback
 from .exception import deprecation_error
 
 # Locate config file and read it
@@ -237,7 +236,3 @@ warnings.filterwarnings(
     category=DeprecationWarning,
     module="modal",
 )
-
-# Set up rich tracebacks, but only on user's end.
-if _user_config:
-    setup_rich_traceback()


### PR DESCRIPTION
This means that `import modal`, as well as Modal in Jupyter notebooks and `python` directly with `app.run()`, will not register global traceback handlers.

## Describe your changes

Resolves MOD-1579.
