### PR TITLE
Catch issue with unhydrated function (alternative to #974)

### DIFF
--- a/modal/object.py
+++ b/modal/object.py
@@ -76,6 +76,7 @@ class _Object:
         pass
 
     def _hydrate(self, object_id: str, client: _Client, metadata: Optional[Message]):
+        assert isinstance(object_id, str)
         self._object_id = object_id
         self._client = client
         self._hydrate_metadata(metadata)

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -407,3 +407,19 @@ def test_rehydrate(client, servicer):
     # Hydration shouldn't overwrite local function definition
     obj = Foo()
     assert obj.bar.local(7) == 343
+
+
+stub_unhydrated = Stub()
+
+
+@stub_unhydrated.cls()
+class FooUnhydrated:
+    @method()
+    def bar(self):
+        ...
+
+
+def test_unhydrated():
+    foo = FooUnhydrated()
+    with pytest.raises(ExecutionError, match="hydrated"):
+        foo.bar.remote(42)


### PR DESCRIPTION
I looked deeper at the issue in #974 and added a unit test. The issue is actually a bit more complex. The problem wasn't the lazy hydration, it was that the code in the lazy hydration tried to hydrate a parametrized function from an unhydrated base function.

Added some assertion and a better error message.