### PR TITLE
pre-deprecated fields in AppCreate

### DIFF
--- a/modal/runner.py
+++ b/modal/runner.py
@@ -63,13 +63,12 @@ async def _run_stub(
         client = await _Client.from_env()
     if output_mgr is None:
         output_mgr = OutputManager(stdout, show_progress, "Running app...")
-    post_init_state = api_pb2.APP_STATE_DETACHED if detach else api_pb2.APP_STATE_EPHEMERAL
+    app_state = api_pb2.APP_STATE_DETACHED if detach else api_pb2.APP_STATE_EPHEMERAL
     app = await _LocalApp._init_new(
         client,
         stub.description,
-        detach=detach,
-        deploying=False,
         environment_name=environment_name,
+        app_state=app_state,
     )
     async with stub._set_local_app(app), TaskContext(grace=config["logs_timeout"]) as tc:
         # Start heartbeats loop to keep the client alive
@@ -86,7 +85,7 @@ async def _run_stub(
         try:
             # Create all members
             await app._create_all_objects(
-                stub._blueprint, post_init_state, environment_name, shell=shell, output_mgr=output_mgr
+                stub._blueprint, app_state, environment_name, shell=shell, output_mgr=output_mgr
             )
 
             # Update all functions client-side to have the output mgr

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -169,9 +169,10 @@ message AppClientDisconnectRequest {
 message AppCreateRequest {
   string client_id = 1 [ (modal.options.audit_target_attr) = true ];
   string description = 2;    // Human readable label for the app
-  bool detach = 3; // deprecated, but needed until 0.48 is the minimum version
-  bool initializing = 4; // deprecated, but needed until 0.48 is the minimum version
+  bool detach = 3; // deprecated, but needed until 0.56 is the minimum version
+  bool initializing = 4; // deprecated, but needed until 0.56 is the minimum version
   string environment_name = 5;
+  AppState app_state = 6;
 }
 
 message AppCreateResponse {


### PR DESCRIPTION
~These are no longer needed since 0.48 is gone.~

Actually deprecated them – will remove them in a subsequent PR so they aren't part of the RPC