### PR TITLE
Docs fixes

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1033,9 +1033,21 @@ class _Function(_Object, type_prefix="fu"):
         is guaranteed to be the same as the input order. Set `order_outputs=False` to return results
         in the order that they are completed instead.
 
-        If applied to a `stub.generator`, the results are returned as they are finished and can be
-        out of order. By yielding zero or more than once, mapping over generators can also be used
+        By yielding zero or more than once, mapping over generators can also be used
         as a "flat map".
+
+        ```python
+        @stub.function()
+        def flat(i: int):
+            choices = [[], ["once"], ["two", "times"], ["three", "times", "a lady"]]
+            for item in choices[i % len(choices)]:
+                yield item
+
+        @stub.local_entrypoint()
+        def main():
+            for item in flat.map(range(10)):
+                print(item)
+        ```
 
         `return_exceptions` can be used to treat exceptions as successful results:
         ```python

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1111,10 +1111,11 @@ class _Function(_Object, type_prefix="fu"):
             yield item
 
     @live_method
-    async def remote(self, *args, **kwargs) -> Awaitable[Any]:  # TODO: Generics/TypeVars
+    async def remote(self, *args, **kwargs) -> Awaitable[Any]:
         """
         Calls the function remotely, executing it with the given arguments and returning the execution's result.
         """
+        # TODO: Generics/TypeVars
         if self._web_url:
             raise InvalidError(
                 "A web endpoint function cannot be invoked for remote execution with `.remote`. "
@@ -1128,10 +1129,11 @@ class _Function(_Object, type_prefix="fu"):
         return await self._call_function(args, kwargs)
 
     @live_method_gen
-    async def remote_gen(self, *args, **kwargs) -> AsyncGenerator[Any, None]:  # TODO: Generics/TypeVars
+    async def remote_gen(self, *args, **kwargs) -> AsyncGenerator[Any, None]:
         """
         Calls the generator remotely, executing it with the given arguments and returning the execution's result.
         """
+        # TODO: Generics/TypeVars
         if self._web_url:
             raise InvalidError(
                 "A web endpoint function cannot be invoked for remote execution with `.remote`. "
@@ -1145,7 +1147,9 @@ class _Function(_Object, type_prefix="fu"):
         async for item in self._call_generator(args, kwargs):  # type: ignore
             yield item
 
-    def call(self, *args, **kwargs) -> Awaitable[Any]:  # TODO: Generics/TypeVars
+    def call(self, *args, **kwargs) -> Awaitable[Any]:
+        """Deprecated. Use `f.remote` or `f.remote_gen` instead."""
+        # TODO: Generics/TypeVars
         if self._is_generator:
             deprecation_error(
                 date(2023, 8, 16), "`f.call(...)` is deprecated. It has been renamed to `f.remote_gen(...)`"
@@ -1177,6 +1181,10 @@ class _Function(_Object, type_prefix="fu"):
 
     @synchronizer.nowrap
     def local(self, *args, **kwargs) -> Any:
+        """
+        Calls the function locally, executing it with the given arguments and returning the execution's result.
+        This method allows a caller to execute the standard Python function wrapped by Modal.
+        """
         # TODO(erikbern): it would be nice to remove the nowrap thing, but right now that would cause
         # "user code" to run on the synchronicity thread, which seems bad
         info = self._get_info()

--- a/modal_docs/gen_reference_docs.py
+++ b/modal_docs/gen_reference_docs.py
@@ -28,6 +28,24 @@ class DocItem(NamedTuple):
     in_sidebar: bool = True
 
 
+def validate_doc_item(docitem: DocItem) -> DocItem:
+    # Check that unwanted strings aren't leaking into our docs.
+    bad_strings = [
+        # Presence of a TODO inside a `DocItem` usually indicates it's been
+        # places inside a function signature definition or right underneath it, before the body.
+        # Fix by moving the TODO into the body, or above the signature.
+        "TODO:"
+    ]
+    for line in docitem.document.splitlines():
+        for bad_str in bad_strings:
+            if bad_str in line:
+                msg = (
+                    f"Found unwanted string '{bad_str}' in content for item '{docitem.label}'. " f"Problem line: {line}"
+                )
+                raise ValueError(msg)
+    return docitem
+
+
 def run(output_dir: str = None):
     """Generate Modal docs."""
     import modal
@@ -80,11 +98,13 @@ def run(output_dir: str = None):
         document = module_str(modulepath, module, title_level=base_title_level, filter_items=modal_default_filter)
         if document:
             ordered_doc_items.append(
-                DocItem(
-                    label=title,
-                    category=Category.MODULE,
-                    document=document,
-                    in_sidebar=title not in sidebar_excluded,
+                validate_doc_item(
+                    DocItem(
+                        label=title,
+                        category=Category.MODULE,
+                        document=document,
+                        in_sidebar=title not in sidebar_excluded,
+                    )
                 )
             )
 
@@ -109,11 +129,13 @@ def run(output_dir: str = None):
             warnings.warn(f"Not sure how to document: {item_name} ({item})")
             continue
         ordered_doc_items.append(
-            DocItem(
-                label=title,
-                category=category,
-                document=content,
-                in_sidebar=title not in sidebar_excluded,
+            validate_doc_item(
+                DocItem(
+                    label=title,
+                    category=category,
+                    document=content,
+                    in_sidebar=title not in sidebar_excluded,
+                )
             )
         )
     ordered_doc_items.sort()

--- a/modal_docs/gen_reference_docs.py
+++ b/modal_docs/gen_reference_docs.py
@@ -31,9 +31,9 @@ class DocItem(NamedTuple):
 def validate_doc_item(docitem: DocItem) -> DocItem:
     # Check that unwanted strings aren't leaking into our docs.
     bad_strings = [
-        # Presence of a TODO inside a `DocItem` usually indicates it's been
-        # places inside a function signature definition or right underneath it, before the body.
-        # Fix by moving the TODO into the body, or above the signature.
+        # Presence of a to-do inside a `DocItem` usually indicates it's been
+        # placed inside a function signature definition or right underneath it, before the body.
+        # Fix by moving the to-do into the body or above the signature.
         "TODO:"
     ]
     for line in docitem.document.splitlines():

--- a/modal_docs/gen_reference_docs.py
+++ b/modal_docs/gen_reference_docs.py
@@ -39,9 +39,7 @@ def validate_doc_item(docitem: DocItem) -> DocItem:
     for line in docitem.document.splitlines():
         for bad_str in bad_strings:
             if bad_str in line:
-                msg = (
-                    f"Found unwanted string '{bad_str}' in content for item '{docitem.label}'. " f"Problem line: {line}"
-                )
+                msg = f"Found unwanted string '{bad_str}' in content for item '{docitem.label}'. Problem line: {line}"
                 raise ValueError(msg)
     return docitem
 


### PR DESCRIPTION
* Improve docstring for `.map`
* Introduce change to fail `inv docs` if "TODO" strings leak into our docs. I've been manually cleaning them up when I spot them and it's time to make it a build-time check. Should have very few false positives.