### PR TITLE
Don't overwrite tokens during tests

### DIFF
--- a/modal/cli/entry_point.py
+++ b/modal/cli/entry_point.py
@@ -1,5 +1,6 @@
 # Copyright Modal Labs 2022
 import subprocess
+from typing import Optional
 
 import typer
 from rich.console import Console
@@ -69,11 +70,11 @@ def check_path():
     console.print(Rule(style="white"))
 
 
-def setup():
+def setup(profile: Optional[str] = None):
     check_path()
 
     # Fetch a new token (same as `modal token new` but redirect to /home once finishes)
-    _new_token(next_url="/home")
+    _new_token(profile=profile, next_url="/home")
 
 
 entrypoint_cli_typer.add_typer(app_cli)

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -112,7 +112,7 @@ def test_app_token_new(servicer, set_env_client, server_url_env):
 
 
 def test_app_setup(servicer, set_env_client, server_url_env):
-    _run(["setup"])
+    _run(["setup", "--profile", "_test"])
 
 
 def test_run(servicer, set_env_client, test_dir):


### PR DESCRIPTION
The test for `modal setup` was overwriting the tokens in the configuration, which was a bit annoying. I run the client tests locally a lot.