### PR TITLE
Add debug logs for RPCs

### DIFF
--- a/modal_utils/grpc_utils.py
+++ b/modal_utils/grpc_utils.py
@@ -186,6 +186,8 @@ def create_channel(
         if inject_tracing_context is not None:
             inject_tracing_context(cast(Dict[str, str], event.metadata))
 
+        logger.debug(f"Sending request to {event.method_name}")
+
     grpclib.events.listen(channel, grpclib.events.SendRequest, send_request)
     return channel
 

--- a/modal_utils/logger.py
+++ b/modal_utils/logger.py
@@ -1,5 +1,14 @@
 # Copyright Modal Labs 2022
 import logging
+import os
 
 # TODO: set this from env.
 logger = logging.getLogger("modal-utils")
+
+ch = logging.StreamHandler()
+
+log_level_numeric = logging.getLevelName(os.environ.get("MODAL_LOGLEVEL", "WARNING").upper())
+logger.setLevel(log_level_numeric)
+ch.setLevel(log_level_numeric)
+ch.setFormatter(logging.Formatter("%(asctime)s %(message)s", datefmt="%Y-%m-%dT%H:%M:%S%z"))
+logger.addHandler(ch)


### PR DESCRIPTION
Configures the logger in `modal_utils` to use `MODAL_LOGLEVEL` if specified. Also adds a debug log for each RPC.

Useful for future debugging with users where things are stuck on the client side—can just ask them to set the env variable to see where things are stuck.