### PR TITLE
Remove environment_name from AppStats

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -258,7 +258,6 @@ message AppStats {
   int32 n_running_tasks = 8;
   string object_entity = 9;
   string name = 10;
-  string environment_name = 11;
 }
 
 message AppListRequest {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -266,7 +266,6 @@ message AppListRequest {
 
 message AppListResponse {
   repeated AppStats apps = 1;
-  string environment_name = 2;
 }
 
 message AppLookupObjectRequest {


### PR DESCRIPTION
This field isn't useful — removing it in https://github.com/modal-labs/modal/pull/8910 to reduce JSON payloads