### PR TITLE
Add protobuf options for methods

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package modal.client;
 
+import "modal_proto/options.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/wrappers.proto";
 
@@ -1357,7 +1358,10 @@ message WebUrlInfo {
 
 service ModalClient {
   // Apps
-  rpc AppCreate(AppCreateRequest) returns (AppCreateResponse);
+  rpc AppCreate(AppCreateRequest) returns (AppCreateResponse) {
+    option (modal.options.audit_event_name) = "Create App";
+    option (modal.options.audit_event_description) = "Creates Modal app";
+  }; 
   rpc AppClientDisconnect(AppClientDisconnectRequest) returns (google.protobuf.Empty);
   rpc AppGetLogs(AppGetLogsRequest) returns (stream TaskLogsBatch);
   rpc AppSetObjects(AppSetObjectsRequest) returns (google.protobuf.Empty);

--- a/modal_proto/options.proto
+++ b/modal_proto/options.proto
@@ -1,0 +1,12 @@
+// Defines custom options used internally at Modal.
+// Custom options must be in the range 50000-99999.
+// Reference: https://protobuf.dev/programming-guides/proto2/#customoptions
+syntax = "proto3";
+
+import "google/protobuf/descriptor.proto";
+
+package modal.options;
+
+extend google.protobuf.FieldOptions {
+  optional bool audit_target_attr = 50000;
+}

--- a/modal_proto/options.proto
+++ b/modal_proto/options.proto
@@ -10,3 +10,8 @@ package modal.options;
 extend google.protobuf.FieldOptions {
   optional bool audit_target_attr = 50000;
 }
+
+extend google.protobuf.MethodOptions {
+  optional string audit_event_name = 50000;
+  optional string audit_event_description = 50001;
+}

--- a/tasks.py
+++ b/tasks.py
@@ -28,9 +28,7 @@ def protoc(ctx):
         + " --python_out=. --grpclib_python_out=. --grpc_python_out=. --mypy_out=. --mypy_grpc_out=."
     )
     print(py_protoc)
-    ctx.run(f"{py_protoc} -I . "
-            "modal_proto/api.proto "
-            "modal_proto/options.proto ")
+    ctx.run(f"{py_protoc} -I . " "modal_proto/api.proto " "modal_proto/options.proto ")
 
 
 @task

--- a/tasks.py
+++ b/tasks.py
@@ -28,7 +28,9 @@ def protoc(ctx):
         + " --python_out=. --grpclib_python_out=. --grpc_python_out=. --mypy_out=. --mypy_grpc_out=."
     )
     print(py_protoc)
-    ctx.run(f"{py_protoc} -I . modal_proto/api.proto")
+    ctx.run(f"{py_protoc} -I . "
+            "modal_proto/api.proto "
+            "modal_proto/options.proto ")
 
 
 @task


### PR DESCRIPTION
We want to display human readable rpc method names and descriptions as documentation for the events tracked. These new options allow for the annotation of methods, which we can then use to generate audit log documentation.