### PR TITLE
Send machine readable platform string

### DIFF
--- a/modal/client.py
+++ b/modal/client.py
@@ -26,12 +26,20 @@ CLIENT_CREATE_TOTAL_TIMEOUT: float = 15.0
 
 
 def _get_metadata(client_type: int, credentials: Optional[Tuple[str, str]], version: str) -> Dict[str, str]:
+    # This implements a simplified version of platform.platform() that's still machine-readable
+    uname: platform.uname_result = platform.uname()
+    if uname.system == "Darwin":
+        system, release = "macOS", platform.mac_ver()[0]
+    else:
+        system, release = uname.system, uname.release
+    platform_str = "-".join(s.replace("-", "_") for s in (system, release, uname.machine))
+
     metadata = {
         "x-modal-client-version": version,
         "x-modal-client-type": str(client_type),
         "x-modal-python-version": platform.python_version(),
         "x-modal-node": platform.node(),
-        "x-modal-platform": platform.platform(),
+        "x-modal-platform": platform_str,
     }
     if credentials and client_type == api_pb2.CLIENT_TYPE_CLIENT:
         token_id, token_secret = credentials

--- a/modal/token_flow.py
+++ b/modal/token_flow.py
@@ -34,6 +34,7 @@ class _TokenFlow:
         async with run_temporary_http_server(app) as url:
             # Create request
             # Send some strings identifying the computer (these are shown to the user for security reasons)
+            # TODO(erikbern): we already send these as metadata for every request - we should remove this
             req = api_pb2.TokenFlowCreateRequest(
                 node_name=platform.node(),
                 platform_name=platform.platform(),


### PR DESCRIPTION
From [`platform.platform` docs](https://docs.python.org/3/library/platform.html#platform.platform): _The output is intended to be human readable rather than machine parseable. It may look different on different platforms and this is intended._

Let's switch to a simpler machine readable string that's always `system-release-machine`.

|    | Before | After |
| - | - | - |
| My laptop | `macOS-11.3-arm64-arm-64bit` | `macOS-11.3-arm64` |
| My devbox | `Linux-5.13.0-1029-aws-x86_64-with-glibc2.31` | `Linux-5.13.0_1029_aws-x86_64` |

Note that these are fairly compatible with `platform.platform()`.