### PR TITLE
Move resolver.load out of all load closures

### DIFF
--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -99,6 +99,11 @@ class Resolver:
         if not cached_future:
             # don't run any awaits within this if-block to prevent race conditions
             async def loader():
+                # Wait for all its dependencies
+                # TODO(erikbern): do we need existing_object_id for those?
+                await asyncio.gather(*[self.load(dep) for dep in obj.deps])
+
+                # Load the object itself
                 await obj._load(obj, self, existing_object_id)
                 if existing_object_id is not None and obj.object_id != existing_object_id:
                     # TODO(erikbern): ignoring images is an ugly fix to a problem that's on the server.


### PR DESCRIPTION
This moves the dependency management to sit inside the resolver instead (which I think we can clean up separately).

Every object that has dependencies (functions, images, sandboxes, classes) now pass a list of dependencies to `_from_loader`.