### PR TITLE
Adds custom modal gRPC options

### DIFF
--- a/modal_proto/options.proto
+++ b/modal_proto/options.proto
@@ -1,0 +1,12 @@
+// Defines custom options used internally at Modal.
+// Custom options must be in the range 50000-99999.
+// Reference: https://protobuf.dev/programming-guides/proto2/#customoptions
+syntax = "proto3";
+
+import "google/protobuf/descriptor.proto";
+
+package modal.options;
+
+extend google.protobuf.FieldOptions {
+  optional bool audit_target_attr = 50000;
+}

--- a/tasks.py
+++ b/tasks.py
@@ -28,9 +28,7 @@ def protoc(ctx):
         + " --python_out=. --grpclib_python_out=. --grpc_python_out=. --mypy_out=. --mypy_grpc_out=."
     )
     print(py_protoc)
-    ctx.run(f"{py_protoc} -I . "
-            "modal_proto/api.proto "
-            "modal_proto/options.proto ")
+    ctx.run(f"{py_protoc} -I . " "modal_proto/api.proto " "modal_proto/options.proto ")
 
 
 @task

--- a/tasks.py
+++ b/tasks.py
@@ -28,7 +28,9 @@ def protoc(ctx):
         + " --python_out=. --grpclib_python_out=. --grpc_python_out=. --mypy_out=. --mypy_grpc_out=."
     )
     print(py_protoc)
-    ctx.run(f"{py_protoc} -I . modal_proto/api.proto")
+    ctx.run(f"{py_protoc} -I . "
+            "modal_proto/api.proto "
+            "modal_proto/options.proto ")
 
 
 @task


### PR DESCRIPTION
Adds custom modal options for gRPC messages allowing the annotation of specific message fields. For example, we can annotate a field indicating that we want to collect audit logs:

```protobuf
message ModalField {
  string object_id = 1 [ (modal.options.audit_target_id) = true ];
}
```