### PR TITLE
Remove output queue from the container

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -105,7 +105,6 @@ class _FunctionIOManager:
         self._stub_name = self.function_def.stub_name
         self._input_concurrency: Optional[int] = None
         self._semaphore: Optional[asyncio.Semaphore] = None
-        self._output_queue: Optional[asyncio.Queue] = None
         self._environment_name = container_args.environment_name
         self._waiting_for_checkpoint = False
 


### PR DESCRIPTION
Write outputs directly without queue indirection.

Tested on a 100k map over sleep(0), sleep(0.1) and sleep(5).