### PR TITLE
[MOD-1518] Add batched API for uploading files to volumes

### DIFF
--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -22,7 +22,7 @@ from modal.cli._download import _glob_download
 from modal.cli.utils import ENV_OPTION, display_table
 from modal.client import _Client
 from modal.environments import ensure_env
-from modal.volume import _Volume
+from modal.volume import _Volume, _VolumeUploadContextManager
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronizer
 from modal_utils.grpc_utils import retry_transient_errors
@@ -227,6 +227,7 @@ async def put(
     vol = await _Volume.lookup(volume_name, environment_name=env)
     if not isinstance(vol, _Volume):
         raise UsageError("The specified app entity is not a modal.Volume")
+
     if remote_path.endswith("/"):
         remote_path = remote_path + os.path.basename(local_path)
     console = Console()
@@ -234,7 +235,8 @@ async def put(
     if Path(local_path).is_dir():
         spinner = step_progress(f"Uploading directory '{local_path}' to '{remote_path}'...")
         with Live(spinner, console=console):
-            await vol._add_local_dir(local_path, remote_path)
+            async with _VolumeUploadContextManager(vol.object_id, vol._client) as batch:
+                batch.put_directory(local_path, remote_path)
         console.print(step_completed(f"Uploaded directory '{local_path}' to '{remote_path}'"))
 
     elif "*" in local_path:
@@ -242,7 +244,8 @@ async def put(
     else:
         spinner = step_progress(f"Uploading file '{local_path}' to '{remote_path}'...")
         with Live(spinner, console=console):
-            await vol._add_local_file(local_path, remote_path)
+            async with _VolumeUploadContextManager(vol.object_id, vol._client) as batch:
+                batch.put_file(local_path, remote_path)
         console.print(step_completed(f"Uploaded file '{local_path}' to '{remote_path}'"))
 
 

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -1,19 +1,28 @@
 # Copyright Modal Labs 2023
 import asyncio
+import concurrent.futures
 import time
 from contextlib import nullcontext
 from pathlib import Path, PurePosixPath
-from typing import IO, AsyncIterator, List, Optional, Sequence, Union
+from typing import IO, AsyncGenerator, AsyncIterator, BinaryIO, Callable, Generator, List, Optional, Sequence, Union
 
+import aiostream
 from grpclib import GRPCError, Status
 
 import modal.exception
 from modal_proto import api_pb2
-from modal_utils.async_utils import ConcurrencyPool, asyncnullcontext, synchronize_api
+from modal_utils.async_utils import asyncnullcontext, synchronize_api
 from modal_utils.grpc_utils import retry_transient_errors, unary_stream
 
-from ._blob_utils import blob_iter, blob_upload_file, get_file_upload_spec
+from ._blob_utils import (
+    FileUploadSpec,
+    blob_iter,
+    blob_upload_file,
+    get_file_upload_spec_from_fileobj,
+    get_file_upload_spec_from_path,
+)
 from ._resolver import Resolver
+from .client import _Client
 from .config import logger
 from .mount import MOUNT_PUT_FILE_CLIENT_TIMEOUT
 from .object import _StatefulObject, live_method, live_method_gen
@@ -269,79 +278,6 @@ class _Volume(_StatefulObject, type_prefix="vo"):
         await retry_transient_errors(self._client.stub.VolumeRemoveFile, req)
 
     @live_method
-    async def _add_local_file(
-        self, local_path: Union[Path, str], remote_path: Optional[Union[str, PurePosixPath, None]] = None
-    ):
-        mount_file = await self._upload_file(local_path, remote_path)
-        request = api_pb2.VolumePutFilesRequest(volume_id=self.object_id, files=[mount_file])
-        await retry_transient_errors(self._client.stub.VolumePutFiles, request, base_delay=1)
-
-    @live_method
-    async def _add_local_dir(
-        self, local_path: Union[Path, str], remote_path: Optional[Union[str, PurePosixPath, None]] = None
-    ):
-        _local_path = Path(local_path)
-        if remote_path is None:
-            remote_path = PurePosixPath("/", _local_path.name).as_posix()
-        else:
-            remote_path = PurePosixPath(remote_path).as_posix()
-
-        assert _local_path.is_dir()
-
-        def gen_transfers():
-            for subpath in _local_path.rglob("*"):
-                if subpath.is_dir():
-                    continue
-                relpath_str = subpath.relative_to(_local_path).as_posix()
-                yield self._upload_file(subpath, PurePosixPath(remote_path, relpath_str))
-
-        files = await ConcurrencyPool(20).run_coros(gen_transfers(), return_exceptions=False)
-        request = api_pb2.VolumePutFilesRequest(volume_id=self.object_id, files=files)
-        await retry_transient_errors(self._client.stub.VolumePutFiles, request, base_delay=1)
-
-    @live_method
-    async def _upload_file(
-        self, local_path: Union[Path, str], remote_path: Optional[Union[str, PurePosixPath, None]] = None
-    ) -> api_pb2.MountFile:
-        local_path = Path(local_path)
-        if remote_path is None:
-            remote_path = PurePosixPath("/", local_path.name).as_posix()
-        else:
-            remote_path = PurePosixPath(remote_path).as_posix()
-
-        file_spec = get_file_upload_spec(local_path, str(remote_path))
-        remote_filename = file_spec.mount_filename
-
-        request = api_pb2.MountPutFileRequest(sha256_hex=file_spec.sha256_hex)
-        response = await retry_transient_errors(self._client.stub.MountPutFile, request, base_delay=1)
-
-        if not response.exists:
-            if file_spec.use_blob:
-                logger.debug(f"Creating blob file for {file_spec.filename} ({file_spec.size} bytes)")
-                with open(file_spec.filename, "rb") as fp:
-                    blob_id = await blob_upload_file(fp, self._client.stub)
-                logger.debug(f"Uploading blob file {file_spec.filename} as {remote_filename}")
-                request2 = api_pb2.MountPutFileRequest(data_blob_id=blob_id, sha256_hex=file_spec.sha256_hex)
-            else:
-                logger.debug(f"Uploading file {file_spec.filename} to {remote_filename} ({file_spec.size} bytes)")
-                request2 = api_pb2.MountPutFileRequest(data=file_spec.content, sha256_hex=file_spec.sha256_hex)
-
-            start_time = time.monotonic()
-            while time.monotonic() - start_time < MOUNT_PUT_FILE_CLIENT_TIMEOUT:
-                response = await retry_transient_errors(self._client.stub.MountPutFile, request2, base_delay=1)
-                if response.exists:
-                    break
-
-            if not response.exists:
-                raise modal.exception.VolumeUploadTimeoutError(f"Uploading of {file_spec.filename} timed out")
-
-        return api_pb2.MountFile(
-            filename=remote_filename,
-            sha256_hex=file_spec.sha256_hex,
-            mode=file_spec.mode,
-        )
-
-    @live_method
     async def copy_files(self, src_paths: Sequence[Union[str, bytes]], dst_path: Union[str, bytes]) -> None:
         """
         Copy files within the volume from src_paths to dst_path.
@@ -354,5 +290,153 @@ class _Volume(_StatefulObject, type_prefix="vo"):
         request = api_pb2.VolumeCopyFilesRequest(volume_id=self.object_id, src_paths=src_paths, dst_path=dst_path)
         await retry_transient_errors(self._client.stub.VolumeCopyFiles, request, base_delay=1)
 
+    @live_method
+    async def batch_upload(self) -> "_VolumeUploadContextManager":
+        """
+        Initiate a batched upload to a volume.
+
+        **Example:**
+
+        ```python notest
+        vol = modal.Volume.lookup("my-modal-volume")
+
+        with vol.put() as batch:
+            batch.put_file("local-path.txt", "/remote-path.txt")
+            batch.put_directory("/local/directory/", "/remote/directory")
+            batch.put_file(io.BytesIO(b"some data"), "/foobar")
+        ```
+        """
+        return _VolumeUploadContextManager(self.object_id, self._client)
+
+
+class _VolumeUploadContextManager:
+    """Context manager for batch-uploading files to a Volume."""
+
+    _volume_id: str
+    _client: _Client
+    _upload_generators: List[Generator[Callable[[], FileUploadSpec], None, None]]
+
+    def __init__(self, volume_id: str, client: _Client):
+        """mdmd:hidden"""
+        self._volume_id = volume_id
+        self._client = client
+        self._upload_generators = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        if not exc_val:
+
+            # Flatten all the uploads yielded by the upload generators in the batch
+            def gen_upload_providers():
+                for gen in self._upload_generators:
+                    yield from gen
+
+            async def gen_file_upload_specs() -> AsyncGenerator[FileUploadSpec, None]:
+                loop = asyncio.get_event_loop()
+                with concurrent.futures.ThreadPoolExecutor() as exe:
+                    # TODO: avoid eagerly expanding
+                    futs = [loop.run_in_executor(exe, f) for f in gen_upload_providers()]
+                    logger.debug(f"Computing checksums for {len(futs)} files using {exe._max_workers} workers")
+                    for fut in asyncio.as_completed(futs):
+                        yield await fut
+
+            # Compute checksums
+            files_stream = aiostream.stream.iterate(gen_file_upload_specs())
+            # Upload files
+            uploads_stream = aiostream.stream.map(files_stream, self._upload_file, task_limit=20)
+            files: List[api_pb2.MountFile] = await aiostream.stream.list(uploads_stream)
+
+            request = api_pb2.VolumePutFilesRequest(volume_id=self._volume_id, files=files)
+            await retry_transient_errors(self._client.stub.VolumePutFiles, request, base_delay=1)
+
+    def put_file(
+        self,
+        local_file: Union[Path, str, BinaryIO],
+        remote_path: Union[PurePosixPath, str],
+        mode: Optional[int] = None,
+    ):
+        """Upload a file from a local file or file-like object.
+
+        Will create any needed parent directories automatically.
+
+        If `local_file` is a file-like object it must remain readable for the lifetime of the batch.
+        """
+        remote_path = PurePosixPath(remote_path).as_posix()
+        if remote_path.endswith("/"):
+            raise ValueError(f"remote_path ({remote_path}) must refer to a file - cannot end with /")
+
+        def gen():
+            if isinstance(local_file, str) or isinstance(local_file, Path):
+                yield lambda: get_file_upload_spec_from_path(local_file, remote_path, mode)
+            else:
+                yield lambda: get_file_upload_spec_from_fileobj(local_file, remote_path, mode or 0o644)
+
+        self._upload_generators.append(gen())
+
+    def put_directory(
+        self,
+        local_path: Union[Path, str],
+        remote_path: Union[PurePosixPath, str],
+        recursive: bool = True,
+    ):
+        """
+        Upload all files in a local directory.
+
+        Will create any needed parent directories automatically.
+        """
+        local_path = Path(local_path)
+        assert local_path.is_dir()
+        remote_path = PurePosixPath(remote_path)
+
+        def create_file_spec_provider(subpath):
+            relpath_str = subpath.relative_to(local_path)
+            return lambda: get_file_upload_spec_from_path(subpath, (remote_path / relpath_str).as_posix())
+
+        def gen():
+            glob = local_path.rglob("*") if recursive else local_path.glob("*")
+            for subpath in glob:
+                # Skip directories and unsupported file types (e.g. block devices)
+                if subpath.is_file():
+                    yield create_file_spec_provider(subpath)
+
+        self._upload_generators.append(gen())
+
+    async def _upload_file(self, file_spec: FileUploadSpec) -> api_pb2.MountFile:
+        remote_filename = file_spec.mount_filename
+
+        request = api_pb2.MountPutFileRequest(sha256_hex=file_spec.sha256_hex)
+        response = await retry_transient_errors(self._client.stub.MountPutFile, request, base_delay=1)
+
+        if not response.exists:
+            if file_spec.use_blob:
+                logger.debug(f"Creating blob file for {file_spec.source_description} ({file_spec.size} bytes)")
+                with file_spec.source() as fp:
+                    blob_id = await blob_upload_file(fp, self._client.stub)
+                logger.debug(f"Uploading blob file {file_spec.source_description} as {remote_filename}")
+                request2 = api_pb2.MountPutFileRequest(data_blob_id=blob_id, sha256_hex=file_spec.sha256_hex)
+            else:
+                logger.debug(
+                    f"Uploading file {file_spec.source_description} to {remote_filename} ({file_spec.size} bytes)"
+                )
+                request2 = api_pb2.MountPutFileRequest(data=file_spec.content, sha256_hex=file_spec.sha256_hex)
+
+            start_time = time.monotonic()
+            while time.monotonic() - start_time < MOUNT_PUT_FILE_CLIENT_TIMEOUT:
+                response = await retry_transient_errors(self._client.stub.MountPutFile, request2, base_delay=1)
+                if response.exists:
+                    break
+
+            if not response.exists:
+                raise modal.exception.VolumeUploadTimeoutError(f"Uploading of {file_spec.source_description} timed out")
+
+        return api_pb2.MountFile(
+            filename=remote_filename,
+            sha256_hex=file_spec.sha256_hex,
+            mode=file_spec.mode,
+        )
+
 
 Volume = synchronize_api(_Volume)
+VolumeUploadContextManager = synchronize_api(_VolumeUploadContextManager)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -42,6 +42,7 @@ from modal_utils.http_utils import run_temporary_http_server
 class VolumeFile:
     data: bytes
     data_blob_id: str
+    mode: int
 
 
 @patch_mock_servicer
@@ -886,7 +887,9 @@ class MockClientServicer(api_grpc.ModalClientBase):
         for file in req.files:
             blob_data = self.files_sha2data[file.sha256_hex]
             self.volume_files[req.volume_id][file.filename] = VolumeFile(
-                data=blob_data["data"], data_blob_id=blob_data["data_blob_id"]
+                data=blob_data["data"],
+                data_blob_id=blob_data["data_blob_id"],
+                mode=file.mode,
             )
         await stream.send_message(Empty())
 

--- a/test/mount_test.py
+++ b/test/mount_test.py
@@ -151,8 +151,8 @@ def test_chained_entries(test_dir):
     assert len(entries) == 2
     files = [file for file in Mount._get_files(entries)]
     assert len(files) == 2
-    files.sort(key=lambda file: file.filename)
-    assert files[0].filename.name == "a.txt"
+    files.sort(key=lambda file: file.source_description)
+    assert files[0].source_description.name == "a.txt"
     assert files[0].mount_filename.endswith("/a.txt")
     assert files[0].content == b"A"
     m = hashlib.sha256()

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -82,7 +82,9 @@ async def test_volume_get(servicer, client, tmp_path):
     file_path = b"foo.txt"
     local_file_path = tmp_path / file_path.decode("utf-8")
     local_file_path.write_bytes(file_contents)
-    await vol._add_local_file.aio(local_file_path, file_path.decode("utf-8"))
+
+    async with vol.batch_upload() as batch:
+        batch.put_file(local_file_path, file_path.decode("utf-8"))
 
     data = b""
     for chunk in vol.read_file(file_path):
@@ -140,29 +142,13 @@ def test_redeploy(servicer, client):
 
 
 @pytest.mark.asyncio
-async def test_volume_add_local_file(servicer, client, tmp_path):
+async def test_volume_batch_upload(servicer, client, tmp_path):
     stub = modal.Stub()
     stub.vol = modal.Volume.new()
+
     local_file_path = tmp_path / "some_file"
     local_file_path.write_text("hello world")
 
-    with stub.run(client=client):
-        stub.vol._add_local_file(local_file_path)
-        stub.vol._add_local_file(local_file_path.as_posix(), remote_path="/foo/other_destination")
-        object_id = stub.vol.object_id
-
-    assert servicer.volume_files[object_id].keys() == {
-        "/some_file",
-        "/foo/other_destination",
-    }
-    assert servicer.volume_files[object_id]["/some_file"].data == b"hello world"
-    assert servicer.volume_files[object_id]["/foo/other_destination"].data == b"hello world"
-
-
-@pytest.mark.asyncio
-async def test_volume_add_local_dir(client, tmp_path, servicer):
-    stub = modal.Stub()
-    stub.vol = modal.Volume.new()
     local_dir = tmp_path / "some_dir"
     local_dir.mkdir()
     (local_dir / "smol").write_text("###")
@@ -172,19 +158,50 @@ async def test_volume_add_local_dir(client, tmp_path, servicer):
     (subdir / "other").write_text("####")
 
     with stub.run(client=client):
-        stub.vol._add_local_dir(local_dir)
+        with open(local_file_path, "rb") as fp:
+            with stub.vol.batch_upload() as batch:
+                batch.put_file(local_file_path, "/some_file")
+                batch.put_directory(local_dir, "/some_dir")
+                batch.put_file(io.BytesIO(b"data from a file-like object"), "/filelike", mode=0o600)
+                batch.put_directory(local_dir, "/non-recursive", recursive=False)
+                batch.put_file(fp, "/filelike2")
         object_id = stub.vol.object_id
 
     assert servicer.volume_files[object_id].keys() == {
+        "/some_file",
         "/some_dir/smol",
         "/some_dir/subdir/other",
+        "/filelike",
+        "/non-recursive/smol",
+        "/filelike2",
     }
+    assert servicer.volume_files[object_id]["/some_file"].data == b"hello world"
     assert servicer.volume_files[object_id]["/some_dir/smol"].data == b"###"
     assert servicer.volume_files[object_id]["/some_dir/subdir/other"].data == b"####"
+    assert servicer.volume_files[object_id]["/filelike"].data == b"data from a file-like object"
+    assert servicer.volume_files[object_id]["/filelike"].mode == 0o600
+    assert servicer.volume_files[object_id]["/non-recursive/smol"].data == b"###"
+    assert servicer.volume_files[object_id]["/filelike2"].data == b"hello world"
+    assert servicer.volume_files[object_id]["/filelike2"].mode == 0o644
 
 
 @pytest.mark.asyncio
-async def test_volume_put_large_file(client, tmp_path, servicer, blob_server, *args):
+async def test_volume_upload_removed_file(servicer, client, tmp_path):
+    stub = modal.Stub()
+    stub.vol = modal.Volume.new()
+
+    local_file_path = tmp_path / "some_file"
+    local_file_path.write_text("hello world")
+
+    with stub.run(client=client):
+        with pytest.raises(FileNotFoundError):
+            with stub.vol.batch_upload() as batch:
+                batch.put_file(local_file_path, "/dest")
+                local_file_path.unlink()
+
+
+@pytest.mark.asyncio
+async def test_volume_upload_large_file(client, tmp_path, servicer, blob_server, *args):
     with mock.patch("modal._blob_utils.LARGE_FILE_LIMIT", 10):
         stub = modal.Stub()
         stub.vol = modal.Volume.new()
@@ -192,19 +209,20 @@ async def test_volume_put_large_file(client, tmp_path, servicer, blob_server, *a
         local_file_path.write_text("hello world, this is a lot of text")
 
         async with stub.run(client=client):
-            await stub.vol._add_local_file.aio(local_file_path)
+            async with stub.vol.batch_upload() as batch:
+                batch.put_file(local_file_path, "/a")
             object_id = stub.vol.object_id
 
-        assert servicer.volume_files[object_id].keys() == {"/bigfile"}
-        assert servicer.volume_files[object_id]["/bigfile"].data == b""
-        assert servicer.volume_files[object_id]["/bigfile"].data_blob_id == "bl-1"
+        assert servicer.volume_files[object_id].keys() == {"/a"}
+        assert servicer.volume_files[object_id]["/a"].data == b""
+        assert servicer.volume_files[object_id]["/a"].data_blob_id == "bl-1"
 
         _, blobs = blob_server
         assert blobs["bl-1"] == b"hello world, this is a lot of text"
 
 
 @pytest.mark.asyncio
-async def test_volume_put_file_timeout(client, tmp_path, servicer, blob_server, *args):
+async def test_volume_upload_file_timeout(client, tmp_path, servicer, blob_server, *args):
     call_count = 0
 
     def mount_put_file(_request):
@@ -223,7 +241,8 @@ async def test_volume_put_file_timeout(client, tmp_path, servicer, blob_server, 
 
                 async with stub.run(client=client):
                     with pytest.raises(VolumeUploadTimeoutError):
-                        await stub.vol._add_local_file.aio(local_file_path)
+                        async with stub.vol.batch_upload() as batch:
+                            batch.put_file(local_file_path, "/dest")
 
                 assert call_count > 2
 
@@ -242,7 +261,8 @@ async def test_volume_copy(client, tmp_path, servicer):
 
     with stub.run(client=client):
         # add local file to volume
-        await stub.vol._add_local_file.aio(local_file_path, src_path)
+        async with stub.vol.batch_upload() as batch:
+            batch.put_file(local_file_path, src_path)
         object_id = stub.vol.object_id
 
         # copy file from src_path to dst_path
@@ -260,7 +280,8 @@ async def test_volume_copy(client, tmp_path, servicer):
         for file_path in file_paths:
             local_file_path = tmp_path / file_path
             local_file_path.write_text("test copy")
-            await stub.vol._add_local_file.aio(local_file_path, file_path)
+            async with stub.vol.batch_upload() as batch:
+                batch.put_file(local_file_path, file_path)
             object_id = stub.vol.object_id
 
         stub.vol.copy_files(file_paths, "test_dir")


### PR DESCRIPTION
Usage example:
    
```
vol = modal.Volume.lookup("some-vol")
    
with vol.put() as batch:
  batch.add_local_file("foo.txt")
  batch.add_local_file("bar.txt", "/optional/remote/path.txt")
  batch.add_local_dir("some_dir")
  batch.add_fileobj(io.BytesIO(b"my data"), "/mydata")
```