### PR TITLE
Chunk web bodies to fit under output item limit

### DIFF
--- a/modal/_asgi.py
+++ b/modal/_asgi.py
@@ -23,7 +23,7 @@ def asgi_app_wrapper(asgi_app):
             if msg["type"] == "http.response.body":
                 body_chunk_size = MAX_OBJECT_SIZE_BYTES - 1024  # reserve 1 KiB for framing
                 size = len(msg.get("body", b""))
-                if size > body_chunk_size:
+                if body_chunk_size < size <= 100 * body_chunk_size:
                     chunks = [msg["body"][i : i + body_chunk_size] for i in range(0, size, body_chunk_size)]
                     for chunk in chunks[:-1]:
                         await messages_from_app.put({"type": "http.response.body", "body": chunk, "more_body": True})


### PR DESCRIPTION
This resolves MOD-1652.

### Performance Gain in Prod

For this web endpoint:

```python
from modal import Stub, web_endpoint


stub = Stub("bad7")


@stub.function(cloud="oci")
@web_endpoint()
def f(size: int = 32):
    return "a" * size
```

We have the following results before (with MAX_OBJECT_SIZE_BYTES = 1 MiB):

<img width="579" alt="image" src="https://github.com/modal-labs/modal-client/assets/7550632/dff3b320-7c1b-4748-8394-df2b98ec7c47">

And after:

<img width="588" alt="image" src="https://github.com/modal-labs/modal-client/assets/7550632/2e02944e-4c5c-43f0-84f4-88ac4800a540">

So returning a 1.2 MB response is almost twice as fast.