### PR TITLE
pass environment_name through ContainerArguments

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -413,6 +413,7 @@ message ContainerArguments {  // This is used to pass data from the worker to th
   bytes serialized_params = 10;
   string runtime = 11;
   bool checkpoint = 12;
+  string environment_name = 13;
 }
 
 message ContainerHeartbeatRequest {


### PR DESCRIPTION
Will add this to the worker code as well.

I know we already have an env var for this but I need this in the container entrypoint code and everything else comes from `ContainerArguments` so I think it's cleaner. env vars imo are for things like (1) information things for users about the environment (2) ways to override defaults. But in this case it's something we need for app construction (later).

