### PR TITLE
Remove tunnel.port reverse compatibility

### DIFF
--- a/modal/_tunnel.py
+++ b/modal/_tunnel.py
@@ -148,8 +148,7 @@ async def _forward(port: int, *, unencrypted: bool = False, client: Optional[_Cl
             raise
 
     try:
-        response_port = response.port or 443  # reverse compatibility
-        yield Tunnel(response.host, response_port, response.unencrypted_host, response.unencrypted_port)
+        yield Tunnel(response.host, response.port, response.unencrypted_host, response.unencrypted_port)
     finally:
         await client.stub.TunnelStop(api_pb2.TunnelStopRequest(port=port))
 


### PR DESCRIPTION
This is unnecessary now because the new relay servers have been deployed, and our worker fleet has cycled!
