### PR TITLE
Adds options to protobuf methods

### DIFF
--- a/modal_proto/options.proto
+++ b/modal_proto/options.proto
@@ -10,3 +10,8 @@ package modal.options;
 extend google.protobuf.FieldOptions {
   optional bool audit_target_attr = 50000;
 }
+
+extend google.protobuf.MethodOptions {
+  optional string audit_event_name = 50000;
+  optional string audit_event_description = 50001;
+}


### PR DESCRIPTION
We want to display human readable rpc method names and descriptions as documentation for the events tracked. These new options allow for the annotation of methods, which we can then use to generate audit log documentation.
