### PR TITLE
Re-add running `__enter__` on local class construction

### DIFF
--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
 import inspect
 import pytest
+import threading
 from typing import TYPE_CHECKING
 
 from typing_extensions import assert_type
@@ -31,7 +32,7 @@ def test_run_class(client, servicer):
         app_id = stub.app_id
 
     objects = servicer.app_objects[app_id]
-    assert len(objects) == 3  # classes and functions
+    assert len(objects) == 2  # classes and functions
     assert objects["Foo.bar"] == function_id
     assert objects["Foo"] == class_id
 
@@ -257,7 +258,10 @@ def test_lookup(client, servicer):
         assert obj.bar.local(1, 2)
 
 
-@stub.cls()
+baz_stub = Stub()
+
+
+@baz_stub.cls()
 class Baz:
     def __init__(self, x):
         self.x = x
@@ -270,3 +274,31 @@ def test_call_not_modal_method():
     baz: Baz = Baz(5)
     assert baz.x == 5
     assert baz.not_modal_method(7) == 35
+
+
+cls_with_enter_stub = Stub()
+
+
+def get_thread_id():
+    return threading.current_thread().name
+
+
+@cls_with_enter_stub.cls()
+class ClsWithEnter:
+    def __init__(self, thread_id):
+        self.x = 0
+        self.thread_id = thread_id
+        assert get_thread_id() == self.thread_id
+
+    def __enter__(self):
+        self.x = 42
+        assert get_thread_id() == self.thread_id
+
+    def f(self, y):
+        assert get_thread_id() == self.thread_id
+        return self.x * y
+
+
+def test_local_enter():
+    obj = ClsWithEnter(get_thread_id())
+    assert obj.f(10) == 420

--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -426,7 +426,7 @@ def test_cls_function(unix_servicer, event_loop):
     client, items = _run_container(unix_servicer, "modal_test_support.functions", "Cls.f")
     assert len(items) == 1
     assert items[0].result.status == api_pb2.GenericResult.GENERIC_STATUS_SUCCESS
-    assert items[0].result.data == serialize(42 * 111)
+    assert deserialize(items[0].result.data, client) == 42 * 111
 
 
 @skip_windows_unix_socket
@@ -437,7 +437,7 @@ def test_param_cls_function(unix_servicer, event_loop):
     )
     assert len(items) == 1
     assert items[0].result.status == api_pb2.GenericResult.GENERIC_STATUS_SUCCESS
-    assert items[0].result.data == serialize("111 foo 42")
+    assert deserialize(items[0].result.data, client) == "111 foo 42"
 
 
 @skip_windows_unix_socket

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -587,7 +587,7 @@ def import_function(function_def: api_pb2.Function, ser_cls, ser_fun, ser_params
             args, kwargs = (), {}
         obj = cls(*args, **kwargs)
         if isinstance(cls, Cls):
-            obj = obj.get_local_obj()
+            obj = obj.get_obj()
         # Bind the function to the instance (using the descriptor protocol!)
         fun = fun.__get__(obj)
     else:

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -72,15 +72,20 @@ class _Obj:
         else:
             self._local_obj_constr = None
 
+    def get_obj(self):
+        """Constructs obj without any caching. Used by container entrypoint."""
+        self._local_obj = self._local_obj_constr()
+        setattr(self._local_obj, "_modal_functions", self._functions)  # Needed for PartialFunction.__get__
+        return self._local_obj
+
     def get_local_obj(self):
-        # Construct local object lazily. Used for .local() calls
+        """Construct local object lazily. Used for .local() calls."""
         if not self._has_local_obj:
-            self._local_obj = self._local_obj_constr()
+            self.get_obj()  # Instantiate object
             if hasattr(self._local_obj, "__enter__"):
                 self._local_obj.__enter__()
             elif hasattr(self._local_obj, "__aenter__"):
                 warnings.warn("Not running asynchronous enter handlers on local objects")
-            setattr(self._local_obj, "_modal_functions", self._functions)  # Needed for PartialFunction.__get__
             self._has_local_obj = True
 
         return self._local_obj

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
 import asyncio
 import pickle
+import warnings
 from datetime import date
 from typing import Any, Callable, Dict, Optional, Type, TypeVar
 
@@ -75,7 +76,10 @@ class _Obj:
         # Construct local object lazily. Used for .local() calls
         if not self._has_local_obj:
             self._local_obj = self._local_obj_constr()
-            # TODO(erikbern): run __enter__?
+            if hasattr(self._local_obj, "__enter__"):
+                self._local_obj.__enter__()
+            elif hasattr(self._local_obj, "__aenter__"):
+                warnings.warn("Not running asynchronous enter handlers on local objects")
             setattr(self._local_obj, "_modal_functions", self._functions)  # Needed for PartialFunction.__get__
             self._has_local_obj = True
 

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -127,8 +127,11 @@ def fastapi_app():
 
 @stub.cls()
 class Cls:
+    def __init__(self):
+        self._k = 11
+
     def __enter__(self):
-        self._k = 111
+        self._k += 100
 
     @method()
     def f(self, x):


### PR DESCRIPTION
Reverts modal-labs/modal-client#883 which was in itself a revert of #880 

Added a test for the underlying problem and also a fix. The code is a bit janky imo but at least somewhat well-tested now.