### PR TITLE
Adds proto definitions to support restore

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -637,7 +637,22 @@ message Function {
   bool is_method = 39;
   bool is_checkpointing_function = 40;
 
+  // Checkpoint and restore
+
   bool checkpointing_enabled = 41;
+
+  enum CheckpointStatus {
+    CHECKPOINT_STATUS_UNSPECIFIED = 0;
+    CHECKPOINT_STATUS_PENDING = 1;
+    CHECKPOINT_STATUS_PROCESSING = 2;
+    CHECKPOINT_STATUS_READY = 3;
+    CHECKPOINT_STATUS_FAILED = 4;
+  }
+  message CheckpointInfo {
+    string checksum = 1;
+    CheckpointStatus status = 2;
+  }
+  CheckpointInfo checkpoint = 42;
 }
 
 message FunctionHandleMetadata {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -565,6 +565,14 @@ message PTYInfo {
   PTYType pty_type = 7;
 }
 
+enum CheckpointStatus {
+  CHECKPOINT_STATUS_UNSPECIFIED = 0;
+  CHECKPOINT_STATUS_PENDING = 1;
+  CHECKPOINT_STATUS_PROCESSING = 2;
+  CHECKPOINT_STATUS_READY = 3;
+  CHECKPOINT_STATUS_FAILED = 4;
+}
+
 message Function {
   string module_name = 1;
   string function_name = 2;
@@ -641,13 +649,6 @@ message Function {
 
   bool checkpointing_enabled = 41;
 
-  enum CheckpointStatus {
-    CHECKPOINT_STATUS_UNSPECIFIED = 0;
-    CHECKPOINT_STATUS_PENDING = 1;
-    CHECKPOINT_STATUS_PROCESSING = 2;
-    CHECKPOINT_STATUS_READY = 3;
-    CHECKPOINT_STATUS_FAILED = 4;
-  }
   message CheckpointInfo {
     string checksum = 1;
     CheckpointStatus status = 2;


### PR DESCRIPTION
Adds proto fields containing the status of the checkpoint and its checksum. This is used internally to identify which checkpoint to use when attempting a restore.
