### PR TITLE
Handle unserializable values in image `run_function` globals

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -202,7 +202,10 @@ class _Image(_Object, type_prefix="im"):
                     try:
                         serialize(v)
                     except Exception:
-                        # Silently skip unserializable values for now.
+                        # Skip unserializable values for now.
+                        logger.warning(
+                            f"Skipping unserializable global variable {k} for {build_function._get_info().function_name}. Changes to this variable won't invalidate the image."
+                        )
                         continue
                     filtered_globals[k] = v
 

--- a/modal/image.py
+++ b/modal/image.py
@@ -195,10 +195,20 @@ class _Image(_Object, type_prefix="im"):
                 build_function_id = (await resolver.load(build_function)).object_id
 
                 globals = build_function._get_info().get_globals()
+                filtered_globals = {}
+                for k, v in globals.items():
+                    if isfunction(v):
+                        continue
+                    try:
+                        serialize(v)
+                    except Exception:
+                        # Silently skip unserializable values for now.
+                        continue
+                    filtered_globals[k] = v
+
                 # Cloudpickle function serialization produces unstable values.
                 # TODO: better way to filter out types that don't have a stable hash?
-                globals = {k: v for k, v in globals.items() if not isfunction(v)}
-                build_function_globals = serialize(globals) if globals else None
+                build_function_globals = serialize(filtered_globals) if filtered_globals else None
             else:
                 build_function_def = None
                 build_function_id = None


### PR DESCRIPTION
I don't love this because it serializes each global value twice. But I wanted to keep the serialization format the same as now. `dill` has a `.pickles()` check, but don't want to add another dep either. 