### PR TITLE
Split the App class

### DIFF
--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 from modal_version import __version__
 
-from .app import App, container_app, is_local
+from .app import container_app, is_local
 from .client import Client
 from .cls import Cls
 from .dict import Dict
@@ -21,7 +21,6 @@ from .volume import Volume
 
 __all__ = [
     "__version__",
-    "App",
     "Client",
     "Cls",
     "Cron",

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -37,7 +37,7 @@ from ._pty import run_in_pty
 from ._serialization import deserialize, deserialize_data_format, serialize, serialize_data_format
 from ._traceback import extract_traceback
 from ._tracing import extract_tracing_context, set_span_tag, trace, wrap
-from .app import _App
+from .app import _ContainerApp
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, Client, _Client
 from .cls import Cls
 from .config import logger
@@ -122,14 +122,14 @@ class _FunctionIOManager:
         self._input_concurrency: Optional[int] = None
         self._semaphore: Optional[asyncio.Semaphore] = None
         self._output_queue: Optional[asyncio.Queue] = None
-        self._container_app: Optional[_App] = None
+        self._container_app: Optional[_ContainerApp] = None
 
         self._client = synchronizer._translate_in(self.client)  # make it a _Client object
         assert isinstance(self._client, _Client)
 
     @wrap()
-    async def initialize_app(self) -> _App:
-        self._container_app = await _App.init_container(self._client, self.app_id, self._stub_name)
+    async def initialize_app(self) -> _ContainerApp:
+        self._container_app = await _ContainerApp.init_container(self._client, self.app_id, self._stub_name)
         return self._container_app
 
     async def _heartbeat(self):

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -123,13 +123,16 @@ class _FunctionIOManager:
         self._semaphore: Optional[asyncio.Semaphore] = None
         self._output_queue: Optional[asyncio.Queue] = None
         self._container_app: Optional[_ContainerApp] = None
+        self._environment_name = container_args.environment_name
 
         self._client = synchronizer._translate_in(self.client)  # make it a _Client object
         assert isinstance(self._client, _Client)
 
     @wrap()
     async def initialize_app(self) -> _ContainerApp:
-        self._container_app = await _ContainerApp.init_container(self._client, self.app_id, self._stub_name)
+        self._container_app = await _ContainerApp.init_container(
+            self._client, self.app_id, self._stub_name, self._environment_name
+        )
         return self._container_app
 
     async def _heartbeat(self):

--- a/modal/app.py
+++ b/modal/app.py
@@ -23,35 +23,12 @@ else:
     Tree = TypeVar("Tree")
 
 
-class _App:
-    """Apps are the user representation of an actively running Modal process.
-
-    You can obtain an `App` from the `Stub.run()` context manager. While the app
-    is running, you can get its `app_id`, `client`, and other useful properties
-    from this object.
-
-    ```python
-    import modal
-
-    stub = modal.Stub()
-    stub.my_secret_object = modal.Secret.from_name("my-secret")
-
-    if __name__ == "__main__":
-        with stub.run() as app:
-            print(app.client)
-            print(app.app_id)
-            print(app.my_secret_object)
-    ```
-    """
-
+class _LocalApp:
     _tag_to_object_id: Dict[str, str]
-    _tag_to_handle_metadata: Dict[str, Optional[Message]]
-
     _client: _Client
     _app_id: str
     _app_page_url: str
     _environment_name: str
-    _associated_stub: Optional[Any]  # TODO(erikbern): type
 
     def __init__(
         self,
@@ -67,10 +44,8 @@ class _App:
         self._app_page_url = app_page_url
         self._client = client
         self._tag_to_object_id = tag_to_object_id or {}
-        self._tag_to_handle_metadata = {}
         self._stub_name = stub_name
         self._environment_name = environment_name
-        self._associated_stub = None
 
     @property
     def client(self) -> _Client:
@@ -81,29 +56,6 @@ class _App:
     def app_id(self) -> str:
         """A unique identifier for this running App."""
         return self._app_id
-
-    def _associate_stub_container(self, stub):
-        if self._associated_stub:
-            if self._stub_name:
-                warning_sub_message = f"stub with the same name ('{self._stub_name}')"
-            else:
-                warning_sub_message = "unnamed stub"
-            logger.warning(
-                f"You have more than one {warning_sub_message}. It's recommended to name all your Stubs uniquely when using multiple stubs"
-            )
-        self._associated_stub = stub
-
-        if stub:
-            # Initialize objects on stub
-            stub_objects: dict[str, _Object] = dict(stub.get_objects())
-            for tag, object_id in self._tag_to_object_id.items():
-                obj = stub_objects.get(tag)
-                if obj is not None:
-                    handle_metadata = self._tag_to_handle_metadata[tag]
-                    obj._hydrate(object_id, self._client, handle_metadata)
-
-    def _associate_stub_local(self, stub):
-        self._associated_stub = stub
 
     async def _create_all_objects(
         self,
@@ -198,41 +150,14 @@ class _App:
             raise AttributeError(f"No such attribute `{tag}`")  # Dumb workaround for doc thing
         deprecation_error(date(2023, 8, 10), "`app.obj` is no longer supported. Use the stub to get objects instead.")
 
-    def _has_object(self, tag: str) -> bool:
-        return tag in self._tag_to_object_id
-
-    def _hydrate_object(self, obj, tag: str):
-        object_id: str = self._tag_to_object_id[tag]
-        metadata: Message = self._tag_to_handle_metadata[tag]
-        obj._hydrate(object_id, self._client, metadata)
-
-    async def _init_container(self, client: _Client, app_id: str, stub_name: str):
-        self._client = client
-        self._app_id = app_id
-        self._stub_name = stub_name
-        req = api_pb2.AppGetObjectsRequest(app_id=self._app_id)
-        resp = await retry_transient_errors(self._client.stub.AppGetObjects, req)
-        for item in resp.items:
-            self._tag_to_object_id[item.tag] = item.object.object_id
-            handle_metadata: Optional[Message] = get_proto_oneof(item.object, "handle_metadata_oneof")
-            self._tag_to_handle_metadata[item.tag] = handle_metadata
-
     @staticmethod
-    async def init_container(client: _Client, app_id: str, stub_name: str = "") -> "_App":
-        """Used by the container to bootstrap the app and all its objects. Not intended to be called by Modal users."""
-        global _container_app, _is_container_app
-        _is_container_app = True
-        await _container_app._init_container(client, app_id, stub_name)
-        return _container_app
-
-    @staticmethod
-    async def _init_existing(client: _Client, existing_app_id: str) -> "_App":
+    async def _init_existing(client: _Client, existing_app_id: str) -> "_LocalApp":
         # Get all the objects first
         obj_req = api_pb2.AppGetObjectsRequest(app_id=existing_app_id)
         obj_resp = await retry_transient_errors(client.stub.AppGetObjects, obj_req)
         app_page_url = f"https://modal.com/apps/{existing_app_id}"  # TODO (elias): this should come from the backend
         object_ids = {item.tag: item.object.object_id for item in obj_resp.items}
-        return _App(client, existing_app_id, app_page_url, tag_to_object_id=object_ids)
+        return _LocalApp(client, existing_app_id, app_page_url, tag_to_object_id=object_ids)
 
     @staticmethod
     async def _init_new(
@@ -241,7 +166,7 @@ class _App:
         detach: bool = False,
         deploying: bool = False,
         environment_name: str = "",
-    ) -> "_App":
+    ) -> "_LocalApp":
         # Start app
         # TODO(erikbern): maybe this should happen outside of this method?
         app_req = api_pb2.AppCreateRequest(
@@ -253,7 +178,7 @@ class _App:
         app_resp = await retry_transient_errors(client.stub.AppCreate, app_req)
         app_page_url = app_resp.app_logs_url
         logger.debug(f"Created new app with id {app_resp.app_id}")
-        return _App(client, app_resp.app_id, app_page_url, environment_name=environment_name)
+        return _LocalApp(client, app_resp.app_id, app_page_url, environment_name=environment_name)
 
     @staticmethod
     async def _init_from_name(
@@ -271,9 +196,11 @@ class _App:
 
         # Grab the app
         if existing_app_id is not None:
-            return await _App._init_existing(client, existing_app_id)
+            return await _LocalApp._init_existing(client, existing_app_id)
         else:
-            return await _App._init_new(client, name, detach=False, deploying=True, environment_name=environment_name)
+            return await _LocalApp._init_new(
+                client, name, detach=False, deploying=True, environment_name=environment_name
+            )
 
     async def deploy(self, name: str, namespace, object_entity: str) -> str:
         """`App.deploy` is deprecated in favor of `modal.runner.deploy_stub`."""
@@ -299,14 +226,14 @@ class _App:
         **kwargs,
     ):
         """Deprecated. Use `Stub.spawn_sandbox` instead."""
-        deprecation_error(date(2023, 9, 11), _App.spawn_sandbox.__doc__)
+        deprecation_error(date(2023, 9, 11), _LocalApp.spawn_sandbox.__doc__)
 
     @staticmethod
     async def _deploy_single_object(
         obj: _Object, type_prefix: str, client: _Client, label: str, namespace: int, environment_name: int
     ):
         """mdmd:hidden"""
-        app = await _App._init_from_name(client, label, namespace, environment_name=environment_name)
+        app = await _LocalApp._init_from_name(client, label, namespace, environment_name=environment_name)
         existing_object_id: Optional[str] = app._tag_to_object_id.get("_object")
         resolver = Resolver(app._client, environment_name=environment_name, app_id=app.app_id)
         await resolver.load(obj, existing_object_id)
@@ -321,6 +248,108 @@ class _App:
         await retry_transient_errors(client.stub.AppSetObjects, req_set)
         await app.deploy(label, namespace, type_prefix)  # TODO(erikbern): not needed if the app already existed
 
+
+class _ContainerApp:
+    _tag_to_object_id: Dict[str, str]
+    _tag_to_handle_metadata: Dict[str, Optional[Message]]
+
+    _client: _Client
+    _app_id: str
+    _associated_stub: Optional[Any]  # TODO(erikbern): type
+
+    def __init__(
+        self,
+        client: _Client,
+        app_id: str,
+        tag_to_object_id: Optional[Dict[str, str]] = None,
+        stub_name: Optional[str] = None,
+    ):
+        """mdmd:hidden This is the app constructor. Users should not call this directly."""
+        self._app_id = app_id
+        self._client = client
+        self._tag_to_object_id = tag_to_object_id or {}
+        self._tag_to_handle_metadata = {}
+        self._stub_name = stub_name
+        self._associated_stub = None
+
+    @property
+    def client(self) -> _Client:
+        """A reference to the running App's server client."""
+        return self._client
+
+    @property
+    def app_id(self) -> str:
+        """A unique identifier for this running App."""
+        return self._app_id
+
+    def _associate_stub_container(self, stub):
+        if self._associated_stub:
+            if self._stub_name:
+                warning_sub_message = f"stub with the same name ('{self._stub_name}')"
+            else:
+                warning_sub_message = "unnamed stub"
+            logger.warning(
+                f"You have more than one {warning_sub_message}. It's recommended to name all your Stubs uniquely when using multiple stubs"
+            )
+        self._associated_stub = stub
+
+        if stub:
+            # Initialize objects on stub
+            stub_objects: dict[str, _Object] = dict(stub.get_objects())
+            for tag, object_id in self._tag_to_object_id.items():
+                obj = stub_objects.get(tag)
+                if obj is not None:
+                    handle_metadata = self._tag_to_handle_metadata[tag]
+                    obj._hydrate(object_id, self._client, handle_metadata)
+
+    def __getitem__(self, tag: str) -> _Object:
+        deprecation_error(date(2023, 8, 10), "`app[...]` is no longer supported. Use the stub to get objects instead.")
+
+    def __contains__(self, tag: str) -> bool:
+        deprecation_error(
+            date(2023, 8, 10), "`obj in app` is no longer supported. Use the stub to get objects instead."
+        )
+
+    def __getattr__(self, tag: str) -> _Object:
+        if tag.startswith("__"):
+            raise AttributeError(f"No such attribute `{tag}`")  # Dumb workaround for doc thing
+        deprecation_error(date(2023, 8, 10), "`app.obj` is no longer supported. Use the stub to get objects instead.")
+
+    def _has_object(self, tag: str) -> bool:
+        return tag in self._tag_to_object_id
+
+    def _hydrate_object(self, obj, tag: str):
+        object_id: str = self._tag_to_object_id[tag]
+        metadata: Message = self._tag_to_handle_metadata[tag]
+        obj._hydrate(object_id, self._client, metadata)
+
+    async def _init_container(self, client: _Client, app_id: str, stub_name: str):
+        self._client = client
+        self._app_id = app_id
+        self._stub_name = stub_name
+        req = api_pb2.AppGetObjectsRequest(app_id=self._app_id)
+        resp = await retry_transient_errors(self._client.stub.AppGetObjects, req)
+        for item in resp.items:
+            self._tag_to_object_id[item.tag] = item.object.object_id
+            handle_metadata: Optional[Message] = get_proto_oneof(item.object, "handle_metadata_oneof")
+            self._tag_to_handle_metadata[item.tag] = handle_metadata
+
+    @staticmethod
+    async def init_container(client: _Client, app_id: str, stub_name: str = "") -> "_ContainerApp":
+        """Used by the container to bootstrap the app and all its objects. Not intended to be called by Modal users."""
+        global _container_app, _is_container_app
+        _is_container_app = True
+        await _container_app._init_container(client, app_id, stub_name)
+        return _container_app
+
+    async def spawn_sandbox(
+        self,
+        *args,
+        **kwargs,
+    ):
+        """Deprecated. Use `Stub.spawn_sandbox` instead."""
+        deprecation_error(date(2023, 9, 11), _ContainerApp.spawn_sandbox.__doc__)
+
     @staticmethod
     def _reset_container():
         # Just used for tests
@@ -329,12 +358,13 @@ class _App:
         _container_app.__init__(None, None, None, None)  # type: ignore
 
 
-App = synchronize_api(_App)
+LocalApp = synchronize_api(_LocalApp)
+ContainerApp = synchronize_api(_ContainerApp)
 
 _is_container_app = False
-_container_app = _App(None, None, None, None)
+_container_app = _ContainerApp(None, None, None, None)
 container_app = synchronize_api(_container_app)
-assert isinstance(container_app, App)
+assert isinstance(container_app, ContainerApp)
 
 
 def is_local() -> bool:

--- a/modal/object.py
+++ b/modal/object.py
@@ -220,7 +220,7 @@ class _Object:
         Note 1: this uses the single-object app method, which we're planning to get rid of later
         Note 2: still considering this an "internal" method, but we'll make it "official" later
         """
-        from .app import _App
+        from .app import _LocalApp
 
         if environment_name is None:
             environment_name = config.get("environment")
@@ -228,7 +228,7 @@ class _Object:
         if client is None:
             client = await _Client.from_env()
 
-        await _App._deploy_single_object(self, self._type_prefix, client, label, namespace, environment_name)
+        await _LocalApp._deploy_single_object(self, self._type_prefix, client, label, namespace, environment_name)
 
     def persist(
         self, label: str, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, environment_name: Optional[str] = None

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -12,7 +12,7 @@ from modal_utils.grpc_utils import retry_transient_errors
 
 from . import _pty
 from ._output import OutputManager, get_app_logs_loop, step_completed, step_progress
-from .app import _App, is_local
+from .app import _LocalApp, is_local
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, _Client
 from .config import config
 from .exception import InvalidError
@@ -64,7 +64,7 @@ async def _run_stub(
     if output_mgr is None:
         output_mgr = OutputManager(stdout, show_progress, "Running app...")
     post_init_state = api_pb2.APP_STATE_DETACHED if detach else api_pb2.APP_STATE_EPHEMERAL
-    app = await _App._init_new(
+    app = await _LocalApp._init_new(
         client,
         stub.description,
         detach=detach,
@@ -143,7 +143,7 @@ async def _serve_update(
     # Used by child process to reinitialize a served app
     client = await _Client.from_env()
     try:
-        app = await _App._init_existing(client, existing_app_id)
+        app = await _LocalApp._init_existing(client, existing_app_id)
 
         # Create objects
         output_mgr = OutputManager(None, True)
@@ -221,7 +221,7 @@ async def _deploy_stub(
 
     output_mgr = OutputManager(stdout, show_progress)
 
-    app = await _App._init_from_name(client, name, namespace, environment_name=environment_name)
+    app = await _LocalApp._init_from_name(client, name, namespace, environment_name=environment_name)
 
     async with TaskContext(0) as tc:
         # Start heartbeats loop to keep the client alive

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -8,7 +8,7 @@ from typing_extensions import assert_type
 
 from modal import Cls, Function, Stub, method
 from modal._serialization import deserialize
-from modal.app import App
+from modal.app import ContainerApp
 from modal.cls import ClsMixin
 from modal.exception import DeprecationError, ExecutionError
 from modal.runner import deploy_stub
@@ -354,7 +354,7 @@ def test_rehydrate(client, servicer):
     app_id = deploy_stub(stub, "my-cls-app", client=client).app_id
 
     # Initialize a container
-    app = App.init_container(client, app_id, "stub")
+    app = ContainerApp.init_container(client, app_id, "stub")
 
     # Associate app with stub
     app._associate_stub_container(stub)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -27,7 +27,7 @@ from google.protobuf.empty_pb2 import Empty
 from grpclib import GRPCError, Status
 
 from modal import __version__
-from modal.app import _App
+from modal.app import _ContainerApp
 from modal.client import Client
 from modal.image import _dockerhub_python_version
 from modal.mount import client_mount_name
@@ -958,7 +958,7 @@ def reset_container_app():
     try:
         yield
     finally:
-        _App._reset_container()
+        _ContainerApp._reset_container()
 
 
 @pytest.fixture(scope="module")

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -5,7 +5,8 @@ import pytest
 from unittest import mock
 
 import modal.secret
-from modal import App, Dict, Image, Stub
+from modal import Dict, Image, Stub
+from modal.app import ContainerApp
 from modal.exception import InvalidError
 from modal_proto import api_pb2
 
@@ -25,7 +26,7 @@ async def test_container_function_lazily_imported(unix_servicer, container_clien
     }
     unix_servicer.app_functions["fu-123"] = api_pb2.Function()
 
-    await App.init_container.aio(container_client, "ap-123")
+    await ContainerApp.init_container.aio(container_client, "ap-123")
     stub = Stub()
 
     # Now, let's create my_f after the app started running and make sure it works
@@ -63,7 +64,7 @@ async def test_is_inside(servicer, unix_servicer, client, container_client):
         unix_servicer.app_objects[app_id] = servicer.app_objects[app_id]
 
         # Pretend that we're inside the container
-        await App.init_container.aio(container_client, app_id)
+        await ContainerApp.init_container.aio(container_client, app_id)
 
         # Create a new stub (TODO: tie it to the previous stub through name or similar)
         stub = get_stub()
@@ -103,7 +104,7 @@ async def test_is_inside_default_image(servicer, unix_servicer, client, containe
     unix_servicer.app_objects = servicer.app_objects
     unix_servicer.app_functions = servicer.app_functions
 
-    await App.init_container.aio(container_client, app_id)
+    await ContainerApp.init_container.aio(container_client, app_id)
 
     # Create a new stub (TODO: tie it to the previous stub through name or similar)
     stub = Stub()

--- a/test/webhook_test.py
+++ b/test/webhook_test.py
@@ -6,8 +6,9 @@ import sys
 
 from fastapi.testclient import TestClient
 
-from modal import App, Stub, asgi_app, web_endpoint, wsgi_app
+from modal import Stub, asgi_app, web_endpoint, wsgi_app
 from modal._asgi import webhook_asgi_app
+from modal.app import ContainerApp
 from modal.exception import InvalidError
 from modal.functions import Function
 from modal_proto import api_pb2
@@ -35,7 +36,7 @@ async def test_webhook(servicer, client):
         assert await f.local(100) == {"square": 10000}
 
         # Make sure the container gets the app id as well
-        container_app = await App.init_container.aio(client, stub.app_id)
+        container_app = await ContainerApp.init_container.aio(client, stub.app_id)
         container_app._associate_stub_container(stub)
         f_c = stub["f"]
         assert isinstance(f_c, Function)


### PR DESCRIPTION
This takes the `App` class and splits it into `ContainerApp` and `LocalApp`.

There's a bit of overlapping code between the two that I simply put in both classes – that's why this PR is like +50 lines.

We should be able to optimize each class quite a bit though, basically removing both long term and merging them into the container code and the runner code. A lot of it can also go to the stub class. And a lot of the overlapping code is just deprecated code throwing the same errors. So there's plenty of opportunity to make this a negative LOC change over time.

This PR also frees up the name "App" to be used by the Stub, which is great. We should hold off making that change for a while, because of the confusion it might cause for people upgrading client versions. But it's great to get this change out as soon as possible so that clock starts ticking. I think we could probably rename Stub to App 1-2 months later.

EDIT: Passes all integration tests.