### PR TITLE
Token flow: don't send redundant platform & node to server

### DIFF
--- a/modal/token_flow.py
+++ b/modal/token_flow.py
@@ -1,5 +1,4 @@
 # Copyright Modal Labs 2023
-import platform
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator, Optional, Tuple
 
@@ -32,12 +31,7 @@ class _TokenFlow:
         app = aiohttp.web.Application()
         app.add_routes([aiohttp.web.get("/", slash)])
         async with run_temporary_http_server(app) as url:
-            # Create request
-            # Send some strings identifying the computer (these are shown to the user for security reasons)
-            # TODO(erikbern): we already send these as metadata for every request - we should remove this
             req = api_pb2.TokenFlowCreateRequest(
-                node_name=platform.node(),
-                platform_name=platform.platform(),
                 utm_source=utm_source,
                 next_url=next_url,
                 localhost_port=int(url.split(":")[-1]),

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1347,8 +1347,6 @@ message TaskResultRequest {
 }
 
 message TokenFlowCreateRequest {
-  string node_name = 1 [ (modal.options.audit_target_attr) = true ];
-  string platform_name = 2;
   string utm_source = 3;
   int32 localhost_port = 4;
   string next_url = 5;


### PR DESCRIPTION
We're already sending these as a part of the metadata since a while ago, so this is redundant.

I just updated the server to use the metadata rather than the payload.