### PR TITLE
Add new `modal setup` command

### DIFF
--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -113,6 +113,11 @@ def test_app_token_new(servicer, set_env_client, server_url_env):
         _run(["token", "new", "--profile", "_test"])
 
 
+def test_app_setup(servicer, set_env_client, server_url_env):
+    with unittest.mock.patch("webbrowser.open_new_tab", lambda url: False):
+        _run(["setup"])
+
+
 def test_run(servicer, set_env_client, test_dir):
     stub_file = test_dir / "supports" / "app_run_tests" / "default_stub.py"
     _run(["run", stub_file.as_posix()])

--- a/modal/cli/entry_point.py
+++ b/modal/cli/entry_point.py
@@ -9,7 +9,7 @@ from .launch import launch_cli
 from .network_file_system import nfs_cli
 from .profile import profile_cli
 from .secret import secret_cli
-from .token import token_cli
+from .token import setup, token_cli
 from .volume import volume_cli
 
 
@@ -65,6 +65,7 @@ entrypoint_cli_typer.command("vol", help="Deprecated, use `modal volume` instead
 entrypoint_cli_typer.command("deploy", help="Deploy a Modal stub as an application.", no_args_is_help=True)(run.deploy)
 entrypoint_cli_typer.command("serve", no_args_is_help=True)(run.serve)
 entrypoint_cli_typer.command("shell", no_args_is_help=True)(run.shell)
+entrypoint_cli_typer.command("setup", help="Bootstrap Modal's configuration.")(setup)
 
 entrypoint_cli = typer.main.get_command(entrypoint_cli_typer)
 entrypoint_cli.add_command(run.run, name="run")  # type: ignore

--- a/modal/token_flow.py
+++ b/modal/token_flow.py
@@ -17,7 +17,9 @@ class _TokenFlow:
         self.stub = client.stub
 
     @asynccontextmanager
-    async def start(self, utm_source: Optional[str] = None) -> AsyncGenerator[Tuple[str, str], None]:
+    async def start(
+        self, utm_source: Optional[str] = None, next_url: Optional[str] = None
+    ) -> AsyncGenerator[Tuple[str, str], None]:
         """mdmd:hidden"""
         # Run a temporary http server returning the token id on /
         # This helps us add direct validation later
@@ -35,6 +37,7 @@ class _TokenFlow:
                 node_name=platform.node(),
                 platform_name=platform.platform(),
                 utm_source=utm_source,
+                next_url=next_url,
                 localhost_port=int(url.split(":")[-1]),
             )
             resp = await self.stub.TokenFlowCreate(req)


### PR DESCRIPTION
This is meant for new users to get started. It does the exact same thing as `modal token new` except in the future it will redirect to `/home` rather than showing this:

<img width="496" alt="image" src="https://github.com/modal-labs/modal-client/assets/1027979/d99398a0-301c-41f2-bc98-eb3a6141853b">

But I need to implement that on the frontend as well. The idea is we should instruct people to get started by running 

```bash
pip install modal
modal setup
```