### PR TITLE
Send function dependencies to server

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -789,6 +789,7 @@ class _Function(_Object, type_prefix="fu"):
                 is_method=bool(cls),
                 checkpointing_enabled=checkpointing_enabled,
                 is_checkpointing_function=False,
+                object_dependencies=[api_pb2.ObjectDependency(object_id=dep.object_id) for dep in deps],
             )
             request = api_pb2.FunctionCreateRequest(
                 app_id=resolver.app_id,

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -573,6 +573,10 @@ enum CheckpointStatus {
   CHECKPOINT_STATUS_FAILED = 4;
 }
 
+message ObjectDependency {
+  string object_id = 1;
+}
+
 message Function {
   string module_name = 1;
   string function_name = 2;
@@ -654,6 +658,7 @@ message Function {
     CheckpointStatus status = 2;
   }
   CheckpointInfo checkpoint = 42;
+  repeated ObjectDependency object_dependencies = 43;
 }
 
 message FunctionHandleMetadata {


### PR DESCRIPTION
This makes sure the function deps are sent to the server as a part of the `Function` message.

This lets the container code rehydrate all dependencies. Trying to ship this early since it depends on workers to be deployed (since they use the same proto definitions)