### PR TITLE
Separates public and private properties for checkpointing

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -797,7 +797,8 @@ class _Function(_Object, type_prefix="fu"):
                 worker_id=config.get("worker_id"),
                 is_auto_snapshot=is_auto_snapshot,
                 is_method=bool(cls),
-                is_checkpointing_function=checkpointing_enabled,
+                checkpointing_enabled=checkpointing_enabled,
+                is_checkpointing_function=False,
             )
             request = api_pb2.FunctionCreateRequest(
                 app_id=resolver.app_id,

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -647,6 +647,8 @@ message Function {
   bool is_auto_snapshot = 38;
   bool is_method = 39;
   bool is_checkpointing_function = 40;
+
+  bool checkpointing_enabled = 41;
 }
 
 message FunctionHandleMetadata {


### PR DESCRIPTION
The `Function` proto message now has two checkpointing-related properties:

```proto
  bool is_checkpointing_function = 40;
  bool checkpointing_enabled = 41;
```

- `is_checkpointing_function`: is an internal property used to trigger the checkpointing routine in container entrypoint. This is set in the backend.
- `checkpointing_enabled`: is a public property set in the client to indicate that the function created is "checkpointable".