### PR TITLE
More helpful warning if you forget parentheses to local_entrypoint

### DIFF
--- a/client_test/stub_test.py
+++ b/client_test/stub_test.py
@@ -310,3 +310,15 @@ def test_keyboard_interrupt(servicer, client):
     with stub.run(client=client):
         # The exit handler should catch this interrupt and exit gracefully
         raise KeyboardInterrupt()
+
+
+def test_local_entrypoint_without_parantheses():
+    stub = Stub()
+
+    with pytest.raises(InvalidError) as excinfo:
+
+        @stub.local_entrypoint  # type: ignore
+        def f():
+            pass
+
+    assert "local_entrypoint()" in str(excinfo.value)

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -396,6 +396,12 @@ class _Stub:
         information on usage.
 
         """
+        if callable(name):
+            raise InvalidError(
+                "Invalid value for `name`. Did you forget parantheses? Suggestion: `@stub.local_entrypoint()`."
+            )
+        if name is not None and not isinstance(name, str):
+            raise InvalidError("Invalid value for `name`: Must be string.")
 
         def wrapped(raw_f: Callable[..., Any]) -> None:
             info = FunctionInfo(raw_f)


### PR DESCRIPTION
If you forgot parentheses, this used to not warn at all, which is pretty confusing.