### PR TITLE
Better support for `cls` inheritance

### DIFF
--- a/client_test/cls_test.py
+++ b/client_test/cls_test.py
@@ -302,3 +302,26 @@ class ClsWithEnter:
 def test_local_enter():
     obj = ClsWithEnter(get_thread_id())
     assert obj.f(10) == 420
+
+
+inheritance_stub = Stub()
+
+
+class BaseCls:
+    def __enter__(self):
+        self.x = 2
+
+    @method()
+    def run(self, y):
+        return self.x * y
+
+
+@inheritance_stub.cls()
+class DerivedCls(BaseCls):
+    pass
+
+
+def test_derived_cls(client, servicer):
+    with inheritance_stub.run(client=client):
+        # default servicer fn just squares the number
+        assert DerivedCls.run.remote(3) == 9

--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -744,11 +744,10 @@ def test_unassociated_function(unix_servicer, event_loop):
 
 
 @skip_windows_unix_socket
-def test_param_cls_function_calling_local(unix_servicer, event_loop):
-    serialized_params = pickle.dumps(([111], {"y": "foo"}))
+def test_derived_cls(unix_servicer, event_loop):
     client, items = _run_container(
-        unix_servicer, "modal_test_support.functions", "ParamCls.g", serialized_params=serialized_params
+        unix_servicer, "modal_test_support.functions", "DerivedCls.run", inputs=_get_inputs(((3,), {}))
     )
     assert len(items) == 1
     assert items[0].result.status == api_pb2.GenericResult.GENERIC_STATUS_SUCCESS
-    assert items[0].result.data == serialize("111 foo 42")
+    assert items[0].result.data == serialize(6)

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -89,13 +89,13 @@ class FunctionInfo:
 
         if name_override is not None:
             self.function_name = name_override
-        elif f.__qualname__ != f.__name__:
+        elif f.__qualname__ != f.__name__ and not serialized:
             # Class function.
-            if len(f.__qualname__.split(".")) > 2 and not serialized:
+            if len(f.__qualname__.split(".")) > 2:
                 raise InvalidError("@stub.cls classes must be defined in global scope")
             self.function_name = f"{cls.__name__}.{f.__name__}"
         else:
-            self.function_name = f.__name__
+            self.function_name = f.__qualname__
 
         self.signature = inspect.signature(f)
         module = inspect.getmodule(f)

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -91,7 +91,8 @@ class FunctionInfo:
             self.function_name = name_override
         elif f.__qualname__ != f.__name__:
             # Class function.
-            # TODO: this doesn't work for functions in doubly-nested classes etc.
+            if len(f.__qualname__.split(".")) > 1:
+                raise InvalidError("@stub.cls classes must be defined in global scope")
             self.function_name = f"{cls.__name__}.{f.__name__}"
         else:
             self.function_name = f.__name__

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -91,7 +91,7 @@ class FunctionInfo:
             self.function_name = name_override
         elif f.__qualname__ != f.__name__:
             # Class function.
-            if len(f.__qualname__.split(".")) > 1:
+            if len(f.__qualname__.split(".")) > 2 and not serialized:
                 raise InvalidError("@stub.cls classes must be defined in global scope")
             self.function_name = f"{cls.__name__}.{f.__name__}"
         else:

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -86,8 +86,16 @@ class FunctionInfo:
     def __init__(self, f, serialized=False, name_override: Optional[str] = None, cls: Optional[Type] = None):
         self.raw_f = f
         self.cls = cls
-        # TODO(erikbern): if f.__qualname__ != f.__name__,  we should infer the class name instead
-        self.function_name = name_override if name_override is not None else f.__qualname__
+
+        if name_override is not None:
+            self.function_name = name_override
+        elif f.__qualname__ != f.__name__:
+            # Class function.
+            # TODO: this doesn't work for functions in doubly-nested classes etc.
+            self.function_name = f"{cls.__name__}.{f.__name__}"
+        else:
+            self.function_name = f.__name__
+
         self.signature = inspect.signature(f)
         module = inspect.getmodule(f)
 

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -609,11 +609,14 @@ class _Stub:
             partial_functions: Dict[str, PartialFunction] = {}
             functions: Dict[str, _Function] = {}
 
-            for k, v in user_cls.__dict__.items():
-                if isinstance(v, PartialFunction):
-                    partial_functions[k] = v
-                    partial_function = synchronizer._translate_in(v)  # TODO: remove need for?
-                    functions[k] = decorator(partial_function, user_cls)
+            for parent_cls in user_cls.mro():
+                if parent_cls is object:
+                    continue
+                for k, v in parent_cls.__dict__.items():
+                    if isinstance(v, PartialFunction):
+                        partial_functions[k] = v
+                        partial_function = synchronizer._translate_in(v)  # TODO: remove need for?
+                        functions[k] = decorator(partial_function, user_cls)
 
             tag: str = user_cls.__name__
             cls: _Cls = _Cls.from_local(user_cls, functions)

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -191,3 +191,17 @@ async def sleep_700_async(x):
 
 def unassociated_function(x):
     return 100 - x
+
+
+class BaseCls:
+    def __enter__(self):
+        self.x = 2
+
+    @method()
+    def run(self, y):
+        return self.x * y
+
+
+@stub.cls()
+class DerivedCls(BaseCls):
+    pass


### PR DESCRIPTION
This now works:

```python
class Base:
    def __enter__(self):
        self.x = 2

    @modal.method()
    def run(self, y):
        return self.x * y

@stub.cls()
class Foo(Base):
    pass

@stub.local_entrypoint()
def main():
    print(Foo().run.remote(3)) # == 6
```