### PR TITLE
Deprecate @stub.function(secret=)

### DIFF
--- a/modal/cli/secret.py
+++ b/modal/cli/secret.py
@@ -77,7 +77,7 @@ modal secret create my-credentials username=john password=-
     env_var_code = "\n    ".join(f'os.getenv("{name}")' for name in env_dict.keys()) if env_dict else "..."
 
     example_code = f"""
-@stub.function(secret=modal.Secret.from_name("{secret_name}"))
+@stub.function(secrets=[modal.Secret.from_name("{secret_name}")])
 def some_function():
     {env_var_code}
 """

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -62,6 +62,7 @@ from .exception import (
     InvalidError,
     RemoteError,
     deprecation_error,
+    deprecation_warning,
 )
 from .gpu import GPU_T, parse_gpu_config
 from .image import _Image
@@ -564,6 +565,10 @@ class _Function(_Object, type_prefix="fu"):
             all_mounts.extend(info.get_mounts().values())  # this would typically only happen for builder functions
 
         if secret:
+            deprecation_warning(
+                date(2023, 10, 26),
+                "`@stub.function(secret=...)` is deprecated. Use @stub.function(secrets=[...])` instead!",
+            )
             secrets = [secret, *secrets]
 
         if isinstance(retries, int):
@@ -602,7 +607,6 @@ class _Function(_Object, type_prefix="fu"):
                 snapshot_info,
                 stub=None,
                 image=image,
-                secret=secret,
                 secrets=secrets,
                 gpu=gpu,
                 mounts=mounts,

--- a/test/stub_test.py
+++ b/test/stub_test.py
@@ -323,7 +323,7 @@ def test_function_image_positional():
 @pytest.mark.asyncio
 async def test_deploy_disconnect(servicer, client):
     stub = Stub()
-    stub.function(secret=modal.Secret.from_name("nonexistent-secret"))(square)
+    stub.function(secrets=[modal.Secret.from_name("nonexistent-secret")])(square)
 
     with pytest.raises(NotFoundError):
         await deploy_stub.aio(stub, "my-app", client=client)


### PR DESCRIPTION
Right now we have both secret= and secrets= as arguments.
