### PR TITLE
Implement relay tunneling support for the client

### DIFF
--- a/modal/_relay_client.py
+++ b/modal/_relay_client.py
@@ -1,0 +1,172 @@
+"""Client for Modal relay servers, allowing users to expose TLS.
+
+Based on the Rust implementation in our internal modal-relay crate. That one is
+end-to-end tested and is the source of truth for our client protocol.
+"""
+
+import asyncio
+import contextlib
+import json
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, Tuple
+
+from google.protobuf.empty_pb2 import Empty
+
+from modal_proto import api_pb2
+from modal_utils.async_utils import TaskContext, synchronize_api
+from modal_utils.grpc_utils import retry_transient_errors
+
+from .client import _Client
+from .config import config, logger
+from .exception import InvalidError
+
+
+async def control_send(writer: asyncio.StreamWriter, obj: Any) -> None:
+    writer.write(json.dumps(obj).encode() + "\0")
+    await writer.drain()
+
+
+async def control_recv(reader: asyncio.StreamReader) -> Any:
+    try:
+        data = await reader.readuntil(b"\0")
+    except asyncio.IncompleteReadError:
+        return None
+    return json.loads(data[:-1].decode("utf-8"))
+
+
+@dataclass
+class RelayClient:
+    host: str
+    port: int
+    task_id: str
+    task_secret: str
+
+    async def start_relay(self, forwarded_host: str, forwarded_port: int) -> Tuple["RelayDriver", str]:
+        reader, writer = await asyncio.open_connection(self.host, self.port, ssl=True)
+        await control_send(writer, {"helloNew": {"taskId": self.task_id, "taskSecret": self.task_secret}})
+
+        resp = await control_recv(reader)
+        host = resp["hello"]["host"]
+        token = resp["hello"]["token"]
+
+        driver = RelayDriver(self, reader, writer, token, forwarded_host, forwarded_port)
+        return driver, host
+
+
+class RelayDriver:
+    def __init__(
+        self,
+        client: RelayClient,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        token: str,
+        forwarded_host: str,
+        forwarded_port: int,
+    ) -> None:
+        self.client = client
+        self.reader = reader
+        self.writer = writer
+        self.token = token
+        self.forwarded_host = forwarded_host
+        self.forwarded_port = forwarded_port
+        self.task_context = TaskContext()
+
+    async def start(self) -> None:
+        await self.task_context.start()
+        await self.task_context.create_task(self._run())
+
+    async def stop(self) -> None:
+        await self.task_context.stop()
+        self.writer.close()
+
+    async def _run(self) -> None:
+        """Drive the TCP proxy, reconnecting on any errors."""
+        while True:
+            try:
+                await self._control()
+            except asyncio.CancelledError:
+                raise  # Do not catch CancelledError
+            except Exception as exc:
+                logger.debug("reconnecting due to error in control loop", exc_info=exc)
+
+            self.writer.close()
+            while True:
+                try:
+                    await self._reconnect()
+                    break
+                except asyncio.CancelledError:
+                    raise  # Do not catch CancelledError
+                except Exception as exc:
+                    logger.debug("error reconnecting to server", exc_info=exc)
+                    await asyncio.sleep(1)
+
+    async def _reconnect(self) -> None:
+        reader, writer = await asyncio.open_connection(self.client.host, self.client.port, ssl=True)
+        await control_send(writer, {"helloReconnect": {"token": self.token}})
+        resp = await control_recv(reader)
+        self.token = resp["hello"]["token"]
+        self.reader = reader
+        self.writer = writer
+
+    async def _control(self) -> None:
+        while True:
+            resp = await control_recv(self.reader)
+            conn: str = resp["forward"]["conn"]
+            logger.debug(f"new relay connection, forwarding to {self.forwarded_host}:{self.forwarded_port}")
+            self.task_context.create_task(self._new_stream(conn))
+
+    async def _new_stream(self, conn: str) -> None:
+        reader, writer = await asyncio.open_connection(self.client.host, self.client.port, ssl=True)
+        await control_send(writer, {"accept": {"conn": conn}})
+        local_reader, local_writer = await asyncio.open_connection(self.forwarded_host, self.forwarded_port)
+        await asyncio.wait(
+            [_asyncio_copy(reader, local_writer), _asyncio_copy(local_reader, writer)],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        writer.close()
+        local_writer.close()
+
+
+async def _asyncio_copy(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+    """Pump bytes from a StreamReader to a StreamWriter."""
+    while True:
+        data = await reader.read(8192)
+        if not data:  # EOF
+            break
+        writer.write(data)
+        await writer.drain()
+
+
+@dataclass
+class Tunnel:
+    host: str
+
+    @property
+    def url(self) -> str:
+        return f"https://{self.host}"
+
+
+@contextlib.asynccontextmanager
+async def _forward(port: int) -> AsyncIterator[Tunnel]:
+    """Forward a port from within a running Modal container."""
+    client = await _Client.from_env()
+
+    response: api_pb2.RelayListResponse = await retry_transient_errors(client.stub.RelayList, Empty())
+
+    # TODO: connect to multiple hostnames concurrently for fault tolerance,
+    # and race them to find the one with lowest latency
+    hostname = response.hostnames[0]
+
+    task_id, task_secret = config.get("task_id"), config.get("task_secret")
+    if not task_id or not task_secret:
+        raise InvalidError("task_id and task_secret must be set in config")
+    relay_client = RelayClient(hostname, 443, task_id, task_secret)
+    driver, relay_host = await relay_client.start_relay("localhost", port)
+    await driver.start()
+    try:
+        yield Tunnel(relay_host)
+    finally:
+        await driver.stop()
+
+
+forward = synchronize_api(_forward)

--- a/modal/client.py
+++ b/modal/client.py
@@ -88,10 +88,10 @@ class _Client:
         self.no_verify = no_verify
         self._pre_stop: Optional[Callable[[], Awaitable[None]]] = None
         self._channel = None
-        self._stub = None
+        self._stub: Optional[api_grpc.ModalClientStub] = None
 
     @property
-    def stub(self):
+    def stub(self) -> Optional[api_grpc.ModalClientStub]:
         """mdmd:hidden"""
         return self._stub
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -810,6 +810,10 @@ message GenericResult {  // Used for both tasks and function outputs
   string propagation_reason = 13;
 }
 
+message RelayListResponse {
+  repeated string hostnames = 1; // A subset of online relays to attempt connection with.
+} 
+
 message Sandbox {
   repeated string entrypoint_args = 1;
   repeated string mount_ids = 2;
@@ -1417,6 +1421,9 @@ service ModalClient {
   rpc QueueGet(QueueGetRequest) returns (QueueGetResponse);
   rpc QueuePut(QueuePutRequest) returns (google.protobuf.Empty);
   rpc QueueLen(QueueLenRequest) returns (QueueLenResponse);
+
+  // Relays
+  rpc RelayList(google.protobuf.Empty) returns (RelayListResponse);
 
   // Sandboxes
   rpc SandboxCreate(SandboxCreateRequest) returns (SandboxCreateResponse);


### PR DESCRIPTION
This is an experimental feature. Relays allow you to forward ports within a running Modal container.

```python
@modal.function()
def my_function():
    with modal.forward(8000, mode="tls") as tunnel:
        print(tunnel.url)
        some_web_server.listen(8000)
```

This gives you a unique, transient HTTPS URL. The tunnel acts on the transport layer (TCP), and it automatically terminates TLS for all incoming connections as well, so data is encrypted at all stages in transit.

This can be used to proxy anything over TCP/TLS, including web servers, Jupyter notebooks, VS Code, web interfaces like Gradio, SSH, and so on. Even an SMTP server, if you really wanted to.

Tunnels support multiple distributed connection to multiple server relays that we can run in all Modal regions, and they automatically detect which instance has the lowest latency to the current container.

While we're developing, I didn't expose this publicly yet. You must import the `tunnel` function from `modal._relay_client`.

See the associated PR on the server side for implementation / ops details.
