### PR TITLE
Move spawn_sandbox to the stub

### DIFF
--- a/client_test/sandbox_test.py
+++ b/client_test/sandbox_test.py
@@ -17,8 +17,8 @@ skip_non_linux = pytest.mark.skipif(platform.system() != "Linux", reason="sandbo
 
 @skip_non_linux
 def test_spawn_sandbox(client, servicer):
-    with stub.run(client=client) as app:
-        sb = app.spawn_sandbox("bash", "-c", "echo bye >&2 && sleep 1 && echo hi && exit 42", timeout=600)
+    with stub.run(client=client):
+        sb = stub.spawn_sandbox("bash", "-c", "echo bye >&2 && sleep 1 && echo hi && exit 42", timeout=600)
 
         t0 = time.time()
         sb.wait()
@@ -35,8 +35,8 @@ def test_spawn_sandbox(client, servicer):
 def test_sandbox_mount(client, servicer, tmpdir):
     tmpdir.join("a.py").write(b"foo")
 
-    with stub.run(client=client) as app:
-        sb = app.spawn_sandbox(
+    with stub.run(client=client):
+        sb = stub.spawn_sandbox(
             "echo",
             "hi",
             mounts=[Mount.from_local_dir(Path(tmpdir), remote_path="/m")],
@@ -51,8 +51,8 @@ def test_sandbox_mount(client, servicer, tmpdir):
 def test_sandbox_image(client, servicer, tmpdir):
     tmpdir.join("a.py").write(b"foo")
 
-    with stub.run(client=client) as app:
-        sb = app.spawn_sandbox("echo", "hi", image=Image.debian_slim().pip_install("foo", "bar", "potato"))
+    with stub.run(client=client):
+        sb = stub.spawn_sandbox("echo", "hi", image=Image.debian_slim().pip_install("foo", "bar", "potato"))
         sb.wait()
 
     idx = max(servicer.images.keys())
@@ -63,8 +63,8 @@ def test_sandbox_image(client, servicer, tmpdir):
 
 @skip_non_linux
 def test_sandbox_secret(client, servicer, tmpdir):
-    with stub.run(client=client) as app:
-        sb = app.spawn_sandbox("echo", "$FOO", secrets=[Secret.from_dict({"FOO": "BAR"})])
+    with stub.run(client=client):
+        sb = stub.spawn_sandbox("echo", "$FOO", secrets=[Secret.from_dict({"FOO": "BAR"})])
         sb.wait()
 
     assert len(servicer.sandbox_defs[0].secret_ids) == 1
@@ -72,12 +72,12 @@ def test_sandbox_secret(client, servicer, tmpdir):
 
 @skip_non_linux
 def test_sandbox_nfs(client, servicer, tmpdir):
-    with stub.run(client=client) as app:
+    with stub.run(client=client):
         nfs = NetworkFileSystem.new()
 
         with pytest.raises(InvalidError):
-            app.spawn_sandbox("echo", "foo > /cache/a.txt", network_file_systems={"/": nfs})
+            stub.spawn_sandbox("echo", "foo > /cache/a.txt", network_file_systems={"/": nfs})
 
-        app.spawn_sandbox("echo", "foo > /cache/a.txt", network_file_systems={"/cache": nfs})
+        stub.spawn_sandbox("echo", "foo > /cache/a.txt", network_file_systems={"/cache": nfs})
 
     assert len(servicer.sandbox_defs[0].nfs_mounts) == 1

--- a/client_test/sandbox_test.py
+++ b/client_test/sandbox_test.py
@@ -7,7 +7,7 @@ import time
 from pathlib import Path
 
 from modal import Image, Mount, NetworkFileSystem, Secret, Stub
-from modal.exception import InvalidError
+from modal.exception import DeprecationError, InvalidError
 
 stub = Stub()
 
@@ -81,3 +81,10 @@ def test_sandbox_nfs(client, servicer, tmpdir):
         stub.spawn_sandbox("echo", "foo > /cache/a.txt", network_file_systems={"/cache": nfs})
 
     assert len(servicer.sandbox_defs[0].nfs_mounts) == 1
+
+
+@skip_non_linux
+def test_spawn_sandbox_on_app_deprecated(client, servicer):
+    with stub.run(client=client) as app:
+        with pytest.warns(DeprecationError):
+            app.spawn_sandbox("bash", "-c", "echo bye >&2 && sleep 1 && echo hi && exit 42", timeout=600)

--- a/client_test/webhook_test.py
+++ b/client_test/webhook_test.py
@@ -36,7 +36,7 @@ async def test_webhook(servicer, client):
 
         # Make sure the container gets the app id as well
         container_app = await App.init_container.aio(client, app.app_id)
-        container_app._associate_stub(stub)
+        container_app._associate_stub_container(stub)
         f_c = container_app._get_object("f")
         assert isinstance(f_c, Function)
         assert f_c.web_url

--- a/modal/app.py
+++ b/modal/app.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2022
-import os
 from datetime import date
-from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, TypeVar
 
 from google.protobuf.message import Message
 
@@ -14,8 +13,6 @@ from ._resolver import Resolver
 from .client import _Client
 from .config import logger
 from .exception import deprecation_warning
-from .gpu import GPU_T
-from .network_file_system import _NetworkFileSystem
 from .object import _Object
 
 if TYPE_CHECKING:
@@ -324,43 +321,12 @@ class _App:
 
     async def spawn_sandbox(
         self,
-        *entrypoint_args: str,
-        image: Optional["modal.image._Image"] = None,  # The image to run as the container for the sandbox.
-        mounts: Sequence["modal.mount._Mount"] = (),  # Mounts to attach to the sandbox.
-        secrets: Sequence["modal.secret._Secret"] = (),  # Environment variables to inject into the sandbox.
-        network_file_systems: Dict[Union[str, os.PathLike], _NetworkFileSystem] = {},
-        timeout: Optional[int] = None,  # Maximum execution time of the sandbox in seconds.
-        workdir: Optional[str] = None,  # Working directory of the sandbox.
-        gpu: GPU_T = None,
-        cloud: Optional[str] = None,
-        cpu: Optional[float] = None,  # How many CPU cores to request. This is a soft limit.
-        memory: Optional[int] = None,  # How much memory to request, in MiB. This is a soft limit.
+        *args,
+        **kwargs,
     ) -> "modal.sandbox._Sandbox":
-        """Sandboxes are a way to run arbitrary commands in dynamically defined environments.
-
-        This function returns a [SandboxHandle](/docs/reference/modal.Sandbox#modalsandboxsandbox), which can be used to interact with the running sandbox.
-
-        Refer to the [docs](/docs/guide/sandbox) on how to spawn and use sandboxes.
-        """
-        from .sandbox import _Sandbox
-        from .stub import _default_image
-
-        resolver = Resolver(self._client, environment_name=self._environment_name, app_id=self.app_id)
-        obj = _Sandbox._new(
-            entrypoint_args,
-            image=image or _default_image,
-            mounts=mounts,
-            secrets=secrets,
-            timeout=timeout,
-            workdir=workdir,
-            gpu=gpu,
-            cloud=cloud,
-            cpu=cpu,
-            memory=memory,
-            network_file_systems=network_file_systems,
-        )
-        await resolver.load(obj)
-        return obj
+        """Deprecated. Use `Stub.spawn_sandbox` instead."""
+        deprecation_warning(date(2023, 9, 11), _App.spawn_sandbox.__doc__)
+        return self._associated_stub.spawn_sandbox(*args, **kwargs)
 
     @staticmethod
     def _reset_container():

--- a/modal/app.py
+++ b/modal/app.py
@@ -90,7 +90,7 @@ class _App:
         """A unique identifier for this running App."""
         return self._app_id
 
-    def _associate_stub(self, stub):
+    def _associate_stub_container(self, stub):
         if self._associated_stub:
             if self._stub_name:
                 warning_sub_message = f"stub with the same name ('{self._stub_name}')"
@@ -115,6 +115,9 @@ class _App:
                 # Can't find the object, create a new one
                 obj = _Object._new_hydrated(object_id, self._client, handle_metadata)
             self._tag_to_object[tag] = obj
+
+    def _associate_stub_local(self, stub):
+        self._associated_stub = stub
 
     async def _create_all_objects(
         self, blueprint: Dict[str, _Object], new_app_state: int, environment_name: str, shell: bool = False

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -66,7 +66,7 @@ async def _run_stub(
         environment_name=environment_name,
         output_mgr=output_mgr,
     )
-    async with stub._set_app(app), TaskContext(grace=config["logs_timeout"]) as tc:
+    async with stub._set_local_app(app), TaskContext(grace=config["logs_timeout"]) as tc:
         # Start heartbeats loop to keep the client alive
         tc.infinite_loop(lambda: _heartbeat(client, app.app_id), sleep=HEARTBEAT_INTERVAL)
 

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -14,6 +14,7 @@ from modal_utils.async_utils import synchronize_api, synchronizer
 from ._function_utils import FunctionInfo
 from ._ipython import is_notebook
 from ._output import OutputManager
+from ._resolver import Resolver
 from .app import _App, _container_app, is_local
 from .client import _Client
 from .cls import _Cls
@@ -29,6 +30,7 @@ from .proxy import _Proxy
 from .queue import _Queue
 from .retries import Retries
 from .runner import _run_stub
+from .sandbox import _Sandbox
 from .schedule import Schedule
 from .secret import _Secret
 from .volume import _Volume
@@ -612,6 +614,50 @@ class _Stub:
                 self._function_mounts[root_path] = mount
             cached_mounts.append(self._function_mounts[root_path])
         return cached_mounts
+
+    async def spawn_sandbox(
+        self,
+        *entrypoint_args: str,
+        image: Optional[_Image] = None,  # The image to run as the container for the sandbox.
+        mounts: Sequence[_Mount] = (),  # Mounts to attach to the sandbox.
+        secrets: Sequence[_Secret] = (),  # Environment variables to inject into the sandbox.
+        network_file_systems: Dict[Union[str, os.PathLike], _NetworkFileSystem] = {},
+        timeout: Optional[int] = None,  # Maximum execution time of the sandbox in seconds.
+        workdir: Optional[str] = None,  # Working directory of the sandbox.
+        gpu: GPU_T = None,
+        cloud: Optional[str] = None,
+        cpu: Optional[float] = None,  # How many CPU cores to request. This is a soft limit.
+        memory: Optional[int] = None,  # How much memory to request, in MiB. This is a soft limit.
+    ) -> _Sandbox:
+        """Sandboxes are a way to run arbitrary commands in dynamically defined environments.
+
+        This function returns a [SandboxHandle](/docs/reference/modal.Sandbox#modalsandboxsandbox), which can be used to interact with the running sandbox.
+
+        Refer to the [docs](/docs/guide/sandbox) on how to spawn and use sandboxes.
+        """
+        from .sandbox import _Sandbox
+        from .stub import _default_image
+
+        if self._app is None:
+            raise InvalidError("`stub.spawn_sandbox` requires a running app.")
+
+        # TODO(erikbern): pulling a lot of app internals here, let's clean up shortly
+        resolver = Resolver(self._app._client, environment_name=self._app._environment_name, app_id=self._app._app_id)
+        obj = _Sandbox._new(
+            entrypoint_args,
+            image=image or _default_image,
+            mounts=mounts,
+            secrets=secrets,
+            timeout=timeout,
+            workdir=workdir,
+            gpu=gpu,
+            cloud=cloud,
+            cpu=cpu,
+            memory=memory,
+            network_file_systems=network_file_systems,
+        )
+        await resolver.load(obj)
+        return obj
 
 
 Stub = synchronize_api(_Stub)

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -165,7 +165,7 @@ class _Stub:
         string_name = self._name or ""
 
         if not is_local() and _container_app._stub_name == string_name:
-            _container_app._associate_stub(self)
+            _container_app._associate_stub_container(self)
             # note that all stubs with the correct name will get the container app assigned
             self._app = _container_app
 
@@ -265,8 +265,9 @@ class _Stub:
         return image._is_inside()
 
     @asynccontextmanager
-    async def _set_app(self, app: _App) -> AsyncGenerator[None, None]:
+    async def _set_local_app(self, app: _App) -> AsyncGenerator[None, None]:
         self._app = app
+        app._associate_stub_local(self)
         try:
             yield
         finally:


### PR DESCRIPTION
Instead of `stub.app.spawn_sandbox`, users should use `stub.spawn_sandbox`

There is a bit of irony in this PR:
1. We're moving methods from the app to the stub, in order to deprecate the app, so that we can rename the stub to the app
2. Part of why stubs and apps should be merged is that there's already annoying mutual dependencies between those two apps. This PR exacerbates these dependencies. But that seems fine since the end goal is to merge those and get rid of the dependencies altogether.
