### PR TITLE
Adds `function_id` to checkpointing gRPC method

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -422,6 +422,7 @@ message ContainerHeartbeatRequest {
 
 message ContainerCheckpointRequest {
   string runtime = 1;
+  string function_id = 2;
 }
 
 message DictContainsRequest {


### PR DESCRIPTION
Functions that call this RPC need to identify themselves. 