### PR TITLE
Add mdmd tests

### DIFF
--- a/client_test/mdmd_data/foo-expected.md
+++ b/client_test/mdmd_data/foo-expected.md
@@ -1,0 +1,34 @@
+# foo
+
+This module does cool stuff
+
+## foo.Foo
+
+```python
+class Foo(object)
+```
+
+A class that foos
+
+### bar
+
+```python
+def bar(self):
+```
+
+## foo.funky
+
+```python
+def funky():
+```
+
+funks the baz
+
+**Usage**
+
+```python
+import foo
+foo.funky()  # outputs something
+```
+
+Enjoy!

--- a/client_test/mdmd_data/foo.py
+++ b/client_test/mdmd_data/foo.py
@@ -1,7 +1,9 @@
+# Copyright Modal Labs 2023
 """This module does cool stuff"""
 
 
-some_dict = {}  # global untyped objects are currently not documented
+# global untyped objects are currently not documented
+some_dict = {}  # type: ignore
 
 
 class Foo:

--- a/client_test/mdmd_data/foo.py
+++ b/client_test/mdmd_data/foo.py
@@ -1,0 +1,32 @@
+"""This module does cool stuff"""
+
+
+some_dict = {}  # global untyped objects are currently not documented
+
+
+class Foo:
+    """A class that foos"""
+
+    def bar(self):
+        pass
+
+
+def funky():
+    """funks the baz
+
+    **Usage**
+
+    ```python
+    import foo
+    foo.funky()  # outputs something
+    ```
+
+    Enjoy!
+    """
+    pass
+
+
+def hidden():
+    """mdmd:hidden
+
+    This is marked as hidden in docs and shouldn't be shown"""

--- a/client_test/mdmd_test.py
+++ b/client_test/mdmd_test.py
@@ -1,3 +1,4 @@
+# Copyright Modal Labs 2023
 import importlib
 import os
 from enum import IntEnum

--- a/client_test/mdmd_test.py
+++ b/client_test/mdmd_test.py
@@ -1,9 +1,14 @@
 # Copyright Modal Labs 2023
 import importlib
 import os
+import pytest
+import sys
 from enum import IntEnum
 
 from modal_docs.mdmd import mdmd
+
+# Skipping a few tests on 3.7 - doesn't matter since we don't generate docs on 3.7
+skip_37 = pytest.mark.skipif(sys.version_info < (3, 8), reason="Requires Python 3.8")
 
 
 def test_simple_function():
@@ -54,6 +59,7 @@ def foo(a: str, *args, **kwargs):
     )
 
 
+@skip_37
 def test_function_has_docstring():
     def foo():
         """short description
@@ -156,6 +162,7 @@ def test_class_with_baseclass_includes_base_methods():
     assert "def foo(self):" in out
 
 
+@skip_37
 def test_module(monkeypatch):
     test_data_dir = os.path.join(os.path.dirname(__file__), "mdmd_data")
     monkeypatch.chdir(test_data_dir)

--- a/client_test/mdmd_test.py
+++ b/client_test/mdmd_test.py
@@ -123,6 +123,7 @@ The possible values are:
 * `BAR`
 * `XYZ`
 """
+
     assert mdmd.class_str("bar", Eee) == expected
 
 

--- a/client_test/mdmd_test.py
+++ b/client_test/mdmd_test.py
@@ -1,0 +1,320 @@
+import importlib
+import os
+from enum import IntEnum
+
+from modal_docs.mdmd import mdmd
+
+
+def test_simple_function():
+    def foo():
+        pass
+
+    assert (
+        mdmd.function_str("bar", foo)
+        == """```python
+def bar():
+```\n\n"""
+    )
+
+
+def test_simple_async_function():
+    async def foo():
+        pass
+
+    assert (
+        mdmd.function_str("bar", foo)
+        == """```python
+async def bar():
+```\n\n"""
+    )
+
+
+def test_async_gen_function():
+    async def foo():
+        yield
+
+    assert (
+        mdmd.function_str("bar", foo)
+        == """```python
+async def bar():
+```\n\n"""
+    )
+
+
+def test_complex_function_signature():
+    def foo(a: str, *args, **kwargs):
+        pass
+
+    assert (
+        mdmd.function_str("foo", foo)
+        == """```python
+def foo(a: str, *args, **kwargs):
+```\n\n"""
+    )
+
+
+def test_function_has_docstring():
+    def foo():
+        """short description
+
+        longer description"""
+
+    assert (
+        mdmd.function_str("foo", foo)
+        == """```python
+def foo():
+```
+
+short description
+
+longer description
+"""
+    )
+
+
+def test_simple_class_with_docstring():
+    class Foo:
+        """The all important Foo"""
+
+        def bar(self, baz: str):
+            """Bars the foo with the baz"""
+
+    assert (
+        mdmd.class_str("Foo", Foo)
+        == """```python
+class Foo(object)
+```
+
+The all important Foo
+
+### bar
+
+```python
+def bar(self, baz: str):
+```
+
+Bars the foo with the baz
+"""
+    )
+
+
+def test_enum():
+    class Eee(IntEnum):
+        FOO = 1
+        BAR = 2
+        XYZ = 3
+
+    expected = """```python
+class bar(enum.IntEnum)
+```
+
+An enumeration.
+
+The possible values are:
+
+* `FOO`
+* `BAR`
+* `XYZ`
+"""
+    assert mdmd.class_str("bar", Eee) == expected
+
+
+def test_class_with_classmethod():
+    class Foo:
+        @classmethod
+        def create_foo(cls, some_arg):
+            pass
+
+    assert (
+        mdmd.class_str("Foo", Foo)
+        == """```python
+class Foo(object)
+```
+
+### create_foo
+
+```python
+@classmethod
+def create_foo(cls, some_arg):
+```
+
+"""
+    )
+
+
+def test_class_with_baseclass_includes_base_methods():
+    class Foo:
+        def foo(self):
+            pass
+
+    class Bar(Foo):
+        def bar(self):
+            pass
+
+    out = mdmd.class_str("Bar", Bar)
+    assert "def foo(self):" in out
+
+
+def test_module(monkeypatch):
+    test_data_dir = os.path.join(os.path.dirname(__file__), "mdmd_data")
+    monkeypatch.chdir(test_data_dir)
+    monkeypatch.syspath_prepend(test_data_dir)
+    test_module = importlib.import_module("foo")
+    expected_output = open("./foo-expected.md").read()
+    assert mdmd.module_str("foo", test_module) == expected_output
+
+
+def test_docstring_format_reindents_code():
+    assert (
+        mdmd.format_docstring(
+            """```python
+        foo
+            bar
+        ```"""
+        )
+        == """```python
+foo
+    bar
+```
+"""
+    )
+
+
+def test_synchronicity_async_and_blocking_interfaces():
+    from synchronicity import Synchronizer
+
+    class Foo:
+        """docky mcdocface"""
+
+        async def foo(self):
+            pass
+
+        def bar(self):
+            pass
+
+    s = Synchronizer()
+    AsyncFoo = s.create_async(Foo, "AsyncFoo")
+    BlockingFoo = s.create_blocking(Foo, "BlockingFoo")
+
+    assert (
+        mdmd.class_str("AsyncFoo", AsyncFoo)
+        == """```python
+class AsyncFoo(object)
+```
+
+docky mcdocface
+
+### foo
+
+```python
+async def foo(self):
+```
+
+### bar
+
+```python
+def bar(self):
+```
+
+"""
+    )
+
+    assert (
+        mdmd.class_str("BlockingFoo", BlockingFoo)
+        == """```python
+class BlockingFoo(object)
+```
+
+docky mcdocface
+
+### foo
+
+```python
+def foo(self):
+```
+
+### bar
+
+```python
+def bar(self):
+```
+
+"""
+    )
+
+
+def test_synchronicity_constructors():
+    from synchronicity import Synchronizer
+
+    class Foo:
+        """docky mcdocface"""
+
+        def __init__(self):
+            """constructy mcconstructorface"""
+
+    s = Synchronizer()
+    AsyncFoo = s.create_async(Foo, "AsyncFoo")
+
+    assert (
+        mdmd.class_str("AsyncFoo", AsyncFoo)
+        == """```python
+class AsyncFoo(object)
+```
+
+docky mcdocface
+
+```python
+def __init__(self):
+```
+
+constructy mcconstructorface
+"""
+    )
+
+
+def test_get_all_signature_comments():
+    def foo(
+        # prefix comment
+        one,  # one comment
+        two,  # two comment
+        # postfix comment
+    ) -> str:  # return value comment
+        pass
+
+    assert (
+        mdmd.function_str("foo", foo)
+        == """```python
+def foo(
+    # prefix comment
+    one,  # one comment
+    two,  # two comment
+    # postfix comment
+) -> str:  # return value comment
+```
+
+"""
+    )
+
+
+def test_get_decorators():
+    BLA = 1
+
+    def my_deco(arg):
+        def wrapper(f):
+            return f
+
+        return wrapper
+
+    @my_deco(BLA)
+    def foo():
+        pass
+
+    assert (
+        mdmd.function_str("foo", foo)
+        == """```python
+@my_deco(BLA)
+def foo():
+```
+
+"""
+    )

--- a/modal_docs/mdmd/mdmd.py
+++ b/modal_docs/mdmd/mdmd.py
@@ -115,12 +115,14 @@ def module_str(header, module, title_level="#", filter_items: Callable[[ModuleTy
             funcdoc = function_str(name, item)
             object_docs.append(f"{member_title_level} {qual_name}\n\n")
             object_docs.append(funcdoc)
-        elif item_doc := getattr(module, f"__doc__{name}", None):
-            # variable documentation
-            object_docs.append(f"{member_title_level} {qual_name}\n\n")
-            object_docs.append(item_doc)
         else:
-            warnings.warn(f"Not sure how to document: {name} ({item}")
+            item_doc = getattr(module, f"__doc__{name}", None)
+            if item_doc:
+                # variable documentation
+                object_docs.append(f"{member_title_level} {qual_name}\n\n")
+                object_docs.append(item_doc)
+            else:
+                warnings.warn(f"Not sure how to document: {name} ({item}")
 
     if object_docs:
         return "".join(header + object_docs)

--- a/modal_docs/mdmd/mdmd.py
+++ b/modal_docs/mdmd/mdmd.py
@@ -46,6 +46,10 @@ class {name}{bases_str}
     parts = [decl]
     docstring = format_docstring(obj.__doc__)
 
+    if isinstance(obj, EnumMeta) and not docstring:
+        # Python 3.11 removed the docstring from enums
+        docstring = "An enumeration.\n"
+
     if docstring:
         parts.append(docstring + "\n")
 
@@ -53,10 +57,11 @@ class {name}{bases_str}
         enum_vals = "\n".join(f"* `{k}`" for k in obj.__members__.keys())
         parts.append(f"The possible values are:\n\n{enum_vals}\n")
 
-    init = inspect.unwrap(obj.__init__)
+    else:
+        init = inspect.unwrap(obj.__init__)
 
-    if (inspect.isfunction(init) or inspect.ismethod(init)) and not object_is_private("constructor", init):
-        parts.append(function_str("__init__", init))
+        if (inspect.isfunction(init) or inspect.ismethod(init)) and not object_is_private("constructor", init):
+            parts.append(function_str("__init__", init))
 
     member_title_level = title_level + "#"
 

--- a/modal_docs/mdmd/signatures.py
+++ b/modal_docs/mdmd/signatures.py
@@ -3,9 +3,10 @@ import ast
 import inspect
 import textwrap
 import warnings
+from typing import Tuple
 
 
-def _signature_from_ast(func) -> tuple[str, str]:
+def _signature_from_ast(func) -> Tuple[str, str]:
     """Get function signature, including decorators and comments, from source code
 
     Traverses functools.wraps-wrappings to get source of underlying function.


### PR DESCRIPTION
Didn't realize we had tests for mdmd – this should have been part of #927 

I added these tests to the base test set even though technically we don't care about the full matrix of Python versions – this code is only used internally. But the tests take a few hundred ms so it's fine. Had to make some minor changes to support Python 3.8 and 3.7.

Edit: actually 2 tests are still failing on 3.7 and I don't think it's worth investigating so I just disabled them on 3.7

Edit 2: mdmd was actually broken in 3.11 and tests caught it. Fixing it.