### PR TITLE
[MOD-1518] Add CLI for uploading files to volumes

### DIFF
--- a/client_test/cli_test.py
+++ b/client_test/cli_test.py
@@ -403,8 +403,7 @@ def test_volume_get(servicer, set_env_client):
         with open(upload_path, "wb") as f:
             f.write(file_contents)
             f.flush()
-        # TODO: when PUT is implemented, do: _run(["volume", "put", vol_name, upload_path, file_path])
-        servicer.volume_files["vo-1"][file_path] = file_contents
+        _run(["volume", "put", vol_name, upload_path, file_path.decode()])
 
         _run(["volume", "get", vol_name, file_path.decode(), tmpdir])
         with open(os.path.join(tmpdir, file_path.decode()), "r") as f:

--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import dataclasses
 import hashlib
 import inspect
 import os
@@ -35,6 +36,12 @@ from modal_utils.async_utils import synchronize_api
 from modal_utils.grpc_testing import patch_mock_servicer
 from modal_utils.grpc_utils import find_free_port
 from modal_utils.http_utils import run_temporary_http_server
+
+
+@dataclasses.dataclass
+class VolumeFile:
+    data: bytes
+    data_blob_id: str
 
 
 @patch_mock_servicer
@@ -91,7 +98,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.task_result = None
 
         self.nfs_files: Dict[str, Dict[str, api_pb2.SharedVolumePutFileRequest]] = defaultdict(dict)
-        self.volume_files: Dict[str, Dict[str, bytes]] = defaultdict(dict)
+        self.volume_files: Dict[str, Dict[str, VolumeFile]] = defaultdict(dict)
         self.images = {}
         self.image_build_function_ids = {}
         self.force_built_images = []
@@ -739,8 +746,20 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def VolumeGetFile(self, stream):
         req = await stream.recv_message()
-        data = self.volume_files[req.volume_id][req.path]
-        await stream.send_message(api_pb2.VolumeGetFileResponse(data=data))
+        vol_file = self.volume_files[req.volume_id][req.path]
+        if vol_file.data_blob_id:
+            await stream.send_message(api_pb2.VolumeGetFileResponse(data_blob_id=vol_file.data_blob_id))
+        else:
+            await stream.send_message(api_pb2.VolumeGetFileResponse(data=vol_file.data))
+
+    async def VolumePutFiles(self, stream):
+        req = await stream.recv_message()
+        for file in req.files:
+            blob_data = self.files_sha2data[file.sha256_hex]
+            self.volume_files[req.volume_id][file.filename] = VolumeFile(
+                data=blob_data["data"], data_blob_id=blob_data["data_blob_id"]
+            )
+        await stream.send_message(Empty())
 
 
 @pytest_asyncio.fixture

--- a/client_test/conftest.py
+++ b/client_test/conftest.py
@@ -746,7 +746,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def VolumeGetFile(self, stream):
         req = await stream.recv_message()
-        vol_file = self.volume_files[req.volume_id][req.path]
+        vol_file = self.volume_files[req.volume_id][req.path.decode("utf-8")]
         if vol_file.data_blob_id:
             await stream.send_message(api_pb2.VolumeGetFileResponse(data_blob_id=vol_file.data_blob_id))
         else:

--- a/client_test/volume_test.py
+++ b/client_test/volume_test.py
@@ -1,6 +1,6 @@
 # Copyright Modal Labs 2023
-
 import pytest
+from unittest import mock
 
 import modal
 from modal.exception import InvalidError
@@ -132,3 +132,67 @@ def test_redeploy(servicer, client):
     # Should be unique and different
     assert len(set(app3_ids)) == 3
     assert set(app1_ids) & set(app3_ids) == set()
+
+
+@pytest.mark.asyncio
+async def test_volume_add_local_file(servicer, client, tmp_path):
+    stub = modal.Stub()
+    stub.vol = modal.Volume.new()
+    local_file_path = tmp_path / "some_file"
+    local_file_path.write_text("hello world")
+
+    with stub.run(client=client):
+        stub.vol.add_local_file(local_file_path)
+        stub.vol.add_local_file(local_file_path.as_posix(), remote_path="/foo/other_destination")
+        object_id = stub.vol.object_id
+
+    assert servicer.volume_files[object_id].keys() == {
+        "/some_file",
+        "/foo/other_destination",
+    }
+    assert servicer.volume_files[object_id]["/some_file"].data == b"hello world"
+    assert servicer.volume_files[object_id]["/foo/other_destination"].data == b"hello world"
+
+
+@pytest.mark.asyncio
+async def test_volume_add_local_dir(client, tmp_path, servicer):
+    stub = modal.Stub()
+    stub.vol = modal.Volume.new()
+    local_dir = tmp_path / "some_dir"
+    local_dir.mkdir()
+    (local_dir / "smol").write_text("###")
+
+    subdir = local_dir / "subdir"
+    subdir.mkdir()
+    (subdir / "other").write_text("####")
+
+    with stub.run(client=client):
+        stub.vol.add_local_dir(local_dir)
+        object_id = stub.vol.object_id
+
+    assert servicer.volume_files[object_id].keys() == {
+        "/some_dir/smol",
+        "/some_dir/subdir/other",
+    }
+    assert servicer.volume_files[object_id]["/some_dir/smol"].data == b"###"
+    assert servicer.volume_files[object_id]["/some_dir/subdir/other"].data == b"####"
+
+
+@pytest.mark.asyncio
+async def test_volume_put_large_file(client, tmp_path, servicer, blob_server, *args):
+    with mock.patch("modal._blob_utils.LARGE_FILE_LIMIT", 10):
+        stub = modal.Stub()
+        stub.vol = modal.Volume.new()
+        local_file_path = tmp_path / "bigfile"
+        local_file_path.write_text("hello world, this is a lot of text")
+
+        async with stub.run(client=client):
+            await stub.vol.add_local_file.aio(local_file_path)
+            object_id = stub.vol.object_id
+
+        assert servicer.volume_files[object_id].keys() == {"/bigfile"}
+        assert servicer.volume_files[object_id]["/bigfile"].data == b""
+        assert servicer.volume_files[object_id]["/bigfile"].data_blob_id == "bl-1"
+
+        _, blobs = blob_server
+        assert blobs["bl-1"] == b"hello world, this is a lot of text"

--- a/client_test/volume_test.py
+++ b/client_test/volume_test.py
@@ -6,6 +6,7 @@ import modal
 from modal.exception import InvalidError
 from modal.runner import deploy_stub
 
+from .conftest import VolumeFile
 from .supports.skip import skip_windows
 
 
@@ -84,7 +85,7 @@ async def test_volume_get(servicer, client):
     with stub.run(client=client):
         object_id = stub.vol.object_id
     # TODO: A PUT implementation for volumes will make this test simpler.
-    servicer.volume_files[object_id][file_path] = file_contents
+    servicer.volume_files[object_id][file_path.decode("utf-8")] = VolumeFile(data=file_contents, data_blob_id="")
 
     vol = await modal.Volume.lookup.aio("my-vol", client=client)  # type: ignore
     data = b""

--- a/client_test/volume_test.py
+++ b/client_test/volume_test.py
@@ -83,7 +83,7 @@ async def test_volume_get(servicer, client, tmp_path):
     file_path = b"foo.txt"
     local_file_path = tmp_path / file_path.decode("utf-8")
     local_file_path.write_bytes(file_contents)
-    await vol.add_local_file.aio(local_file_path, file_path.decode("utf-8"))
+    await vol._add_local_file.aio(local_file_path, file_path.decode("utf-8"))
 
     data = b""
     for chunk in vol.read_file(file_path):
@@ -140,8 +140,8 @@ async def test_volume_add_local_file(servicer, client, tmp_path):
     local_file_path.write_text("hello world")
 
     with stub.run(client=client):
-        stub.vol.add_local_file(local_file_path)
-        stub.vol.add_local_file(local_file_path.as_posix(), remote_path="/foo/other_destination")
+        stub.vol._add_local_file(local_file_path)
+        stub.vol._add_local_file(local_file_path.as_posix(), remote_path="/foo/other_destination")
         object_id = stub.vol.object_id
 
     assert servicer.volume_files[object_id].keys() == {
@@ -165,7 +165,7 @@ async def test_volume_add_local_dir(client, tmp_path, servicer):
     (subdir / "other").write_text("####")
 
     with stub.run(client=client):
-        stub.vol.add_local_dir(local_dir)
+        stub.vol._add_local_dir(local_dir)
         object_id = stub.vol.object_id
 
     assert servicer.volume_files[object_id].keys() == {
@@ -185,7 +185,7 @@ async def test_volume_put_large_file(client, tmp_path, servicer, blob_server, *a
         local_file_path.write_text("hello world, this is a lot of text")
 
         async with stub.run(client=client):
-            await stub.vol.add_local_file.aio(local_file_path)
+            await stub.vol._add_local_file.aio(local_file_path)
             object_id = stub.vol.object_id
 
         assert servicer.volume_files[object_id].keys() == {"/bigfile"}

--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -229,7 +229,7 @@ async def put(
     if Path(local_path).is_dir():
         spinner = step_progress(f"Uploading directory '{local_path}' to '{remote_path}'...")
         with Live(spinner, console=console):
-            await vol.add_local_dir(local_path, remote_path)
+            await vol._add_local_dir(local_path, remote_path)
         console.print(step_completed(f"Uploaded directory '{local_path}' to '{remote_path}'"))
 
     elif "*" in local_path:
@@ -237,5 +237,5 @@ async def put(
     else:
         spinner = step_progress(f"Uploading file '{local_path}' to '{remote_path}'...")
         with Live(spinner, console=console):
-            await vol.add_local_file(local_path, remote_path)
+            await vol._add_local_file(local_path, remote_path)
         console.print(step_completed(f"Uploaded file '{local_path}' to '{remote_path}'"))

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -1,13 +1,17 @@
 # Copyright Modal Labs 2023
 import asyncio
+import time
+from pathlib import Path, PurePosixPath
 from typing import AsyncIterator, List, Optional, Union
 
 from modal_proto import api_pb2
-from modal_utils.async_utils import asyncnullcontext, synchronize_api
+from modal_utils.async_utils import ConcurrencyPool, asyncnullcontext, synchronize_api
 from modal_utils.grpc_utils import retry_transient_errors, unary_stream
 
-from ._blob_utils import blob_iter
+from ._blob_utils import blob_iter, blob_upload_file, get_file_upload_spec
 from ._resolver import Resolver
+from .config import logger
+from .mount import MOUNT_PUT_FILE_CLIENT_TIMEOUT
 from .object import _Object, live_method, live_method_gen
 
 
@@ -191,6 +195,76 @@ class _Volume(_Object, type_prefix="vo"):
         else:
             async for data in blob_iter(response.data_blob_id, self._client.stub):
                 yield data
+
+    @live_method
+    async def add_local_file(
+        self, local_path: Union[Path, str], remote_path: Optional[Union[str, PurePosixPath, None]] = None
+    ):
+        mount_file = await self._upload_file(local_path, remote_path)
+        request = api_pb2.VolumePutFilesRequest(volume_id=self.object_id, files=[mount_file])
+        await retry_transient_errors(self._client.stub.VolumePutFiles, request, base_delay=1)
+
+    @live_method
+    async def add_local_dir(
+        self, local_path: Union[Path, str], remote_path: Optional[Union[str, PurePosixPath, None]] = None
+    ):
+        _local_path = Path(local_path)
+        if remote_path is None:
+            remote_path = PurePosixPath("/", _local_path.name).as_posix()
+        else:
+            remote_path = PurePosixPath(remote_path).as_posix()
+
+        assert _local_path.is_dir()
+
+        def gen_transfers():
+            for subpath in _local_path.rglob("*"):
+                if subpath.is_dir():
+                    continue
+                relpath_str = subpath.relative_to(_local_path).as_posix()
+                yield self._upload_file(subpath, PurePosixPath(remote_path, relpath_str))
+
+        files = await ConcurrencyPool(20).run_coros(gen_transfers(), return_exceptions=True)
+        request = api_pb2.VolumePutFilesRequest(volume_id=self.object_id, files=files)
+        await retry_transient_errors(self._client.stub.VolumePutFiles, request, base_delay=1)
+
+    @live_method
+    async def _upload_file(
+        self, local_path: Union[Path, str], remote_path: Optional[Union[str, PurePosixPath, None]] = None
+    ) -> api_pb2.MountFile:
+        local_path = Path(local_path)
+        if remote_path is None:
+            remote_path = PurePosixPath("/", local_path.name).as_posix()
+        else:
+            remote_path = PurePosixPath(remote_path).as_posix()
+
+        file_spec = get_file_upload_spec(local_path, str(remote_path))
+        remote_filename = file_spec.mount_filename
+
+        request = api_pb2.MountPutFileRequest(sha256_hex=file_spec.sha256_hex)
+        response = await retry_transient_errors(self._client.stub.MountPutFile, request, base_delay=1)
+
+        if not response.exists:
+            if file_spec.use_blob:
+                logger.debug(f"Creating blob file for {file_spec.filename} ({file_spec.size} bytes)")
+                with open(file_spec.filename, "rb") as fp:
+                    blob_id = await blob_upload_file(fp, self._client.stub)
+                logger.debug(f"Uploading blob file {file_spec.filename} as {remote_filename}")
+                request2 = api_pb2.MountPutFileRequest(data_blob_id=blob_id, sha256_hex=file_spec.sha256_hex)
+            else:
+                logger.debug(f"Uploading file {file_spec.filename} to {remote_filename} ({file_spec.size} bytes)")
+                request2 = api_pb2.MountPutFileRequest(data=file_spec.content, sha256_hex=file_spec.sha256_hex)
+
+            start_time = time.monotonic()
+            while time.monotonic() - start_time < MOUNT_PUT_FILE_CLIENT_TIMEOUT:
+                response = await retry_transient_errors(self._client.stub.MountPutFile, request2, base_delay=1)
+                if response.exists:
+                    break
+
+        return api_pb2.MountFile(
+            filename=remote_filename,
+            sha256_hex=file_spec.sha256_hex,
+            mode=file_spec.mode,
+        )
 
 
 Volume = synchronize_api(_Volume)

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -200,6 +200,16 @@ class _Volume(_Object, type_prefix="vo"):
     async def add_local_file(
         self, local_path: Union[Path, str], remote_path: Optional[Union[str, PurePosixPath, None]] = None
     ):
+        """
+        Upload a local file to the modal.Volume.
+
+        **Example:**
+
+        ```python notest
+        vol = modal.Volume.lookup("my-modal-volume")
+        vol.add_local_file("my-file.txt", "/remote-path/")
+        ```
+        """
         mount_file = await self._upload_file(local_path, remote_path)
         request = api_pb2.VolumePutFilesRequest(volume_id=self.object_id, files=[mount_file])
         await retry_transient_errors(self._client.stub.VolumePutFiles, request, base_delay=1)
@@ -208,6 +218,16 @@ class _Volume(_Object, type_prefix="vo"):
     async def add_local_dir(
         self, local_path: Union[Path, str], remote_path: Optional[Union[str, PurePosixPath, None]] = None
     ):
+        """
+        Upload a local directory to the modal.Volume.
+
+        **Example:**
+
+        ```python notest
+        vol = modal.Volume.lookup("my-modal-volume")
+        vol.add_local_dir("my-local-dir", "/remote-path/")
+        ```
+        """
         _local_path = Path(local_path)
         if remote_path is None:
             remote_path = PurePosixPath("/", _local_path.name).as_posix()

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -243,7 +243,7 @@ class _Volume(_Object, type_prefix="vo"):
                 relpath_str = subpath.relative_to(_local_path).as_posix()
                 yield self._upload_file(subpath, PurePosixPath(remote_path, relpath_str))
 
-        files = await ConcurrencyPool(20).run_coros(gen_transfers(), return_exceptions=True)
+        files = await ConcurrencyPool(20).run_coros(gen_transfers(), return_exceptions=False)
         request = api_pb2.VolumePutFilesRequest(volume_id=self.object_id, files=files)
         await retry_transient_errors(self._client.stub.VolumePutFiles, request, base_delay=1)
 

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -197,37 +197,17 @@ class _Volume(_Object, type_prefix="vo"):
                 yield data
 
     @live_method
-    async def add_local_file(
+    async def _add_local_file(
         self, local_path: Union[Path, str], remote_path: Optional[Union[str, PurePosixPath, None]] = None
     ):
-        """
-        Upload a local file to the modal.Volume.
-
-        **Example:**
-
-        ```python notest
-        vol = modal.Volume.lookup("my-modal-volume")
-        vol.add_local_file("my-file.txt", "/remote-path/")
-        ```
-        """
         mount_file = await self._upload_file(local_path, remote_path)
         request = api_pb2.VolumePutFilesRequest(volume_id=self.object_id, files=[mount_file])
         await retry_transient_errors(self._client.stub.VolumePutFiles, request, base_delay=1)
 
     @live_method
-    async def add_local_dir(
+    async def _add_local_dir(
         self, local_path: Union[Path, str], remote_path: Optional[Union[str, PurePosixPath, None]] = None
     ):
-        """
-        Upload a local directory to the modal.Volume.
-
-        **Example:**
-
-        ```python notest
-        vol = modal.Volume.lookup("my-modal-volume")
-        vol.add_local_dir("my-local-dir", "/remote-path/")
-        ```
-        """
         _local_path = Path(local_path)
         if remote_path is None:
             remote_path = PurePosixPath("/", _local_path.name).as_posix()

--- a/modal_utils/async_utils.py
+++ b/modal_utils/async_utils.py
@@ -344,7 +344,7 @@ class ConcurrencyPool:
                 res = await coro
                 self.semaphore.release()
                 return res
-            except Exception as e:
+            except BaseException as e:
                 if return_exceptions:
                     self.semaphore.release()
                 raise e
@@ -355,7 +355,7 @@ class ConcurrencyPool:
         g = asyncio.gather(*tasks, return_exceptions=return_exceptions)
         try:
             return await g
-        except Exception as e:
+        except BaseException as e:
             for t in tasks:
                 t.cancel()
             raise e


### PR DESCRIPTION
Example usage:
```
$ MODAL_PROFILE=local modal volume put voltest large.file /foo/bar/a.file
⠼ Uploading file 'large.file' to '/foo/bar/a.file'...
✓ Uploaded file 'large.file' to '/foo/bar/a.file'
```

Which then shows up in the volume:
```
$ MODAL_PROFILE=local modal shell voltest.py
...
Spawning /bin/bash
root@modal:~# ls -l /volume/foo/bar/
total 204800
-rw-rw-r-- 1 root root 209715200 Jan  1  1970 a.file
root@modal:~#
```

(As a follow-up, we should probably set ctime based on the upload time)

Like for mounts, uploads are lazy - we don't reupload if a file with the same contents already exists:

```
$ fallocate -l 200M large.file
$ time MODAL_PROFILE=local modal volume put voltest large.file
⠧ Uploading file 'large.file' to '/large.file'...
✓ Uploaded file 'large.file' to '/large.file'

real	0m20,541s
user	0m1,417s
sys	0m0,517s
$ time MODAL_PROFILE=local modal volume put voltest large.file
⠼ Uploading file 'large.file' to '/large.file'...
✓ Uploaded file 'large.file' to '/large.file'

real	0m1,095s
user	0m0,510s
sys	0m0,098s
```

**Note that this will happily overwrite existing files and directories with impunity!** We should fix that. It's pretty easy to shoot yourself in the foot as is:

```
$ modal volume put some-dir /some-dir
$ modal volume put some-file.txt /some-dir   # note the lack of a trailing slash
# Oops! /some-dir was now wiped and replaced by a file :scream: 
```