### PR TITLE
bump minor version to 52

### DIFF
--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -7,7 +7,7 @@ from ._version_generated import build_number  # Written by GitHub
 major_number = 0
 
 # Bump this manually on any major changes
-minor_number = 51
+minor_number = 52
 
 # Right now, set the patch number (the 3rd field) to the job run number in GitHub
 __version__ = f"{major_number}.{minor_number}.{build_number}"


### PR DESCRIPTION
0.52 (and late 0.51 clients) fixes a couple of big things:

* New syntax for parametrized functions
* No more 20GB A100s