### PR TITLE
inline 4 app methods into `_deploy_single_app`

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -233,6 +233,8 @@ class _LocalApp:
         existing_object_id: Optional[str] = app._tag_to_object_id.get("_object")
         resolver = Resolver(app._client, environment_name=environment_name, app_id=app.app_id)
         await resolver.load(obj, existing_object_id)
+        if existing_object_id is not None:
+            assert obj.object_id == existing_object_id
         indexed_object_ids = {"_object": obj.object_id}
         unindexed_object_ids = [obj.object_id for obj in resolver.objects() if obj.object_id is not obj.object_id]
         req_set = api_pb2.AppSetObjectsRequest(

--- a/modal/app.py
+++ b/modal/app.py
@@ -276,7 +276,7 @@ class _LocalApp:
             object_entity=type_prefix,
         )
         try:
-            deploy_response = await retry_transient_errors(client.stub.AppDeploy, deploy_req)
+            await retry_transient_errors(client.stub.AppDeploy, deploy_req)
         except GRPCError as exc:
             if exc.status == Status.INVALID_ARGUMENT:
                 raise InvalidError(exc.message)


### PR DESCRIPTION
We currently have the same code paths for deploying an app as for deploying a single object.

I'm working on getting the latter out into its own set of RPCs so that we can refactor the storage on the backend later. However it's hard to refactor the code because there's two code paths that depend on the same set of helpers.

So in order to make it easier to work with the single object case, I'm duplicating all the code so that the "regular app" case is completely separate. So this PR is noop refactor that just rewrites `_deploy_single_app` so it doesn't depend on a bunch of app helper methods:
* `_init_from_name`
* `_init_new`
* `_init_existing`
* `deploy`

It just duplicates the code and inlines it for now, but it's a starting point. This way I can rewrite the RPC flow gradually for single apps without affecting how we deploy "regular" apps.