### PR TITLE
Allow specifying multiple GPUs as `type:count`.

### DIFF
--- a/client_test/gpu_test.py
+++ b/client_test/gpu_test.py
@@ -48,6 +48,25 @@ def test_gpu_string_config(client, servicer):
     assert func_def.resources.gpu_config.type == api_pb2.GPU_TYPE_A100
 
 
+def test_gpu_string_count_config(client, servicer):
+    stub = Stub()
+
+    # Invalid count values.
+    with pytest.raises(InvalidError):
+        stub.function(gpu="A10G:hello")(dummy)
+    with pytest.raises(InvalidError):
+        stub.function(gpu="Nonexistent:2")(dummy)
+
+    stub.function(gpu="A10G:4")(dummy)
+    with stub.run(client=client):
+        pass
+
+    assert len(servicer.app_functions) == 1
+    func_def = next(iter(servicer.app_functions.values()))
+    assert func_def.resources.gpu_config.count == 4
+    assert func_def.resources.gpu_config.type == api_pb2.GPU_TYPE_A10G
+
+
 def test_gpu_config_function(client, servicer):
     import modal
 

--- a/modal/gpu.py
+++ b/modal/gpu.py
@@ -133,14 +133,14 @@ class Any(_GPUConfig):
 
 
 STRING_TO_GPU_CONFIG = {
-    "t4": T4(),
-    "l4": L4(),
-    "a100": A100(),
-    "a10g": A10G(),
-    "inf2": Inferentia2(),
-    "any": Any(),
+    "t4": T4,
+    "l4": L4,
+    "a100": A100,
+    "a10g": A10G,
+    "inf2": Inferentia2,
+    "any": Any,
 }
-display_string_to_config = "\n".join(f'- "{key}" → `{value}`' for key, value in STRING_TO_GPU_CONFIG.items())
+display_string_to_config = "\n".join(f'- "{key}" → `{cls()}`' for key, cls in STRING_TO_GPU_CONFIG.items())
 __doc__ = f"""
 **GPU configuration shortcodes**
 
@@ -159,14 +159,19 @@ def _parse_gpu_config(value: GPU_T, raise_on_true: bool = True) -> Optional[_GPU
     if isinstance(value, _GPUConfig):
         return value
     elif isinstance(value, str):
+        count = 1
+        if ":" in value:
+            value, count_str = value.split(":", 1)
+            count = int(count_str)
+
         if value.lower() == "a100-20g":
-            return A100(memory=20)  # trigger deprecation warning at this point
+            return A100(memory=20, count=count)  # trigger deprecation warning at this point
         elif value.lower() not in STRING_TO_GPU_CONFIG:
             raise InvalidError(
                 f"Invalid GPU type: {value}. Value must be one of {list(STRING_TO_GPU_CONFIG.keys())} (case-insensitive)."
             )
         else:
-            return STRING_TO_GPU_CONFIG[value.lower()]
+            return STRING_TO_GPU_CONFIG[value.lower()](count=count)
     elif value is True:
         if raise_on_true:
             deprecation_error(

--- a/modal/gpu.py
+++ b/modal/gpu.py
@@ -162,7 +162,10 @@ def _parse_gpu_config(value: GPU_T, raise_on_true: bool = True) -> Optional[_GPU
         count = 1
         if ":" in value:
             value, count_str = value.split(":", 1)
-            count = int(count_str)
+            try:
+                count = int(count_str)
+            except ValueError:
+                raise InvalidError(f"Invalid GPU count: {count_str}. Value must be an integer.")
 
         if value.lower() == "a100-20g":
             return A100(memory=20, count=count)  # trigger deprecation warning at this point


### PR DESCRIPTION
For example, `a10g:2` asks for 2 A10G GPUs.

This can be used right now in `modal launch` and in the future with `modal shell`.