### PR TITLE
Print warning about paths if `modal` is not found

### DIFF
--- a/modal/cli/entry_point.py
+++ b/modal/cli/entry_point.py
@@ -45,20 +45,32 @@ def modal(
     pass
 
 
-def setup():
-    # Sanity check the path
+def check_path():
+    """Checks whether the `modal` executable is on the path and usable."""
+    console = Console()
+    url = "https://modal.com/docs/guide/troubleshooting#command-not-found-errors"
     try:
         subprocess.run(["modal", "--help"], capture_output=True)
         # TODO(erikbern): check returncode?
+        return
     except FileNotFoundError:
-        console = Console()
-        url = "https://modal.com/docs/guide/troubleshooting#command-not-found-errors"
         console.print(
             "[red]The `[white]modal[/white]` command was not found on your path!\n"
-            "You may need to add it to your path or use `[white]python -m modal[/white]` as a workaround.\n"
-            "See more information here:[/red]\n\n"
-            f"[link={url}]{url}[/link]\n"
+            "You may need to add it to your path or use `[white]python -m modal[/white]` as a workaround.[/red]\n"
         )
+    except PermissionError:
+        console.print(
+            "[red]The `[white]modal[/white]` command is not executable!\n"
+            "You may need to give it permissions or use `[white]python -m modal[/white]` as a workaround.[/red]\n"
+        )
+    console.print(
+        "See more information here:\n\n"
+        f"[link={url}]{url}[/link]\n"
+    )
+
+
+def setup():
+    check_path()
 
     # Fetch a new token (same as `modal token new` but redirect to /home once finishes)
     _new_token(next_url="/home")

--- a/modal/cli/entry_point.py
+++ b/modal/cli/entry_point.py
@@ -3,6 +3,7 @@ import subprocess
 
 import typer
 from rich.console import Console
+from rich.rule import Rule
 
 from . import run
 from .app import app_cli
@@ -47,26 +48,25 @@ def modal(
 
 def check_path():
     """Checks whether the `modal` executable is on the path and usable."""
-    console = Console()
     url = "https://modal.com/docs/guide/troubleshooting#command-not-found-errors"
     try:
         subprocess.run(["modal", "--help"], capture_output=True)
         # TODO(erikbern): check returncode?
         return
     except FileNotFoundError:
-        console.print(
+        text = (
             "[red]The `[white]modal[/white]` command was not found on your path!\n"
             "You may need to add it to your path or use `[white]python -m modal[/white]` as a workaround.[/red]\n"
         )
     except PermissionError:
-        console.print(
+        text = (
             "[red]The `[white]modal[/white]` command is not executable!\n"
             "You may need to give it permissions or use `[white]python -m modal[/white]` as a workaround.[/red]\n"
         )
-    console.print(
-        "See more information here:\n\n"
-        f"[link={url}]{url}[/link]\n"
-    )
+    text += "See more information here:\n\n" f"[link={url}]{url}[/link]\n"
+    console = Console()
+    console.print(text)
+    console.print(Rule(style="white"))
 
 
 def setup():

--- a/modal/cli/entry_point.py
+++ b/modal/cli/entry_point.py
@@ -1,5 +1,8 @@
 # Copyright Modal Labs 2022
+import subprocess
+
 import typer
+from rich.console import Console
 
 from . import run
 from .app import app_cli
@@ -9,7 +12,7 @@ from .launch import launch_cli
 from .network_file_system import nfs_cli
 from .profile import profile_cli
 from .secret import secret_cli
-from .token import setup, token_cli
+from .token import _new_token, token_cli
 from .volume import volume_cli
 
 
@@ -40,6 +43,25 @@ def modal(
     version: bool = typer.Option(None, "--version", callback=version_callback),
 ):
     pass
+
+
+def setup():
+    # Sanity check the path
+    try:
+        subprocess.run(["modal", "--help"], capture_output=True)
+        # TODO(erikbern): check returncode?
+    except FileNotFoundError:
+        console = Console()
+        url = "https://modal.com/docs/guide/troubleshooting#command-not-found-errors"
+        console.print(
+            "[red]The `[white]modal[/white]` command was not found on your path!\n"
+            "You may need to add it to your path or use `[white]python -m modal[/white]` as a workaround.\n"
+            "See more information here:[/red]\n\n"
+            f"[link={url}]{url}[/link]\n"
+        )
+
+    # Fetch a new token (same as `modal token new` but redirect to /home once finishes)
+    _new_token(next_url="/home")
 
 
 entrypoint_cli_typer.add_typer(app_cli)

--- a/modal/cli/token.py
+++ b/modal/cli/token.py
@@ -61,14 +61,15 @@ def _new_token(
                 # Open the web url in the browser
                 if webbrowser.open_new_tab(web_url):
                     console.print(
-                        "If the web browser didn't open, please copy this URL into your web browser manually:"
+                        "The web browser should have opened for you to authenticate and get an API token.\n"
+                        "If it didn't, please copy this URL into your web browser manually:\n"
                     )
                 else:
                     console.print(
-                        "[red]Was not able to launch web browser[/red]"
-                        " - please go to this URL manually and complete the flow:"
+                        "[red]Was not able to launch web browser[/red]\n"
+                        "Please go to this URL manually and complete the flow:\n"
                     )
-                console.print(f"\n[link={web_url}]{web_url}[/link]\n")
+                console.print(f"[link={web_url}]{web_url}[/link]\n")
                 if code:
                     console.print(f"Enter this code: [yellow]{code}[/yellow]\n")
 

--- a/modal/cli/token.py
+++ b/modal/cli/token.py
@@ -99,8 +99,3 @@ def _new_token(
 @token_cli.command(help="Creates a new token by using an authenticated web session.")
 def new(profile: Optional[str] = profile_option, no_verify: bool = False, source: Optional[str] = None):
     _new_token(profile, no_verify, source)
-
-
-def setup():
-    """The `modal setup` command is identical to `modal token new` except it redirects to /home when it's done."""
-    _new_token(next_url="/home")


### PR DESCRIPTION
This checks whether the `modal` binary is present on the path. If not, it outputs a warning and a link to more information (in the future we could also try to resolve the problem automatically).

This assumes the user is able to run the script using `python -m modal setup`

You can try this by deleting the `modal` binary after installation.

<img width="767" alt="image" src="https://github.com/modal-labs/modal-client/assets/1027979/c62660c1-cf92-45db-8571-e5f0012c0169">
