### PR TITLE
Add container test for recursive calls

### DIFF
--- a/client_test/container_test.py
+++ b/client_test/container_test.py
@@ -559,6 +559,7 @@ def _run_e2e_function(
         is_builder_function=is_builder_function,
     )
     assert items[0].result.status == assert_result
+    return deserialize(items[0].result.data, client)
 
 
 @skip_windows_unix_socket
@@ -758,3 +759,11 @@ def test_derived_cls(unix_servicer, event_loop):
     assert len(items) == 1
     assert items[0].result.status == api_pb2.GenericResult.GENERIC_STATUS_SUCCESS
     assert items[0].result.data == serialize(6)
+
+
+@skip_windows_unix_socket
+def test_call_function_that_calls_function(unix_servicer, event_loop):
+    result = _run_e2e_function(
+        unix_servicer, "modal_test_support.functions", "stub", "cube", inputs=_get_inputs(((42,), {}))
+    )
+    assert result == 42**3

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -205,3 +205,12 @@ class BaseCls:
 @stub.cls()
 class DerivedCls(BaseCls):
     pass
+
+
+@stub.function()
+def cube(x):
+    # Note: this ends up calling the servicer fixture,
+    # which always just returns the sum of the squares of the inputs,
+    # regardless of the actual funtion.
+    assert square.is_hydrated()
+    return square.remote(x) * x


### PR DESCRIPTION
Following up on #922 I'm trying add more extensive tests to catch these types of regressions going forward. I realized we don't have tests for remote calls made within containers, so I'm adding it. First just adding a plain one, then in a later PR I'll add a class call (which I hope will repro the issue).