### PR TITLE
Hydrate all function dependencies in container

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -16,7 +16,7 @@ import time
 import traceback
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, AsyncGenerator, AsyncIterator, Callable, Optional, Type
+from typing import TYPE_CHECKING, Any, AsyncGenerator, AsyncIterator, Callable, List, Optional, Type
 
 from grpclib import Status
 
@@ -42,7 +42,7 @@ from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, Client, _Client
 from .cls import Cls
 from .config import config, logger
 from .exception import InvalidError
-from .functions import Function, _set_current_input_id  # type: ignore
+from .functions import Function, _Function, _set_current_input_id  # type: ignore
 
 if TYPE_CHECKING:
     from types import ModuleType

--- a/modal/app.py
+++ b/modal/app.py
@@ -18,6 +18,7 @@ from .object import _Object
 
 if TYPE_CHECKING:
     from rich.tree import Tree
+
     from .functions import _Function
 
 else:

--- a/modal/object.py
+++ b/modal/object.py
@@ -84,6 +84,12 @@ class _Object:
 
     def _hydrate(self, object_id: str, client: _Client, metadata: Optional[Message]):
         assert isinstance(object_id, str)
+        if not object_id.startswith(self._type_prefix):
+            raise ExecutionError(
+                f"Can not hydrate {type(self)}:"
+                f" it has type prefix {self._type_prefix}"
+                f" but the object_id starts with {object_id[:3]}"
+            )
         self._object_id = object_id
         self._client = client
         self._hydrate_metadata(metadata)

--- a/modal/object.py
+++ b/modal/object.py
@@ -2,7 +2,7 @@
 import uuid
 from datetime import date
 from functools import wraps
-from typing import Any, Awaitable, Callable, ClassVar, Dict, List, Optional, Type, TypeVar
+from typing import Awaitable, Callable, ClassVar, Dict, List, Optional, Type, TypeVar
 
 from google.protobuf.message import Message
 from grpclib import GRPCError, Status

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -5,7 +5,7 @@ import asyncio
 import time
 from datetime import date
 
-from modal import Stub, asgi_app, method, web_endpoint
+from modal import Image, Stub, Volume, asgi_app, method, web_endpoint
 from modal.exception import deprecation_warning
 
 SLEEP_DELAY = 0.1
@@ -220,3 +220,17 @@ def cube(x):
 def function_calling_method(x, y, z):
     obj = ParamCls(x, y)
     return obj.f.remote(z)
+
+
+image = Image.debian_slim().pip_install("xyz")
+other_image = Image.debian_slim().pip_install("abc")
+volume = Volume.new()
+other_volume = Volume.new()
+
+
+@stub.function(image=image, volumes={"/tmp/xyz": volume})
+def check_dep_hydration(x):
+    assert image.is_hydrated
+    assert not other_image.is_hydrated
+    assert volume.is_hydrated
+    assert not other_volume.is_hydrated

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -82,7 +82,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
             "ap-proxy": "pr-123",
         }
         self.app_unindexed_objects = {
-            "ap-1": ["im-0"],
+            "ap-1": ["im-1", "vo-1"],
         }
         self.n_inputs = 0
         self.n_queues = 0

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -552,7 +552,7 @@ def test_cli(unix_servicer, event_loop):
 
 
 @skip_windows_unix_socket
-def test_function_subling_hydration(unix_servicer):
+def test_function_sibling_hydration(unix_servicer):
     deploy_stub_externally(unix_servicer, "modal_test_support.functions", "stub")
     ret = _run_container(unix_servicer, "modal_test_support.functions", "check_sibling_hydration")
     assert _unwrap_scalar(ret) is None

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -87,6 +87,7 @@ def _run_container(
             is_builder_function=is_builder_function,
             allow_concurrent_inputs=allow_concurrent_inputs,
             is_checkpointing_function=is_checkpointing_function,
+            object_dependencies=[api_pb2.ObjectDependency(object_id="im-0")],
         )
 
         container_args = api_pb2.ContainerArguments(
@@ -519,14 +520,18 @@ def test_cli(unix_servicer, event_loop):
         function_name="square",
         function_type=api_pb2.Function.FUNCTION_TYPE_FUNCTION,
         definition_type=api_pb2.Function.DEFINITION_TYPE_FILE,
+        object_dependencies=[api_pb2.ObjectDependency(object_id="im-123")],
     )
     container_args = api_pb2.ContainerArguments(
         task_id="ta-123",
         function_id="fu-123",
-        app_id="se-123",
+        app_id="ap-123",
         function_def=function_def,
     )
     data_base64: str = base64.b64encode(container_args.SerializeToString()).decode("ascii")
+
+    # Needed for function hydration
+    unix_servicer.app_objects["ap-123"] = {"": "im-123"}
 
     # Inputs that will be consumed by the container
     unix_servicer.container_inputs = _get_inputs()


### PR DESCRIPTION
This lets us avoid stub assignments in many cases. Example:

```python
import modal

stub = modal.Stub()
volume = modal.Volume.new()

@stub.function(volumes={"/xyz": volume})
def run():
    with open("/xyz/abc.txt", "w") as f:
        f.write("hello")
    volume.commit()
```

This works because we track that the volume is a dependency of the function, and inside the container we hydrate the volume back. This works for _any_ object, including images (useful for `.run_inside`) etc.

Note that we currently don't track objects referred to inside of functions. It has to be an explicit dependency. So this won't work – yet:



```python
import modal

stub = modal.Stub()
queue = modal.Queue.new()

@stub.function()
def run():
    queue.push(123)
```

In order for this to work, we also need to add all `inspect.closurevars` of the function. I'll add that later. With these changes, we should be able to deprecate stub assignments.