### PR TITLE
Deprecation warning on stub.app

### DIFF
--- a/modal/runner.py
+++ b/modal/runner.py
@@ -47,7 +47,7 @@ async def _run_stub(
             " Are you calling stub.run() directly?"
             " Consider using the `modal run` shell command."
         )
-    if stub.app:
+    if stub._app:
         raise InvalidError(
             "App is already running and can't be started again.\n"
             "You should not use `stub.run` or `run_stub` within a Modal local_entrypoint"

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -19,7 +19,7 @@ from .app import _App, _container_app, is_local
 from .client import _Client
 from .cls import _Cls
 from .config import logger
-from .exception import InvalidError, deprecation_error
+from .exception import InvalidError, deprecation_error, deprecation_warning
 from .functions import PartialFunction, _Function, _PartialFunction
 from .gpu import GPU_T
 from .image import _Image
@@ -179,6 +179,7 @@ class _Stub:
     @property
     def app(self) -> Optional[_App]:
         """Reference to the currently running app, if any."""
+        deprecation_warning(date(2023, 9, 11), "Access to `.app` is deprecated.")
         return self._app
 
     @property

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -107,7 +107,6 @@ class _Stub:
 
     _name: Optional[str]
     _description: Optional[str]
-    _app_id: str
     _blueprint: Dict[str, _Object]
     _function_mounts: Dict[str, _Mount]
     _mounts: Sequence[_Mount]
@@ -181,6 +180,11 @@ class _Stub:
         """Reference to the currently running app, if any."""
         deprecation_warning(date(2023, 9, 11), "Access to `.app` is deprecated.")
         return self._app
+
+    @property
+    def app_id(self) -> Optional[str]:
+        """Return the app_id, if the stub is running."""
+        return self._app.app_id if self._app else None
 
     @property
     def description(self) -> Optional[str]:
@@ -644,7 +648,7 @@ class _Stub:
             raise InvalidError("`stub.spawn_sandbox` requires a running app.")
 
         # TODO(erikbern): pulling a lot of app internals here, let's clean up shortly
-        resolver = Resolver(self._app._client, environment_name=self._app._environment_name, app_id=self._app._app_id)
+        resolver = Resolver(self._app._client, environment_name=self._app._environment_name, app_id=self.app_id)
         obj = _Sandbox._new(
             entrypoint_args,
             image=image or _default_image,


### PR DESCRIPTION
Add a deprecation warning when you try to access `.app` on a stub. This helps us deprecate the app.

Also added an `app_id` property since we grab it from the app in few examples