### PR TITLE
Reliability: Backpressure the container output queue

### DIFF
--- a/modal/_asgi.py
+++ b/modal/_asgi.py
@@ -11,10 +11,10 @@ from ._blob_utils import MAX_OBJECT_SIZE_BYTES
 
 def asgi_app_wrapper(asgi_app):
     async def fn(scope, body=None):
-        messages_from_app: asyncio.Queue[Dict[str, Any]] = asyncio.Queue()
+        messages_from_app: asyncio.Queue[Dict[str, Any]] = asyncio.Queue(1)
 
         # TODO: send disconnect at some point.
-        messages_to_app: asyncio.Queue[Dict[str, Any]] = asyncio.Queue()
+        messages_to_app: asyncio.Queue[Dict[str, Any]] = asyncio.Queue(1)
         await messages_to_app.put({"type": "http.request", "body": body})
 
         async def send(msg):

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -48,7 +48,7 @@ from .functions import Function, _set_current_input_id  # type: ignore
 if TYPE_CHECKING:
     from types import ModuleType
 
-MAX_OUTPUT_BATCH_SIZE: int = 100
+MAX_OUTPUT_BATCH_SIZE: int = 49
 
 RTT_S: float = 0.5  # conservative estimate of RTT in seconds.
 
@@ -254,7 +254,7 @@ class _FunctionIOManager:
 
     async def run_inputs_outputs(self, input_concurrency: int = 1):
         # This also makes sure to terminate the outputs
-        self._output_queue = asyncio.Queue()
+        self._output_queue = asyncio.Queue(MAX_OUTPUT_BATCH_SIZE)
 
         # Ensure we do not fetch new inputs when container is too busy.
         # Before trying to fetch an input, acquire the semaphore:


### PR DESCRIPTION
These queues were not size-limited in the past, which means they could go up to infinity.

We need to rework the request input/output lifecycle and our ad-hoc pipelining implementation to not queue up outputs infinitely, if we want to support high-performance in the future. But this is a step towards it for our current system.