### PR TITLE
Implement demo `modal jupyter lab` CLI

### DIFF
--- a/modal/cli/entry_point.py
+++ b/modal/cli/entry_point.py
@@ -1,11 +1,11 @@
 # Copyright Modal Labs 2022
 import typer
 
-from modal.cli import run
-from modal.cli.environment import environment_cli
-
+from . import run
 from .app import app_cli
 from .config import config_cli
+from .environment import environment_cli
+from .jupyter import jupyter_cli
 from .network_file_system import nfs_cli
 from .profile import profile_cli
 from .secret import secret_cli
@@ -45,11 +45,12 @@ def modal(
 entrypoint_cli_typer.add_typer(app_cli)
 entrypoint_cli_typer.add_typer(config_cli)
 entrypoint_cli_typer.add_typer(environment_cli)
+entrypoint_cli_typer.add_typer(jupyter_cli)
 entrypoint_cli_typer.add_typer(nfs_cli)
-entrypoint_cli_typer.add_typer(volume_cli)
 entrypoint_cli_typer.add_typer(profile_cli)
 entrypoint_cli_typer.add_typer(secret_cli)
 entrypoint_cli_typer.add_typer(token_cli)
+entrypoint_cli_typer.add_typer(volume_cli)
 
 
 # TODO: remove this in a future release

--- a/modal/cli/jupyter.py
+++ b/modal/cli/jupyter.py
@@ -1,0 +1,28 @@
+# Copyright Modal Labs 2023
+import subprocess
+import tempfile
+from pathlib import Path
+
+from typer import Typer
+
+jupyter_cli = Typer(
+    name="jupyter",
+    no_args_is_help=True,
+    help="""
+    [Preview] Open a serverless Jupyter instance on Modal.
+
+    This command is in preview and may change in the future.
+    """,
+)
+
+
+@jupyter_cli.command(name="lab", help="Start Jupyter Lab on Modal.")
+def lab():
+    contents = (Path(__file__).parent / "programs" / "jupyterlab.py").read_text()
+
+    # TODO: This is a big hack and can break for unexpected $PATH reasons. Make an actual code path
+    # for correctly setting up and running a program in the CLI.
+    with tempfile.TemporaryDirectory() as tmpdir:
+        f = Path(tmpdir) / "_main.py"
+        f.write_text(contents)
+        subprocess.run(["modal", "run", f])

--- a/modal/cli/programs/jupyterlab.py
+++ b/modal/cli/programs/jupyterlab.py
@@ -1,4 +1,5 @@
 # Copyright Modal Labs 2023
+# type: ignore
 import os
 import secrets
 import subprocess

--- a/modal/cli/programs/jupyterlab.py
+++ b/modal/cli/programs/jupyterlab.py
@@ -1,0 +1,47 @@
+# Copyright Modal Labs 2023
+import os
+import secrets
+import subprocess
+import time
+import webbrowser
+
+from modal import Image, Queue, Stub
+from modal._relay_client import forward
+
+stub = Stub()
+stub.image = Image.debian_slim().pip_install("jupyterlab")
+stub.q = Queue.new()
+
+token = secrets.token_urlsafe(13)
+
+
+@stub.function(timeout=3600)
+def run_jupyter():
+    with forward(8888) as tunnel:
+        url = tunnel.url + "/?token=" + token
+        stub.q.put(url)
+        subprocess.run(
+            [
+                "jupyter",
+                "lab",
+                "--no-browser",
+                "--allow-root",
+                "--port=8888",
+                "--LabApp.allow_origin='*'",
+                "--LabApp.allow_remote_access=1",
+            ],
+            env={**os.environ, "JUPYTER_TOKEN": token, "SHELL": "/bin/bash"},
+            stderr=subprocess.DEVNULL,
+        )
+    stub.q.put("done")
+
+
+@stub.local_entrypoint()
+def main():
+    stub.run_jupyter.spawn()
+    url = stub.q.get()
+    time.sleep(1)  # Give Jupyter a chance to start up
+    print("\nJupyter on Modal, opening in browser...")
+    print(f"   -> {url}\n")
+    webbrowser.open(url)
+    assert stub.q.get() == "done"


### PR DESCRIPTION
This starts a Jupyter Lab on Modal and opens it in your browser.

The command is _very_ janky right now since it builds an image on the first run, and it also shells out to `modal run`. Just a demo. We can remove it later.