### PR TITLE
Deprecate old stuff in AppGetObjects & AppLookupObject

### DIFF
--- a/modal/object.py
+++ b/modal/object.py
@@ -276,9 +276,6 @@ class _Object:
             )
             try:
                 response = await retry_transient_errors(resolver.client.stub.AppLookupObject, request)
-                if not response.object.object_id:
-                    # Legacy error message: remove soon
-                    raise NotFoundError(response.error_message)
             except GRPCError as exc:
                 if exc.status == Status.NOT_FOUND:
                     raise NotFoundError(exc.message)

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -223,11 +223,11 @@ message AppGetObjectsRequest {
 
 message AppGetObjectsItem {
   string tag = 1;
-  string object_id = 2;  // deprecated
-  oneof handle_metadata_oneof {  // deprecated
-    FunctionHandleMetadata function_handle_metadata = 3;
-    MountHandleMetadata mount_handle_metadata = 4;
-    ClassHandleMetadata class_handle_metadata = 5;
+  string object_id = 2 [deprecated=true]; // needed by 0.51
+  oneof handle_metadata_oneof {
+    FunctionHandleMetadata function_handle_metadata = 3 [deprecated=true]; // needed by 0.51
+    MountHandleMetadata mount_handle_metadata = 4 [deprecated=true]; // needed by 0.51
+    ClassHandleMetadata class_handle_metadata = 5 [deprecated=true]; // needed by 0.51
   }
   Object object = 6;
 }
@@ -267,12 +267,12 @@ message AppLookupObjectRequest {
 }
 
 message AppLookupObjectResponse {
-  string object_id = 1; // deprecated
-  string error_message = 2;
-  oneof handle_metadata_oneof { // deprecated
-    FunctionHandleMetadata function_handle_metadata = 3;
-    MountHandleMetadata mount_handle_metadata = 4;
-    ClassHandleMetadata class_handle_metadata = 5;
+  string object_id = 1 [deprecated=true]; // needed by 0.51
+  string error_message = 2 [deprecated=true]; // needed by 0.55
+  oneof handle_metadata_oneof {
+    FunctionHandleMetadata function_handle_metadata = 3 [deprecated=true]; // needed by 0.51
+    MountHandleMetadata mount_handle_metadata = 4 [deprecated=true]; // needed by 0.51
+    ClassHandleMetadata class_handle_metadata = 5 [deprecated=true]; // needed by 0.51
   }
   Object object = 6;
 }


### PR DESCRIPTION
1. Don't read `error_message` in AppLookup
2. Annotate a bunch of fields with deprecations
