### PR TITLE
fix: Quote url as single shell token

### DIFF
--- a/client_test/image_test.py
+++ b/client_test/image_test.py
@@ -202,11 +202,11 @@ def test_image_pip_install_private_repos(servicer, client):
         layers = get_image_layers(stub["image"].object_id, servicer)
         assert len(layers[0].secret_ids) == 2
         assert any(
-            "pip install git+https://erikbern:$GITHUB_TOKEN@github.com/corp/private-one@1.0.0" in cmd
+            "pip install 'git+https://erikbern:$GITHUB_TOKEN@github.com/corp/private-one@1.0.0'" in cmd
             for cmd in layers[0].dockerfile_commands
         )
         assert any(
-            "pip install git+https://erikbern:$GITLAB_TOKEN@gitlab.com/corp2/private-two@0.0.2" in cmd
+            "pip install 'git+https://erikbern:$GITLAB_TOKEN@gitlab.com/corp2/private-two@0.0.2'" in cmd
             for cmd in layers[0].dockerfile_commands
         )
 

--- a/modal/image.py
+++ b/modal/image.py
@@ -501,7 +501,7 @@ class _Image(_Object, type_prefix="im"):
             )
 
         dockerfile_commands.extend(["RUN apt-get update && apt-get install -y git"])
-        dockerfile_commands.extend([f"RUN python3 -m pip install {url}" for url in install_urls])
+        dockerfile_commands.extend([f"RUN python3 -m pip install {shlex.quote(url)}" for url in install_urls])
 
         gpu_config = parse_gpu_config(gpu)
 


### PR DESCRIPTION
Wasn't quoting the URL and an `&` character was causing install to run in background 😖. 
