### PR TITLE
fix `modal token new` on zsh with zpresto on macos

### DIFF
--- a/modal/cli/token.py
+++ b/modal/cli/token.py
@@ -52,7 +52,8 @@ def _open_url(url: str) -> bool:
         return False
     try:
         browser = webbrowser.get()
-        if isinstance(browser, webbrowser.GenericBrowser):
+        # zpresto defines `BROWSER=open` by default on macOS, which causes `webbrowser` to return `GenericBrowser`.
+        if isinstance(browser, webbrowser.GenericBrowser) and browser.name != "open":
             return False
         else:
             return browser.open_new_tab(url)


### PR DESCRIPTION
[MOD-1739](https://linear.app/modal-labs/issue/MOD-1739/model-token-new-fails-to-open-browser-on-zsh-with-zpresto-on-macos)

Not sure why but zpresto exports `BROWSER=open` by default on macos (darwin), which causes `webbrowser.get()` to return a `GenericBrowser` which we currently interpret as being a console browser.

https://github.com/sorin-ionescu/prezto/blob/5ac930d96be3a51730f7d9d7330f28d9c9c36e0a/runcoms/zprofile#L12

I noticed this because `modal token new` did not work on my laptop. See linear ticket.

With this change `modal token new` again works for me as expected.