### PR TITLE
Disallow getting the app from the stub

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -13,14 +13,12 @@ from ._output import OutputManager
 from ._resolver import Resolver
 from .client import _Client
 from .config import logger
-from .exception import InvalidError, deprecation_error, deprecation_warning
+from .exception import InvalidError, deprecation_error
 from .object import _Object
 
 if TYPE_CHECKING:
     from rich.tree import Tree
 
-    import modal.image
-    import modal.sandbox
 else:
     Tree = TypeVar("Tree")
 
@@ -304,10 +302,9 @@ class _App:
         self,
         *args,
         **kwargs,
-    ) -> "modal.sandbox._Sandbox":
+    ):
         """Deprecated. Use `Stub.spawn_sandbox` instead."""
-        deprecation_warning(date(2023, 9, 11), _App.spawn_sandbox.__doc__)
-        return self._associated_stub.spawn_sandbox(*args, **kwargs)
+        deprecation_error(date(2023, 9, 11), _App.spawn_sandbox.__doc__)
 
     @staticmethod
     async def _deploy_single_object(

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -19,7 +19,7 @@ from .app import _App, _container_app, is_local
 from .client import _Client
 from .cls import _Cls
 from .config import config, logger
-from .exception import ExecutionError, InvalidError, deprecation_error, deprecation_warning
+from .exception import InvalidError, deprecation_error
 from .functions import PartialFunction, _Function, _PartialFunction
 from .gpu import GPU_T
 from .image import _Image
@@ -178,17 +178,11 @@ class _Stub:
         return self._name
 
     @property
-    def app(self) -> Optional[_App]:
+    def app(self):
         """`stub.app` is deprecated: use e.g. `stub.obj` instead of `stub.app.obj`
         if you need to access objects on the running app.
         """
-        deprecation_warning(date(2023, 9, 11), _Stub.app.__doc__)
-        if self._container_app:
-            return self._container_app
-        elif self._local_app:
-            return self._local_app
-        else:
-            raise ExecutionError("No app available")
+        deprecation_error(date(2023, 9, 11), _Stub.app.__doc__)
 
     @property
     def app_id(self) -> Optional[str]:

--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -7,7 +7,7 @@ from ._version_generated import build_number  # Written by GitHub
 major_number = 0
 
 # Bump this manually on any major changes
-minor_number = 53
+minor_number = 54
 
 # Right now, set the patch number (the 3rd field) to the job run number in GitHub
 __version__ = f"{major_number}.{minor_number}.{build_number}"

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -7,7 +7,7 @@ import time
 from pathlib import Path
 
 from modal import Image, Mount, NetworkFileSystem, Secret, Stub
-from modal.exception import DeprecationError, InvalidError
+from modal.exception import InvalidError
 
 stub = Stub()
 
@@ -81,12 +81,3 @@ def test_sandbox_nfs(client, servicer, tmpdir):
         stub.spawn_sandbox("echo", "foo > /cache/a.txt", network_file_systems={"/cache": nfs})
 
     assert len(servicer.sandbox_defs[0].nfs_mounts) == 1
-
-
-@skip_non_linux
-def test_spawn_sandbox_on_app_deprecated(client, servicer):
-    with stub.run(client=client):
-        with pytest.warns(DeprecationError):
-            app = stub.app
-        with pytest.warns(DeprecationError):
-            app.spawn_sandbox("bash", "-c", "echo bye >&2 && sleep 1 && echo hi && exit 42", timeout=600)


### PR DESCRIPTION
This turns a warning into an error, which lets me remove the `Stub._local_app` member next.

EDIT: also ended up removing the `spawn_sandbox` method from the `App` class since it's near pointless with `stub.app` (you _could_ call it from the global `container_app`, but I doubt it's common)

EDIT 2: passes all integration tests