### PR TITLE
handle metadata plumbing

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -137,7 +137,7 @@ class _Cls(_Object, type_prefix="cs"):
             for f_name, f in base_functions.items():
                 req.methods.append(api_pb2.ClassMethod(function_name=f_name, function_id=f.object_id))
             resp = await resolver.client.stub.ClassCreate(req)
-            provider._hydrate(resp.class_id, resolver.client, None)
+            provider._hydrate(resp.class_id, resolver.client, resp.handle_metadata)
 
         rep = f"Cls({user_cls.__name__})"
         cls = _Cls._from_loader(_load, rep)

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -126,6 +126,16 @@ class _Cls(_Object, type_prefix="cs"):
                     method.function_id, self._client, method.function_handle_metadata
                 )
 
+    def _get_metadata(self) -> api_pb2.ClassHandleMetadata:
+        class_handle_metadata = api_pb2.ClassHandleMetadata()
+        for f_name, f in self._base_functions.items():
+            class_handle_metadata.methods.append(
+                api_pb2.ClassMethod(
+                    function_name=f_name, function_id=f.object_id, function_handle_metadata=f._get_metadata()
+                )
+            )
+        return class_handle_metadata
+
     @staticmethod
     def from_local(user_cls, base_functions: Dict[str, _Function]) -> "_Cls":
         async def _load(provider: _Object, resolver: Resolver, existing_object_id: Optional[str]):

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -175,7 +175,7 @@ class _Mount(_Object, type_prefix="mo"):
         """mdmd:hidden"""
         return self._entries
 
-    def _hydrate_metadata(self, handle_metadata: Message):
+    def _hydrate_metadata(self, handle_metadata: Optional[Message]):
         assert isinstance(handle_metadata, api_pb2.MountHandleMetadata)
         self._content_checksum_sha256_hex = handle_metadata.content_checksum_sha256_hex
 

--- a/modal/object.py
+++ b/modal/object.py
@@ -78,11 +78,10 @@ class _Object:
     def _hydrate(self, object_id: str, client: _Client, metadata: Optional[Message]):
         self._object_id = object_id
         self._client = client
-        if metadata:
-            self._hydrate_metadata(metadata)
+        self._hydrate_metadata(metadata)
         self._is_hydrated = True
 
-    def _hydrate_metadata(self, metadata: Message):
+    def _hydrate_metadata(self, metadata: Optional[Message]):
         # override this is subclasses that need additional data (other than an object_id) for a functioning Handle
         pass
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -305,6 +305,7 @@ message ClassCreateRequest {
 
 message ClassCreateResponse {
   string class_id = 1;
+  ClassHandleMetadata handle_metadata = 2;
 }
 
 message ClassHandleMetadata {

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -428,7 +428,12 @@ def test_environment_flag(test_dir, servicer, command):
     with servicer.intercept() as ctx:
         ctx.add_response(
             "AppLookupObject",
-            api_pb2.AppLookupObjectResponse(object=api_pb2.Object(object_id="mo-123")),
+            api_pb2.AppLookupObjectResponse(
+                object=api_pb2.Object(
+                    object_id="mo-123",
+                    mount_handle_metadata=api_pb2.MountHandleMetadata(content_checksum_sha256_hex="abc123"),
+                )
+            ),
             request_filter=lambda req: req.app_name.startswith("modal-client-mount"),
         )  # built-in client lookup
         ctx.add_response(
@@ -466,7 +471,12 @@ def test_environment_noflag(test_dir, servicer, command, monkeypatch):
     with servicer.intercept() as ctx:
         ctx.add_response(
             "AppLookupObject",
-            api_pb2.AppLookupObjectResponse(object=api_pb2.Object(object_id="mo-123")),
+            api_pb2.AppLookupObjectResponse(
+                object=api_pb2.Object(
+                    object_id="mo-123",
+                    mount_handle_metadata=api_pb2.MountHandleMetadata(content_checksum_sha256_hex="abc123"),
+                )
+            ),
             request_filter=lambda req: req.app_name.startswith("modal-client-mount"),
         )  # built-in client lookup
         ctx.add_response(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -155,20 +155,27 @@ class MockClientServicer(api_grpc.ModalClientBase):
             web_url=definition.web_url,
         )
 
+    def get_class_metadata(self, object_id: str) -> api_pb2.ClassHandleMetadata:
+        class_handle_metadata = api_pb2.ClassHandleMetadata()
+        for f_name, f_id in self.classes[object_id].items():
+            function_handle_metadata = self.get_function_metadata(f_id)
+            class_handle_metadata.methods.append(
+                api_pb2.ClassMethod(
+                    function_name=f_name, function_id=f_id, function_handle_metadata=function_handle_metadata
+                )
+            )
+        return class_handle_metadata
+
     def get_object_metadata(self, object_id) -> api_pb2.Object:
         if object_id.startswith("fu-"):
             res = api_pb2.Object(function_handle_metadata=self.get_function_metadata(object_id))
 
         elif object_id.startswith("cs-"):
-            class_handle_metadata = api_pb2.ClassHandleMetadata()
-            for f_name, f_id in self.classes[object_id].items():
-                function_handle_metadata = self.get_function_metadata(f_id)
-                class_handle_metadata.methods.append(
-                    api_pb2.ClassMethod(
-                        function_name=f_name, function_id=f_id, function_handle_metadata=function_handle_metadata
-                    )
-                )
-            res = api_pb2.Object(class_handle_metadata=class_handle_metadata)
+            res = api_pb2.Object(class_handle_metadata=self.get_class_metadata(object_id))
+
+        elif object_id.startswith("mo-"):
+            mount_handle_metadata = api_pb2.MountHandleMetadata(content_checksum_sha256_hex="abc123")
+            res = api_pb2.Object(mount_handle_metadata=mount_handle_metadata)
 
         else:
             res = api_pb2.Object()
@@ -319,7 +326,9 @@ class MockClientServicer(api_grpc.ModalClientBase):
         methods: dict[str, str] = {method.function_name: method.function_id for method in request.methods}
         class_id = "cs-" + str(len(self.classes))
         self.classes[class_id] = methods
-        await stream.send_message(api_pb2.ClassCreateResponse(class_id=class_id))
+        await stream.send_message(
+            api_pb2.ClassCreateResponse(class_id=class_id, handle_metadata=self.get_class_metadata(class_id))
+        )
 
     ### Client
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -156,12 +156,8 @@ class MockClientServicer(api_grpc.ModalClientBase):
         )
 
     def get_object_metadata(self, object_id) -> api_pb2.Object:
-        # TODO(erikbern): support mount metadata
-        function_handle_metadata: api_pb2.FunctionHandleMetadata = None
-        class_handle_metadata: api_pb2.ClassHandleMetadata = None
-
         if object_id.startswith("fu-"):
-            function_handle_metadata = self.get_function_metadata(object_id)
+            res = api_pb2.Object(function_handle_metadata=self.get_function_metadata(object_id))
 
         elif object_id.startswith("cs-"):
             class_handle_metadata = api_pb2.ClassHandleMetadata()
@@ -172,12 +168,13 @@ class MockClientServicer(api_grpc.ModalClientBase):
                         function_name=f_name, function_id=f_id, function_handle_metadata=function_handle_metadata
                     )
                 )
+            res = api_pb2.Object(class_handle_metadata=class_handle_metadata)
 
-        return api_pb2.Object(
-            object_id=object_id,
-            function_handle_metadata=function_handle_metadata,
-            class_handle_metadata=class_handle_metadata,
-        )
+        else:
+            res = api_pb2.Object()
+
+        res.object_id = object_id
+        return res
 
     ### App
 


### PR DESCRIPTION
Big delta but this is just a lot of plumbing (mostly updating test fixtures) – it just makes sure we populate the handle metadata on a bunch of server calls properly, and the client now _expects_ those fields to be set (rather than before when they were optional).