### PR TITLE
Don't fail if object_id for an imported object fails

### DIFF
--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -109,7 +109,7 @@ class Resolver:
                     #
                     # Persisted refs are ignored because their life cycle is managed independently.
                     # The same tag on an app can be pointed at different objects.
-                    if not obj._is_persisted_ref and not existing_object_id.startswith("im-"):
+                    if not obj._is_another_app and not existing_object_id.startswith("im-"):
                         raise Exception(
                             f"Tried creating an object using existing id {existing_object_id}"
                             f" but it has id {obj.object_id}"

--- a/modal/object.py
+++ b/modal/object.py
@@ -50,7 +50,7 @@ class _Object:
         self,
         rep: str,
         load: Optional[Callable[[O, Resolver, Optional[str]], Awaitable[None]]] = None,
-        is_persisted_ref: bool = False,
+        is_another_app: bool = False,
         preload: Optional[Callable[[O, Resolver, Optional[str]], Awaitable[None]]] = None,
         hydrate_lazily: bool = False,
     ):
@@ -58,7 +58,7 @@ class _Object:
         self._load = load
         self._preload = preload
         self._rep = rep
-        self._is_persisted_ref = is_persisted_ref
+        self._is_another_app = is_another_app
         self._hydrate_lazily = hydrate_lazily
 
         self._object_id = None
@@ -95,20 +95,20 @@ class _Object:
 
     def _init_from_other(self, other: O):
         # Transient use case, see Dict, Queue, and SharedVolume
-        self._init(other._rep, other._load, other._is_persisted_ref, other._preload)
+        self._init(other._rep, other._load, other._is_another_app, other._preload)
 
     @classmethod
     def _from_loader(
         cls,
         load: Callable[[O, Resolver, Optional[str]], Awaitable[None]],
         rep: str,
-        is_persisted_ref: bool = False,
+        is_another_app: bool = False,
         preload: Optional[Callable[[O, Resolver, Optional[str]], Awaitable[None]]] = None,
         hydrate_lazily: bool = False,
     ):
         # TODO(erikbern): flip the order of the two first arguments
         obj = _Object.__new__(cls)
-        obj._init(rep, load, is_persisted_ref, preload, hydrate_lazily)
+        obj._init(rep, load, is_another_app, preload, hydrate_lazily)
         return obj
 
     @classmethod
@@ -226,7 +226,7 @@ class _Object:
 
         cls = type(self)
         rep = f"PersistedRef<{self}>({label})"
-        return cls._from_loader(_load_persisted, rep, is_persisted_ref=True)
+        return cls._from_loader(_load_persisted, rep, is_another_app=True)
 
     @classmethod
     def from_name(
@@ -284,7 +284,7 @@ class _Object:
             obj._hydrate(response.object.object_id, resolver.client, handle_metadata)
 
         rep = f"Ref({app_name})"
-        return cls._from_loader(_load_remote, rep)
+        return cls._from_loader(_load_remote, rep, is_another_app=True)
 
     @classmethod
     async def lookup(

--- a/test/stub_test.py
+++ b/test/stub_test.py
@@ -332,3 +332,18 @@ async def test_deploy_disconnect(servicer, client):
         api_pb2.APP_STATE_INITIALIZING,
         api_pb2.APP_STATE_STOPPED,
     ]
+
+
+def test_redeploy_from_name_change(servicer, client):
+    stub = Stub()
+    stub.q = modal.Queue.from_name("foo-queue")
+    deploy_stub(stub, "my-app", client=client)
+
+    # Change the object id of foo-queue
+    q_app_id = servicer.deployed_apps["foo-queue"]
+    servicer.app_single_objects[q_app_id]
+    servicer.app_single_objects[q_app_id] = "qu-baz123"
+
+    # Redeploy app
+    # This should not fail because the object_id changed - it's a different app
+    deploy_stub(stub, "my-app", client=client)


### PR DESCRIPTION
Resolves MOD-1801

Basically generalize `is_persisted_ref` to `is_another_app` – turns out there's multiple ways objects can be imported from other apps, and this check pertains to any such case.

