### PR TITLE
Handle `web_endpoint` without parens, unify decorator check between `web_endpoint`, `asgi_app`, and `wsgi_app`

### DIFF
--- a/client_test/decorator_test.py
+++ b/client_test/decorator_test.py
@@ -8,51 +8,43 @@ from modal.exception import InvalidError
 def test_local_entrypoint_forgot_parentheses():
     stub = Stub()
 
-    with pytest.raises(InvalidError) as excinfo:
+    with pytest.raises(InvalidError, match="local_entrypoint()") as excinfo:
 
         @stub.local_entrypoint  # type: ignore
         def f():
             pass
 
-    assert "local_entrypoint()" in str(excinfo.value)
-
 
 def test_function_forgot_parentheses():
     stub = Stub()
 
-    with pytest.raises(InvalidError) as excinfo:
+    with pytest.raises(InvalidError, match="function()") as excinfo:
 
         @stub.function  # type: ignore
         def f():
             pass
 
-    assert "function()" in str(excinfo.value)
-
 
 def test_cls_forgot_parentheses():
     stub = Stub()
 
-    with pytest.raises(InvalidError) as excinfo:
+    with pytest.raises(InvalidError, match="cls()") as excinfo:
 
         @stub.cls  # type: ignore
         class XYZ:
             pass
 
-    assert "cls()" in str(excinfo.value)
-
 
 def test_method_forgot_parentheses():
     stub = Stub()
 
-    with pytest.raises(InvalidError) as excinfo:
+    with pytest.raises(InvalidError, match="method()") as excinfo:
 
         @stub.cls()
         class XYZ:
             @method  # type: ignore
             def f(self):
                 pass
-
-    assert "method()" in str(excinfo.value)
 
 
 def test_invalid_web_decorator_usage():

--- a/client_test/decorator_test.py
+++ b/client_test/decorator_test.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2023
 import pytest
 
-from modal import Stub, method, web_endpoint
+from modal import Stub, method, web_endpoint, asgi_app, wsgi_app
 from modal.exception import InvalidError
 
 
@@ -55,15 +55,26 @@ def test_method_forgot_parentheses():
     assert "method()" in str(excinfo.value)
 
 
-def test_web_endpoint_forgot_parentheses():
+def test_invalid_web_decorator_usage():
     stub = Stub()
 
-    with pytest.raises(InvalidError) as excinfo:
+    with pytest.raises(InvalidError, match="web_endpoint()"):
 
-        @stub.cls()
-        class XYZ:
-            @web_endpoint  # type: ignore
-            def f(self):
-                pass
+        @stub.function()  # type: ignore
+        @web_endpoint  # type: ignore
+        def my_handle():
+            pass
 
-    assert "web_endpoint()" in str(excinfo.value)
+    with pytest.raises(InvalidError, match="asgi_app()"):
+
+        @stub.function()  # type: ignore
+        @asgi_app  # type: ignore
+        def my_handle_asgi():
+            pass
+
+    with pytest.raises(InvalidError, match="wsgi_app()"):
+
+        @stub.function()  # type: ignore
+        @wsgi_app  # type: ignore
+        def my_handle_wsgi():
+            pass

--- a/client_test/decorator_test.py
+++ b/client_test/decorator_test.py
@@ -1,14 +1,14 @@
 # Copyright Modal Labs 2023
 import pytest
 
-from modal import Stub, method, web_endpoint, asgi_app, wsgi_app
+from modal import Stub, asgi_app, method, web_endpoint, wsgi_app
 from modal.exception import InvalidError
 
 
 def test_local_entrypoint_forgot_parentheses():
     stub = Stub()
 
-    with pytest.raises(InvalidError, match="local_entrypoint()") as excinfo:
+    with pytest.raises(InvalidError, match="local_entrypoint()"):
 
         @stub.local_entrypoint  # type: ignore
         def f():
@@ -18,7 +18,7 @@ def test_local_entrypoint_forgot_parentheses():
 def test_function_forgot_parentheses():
     stub = Stub()
 
-    with pytest.raises(InvalidError, match="function()") as excinfo:
+    with pytest.raises(InvalidError, match="function()"):
 
         @stub.function  # type: ignore
         def f():
@@ -28,7 +28,7 @@ def test_function_forgot_parentheses():
 def test_cls_forgot_parentheses():
     stub = Stub()
 
-    with pytest.raises(InvalidError, match="cls()") as excinfo:
+    with pytest.raises(InvalidError, match="cls()"):
 
         @stub.cls  # type: ignore
         class XYZ:
@@ -38,7 +38,7 @@ def test_cls_forgot_parentheses():
 def test_method_forgot_parentheses():
     stub = Stub()
 
-    with pytest.raises(InvalidError, match="method()") as excinfo:
+    with pytest.raises(InvalidError, match="method()"):
 
         @stub.cls()
         class XYZ:

--- a/client_test/decorator_test.py
+++ b/client_test/decorator_test.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2023
 import pytest
 
-from modal import Stub, method
+from modal import Stub, method, web_endpoint
 from modal.exception import InvalidError
 
 
@@ -53,3 +53,17 @@ def test_method_forgot_parentheses():
                 pass
 
     assert "method()" in str(excinfo.value)
+
+
+def test_web_endpoint_forgot_parentheses():
+    stub = Stub()
+
+    with pytest.raises(InvalidError) as excinfo:
+
+        @stub.cls()
+        class XYZ:
+            @web_endpoint  # type: ignore
+            def f(self):
+                pass
+
+    assert "web_endpoint()" in str(excinfo.value)

--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -8,7 +8,7 @@ import typing
 import cloudpickle
 from synchronicity.exceptions import UserCodeException
 
-from modal import NetworkFileSystem, Proxy, Stub, asgi_app, web_endpoint, wsgi_app
+from modal import NetworkFileSystem, Proxy, Stub, web_endpoint
 from modal.exception import DeprecationError, ExecutionError, InvalidError
 from modal.functions import Function, FunctionCall, gather
 from modal.runner import deploy_stub

--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -611,29 +611,6 @@ def test_serialize_deserialize_function_handle(servicer, client):
         assert rehydrated_function_handle.web_url == "http://xyz.internal"
 
 
-def test_invalid_web_decorator_usage():
-    with pytest.raises(InvalidError, match="Add empty parens to the decorator"):
-
-        @stub.function()  # type: ignore
-        @web_endpoint  # type: ignore
-        def my_handle():
-            pass
-
-    with pytest.raises(InvalidError, match="Add empty parens to the decorator"):
-
-        @stub.function()  # type: ignore
-        @asgi_app  # type: ignore
-        def my_handle_asgi():
-            pass
-
-    with pytest.raises(InvalidError, match="Add empty parens to the decorator"):
-
-        @stub.function()  # type: ignore
-        @wsgi_app  # type: ignore
-        def my_handle_wsgi():
-            pass
-
-
 def test_default_cloud_provider(client, servicer, monkeypatch):
     stub = Stub()
 

--- a/client_test/webhook_test.py
+++ b/client_test/webhook_test.py
@@ -137,9 +137,9 @@ async def test_asgi_wsgi(servicer, client):
 
 
 def test_positional_method(servicer, client):
-    with pytest.raises(InvalidError, match="method=") as excinfo:
+    with pytest.raises(InvalidError, match="method="):
         web_endpoint("GET")
-    with pytest.raises(InvalidError, match="label=") as excinfo:
+    with pytest.raises(InvalidError, match="label="):
         asgi_app("baz")
-    with pytest.raises(InvalidError, match="label=") as excinfo:
+    with pytest.raises(InvalidError, match="label="):
         wsgi_app("baz")

--- a/client_test/webhook_test.py
+++ b/client_test/webhook_test.py
@@ -137,10 +137,9 @@ async def test_asgi_wsgi(servicer, client):
 
 
 def test_positional_method(servicer, client):
-    with pytest.raises(InvalidError) as excinfo:
-
-        @web_endpoint("GET")
-        def g(x):
-            pass
-
-    assert "method" in str(excinfo.value).lower()
+    with pytest.raises(InvalidError, match="method=") as excinfo:
+        web_endpoint("GET")
+    with pytest.raises(InvalidError, match="label=") as excinfo:
+        asgi_app("baz")
+    with pytest.raises(InvalidError, match="label=") as excinfo:
+        wsgi_app("baz")

--- a/client_test/webhook_test.py
+++ b/client_test/webhook_test.py
@@ -134,3 +134,13 @@ async def test_asgi_wsgi(servicer, client):
     assert len(servicer.app_functions) == 2
     assert servicer.app_functions["fu-1"].webhook_config.type == api_pb2.WEBHOOK_TYPE_ASGI_APP
     assert servicer.app_functions["fu-2"].webhook_config.type == api_pb2.WEBHOOK_TYPE_WSGI_APP
+
+
+def test_positional_method(servicer, client):
+    with pytest.raises(InvalidError) as excinfo:
+
+        @web_endpoint("GET")
+        def g(x):
+            pass
+
+    assert "method" in str(excinfo.value).lower()

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1394,6 +1394,8 @@ def _parse_custom_domains(custom_domains: Optional[Iterable[str]] = None) -> Lis
 
 @typechecked
 def _web_endpoint(
+    _warn_parentheses_missing=None,
+    *,
     method: str = "GET",  # REST method for the created endpoint.
     label: Optional[str] = None,  # Label for created endpoint. Final subdomain will be <workspace>--<label>.modal.run.
     wait_for_response: bool = True,  # Whether requests should wait for and return the function response.
@@ -1422,12 +1424,13 @@ def _web_endpoint(
     * `wait_for_response=True` - tries to fulfill the request on the original URL, but returns a 302 redirect after ~150s to a result URL (original URL with an added `__modal_function_id=...` query parameter)
     * `wait_for_response=False` - immediately returns a 202 ACCEPTED response with a JSON payload: `{"result_url": "..."}` containing the result "redirect" URL from above (which in turn redirects to itself every ~150s)
     """
-    if not isinstance(method, str):
+    if isinstance(_warn_parentheses_missing, str):
+        # Probably passing the method string as a positional argument.
         raise InvalidError(
-            f"Unexpected argument {method} of type {type(method)} for `method` parameter. "
-            "Add empty parens to the decorator, e.g. @web_endpoint() if there are no arguments. "
-            "Otherwise, pass an argument of type `str`: @web_endpoint(method='POST')"
+            'Positional arguments to `@web_endpoint` are not allowed. Suggestion: `@web_endpoint(method="GET")`.'
         )
+    elif _warn_parentheses_missing:
+        raise InvalidError("Did you forget parentheses? Suggestion: `@web_endpoint()`.")
 
     def wrapper(raw_f: Callable[..., Any]) -> _PartialFunction:
         if isinstance(raw_f, _Function):

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1375,7 +1375,7 @@ def _method(
     ```
     """
     if _warn_parentheses_missing:
-        raise InvalidError("Did you forget parentheses? Suggestion: `@method()`.")
+        raise InvalidError("Positional arguments are not allowed. Did you forget parentheses? Suggestion: `@method()`.")
 
     def wrapper(raw_f: Callable[..., Any]) -> _PartialFunction:
         return _PartialFunction(raw_f, is_generator=is_generator)
@@ -1430,7 +1430,7 @@ def _web_endpoint(
             'Positional arguments to `@web_endpoint` are not allowed. Suggestion: `@web_endpoint(method="GET")`.'
         )
     elif _warn_parentheses_missing:
-        raise InvalidError("Did you forget parentheses? Suggestion: `@web_endpoint()`.")
+        raise InvalidError("Positional arguments are not allowed. Did you forget parentheses? Suggestion: `@web_endpoint()`.")
 
     def wrapper(raw_f: Callable[..., Any]) -> _PartialFunction:
         if isinstance(raw_f, _Function):
@@ -1462,6 +1462,8 @@ def _web_endpoint(
 
 @typechecked
 def _asgi_app(
+    _warn_parentheses_missing=None,
+    *,
     label: Optional[str] = None,  # Label for created endpoint. Final subdomain will be <workspace>--<label>.modal.run.
     wait_for_response: bool = True,  # Whether requests should wait for and return the function response.
     custom_domains: Optional[
@@ -1493,12 +1495,8 @@ def _asgi_app(
     * wait_for_response=True - tries to fulfill the request on the original URL, but returns a 302 redirect after ~150s to a result URL (original URL with an added `__modal_function_id=fc-1234abcd` query parameter)
     * wait_for_response=False - immediately returns a 202 ACCEPTED response with a JSON payload: `{"result_url": "..."}` containing the result "redirect" url from above (which in turn redirects to itself every 150s)
     """
-    if label and not isinstance(label, str):
-        raise InvalidError(
-            f"Unexpected argument {label} of type {type(label)} for `label` parameter. "
-            "Add empty parens to the decorator, e.g. @asgi_app() if there are no arguments. "
-            "Otherwise, pass an argument of type `str`: @asgi_app(label='mylabel')"
-        )
+    if _warn_parentheses_missing:
+        raise InvalidError("Positional arguments are not allowed. Did you forget parentheses? Suggestion: `@asgi_app()`.")
 
     def wrapper(raw_f: Callable[..., Any]) -> _PartialFunction:
         if not wait_for_response:
@@ -1521,6 +1519,8 @@ def _asgi_app(
 
 @typechecked
 def _wsgi_app(
+    _warn_parentheses_missing=None,
+    *,
     label: Optional[str] = None,  # Label for created endpoint. Final subdomain will be <workspace>--<label>.modal.run.
     wait_for_response: bool = True,  # Whether requests should wait for and return the function response.
     custom_domains: Optional[
@@ -1549,12 +1549,8 @@ def _wsgi_app(
 
     For documentation on this decorator's arguments see [`asgi_app`](/docs/reference/modal.asgi_app).
     """
-    if label and not isinstance(label, str):
-        raise InvalidError(
-            f"Unexpected argument {label} of type {type(label)} for `label` parameter. "
-            "Add empty parens to the decorator, e.g. @wsgi_app() if there are no arguments. "
-            "Otherwise, pass an argument of type `str`: @wsgi_app(label='mylabel')"
-        )
+    if _warn_parentheses_missing:
+        raise InvalidError("Positional arguments are not allowed. Did you forget parentheses? Suggestion: `@wsgi_app()`.")
 
     def wrapper(raw_f: Callable[..., Any]) -> _PartialFunction:
         if not wait_for_response:

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1426,11 +1426,11 @@ def _web_endpoint(
     """
     if isinstance(_warn_parentheses_missing, str):
         # Probably passing the method string as a positional argument.
-        raise InvalidError(
-            'Positional arguments to `@web_endpoint` are not allowed. Suggestion: `@web_endpoint(method="GET")`.'
-        )
+        raise InvalidError('Positional arguments are not allowed. Suggestion: `@web_endpoint(method="GET")`.')
     elif _warn_parentheses_missing:
-        raise InvalidError("Positional arguments are not allowed. Did you forget parentheses? Suggestion: `@web_endpoint()`.")
+        raise InvalidError(
+            "Positional arguments are not allowed. Did you forget parentheses? Suggestion: `@web_endpoint()`."
+        )
 
     def wrapper(raw_f: Callable[..., Any]) -> _PartialFunction:
         if isinstance(raw_f, _Function):
@@ -1495,8 +1495,12 @@ def _asgi_app(
     * wait_for_response=True - tries to fulfill the request on the original URL, but returns a 302 redirect after ~150s to a result URL (original URL with an added `__modal_function_id=fc-1234abcd` query parameter)
     * wait_for_response=False - immediately returns a 202 ACCEPTED response with a JSON payload: `{"result_url": "..."}` containing the result "redirect" url from above (which in turn redirects to itself every 150s)
     """
-    if _warn_parentheses_missing:
-        raise InvalidError("Positional arguments are not allowed. Did you forget parentheses? Suggestion: `@asgi_app()`.")
+    if isinstance(_warn_parentheses_missing, str):
+        raise InvalidError('Positional arguments are not allowed. Suggestion: `@asgi_app(label="foo")`.')
+    elif _warn_parentheses_missing:
+        raise InvalidError(
+            "Positional arguments are not allowed. Did you forget parentheses? Suggestion: `@asgi_app()`."
+        )
 
     def wrapper(raw_f: Callable[..., Any]) -> _PartialFunction:
         if not wait_for_response:
@@ -1549,8 +1553,12 @@ def _wsgi_app(
 
     For documentation on this decorator's arguments see [`asgi_app`](/docs/reference/modal.asgi_app).
     """
-    if _warn_parentheses_missing:
-        raise InvalidError("Positional arguments are not allowed. Did you forget parentheses? Suggestion: `@wsgi_app()`.")
+    if isinstance(_warn_parentheses_missing, str):
+        raise InvalidError('Positional arguments are not allowed. Suggestion: `@wsgi_app(label="foo")`.')
+    elif _warn_parentheses_missing:
+        raise InvalidError(
+            "Positional arguments are not allowed. Did you forget parentheses? Suggestion: `@wsgi_app()`."
+        )
 
     def wrapper(raw_f: Callable[..., Any]) -> _PartialFunction:
         if not wait_for_response:


### PR DESCRIPTION
I forgot to handle `web_endpoint` in https://github.com/modal-labs/modal-client/pull/853 – adding it

EDIT: also adding `asgi_app` and `wsgi_app`

Turns out we already had a check but I'm changing it slightly to not allow method as a positional arg. I doubt people pass `method` as a positional argument? But if they do for whatever reason, they will get an error about it:
```
Positional arguments to `@web_endpoint` are not allowed. Suggestion: `@web_endpoint(method="GET")`
```

EDIT: turns out we also had a check for `asgi_app` and `wsgi_app` that did allow for `label` to be provided positionally.
