### PR TITLE
Expose "modal.forward" and fix reference docs

### DIFF
--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
 from modal_version import __version__
 
+from ._tunnel import Tunnel, forward
 from .app import container_app, is_local
 from .client import Client
 from .cls import Cls
@@ -37,11 +38,13 @@ __all__ = [
     "Secret",
     "SharedVolume",
     "Stub",
+    "Tunnel",
     "Volume",
     "asgi_app",
     "container_app",
     "create_package_mounts",
     "current_input_id",
+    "forward",
     "is_local",
     "method",
     "web_endpoint",

--- a/modal/_tunnel.py
+++ b/modal/_tunnel.py
@@ -51,9 +51,9 @@ async def _forward(port: int) -> AsyncIterator[Tunnel]:
 
     @stub.function()
     def run_app():
-        # Suppose we run a web server inside the container at port 8080. `modal.forward(8080)` lets us
+        # Start a web server inside the container at port 8000. `modal.forward(8000)` lets us
         # expose that port to the world at a random HTTPS URL.
-        with modal.forward(8080) as tunnel:
+        with modal.forward(800) as tunnel:
             print("Server listening at", tunnel.url)
             app.run("0.0.0.0", 8000)
     ```

--- a/modal/_tunnel.py
+++ b/modal/_tunnel.py
@@ -53,7 +53,7 @@ async def _forward(port: int) -> AsyncIterator[Tunnel]:
     def run_app():
         # Start a web server inside the container at port 8000. `modal.forward(8000)` lets us
         # expose that port to the world at a random HTTPS URL.
-        with modal.forward(800) as tunnel:
+        with modal.forward(8000) as tunnel:
             print("Server listening at", tunnel.url)
             app.run("0.0.0.0", 8000)
     ```

--- a/modal/_tunnel.py
+++ b/modal/_tunnel.py
@@ -17,16 +17,47 @@ from .exception import InvalidError, RemoteError
 
 @dataclass
 class Tunnel:
+    """A port forwarded from within a running Modal container. Created by `modal.forward()`.
+
+    This is an EXPERIMENTAL API and may change in the future.
+    """
+
     host: str
 
     @property
     def url(self) -> str:
+        """Get the public HTTPS URL of the forwarded port."""
         return f"https://{self.host}"
 
 
 @contextlib.asynccontextmanager
 async def _forward(port: int) -> AsyncIterator[Tunnel]:
-    """Forward a port from within a running Modal container."""
+    """Expose a port publicly from inside a running Modal container, with TLS.
+
+    This is an EXPERIMENTAL API and may change in the future.
+
+    **Usage:**
+
+    ```python
+    from flask import Flask
+
+
+    app = Flask(__name__)
+
+    @app.route("/")
+    def hello_world():
+        return "Hello, World!"
+
+
+    @stub.function()
+    def run_app():
+        # Suppose we run a web server inside the container at port 8080. `modal.forward(8080)` lets us
+        # expose that port to the world at a random HTTPS URL.
+        with modal.forward(8080) as tunnel:
+            print("Server listening at", tunnel.url)
+            app.run("0.0.0.0", 8000)
+    ```
+    """
     if not isinstance(port, int) or port < 1 or port > 65535:
         raise InvalidError(f"Invalid port number {port}")
 

--- a/modal/cli/programs/jupyterlab.py
+++ b/modal/cli/programs/jupyterlab.py
@@ -9,8 +9,7 @@ import time
 import webbrowser
 from typing import Any
 
-from modal import Image, Queue, Stub
-from modal._relay_client import forward
+from modal import Image, Queue, Stub, forward
 
 args: Any = {}
 

--- a/modal/cli/programs/vscode.py
+++ b/modal/cli/programs/vscode.py
@@ -9,8 +9,7 @@ import time
 import webbrowser
 from typing import Any
 
-from modal import Image, Queue, Stub
-from modal._relay_client import forward
+from modal import Image, Queue, Stub, forward
 
 args: Any = {}
 

--- a/modal_docs/mdmd/signatures.py
+++ b/modal_docs/mdmd/signatures.py
@@ -5,6 +5,8 @@ import textwrap
 import warnings
 from typing import Tuple
 
+from synchronicity.synchronizer import FunctionWithAio
+
 
 def _signature_from_ast(func) -> Tuple[str, str]:
     """Get function signature, including decorators and comments, from source code
@@ -42,7 +44,7 @@ def get_signature(name, callable) -> str:
     TODO: use source parsing *only* to extract default arguments, comments (and possibly decorators) and "merge"
           that definition with the outer-most definition."""
 
-    if not (inspect.isfunction(callable) or inspect.ismethod(callable)):
+    if not (inspect.isfunction(callable) or inspect.ismethod(callable) or isinstance(callable, FunctionWithAio)):
         assert hasattr(callable, "__call__")
         callable = callable.__call__
 
@@ -65,5 +67,7 @@ def get_signature(name, callable) -> str:
         # hack to "reset" signature to a blocking one if the underlying source definition is async
         # but the wrapper function isn't (like when synchronicity wraps an async function as a blocking one)
         definition_source = definition_source.replace("async def", "def")
+        definition_source = definition_source.replace("asynccontextmanager", "contextmanager")
+        definition_source = definition_source.replace("AsyncIterator", "Iterator")
 
     return definition_source


### PR DESCRIPTION
This is the generated doc:

---

# modal.forward

```python
@contextlib.contextmanager
def forward(port: int) -> Iterator[Tunnel]:
```

Expose a port publicly from inside a running Modal container, with TLS.

This is an EXPERIMENTAL API and may change in the future.

**Usage:**

```python
from flask import Flask


app = Flask(__name__)

@app.route("/")
def hello_world():
    return "Hello, World!"


@stub.function()
def run_app():
    # Start a web server inside the container at port 8000. `modal.forward(8000)` lets us
    # expose that port to the world at a random HTTPS URL.
    with modal.forward(8000) as tunnel:
        print("Server listening at", tunnel.url)
        app.run("0.0.0.0", 8000)
```
