### PR TITLE
[MOD-1611] Add internal runtime_debug client-side

### DIFF
--- a/modal/config.py
+++ b/modal/config.py
@@ -153,6 +153,7 @@ _SETTINGS = {
     "profiling_enabled": _Setting(False, transform=lambda x: x not in ("", "0")),
     "heartbeat_interval": _Setting(15, float),
     "function_runtime": _Setting(),
+    "function_runtime_debug": _Setting(False, transform=lambda x: x not in ("", "0")),  # For internal debugging use.
     "environment": _Setting(),
     "default_cloud": _Setting(None, transform=lambda x: x if x else None),
     "worker_id": _Setting(),  # For internal debugging use.

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -765,6 +765,7 @@ class _Function(_Object, type_prefix="fu"):
                 cloud_provider=cloud_provider,
                 warm_pool_size=keep_warm,
                 runtime=config.get("function_runtime"),
+                runtime_debug=config.get("function_runtime_debug"),
                 stub_name=stub_name,
                 is_builder_function=is_builder_function,
                 allow_concurrent_inputs=allow_concurrent_inputs,

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -538,6 +538,8 @@ message Function {
   repeated CustomDomainInfo custom_domain_info = 35;
 
   string worker_id = 36; // For internal debugging use only.
+
+  bool runtime_debug = 37; // For internal debugging use only.
 }
 
 message FunctionHandleMetadata {


### PR DESCRIPTION
### Describe your changes

Will be used internally to selectively enable runtime debugging.

- MOD-1611


### Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
    - Old server will just ignore field.
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.
