### PR TITLE
Annotate .modal.toml with metadata

### DIFF
--- a/modal/cli/token.py
+++ b/modal/cli/token.py
@@ -1,4 +1,5 @@
 # Copyright Modal Labs 2022
+import datetime
 import getpass
 import itertools
 import webbrowser
@@ -89,5 +90,10 @@ def new(profile: Optional[str] = profile_option, no_verify: bool = False, source
             console.print("[green]Token verified successfully![/green]")
 
     with console.status("Storing token", spinner="dots"):
-        _store_user_config({"token_id": result.token_id, "token_secret": result.token_secret}, profile=profile)
+        comment = "created on " + str(datetime.date.today())
+        if result.workspace_username:
+            comment += " for workspace " + result.workspace_username
+        _store_user_config(
+            {"token_id": result.token_id, "token_secret": result.token_secret}, profile=profile, comment=comment
+        )
         console.print(f"[green]Token written to [white]{user_config_path}[/white] successfully![/green]")

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     rich>=12.0.0
     synchronicity~=0.5.3
     tblib>=1.7.0
-    toml
+    tomlkit
     typer~=0.9.0
     types-certifi
     types-toml


### PR DESCRIPTION
This change makes it so that
1. We preserve any comments in `~/.modal.toml`
2. When a token is created, it adds a comment such as `created on 2023-09-19 for workspace modal-labs`

E.g. I have a million tokens and it's a bit annoying to keep track of them:

```
[personal]
token_id = "ak-xxx"
token_secret = "as-yyy"
sentry_dsn = ""

[dev]
server_url = "http://localhost:8888"
sentry_dsn = ""
token_id = "ak-xxx"
token_secret = "as-yyy"

[bot]
token_id = "ak-xxx"
token_secret = "as-yyy"

[modal_labs] # created on 2023-09-19 for workspace modal-labs
token_id = "ak-xxx"
token_secret = "as-yyy"
environment = "main"
active = true

[_test]
token_id = "abc"
token_secret = "xyz"

[localhost-test]
token_id = "ak-xxx"
token_secret = "as-yyy"
```

ANOTHER OPTION: We could potentially write it into the config as real payload data:

```
[modal_labs]
token_id = "ak-xxx"
token_secret = "as-yyy"
environment = "main"
active = true
created_on = 2023-09-19
workspace_username = "modal-labs"
```

the last two would be dummy config in the sense that it's not actually used