### PR TITLE
Patch progress bars for methods in `_Cls`

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -104,10 +104,7 @@ class _Cls(_Object, type_prefix="cs"):
         self._output_mgr: Optional[OutputManager] = None
 
     def _set_output_mgr(self, output_mgr: OutputManager):
-        for f in self._base_functions.values():
-            f._set_output_mgr(output_mgr)
-
-        self._output_mgr = output_mgr  # Save to propagate to parameterized functions
+        self._output_mgr = output_mgr
 
     def _hydrate_metadata(self, metadata: Message):
         self._base_functions = {}

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -50,7 +50,9 @@ class _Obj:
     _local_obj: Any
     _local_obj_constr: Optional[Callable[[], Any]]
 
-    def __init__(self, user_cls: type, output_mgr: Optional[OutputManager], base_functions: Dict[str, _Function], args, kwargs):
+    def __init__(
+        self, user_cls: type, output_mgr: Optional[OutputManager], base_functions: Dict[str, _Function], args, kwargs
+    ):
         for i, arg in enumerate(args):
             check_picklability(i + 1, arg)
         for key, kwarg in kwargs.items():
@@ -60,7 +62,6 @@ class _Obj:
         for k, fun in base_functions.items():
             self._functions[k] = fun.from_parametrized(self, args, kwargs)
             self._functions[k]._set_output_mgr(output_mgr)
-
 
         # Used for construction local object lazily
         self._has_local_obj = False
@@ -106,7 +107,7 @@ class _Cls(_Object, type_prefix="cs"):
         for f in self._base_functions.values():
             f._set_output_mgr(output_mgr)
 
-        self._output_mgr = output_mgr # Save to propagate to parameterized functions
+        self._output_mgr = output_mgr  # Save to propagate to parameterized functions
 
     def _hydrate_metadata(self, metadata: Message):
         self._base_functions = {}

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -86,6 +86,10 @@ async def _run_stub(
             for obj in stub.registered_functions.values():
                 obj._set_output_mgr(output_mgr)
 
+            # Update all the classes client-side to propagate output manager to their methods.
+            for obj in stub.registered_classes.values():
+                obj._set_output_mgr(output_mgr)
+
             # Show logs from dynamically created images.
             # TODO: better way to do this
             output_mgr.enable_image_logs()

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -346,7 +346,7 @@ class _Stub:
     @property
     def registered_functions(self) -> Dict[str, _Function]:
         """All modal.Function objects registered on the stub."""
-        return {tag: obj for tag, obj in self._blueprint.items() if isinstance(obj, _Function)}
+        return {tag: obj for tag, obj in self._blueprint.items() if isinstance(obj, (_Function, _Cls))}
 
     @property
     def registered_entrypoints(self) -> Dict[str, _LocalEntrypoint]:

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -346,7 +346,12 @@ class _Stub:
     @property
     def registered_functions(self) -> Dict[str, _Function]:
         """All modal.Function objects registered on the stub."""
-        return {tag: obj for tag, obj in self._blueprint.items() if isinstance(obj, (_Function, _Cls))}
+        return {tag: obj for tag, obj in self._blueprint.items() if isinstance(obj, _Function)}
+
+    @property
+    def registered_classes(self) -> Dict[str, _Function]:
+        """All modal.Cls objects registered on the stub."""
+        return {tag: obj for tag, obj in self._blueprint.items() if isinstance(obj, _Cls)}
 
     @property
     def registered_entrypoints(self) -> Dict[str, _LocalEntrypoint]:


### PR DESCRIPTION
### Brief

Save `OutputManager` object on `_Cls`. Then, when building methods, set their output manager from the `_Cls`.

After (both class function f and regular function go)

https://github.com/modal-labs/modal-client/assets/8001209/79176919-838c-43ab-9a99-2c0ab5b0684f

Before (only regular function go)


https://github.com/modal-labs/modal-client/assets/8001209/d5390cdc-6b92-4406-b217-487dbfd9d853

