### PR TITLE
Revert "Use AppLookup for deploying objects"

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -231,28 +231,14 @@ class _LocalApp:
         obj: _Object, type_prefix: str, client: _Client, label: str, namespace: int, environment_name: int
     ):
         """mdmd:hidden"""
-        existing_object_id: Optional[str]
-        existing_app_id: Optional[str]
-
-        # Look up existing app+object
-        request = api_pb2.AppLookupObjectRequest(
-            app_name=label,
+        # Look up any existing deployment (duplicated from `_init_from_name` temporarily)
+        app_req = api_pb2.AppGetByDeploymentNameRequest(
+            name=label,
             namespace=namespace,
-            object_entity=type_prefix,
             environment_name=environment_name,
         )
-        try:
-            response = await retry_transient_errors(client.stub.AppLookupObject, request)
-            existing_object_id = response.object.object_id
-            existing_app_id = response.app_id
-            assert existing_object_id
-            assert existing_app_id
-        except GRPCError as exc:
-            if exc.status == Status.NOT_FOUND:
-                existing_object_id = None
-                existing_app_id = None
-            else:
-                raise
+        app_resp = await retry_transient_errors(client.stub.AppGetByDeploymentName, app_req)
+        existing_app_id = app_resp.app_id or None
 
         if existing_app_id is None:
             # Create new app if it doesn't exist (duplicated from `_init_new` temporarily)
@@ -263,8 +249,15 @@ class _LocalApp:
             )
             app_resp = await retry_transient_errors(client.stub.AppCreate, app_req)
             existing_app_id = app_resp.app_id
+            object_ids = {}
+        else:
+            # Fetch existing objects (duplicated from `_init_existing` temporarily)
+            obj_req = api_pb2.AppGetObjectsRequest(app_id=existing_app_id)
+            obj_resp = await retry_transient_errors(client.stub.AppGetObjects, obj_req)
+            object_ids = {item.tag: item.object.object_id for item in obj_resp.items}
 
         # Create object
+        existing_object_id: Optional[str] = object_ids.get("_object")
         resolver = Resolver(client, environment_name=environment_name, app_id=existing_app_id)
         await resolver.load(obj, existing_object_id)
         if existing_object_id is not None:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -263,7 +263,6 @@ class MockClientServicer(api_grpc.ModalClientBase):
             else:
                 (object_id,) = list(app_objects.values())
         else:
-            app_id = None
             object_id = request.object_id
 
         if request.app_name:
@@ -271,7 +270,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
             if object_id:
                 assert object_id.startswith(request.object_entity)
 
-        response = api_pb2.AppLookupObjectResponse(object=self.get_object_metadata(object_id), app_id=app_id)
+        response = api_pb2.AppLookupObjectResponse(object=self.get_object_metadata(object_id))
         await stream.send_message(response)
 
     async def AppHeartbeat(self, stream):


### PR DESCRIPTION
Reverts modal-labs/modal-client#1010

This is breaking an internal test. Reverting for now.