### PR TITLE
Add test for lazy lookups

### DIFF
--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -268,6 +268,14 @@ def test_lookup(client, servicer):
         assert obj.bar.local(1, 2)
 
 
+def test_lookup_lazy(client, servicer):
+    # See #972 (PR) and #985 (revert PR): adding unit test to catch regression
+    deploy_stub(stub, "my-cls-app", client=client)
+    cls: Cls = Cls.lookup("my-cls-app", "Foo", client=client)
+    obj = cls("foo", 234)
+    assert obj.bar.remote(42, 77) == 7693
+
+
 baz_stub = Stub()
 
 


### PR DESCRIPTION
This broke in #972 – adding a test for it so we can prevent it next time.
