### PR TITLE
Bump max function input size and mount file limit size

### DIFF
--- a/modal/_blob_utils.py
+++ b/modal/_blob_utils.py
@@ -22,11 +22,11 @@ from modal_utils.http_utils import http_client_with_tls
 from modal_utils.logger import logger
 
 # Max size for function inputs and outputs.
-MAX_OBJECT_SIZE_BYTES = 1024 * 1024  # 1 MiB
+MAX_OBJECT_SIZE_BYTES = 2 * 1024 * 1024  # 2 MiB
 
 #  If a file is LARGE_FILE_LIMIT bytes or larger, it's uploaded to blob store (s3) instead of going through grpc
 #  It will also make sure to chunk the hash calculation to avoid reading the entire file into memory
-LARGE_FILE_LIMIT = 1024 * 1024  # 1 MiB
+LARGE_FILE_LIMIT = 4 * 1024 * 1024  # 4 MiB
 
 # Max parallelism during map calls
 BLOB_MAX_PARALLELISM = 10


### PR DESCRIPTION
This doubles the threshold before we upload chunks to S3 for inputs / outputs, which adds quite a lot of latency right now for files that aren't that big (<2 MiB, even).

LARGE_FILE_LIMIT hasn't been updated since May 2022 (https://github.com/modal-labs/modal/pull/1610) — and I see no systems reason why it should be this low, since it's a transient transfer that we we don't store in-database on the server anyway.

If the user has a mount that has _a lot of files_ between 1 MiB and 4 MiB, this might make them use more memory when starting their mount process, but that's something we should resolve on the client side if and when it happens, with a semaphore.
