### PR TITLE
Fix function decorator in different file

### DIFF
--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -150,10 +150,7 @@ class FunctionInfo:
             # python foo/bar/baz.py
 
             # If it's a cls, the @method could be defined in a base class in a different file.
-            if cls is not None:
-                self.file = os.path.abspath(inspect.getfile(cls))
-            else:
-                self.file = os.path.abspath(inspect.getfile(f))
+            self.file = os.path.abspath(inspect.getfile(module))
             self.module_name = inspect.getmodulename(self.file)
             self.base_dir = os.path.dirname(self.file)
             self.definition_type = api_pb2.Function.DEFINITION_TYPE_FILE


### PR DESCRIPTION
We already get the correct module for the function / cls, so we should use it for getting the file as well.

This is needed because if a decorator is defined in a separate file, `functools.wraps` will update `__module__` correctly, but it can't patch the `__code__` object, which is what `inspect.getfile()` uses for figuring out the file for the function.
