### PR TITLE
Add boolean for AppGetObjects to include unindexed

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -231,6 +231,7 @@ message AppGetLogsRequest {
 
 message AppGetObjectsRequest {
   string app_id = 1;
+  bool include_unindexed = 2;
 }
 
 message AppGetObjectsItem {


### PR DESCRIPTION
In order to hydrate all objects in the container, we need to get data for _all_ object, not just indexed ones.

The idea is that newer client will use this flag set to `True` and the server will send back a full list of all app objects, but with the `tag` set to the empty string for any unindexed ones. I'm adding this bool to not break old clients which require the tag to be set. Newer clients will always set this flag to `True` (but I need to implement this on the server first).