### PR TITLE
Better error message for invalid constructors

### DIFF
--- a/client_test/object_test.py
+++ b/client_test/object_test.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 import pytest
 
-from modal import Queue, Stub
+from modal import Queue, Secret, Stub
 from modal.exception import DeprecationError, InvalidError
 
 
@@ -45,3 +45,11 @@ def test_new_hydrated(client):
 
     with pytest.raises(InvalidError):
         _Object._new_hydrated("xy-123", client, None)
+
+
+def test_constructor():
+    with pytest.raises(InvalidError) as excinfo:
+        Secret({"foo": 123})
+
+    assert "Secret" in str(excinfo.value)
+    assert "constructor" in str(excinfo.value)

--- a/modal/object.py
+++ b/modal/object.py
@@ -42,8 +42,8 @@ class _Object:
             cls._type_prefix = type_prefix
             cls._prefix_to_type[type_prefix] = cls
 
-    def __init__(self):
-        raise Exception("__init__ disallowed, use proper classmethods")
+    def __init__(self, *args, **kwargs):
+        raise InvalidError(f"Class {type(self).__name__} has no constructor. Use class constructor methods instead.")
 
     def _init(
         self,


### PR DESCRIPTION
If you tried to instantiate `Secret({"foo": 123}")` (old syntax) it would print a cryptic error message:

```
    def my_init(self, *args, **kwargs):
        # Create base instance
        args = synchronizer_self._translate_in(args)
        kwargs = synchronizer_self._translate_in(kwargs)
>       instance = cls(*args, **kwargs)
E       TypeError: _Object.__init__() takes 1 positional argument but 2 were given

../synchronicity/synchronicity/synchronizer.py:544: TypeError
```

Now it prints this:

```
    def __init__(self, *args, **kwargs):
>       raise Exception(f"Class {type(self).__name__} has no constructor. Use class constructor methods instead.")
E       Exception: Class _Secret has no constructor. Use class constructor methods instead.

modal/object.py:46: Exception
```