### PR TITLE
stub.run() and run_stub() now returns the stub itself

### DIFF
--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -24,12 +24,13 @@ class Foo:
 
 def test_run_class(client, servicer):
     assert servicer.n_functions == 0
-    with stub.run(client=client) as app:
+    with stub.run(client=client):
         function_id = Foo.bar.object_id
         assert isinstance(Foo, Cls)
         class_id = Foo.object_id
+        app_id = stub.app_id
 
-    objects = servicer.app_objects[app.app_id]
+    objects = servicer.app_objects[app_id]
     assert len(objects) == 3  # classes and functions
     assert objects["Foo.bar"] == function_id
     assert objects["Foo"] == class_id

--- a/client_test/container_app_test.py
+++ b/client_test/container_app_test.py
@@ -50,13 +50,13 @@ async def test_is_inside(servicer, unix_servicer, client, container_client):
     stub = get_stub()
 
     # Run container
-    async with stub.run(client=client) as app:
+    async with stub.run(client=client):
         # We're not inside the container (yet)
         assert not stub.is_inside()
         assert not stub.is_inside(stub.image)
         assert not stub.is_inside(stub.image_2)
 
-        app_id = app.app_id
+        app_id = stub.app_id
         image_1_id = stub["image"].object_id
         image_2_id = stub["image_2"].object_id
 

--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -616,8 +616,8 @@ def test_default_cloud_provider(client, servicer, monkeypatch):
 
     monkeypatch.setenv("MODAL_DEFAULT_CLOUD", "oci")
     stub.function()(dummy)
-    with stub.run(client=client) as app:
-        f = servicer.app_functions[app._get_object("dummy").object_id]
+    with stub.run(client=client):
+        f = servicer.app_functions[stub.dummy.object_id]
 
     assert f.cloud_provider == api_pb2.CLOUD_PROVIDER_OCI
 

--- a/client_test/live_reload_test.py
+++ b/client_test/live_reload_test.py
@@ -4,6 +4,7 @@ import pytest
 import threading
 from unittest import mock
 
+from modal import Function
 from modal.serving import serve_stub
 
 from .supports.app_run_tests.webhook import stub
@@ -40,6 +41,7 @@ def test_file_changes_trigger_reloads(stub_ref, server_url_env, servicer):
     assert servicer.app_set_objects_count == 4  # 1 + number of file changes
     assert servicer.app_client_disconnect_count == 1
     assert servicer.app_get_logs_initial_count == 1
+    assert isinstance(stub.foo, Function)
     assert stub.foo.web_url.startswith("http://")
 
 

--- a/client_test/live_reload_test.py
+++ b/client_test/live_reload_test.py
@@ -34,14 +34,13 @@ def test_file_changes_trigger_reloads(stub_ref, server_url_env, servicer):
             yield
         watcher_done.set()
 
-    with serve_stub(stub, stub_ref, _watcher=fake_watch()) as app:
+    with serve_stub(stub, stub_ref, _watcher=fake_watch()):
         watcher_done.wait()  # wait until watcher loop is done
 
     assert servicer.app_set_objects_count == 4  # 1 + number of file changes
     assert servicer.app_client_disconnect_count == 1
     assert servicer.app_get_logs_initial_count == 1
-    foo = app._get_object("foo")
-    assert foo.web_url.startswith("http://")
+    assert stub.foo.web_url.startswith("http://")
 
 
 @pytest.mark.asyncio

--- a/client_test/object_test.py
+++ b/client_test/object_test.py
@@ -9,12 +9,12 @@ from modal.exception import DeprecationError, InvalidError
 async def test_async_factory(client):
     stub = Stub()
     stub["my_factory"] = Queue.new()
-    async with stub.run(client=client) as running_app:
+    async with stub.run(client=client):
         assert isinstance(stub["my_factory"], Queue)
         assert stub["my_factory"].object_id == "qu-1"
         with pytest.warns(DeprecationError):
-            assert isinstance(running_app["my_factory"], Queue)
-            assert running_app["my_factory"].object_id == "qu-1"
+            assert isinstance(stub.app["my_factory"], Queue)
+            assert stub.app["my_factory"].object_id == "qu-1"
 
 
 @pytest.mark.asyncio
@@ -23,10 +23,10 @@ async def test_use_object(client):
     q = Queue.from_name("foo-queue")
     assert isinstance(q, Queue)
     stub["my_q"] = q
-    async with stub.run(client=client) as running_app:
+    async with stub.run(client=client):
         assert stub["my_q"].object_id == "qu-foo"
         with pytest.warns(DeprecationError):
-            assert running_app["my_q"].object_id == "qu-foo"
+            assert stub.app["my_q"].object_id == "qu-foo"
 
 
 def test_new_hydrated(client):

--- a/client_test/sandbox_test.py
+++ b/client_test/sandbox_test.py
@@ -85,6 +85,8 @@ def test_sandbox_nfs(client, servicer, tmpdir):
 
 @skip_non_linux
 def test_spawn_sandbox_on_app_deprecated(client, servicer):
-    with stub.run(client=client) as app:
+    with stub.run(client=client):
+        with pytest.warns(DeprecationError):
+            app = stub.app
         with pytest.warns(DeprecationError):
             app.spawn_sandbox("bash", "-c", "echo bye >&2 && sleep 1 && echo hi && exit 42", timeout=600)

--- a/client_test/stub_test.py
+++ b/client_test/stub_test.py
@@ -20,7 +20,7 @@ async def test_kwargs(servicer, client):
         d=Dict.new(),
         q=Queue.new(),
     )
-    async with stub.run(client=client) as app:
+    async with stub.run(client=client):
         # TODO: interface to get type safe objects from live apps
         await stub["d"].put.aio("foo", "bar")  # type: ignore
         await stub["q"].put.aio("baz")  # type: ignore
@@ -28,9 +28,9 @@ async def test_kwargs(servicer, client):
         assert await stub["q"].get.aio() == "baz"  # type: ignore
 
         with pytest.warns(DeprecationError):
-            assert isinstance(app["d"], Dict)
+            assert isinstance(stub.app["d"], Dict)
         with pytest.warns(DeprecationError):
-            assert isinstance(app["q"], Queue)
+            assert isinstance(stub.app["q"], Queue)
 
 
 @pytest.mark.asyncio
@@ -38,16 +38,16 @@ async def test_attrs(servicer, client):
     stub = Stub()
     stub.d = Dict.new()
     stub.q = Queue.new()
-    async with stub.run(client=client) as app:
+    async with stub.run(client=client):
         await stub.d.put.aio("foo", "bar")  # type: ignore
         await stub.q.put.aio("baz")  # type: ignore
         assert await stub.d.get.aio("foo") == "bar"  # type: ignore
         assert await stub.q.get.aio() == "baz"  # type: ignore
 
         with pytest.warns(DeprecationError):
-            assert isinstance(app.d, Dict)
+            assert isinstance(stub.app.d, Dict)
         with pytest.warns(DeprecationError):
-            assert isinstance(app.q, Queue)
+            assert isinstance(stub.app.q, Queue)
 
 
 @pytest.mark.asyncio
@@ -174,8 +174,8 @@ def test_same_function_name(caplog):
 
 def test_run_state(client, servicer):
     stub = Stub()
-    with stub.run(client=client) as app:
-        assert servicer.app_state_history[app.app_id] == [api_pb2.APP_STATE_INITIALIZING, api_pb2.APP_STATE_EPHEMERAL]
+    with stub.run(client=client):
+        assert servicer.app_state_history[stub.app_id] == [api_pb2.APP_STATE_INITIALIZING, api_pb2.APP_STATE_EPHEMERAL]
 
 
 def test_deploy_state(client, servicer):
@@ -186,8 +186,8 @@ def test_deploy_state(client, servicer):
 
 def test_detach_state(client, servicer):
     stub = Stub()
-    with stub.run(client=client, detach=True) as app:
-        assert servicer.app_state_history[app.app_id] == [api_pb2.APP_STATE_INITIALIZING, api_pb2.APP_STATE_DETACHED]
+    with stub.run(client=client, detach=True):
+        assert servicer.app_state_history[stub.app_id] == [api_pb2.APP_STATE_INITIALIZING, api_pb2.APP_STATE_DETACHED]
 
 
 @pytest.mark.asyncio

--- a/client_test/webhook_test.py
+++ b/client_test/webhook_test.py
@@ -23,7 +23,7 @@ async def f(x):
 
 @pytest.mark.asyncio
 async def test_webhook(servicer, client):
-    async with stub.run(client=client) as app:
+    async with stub.run(client=client):
         assert f.web_url
 
         assert servicer.app_functions["fu-1"].webhook_config.type == api_pb2.WEBHOOK_TYPE_FUNCTION
@@ -35,7 +35,7 @@ async def test_webhook(servicer, client):
         assert await f.local(100) == {"square": 10000}
 
         # Make sure the container gets the app id as well
-        container_app = await App.init_container.aio(client, app.app_id)
+        container_app = await App.init_container.aio(client, stub.app_id)
         container_app._associate_stub_container(stub)
         f_c = container_app._get_object("f")
         assert isinstance(f_c, Function)

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -28,7 +28,7 @@ async def _heartbeat(client, app_id):
 
 @contextlib.asynccontextmanager
 async def _run_stub(
-    stub,
+    stub: "_Stub",
     client: Optional[_Client] = None,
     stdout=None,
     show_progress: bool = True,
@@ -36,7 +36,7 @@ async def _run_stub(
     output_mgr: Optional[OutputManager] = None,
     environment_name: Optional[str] = None,
     shell=False,
-) -> AsyncGenerator[_App, None]:
+) -> AsyncGenerator["_Stub", None]:
     """mdmd:hidden"""
     if environment_name is None:
         environment_name = config.get("environment")
@@ -98,11 +98,11 @@ async def _run_stub(
             if stub._pty_input_stream:
                 output_mgr._visible_progress = False
                 async with _pty.write_stdin_to_pty_stream(stub._pty_input_stream):
-                    yield app
+                    yield stub
                 output_mgr._visible_progress = True
             else:
                 with output_mgr.show_status_spinner():
-                    yield app
+                    yield stub
         except KeyboardInterrupt:
             # mute cancellation errors on all function handles to prevent exception spam
             for obj in stub.registered_functions.values():
@@ -150,7 +150,7 @@ async def _serve_update(
 
 
 async def _deploy_stub(
-    stub,
+    stub: "_Stub",
     name: str = None,
     namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
     client=None,

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -2,7 +2,7 @@
 import asyncio
 import contextlib
 from multiprocessing.synchronize import Event
-from typing import AsyncGenerator, Optional
+from typing import TYPE_CHECKING, AsyncGenerator, Optional, TypeVar
 
 from modal_proto import api_pb2
 from modal_utils.app_utils import is_valid_app_name
@@ -17,6 +17,11 @@ from .config import config
 from .exception import InvalidError
 from .functions import _Function
 
+if TYPE_CHECKING:
+    from .stub import _Stub
+else:
+    _Stub = TypeVar("_Stub")
+
 
 async def _heartbeat(client, app_id):
     request = api_pb2.AppHeartbeatRequest(app_id=app_id)
@@ -28,7 +33,7 @@ async def _heartbeat(client, app_id):
 
 @contextlib.asynccontextmanager
 async def _run_stub(
-    stub: "_Stub",
+    stub: _Stub,
     client: Optional[_Client] = None,
     stdout=None,
     show_progress: bool = True,
@@ -36,7 +41,7 @@ async def _run_stub(
     output_mgr: Optional[OutputManager] = None,
     environment_name: Optional[str] = None,
     shell=False,
-) -> AsyncGenerator["_Stub", None]:
+) -> AsyncGenerator[_Stub, None]:
     """mdmd:hidden"""
     if environment_name is None:
         environment_name = config.get("environment")
@@ -150,7 +155,7 @@ async def _serve_update(
 
 
 async def _deploy_stub(
-    stub: "_Stub",
+    stub: _Stub,
     name: str = None,
     namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
     client=None,

--- a/modal/serving.py
+++ b/modal/serving.py
@@ -6,7 +6,7 @@ import platform
 import sys
 from multiprocessing.context import SpawnProcess
 from multiprocessing.synchronize import Event
-from typing import AsyncGenerator, Optional
+from typing import TYPE_CHECKING, AsyncGenerator, Optional, TypeVar
 
 from synchronicity import Interface
 
@@ -14,11 +14,15 @@ from modal_utils.async_utils import TaskContext, asyncify, synchronize_api, sync
 
 from ._output import OutputManager
 from ._watcher import watch
-from .app import _App
 from .cli.import_refs import import_stub
 from .client import _Client
 from .config import config
 from .runner import _run_stub, serve_update
+
+if TYPE_CHECKING:
+    from .stub import _Stub
+else:
+    _Stub = TypeVar("_Stub")
 
 
 def _run_serve(stub_ref: str, existing_app_id: str, is_ready: Event, environment_name: str):

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -288,18 +288,20 @@ class _Stub:
         show_progress: bool = True,
         detach: bool = False,
         output_mgr: Optional[OutputManager] = None,
-    ) -> AsyncGenerator[_App, None]:
+    ) -> AsyncGenerator["_Stub", None]:
         """Context manager that runs an app on Modal.
 
         Use this as the main entry point for your Modal application. All calls
         to Modal functions should be made within the scope of this context
         manager, and they will correspond to the current app.
 
-        See the documentation for the [`App`](modal.App) class for more details.
+        Note that this method used to return a separate "App" object. This is
+        no longer useful since you can use the stub itself for access to all
+        objects. For backwards compatibility reasons, it returns the same stub.
         """
         # TODO(erikbern): deprecate this one too?
-        async with _run_stub(self, client, stdout, show_progress, detach, output_mgr) as app:
-            yield app
+        async with _run_stub(self, client, stdout, show_progress, detach, output_mgr):
+            yield self
 
     def _get_default_image(self):
         if "image" in self._blueprint:


### PR DESCRIPTION
Another step towards making the `App` class purely internal. `stub.run()` and `run_stub` now returns the stub itself, since it implements basically the same interface (leveraging duck typing, basically).

This shouldn't break any user code unless they are doing something very hacky with Modal internals.