### PR TITLE
Only include explicit mounts in function deps

### DIFF
--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -101,7 +101,7 @@ class Resolver:
             async def loader():
                 # Wait for all its dependencies
                 # TODO(erikbern): do we need existing_object_id for those?
-                await asyncio.gather(*[self.load(dep) for dep in obj.deps])
+                await asyncio.gather(*[self.load(dep) for dep in obj.deps()])
 
                 # Load the object itself
                 await obj._load(obj, self, existing_object_id)

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 import pickle
 from datetime import date
-from typing import Any, Callable, Dict, Optional, TypeVar
+from typing import Any, Callable, Dict, List, Optional, TypeVar
 
 from google.protobuf.message import Message
 
@@ -151,7 +151,8 @@ class _Cls(_Object, type_prefix="cs"):
 
     @staticmethod
     def from_local(user_cls, base_functions: Dict[str, _Function]) -> "_Cls":
-        deps = list(base_functions.values())
+        def _deps() -> List[_Function]:
+            return list(base_functions.values())
 
         async def _load(provider: _Object, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.ClassCreateRequest(app_id=resolver.app_id, existing_class_id=existing_object_id)
@@ -161,7 +162,7 @@ class _Cls(_Object, type_prefix="cs"):
             provider._hydrate(resp.class_id, resolver.client, resp.handle_metadata)
 
         rep = f"Cls({user_cls.__name__})"
-        cls = _Cls._from_loader(_load, rep, deps=deps)
+        cls = _Cls._from_loader(_load, rep, deps=_deps)
         cls._user_cls = user_cls
         cls._base_functions = base_functions
         setattr(cls._user_cls, "_modal_functions", base_functions)  # Needed for PartialFunction.__get__

--- a/modal/image.py
+++ b/modal/image.py
@@ -177,13 +177,15 @@ class _Image(_Object, type_prefix="im"):
         if build_function and len(base_images) != 1:
             raise InvalidError("Cannot run a build function with multiple base images!")
 
-        deps: List[_Object] = list(base_images.values()) + list(secrets)
-        if build_function:
-            deps.append(build_function)
-        if context_mount:
-            deps.append(context_mount)
-        if image_registry_config.secret:
-            deps.append(image_registry_config.secret)
+        def _deps() -> List[_Object]:
+            deps: List[_Object] = list(base_images.values()) + list(secrets)
+            if build_function:
+                deps.append(build_function)
+            if context_mount:
+                deps.append(context_mount)
+            if image_registry_config.secret:
+                deps.append(image_registry_config.secret)
+            return deps
 
         async def _load(provider: _Image, resolver: Resolver, existing_object_id: Optional[str]):
             base_images_pb2s = [
@@ -308,7 +310,7 @@ class _Image(_Object, type_prefix="im"):
             provider._hydrate(image_id, resolver.client, None)
 
         rep = f"Image({dockerfile_commands})"
-        obj = _Image._from_loader(_load, rep, deps=deps)
+        obj = _Image._from_loader(_load, rep, deps=_deps)
         obj.force_build = force_build
         return obj
 

--- a/modal/object.py
+++ b/modal/object.py
@@ -33,7 +33,7 @@ class _Object:
     _rep: str
     _is_another_app: bool
     _hydrate_lazily: bool
-    _deps: List["_Object"]
+    _deps: Optional[Callable[[], List["_Object"]]]
 
     # For hydrated objects
     _object_id: str
@@ -57,7 +57,7 @@ class _Object:
         is_another_app: bool = False,
         preload: Optional[Callable[[O, Resolver, Optional[str]], Awaitable[None]]] = None,
         hydrate_lazily: bool = False,
-        deps: List["_Object"] = [],
+        deps: Optional[Callable[[], List["_Object"]]] = None,
     ):
         self._local_uuid = str(uuid.uuid4())
         self._load = load
@@ -111,7 +111,7 @@ class _Object:
         is_another_app: bool = False,
         preload: Optional[Callable[[O, Resolver, Optional[str]], Awaitable[None]]] = None,
         hydrate_lazily: bool = False,
-        deps: List["_Object"] = [],
+        deps: Optional[Callable[[], List["_Object"]]] = None,
     ):
         # TODO(erikbern): flip the order of the two first arguments
         obj = _Object.__new__(cls)
@@ -177,9 +177,8 @@ class _Object:
         """mdmd:hidden"""
         return self._is_hydrated
 
-    @property
     def deps(self) -> List[O]:
-        return self._deps
+        return self._deps() if self._deps else []
 
     async def resolve(self):
         """mdmd:hidden"""

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -125,9 +125,11 @@ class _Sandbox(_Object, type_prefix="sb"):
             raise InvalidError("network_file_systems must be a dict[str, NetworkFileSystem] where the keys are paths")
         validated_network_file_systems = validate_mount_points("Network file system", network_file_systems)
 
-        deps: List[_Object] = [image] + list(mounts) + list(secrets)
-        for _, vol in validated_network_file_systems:
-            deps.append(vol)
+        def _deps() -> List[_Object]:
+            deps: List[_Object] = [image] + list(mounts) + list(secrets)
+            for _, vol in validated_network_file_systems:
+                deps.append(vol)
+            return deps
 
         async def _load(provider: _Sandbox, resolver: Resolver, _existing_object_id: Optional[str]):
             gpu_config = parse_gpu_config(gpu)
@@ -159,7 +161,7 @@ class _Sandbox(_Object, type_prefix="sb"):
             provider._stdout = LogsReader(api_pb2.FILE_DESCRIPTOR_STDOUT, sandbox_id, resolver.client)
             provider._stderr = LogsReader(api_pb2.FILE_DESCRIPTOR_STDERR, sandbox_id, resolver.client)
 
-        return _Sandbox._from_loader(_load, "Sandbox()", deps=deps)
+        return _Sandbox._from_loader(_load, "Sandbox()", deps=_deps)
 
     # Live handle methods
 

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -659,7 +659,5 @@ def test_deps(client, servicer):
     with stub.run(client=client):
         f = servicer.app_functions[stub.dummy.object_id]
 
-    dep_object_ids = [d.object_id for d in f.object_dependencies]
-    assert image.object_id in dep_object_ids
-    assert nfs_1.object_id in dep_object_ids
-    assert nfs_2.object_id in dep_object_ids
+    dep_object_ids = set(d.object_id for d in f.object_dependencies)
+    assert dep_object_ids == set([image.object_id, nfs_1.object_id, nfs_2.object_id])


### PR DESCRIPTION
While working on getting rid of stub assignments, I ran into a problem which is that the function dependencies change between local and container. This is because a bunch of the mount stuff is inferred automagically.

Rewriting the object code a bit so that `deps` is a method not a property. This lets me add a boolean flag in the case of functions to alter the behavior to use only explicit mounts. That way I can use the same logic container-side later to hydrate the exact same objects.