### PR TITLE
Test for issue in #922 and bugfix (make cls robust to rehydration)

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -116,12 +116,15 @@ class _Cls(_Object, type_prefix="cs"):
         self._output_mgr = output_mgr
 
     def _hydrate_metadata(self, metadata: Message):
-        self._base_functions = {}
         for method in metadata.methods:
-            function: _Function = _Function._new_hydrated(
-                method.function_id, self._client, method.function_handle_metadata
-            )
-            self._base_functions[method.function_name] = function
+            if method.function_name in self._base_functions:
+                self._base_functions[method.function_name]._hydrate(
+                    method.function_id, self._client, method.function_handle_metadata
+                )
+            else:
+                self._base_functions[method.function_name] = _Function._new_hydrated(
+                    method.function_id, self._client, method.function_handle_metadata
+                )
 
     @staticmethod
     def from_local(user_cls, base_functions: Dict[str, _Function]) -> "_Cls":


### PR DESCRIPTION
#922 caused container initialization to change in a slight way which caused cls objects to be hydrated _before_ looking up the local function definition. This caused all containers using classes to fail in a way where it was super easy to repro on prod but quite hard to turn it into a unit test.

I reverted the change and added a container test in #931 which however is somewhat indirect.

Adding a separate test for the cls behavior that's more direct in this PR, together with a fix. The fix should in theory let us reapply #922. However I realized there's a bunch of complexity with container initialization and it might be worth simplifying this a bit first. One thing for instance is that it seems better to initialize container stubs _after_ importing functions.