### PR TITLE
Add client test for tunnels and mock the RPCs

### DIFF
--- a/modal/_tunnel.py
+++ b/modal/_tunnel.py
@@ -1,9 +1,9 @@
 # Copyright Modal Labs 2023
 """Client for Modal relay servers, allowing users to expose TLS."""
 
-import contextlib
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import AsyncIterator
+from typing import AsyncIterator, Optional
 
 from grpclib import GRPCError, Status
 
@@ -11,7 +11,6 @@ from modal_proto import api_pb2
 from modal_utils.async_utils import synchronize_api
 
 from .client import _Client
-from .config import config
 from .exception import InvalidError, RemoteError
 
 
@@ -30,8 +29,8 @@ class Tunnel:
         return f"https://{self.host}"
 
 
-@contextlib.asynccontextmanager
-async def _forward(port: int) -> AsyncIterator[Tunnel]:
+@asynccontextmanager
+async def _forward(port: int, client: Optional[_Client] = None) -> AsyncIterator[Tunnel]:
     """Expose a port publicly from inside a running Modal container, with TLS.
 
     This is an EXPERIMENTAL API and may change in the future.
@@ -61,10 +60,11 @@ async def _forward(port: int) -> AsyncIterator[Tunnel]:
     if not isinstance(port, int) or port < 1 or port > 65535:
         raise InvalidError(f"Invalid port number {port}")
 
-    if not config.get("task_id"):
-        raise InvalidError("Forwarding ports only works inside a Modal container")
+    if not client:
+        client = await _Client.from_env()
 
-    client = await _Client.from_env()
+    if client.client_type != api_pb2.CLIENT_TYPE_CONTAINER:
+        raise InvalidError("Forwarding ports only works inside a Modal container")
 
     try:
         response = await client.stub.TunnelStart(api_pb2.TunnelStartRequest(port=port))

--- a/modal/client.py
+++ b/modal/client.py
@@ -75,6 +75,8 @@ class _Client:
     _client_from_env = None
     _client_from_env_lock = None
 
+    client_type: int
+
     def __init__(
         self,
         server_url,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -735,6 +735,17 @@ class MockClientServicer(api_grpc.ModalClientBase):
             )
         )
 
+    ### Tunnel
+
+    async def TunnelStart(self, stream):
+        request: api_pb2.TunnelStartRequest = await stream.recv_message()
+        port = request.port
+        await stream.send_message(api_pb2.TunnelStartResponse(host=f"{port}.modal.test"))
+
+    async def TunnelStop(self, stream):
+        await stream.recv_message()
+        await stream.send_message(api_pb2.TunnelStopResponse(exists=True))
+
     ### Volume
 
     async def VolumeCreate(self, stream):

--- a/test/tunnel_test.py
+++ b/test/tunnel_test.py
@@ -5,6 +5,8 @@ import pytest
 from modal import forward
 from modal.exception import InvalidError
 
+from .supports.skip import skip_windows_unix_socket
+
 
 def test_tunnel_outside_container(client):
     with pytest.raises(InvalidError):
@@ -12,6 +14,7 @@ def test_tunnel_outside_container(client):
             pass
 
 
+@skip_windows_unix_socket
 def test_invalid_port_numbers(container_client):
     for port in (-1, 0, 65536):
         with pytest.raises(InvalidError):
@@ -19,6 +22,7 @@ def test_invalid_port_numbers(container_client):
                 pass
 
 
+@skip_windows_unix_socket
 def test_create_tunnel(container_client):
     with forward(8000, client=container_client) as tunnel:
         assert tunnel.host == "8000.modal.test"

--- a/test/tunnel_test.py
+++ b/test/tunnel_test.py
@@ -1,0 +1,25 @@
+# Copyright Modal Labs 2023
+
+import pytest
+
+from modal import forward
+from modal.exception import InvalidError
+
+
+def test_tunnel_outside_container(client):
+    with pytest.raises(InvalidError):
+        with forward(8000, client=client):
+            pass
+
+
+def test_invalid_port_numbers(container_client):
+    for port in (-1, 0, 65536):
+        with pytest.raises(InvalidError):
+            with forward(port, client=container_client):
+                pass
+
+
+def test_create_tunnel(container_client):
+    with forward(8000, client=container_client) as tunnel:
+        assert tunnel.host == "8000.modal.test"
+        assert tunnel.url == "https://8000.modal.test"


### PR DESCRIPTION
## Describe your changes

This adds a mock test for tunnels in the Modal client. Was quite easy to do with the `container_client` fixture that we have!

Resolves MOD-1786.
