### PR TITLE
Don't launch Lynx for the token flow

### DIFF
--- a/modal/cli/token.py
+++ b/modal/cli/token.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
 import getpass
 import itertools
+import os
 import webbrowser
 from typing import Optional
 
@@ -47,11 +48,16 @@ def set(
 
 def _open_url(url: str) -> bool:
     # Make sure we open the URL in some sane web browser (i.e. not Lynx)
-    browser = webbrowser.get()
-    if isinstance(browser, webbrowser.GenericBrowser):
+    if "PYTEST_CURRENT_TEST" in os.environ:
         return False
-    else:
-        return browser.open_new_tab(url)
+    try:
+        browser = webbrowser.get()
+        if isinstance(browser, webbrowser.GenericBrowser):
+            return False
+        else:
+            return browser.open_new_tab(url)
+    except webbrowser.Error:
+        return False
 
 
 def _new_token(

--- a/modal/cli/token.py
+++ b/modal/cli/token.py
@@ -47,7 +47,7 @@ def set(
 
 
 def _open_url(url: str) -> bool:
-    # Make sure we open the URL in some sane web browser (i.e. not Lynx)
+    """Opens url in web browser, making sure we use a modern one (not Lynx etc)"""
     if "PYTEST_CURRENT_TEST" in os.environ:
         return False
     try:

--- a/modal/cli/token.py
+++ b/modal/cli/token.py
@@ -45,6 +45,15 @@ def set(
     rich.print(f"Token written to {user_config_path}")
 
 
+def _open_url(url: str) -> bool:
+    # Make sure we open the URL in some sane web browser (i.e. not Lynx)
+    browser = webbrowser.get()
+    if isinstance(browser, webbrowser.GenericBrowser):
+        return False
+    else:
+        return browser.open_new_tab(url)
+
+
 def _new_token(
     profile: Optional[str] = None, no_verify: bool = False, source: Optional[str] = None, next_url: Optional[str] = None
 ):
@@ -59,7 +68,7 @@ def _new_token(
         with token_flow.start(source, next_url) as (token_flow_id, web_url, code):
             with console.status("Waiting for authentication in the web browser", spinner="dots"):
                 # Open the web url in the browser
-                if webbrowser.open_new_tab(web_url):
+                if _open_url(web_url):
                     console.print(
                         "The web browser should have opened for you to authenticate and get an API token.\n"
                         "If it didn't, please copy this URL into your web browser manually:\n"

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -4,7 +4,6 @@ import pytest
 import sys
 import tempfile
 import traceback
-import unittest.mock
 from typing import List, Optional
 from unittest import mock
 
@@ -109,13 +108,11 @@ def test_secret_list(servicer, set_env_client):
 
 
 def test_app_token_new(servicer, set_env_client, server_url_env):
-    with unittest.mock.patch("webbrowser.open_new_tab", lambda url: False):
-        _run(["token", "new", "--profile", "_test"])
+    _run(["token", "new", "--profile", "_test"])
 
 
 def test_app_setup(servicer, set_env_client, server_url_env):
-    with unittest.mock.patch("webbrowser.open_new_tab", lambda url: False):
-        _run(["setup"])
+    _run(["setup"])
 
 
 def test_run(servicer, set_env_client, test_dir):


### PR DESCRIPTION
Irfan found a hilarious problem that `modal setup` would launch Lynx on his devbox. It's easy to replicate if you just `apt install lynx`. When you run `modal setup` this is what it looks like:

<img width="725" alt="image" src="https://github.com/modal-labs/modal-client/assets/1027979/132ce8df-a625-43dc-83cd-c575c51f9bc4">

After this fix:

<img width="725" alt="image" src="https://github.com/modal-labs/modal-client/assets/1027979/8a95ce30-a467-4cae-aa37-c5a97138d465">
