### PR TITLE
Spawn @live_method

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1238,6 +1238,7 @@ class _Function(_Object, type_prefix="fu"):
                 " a Modal container in the cloud",
             )
 
+    @live_method
     async def spawn(self, *args, **kwargs) -> Optional["_FunctionCall"]:
         """Calls the function with the given arguments, without waiting for the results.
 

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -268,12 +268,21 @@ def test_lookup(client, servicer):
         assert obj.bar.local(1, 2)
 
 
-def test_lookup_lazy(client, servicer):
+def test_lookup_lazy_remote(client, servicer):
     # See #972 (PR) and #985 (revert PR): adding unit test to catch regression
     deploy_stub(stub, "my-cls-app", client=client)
     cls: Cls = Cls.lookup("my-cls-app", "Foo", client=client)
     obj = cls("foo", 234)
     assert obj.bar.remote(42, 77) == 7693
+
+
+def test_lookup_lazy_spawn(client, servicer):
+    # See #1071
+    deploy_stub(stub, "my-cls-app", client=client)
+    cls: Cls = Cls.lookup("my-cls-app", "Foo", client=client)
+    obj = cls("foo", 234)
+    function_call = obj.bar.spawn(42, 77)
+    assert function_call.get() == 7693
 
 
 baz_stub = Stub()


### PR DESCRIPTION
This is definitely a bug which can cause `.spawn` on unhydrated functions to fail with this:

```
AttributeError: 'NoneType' object has no attribute 'stub'
```