### PR TITLE
run `__enter__` on local class construction

### DIFF
--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
 import inspect
 import pytest
+import threading
 from typing import TYPE_CHECKING
 
 from typing_extensions import assert_type
@@ -278,18 +279,26 @@ def test_call_not_modal_method():
 cls_with_enter_stub = Stub()
 
 
+def get_thread_id():
+    return threading.current_thread().name
+
+
 @cls_with_enter_stub.cls()
 class ClsWithEnter:
-    def __init__(self):
+    def __init__(self, thread_id):
         self.x = 0
+        self.thread_id = thread_id
+        assert get_thread_id() == self.thread_id
 
     def __enter__(self):
         self.x = 42
+        assert get_thread_id() == self.thread_id
 
     def f(self, y):
+        assert get_thread_id() == self.thread_id
         return self.x * y
 
 
 def test_local_enter():
-    obj = ClsWithEnter()
+    obj = ClsWithEnter(get_thread_id())
     assert obj.f(10) == 420

--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -31,7 +31,7 @@ def test_run_class(client, servicer):
         app_id = stub.app_id
 
     objects = servicer.app_objects[app_id]
-    assert len(objects) == 3  # classes and functions
+    assert len(objects) == 2  # classes and functions
     assert objects["Foo.bar"] == function_id
     assert objects["Foo"] == class_id
 
@@ -257,7 +257,10 @@ def test_lookup(client, servicer):
         assert obj.bar.local(1, 2)
 
 
-@stub.cls()
+baz_stub = Stub()
+
+
+@baz_stub.cls()
 class Baz:
     def __init__(self, x):
         self.x = x
@@ -270,3 +273,23 @@ def test_call_not_modal_method():
     baz: Baz = Baz(5)
     assert baz.x == 5
     assert baz.not_modal_method(7) == 35
+
+
+cls_with_enter_stub = Stub()
+
+
+@cls_with_enter_stub.cls()
+class ClsWithEnter:
+    def __init__(self):
+        self.x = 0
+
+    def __enter__(self):
+        self.x = 42
+
+    def f(self, y):
+        return self.x * y
+
+
+def test_local_enter():
+    obj = ClsWithEnter()
+    assert obj.f(10) == 420

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
 import asyncio
 import pickle
+import warnings
 from datetime import date
 from typing import Any, Callable, Dict, Optional, Type, TypeVar
 
@@ -75,7 +76,10 @@ class _Obj:
         # Construct local object lazily. Used for .local() calls
         if not self._has_local_obj:
             self._local_obj = self._local_obj_constr()
-            # TODO(erikbern): run __enter__?
+            if hasattr(self._local_obj, "__enter__"):
+                self._local_obj.__enter__()
+            elif hasattr(self._local_obj, "__aenter__"):
+                warnings.warn("Not running asynchronous enter handlers on local objects")
             setattr(self._local_obj, "_modal_functions", self._functions)  # Needed for PartialFunction.__get__
             self._has_local_obj = True
 


### PR DESCRIPTION
This makes the behavior more consistent with remote calls.

~Not sure if this causes it to run on the synchronicity thread – will see if I can figure it out.~ EDIT: verifying this using a bunch of assertions