### PR TITLE
Annotates messages for audit logging

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -841,7 +841,7 @@ message SandboxCreateResponse {
 }
 
 message SandboxWaitRequest {
-  string sandbox_id = 1 [ (modal.options.audit_target_attr) = true ];
+  string sandbox_id = 1;
   float timeout = 2;
 }
 
@@ -1099,7 +1099,7 @@ message SecretListItem {
 }
 
 message SecretListRequest {
-  string environment_name = 1 [ (modal.options.audit_target_attr) = true ]; // leaving empty will assume a singular environment
+  string environment_name = 1; // leaving empty will assume a singular environment
 }
 
 message SecretListResponse {
@@ -1124,7 +1124,7 @@ message SharedVolumeListItem {
 }
 
 message SharedVolumeListRequest {
-  string environment_name = 1 [ (modal.options.audit_target_attr) = true ];
+  string environment_name = 1;
 }
 
 message SharedVolumeListResponse {
@@ -1133,7 +1133,7 @@ message SharedVolumeListResponse {
 }
 
 message SharedVolumeListFilesRequest {
-  string shared_volume_id = 1 [ (modal.options.audit_target_attr) = true ];
+  string shared_volume_id = 1;
   string path = 2;
 }
 
@@ -1153,7 +1153,7 @@ message SharedVolumePutFileResponse {
 }
 
 message SharedVolumeGetFileRequest {
-  string shared_volume_id = 1 [ (modal.options.audit_target_attr) = true ];
+  string shared_volume_id = 1;
   string path = 2;
 }
 
@@ -1271,7 +1271,7 @@ message VolumeCommitRequest {
 }
 
 message VolumeGetFileRequest {
-  string volume_id = 1 [ (modal.options.audit_target_attr) = true ];
+  string volume_id = 1;
   bytes path = 2;
 }
 
@@ -1296,7 +1296,7 @@ message VolumeListFilesEntry {
 }
 
 message VolumeListFilesRequest {
-  string volume_id = 1 [ (modal.options.audit_target_attr) = true ];
+  string volume_id = 1;
   string path = 2;
 }
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package modal.client;
 
+import "modal_proto/options.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/wrappers.proto";
 
@@ -95,7 +96,7 @@ message AppClientDisconnectRequest {
 }
 
 message AppCreateRequest {
-  string client_id = 1;
+  string client_id = 1 [ (modal.options.audit_target_attr) = true ];
   string description = 2;    // Human readable label for the app
   bool detach = 3; // deprecated, but needed until 0.48 is the minimum version
   bool initializing = 4; // deprecated, but needed until 0.48 is the minimum version
@@ -108,11 +109,11 @@ message AppCreateResponse {
 }
 
 message AppStopRequest {
-  string app_id = 1;
+  string app_id = 1 [ (modal.options.audit_target_attr) = true ];
 }
 
 message AppDeployRequest {
-  string app_id = 1;
+  string app_id = 1 [ (modal.options.audit_target_attr) = true ];
   DeploymentNamespace namespace = 2;
   string name = 3;
   string object_entity = 4;
@@ -228,7 +229,7 @@ message ClassMethod {
 }
 
 message ClassCreateRequest {
-  string app_id = 1;
+  string app_id = 1  [ (modal.options.audit_target_attr) = true ];
   string existing_class_id = 2;
   repeated ClassMethod methods = 3;
 }
@@ -312,7 +313,7 @@ message BlobGetResponse {
 }
 
 message ClientCreateRequest {
-  ClientType client_type = 1;
+  ClientType client_type = 1  [ (modal.options.audit_target_attr) = true ];
   string version = 2;
 }
 
@@ -358,7 +359,7 @@ message DictContainsResponse {
 
 message DictCreateRequest {
   repeated DictEntry data = 1;
-  string app_id = 2;
+  string app_id = 2  [ (modal.options.audit_target_attr) = true ];
   string existing_dict_id = 3;
 }
 
@@ -420,7 +421,7 @@ message DNSRecord {
 }
 
 message DomainCreateRequest {
-  string domain_name = 1;
+  string domain_name = 1  [ (modal.options.audit_target_attr) = true ];
 }
 
 message DomainCreateResponse {
@@ -555,14 +556,14 @@ message FunctionHandleMetadata {
 
 message FunctionCreateRequest {
   Function function = 1;
-  string app_id = 2;
+  string app_id = 2  [ (modal.options.audit_target_attr) = true ];
   Schedule schedule = 6;
   string existing_function_id = 7;
 }
 
 message FunctionPrecreateRequest {
   string app_id = 1;
-  string function_name = 2;
+  string function_name = 2  [ (modal.options.audit_target_attr) = true ];
   string existing_function_id = 3;
   Function.FunctionType function_type = 4;
   WebhookConfig webhook_config = 5;
@@ -831,7 +832,7 @@ message Sandbox {
 }
 
 message SandboxCreateRequest {
-  string app_id = 1;
+  string app_id = 1 [ (modal.options.audit_target_attr) = true ];
   Sandbox definition = 2;
 }
 
@@ -840,7 +841,7 @@ message SandboxCreateResponse {
 }
 
 message SandboxWaitRequest {
-  string sandbox_id = 1;
+  string sandbox_id = 1 [ (modal.options.audit_target_attr) = true ];
   float timeout = 2;
 }
 
@@ -938,7 +939,7 @@ message ImageJoinStreamingResponse {
 }
 
 message MountBuildRequest {
-  string app_id = 2;
+  string app_id = 2 [ (modal.options.audit_target_attr) = true ];
   string existing_mount_id = 3;
   repeated MountFile files = 4;
 }
@@ -1080,7 +1081,7 @@ message Schedule {
 
 message SecretCreateRequest {
   map<string, string> env_dict = 1;
-  string app_id = 2;
+  string app_id = 2 [ (modal.options.audit_target_attr) = true ];
   string template_type = 3;
   string existing_secret_id = 4;
 }
@@ -1098,7 +1099,7 @@ message SecretListItem {
 }
 
 message SecretListRequest {
-  string environment_name = 1; // leaving empty will assume a singular environment
+  string environment_name = 1 [ (modal.options.audit_target_attr) = true ]; // leaving empty will assume a singular environment
 }
 
 message SecretListResponse {
@@ -1107,7 +1108,7 @@ message SecretListResponse {
 }
 
 message SharedVolumeCreateRequest {
-  string app_id = 1;
+  string app_id = 1 [ (modal.options.audit_target_attr) = true ];
   CloudProvider cloud_provider = 2;
 }
 
@@ -1123,7 +1124,7 @@ message SharedVolumeListItem {
 }
 
 message SharedVolumeListRequest {
-  string environment_name = 1;
+  string environment_name = 1 [ (modal.options.audit_target_attr) = true ];
 }
 
 message SharedVolumeListResponse {
@@ -1132,12 +1133,12 @@ message SharedVolumeListResponse {
 }
 
 message SharedVolumeListFilesRequest {
-  string shared_volume_id = 1;
+  string shared_volume_id = 1 [ (modal.options.audit_target_attr) = true ];
   string path = 2;
 }
 
 message SharedVolumePutFileRequest {
-  string shared_volume_id = 1;
+  string shared_volume_id = 1 [ (modal.options.audit_target_attr) = true ];
   string path = 2;
   string sha256_hex = 3;
   oneof data_oneof {
@@ -1152,7 +1153,7 @@ message SharedVolumePutFileResponse {
 }
 
 message SharedVolumeGetFileRequest {
-  string shared_volume_id = 1;
+  string shared_volume_id = 1 [ (modal.options.audit_target_attr) = true ];
   string path = 2;
 }
 
@@ -1164,7 +1165,7 @@ message SharedVolumeGetFileResponse {
 }
 
 message SharedVolumeRemoveFileRequest {
-  string shared_volume_id = 1;
+  string shared_volume_id = 1 [ (modal.options.audit_target_attr) = true ];
   string path = 2;
   bool recursive = 3;
 }
@@ -1228,7 +1229,7 @@ message TaskResultRequest {
 }
 
 message TokenFlowCreateRequest {
-  string node_name = 1;
+  string node_name = 1 [ (modal.options.audit_target_attr) = true ];
   string platform_name = 2;
   string utm_source = 3;
   int32 localhost_port = 4;
@@ -1256,7 +1257,7 @@ message TokenFlowWaitResponse {
 }
 
 message VolumeCreateRequest {
-  string app_id = 1;
+  string app_id = 1 [ (modal.options.audit_target_attr) = true ];
 }
 
 message VolumeCreateResponse {
@@ -1266,11 +1267,11 @@ message VolumeCreateResponse {
 message VolumeCommitRequest {
   // NOTE(staffan): Mounting a volume in multiple locations is not supported, so volume_id alone uniquely identifies
   // a volume mount.
-  string volume_id = 1;
+  string volume_id = 1 [ (modal.options.audit_target_attr) = true ];
 }
 
 message VolumeGetFileRequest {
-  string volume_id = 1;
+  string volume_id = 1 [ (modal.options.audit_target_attr) = true ];
   bytes path = 2;
 }
 
@@ -1295,7 +1296,7 @@ message VolumeListFilesEntry {
 }
 
 message VolumeListFilesRequest {
-  string volume_id = 1;
+  string volume_id = 1 [ (modal.options.audit_target_attr) = true ];
   string path = 2;
 }
 


### PR DESCRIPTION
Annotates gRPC messages that need to collected by our audit logs system. I picked messages based on the mutability of objects in Modal: if an RPC mutates a Modal object (e.g. creating an App or a Volume) then we create an audit log entry.