### PR TITLE
client proto: return handle_metadata with ClassCreate

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -305,6 +305,7 @@ message ClassCreateRequest {
 
 message ClassCreateResponse {
   string class_id = 1;
+  ClassHandleMetadata handle_metadata = 2;
 }
 
 message ClassHandleMetadata {


### PR DESCRIPTION
deep in the yak hole, but adding this metadata handle (and implementing it server side) lets me unify how objects are created somewhat, which is quite good in itself and something i've always wanted to do.

but also more tactically, it unblocks a minor thing (which unblocks another thing, which unblocks a third thing ... i'm deep in the hole like i mentioned).

