### PR TITLE
a bunch of deprecation warnings -> errors

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -2,7 +2,7 @@
 import asyncio
 import pickle
 from datetime import date
-from typing import Any, Callable, Dict, Optional, Type, TypeVar
+from typing import Any, Callable, Dict, Optional, TypeVar
 
 from google.protobuf.message import Message
 
@@ -11,7 +11,7 @@ from modal_utils.async_utils import synchronize_api, synchronizer
 
 from ._output import OutputManager
 from ._resolver import Resolver
-from .exception import deprecation_warning
+from .exception import deprecation_error
 from .functions import _Function
 from .object import _Object
 
@@ -20,15 +20,7 @@ T = TypeVar("T")
 
 class ClsMixin:
     def __init_subclass__(cls):
-        deprecation_warning(date(2023, 9, 1), "`ClsMixin` is deprecated and can be safely removed.")
-
-    @classmethod
-    def remote(cls: Type[T], *args, **kwargs) -> T:
-        ...
-
-    @classmethod
-    async def aio_remote(cls: Type[T], *args, **kwargs) -> T:
-        ...
+        deprecation_error(date(2023, 9, 1), "`ClsMixin` is deprecated and can be safely removed.")
 
 
 def check_picklability(key, arg):
@@ -189,11 +181,10 @@ class _Cls(_Object, type_prefix="cs"):
         """This acts as the class constructor."""
         return _Obj(self._user_cls, self._output_mgr, self._base_functions, args, kwargs)
 
-    async def remote(self, *args, **kwargs) -> _Obj:
-        deprecation_warning(
+    async def remote(self, *args, **kwargs):
+        deprecation_error(
             date(2023, 9, 1), "`Cls.remote(...)` on classes is deprecated. Use the constructor: `Cls(...)`."
         )
-        return self(*args, **kwargs)
 
     def __getattr__(self, k):
         # Used by CLI and container entrypoint

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -61,7 +61,7 @@ from .exception import (
     FunctionTimeoutError,
     InvalidError,
     RemoteError,
-    deprecation_warning,
+    deprecation_error,
 )
 from .gpu import GPU_T, parse_gpu_config
 from .image import _Image
@@ -1135,15 +1135,11 @@ class _Function(_Object, type_prefix="fu"):
 
     def call(self, *args, **kwargs) -> Awaitable[Any]:  # TODO: Generics/TypeVars
         if self._is_generator:
-            deprecation_warning(
+            deprecation_error(
                 date(2023, 8, 16), "`f.call(...)` is deprecated. It has been renamed to `f.remote_gen(...)`"
             )
-            return self.remote_gen(*args, **kwargs)
         else:
-            deprecation_warning(
-                date(2023, 8, 16), "`f.call(...)` is deprecated. It has been renamed to `f.remote(...)`"
-            )
-            return self.remote(*args, **kwargs)
+            deprecation_error(date(2023, 8, 16), "`f.call(...)` is deprecated. It has been renamed to `f.remote(...)`")
 
     @live_method
     async def shell(self, *args, **kwargs) -> None:
@@ -1203,20 +1199,18 @@ class _Function(_Object, type_prefix="fu"):
     @synchronizer.nowrap
     def __call__(self, *args, **kwargs) -> Any:  # TODO: Generics/TypeVars
         if self._get_is_remote_cls_method():
-            deprecation_warning(
+            deprecation_error(
                 date(2023, 9, 1),
                 "Calling remote class methods like `obj.f(...)` is deprecated. Use `obj.f.remote(...)` for remote calls"
                 " and `obj.f.local(...)` for local calls",
             )
-            return self.remote(*args, **kwargs)
         else:
-            deprecation_warning(
+            deprecation_error(
                 date(2023, 8, 16),
                 "Calling Modal functions like `f(...)` is deprecated. Use `f.local(...)` if you want to call the"
                 " function in the same Python process. Use `f.remote(...)` if you want to call the function in"
                 " a Modal container in the cloud",
             )
-            return self.local(*args, **kwargs)
 
     async def spawn(self, *args, **kwargs) -> Optional["_FunctionCall"]:
         """Calls the function with the given arguments, without waiting for the results.

--- a/modal/image.py
+++ b/modal/image.py
@@ -21,7 +21,7 @@ from ._resolver import Resolver
 from ._serialization import serialize
 from .app import is_local
 from .config import config, logger
-from .exception import InvalidError, NotFoundError, RemoteError, deprecation_warning
+from .exception import InvalidError, NotFoundError, RemoteError, deprecation_error
 from .gpu import GPU_T, parse_gpu_config
 from .mount import _Mount, python_standalone_mount_name
 from .network_file_system import _NetworkFileSystem
@@ -974,15 +974,9 @@ class _Image(_Object, type_prefix="im"):
         setup_dockerfile_commands: List[str] = [],
         force_build: bool = False,
         **kwargs,
-    ) -> "_Image":
+    ):
         f"""{_from_dockerhub_deprecation_msg}"""
-        deprecation_warning(date(2023, 8, 25), _from_dockerhub_deprecation_msg)
-        return _Image.from_registry(
-            tag,
-            setup_dockerfile_commands=setup_dockerfile_commands,
-            force_build=force_build,
-            **kwargs,
-        )
+        deprecation_error(date(2023, 8, 25), _from_dockerhub_deprecation_msg)
 
     @staticmethod
     @typechecked
@@ -1243,11 +1237,12 @@ class _Image(_Object, type_prefix="im"):
         info = FunctionInfo(raw_f)
 
         if shared_volumes or network_file_systems:
-            deprecation_warning(
+            deprecation_error(
                 date(2023, 8, 19),
-                "Support for mounting NetworkFileSystems or Volumes will soon be removed from `run_function`. If you are trying to download model weights, downloading it to the image itself is recommended and sufficient. Please refer to the docs for more on this, or reach out to us if your use case is not covered.",
+                "Support for mounting NetworkFileSystems or Volumes has been removed from `run_function`."
+                " If you are trying to download model weights, downloading it to the image itself is recommended and sufficient."
+                " Please refer to the docs for more on this, or reach out to us if your use case is not covered.",
             )
-            network_file_systems = {**network_file_systems, **shared_volumes}
 
         function = _Function.from_args(
             info,

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -493,14 +493,12 @@ _create_package_mounts_deprecation_msg = (
 
 
 @typechecked
-def _create_package_mounts(module_names: Sequence[str]) -> List[_Mount]:
+def _create_package_mounts(module_names: Sequence[str]):
     f"""{_create_package_mounts_deprecation_msg}"""
-    modal.exception.deprecation_warning(
+    modal.exception.deprecation_error(
         date(2023, 7, 19),
         _create_package_mounts_deprecation_msg,
-        pending=True,
     )
-    return [_Mount.from_local_python_packages(*module_names)]
 
 
 create_package_mounts = synchronize_api(_create_package_mounts)

--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -7,7 +7,7 @@ from ._version_generated import build_number  # Written by GitHub
 major_number = 0
 
 # Bump this manually on any major changes
-minor_number = 54
+minor_number = 55
 
 # Right now, set the patch number (the 3rd field) to the job run number in GitHub
 __version__ = f"{major_number}.{minor_number}.{build_number}"

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -65,19 +65,19 @@ class FooRemote:
 
 def test_call_cls_remote_sync(client):
     with stub_remote.run(client=client):
-        foo_remote: FooRemote
-        with pytest.warns(DeprecationError):
-            foo_remote = FooRemote.remote(3, "hello")  # type: ignore
-        # Mock servicer just squares the argument
-        # This means remote function call is taking place.
-        assert foo_remote.bar.remote(8) == 64
-        with pytest.warns(DeprecationError):
-            assert foo_remote.bar(8) == 64
+        # Check old cls syntax
+        with pytest.raises(DeprecationError):
+            FooRemote.remote(3, "hello")  # type: ignore
 
         # Check new syntax
-        foo_remote_2: FooRemote = FooRemote(3, "hello")
-        ret: float = foo_remote_2.bar.remote(8)
-        assert ret == 64
+        foo_remote: FooRemote = FooRemote(3, "hello")
+        ret: float = foo_remote.bar.remote(8)
+        assert ret == 64  # Mock servicer just squares the argument
+
+        # Check old method syntax
+        assert foo_remote.bar.remote(8) == 64
+        with pytest.raises(DeprecationError):
+            foo_remote.bar(8)
 
 
 def test_call_cls_remote_invalid_type(client):
@@ -106,10 +106,11 @@ class Bar:
 @pytest.mark.asyncio
 async def test_call_class_async(client, servicer):
     async with stub_2.run(client=client):
-        with pytest.warns(DeprecationError):
-            bar = await Bar.remote.aio()  # type: ignore
         bar = Bar()
         assert await bar.baz.remote.aio(42) == 1764
+
+        with pytest.raises(DeprecationError):
+            await Bar.remote.aio()  # type: ignore
 
 
 def test_run_class_serialized(client, servicer):
@@ -158,15 +159,18 @@ class BarRemote:
 @pytest.mark.asyncio
 async def test_call_cls_remote_async(client):
     async with stub_remote_2.run(client=client):
+        bar_remote = BarRemote(3, "hello")
+        assert await bar_remote.baz.remote.aio(8) == 64  # Mock servicer just squares the argument
+
+        # Check deprecated method syntax
+        with pytest.raises(DeprecationError):
+            bar_remote.baz(8)
+
+        # Check deprecated cls syntax
         coro = BarRemote.remote.aio(3, "hello")  # type: ignore
         assert inspect.iscoroutine(coro)
-        with pytest.warns(DeprecationError):
-            bar_remote = await coro
-        # Mock servicer just squares the argument
-        # This means remote function call is taking place.
-        assert await bar_remote.baz.remote.aio(8) == 64
-        with pytest.warns(DeprecationError):
-            assert bar_remote.baz(8) == 64
+        with pytest.raises(DeprecationError):
+            await coro
 
 
 stub_local = Stub()
@@ -215,19 +219,21 @@ class NoArgRemote:
 
 def test_call_cls_remote_no_args(client):
     with stub_remote_3.run(client=client):
-        with pytest.warns(DeprecationError):
-            foo_remote = NoArgRemote.remote()  # type: ignore
-        # Mock servicer just squares the argument
-        # This means remote function call is taking place.
-        with pytest.warns(DeprecationError):
-            assert foo_remote.baz(8) == 64
-
+        # Check new cls syntax
         foo_remote = NoArgRemote()
-        assert foo_remote.baz.remote(8) == 64
+        assert foo_remote.baz.remote(8) == 64  # Mock servicer just squares the argument
+
+        # Check old cls syntax
+        with pytest.raises(DeprecationError):
+            NoArgRemote.remote()  # type: ignore
+
+        # Check old method syntax
+        with pytest.raises(DeprecationError):
+            foo_remote.baz(8)
 
 
 def test_deprecated_mixin():
-    with pytest.warns(DeprecationError):
+    with pytest.raises(DeprecationError):
 
         class FooRemote(ClsMixin):
             pass

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -35,27 +35,28 @@ def test_run_function(client, servicer):
     assert len(servicer.cleared_function_calls) == 0
     with stub.run(client=client):
         # Old-style remote calls
-        with pytest.warns(DeprecationError):
-            assert foo.call(2, 4) == 20
-            assert len(servicer.cleared_function_calls) == 1
+        with pytest.raises(DeprecationError):
+            foo.call(2, 4)
 
         # New-style remote calls
         assert foo.remote(2, 4) == 20
-        assert len(servicer.cleared_function_calls) == 2
+        assert len(servicer.cleared_function_calls) == 1
 
         # Make sure we can also call the Function object
         fun = stub.foo
         assert isinstance(fun, Function)
         assert fun.remote(2, 4) == 20
-        assert len(servicer.cleared_function_calls) == 3
+        assert len(servicer.cleared_function_calls) == 2
 
 
 @pytest.mark.asyncio
 async def test_call_function_locally(client, servicer):
     # Old-style local calls
-    with pytest.warns(DeprecationError):
-        assert foo(22, 44) == 77  # call it locally
-        assert await async_foo(22, 44) == 78
+    with pytest.raises(DeprecationError):
+        foo(22, 44)
+
+    with pytest.raises(DeprecationError):
+        await async_foo(22, 44)
 
     # New-style local calls
     assert foo.local(22, 44) == 77  # call it locally
@@ -63,20 +64,20 @@ async def test_call_function_locally(client, servicer):
 
     with stub.run(client=client):
         assert foo.remote(2, 4) == 20
-        with pytest.warns(DeprecationError):
-            assert foo(22, 55) == 88
-        with pytest.warns(DeprecationError):
-            assert await async_foo(22, 44) == 78
+        with pytest.raises(DeprecationError):
+            foo(22, 55)
+        with pytest.raises(DeprecationError):
+            await async_foo(22, 44)
         assert async_foo.remote(2, 4) == 20
         assert await async_foo.remote.aio(2, 4) == 20
 
         # Make sure we can also call the Function object
         assert isinstance(stub.foo, Function)
         assert isinstance(stub.async_foo, Function)
-        with pytest.warns(DeprecationError):
-            assert stub.foo(22, 55) == 88
-        with pytest.warns(DeprecationError):
-            assert await stub.async_foo(22, 44) == 78
+        with pytest.raises(DeprecationError):
+            stub.foo(22, 55)
+        with pytest.raises(DeprecationError):
+            await stub.async_foo(22, 44)
 
 
 @pytest.mark.parametrize("slow_put_inputs", [False, True])
@@ -241,9 +242,8 @@ async def test_generator(client, servicer):
         assert len(servicer.cleared_function_calls) == 1
 
         # Check deprecated interface
-        with pytest.warns(DeprecationError):
-            res = later_gen_modal.call()
-            assert next(res) == "bar"
+        with pytest.raises(DeprecationError):
+            later_gen_modal.call()
 
 
 @pytest.mark.asyncio

--- a/test/lookup_test.py
+++ b/test/lookup_test.py
@@ -53,10 +53,8 @@ def test_lookup_function(servicer, client):
         assert f.local(2, 4) == 20
 
     # Make sure the old-style local calls raise an error
-    with pytest.raises(ExecutionError):
-        # It also throws a deprecation warning, so let's ignore that
-        with pytest.warns(DeprecationError):
-            assert f(2, 4) == 20
+    with pytest.raises(DeprecationError):
+        assert f(2, 4)
 
 
 def test_webhook_lookup(servicer, client):


### PR DESCRIPTION
Turning warnings into errors for a few things:
* `f.call(...)`
* any use of `ClsMixin`
* calling `.remote` on a `cls`
* `__call__` on a remote method
* minor thing with images and mounts

Bumping the version to 0.55 to signify this.

We should keep the code raising the errors for a few months at least. But eventually we can remove the code.