### PR TITLE
Refactor lookups

### DIFF
--- a/modal/object.py
+++ b/modal/object.py
@@ -52,6 +52,7 @@ class _Object:
         is_persisted_ref: bool = False,
         preload: Optional[Callable[[O, Resolver, Optional[str]], Awaitable[None]]] = None,
         hydrate_lazily: bool = False,
+        client: Optional[_Client] = None,
     ):
         self._local_uuid = str(uuid.uuid4())
         self._load = load
@@ -61,8 +62,8 @@ class _Object:
         self._hydrate_lazily = hydrate_lazily
 
         self._object_id = None
-        self._client = None
         self._is_hydrated = False
+        self._client = client
 
         self._initialize_from_empty()
 
@@ -104,10 +105,11 @@ class _Object:
         is_persisted_ref: bool = False,
         preload: Optional[Callable[[O, Resolver, Optional[str]], Awaitable[None]]] = None,
         hydrate_lazily: bool = False,
+        client: Optional[_Client] = None,
     ):
         # TODO(erikbern): flip the order of the two first arguments
         obj = _Object.__new__(cls)
-        obj._init(rep, load, is_persisted_ref, preload, hydrate_lazily)
+        obj._init(rep, load, is_persisted_ref, preload, hydrate_lazily, client)
         return obj
 
     @classmethod
@@ -270,6 +272,7 @@ class _Object:
         app_name: str,
         tag: Optional[str] = None,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
     ) -> O:
         """Retrieve an object with a given name and tag.
@@ -305,7 +308,7 @@ class _Object:
             )
 
         rep = f"Ref({app_name})"
-        return cls._from_loader(_load_remote, rep, hydrate_lazily=True)
+        return cls._from_loader(_load_remote, rep, hydrate_lazily=True, client=client)
 
     @classmethod
     async def lookup(
@@ -336,8 +339,7 @@ class _Object:
         my_dict = Dict.lookup("my-dict")
         ```
         """
-        obj = cls.from_name(app_name, tag, namespace, environment_name)
-        obj._client = client
+        obj = cls.from_name(app_name, tag, namespace, client, environment_name)
         return obj
 
     @classmethod

--- a/modal/object.py
+++ b/modal/object.py
@@ -204,7 +204,7 @@ class _Object:
         """mdmd:hidden"""
         return self._is_hydrated
 
-    async def resolve(self):
+    async def resolve(self: O):
         if self._is_hydrated:
             return
         elif not self._hydrate_lazily:
@@ -215,7 +215,7 @@ class _Object:
                 " wasn't defined in global scope."
             )
         else:
-            resolver = Resolver()
+            resolver = Resolver(client=self._client)
             await resolver.load(self)
 
     async def _deploy(
@@ -305,7 +305,7 @@ class _Object:
             )
 
         rep = f"Ref({app_name})"
-        return cls._from_loader(_load_remote, rep)
+        return cls._from_loader(_load_remote, rep, hydrate_lazily=True)
 
     @classmethod
     async def lookup(
@@ -336,11 +336,8 @@ class _Object:
         my_dict = Dict.lookup("my-dict")
         ```
         """
-        # TODO(erikbern): this code is very duplicated. Clean up once handles are gone.
-        rep = f"Object({app_name})"  # TODO(erikbern): dumb
-        obj = _Object.__new__(cls)
-        obj._init(rep)
-        await obj._hydrate_from_app(app_name, tag, namespace, client, environment_name=environment_name)
+        obj = cls.from_name(app_name, tag, namespace, environment_name)
+        obj._client = client
         return obj
 
     @classmethod

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -243,6 +243,7 @@ def test_lookup(client, servicer):
     deploy_stub(stub, "my-cls-app", client=client)
 
     cls: Cls = Cls.lookup("my-cls-app", "Foo", client=client)
+    cls.resolve()
 
     assert cls.object_id.startswith("cs-")
     assert cls.bar.object_id.startswith("fu-")

--- a/test/lookup_test.py
+++ b/test/lookup_test.py
@@ -12,11 +12,13 @@ def test_persistent_object(servicer, client):
     deploy_stub(stub, "my-queue", client=client)
 
     q: Queue = Queue.lookup("my-queue", client=client)
+    q.resolve()
     assert isinstance(q, Queue)
     assert q.object_id == "qu-1"
 
+    q = Queue.lookup("bazbazbaz", client=client)
     with pytest.raises(NotFoundError):
-        Queue.lookup("bazbazbaz", client=client)
+        q.resolve()
 
 
 def square(x):
@@ -31,13 +33,16 @@ def test_lookup_function(servicer, client):
     deploy_stub(stub, "my-function", client=client)
 
     f = Function.lookup("my-function", client=client)
+    f.resolve()
     assert f.object_id == "fu-1"
 
     # Call it using two arguments
     f = Function.lookup("my-function", "square", client=client)
+    f.resolve()
     assert f.object_id == "fu-1"
+    g = Function.lookup("my-function", "cube", client=client)
     with pytest.raises(NotFoundError):
-        f = Function.lookup("my-function", "cube", client=client)
+        g.resolve()
 
     # Make sure we can call this function
     assert f.remote(2, 4) == 20
@@ -60,6 +65,7 @@ def test_webhook_lookup(servicer, client):
     deploy_stub(stub, "my-webhook", client=client)
 
     f = Function.lookup("my-webhook", client=client)
+    f.resolve()
     assert f.web_url
 
 
@@ -69,6 +75,7 @@ def test_deploy_exists(servicer, client):
     q1._deploy("my-queue", client=client)
     assert Queue._exists("my-queue", client=client)
     q2: Queue = Queue.lookup("my-queue", client=client)
+    q2.resolve()
     assert q1.object_id == q2.object_id
 
 


### PR DESCRIPTION
This one unifies `lookup` and `from_name` by making `lookup` a wrapper around `from_name`. In particular `lookup` was always "eager" but this PR changes the behavior such that `lookup` is now lazy. This introduces subtle changes, e.g.

1. If the object doesn't exist, the exception isn't raised until you call a method on the object (which forces the hydration)
2. Attributes such as `object_id` aren't written until later

You can call `.resolve()` on the object to force it to hydrate though.

Note that `from_name` was always lazy and wasn't possible to use previously outside of app initialization – the only use case was basically things like `stub.xyz = Dict.from_name("foo")` and then use `stub.xyz` to refer to the dict once the app was hydrated.

Why are we doing this? This is a precursor to a larger change we deprecate both `lookup` and `from_name` and replace them with two other methods. If we don't merge `lookup` and `from_name`, then we will end up with 2*2 different methods. So I think it's preferable to merge `lookup` and `from_name` even though they are slightly different – the similarities are far greater imo.