### PR TITLE
Token flow: run a local http server validating the request

### DIFF
--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -129,6 +129,8 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.sandbox_defs = []
         self.sandbox: subprocess.Popen = None
 
+        self.token_flow_localhost_port = None
+
         @self.function_body
         def default_function_body(*args, **kwargs):
             return sum(arg**2 for arg in args) + sum(value**2 for key, value in kwargs.items())
@@ -702,6 +704,8 @@ class MockClientServicer(api_grpc.ModalClientBase):
     ### Token flow
 
     async def TokenFlowCreate(self, stream):
+        request: api_pb2.TokenFlowCreateRequest = await stream.recv_message()
+        self.token_flow_localhost_port = request.localhost_port
         await stream.send_message(
             api_pb2.TokenFlowCreateResponse(token_flow_id="tc-123", web_url="https://localhost/xyz/abc")
         )

--- a/client_test/token_flow_test.py
+++ b/client_test/token_flow_test.py
@@ -1,0 +1,17 @@
+# Copyright Modal Labs 2023
+import aiohttp
+import pytest
+
+from modal.token_flow import TokenFlow
+
+
+@pytest.mark.asyncio
+async def test_token_flow_server(servicer, client):
+    tf = TokenFlow(client)
+    async with tf.start() as (token_flow_id, web_url):
+        # Make a request against the local web server and make sure it validates
+        localhost_url = f"http://localhost:{servicer.token_flow_localhost_port}"
+        async with aiohttp.ClientSession() as session:
+            async with session.get(localhost_url) as resp:
+                text = await resp.text()
+                assert text == token_flow_id

--- a/client_test/token_flow_test.py
+++ b/client_test/token_flow_test.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2023
-import aiohttp
 import pytest
+
+import aiohttp
 
 from modal.token_flow import TokenFlow
 
@@ -8,7 +9,7 @@ from modal.token_flow import TokenFlow
 @pytest.mark.asyncio
 async def test_token_flow_server(servicer, client):
     tf = TokenFlow(client)
-    async with tf.start() as (token_flow_id, web_url):
+    async with tf.start() as (token_flow_id, _):
         # Make a request against the local web server and make sure it validates
         localhost_url = f"http://localhost:{servicer.token_flow_localhost_port}"
         async with aiohttp.ClientSession() as session:

--- a/modal/cli/token.py
+++ b/modal/cli/token.py
@@ -53,26 +53,28 @@ def new(profile: Optional[str] = profile_option, no_verify: bool = False, source
     with Client.unauthenticated_client(server_url) as client:
         token_flow = TokenFlow(client)
 
-        token_flow_id, web_url = token_flow.start(source)
-        with console.status("Waiting for authentication in the web browser", spinner="dots"):
-            # Open the web url in the browser
-            if webbrowser.open_new_tab(web_url):
-                console.print("If the web browser didn't open, please copy this URL into your web browser manually:")
-            else:
-                console.print(
-                    "[red]Was not able to launch web browser[/red]"
-                    " - please go to this URL manually and complete the flow:"
-                )
-            console.print(f"\n[link={web_url}]{web_url}[/link]\n")
-
-        with console.status("Waiting for token flow to complete...", spinner="dots") as status:
-            for attempt in itertools.count():
-                res = token_flow.finish()
-                if res is None:
-                    status.update(f"Waiting for token flow to complete... (attempt {attempt+2})")
+        with token_flow.start(source) as (token_flow_id, web_url):
+            with console.status("Waiting for authentication in the web browser", spinner="dots"):
+                # Open the web url in the browser
+                if webbrowser.open_new_tab(web_url):
+                    console.print(
+                        "If the web browser didn't open, please copy this URL into your web browser manually:"
+                    )
                 else:
-                    token_id, token_secret = res
-                    break
+                    console.print(
+                        "[red]Was not able to launch web browser[/red]"
+                        " - please go to this URL manually and complete the flow:"
+                    )
+                console.print(f"\n[link={web_url}]{web_url}[/link]\n")
+
+            with console.status("Waiting for token flow to complete...", spinner="dots") as status:
+                for attempt in itertools.count():
+                    res = token_flow.finish()
+                    if res is None:
+                        status.update(f"Waiting for token flow to complete... (attempt {attempt+2})")
+                    else:
+                        token_id, token_secret = res
+                        break
 
         console.print("[green]Web authentication finished successfully![/green]")
 

--- a/modal/cli/token.py
+++ b/modal/cli/token.py
@@ -9,8 +9,8 @@ import typer
 from rich.console import Console
 
 from modal.client import Client
-from modal.token_flow import TokenFlow
 from modal.config import _store_user_config, config, user_config_path
+from modal.token_flow import TokenFlow
 
 token_cli = typer.Typer(name="token", help="Manage tokens.", no_args_is_help=True)
 

--- a/modal/client.py
+++ b/modal/client.py
@@ -1,6 +1,5 @@
 # Copyright Modal Labs 2022
 import asyncio
-import platform
 import warnings
 from typing import Awaitable, Callable, Dict, Optional, Tuple
 
@@ -170,28 +169,6 @@ class _Client:
         # Create a connection with no credentials
         # To be used with the token flow
         return _Client(server_url, api_pb2.CLIENT_TYPE_CLIENT, None, no_verify=True)
-
-    async def start_token_flow(self, utm_source: Optional[str] = None) -> Tuple[str, str]:
-        """mdmd:hidden"""
-        # Create token creation request
-        # Send some strings identifying the computer (these are shown to the user for security reasons)
-        req = api_pb2.TokenFlowCreateRequest(
-            node_name=platform.node(),
-            platform_name=platform.platform(),
-            utm_source=utm_source,
-        )
-        resp = await self.stub.TokenFlowCreate(req)
-        return (resp.token_flow_id, resp.web_url)
-
-    async def finish_token_flow(self, token_flow_id: str, timeout: float = 40) -> Optional[Tuple[str, str]]:
-        """mdmd:hidden"""
-        # Wait for token flow to finish
-        req = api_pb2.TokenFlowWaitRequest(token_flow_id=token_flow_id, timeout=timeout)
-        resp = await self.stub.TokenFlowWait(req)
-        if not resp.timeout:
-            return (resp.token_id, resp.token_secret)
-        else:
-            return
 
     @classmethod
     async def from_env(cls, _override_config=None) -> "_Client":

--- a/modal/token_flow.py
+++ b/modal/token_flow.py
@@ -1,0 +1,38 @@
+# Copyright Modal Labs 2023
+import platform
+from typing import Optional, Tuple
+
+from modal_utils.async_utils import synchronize_api
+from modal_proto import api_grpc, api_pb2
+
+from .client import _Client
+
+class _TokenFlow:
+    def __init__(self, client: _Client):
+        self.stub = client.stub
+
+    async def start(self, utm_source: Optional[str] = None) -> Tuple[str, str]:
+        """mdmd:hidden"""
+        # Create token creation request
+        # Send some strings identifying the computer (these are shown to the user for security reasons)
+        req = api_pb2.TokenFlowCreateRequest(
+            node_name=platform.node(),
+            platform_name=platform.platform(),
+            utm_source=utm_source,
+        )
+        resp = await self.stub.TokenFlowCreate(req)
+        self.token_flow_id = resp.token_flow_id
+        return (resp.token_flow_id, resp.web_url)
+
+    async def finish(self, timeout: float = 40) -> Optional[Tuple[str, str]]:
+        """mdmd:hidden"""
+        # Wait for token flow to finish
+        req = api_pb2.TokenFlowWaitRequest(token_flow_id=self.token_flow_id, timeout=timeout)
+        resp = await self.stub.TokenFlowWait(req)
+        if not resp.timeout:
+            return (resp.token_id, resp.token_secret)
+        else:
+            return
+
+
+TokenFlow = synchronize_api(_TokenFlow)

--- a/modal/token_flow.py
+++ b/modal/token_flow.py
@@ -1,12 +1,13 @@
 # Copyright Modal Labs 2023
-import aiohttp.web
-from contextlib import asynccontextmanager
 import platform
+from contextlib import asynccontextmanager
 from typing import Optional, Tuple
 
+import aiohttp.web
+
+from modal_proto import api_pb2
 from modal_utils.async_utils import synchronize_api
 from modal_utils.http_utils import run_temporary_http_server
-from modal_proto import api_grpc, api_pb2
 
 from .client import _Client
 

--- a/modal/token_flow.py
+++ b/modal/token_flow.py
@@ -1,28 +1,43 @@
 # Copyright Modal Labs 2023
+import aiohttp.web
+from contextlib import asynccontextmanager
 import platform
 from typing import Optional, Tuple
 
 from modal_utils.async_utils import synchronize_api
+from modal_utils.http_utils import run_temporary_http_server
 from modal_proto import api_grpc, api_pb2
 
 from .client import _Client
+
 
 class _TokenFlow:
     def __init__(self, client: _Client):
         self.stub = client.stub
 
+    @asynccontextmanager
     async def start(self, utm_source: Optional[str] = None) -> Tuple[str, str]:
         """mdmd:hidden"""
-        # Create token creation request
-        # Send some strings identifying the computer (these are shown to the user for security reasons)
-        req = api_pb2.TokenFlowCreateRequest(
-            node_name=platform.node(),
-            platform_name=platform.platform(),
-            utm_source=utm_source,
-        )
-        resp = await self.stub.TokenFlowCreate(req)
-        self.token_flow_id = resp.token_flow_id
-        return (resp.token_flow_id, resp.web_url)
+        # Run a temporary http server returning the token id on /
+        # This helps us add direct validation later
+
+        async def slash(request):
+            return aiohttp.web.Response(text=self.token_flow_id)
+
+        app = aiohttp.web.Application()
+        app.add_routes([aiohttp.web.get("/", slash)])
+        async with run_temporary_http_server(app) as url:
+            # Create request
+            # Send some strings identifying the computer (these are shown to the user for security reasons)
+            req = api_pb2.TokenFlowCreateRequest(
+                node_name=platform.node(),
+                platform_name=platform.platform(),
+                utm_source=utm_source,
+                localhost_port=int(url.split(":")[-1]),
+            )
+            resp = await self.stub.TokenFlowCreate(req)
+            self.token_flow_id = resp.token_flow_id
+            yield (resp.token_flow_id, resp.web_url)
 
     async def finish(self, timeout: float = 40) -> Optional[Tuple[str, str]]:
         """mdmd:hidden"""

--- a/modal/token_flow.py
+++ b/modal/token_flow.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2023
 import platform
 from contextlib import asynccontextmanager
-from typing import Optional, Tuple
+from typing import AsyncGenerator, Optional, Tuple
 
 import aiohttp.web
 
@@ -17,7 +17,7 @@ class _TokenFlow:
         self.stub = client.stub
 
     @asynccontextmanager
-    async def start(self, utm_source: Optional[str] = None) -> Tuple[str, str]:
+    async def start(self, utm_source: Optional[str] = None) -> AsyncGenerator[Tuple[str, str], None]:
         """mdmd:hidden"""
         # Run a temporary http server returning the token id on /
         # This helps us add direct validation later
@@ -48,7 +48,7 @@ class _TokenFlow:
         if not resp.timeout:
             return (resp.token_id, resp.token_secret)
         else:
-            return
+            return None
 
 
 TokenFlow = synchronize_api(_TokenFlow)

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1227,6 +1227,7 @@ message TokenFlowCreateRequest {
   string node_name = 1;
   string platform_name = 2;
   string utm_source = 3;
+  int32 localhost_port = 4;
 }
 
 message TokenFlowCreateResponse {


### PR DESCRIPTION
This isn't used yet, but the frontend could in theory hit localhost:xyz and validate the token flow now rather than asking the user to click a button.

Took 10 min to implement so now we have it. We can add support for it in the frontend later.

Regarding security, I think there are only two threats that are easily mitigated:
* If the validation URL is an arbitrary URL, an attacker can run their own validation server on the public internet. To prevent this, we restrict it to `localhost` only – we only store a port number
* We don't want the validation to be something too dumb (eg relying on just 200 OK), since then an attacker could potentially leverage some http server that's commonly running on localhost. So we make sure to return the token flow id as an arbitrary identifier which the frontend can sanity check.