### PR TITLE
Unify object metadata in protobuf

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -150,12 +150,13 @@ message AppGetObjectsRequest {
 
 message AppGetObjectsItem {
   string tag = 1;
-  string object_id = 2;
-  oneof handle_metadata_oneof {
+  string object_id = 2;  // deprecated soon
+  oneof handle_metadata_oneof {  // deprecated soon
     FunctionHandleMetadata function_handle_metadata = 3;
     MountHandleMetadata mount_handle_metadata = 4;
     ClassHandleMetadata class_handle_metadata = 5;
   }
+  Object object = 6;
 }
 
 message AppGetObjectsResponse {
@@ -193,13 +194,14 @@ message AppLookupObjectRequest {
 }
 
 message AppLookupObjectResponse {
-  string object_id = 1;
+  string object_id = 1; // deprecated soon
   string error_message = 2;
-  oneof handle_metadata_oneof {
+  oneof handle_metadata_oneof { // deprecated soon
     FunctionHandleMetadata function_handle_metadata = 3;
     MountHandleMetadata mount_handle_metadata = 4;
     ClassHandleMetadata class_handle_metadata = 5;
   }
+  Object object = 6;
 }
 
 message AppSetObjectsRequest {
@@ -959,6 +961,15 @@ message MountPutFileRequest {
 
 message MountPutFileResponse {
   bool exists = 2;
+}
+
+message Object {
+  string object_id = 1;
+  oneof handle_metadata_oneof {
+    FunctionHandleMetadata function_handle_metadata = 3;
+    MountHandleMetadata mount_handle_metadata = 4;
+    ClassHandleMetadata class_handle_metadata = 5;
+  }
 }
 
 message ProxyInfo {


### PR DESCRIPTION
My earlier fixes to unify things by changing the proto names caused a lot of pain. I think a better approach is to just put it in a joint message type.

Unfortunately doing that will cause a long deprecation path because of old clients. But let's at least start writing to this new field. It requires a couple more changes (on the server side, then on the client to read the new field). But it's not a ton of work all in all.