### PR TITLE
token flow: add unique client secret

### DIFF
--- a/client_test/token_flow_test.py
+++ b/client_test/token_flow_test.py
@@ -9,7 +9,7 @@ from modal.token_flow import TokenFlow
 @pytest.mark.asyncio
 async def test_token_flow_server(servicer, client):
     tf = TokenFlow(client)
-    async with tf.start() as (token_flow_id, _):
+    async with tf.start() as (token_flow_id, _, _):
         # Make a request against the local web server and make sure it validates
         localhost_url = f"http://localhost:{servicer.token_flow_localhost_port}"
         async with aiohttp.ClientSession() as session:

--- a/modal/cli/token.py
+++ b/modal/cli/token.py
@@ -56,7 +56,7 @@ def _new_token(
     with Client.unauthenticated_client(server_url) as client:
         token_flow = TokenFlow(client)
 
-        with token_flow.start(source, next_url) as (token_flow_id, web_url):
+        with token_flow.start(source, next_url) as (token_flow_id, web_url, code):
             with console.status("Waiting for authentication in the web browser", spinner="dots"):
                 # Open the web url in the browser
                 if webbrowser.open_new_tab(web_url):
@@ -69,6 +69,8 @@ def _new_token(
                         " - please go to this URL manually and complete the flow:"
                     )
                 console.print(f"\n[link={web_url}]{web_url}[/link]\n")
+                if code:
+                    console.print(f"Enter this code: [yellow]{code}[/yellow]\n")
 
             with console.status("Waiting for token flow to complete...", spinner="dots") as status:
                 for attempt in itertools.count():

--- a/modal/token_flow.py
+++ b/modal/token_flow.py
@@ -20,7 +20,7 @@ class _TokenFlow:
     @asynccontextmanager
     async def start(
         self, utm_source: Optional[str] = None, next_url: Optional[str] = None
-    ) -> AsyncGenerator[Tuple[str, str], None]:
+    ) -> AsyncGenerator[Tuple[str, str, str], None]:
         """mdmd:hidden"""
         # Create a unique random value that's used to identify this client
         self.client_secret = str(uuid.uuid4())
@@ -48,7 +48,7 @@ class _TokenFlow:
             )
             resp = await self.stub.TokenFlowCreate(req)
             self.token_flow_id = resp.token_flow_id
-            yield (resp.token_flow_id, resp.web_url)
+            yield (resp.token_flow_id, resp.web_url, resp.code)
 
     async def finish(
         self, timeout: float = 40.0, grpc_extra_timeout: float = 5.0

--- a/modal/token_flow.py
+++ b/modal/token_flow.py
@@ -1,6 +1,5 @@
 # Copyright Modal Labs 2023
 import platform
-import uuid
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator, Optional, Tuple
 
@@ -22,9 +21,6 @@ class _TokenFlow:
         self, utm_source: Optional[str] = None, next_url: Optional[str] = None
     ) -> AsyncGenerator[Tuple[str, str, str], None]:
         """mdmd:hidden"""
-        # Create a unique random value that's used to identify this client
-        self.client_secret = str(uuid.uuid4())
-
         # Run a temporary http server returning the token id on /
         # This helps us add direct validation later
         # TODO(erikbern): handle failure launching server
@@ -44,10 +40,10 @@ class _TokenFlow:
                 utm_source=utm_source,
                 next_url=next_url,
                 localhost_port=int(url.split(":")[-1]),
-                client_secret=self.client_secret,
             )
             resp = await self.stub.TokenFlowCreate(req)
             self.token_flow_id = resp.token_flow_id
+            self.wait_secret = resp.wait_secret
             yield (resp.token_flow_id, resp.web_url, resp.code)
 
     async def finish(
@@ -56,7 +52,7 @@ class _TokenFlow:
         """mdmd:hidden"""
         # Wait for token flow to finish
         req = api_pb2.TokenFlowWaitRequest(
-            token_flow_id=self.token_flow_id, timeout=timeout, client_secret=self.client_secret
+            token_flow_id=self.token_flow_id, timeout=timeout, wait_secret=self.wait_secret
         )
         resp = await self.stub.TokenFlowWait(req, timeout=(timeout + grpc_extra_timeout))
         if not resp.timeout:

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1233,6 +1233,7 @@ message TokenFlowCreateRequest {
   string utm_source = 3;
   int32 localhost_port = 4;
   string next_url = 5;
+  string client_secret = 6;
 }
 
 message TokenFlowCreateResponse {
@@ -1243,6 +1244,7 @@ message TokenFlowCreateResponse {
 message TokenFlowWaitRequest {
   float timeout = 1;
   string token_flow_id = 2;
+  string client_secret = 3;
 }
 
 message TokenFlowWaitResponse {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1239,6 +1239,7 @@ message TokenFlowCreateRequest {
 message TokenFlowCreateResponse {
   string token_flow_id = 1;
   string web_url = 2;
+  string code = 3;
 };
 
 message TokenFlowWaitRequest {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1233,19 +1233,19 @@ message TokenFlowCreateRequest {
   string utm_source = 3;
   int32 localhost_port = 4;
   string next_url = 5;
-  string client_secret = 6;
 }
 
 message TokenFlowCreateResponse {
   string token_flow_id = 1;
   string web_url = 2;
   string code = 3;
+  string wait_secret = 4;
 };
 
 message TokenFlowWaitRequest {
   float timeout = 1;
   string token_flow_id = 2;
-  string client_secret = 3;
+  string wait_secret = 3;
 }
 
 message TokenFlowWaitResponse {


### PR DESCRIPTION
Since `TokenFlowCreate` and `TokenFlowWait` are unprotected endpoints, in theory a malicious user with access to the `token_flow_id` could hijack a victim's tokens if they do it quickly. This can especially happen if a token flow is successful but abandoned for some reason, in conjunction with a user leaking their `token_flow_id` (maybe sharing a link to it by mistake).

Adding a secret to the client that's used to correlate `Create` and `Wait` requests. Unlike the token flow id, the secret is never displayed (and never part of an URL) so there should be no risk of a leak (it would require network snooping, but in that case the attacker can get access in other ways).