### PR TITLE
`modal shell` skips import and constructors

### DIFF
--- a/modal/_pty.py
+++ b/modal/_pty.py
@@ -118,9 +118,6 @@ def run_in_pty(fn, queue, pty_info: api_pb2.PTYInfo):
     import pty
     import threading
 
-    if pty_info.pty_type == api_pb2.PTYInfo.PTY_TYPE_SHELL:
-        fn = exec_cmd
-
     @functools.wraps(fn)
     def wrapped_fn(*args, **kwargs):
         write_fd, read_fd = pty.openpty()


### PR DESCRIPTION
The refactors to `modal shell` a few months ago caused a regression where we started to import the function and run `__enter__` and `__init__` as well. This causes shell to break when `__init__` expects arguments etc.

We should add tests for `modal shell`, but fixing it for now.

Resolves MOD-1584