### PR TITLE
`from_name` simplification

### DIFF
--- a/modal/object.py
+++ b/modal/object.py
@@ -337,11 +337,9 @@ class _Object:
         my_dict = Dict.lookup("my-dict")
         ```
         """
-        # TODO(erikbern): this code is very duplicated. Clean up once handles are gone.
-        rep = f"Object({app_name})"  # TODO(erikbern): dumb
-        obj = _Object.__new__(cls)
-        obj._init(rep)
-        await obj._hydrate_from_app(app_name, tag, namespace, client, environment_name=environment_name)
+        obj = cls.from_name(app_name, tag, namespace=namespace, environment_name=environment_name)
+        resolver = Resolver(client=client)
+        await resolver.load(obj)
         return obj
 
     @classmethod

--- a/modal/object.py
+++ b/modal/object.py
@@ -320,6 +320,8 @@ class _Object:
         ```
         """
         obj = cls.from_name(app_name, tag, namespace=namespace, environment_name=environment_name)
+        if client is None:
+            client = await _Client.from_env()
         resolver = Resolver(client=client)
         await resolver.load(obj)
         return obj


### PR DESCRIPTION
Should be a noop that just reduces some lines. It's a part of refactoring single-object apps.

1. Make `lookup` call `from_name`
2. Move the implementation of `_hydrate_from_app` into `from_name`

