### PR TITLE
Don't override patch version if specified

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -52,6 +52,11 @@ def _dockerhub_python_version(python_version=None):
     if python_version is None:
         python_version = "%d.%d" % sys.version_info[:2]
 
+    parts = python_version.split(".")
+
+    if len(parts) > 2:
+        return python_version
+
     # We use the same major/minor version, but the highest micro version
     # See https://hub.docker.com/_/python
     latest_micro_version = {
@@ -61,7 +66,7 @@ def _dockerhub_python_version(python_version=None):
         "3.8": "15",
         "3.7": "15",
     }
-    major_minor_version = ".".join(python_version.split(".")[:2])
+    major_minor_version = ".".join(parts[:2])
     python_version = major_minor_version + "." + latest_micro_version[major_minor_version]
     return python_version
 

--- a/modal/image.py
+++ b/modal/image.py
@@ -55,10 +55,10 @@ def _dockerhub_python_version(python_version=None):
     # We use the same major/minor version, but the highest micro version
     # See https://hub.docker.com/_/python
     latest_micro_version = {
-        "3.11": "6",
-        "3.10": "13",
-        "3.9": "18",
-        "3.8": "18",
+        "3.11": "0",
+        "3.10": "8",
+        "3.9": "15",
+        "3.8": "15",
         "3.7": "15",
     }
     major_minor_version = ".".join(python_version.split(".")[:2])

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -14,7 +14,7 @@ from modal_proto import api_pb2
 
 
 def test_python_version():
-    assert _dockerhub_python_version("3.9.1") == "3.9.15"
+    assert _dockerhub_python_version("3.9.1") == "3.9.1"
     assert _dockerhub_python_version("3.9") == "3.9.15"
     v = _dockerhub_python_version().split(".")
     assert len(v) == 3

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -14,8 +14,8 @@ from modal_proto import api_pb2
 
 
 def test_python_version():
-    assert _dockerhub_python_version("3.9.1") == "3.9.18"
-    assert _dockerhub_python_version("3.9") == "3.9.18"
+    assert _dockerhub_python_version("3.9.1") == "3.9.15"
+    assert _dockerhub_python_version("3.9") == "3.9.15"
     v = _dockerhub_python_version().split(".")
     assert len(v) == 3
     assert (int(v[0]), int(v[1])) == sys.version_info[:2]


### PR DESCRIPTION
Allow users to specify granular patch versions, such as `python_version=3.10.11`. 

Restores the default versions we had before #1036, so that all users aren't forced to rebuild their images when they update their client.