### PR TITLE
fix: flaky test_heartbeats

### DIFF
--- a/test/live_reload_test.py
+++ b/test/live_reload_test.py
@@ -72,4 +72,5 @@ async def test_heartbeats(stub_ref, server_url_env, servicer):
     apps = list(servicer.app_heartbeats.keys())
     assert len(apps) == 1
     # Typically [0s, 1s, 2s, 3s], but asyncio.sleep may lag.
-    assert servicer.app_heartbeats[apps[0]] == total_secs + 1
+    actual_heartbeats = servicer.app_heartbeats[apps[0]]
+    assert abs(actual_heartbeats - (total_secs + 1)) <= 1


### PR DESCRIPTION
Apparently this test became flaky on Windows, but it's now also flaky on Linux: https://github.com/modal-labs/modal-client/actions/runs/6589553878/job/17904274654.

It's likely because the asyncio loop lags, so basing num of expected heartbeats on app's actual lifetime.

**Edit:**

Ok this doesn't help:

```
    @pytest.mark.asyncio
    async def test_heartbeats(stub_ref, server_url_env, servicer):
        with mock.patch("modal.runner.HEARTBEAT_INTERVAL", 1):
            t0 = time.time()
            async with serve_stub.aio(stub, stub_ref):
                await asyncio.sleep(3.1)
            total_secs = int(time.time() - t0)
    
        apps = list(servicer.app_heartbeats.keys())
        assert len(apps) == 1
        # Typically [0s, 1s, 2s, 3s], but asyncio.sleep may lag.
>       assert servicer.app_heartbeats[apps[0]] == total_secs + 1
E       assert 4 == (4 + 1)
```