### PR TITLE
[mod 1599] Volume.read_file support

### DIFF
--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -668,7 +668,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         items = [api_pb2.SecretListItem(label=f"dummy-secret-{i}") for i, _ in enumerate(self.secrets)]
         await stream.send_message(api_pb2.SecretListResponse(items=items))
 
-    ### Shared volume
+    ### Network File System (née Shared volume)
 
     async def SharedVolumeCreate(self, stream):
         nfs_id = f"sv-{len(self.nfs_files)}"
@@ -711,6 +711,8 @@ class MockClientServicer(api_grpc.ModalClientBase):
                 token_secret="xyz",
             )
         )
+
+    ### Volume
 
     async def VolumeCreate(self, stream):
         await stream.recv_message()

--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -91,6 +91,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.task_result = None
 
         self.nfs_files: Dict[str, Dict[str, api_pb2.SharedVolumePutFileRequest]] = defaultdict(dict)
+        self.volume_files: Dict[str, Dict[str, bytes]] = defaultdict(dict)
         self.images = {}
         self.image_build_function_ids = {}
         self.force_built_images = []
@@ -256,7 +257,8 @@ class MockClientServicer(api_grpc.ModalClientBase):
             if object_id:
                 assert object_id.startswith(request.object_entity)
 
-        await stream.send_message(api_pb2.AppLookupObjectResponse(object=self.get_object_metadata(object_id)))
+        response = api_pb2.AppLookupObjectResponse(object=self.get_object_metadata(object_id))
+        await stream.send_message(response)
 
     async def AppHeartbeat(self, stream):
         request: api_pb2.AppHeartbeatRequest = await stream.recv_message()
@@ -717,7 +719,9 @@ class MockClientServicer(api_grpc.ModalClientBase):
     async def VolumeCreate(self, stream):
         await stream.recv_message()
         self.volume_counter += 1
-        await stream.send_message(api_pb2.VolumeCreateResponse(volume_id=f"vo-{self.volume_counter}"))
+        volume_id = f"vo-{self.volume_counter}"
+        self.volume_files[volume_id] = {}
+        await stream.send_message(api_pb2.VolumeCreateResponse(volume_id=volume_id))
 
     async def VolumeCommit(self, stream):
         req = await stream.recv_message()
@@ -728,6 +732,11 @@ class MockClientServicer(api_grpc.ModalClientBase):
         req = await stream.recv_message()
         self.volume_reloads[req.volume_id] += 1
         await stream.send_message(Empty())
+
+    async def VolumeGetFile(self, stream):
+        req = await stream.recv_message()
+        data = self.volume_files[req.volume_id][req.path]
+        await stream.send_message(api_pb2.VolumeGetFileResponse(data=data))
 
 
 @pytest_asyncio.fixture

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -164,7 +164,19 @@ class _Volume(_Object, type_prefix="vo"):
         return [entry async for entry in self.iterdir(path)]
 
     async def read_file(self, path: Union[str, bytes]) -> AsyncIterator[bytes]:
-        """Read a file from the modal.Volume."""
+        """
+        Read a file from the modal.Volume.
+
+        **Example:**
+
+        ```python notest
+        vol = modal.Volume.lookup("my-modal-volume")
+        data = b""
+        for chunk in vol.read_file("1mb.csv"):
+            data += chunk
+        print(len(data))  # == 1024 * 1024
+        ```
+        """
         if isinstance(path, str):
             path = path.encode("utf-8")
         req = api_pb2.VolumeGetFileRequest(volume_id=self.object_id, path=path)

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -1,6 +1,6 @@
 # Copyright Modal Labs 2023
 import asyncio
-from typing import AsyncIterator, List, Optional
+from typing import AsyncIterator, List, Optional, Union
 
 from modal_proto import api_pb2
 from modal_utils.async_utils import asyncnullcontext, synchronize_api
@@ -164,8 +164,10 @@ class _Volume(_Object, type_prefix="vo"):
         """
         return [entry async for entry in self.iterdir(path)]
 
-    async def read_file(self, path: str) -> AsyncIterator[bytes]:
+    async def read_file(self, path: Union[str, bytes]) -> AsyncIterator[bytes]:
         """Read a file from the modal.Volume."""
+        if isinstance(path, str):
+            path = path.encode("utf-8")
         req = api_pb2.VolumeGetFileRequest(volume_id=self.object_id, path=path)
         response = await retry_transient_errors(self._client.stub.VolumeGetFile, req)
         if response.WhichOneof("data_oneof") == "data":

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -6,7 +6,6 @@ from modal_proto import api_pb2
 from modal_utils.async_utils import asyncnullcontext, synchronize_api
 from modal_utils.grpc_utils import retry_transient_errors, unary_stream
 
-from ._blob_utils import blob_iter
 from ._resolver import Resolver
 from .object import _Object
 
@@ -169,12 +168,8 @@ class _Volume(_Object, type_prefix="vo"):
         if isinstance(path, str):
             path = path.encode("utf-8")
         req = api_pb2.VolumeGetFileRequest(volume_id=self.object_id, path=path)
-        response = await retry_transient_errors(self._client.stub.VolumeGetFile, req)
-        if response.WhichOneof("data_oneof") == "data":
-            yield response.data
-        else:
-            async for data in blob_iter(response.data_blob_id, self._client.stub):
-                yield data
+        async for bytes_wrapper in unary_stream(self._client.stub.VolumeGetFile, req):
+            yield bytes_wrapper.value
 
 
 Volume = synchronize_api(_Volume)

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1445,7 +1445,7 @@ service ModalClient {
   // Volumes
   rpc VolumeCreate(VolumeCreateRequest) returns (VolumeCreateResponse);
   rpc VolumeCommit(VolumeCommitRequest) returns (google.protobuf.Empty);
-  rpc VolumeGetFile(VolumeGetFileRequest) returns (VolumeGetFileResponse);
+  rpc VolumeGetFile(VolumeGetFileRequest) returns (stream google.protobuf.BytesValue);
   rpc VolumeList(VolumeListRequest) returns (VolumeListResponse);
   rpc VolumeListFiles(VolumeListFilesRequest) returns (stream VolumeListFilesResponse);
   rpc VolumeReload(VolumeReloadRequest) returns (google.protobuf.Empty);

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1262,6 +1262,13 @@ message VolumeGetFileRequest {
   bytes path = 2;
 }
 
+message VolumeGetFileResponse {
+  oneof data_oneof {
+    bytes data = 1;
+    string data_blob_id = 2;
+  }
+}
+
 message VolumeListFilesEntry {
   enum FileType {
     UNSPECIFIED = 0;
@@ -1438,7 +1445,7 @@ service ModalClient {
   // Volumes
   rpc VolumeCreate(VolumeCreateRequest) returns (VolumeCreateResponse);
   rpc VolumeCommit(VolumeCommitRequest) returns (google.protobuf.Empty);
-  rpc VolumeGetFile(VolumeGetFileRequest) returns (stream google.protobuf.BytesValue);
+  rpc VolumeGetFile(VolumeGetFileRequest) returns (VolumeGetFileResponse);
   rpc VolumeList(VolumeListRequest) returns (VolumeListResponse);
   rpc VolumeListFiles(VolumeListFilesRequest) returns (stream VolumeListFilesResponse);
   rpc VolumeReload(VolumeReloadRequest) returns (google.protobuf.Empty);

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1257,6 +1257,18 @@ message VolumeCommitRequest {
   string volume_id = 1;
 }
 
+message VolumeGetFileRequest {
+  string volume_id = 1;
+  string path = 2;
+}
+
+message VolumeGetFileResponse {
+  oneof data_oneof {
+    bytes data = 1;
+    string data_blob_id = 2;
+  }
+}
+
 message VolumeListFilesEntry {
   enum FileType {
     UNSPECIFIED = 0;
@@ -1433,6 +1445,7 @@ service ModalClient {
   // Volumes
   rpc VolumeCreate(VolumeCreateRequest) returns (VolumeCreateResponse);
   rpc VolumeCommit(VolumeCommitRequest) returns (google.protobuf.Empty);
+  rpc VolumeGetFile(VolumeGetFileRequest) returns (VolumeGetFileResponse);
   rpc VolumeList(VolumeListRequest) returns (VolumeListResponse);
   rpc VolumeListFiles(VolumeListFilesRequest) returns (stream VolumeListFilesResponse);
   rpc VolumeReload(VolumeReloadRequest) returns (google.protobuf.Empty);

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1262,13 +1262,6 @@ message VolumeGetFileRequest {
   bytes path = 2;
 }
 
-message VolumeGetFileResponse {
-  oneof data_oneof {
-    bytes data = 1;
-    string data_blob_id = 2;
-  }
-}
-
 message VolumeListFilesEntry {
   enum FileType {
     UNSPECIFIED = 0;

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1259,7 +1259,7 @@ message VolumeCommitRequest {
 
 message VolumeGetFileRequest {
   string volume_id = 1;
-  string path = 2;
+  bytes path = 2;
 }
 
 message VolumeGetFileResponse {


### PR DESCRIPTION
### Describe your changes

Proto msgs and `Volume.read_file` method for volumes. 

- MOD-1599


### Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
   - Requires servers to be deployed with implementations of RPCs
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.
