### PR TITLE
pass in 'runtime' and 'runtime_debug' to image builds

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -243,7 +243,9 @@ class _Image(_Object, type_prefix="im"):
                 gpu_config=gpu_config,  # Note: as of 2023-01-27, server ignores this
                 image_registry_config=await image_registry_config.resolve(
                     resolver
-                ),  # Resolves private registry secret.
+                ),  # Resolves private registry secret.,
+                runtime=config.get("function_runtime"),
+                runtime_debug=config.get("function_runtime_debug"),
             )
 
             req = api_pb2.ImageGetOrCreateRequest(

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -978,6 +978,11 @@ message Image {
 
   string build_function_def = 14;
   bytes build_function_globals = 18;
+
+  // If set, overrides the runtime used by the function. Specify either "runc" or "gvisor".
+  string runtime = 19;
+  // Not included in image definition checksum as debug features do not affect built image.
+  bool runtime_debug = 20;
 }
 
 message ImageContextFile {


### PR DESCRIPTION
Required to make the image build tasks runtime configuration. Right now we always use the default runtime.
