### PR TITLE
Don't send indexed_object_ids

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -269,11 +269,9 @@ class _LocalApp:
         await resolver.load(obj, existing_object_id)
         if existing_object_id is not None:
             assert obj.object_id == existing_object_id
-        indexed_object_ids = {"_object": obj.object_id}
         assert len(resolver.objects()) == 1
         req_set = api_pb2.AppSetObjectsRequest(
             app_id=existing_app_id,
-            indexed_object_ids=indexed_object_ids,  # TODO(erikbern): remove in next PR
             new_app_state=api_pb2.APP_STATE_UNSPECIFIED,  # app is either already deployed or will be set to deployed after this call
             single_object_id=obj.object_id,
         )

--- a/modal/app.py
+++ b/modal/app.py
@@ -272,7 +272,6 @@ class _LocalApp:
         assert len(resolver.objects()) == 1
         req_set = api_pb2.AppSetObjectsRequest(
             app_id=existing_app_id,
-            new_app_state=api_pb2.APP_STATE_UNSPECIFIED,  # app is either already deployed or will be set to deployed after this call
             single_object_id=obj.object_id,
         )
         await retry_transient_errors(client.stub.AppSetObjects, req_set)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -73,11 +73,13 @@ class MockClientServicer(api_grpc.ModalClientBase):
             "my-proxy": "ap-proxy",
         }
         self.app_objects = {
-            "ap-x": {"": "mo-123"},
-            "ap-y": {"foo-queue": "qu-foo"},
             "ap-z": {"": "im-123"},
             "ap-c": {"": "im-456"},
-            "ap-proxy": {"": "pr-123"},
+        }
+        self.app_single_objects = {
+            "ap-x": "mo-123",
+            "ap-y": "qu-foo",
+            "ap-proxy": "pr-123",
         }
         self.n_inputs = 0
         self.n_queues = 0
@@ -234,6 +236,8 @@ class MockClientServicer(api_grpc.ModalClientBase):
     async def AppSetObjects(self, stream):
         request: api_pb2.AppSetObjectsRequest = await stream.recv_message()
         self.app_objects[request.app_id] = dict(request.indexed_object_ids)
+        if request.single_object_id:
+            self.app_single_objects[request.app_id] = request.single_object_id
         self.app_set_objects_count += 1
         if request.new_app_state:
             self.app_state_history[request.app_id].append(request.new_app_state)
@@ -255,13 +259,15 @@ class MockClientServicer(api_grpc.ModalClientBase):
             app_id = self.deployed_apps.get(request.app_name)
             if app_id is None:
                 raise GRPCError(Status.NOT_FOUND, f"can't find app {request.app_name}")
-            app_objects = self.app_objects[app_id]
             if request.object_tag:
+                app_objects = self.app_objects[app_id]
                 object_id = app_objects.get(request.object_tag)
                 if object_id is None:
                     raise GRPCError(Status.NOT_FOUND, f"can't find object {request.object_tag}")
             else:
-                (object_id,) = list(app_objects.values())
+                object_id = self.app_single_objects.get(app_id)
+                if object_id is None:
+                    raise GRPCError(Status.NOT_FOUND, f"can't find single object for app")
         else:
             app_id = None
             object_id = request.object_id

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -267,7 +267,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
             else:
                 object_id = self.app_single_objects.get(app_id)
                 if object_id is None:
-                    raise GRPCError(Status.NOT_FOUND, f"can't find single object for app")
+                    raise GRPCError(Status.NOT_FOUND, "can't find single object for app")
         else:
             app_id = None
             object_id = request.object_id

--- a/test/lookup_test.py
+++ b/test/lookup_test.py
@@ -11,7 +11,7 @@ def test_persistent_object(servicer, client):
     stub["q_1"] = Queue.new()
     deploy_stub(stub, "my-queue", client=client)
 
-    q: Queue = Queue.lookup("my-queue", client=client)
+    q: Queue = Queue.lookup("my-queue", "q_1", client=client)
     assert isinstance(q, Queue)
     assert q.object_id == "qu-1"
 
@@ -30,7 +30,7 @@ def test_lookup_function(servicer, client):
     stub.function()(square)
     deploy_stub(stub, "my-function", client=client)
 
-    f = Function.lookup("my-function", client=client)
+    f = Function.lookup("my-function", "square", client=client)
     assert f.object_id == "fu-1"
 
     # Call it using two arguments
@@ -57,7 +57,7 @@ def test_webhook_lookup(servicer, client):
     stub.function()(web_endpoint(method="POST")(square))
     deploy_stub(stub, "my-webhook", client=client)
 
-    f = Function.lookup("my-webhook", client=client)
+    f = Function.lookup("my-webhook", "square", client=client)
     assert f.web_url
 
 


### PR DESCRIPTION
No longer needed once server changes are out.

Most of the delta is updating tests – turns out our test fixtures were a bit weird