### PR TITLE
Print the workspace on stdout

### DIFF
--- a/modal/token_flow.py
+++ b/modal/token_flow.py
@@ -40,13 +40,15 @@ class _TokenFlow:
             self.token_flow_id = resp.token_flow_id
             yield (resp.token_flow_id, resp.web_url)
 
-    async def finish(self, timeout: float = 40.0, grpc_extra_timeout: float = 5.0) -> Optional[Tuple[str, str]]:
+    async def finish(
+        self, timeout: float = 40.0, grpc_extra_timeout: float = 5.0
+    ) -> Optional[api_pb2.TokenFlowWaitResponse]:
         """mdmd:hidden"""
         # Wait for token flow to finish
         req = api_pb2.TokenFlowWaitRequest(token_flow_id=self.token_flow_id, timeout=timeout)
         resp = await self.stub.TokenFlowWait(req, timeout=(timeout + grpc_extra_timeout))
         if not resp.timeout:
-            return (resp.token_id, resp.token_secret)
+            return resp
         else:
             return None
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1244,6 +1244,7 @@ message TokenFlowWaitResponse {
   string token_id = 1;
   string token_secret = 2;
   bool timeout = 3;
+  string workspace_username = 4;
 }
 
 message VolumeCreateRequest {


### PR DESCRIPTION
Another minor QoL improvement for the token bootstrapping. Prints what workspace the token is for.

Hasn't been implemented on the server yet but will ship it later.
