### PR TITLE
Unit test that reproduces issue in #951

### DIFF
--- a/modal/stub.py
+++ b/modal/stub.py
@@ -214,9 +214,8 @@ class _Stub:
 
     def _add_object(self, tag, obj):
         if self._container_app:
-            # If this is inside a container, and some module is loaded lazily, then a function may be
-            # defined later than the container initialization. If this happens then lets hydrate the
-            # function at this point
+            # If this is inside a container, then objects can be defined after app initialization.
+            # So we may have to initialize objects once they get bound to the stub.
             other_obj = self._container_app._get_object(tag)
             if other_obj is not None:
                 obj._hydrate_from_other(other_obj)


### PR DESCRIPTION
This reproduces an issue caught by integration tests but not by unit tests.

The fix itself is a trivial one-liner. What happens is that metadata for most objects is `None` and we don't write those to `_tag_to_handle_metadata`, which then later causes a `KeyError`. I didn't fix the issue in this PR though, but will fix it and then reapply #951

Also updated a comment that was misleading – I was confused about the initialization flow when I wrote it.