### PR TITLE
Support keep_warm on method and warn if it's on the cls with 2+ methods

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1377,10 +1377,12 @@ class _PartialFunction:
         raw_f: Callable[..., Any],
         webhook_config: Optional[api_pb2.WebhookConfig] = None,
         is_generator: Optional[bool] = None,
+        keep_warm: Optional[int] = None,
     ):
         self.raw_f = raw_f
         self.webhook_config = webhook_config
         self.is_generator = is_generator
+        self.keep_warm = keep_warm
         self.wrapped = False  # Make sure that this was converted into a FunctionHandle
 
     def __get__(self, obj, objtype=None) -> _Function:
@@ -1409,6 +1411,7 @@ def _method(
     # Set this to True if it's a non-generator function returning
     # a [sync/async] generator object
     is_generator: Optional[bool] = None,
+    keep_warm: Optional[int] = None,  # An optional number of containers to always keep warm.
 ) -> Callable[[Callable[..., Any]], _PartialFunction]:
     """Decorator for methods that should be transformed into a Modal Function registered against this class's stub.
 
@@ -1427,7 +1430,7 @@ def _method(
         raise InvalidError("Positional arguments are not allowed. Did you forget parentheses? Suggestion: `@method()`.")
 
     def wrapper(raw_f: Callable[..., Any]) -> _PartialFunction:
-        return _PartialFunction(raw_f, is_generator=is_generator)
+        return _PartialFunction(raw_f, is_generator=is_generator, keep_warm=keep_warm)
 
     return wrapper
 

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -585,7 +585,7 @@ class _Stub:
         container_idle_timeout: Optional[int] = None,  # Timeout for idle containers waiting for inputs to shut down.
         timeout: Optional[int] = None,  # Maximum execution time of the function in seconds.
         interactive: bool = False,  # Whether to run the function in interactive mode.
-        keep_warm: Optional[int] = None,  # DEPRECATED: use `@method(keep_warm=...)` instead!
+        keep_warm: Optional[int] = None,  # An optional number of containers to always keep warm.
         cloud: Optional[str] = None,  # Cloud provider to run the function on. Possible values are aws, gcp, oci, auto.
         auto_snapshot_enabled: Optional[bool] = None,  # Whether to run and snapshot __enter__ as part of image build.
     ) -> Callable[[CLS_T], _Cls]:
@@ -594,11 +594,6 @@ class _Stub:
 
         if auto_snapshot_enabled is None:
             auto_snapshot_enabled = config.get("auto_snapshot")
-
-        if keep_warm is not None:
-            deprecation_warning(
-                date(2023, 10, 20), "`@stub.cls(keep_warm=...)` is deprecated: use `@method(keep_warm=...)` instead!"
-            )
 
         decorator: Callable[[PartialFunction, type], _Function] = self.function(
             image=image,
@@ -640,6 +635,13 @@ class _Stub:
                             user_cls,
                             auto_snapshot_enabled,
                         )
+
+            if len(functions) > 1 and keep_warm is not None:
+                deprecation_warning(
+                    date(2023, 10, 20),
+                    "`@stub.cls(keep_warm=...)` is deprecated when there is more than 1 method."
+                    " Use `@method(keep_warm=...)` on each method instead!",
+                )
 
             tag: str = user_cls.__name__
             cls: _Cls = _Cls.from_local(user_cls, functions)

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -455,8 +455,33 @@ class XYZ:
 
 
 def test_method_args(servicer, client):
-    XYZ()
     with stub_method_args.run(client=client):
         funcs = servicer.app_functions.values()
         assert [f.function_name for f in funcs] == ["XYZ.foo", "XYZ.bar"]
         assert [f.warm_pool_size for f in funcs] == [3, 7]
+
+
+class ClsWith1Method:
+    @method()
+    def foo(self):
+        ...
+
+
+class ClsWith2Methods:
+    @method()
+    def foo(self):
+        ...
+
+    @method()
+    def bar(self):
+        ...
+
+
+def test_keep_warm_depr():
+    stub = Stub()
+
+    # This should be fine
+    stub.cls(keep_warm=2)(ClsWith1Method)
+
+    with pytest.warns(DeprecationError, match="@method"):
+        stub.cls(keep_warm=2)(ClsWith2Methods)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -126,8 +126,6 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.app_get_logs_initial_count = 0
         self.app_set_objects_count = 0
 
-        self.function2params = {}
-
         self.volume_counter = 0
         # Volume-id -> commit/reload count
         self.volume_commits: Dict[str, int] = defaultdict(lambda: 0)
@@ -398,7 +396,6 @@ class MockClientServicer(api_grpc.ModalClientBase):
         assert request.function_id
         assert request.serialized_params
         self.n_functions += 1
-        self.function2params[self.n_functions] = request.serialized_params
         function_id = f"fu-{self.n_functions}"
 
         await stream.send_message(api_pb2.FunctionBindParamsResponse(bound_function_id=function_id))


### PR DESCRIPTION
Fixing a counterintuitive thing – previously if you had code like this:

```python
@stub.cls(keep_warm=2)
class Cls:
    @method()
    def f(self):
        ...

    @method()
    def g(self):
        ...
```

Then you'd end up with 4 idle containers. This change moves `keep_warm` to sit on the method instead (with a deprecation warning if you use it on the cls:



```python
@stub.cls()
class Cls:
    @method(keep_warm=2)
    def f(self):
        ...

    @method()  # this one will not have idle containers
    def g(self):
        ...
```

There are obviously many other function arguments but most of them are about the _environment_ the function is running in, which doesn't make sense to have on a method level – i think it makes it more confusing where `__enter__` is running.

However these are the ones that modify the _function_ behavior that we could potentially move too:

* `retries`
* `concurrency_limit`
* `allow_concurrent_inputs`
* `container_idle_timeout`
* `timeout`
* `interactive`

I don't have super strong feelings although some of them seem like they could make sense in either place.