### PR TITLE
Create classes on the backend, support class lookups

### DIFF
--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -9,8 +9,8 @@ from modal import Cls, Function, Stub, method
 from modal._serialization import deserialize
 from modal.cls import ClsMixin
 from modal.exception import DeprecationError, ExecutionError
-from modal_proto import api_pb2
 from modal.runner import deploy_stub
+from modal_proto import api_pb2
 
 stub = Stub()
 

--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -8,7 +8,7 @@ from typing_extensions import assert_type
 from modal import Cls, Function, Stub, method
 from modal._serialization import deserialize
 from modal.cls import ClsMixin
-from modal.exception import DeprecationError
+from modal.exception import DeprecationError, ExecutionError
 from modal_proto import api_pb2
 from modal.runner import deploy_stub
 
@@ -243,6 +243,13 @@ def test_lookup(client, servicer):
     # Check that function properties are preserved
     assert cls.bar.is_generator is False
 
-    # Make sure we can all this methods
+    # Make sure we can instantiate the class
+    obj = cls("foo", 234)
+
+    # Make sure we can methods
     # (mock servicer just returns the sum of the squares of the args)
-    assert cls.bar.remote(42, 77) == 7693
+    assert obj.bar.remote(42, 77) == 7693
+
+    # Make sure local calls fail
+    with pytest.raises(ExecutionError):
+        assert obj.bar.local(1, 2)

--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -26,6 +26,7 @@ def test_run_class(client, servicer):
     assert servicer.n_functions == 0
     with stub.run(client=client) as app:
         function_id = Foo.bar.object_id
+        assert isinstance(Foo, Cls)
         class_id = Foo.object_id
 
     objects = servicer.app_objects[app.app_id]

--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -239,3 +239,10 @@ def test_lookup(client, servicer):
 
     assert cls.object_id.startswith("cs-")
     assert cls.bar.object_id.startswith("fu-")
+
+    # Check that function properties are preserved
+    assert cls.bar.is_generator is False
+
+    # Make sure we can all this methods
+    # (mock servicer just returns the sum of the squares of the args)
+    assert cls.bar.remote(42, 77) == 7693

--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -5,11 +5,12 @@ from typing import TYPE_CHECKING
 
 from typing_extensions import assert_type
 
-from modal import Function, Stub, method
+from modal import Cls, Function, Stub, method
 from modal._serialization import deserialize
 from modal.cls import ClsMixin
 from modal.exception import DeprecationError
 from modal_proto import api_pb2
+from modal.runner import deploy_stub
 
 stub = Stub()
 
@@ -24,14 +25,13 @@ class Foo:
 def test_run_class(client, servicer):
     assert servicer.n_functions == 0
     with stub.run(client=client) as app:
-        pass
+        function_id = Foo.bar.object_id
+        class_id = Foo.object_id
 
-    assert servicer.n_functions == 1
-    (function_id,) = servicer.app_functions.keys()
-    function = servicer.app_functions[function_id]
-    assert function.function_name == "Foo.bar"
     objects = servicer.app_objects[app.app_id]
-    assert objects == {"Foo.bar": function_id}
+    assert len(objects) == 2  # class and functions
+    assert objects["Foo.bar"] == function_id
+    assert objects["Foo"] == class_id
 
 
 def test_call_class_sync(client, servicer):
@@ -230,3 +230,12 @@ if TYPE_CHECKING:
     # Check that type annotations carry through to the decorated classes
     assert_type(Foo(), Foo)
     assert_type(Foo().bar, Function)
+
+
+def test_lookup(client, servicer):
+    deploy_stub(stub, "my-cls-app", client=client)
+
+    cls: Cls = Cls.lookup("my-cls-app", "Foo", client=client)
+
+    assert cls.object_id.startswith("cs-")
+    assert cls.bar.object_id.startswith("fu-")

--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -14,7 +14,7 @@ import tempfile
 import traceback
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict
 
 import aiohttp.web
 import aiohttp.web_runner
@@ -306,7 +306,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
     ### Class
 
     async def ClassCreate(self, stream):
-        request: ClassCreateRequest = await stream.recv_message()
+        request: api_pb2.ClassCreateRequest = await stream.recv_message()
         methods: dict[str, str] = {method.function_name: method.function_id for method in request.methods}
         class_id = "cs-" + str(len(self.classes))
         self.classes[class_id] = methods

--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -307,6 +307,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def ClassCreate(self, stream):
         request: api_pb2.ClassCreateRequest = await stream.recv_message()
+        assert request.app_id
         methods: dict[str, str] = {method.function_name: method.function_id for method in request.methods}
         class_id = "cs-" + str(len(self.classes))
         self.classes[class_id] = methods

--- a/client_test/container_app_test.py
+++ b/client_test/container_app_test.py
@@ -7,6 +7,7 @@ from unittest import mock
 import modal.secret
 from modal import App, Image, Stub
 from modal.exception import InvalidError
+from modal_proto import api_pb2
 
 from .supports.skip import skip_windows_unix_socket
 
@@ -26,6 +27,8 @@ async def test_container_function_lazily_imported(unix_servicer, container_clien
         "my_f_1": "fu-123",
         "my_f_2": "fu-456",
     }
+    unix_servicer.app_functions["fu-123"] = api_pb2.Function()
+    unix_servicer.app_functions["fu-456"] = api_pb2.Function()
 
     await App.init_container.aio(container_client, "ap-123")
     stub = Stub()

--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -3,6 +3,7 @@ from modal_version import __version__
 
 from .app import App, container_app, is_local
 from .client import Client
+from .cls import Cls
 from .dict import Dict
 from .exception import Error
 from .functions import Function, asgi_app, current_input_id, method, web_endpoint, wsgi_app
@@ -22,6 +23,7 @@ __all__ = [
     "__version__",
     "App",
     "Client",
+    "Cls",
     "Cron",
     "Dict",
     "Error",

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -1,12 +1,16 @@
 # Copyright Modal Labs 2022
+import asyncio
 import pickle
 from datetime import date
-from typing import Any, Callable, Dict, Type, TypeVar
+from typing import Any, Callable, Dict, Optional, Type, TypeVar
 
+from modal_proto import api_pb2
 from modal_utils.async_utils import synchronize_api
 
+from ._resolver import Resolver
 from .exception import deprecation_warning
 from .functions import _Function
+from .object import _Object
 
 T = TypeVar("T")
 
@@ -74,15 +78,29 @@ class _Obj:
 Obj = synchronize_api(_Obj)
 
 
-class _Cls:
-    # TODO(erikbern): Make this inherit from Object (needs backend support for this)
+class _Cls(_Object, type_prefix="cs"):
     _user_cls: type
     _functions: Dict[str, _Function]
 
-    def __init__(self, user_cls, base_functions: Dict[str, _Function]):
-        self._user_cls = user_cls
-        self._base_functions = base_functions
-        setattr(self._user_cls, "_modal_functions", base_functions)  # Needed for PartialFunction.__get__
+    @staticmethod
+    def from_local(user_cls, base_functions: Dict[str, _Function]) -> "_Cls":
+        async def _load(provider: _Object, resolver: Resolver, existing_object_id: Optional[str]):
+            # Make sure all functions are loaded
+            await asyncio.gather(*[resolver.load(function) for function in base_functions.values()])
+
+            # Create class remotely
+            req = api_pb2.ClassCreateRequest()
+            for f_name, f in base_functions.items():
+                req.methods.append(api_pb2.ClassMethod(function_name=f_name, function_id=f.object_id))
+            resp = await resolver.client.stub.ClassCreate(req)
+            provider._hydrate(response.class_id, resolver.client, None)
+
+        rep = f"Cls({user_cls.__name__})"
+        cls = _Cls._from_loader(_load, rep)
+        cls._user_cls = user_cls
+        cls._base_functions = base_functions
+        setattr(cls._user_cls, "_modal_functions", base_functions)  # Needed for PartialFunction.__get__
+        return cls
 
     def get_user_cls(self):
         # Used by the container entrypoint

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -81,10 +81,11 @@ Obj = synchronize_api(_Obj)
 
 
 class _Cls(_Object, type_prefix="cs"):
-    _user_cls: type
+    _user_cls: Optional[type]
     _functions: Dict[str, _Function]
 
     def _initialize_from_empty(self):
+        self._user_cls = None
         self._base_functions = {}
 
     def _hydrate_metadata(self, metadata: Message):

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -103,7 +103,7 @@ class _Cls(_Object, type_prefix="cs"):
             await asyncio.gather(*[resolver.load(function) for function in base_functions.values()])
 
             # Create class remotely
-            req = api_pb2.ClassCreateRequest()
+            req = api_pb2.ClassCreateRequest(app_id=resolver.app_id, existing_class_id=existing_object_id)
             for f_name, f in base_functions.items():
                 req.methods.append(api_pb2.ClassMethod(function_name=f_name, function_id=f.object_id))
             resp = await resolver.client.stub.ClassCreate(req)

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -91,7 +91,9 @@ class _Cls(_Object, type_prefix="cs"):
     def _hydrate_metadata(self, metadata: Message):
         self._base_functions = {}
         for method in metadata.methods:
-            function: _Function = _Function._new_hydrated(method.function_id, self._client, method.function_handle_metadata)
+            function: _Function = _Function._new_hydrated(
+                method.function_id, self._client, method.function_handle_metadata
+            )
             self._base_functions[method.function_name] = function
 
     @staticmethod

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -88,7 +88,10 @@ class _Cls(_Object, type_prefix="cs"):
         self._base_functions = {}
 
     def _hydrate_metadata(self, metadata: Message):
-        self._base_functions = {method.function_name: method.function_id for method in metadata.methods}
+        self._base_functions = {}
+        for method in metadata.methods:
+            function: _Function = _Function._new_hydrated(method.function_id, self._client, method.function_handle_metadata)
+            self._base_functions[method.function_name] = function
 
     @staticmethod
     def from_local(user_cls, base_functions: Dict[str, _Function]) -> "_Cls":

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -579,7 +579,10 @@ class _Stub:
                     partial_function = synchronizer._translate_in(v)  # TODO: remove need for?
                     functions[k] = decorator(partial_function, user_cls)
 
-            return _Cls(user_cls, functions)
+            tag: str = user_cls.__name__
+            cls: _Cls = _Cls.from_local(user_cls, functions)
+            self._add_object(tag, cls)
+            return cls
 
         return wrapper
 


### PR DESCRIPTION
This enables code such as

```python
MyClass = Cls.lookup("my-cls-app", "Foo")  # lookup class
my_object = MyClass("foo", 123)  # instantiate class
res = my_object.method.remote(1, 2, 3, "xyz")  # call method on object
```

Besides test fixtures and tests (most of this PR), the actual logic is not advanced – just plumbing to hydrate from metadata properly.