### PR TITLE
Remove interactive function selection

### DIFF
--- a/client_test/function_test.py
+++ b/client_test/function_test.py
@@ -534,15 +534,6 @@ def test_from_id(client, servicer):
     assert rehydrated_function_call.object_id == function_call.object_id
 
 
-def test_panel(client, servicer):
-    stub = Stub()
-    stub.function()(dummy)
-    function = stub["dummy"]
-    assert isinstance(function, Function)
-    image = stub._get_default_image()
-    assert function.get_panel_items() == [repr(image)]
-
-
 lc_stub = Stub()
 
 

--- a/modal/cli/import_refs.py
+++ b/modal/cli/import_refs.py
@@ -13,10 +13,8 @@ from pathlib import Path
 from typing import Any, Optional, Union
 
 import click
-from rich.console import Console, Group
+from rich.console import Console
 from rich.markdown import Markdown
-from rich.panel import Panel
-from rich.prompt import Prompt
 
 import modal
 from modal.functions import Function

--- a/modal/cli/import_refs.py
+++ b/modal/cli/import_refs.py
@@ -110,35 +110,8 @@ def get_by_object_path(obj: Any, obj_path: str):
     return obj
 
 
-def make_function_panel(idx: int, tag: str, function: Function, stub: Stub) -> Panel:
-    items = [f"- {i}" for i in function.get_panel_items()]
-    return Panel(
-        Markdown("\n".join(items)),
-        title=f"[bright_magenta]{idx}. [/bright_magenta][bold]{tag}[/bold]",
-        title_align="left",
-    )
-
-
-def choose_function_interactive(stub: Stub, console: Console) -> str:
-    # TODO: allow selection of local_entrypoints when used from `modal run`
-    functions = list(stub.registered_functions.items())
-    function_panels = [make_function_panel(idx, tag, obj, stub) for idx, (tag, obj) in enumerate(functions)]
-
-    renderable = Panel(Group(*function_panels))
-    console.print(renderable)
-
-    choice = Prompt.ask(
-        "[yellow] Pick a function definition: [/yellow]",
-        choices=[str(i) for i in range(len(functions))],
-        default="0",
-        show_default=False,
-    )
-
-    return functions[int(choice)][0]
-
-
 def infer_function_or_help(
-    stub: Stub, interactive: bool, accept_local_entrypoint: bool, accept_webhook: bool
+    stub: Stub, accept_local_entrypoint: bool, accept_webhook: bool
 ) -> Union[Function, LocalEntrypoint]:
     function_choices = set(stub.registered_functions.keys())
     if not accept_webhook:
@@ -160,9 +133,6 @@ def infer_function_or_help(
         else:
             err_msg = "Modal stub has no registered functions. Nothing to run."
         raise click.UsageError(err_msg)
-    elif interactive:
-        console = Console()
-        function_name = choose_function_interactive(stub, console)
     else:
         help_text = f"""You need to specify a Modal function or local entrypoint to run, e.g.
 
@@ -242,7 +212,7 @@ You would run foo as [bold green]{base_cmd} app.py::foo[/bold green]"""
 
 
 def import_function(
-    func_ref: str, base_cmd: str, accept_local_entrypoint=True, accept_webhook=False, interactive=False
+    func_ref: str, base_cmd: str, accept_local_entrypoint=True, accept_webhook=False
 ) -> Union[Function, LocalEntrypoint]:
     import_ref = parse_import_ref(func_ref)
     try:
@@ -256,7 +226,7 @@ def import_function(
     if isinstance(stub_or_function, Stub):
         # infer function or display help for how to select one
         stub = stub_or_function
-        function_handle = infer_function_or_help(stub, interactive, accept_local_entrypoint, accept_webhook)
+        function_handle = infer_function_or_help(stub, accept_local_entrypoint, accept_webhook)
         return function_handle
     elif isinstance(stub_or_function, Function):
         return stub_or_function

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -158,9 +158,7 @@ def _get_click_command_for_local_entrypoint(stub: Stub, entrypoint: LocalEntrypo
 
 class RunGroup(click.Group):
     def get_command(self, ctx, func_ref):
-        function_or_entrypoint = import_function(
-            func_ref, accept_local_entrypoint=True, interactive=False, base_cmd="modal run"
-        )
+        function_or_entrypoint = import_function(func_ref, accept_local_entrypoint=True, base_cmd="modal run")
         stub: Stub = function_or_entrypoint.stub
         if stub.description is None:
             stub.set_description(_get_clean_stub_description(func_ref))
@@ -294,9 +292,7 @@ def shell(
     if not console.is_terminal:
         raise click.UsageError("`modal shell` can only be run from a terminal.")
 
-    function = import_function(
-        func_ref, accept_local_entrypoint=False, accept_webhook=True, interactive=True, base_cmd="modal shell"
-    )
+    function = import_function(func_ref, accept_local_entrypoint=False, accept_webhook=True, base_cmd="modal shell")
     assert isinstance(function, Function)  # ensured by accept_local_entrypoint=False
     interactive_shell(
         function,

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -62,7 +62,7 @@ from .exception import (
     RemoteError,
     deprecation_warning,
 )
-from .gpu import GPU_T, display_gpu_config, parse_gpu_config
+from .gpu import GPU_T, parse_gpu_config
 from .image import _Image
 from .mount import _get_client_mount, _Mount
 from .network_file_system import _NetworkFileSystem, load_network_file_systems

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -593,21 +593,6 @@ class _Function(_Object, type_prefix="fu"):
         else:
             cloud_provider = None
 
-        panel_items = [
-            str(i)
-            for i in [
-                *mounts,
-                image,
-                *secrets,
-                *network_file_systems.values(),
-                *volumes.values(),
-            ]
-        ]
-        if gpu:
-            panel_items.append(display_gpu_config(gpu))
-        if cloud:
-            panel_items.append(f"Cloud({cloud.upper()})")
-
         if is_generator and webhook_config:
             if webhook_config.type == api_pb2.WEBHOOK_TYPE_FUNCTION:
                 raise InvalidError(
@@ -823,7 +808,6 @@ class _Function(_Object, type_prefix="fu"):
         obj._info = info
         obj._tag = tag
         obj._all_mounts = all_mounts  # needed for modal.serve file watching
-        obj._panel_items = panel_items
         obj._stub = stub  # Needed for CLI right now
         obj._obj = None
         obj._is_generator = is_generator
@@ -859,10 +843,6 @@ class _Function(_Object, type_prefix="fu"):
         provider._info = self._info
         provider._obj = obj
         return provider
-
-    def get_panel_items(self) -> List[str]:
-        """mdmd:hidden"""
-        return self._panel_items
 
     @property
     def tag(self):


### PR DESCRIPTION
We have an interactive function picker when you run `modal shell` (but not `modal run`).

A user just reported a bug that is caused because functions from other apps don't set this property.

In general I want to harmonize object construction so that objects constructed from different methods end up having the same properties. But this will take a fair bit of work – for it to work on remote objects, we have to make sure all properties are a part of the metadata returned from the server.

Until then, fixing this is unfortunately somewhat annoying, other than fixing it in some hacky ways. More generally, maintaining the panel code has caused me considerable cost already during various refactorings. I see the value of the interactive picker, but it feels pretty limited? I think removing it is best route forward - it fixes the immediate user problem and should reduce overall maintenance cost a bit.

This is also one out of two code paths in the client that relies on string representation of objects (the other one being `run_function` so this gets me halfway towards my goal of removing those as well. See #757. That would let us get rid of another thing that has a bunch of maintenance cost for not a ton of benefit (imo).

