### PR TITLE
Add a client-side timeout to TokenFlowWait

### DIFF
--- a/modal/token_flow.py
+++ b/modal/token_flow.py
@@ -40,11 +40,11 @@ class _TokenFlow:
             self.token_flow_id = resp.token_flow_id
             yield (resp.token_flow_id, resp.web_url)
 
-    async def finish(self, timeout: float = 40) -> Optional[Tuple[str, str]]:
+    async def finish(self, timeout: float = 40.0, grpc_extra_timeout: float = 5.0) -> Optional[Tuple[str, str]]:
         """mdmd:hidden"""
         # Wait for token flow to finish
         req = api_pb2.TokenFlowWaitRequest(token_flow_id=self.token_flow_id, timeout=timeout)
-        resp = await self.stub.TokenFlowWait(req)
+        resp = await self.stub.TokenFlowWait(req, timeout=(timeout + grpc_extra_timeout))
         if not resp.timeout:
             return (resp.token_id, resp.token_secret)
         else:


### PR DESCRIPTION
I was debugging something earlier today which caused the token flow to get stuck forever. It lead me to implement #872 and #873 which made the output much nicer, plus some stuff on the backend side. Unfortunately none of this solved the issue.

Turns out the underlying issue was that a network problem (in particular closing the lid on your laptop and opening it much later) would cause GRPC requests to get stuck in a bad way where they never return. This causes the token flow to look like it's still waiting.

This fix causes these issues to fail with `TimeoutError: Deadline exceeded` which hopefully causes the user to retry it.