### PR TITLE
Remove `_App._tag_to_object` (3rd attempt)

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -216,9 +216,13 @@ class _App:
             raise AttributeError(f"No such attribute `{tag}`")  # Dumb workaround for doc thing
         deprecation_error(date(2023, 8, 10), "`app.obj` is no longer supported. Use the stub to get objects instead.")
 
-    def _get_object(self, tag: str) -> Optional[_Object]:
-        # TODO(erikbern): remove objects from apps soon
-        return self._tag_to_object.get(tag)
+    def _has_object(self, tag: str) -> bool:
+        return tag in self._tag_to_object_id
+
+    def _hydrate_object(self, obj, tag: str):
+        object_id: str = self._tag_to_object_id[tag]
+        metadata: Message = self._tag_to_handle_metadata[tag]
+        obj._hydrate(object_id, self._client, metadata)
 
     async def _init_container(self, client: _Client, app_id: str, stub_name: str):
         self._client = client

--- a/modal/app.py
+++ b/modal/app.py
@@ -47,7 +47,7 @@ class _App:
     """
 
     _tag_to_object_id: Dict[str, str]
-    _tag_to_handle_metadata: Dict[str, Message]
+    _tag_to_handle_metadata: Dict[str, Optional[Message]]
 
     _client: _Client
     _app_id: str
@@ -221,8 +221,7 @@ class _App:
         for item in resp.items:
             self._tag_to_object_id[item.tag] = item.object.object_id
             handle_metadata: Optional[Message] = get_proto_oneof(item.object, "handle_metadata_oneof")
-            if handle_metadata is not None:
-                self._tag_to_handle_metadata[item.tag] = handle_metadata
+            self._tag_to_handle_metadata[item.tag] = handle_metadata
 
     @staticmethod
     async def init_container(client: _Client, app_id: str, stub_name: str = "") -> "_App":

--- a/modal/app.py
+++ b/modal/app.py
@@ -46,7 +46,6 @@ class _App:
     ```
     """
 
-    _tag_to_object: Dict[str, _Object]
     _tag_to_object_id: Dict[str, str]
     _tag_to_handle_metadata: Dict[str, Message]
 
@@ -64,7 +63,6 @@ class _App:
         app_id: str,
         app_page_url: str,
         output_mgr: Optional[OutputManager],
-        tag_to_object: Optional[Dict[str, _Object]] = None,
         tag_to_object_id: Optional[Dict[str, str]] = None,
         stub_name: Optional[str] = None,
         environment_name: Optional[str] = None,
@@ -73,7 +71,6 @@ class _App:
         self._app_id = app_id
         self._app_page_url = app_page_url
         self._client = client
-        self._tag_to_object = tag_to_object or {}
         self._tag_to_object_id = tag_to_object_id or {}
         self._tag_to_handle_metadata = {}
         self._stub_name = stub_name
@@ -115,7 +112,6 @@ class _App:
             else:
                 # Can't find the object, create a new one
                 obj = _Object._new_hydrated(object_id, self._client, handle_metadata)
-            self._tag_to_object[tag] = obj
 
     def _associate_stub_local(self, stub):
         self._associated_stub = stub
@@ -138,8 +134,6 @@ class _App:
 
             # Assign all objects
             for tag, obj in blueprint.items():
-                self._tag_to_object[tag] = obj
-
                 # Reset object_id in case the app runs twice
                 # TODO(erikbern): clean up the interface
                 obj._unhydrate()
@@ -178,7 +172,6 @@ class _App:
             new_app_state=new_app_state,  # type: ignore
         )
         await retry_transient_errors(self._client.stub.AppSetObjects, req_set)
-        return self._tag_to_object
 
     async def disconnect(self):
         """Tell the server the client has disconnected for this app. Terminates all running tasks

--- a/modal/app.py
+++ b/modal/app.py
@@ -180,11 +180,6 @@ class _App:
         await retry_transient_errors(self._client.stub.AppSetObjects, req_set)
         return self._tag_to_object
 
-    def _uncreate_all_objects(self):
-        # TODO(erikbern): this doesn't unhydrate objects that aren't tagged
-        for obj in self._tag_to_object.values():
-            obj._unhydrate()
-
     async def disconnect(self):
         """Tell the server the client has disconnected for this app. Terminates all running tasks
         for ephemeral apps."""

--- a/modal/app.py
+++ b/modal/app.py
@@ -170,9 +170,7 @@ class _App:
         assert indexed_object_ids == self._tag_to_object_id
         all_objects = resolver.objects()
 
-        unindexed_object_ids = list(
-            set(obj.object_id for obj in all_objects) - set(obj.object_id for obj in self._tag_to_object.values())
-        )
+        unindexed_object_ids = list(set(obj.object_id for obj in all_objects) - set(self._tag_to_object_id.values()))
         req_set = api_pb2.AppSetObjectsRequest(
             app_id=self._app_id,
             indexed_object_ids=indexed_object_ids,

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -125,8 +125,8 @@ async def _run_stub(
                     "Disconnecting from Modal - This will terminate your Modal app in a few seconds.\n"
                 )
         finally:
-            app._uncreate_all_objects()
             await app.disconnect()
+            stub._uncreate_all_objects()
 
     output_mgr.print_if_visible(step_completed("App completed."))
 

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -251,6 +251,11 @@ class _Stub:
         """Used by the container app to initialize objects."""
         return list(self._blueprint.items())
 
+    def _uncreate_all_objects(self):
+        # TODO(erikbern): this doesn't unhydrate objects that aren't tagged
+        for obj in self._blueprint.values():
+            obj._unhydrate()
+
     @typechecked
     def is_inside(self, image: Optional[_Image] = None) -> bool:
         """Returns if the program is currently running inside a container for this app."""

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -216,9 +216,8 @@ class _Stub:
         if self._container_app:
             # If this is inside a container, then objects can be defined after app initialization.
             # So we may have to initialize objects once they get bound to the stub.
-            other_obj = self._container_app._get_object(tag)
-            if other_obj is not None:
-                obj._hydrate_from_other(other_obj)
+            if self._container_app._has_object(tag):
+                self._container_app._hydrate_object(obj, tag)
 
         self._blueprint[tag] = obj
 

--- a/test/webhook_test.py
+++ b/test/webhook_test.py
@@ -37,7 +37,7 @@ async def test_webhook(servicer, client):
         # Make sure the container gets the app id as well
         container_app = await App.init_container.aio(client, stub.app_id)
         container_app._associate_stub_container(stub)
-        f_c = container_app._get_object("f")
+        f_c = stub["f"]
         assert isinstance(f_c, Function)
         assert f_c.web_url
 


### PR DESCRIPTION
Basically #922 rebased, similar to #951, but contains a bugfix for an issue introduced in #951 (see #952 for a new unit test catching this).

This passes all integration tests as well.

Background for this PR: I want to reduce the role of the existing app class step by step (possibly by splitting it next). This PR lets us remove the app class, which lets us rename `Stub` to `App`.