### PR TITLE
split stub's app into local vs container

### DIFF
--- a/modal/runner.py
+++ b/modal/runner.py
@@ -52,7 +52,7 @@ async def _run_stub(
             " Are you calling stub.run() directly?"
             " Consider using the `modal run` shell command."
         )
-    if stub._app:
+    if stub._local_app:
         raise InvalidError(
             "App is already running and can't be started again.\n"
             "You should not use `stub.run` or `run_stub` within a Modal local_entrypoint"

--- a/modal/serving.py
+++ b/modal/serving.py
@@ -120,7 +120,7 @@ async def _serve_stub(
         watcher = watch(mounts_to_watch, output_mgr)
 
     async with _run_stub(stub, client=client, output_mgr=output_mgr, environment_name=environment_name):
-        client.set_pre_stop(stub._app.disconnect)
+        client.set_pre_stop(stub._local_app.disconnect)
         async with TaskContext(grace=0.1) as tc:
             tc.create_task(_run_watch_loop(stub_ref, stub.app_id, output_mgr, watcher, environment_name))
             yield stub


### PR DESCRIPTION
Going to try a bit of divide & conquer with the rest of the app – I think one step towards removing the `App` class is to split it up into a class for the local app (the launcher process) and one for the container. Starting with the stub code.