### PR TITLE
Use AppLookup for deploying objects

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -245,6 +245,8 @@ class _LocalApp:
             response = await retry_transient_errors(client.stub.AppLookupObject, request)
             existing_object_id = response.object.object_id
             existing_app_id = response.app_id
+            assert existing_object_id
+            assert existing_app_id
         except GRPCError as exc:
             if exc.status == Status.NOT_FOUND:
                 existing_object_id = None

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -263,6 +263,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
             else:
                 (object_id,) = list(app_objects.values())
         else:
+            app_id = None
             object_id = request.object_id
 
         if request.app_name:
@@ -270,7 +271,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
             if object_id:
                 assert object_id.startswith(request.object_entity)
 
-        response = api_pb2.AppLookupObjectResponse(object=self.get_object_metadata(object_id))
+        response = api_pb2.AppLookupObjectResponse(object=self.get_object_metadata(object_id), app_id=app_id)
         await stream.send_message(response)
 
     async def AppHeartbeat(self, stream):


### PR DESCRIPTION
Instead of `AppGetByDeploymentName`, use `AppLookup` for deploying single-object apps

The benefit is that `AppLookup` sends type information to the server, which means we can disambiguate deployments by object type going forward. This lets us support deployed objects with different types but with the same name, after some grace period.