### PR TITLE
Remove `App._tag_to_object`

### DIFF
--- a/client_test/token_flow_test.py
+++ b/client_test/token_flow_test.py
@@ -9,7 +9,7 @@ from modal.token_flow import TokenFlow
 @pytest.mark.asyncio
 async def test_token_flow_server(servicer, client):
     tf = TokenFlow(client)
-    async with tf.start() as (token_flow_id, _):
+    async with tf.start() as (token_flow_id, _, _):
         # Make a request against the local web server and make sure it validates
         localhost_url = f"http://localhost:{servicer.token_flow_localhost_port}"
         async with aiohttp.ClientSession() as session:

--- a/client_test/webhook_test.py
+++ b/client_test/webhook_test.py
@@ -37,7 +37,7 @@ async def test_webhook(servicer, client):
         # Make sure the container gets the app id as well
         container_app = await App.init_container.aio(client, stub.app_id)
         container_app._associate_stub_container(stub)
-        f_c = container_app._get_object("f")
+        f_c = stub["f"]
         assert isinstance(f_c, Function)
         assert f_c.web_url
 

--- a/modal/app.py
+++ b/modal/app.py
@@ -46,7 +46,6 @@ class _App:
     ```
     """
 
-    _tag_to_object: Dict[str, _Object]
     _tag_to_object_id: Dict[str, str]
     _tag_to_handle_metadata: Dict[str, Message]
 
@@ -64,7 +63,6 @@ class _App:
         app_id: str,
         app_page_url: str,
         output_mgr: Optional[OutputManager],
-        tag_to_object: Optional[Dict[str, _Object]] = None,
         tag_to_object_id: Optional[Dict[str, str]] = None,
         stub_name: Optional[str] = None,
         environment_name: Optional[str] = None,
@@ -73,7 +71,6 @@ class _App:
         self._app_id = app_id
         self._app_page_url = app_page_url
         self._client = client
-        self._tag_to_object = tag_to_object or {}
         self._tag_to_object_id = tag_to_object_id or {}
         self._tag_to_handle_metadata = {}
         self._stub_name = stub_name
@@ -115,7 +112,6 @@ class _App:
             else:
                 # Can't find the object, create a new one
                 obj = _Object._new_hydrated(object_id, self._client, handle_metadata)
-            self._tag_to_object[tag] = obj
 
     def _associate_stub_local(self, stub):
         self._associated_stub = stub
@@ -138,8 +134,6 @@ class _App:
 
             # Assign all objects
             for tag, obj in blueprint.items():
-                self._tag_to_object[tag] = obj
-
                 # Reset object_id in case the app runs twice
                 # TODO(erikbern): clean up the interface
                 obj._unhydrate()
@@ -178,7 +172,6 @@ class _App:
             new_app_state=new_app_state,  # type: ignore
         )
         await retry_transient_errors(self._client.stub.AppSetObjects, req_set)
-        return self._tag_to_object
 
     async def disconnect(self):
         """Tell the server the client has disconnected for this app. Terminates all running tasks

--- a/modal/app.py
+++ b/modal/app.py
@@ -180,11 +180,6 @@ class _App:
         await retry_transient_errors(self._client.stub.AppSetObjects, req_set)
         return self._tag_to_object
 
-    def _uncreate_all_objects(self):
-        # TODO(erikbern): this doesn't unhydrate objects that aren't tagged
-        for obj in self._tag_to_object.values():
-            obj._unhydrate()
-
     async def disconnect(self):
         """Tell the server the client has disconnected for this app. Terminates all running tasks
         for ephemeral apps."""

--- a/modal/app.py
+++ b/modal/app.py
@@ -170,9 +170,7 @@ class _App:
         assert indexed_object_ids == self._tag_to_object_id
         all_objects = resolver.objects()
 
-        unindexed_object_ids = list(
-            set(obj.object_id for obj in all_objects) - set(obj.object_id for obj in self._tag_to_object.values())
-        )
+        unindexed_object_ids = list(set(obj.object_id for obj in all_objects) - set(self._tag_to_object_id.values()))
         req_set = api_pb2.AppSetObjectsRequest(
             app_id=self._app_id,
             indexed_object_ids=indexed_object_ids,

--- a/modal/app.py
+++ b/modal/app.py
@@ -207,15 +207,15 @@ class _App:
 
     def __getitem__(self, tag: str) -> _Object:
         deprecation_warning(date(2023, 8, 10), "`app[...]` is deprecated. Use the stub to get objects instead.")
-        return self._tag_to_object[tag]
+        return self._associated_stub[tag]
 
     def __contains__(self, tag: str) -> bool:
         deprecation_warning(date(2023, 8, 10), "`obj in app` is deprecated. Use the stub to get objects instead.")
-        return tag in self._tag_to_object
+        return tag in self._associated_stub
 
     def __getattr__(self, tag: str) -> _Object:
         deprecation_warning(date(2023, 8, 10), "`app.obj` is deprecated. Use the stub to get objects instead.")
-        return self._tag_to_object[tag]
+        return self._associated_stub[tag]
 
     def _get_object(self, tag: str) -> Optional[_Object]:
         # TODO(erikbern): remove objects from apps soon

--- a/modal/app.py
+++ b/modal/app.py
@@ -215,9 +215,13 @@ class _App:
         deprecation_warning(date(2023, 8, 10), "`app.obj` is deprecated. Use the stub to get objects instead.")
         return self._associated_stub[tag]
 
-    def _get_object(self, tag: str) -> Optional[_Object]:
-        # TODO(erikbern): remove objects from apps soon
-        return self._tag_to_object.get(tag)
+    def _has_object(self, tag: str) -> bool:
+        return tag in self._tag_to_object_id
+
+    def _hydrate_object(self, obj, tag: str):
+        object_id: str = self._tag_to_object_id[tag]
+        metadata: Message = self._tag_to_handle_metadata[tag]
+        obj._hydrate(object_id, self._client, metadata)
 
     async def _init_container(self, client: _Client, app_id: str, stub_name: str):
         self._client = client

--- a/modal/cli/token.py
+++ b/modal/cli/token.py
@@ -56,7 +56,7 @@ def _new_token(
     with Client.unauthenticated_client(server_url) as client:
         token_flow = TokenFlow(client)
 
-        with token_flow.start(source, next_url) as (token_flow_id, web_url):
+        with token_flow.start(source, next_url) as (token_flow_id, web_url, code):
             with console.status("Waiting for authentication in the web browser", spinner="dots"):
                 # Open the web url in the browser
                 if webbrowser.open_new_tab(web_url):
@@ -69,6 +69,8 @@ def _new_token(
                         " - please go to this URL manually and complete the flow:"
                     )
                 console.print(f"\n[link={web_url}]{web_url}[/link]\n")
+                if code:
+                    console.print(f"Enter this code: [yellow]{code}[/yellow]\n")
 
             with console.status("Waiting for token flow to complete...", spinner="dots") as status:
                 for attempt in itertools.count():

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -125,8 +125,8 @@ async def _run_stub(
                     "Disconnecting from Modal - This will terminate your Modal app in a few seconds.\n"
                 )
         finally:
-            app._uncreate_all_objects()
             await app.disconnect()
+            stub._uncreate_all_objects()
 
     output_mgr.print_if_visible(step_completed("App completed."))
 

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -205,9 +205,8 @@ class _Stub:
             # If this is inside a container, and some module is loaded lazily, then a function may be
             # defined later than the container initialization. If this happens then lets hydrate the
             # function at this point
-            other_obj = self._app._get_object(tag)
-            if other_obj is not None:
-                obj._hydrate_from_other(other_obj)
+            if self._app._has_object(tag):
+                self._app._hydrate_object(obj, tag)
 
         self._blueprint[tag] = obj
 

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -240,6 +240,11 @@ class _Stub:
         """Used by the container app to initialize objects."""
         return list(self._blueprint.items())
 
+    def _uncreate_all_objects(self):
+        # TODO(erikbern): this doesn't unhydrate objects that aren't tagged
+        for obj in self._blueprint.values():
+            obj._unhydrate()
+
     @typechecked
     def is_inside(self, image: Optional[_Image] = None) -> bool:
         """Returns if the program is currently running inside a container for this app."""

--- a/modal/token_flow.py
+++ b/modal/token_flow.py
@@ -20,7 +20,7 @@ class _TokenFlow:
     @asynccontextmanager
     async def start(
         self, utm_source: Optional[str] = None, next_url: Optional[str] = None
-    ) -> AsyncGenerator[Tuple[str, str], None]:
+    ) -> AsyncGenerator[Tuple[str, str, str], None]:
         """mdmd:hidden"""
         # Create a unique random value that's used to identify this client
         self.client_secret = str(uuid.uuid4())
@@ -48,7 +48,7 @@ class _TokenFlow:
             )
             resp = await self.stub.TokenFlowCreate(req)
             self.token_flow_id = resp.token_flow_id
-            yield (resp.token_flow_id, resp.web_url)
+            yield (resp.token_flow_id, resp.web_url, resp.code)
 
     async def finish(
         self, timeout: float = 40.0, grpc_extra_timeout: float = 5.0

--- a/modal/token_flow.py
+++ b/modal/token_flow.py
@@ -1,6 +1,5 @@
 # Copyright Modal Labs 2023
 import platform
-import uuid
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator, Optional, Tuple
 
@@ -22,9 +21,6 @@ class _TokenFlow:
         self, utm_source: Optional[str] = None, next_url: Optional[str] = None
     ) -> AsyncGenerator[Tuple[str, str, str], None]:
         """mdmd:hidden"""
-        # Create a unique random value that's used to identify this client
-        self.client_secret = str(uuid.uuid4())
-
         # Run a temporary http server returning the token id on /
         # This helps us add direct validation later
         # TODO(erikbern): handle failure launching server
@@ -44,10 +40,10 @@ class _TokenFlow:
                 utm_source=utm_source,
                 next_url=next_url,
                 localhost_port=int(url.split(":")[-1]),
-                client_secret=self.client_secret,
             )
             resp = await self.stub.TokenFlowCreate(req)
             self.token_flow_id = resp.token_flow_id
+            self.wait_secret = resp.wait_secret
             yield (resp.token_flow_id, resp.web_url, resp.code)
 
     async def finish(
@@ -56,7 +52,7 @@ class _TokenFlow:
         """mdmd:hidden"""
         # Wait for token flow to finish
         req = api_pb2.TokenFlowWaitRequest(
-            token_flow_id=self.token_flow_id, timeout=timeout, client_secret=self.client_secret
+            token_flow_id=self.token_flow_id, timeout=timeout, wait_secret=self.wait_secret
         )
         resp = await self.stub.TokenFlowWait(req, timeout=(timeout + grpc_extra_timeout))
         if not resp.timeout:

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1233,6 +1233,7 @@ message TokenFlowCreateRequest {
   string utm_source = 3;
   int32 localhost_port = 4;
   string next_url = 5;
+  string client_secret = 6;
 }
 
 message TokenFlowCreateResponse {
@@ -1243,6 +1244,7 @@ message TokenFlowCreateResponse {
 message TokenFlowWaitRequest {
   float timeout = 1;
   string token_flow_id = 2;
+  string client_secret = 3;
 }
 
 message TokenFlowWaitResponse {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1239,6 +1239,7 @@ message TokenFlowCreateRequest {
 message TokenFlowCreateResponse {
   string token_flow_id = 1;
   string web_url = 2;
+  string code = 3;
 };
 
 message TokenFlowWaitRequest {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1233,19 +1233,19 @@ message TokenFlowCreateRequest {
   string utm_source = 3;
   int32 localhost_port = 4;
   string next_url = 5;
-  string client_secret = 6;
 }
 
 message TokenFlowCreateResponse {
   string token_flow_id = 1;
   string web_url = 2;
   string code = 3;
+  string wait_secret = 4;
 };
 
 message TokenFlowWaitRequest {
   float timeout = 1;
   string token_flow_id = 2;
-  string client_secret = 3;
+  string wait_secret = 3;
 }
 
 message TokenFlowWaitResponse {


### PR DESCRIPTION
A set of small commits removing the use of `_tag_to_object` in the `_App` class.

Main point is to reduce the scope of the `_App` class further so that we can get rid of it soon