### PR TITLE
Add client support for unencrypted tunnels

### DIFF
--- a/modal/_tunnel.py
+++ b/modal/_tunnel.py
@@ -3,7 +3,7 @@
 
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import AsyncIterator, Optional
+from typing import AsyncIterator, Optional, Tuple
 
 from grpclib import GRPCError, Status
 
@@ -22,16 +22,36 @@ class Tunnel:
     """
 
     host: str
+    unencrypted_host: str
+    unencrypted_port: int
 
     @property
     def url(self) -> str:
         """Get the public HTTPS URL of the forwarded port."""
         return f"https://{self.host}"
 
+    @property
+    def tls(self) -> Tuple[str, int]:
+        """Get the public TLS socket as a (host, port) tuple."""
+        return (self.host, 443)
+
+    @property
+    def tcp(self) -> Tuple[str, int]:
+        """Get the public TCP socket as a (host, port) tuple."""
+        if not self.unencrypted_host:
+            raise InvalidError(
+                "This tunnel is not configured for unencrypted TCP. Please use `forward(..., unencrypted=True)`."
+            )
+        return (self.unencrypted_host, self.unencrypted_port)
+
 
 @asynccontextmanager
-async def _forward(port: int, client: Optional[_Client] = None) -> AsyncIterator[Tunnel]:
+async def _forward(port: int, *, unencrypted: bool = False, client: Optional[_Client] = None) -> AsyncIterator[Tunnel]:
     """Expose a port publicly from inside a running Modal container, with TLS.
+
+    If `unencrypted` is set, this allows you to expose a raw TCP port without encryption. This is
+    useful for exposing SSH servers. Note that the socket lives on the public Internet, so make
+    sure you are using a secure protocol over TCP.
 
     This is an EXPERIMENTAL API and may change in the future.
 
@@ -67,7 +87,7 @@ async def _forward(port: int, client: Optional[_Client] = None) -> AsyncIterator
         raise InvalidError("Forwarding ports only works inside a Modal container")
 
     try:
-        response = await client.stub.TunnelStart(api_pb2.TunnelStartRequest(port=port))
+        response = await client.stub.TunnelStart(api_pb2.TunnelStartRequest(port=port, unencrypted=unencrypted))
     except GRPCError as exc:
         if exc.status == Status.ALREADY_EXISTS:
             raise InvalidError(f"Port {port} is already forwarded")
@@ -77,7 +97,7 @@ async def _forward(port: int, client: Optional[_Client] = None) -> AsyncIterator
             raise
 
     try:
-        yield Tunnel(response.host)
+        yield Tunnel(response.host, response.unencrypted_host, response.unecrypted_port)
     finally:
         await client.stub.TunnelStop(api_pb2.TunnelStopRequest(port=port))
 

--- a/modal/_tunnel.py
+++ b/modal/_tunnel.py
@@ -97,7 +97,7 @@ async def _forward(port: int, *, unencrypted: bool = False, client: Optional[_Cl
             raise
 
     try:
-        yield Tunnel(response.host, response.unencrypted_host, response.unecrypted_port)
+        yield Tunnel(response.host, response.unencrypted_host, response.unencrypted_port)
     finally:
         await client.stub.TunnelStop(api_pb2.TunnelStopRequest(port=port))
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1377,7 +1377,7 @@ message TunnelStartRequest {
 
 message TunnelStartResponse {
   string host = 1;
-  int port = 2;
+  uint32 port = 2;
   optional string unencrypted_host = 3;
   optional uint32 unencrypted_port = 4;
 }

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1372,10 +1372,14 @@ message TokenFlowWaitResponse {
 
 message TunnelStartRequest {
   uint32 port = 1;
+  bool unencrypted = 2;
 }
 
 message TunnelStartResponse {
   string host = 1;
+  string port = 2;
+  optional string unencrypted_host = 3;
+  optional uint32 unencrypted_port = 4;
 }
 
 message TunnelStopRequest {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1377,7 +1377,7 @@ message TunnelStartRequest {
 
 message TunnelStartResponse {
   string host = 1;
-  string port = 2;
+  int port = 2;
   optional string unencrypted_host = 3;
   optional uint32 unencrypted_port = 4;
 }

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -767,7 +767,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
     async def TunnelStart(self, stream):
         request: api_pb2.TunnelStartRequest = await stream.recv_message()
         port = request.port
-        await stream.send_message(api_pb2.TunnelStartResponse(host=f"{port}.modal.test"))
+        await stream.send_message(api_pb2.TunnelStartResponse(host=f"{port}.modal.test", port=443))
 
     async def TunnelStop(self, stream):
         await stream.recv_message()


### PR DESCRIPTION
Allows tunnels to forward raw TCP sockets from containers. This won't work immediately. After we merge this, I also need to merge in the server implementation.

See companion PR internally which implements this on `modal-relay` servers.