### PR TITLE
Pass output_mgr to create_all_objects

### DIFF
--- a/modal/runner.py
+++ b/modal/runner.py
@@ -85,7 +85,9 @@ async def _run_stub(
 
         try:
             # Create all members
-            await app._create_all_objects(stub._blueprint, post_init_state, environment_name, shell=shell)
+            await app._create_all_objects(
+                stub._blueprint, post_init_state, environment_name, shell=shell, output_mgr=output_mgr
+            )
 
             # Update all functions client-side to have the output mgr
             for obj in stub.registered_functions.values():


### PR DESCRIPTION
This got lost in #958 for some reason, and breaks an integration test. Might also break image logs for latest clients.

Merging a fix for now, but I'll add a client test later today for this.