### PR TITLE
Revert run `__enter__` on local class construction

### DIFF
--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2022
 import inspect
 import pytest
-import threading
 from typing import TYPE_CHECKING
 
 from typing_extensions import assert_type
@@ -32,7 +31,7 @@ def test_run_class(client, servicer):
         app_id = stub.app_id
 
     objects = servicer.app_objects[app_id]
-    assert len(objects) == 2  # classes and functions
+    assert len(objects) == 3  # classes and functions
     assert objects["Foo.bar"] == function_id
     assert objects["Foo"] == class_id
 
@@ -258,10 +257,7 @@ def test_lookup(client, servicer):
         assert obj.bar.local(1, 2)
 
 
-baz_stub = Stub()
-
-
-@baz_stub.cls()
+@stub.cls()
 class Baz:
     def __init__(self, x):
         self.x = x
@@ -274,31 +270,3 @@ def test_call_not_modal_method():
     baz: Baz = Baz(5)
     assert baz.x == 5
     assert baz.not_modal_method(7) == 35
-
-
-cls_with_enter_stub = Stub()
-
-
-def get_thread_id():
-    return threading.current_thread().name
-
-
-@cls_with_enter_stub.cls()
-class ClsWithEnter:
-    def __init__(self, thread_id):
-        self.x = 0
-        self.thread_id = thread_id
-        assert get_thread_id() == self.thread_id
-
-    def __enter__(self):
-        self.x = 42
-        assert get_thread_id() == self.thread_id
-
-    def f(self, y):
-        assert get_thread_id() == self.thread_id
-        return self.x * y
-
-
-def test_local_enter():
-    obj = ClsWithEnter(get_thread_id())
-    assert obj.f(10) == 420

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2022
 import asyncio
 import pickle
-import warnings
 from datetime import date
 from typing import Any, Callable, Dict, Optional, Type, TypeVar
 
@@ -76,10 +75,7 @@ class _Obj:
         # Construct local object lazily. Used for .local() calls
         if not self._has_local_obj:
             self._local_obj = self._local_obj_constr()
-            if hasattr(self._local_obj, "__enter__"):
-                self._local_obj.__enter__()
-            elif hasattr(self._local_obj, "__aenter__"):
-                warnings.warn("Not running asynchronous enter handlers on local objects")
+            # TODO(erikbern): run __enter__?
             setattr(self._local_obj, "_modal_functions", self._functions)  # Needed for PartialFunction.__get__
             self._has_local_obj = True
 


### PR DESCRIPTION
Reverts modal-labs/modal-client#880

Reverting because it appears to have some unintended side effects - `__enter__` now runs twice in the container:

```python
import os
from modal import Stub, method

stub = Stub()

@stub.cls()
class Test:
  def __init__(self):
    print(f"__init__, pid={os.getpid()}, is_inside={stub.is_inside()}")

  def __enter__(self):
    print(f"__enter__, pid={os.getpid()}, is_inside={stub.is_inside()}")

  @method()
  def f(self):
    print(f"f, pid={os.getpid()}, is_inside={stub.is_inside()}")


@stub.local_entrypoint()
def main():
    print(f"local pid={os.getpid()}")
    t = Test()
    t.f.remote()
```

-->

```
local pid=628711
__init__, pid=7, is_inside=True
__enter__, pid=7, is_inside=True
__enter__, pid=7, is_inside=True
f, pid=7, is_inside=True
```

Prior to this change the output was:

```
local pid=629011
__init__, pid=7, is_inside=True
__enter__, pid=7, is_inside=True
f, pid=7, is_inside=True
```