### PR TITLE
Use new unified Object protobuf message

### DIFF
--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -399,12 +399,12 @@ def test_environment_flag(test_dir, servicer, command):
     with servicer.intercept() as ctx:
         ctx.add_response(
             "AppLookupObject",
-            api_pb2.AppLookupObjectResponse(object_id="mo-123"),
+            api_pb2.AppLookupObjectResponse(object=api_pb2.Object(object_id="mo-123")),
             request_filter=lambda req: req.app_name.startswith("modal-client-mount"),
         )  # built-in client lookup
         ctx.add_response(
             "AppLookupObject",
-            api_pb2.AppLookupObjectResponse(object_id="sv-123"),
+            api_pb2.AppLookupObjectResponse(object=api_pb2.Object(object_id="sv-123")),
             request_filter=lambda req: req.app_name == "volume_app",
         )
         _run(command + ["--env=staging", str(stub_file)])
@@ -437,12 +437,12 @@ def test_environment_noflag(test_dir, servicer, command, monkeypatch):
     with servicer.intercept() as ctx:
         ctx.add_response(
             "AppLookupObject",
-            api_pb2.AppLookupObjectResponse(object_id="mo-123"),
+            api_pb2.AppLookupObjectResponse(object=api_pb2.Object(object_id="mo-123")),
             request_filter=lambda req: req.app_name.startswith("modal-client-mount"),
         )  # built-in client lookup
         ctx.add_response(
             "AppLookupObject",
-            api_pb2.AppLookupObjectResponse(object_id="sv-123"),
+            api_pb2.AppLookupObjectResponse(object=api_pb2.Object(object_id="sv-123")),
             request_filter=lambda req: req.app_name == "volume_app",
         )
         _run(command + [str(stub_file)])

--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -188,8 +188,10 @@ class MockClientServicer(api_grpc.ModalClientBase):
         items = [
             api_pb2.AppGetObjectsItem(
                 tag=tag,
-                object_id=object_id,
-                function_handle_metadata=function_definition_to_handle_metadata(self.app_functions.get(object_id)),
+                object=api_pb2.Object(
+                    object_id=object_id,
+                    function_handle_metadata=function_definition_to_handle_metadata(self.app_functions.get(object_id)),
+                ),
             )
             for tag, object_id in object_ids.items()
         ]
@@ -236,7 +238,9 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
         function_handle_metadata = function_definition_to_handle_metadata(self.app_functions.get(object_id))
         await stream.send_message(
-            api_pb2.AppLookupObjectResponse(object_id=object_id, function_handle_metadata=function_handle_metadata)
+            api_pb2.AppLookupObjectResponse(
+                object=api_pb2.Object(object_id=object_id, function_handle_metadata=function_handle_metadata),
+            )
         )
 
     async def AppHeartbeat(self, stream):

--- a/client_test/runner_test.py
+++ b/client_test/runner_test.py
@@ -28,7 +28,7 @@ def test_run_stub_profile_env_with_refs(servicer, client, monkeypatch):
     assert ctx.calls == []  # all calls should be deferred
 
     with servicer.intercept() as ctx:
-        ctx.add_response("AppLookupObject", api_pb2.AppLookupObjectResponse(object_id="st-123"))
+        ctx.add_response("AppLookupObject", api_pb2.AppLookupObjectResponse(object=api_pb2.Object(object_id="st-123")))
         with run_stub(dummy_stub, client=client):
             pass
 
@@ -51,8 +51,8 @@ def test_run_stub_custom_env_with_refs(servicer, client, monkeypatch):
     )  # explicit lookup
 
     with servicer.intercept() as ctx:
-        ctx.add_response("AppLookupObject", api_pb2.AppLookupObjectResponse(object_id="st-123"))
-        ctx.add_response("AppLookupObject", api_pb2.AppLookupObjectResponse(object_id="st-456"))
+        ctx.add_response("AppLookupObject", api_pb2.AppLookupObjectResponse(object=api_pb2.Object(object_id="st-123")))
+        ctx.add_response("AppLookupObject", api_pb2.AppLookupObjectResponse(object=api_pb2.Object(object_id="st-456")))
         with run_stub(dummy_stub, client=client, environment_name="custom"):
             pass
 

--- a/modal/app.py
+++ b/modal/app.py
@@ -227,8 +227,8 @@ class _App:
         req = api_pb2.AppGetObjectsRequest(app_id=self._app_id)
         resp = await retry_transient_errors(self._client.stub.AppGetObjects, req)
         for item in resp.items:
-            self._tag_to_object_id[item.tag] = item.object_id
-            handle_metadata: Optional[Message] = get_proto_oneof(item, "handle_metadata_oneof")
+            self._tag_to_object_id[item.tag] = item.object.object_id
+            handle_metadata: Optional[Message] = get_proto_oneof(item.object, "handle_metadata_oneof")
             if handle_metadata is not None:
                 self._tag_to_handle_metadata[item.tag] = handle_metadata
 
@@ -248,7 +248,7 @@ class _App:
         obj_req = api_pb2.AppGetObjectsRequest(app_id=existing_app_id)
         obj_resp = await retry_transient_errors(client.stub.AppGetObjects, obj_req)
         app_page_url = f"https://modal.com/apps/{existing_app_id}"  # TODO (elias): this should come from the backend
-        object_ids = {item.tag: item.object_id for item in obj_resp.items}
+        object_ids = {item.tag: item.object.object_id for item in obj_resp.items}
         return _App(client, existing_app_id, app_page_url, output_mgr, tag_to_object_id=object_ids)
 
     @staticmethod

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -150,8 +150,8 @@ message AppGetObjectsRequest {
 
 message AppGetObjectsItem {
   string tag = 1;
-  string object_id = 2;  // deprecated soon
-  oneof handle_metadata_oneof {  // deprecated soon
+  string object_id = 2;  // deprecated
+  oneof handle_metadata_oneof {  // deprecated
     FunctionHandleMetadata function_handle_metadata = 3;
     MountHandleMetadata mount_handle_metadata = 4;
     ClassHandleMetadata class_handle_metadata = 5;
@@ -194,9 +194,9 @@ message AppLookupObjectRequest {
 }
 
 message AppLookupObjectResponse {
-  string object_id = 1; // deprecated soon
+  string object_id = 1; // deprecated
   string error_message = 2;
-  oneof handle_metadata_oneof { // deprecated soon
+  oneof handle_metadata_oneof { // deprecated
     FunctionHandleMetadata function_handle_metadata = 3;
     MountHandleMetadata mount_handle_metadata = 4;
     ClassHandleMetadata class_handle_metadata = 5;


### PR DESCRIPTION
Uses the new message on the client side since the server is now returning it as well.

This will let us remove the old fields later (in a few months). Old clients still rely on those fields to the server needs to send them for a while.