### PR TITLE
Set type information for _Stub.image

### DIFF
--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -318,9 +318,8 @@ def shell(
     if func_ref is not None:
         function = import_function(func_ref, accept_local_entrypoint=False, accept_webhook=True, base_cmd="modal shell")
     else:
-        stub = Stub("modal shell")
-        if image:
-            stub.image = Image.from_registry(image, add_python=add_python)
+        image_obj = Image.from_registry(image, add_python=add_python) if image else None
+        stub = Stub("modal shell", image=image_obj)
         function = stub.function(
             serialized=True,
             cpu=cpu,

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -241,6 +241,12 @@ class _Stub:
             self._validate_blueprint_value(tag, obj)
             self._add_object(tag, obj)
 
+    @property
+    def image(self) -> _Image:
+        # Exists to get the type inference working for `stub.image`
+        # Will also keep this one after we remove [get/set][item/attr]
+        return self._blueprint["image"]
+
     def get_objects(self) -> List[Tuple[str, _Object]]:
         """Used by the container app to initialize objects."""
         return list(self._blueprint.items())

--- a/test/stub_test.py
+++ b/test/stub_test.py
@@ -67,9 +67,8 @@ def square(x):
 
 @pytest.mark.asyncio
 async def test_redeploy(servicer, client):
-    stub = Stub()
+    stub = Stub(image=Image.debian_slim().pip_install("pandas"))
     stub.function()(square)
-    stub.image = Image.debian_slim().pip_install("pandas")
 
     # Deploy app
     app = await deploy_stub.aio(stub, "my-app", client=client)
@@ -241,17 +240,15 @@ def test_set_image_on_stub_as_attribute():
     # TODO: do we want to deprecate this syntax? It's kind of random for image to
     #     have a reserved name in the blueprint, and being the only of the construction
     #     arguments that can be set on the instance after construction
-    stub = Stub()
     custom_img = modal.Image.debian_slim().apt_install("emacs")
-    stub.image = custom_img
+    stub = Stub(image=custom_img)
     assert stub._get_default_image() == custom_img
 
 
 @pytest.mark.asyncio
 async def test_redeploy_persist(servicer, client):
-    stub = Stub()
+    stub = Stub(image=Image.debian_slim().pip_install("pandas"))
     stub.function()(square)
-    stub.image = Image.debian_slim().pip_install("pandas")
 
     stub.d = Dict.new()
 


### PR DESCRIPTION
Broke this out of #4087 because it's mostly unrelated.

This makes sure `_Stub.image` is annotated with type information. It breaks type inference for assignment since synchronicity doesn't support property setters but it still works in runtime, i.e. you can do `stub.image = modal.Image.debian_slim()` but mypy will complain about it.

This is needed to make mypy not complain about `stub.image.run_inside()`

This prepares for a post-assignment world where `__[get|set][item|attr]__` is gone. We still want to support the image attribute since it's special in some sense – we use it for the stub's default image.