### PR TITLE
local enter fixes

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -30,7 +30,7 @@ from modal_utils.grpc_utils import retry_transient_errors
 
 from ._asgi import asgi_app_wrapper, webhook_asgi_app, wsgi_app_wrapper
 from ._blob_utils import MAX_OBJECT_SIZE_BYTES, blob_download, blob_upload
-from ._function_utils import LocalFunctionError, is_global_function
+from ._function_utils import LocalFunctionError, is_async as get_is_async, is_global_function
 from ._proxy_tunnel import proxy_tunnel
 from ._pty import run_in_pty
 from ._serialization import deserialize, deserialize_data_format, serialize, serialize_data_format
@@ -66,21 +66,6 @@ class SequenceNumber:
     @property
     def value(self) -> int:
         return self._value
-
-
-def get_is_async(function):
-    # TODO: this is somewhat hacky. We need to know whether the function is async or not in order to
-    # coerce the input arguments to the right type. The proper way to do is to call the function and
-    # see if you get a coroutine (or async generator) back. However at this point, it's too late to
-    # coerce the type. For now let's make a determination based on inspecting the function definition.
-    # This sometimes isn't correct, since a "vanilla" Python function can return a coroutine if it
-    # wraps async code or similar. Let's revisit this shortly.
-    if inspect.iscoroutinefunction(function) or inspect.isasyncgenfunction(function):
-        return True
-    elif inspect.isfunction(function) or inspect.isgeneratorfunction(function):
-        return False
-    else:
-        raise RuntimeError(f"Function {function} is a strange type {type(function)}")
 
 
 def run_with_signal_handler(coro):

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -78,6 +78,21 @@ def is_global_function(function_qual_name):
     return "<locals>" not in function_qual_name.split(".")
 
 
+def is_async(function):
+    # TODO: this is somewhat hacky. We need to know whether the function is async or not in order to
+    # coerce the input arguments to the right type. The proper way to do is to call the function and
+    # see if you get a coroutine (or async generator) back. However at this point, it's too late to
+    # coerce the type. For now let's make a determination based on inspecting the function definition.
+    # This sometimes isn't correct, since a "vanilla" Python function can return a coroutine if it
+    # wraps async code or similar. Let's revisit this shortly.
+    if inspect.iscoroutinefunction(function) or inspect.isasyncgenfunction(function):
+        return True
+    elif inspect.isfunction(function) or inspect.isgeneratorfunction(function):
+        return False
+    else:
+        raise RuntimeError(f"Function {function} is a strange type {type(function)}")
+
+
 class FunctionInfo:
     """Class the helps us extract a bunch of information about a function."""
 

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -47,7 +47,8 @@ class _Obj:
     All this class does is to return `Function` objects."""
 
     _functions: Dict[str, _Function]
-    _has_local_obj: bool
+    _inited: bool
+    _entered: bool
     _local_obj: Any
     _local_obj_constr: Optional[Callable[[], Any]]
 
@@ -65,7 +66,8 @@ class _Obj:
             self._functions[k]._set_output_mgr(output_mgr)
 
         # Used for construction local object lazily
-        self._has_local_obj = False
+        self._inited = False
+        self._entered = False
         self._local_obj = None
         if user_cls:
             self._local_obj_constr = lambda: user_cls(*args, **kwargs)
@@ -80,13 +82,13 @@ class _Obj:
 
     def get_local_obj(self):
         """Construct local object lazily. Used for .local() calls."""
-        if not self._has_local_obj:
+        if not self._inited:
             self.get_obj()  # Instantiate object
-            if hasattr(self._local_obj, "__enter__"):
-                self._local_obj.__enter__()
-            elif hasattr(self._local_obj, "__aenter__"):
-                warnings.warn("Not running asynchronous enter handlers on local objects")
-            self._has_local_obj = True
+            #if hasattr(self._local_obj, "__enter__"):
+            #    self._local_obj.__enter__()
+            #elif hasattr(self._local_obj, "__aenter__"):
+            #    warnings.warn("Not running asynchronous enter handlers on local objects")
+            self._inited = True
 
         return self._local_obj
 

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2022
 import asyncio
 import pickle
-import warnings
 from datetime import date
 from typing import Any, Callable, Dict, Optional, Type, TypeVar
 

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -329,6 +329,28 @@ def test_enter_on_local_modal_call():
     assert obj.entered
 
 
+@cls_with_enter_stub.cls()
+class ClsWithAenter:
+    def __init__(self):
+        self.inited = True
+        self.entered = False
+
+    async def __aenter__(self):
+        self.entered = True
+
+    @method()
+    async def modal_method(self, y: int) -> int:
+        return y**2
+
+
+@pytest.mark.asyncio
+async def test_aenter_on_local_modal_call():
+    obj = ClsWithAenter()
+    assert await obj.modal_method.local(7) == 49
+    assert obj.inited
+    assert obj.entered
+
+
 inheritance_stub = Stub()
 
 


### PR DESCRIPTION
This solves two issues:

* We call `__enter__` very eagerly, in particular when the user tries to access an attribute that doesn't exist on a class – this leads to confusing errors such as no GPU available
* We don't support `__aenter__` on local function calls

It solves these by moving the responsibility of calling `__enter__` and `__aenter__` to the local call instead, i.e. unless you call a function, we don't run those locally (however, we still call the constructor).

The fix is more complex than I anticipated. Not sure how to simplify it though. We might want to unify some code for calling local functions with the container entrypoint code at some point.