### PR TITLE
Add args and gpu to relay, with any image

### DIFF
--- a/modal/cli/programs/jupyterlab.py
+++ b/modal/cli/programs/jupyterlab.py
@@ -7,12 +7,15 @@ import subprocess
 import threading
 import time
 import webbrowser
+from typing import Any
 
 from modal import Image, Queue, Stub
 from modal._relay_client import forward
 
+args: Any = {}
+
 stub = Stub()
-stub.image = Image.debian_slim().pip_install("jupyterlab")
+stub.image = Image.from_registry(args["image"], add_python=args["add_python"]).pip_install("jupyterlab")
 stub.q = Queue.new()
 
 
@@ -29,7 +32,7 @@ def wait_for_port(url: str):
     stub.q.put(url)
 
 
-@stub.function(timeout=3600)
+@stub.function(cpu=args["cpu"], memory=args["memory"], gpu=args["gpu"], timeout=args["timeout"])
 def run_jupyter():
     os.mkdir("/lab")
     token = secrets.token_urlsafe(13)

--- a/modal/cli/programs/vscode.py
+++ b/modal/cli/programs/vscode.py
@@ -7,9 +7,12 @@ import subprocess
 import threading
 import time
 import webbrowser
+from typing import Any
 
 from modal import Image, Queue, Stub
 from modal._relay_client import forward
+
+args: Any = {}
 
 stub = Stub()
 stub.image = Image.from_registry("codercom/code-server", add_python="3.11").dockerfile_commands("ENTRYPOINT []")
@@ -29,7 +32,7 @@ def wait_for_port(data):
     stub.q.put(data)
 
 
-@stub.function(timeout=3600)
+@stub.function(cpu=args["cpu"], memory=args["memory"], gpu=args["gpu"], timeout=args["timeout"])
 def run_jupyter():
     os.chdir("/home/coder")
     token = secrets.token_urlsafe(13)


### PR DESCRIPTION
This allows you to run

```python
modal launch jupyter --gpu a100 --cpu 16
```

to immediately launch a serverless JupyterLab instance with an A100 and 16 CPUs