### PR TITLE
ClassHandleMetadata needs to contain FunctionHandleMetadata

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -222,6 +222,9 @@ message AppHeartbeatRequest {
 message ClassMethod {
   string function_name = 1;
   string function_id = 2;
+
+  // Class methods need to hydrate all functions on the class
+  FunctionHandleMetadata function_handle_metadata = 3;
 }
 
 message ClassCreateRequest {


### PR DESCRIPTION
Small thing needed for class lookups. Since classes hold references to functions, we need to return the information needed to hydrate those functions as well. Adding it to the proto here, will make a separate backend change to return that data.

Needed for https://github.com/modal-labs/modal-client/pull/842 to work