### PR TITLE
Deprecate `Stub.is_inside(...)` in favor of `Image.run_inside()`

### DIFF
--- a/modal/extensions/pymc.py
+++ b/modal/extensions/pymc.py
@@ -16,7 +16,7 @@ pymc_stub = modal.Stub(
     .apt_install("zlib1g")
 )
 
-if pymc_stub.is_inside():
+with pymc_stub.image.run_inside():
     import numpy as np
     from fastprogress.fastprogress import progress_bar
     from pymc3 import theanof

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -258,7 +258,15 @@ class _Stub:
 
     @typechecked
     def is_inside(self, image: Optional[_Image] = None) -> bool:
-        """Returns if the program is currently running inside a container for this app."""
+        """Deprecated: use `Image.run_inside()` instead! Usage:
+        ```
+        my_image = modal.Image.debian_slim().pip_install("torch")
+        with my_image.run_inside():
+            import torch
+        ```
+        """
+        deprecation_warning(date(2023, 11, 8), _Stub.is_inside.__doc__)
+
         if self._container_app is None:
             return False
         elif self._container_app != _container_app:

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -7,7 +7,7 @@ from unittest import mock
 import modal.secret
 from modal import Dict, Image, Stub
 from modal.app import container_app
-from modal.exception import InvalidError
+from modal.exception import DeprecationError, InvalidError
 from modal_proto import api_pb2
 
 from .supports.skip import skip_windows_unix_socket
@@ -51,10 +51,11 @@ async def test_is_inside(servicer, unix_servicer, client, container_client):
 
     # Run container
     async with stub.run(client=client):
-        # We're not inside the container (yet)
-        assert not stub.is_inside()
-        assert not stub.is_inside(stub.image)
-        assert not stub.is_inside(stub.image_2)
+        with pytest.warns(DeprecationError, match="run_inside"):
+            # We're not inside the container (yet)
+            assert not stub.is_inside()
+            assert not stub.is_inside(stub.image)
+            assert not stub.is_inside(stub.image_2)
 
         app_id = stub.app_id
         image_1_id = stub["image"].object_id
@@ -71,15 +72,17 @@ async def test_is_inside(servicer, unix_servicer, client, container_client):
 
         # Pretend that we're inside image 1
         with mock.patch.dict(os.environ, {"MODAL_IMAGE_ID": image_1_id}):
-            assert stub.is_inside()
-            assert stub.is_inside(stub.image)
-            assert not stub.is_inside(stub.image_2)
+            with pytest.warns(DeprecationError, match="run_inside"):
+                assert stub.is_inside()
+                assert stub.is_inside(stub.image)
+                assert not stub.is_inside(stub.image_2)
 
         # Pretend that we're inside image 2
         with mock.patch.dict(os.environ, {"MODAL_IMAGE_ID": image_2_id}):
-            assert stub.is_inside()
-            assert not stub.is_inside(stub.image)
-            assert stub.is_inside(stub.image_2)
+            with pytest.warns(DeprecationError, match="run_inside"):
+                assert stub.is_inside()
+                assert not stub.is_inside(stub.image)
+                assert stub.is_inside(stub.image_2)
 
 
 def f():
@@ -92,7 +95,8 @@ async def test_is_inside_default_image(servicer, unix_servicer, client, containe
     stub = Stub()
     stub.function()(f)
 
-    assert not stub.is_inside()
+    with pytest.warns(DeprecationError, match="run_inside"):
+        assert not stub.is_inside()
 
     from modal.stub import _default_image
 
@@ -110,7 +114,8 @@ async def test_is_inside_default_image(servicer, unix_servicer, client, containe
     stub = Stub()
 
     with mock.patch.dict(os.environ, {"MODAL_IMAGE_ID": default_image_id}):
-        assert stub.is_inside()
+        with pytest.warns(DeprecationError, match="run_inside"):
+            assert stub.is_inside()
 
 
 @pytest.mark.skip("runtime type checking has been temporarily disabled")

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -19,7 +19,7 @@ from grpclib.exceptions import GRPCError
 from modal import Client
 from modal._container_entrypoint import UserException, main
 from modal._serialization import deserialize, deserialize_data_format, serialize
-from modal.exception import InvalidError
+from modal.exception import DeprecationError, InvalidError
 from modal.stub import _Stub
 from modal_proto import api_pb2
 
@@ -631,11 +631,8 @@ def test_image_run_function_no_warn(unix_servicer, caplog):
 
 @skip_windows_unix_socket
 def test_is_inside(unix_servicer, caplog, capsys):
-    ret = _run_container(
-        unix_servicer,
-        "modal_test_support.is_inside",
-        "foo",
-    )
+    with pytest.warns(DeprecationError, match="run_inside"):
+        ret = _run_container(unix_servicer, "modal_test_support.is_inside", "foo")
     assert _unwrap_scalar(ret) is None
     assert len(caplog.messages) == 0
     out, err = capsys.readouterr()
@@ -645,7 +642,8 @@ def test_is_inside(unix_servicer, caplog, capsys):
 
 @skip_windows_unix_socket
 def test_multistub_is_inside(unix_servicer, caplog, capsys):
-    ret = _run_container(unix_servicer, "modal_test_support.multistub_is_inside", "foo", stub_name="a")
+    with pytest.warns(DeprecationError, match="run_inside"):
+        ret = _run_container(unix_servicer, "modal_test_support.multistub_is_inside", "foo", stub_name="a")
     assert _unwrap_scalar(ret) is None
     assert len(caplog.messages) == 0
     out, err = capsys.readouterr()
@@ -655,11 +653,8 @@ def test_multistub_is_inside(unix_servicer, caplog, capsys):
 
 @skip_windows_unix_socket
 def test_multistub_is_inside_warning(unix_servicer, caplog, capsys):
-    ret = _run_container(
-        unix_servicer,
-        "modal_test_support.multistub_is_inside_warning",
-        "foo",
-    )
+    with pytest.warns(DeprecationError, match="run_inside"):
+        ret = _run_container(unix_servicer, "modal_test_support.multistub_is_inside_warning", "foo")
     assert _unwrap_scalar(ret) is None
     assert len(caplog.messages) == 1
     assert "You have more than one unnamed stub" in caplog.text

--- a/test/stub_test.py
+++ b/test/stub_test.py
@@ -137,7 +137,8 @@ def test_run_function_without_app_error():
 
 def test_is_inside_basic():
     stub = Stub()
-    assert stub.is_inside() is False
+    with pytest.warns(DeprecationError, match="run_inside"):
+        assert stub.is_inside() is False
 
 
 def test_missing_attr():


### PR DESCRIPTION
I've mentioned it before but a lot of complexity in the client comes from the fact that `is_inside` needs to run in global scope – this makes object hydration much messier than it otherwise would be. `run_inside` also doesn't require images to be attached to the stub, which means we can remove stub assignments later.