### PR TITLE
single object app proto changes

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -195,25 +195,15 @@ message AppDeployResponse {
   string url = 1;
 }
 
-message AppPrepareSingleObjectRequest {
-  string name = 1;
-  DeploymentNamespace namespace = 2;
-  string environment_name = 3;
-  string object_entity = 4;
-}
-
-message AppPrepareSingleObjectResponse {
-  string app_id = 1;     // Of existing or new app
-  string object_id = 2;  // If the app already existed, otherwise empty
-}
-
 message AppDeploySingleObjectRequest {
   string name = 1;
   DeploymentNamespace namespace = 2;
   string environment_name = 3;
-  string object_entity = 4;
-  string app_id = 5;     // Same app_id as previous step, just to check for races
-  string object_id = 6;  // If the object already existed, same as before
+  string object_id = 4;
+}
+
+message AppDeploySingleObjectResponse {
+  string app_id = 1;
 }
 
 message AppGetByDeploymentNameRequest {
@@ -1491,8 +1481,7 @@ service ModalClient {
   rpc AppList(AppListRequest) returns (AppListResponse);
   rpc AppLookupObject(AppLookupObjectRequest) returns (AppLookupObjectResponse);
   rpc AppDeploy(AppDeployRequest) returns (AppDeployResponse);
-  rpc AppPrepareSingleObject(AppPrepareSingleObjectRequest) returns (AppPrepareSingleObjectResponse);
-  rpc AppDeploySingleObject(AppDeploySingleObjectRequest) returns (google.protobuf.Empty);
+  rpc AppDeploySingleObject(AppDeploySingleObjectRequest) returns (AppDeploySingleObjectResponse);
   rpc AppGetByDeploymentName(AppGetByDeploymentNameRequest) returns (AppGetByDeploymentNameResponse);
   rpc AppStop(AppStopRequest) returns (google.protobuf.Empty);
   rpc AppHeartbeat(AppHeartbeatRequest) returns (google.protobuf.Empty);

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -286,17 +286,16 @@ message AppLookupObjectResponse {
     ClassHandleMetadata class_handle_metadata = 5 [deprecated=true]; // needed by 0.51
   }
   Object object = 6;
+  string app_id = 7;
 }
 
 message AppSetObjectsRequest {
-  // TODO: this is a bit of a hacky request meant to be somewhat temporary
-  // At some point, every object should be assigned to a app/namespace when created,
-  // so this method won't be necessary.
   string app_id = 1;
   map<string, string> indexed_object_ids = 2;
   string client_id = 3;
   repeated string unindexed_object_ids = 4;
   AppState new_app_state = 5; // promotes an app from initializing to this new state
+  string single_object_id = 6;
 }
 
 message AppHeartbeatRequest {


### PR DESCRIPTION
I completely de-scoped this project. Reverted the previous PR. Just going to focus on

1. Getting rid of the `_object` stuff from the client
2. Making it possible to have apps with the same name but different type (requires us to send the type information during lookups)

This should be quite easy to do, and just a few lines code changes on the server.