### PR TITLE
fix: modal.Function.lookup env resolving issue

### DIFF
--- a/modal/object.py
+++ b/modal/object.py
@@ -262,9 +262,10 @@ class _Object:
         async def _load_remote(obj: _Object, resolver: Resolver, existing_object_id: Optional[str]):
             nonlocal environment_name
             if environment_name is None:
-                # resolver always has an environment name, associated with the current app setup
-                # fall back on that one if no explicit environment was set in the call itself
-                environment_name = resolver.environment_name
+                # fall back if no explicit environment was set in the call itself.
+                # If there is a current app setup, the resolver has the env name. If doing a .lookup
+                # with no associated app, must fetch environment from config.
+                environment_name = resolver.environment_name or config.get("environment")
 
             request = api_pb2.AppLookupObjectRequest(
                 app_name=app_name,


### PR DESCRIPTION
"resolver always has an environment name" is not true if doing something like: 

```python
import modal

if __name__ == "__main__":
    f = Function.lookup(full_app_name, "StableDiffusionColdStart.run")
```