### PR TITLE
Proper exception if people stack `@web_endpoint` and `@method`

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1424,6 +1424,11 @@ def _method(
         raise InvalidError("Positional arguments are not allowed. Did you forget parentheses? Suggestion: `@method()`.")
 
     def wrapper(raw_f: Callable[..., Any]) -> _PartialFunction:
+        if isinstance(raw_f, _PartialFunction) and raw_f.webhook_config:
+            raw_f.wrapped = True  # suppress later warning
+            raise InvalidError(
+                "Web endpoints on classes should not be wrapped by `@method`. Suggestion: remove the `@method` decorator."
+            )
         return _PartialFunction(raw_f, is_generator=is_generator, keep_warm=keep_warm)
 
     return wrapper

--- a/test/decorator_test.py
+++ b/test/decorator_test.py
@@ -70,3 +70,16 @@ def test_invalid_web_decorator_usage():
         @wsgi_app  # type: ignore
         def my_handle_wsgi():
             pass
+
+
+def test_web_endpoint_method():
+    stub = Stub()
+
+    with pytest.raises(InvalidError, match="remove the `@method`"):
+
+        @stub.cls()
+        class Container:
+            @method()  # type: ignore
+            @web_endpoint()
+            def generate(self):
+                pass


### PR DESCRIPTION
Before:

```
│ /Users/erikbern/modal-client/modal/_function_utils.py:107 in __init__                            │
│                                                                                                  │
│   106 │   │   │   self.function_name = name_override                                             │
│ ❱ 107 │   │   elif f.__qualname__ != f.__name__ and not serialized:                              │
│   108 │   │   │   # Class function.                                                              │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
AttributeError: '_PartialFunction' object has no attribute '__qualname__'
2023-11-02T13:59:15-0400 Method or web function <function Container.generate at 0x105203520> was never turned into a function. Did you forget a @stub.function or @stub.cls decorator?
2023-11-02T13:59:15-0400 Method or web function <function Container.generate at 0x105203520> was never turned into a function. Did you forget a @stub.function or @stub.cls decorator?
```

After:

```
│ /Users/erikbern/modal-client/modal/functions.py:1429 in wrapper                                  │
│                                                                                                  │
│   1428 │   │   │   raw_f.wrapped = True  # suppress later warning                                │
│ ❱ 1429 │   │   │   raise InvalidError(                                                           │
│   1430 │   │   │   │   "Web endpoints on classes can not be wrapped as methods."                 │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
InvalidError: Web endpoints on classes should not be wrapped by `@method`. Suggestion: remove the `@method` decorator.
```