### PR TITLE
Reduce flickering on green completed substeps

### DIFF
--- a/modal/_output.py
+++ b/modal/_output.py
@@ -70,11 +70,11 @@ def step_progress_update(spinner: Spinner, message: str):
 def step_completed(message: str, is_substep: bool = False) -> RenderableType:
     """Returns the element to be rendered when a step is completed."""
 
-    STEP_COMPLETED = "✓"
+    STEP_COMPLETED = "[green]✓[/green]"
     SUBSTEP_COMPLETED = "🔨"
 
     symbol = SUBSTEP_COMPLETED if is_substep else STEP_COMPLETED
-    return f"[green]{symbol}[/green] " + message
+    return f"{symbol} {message}"
 
 
 class LineBufferedOutput(io.StringIO):


### PR DESCRIPTION
During an application run or image build, where logs are coming dynamically, sometimes Rich has a bug where it flickers `[green]` as an output. This styling doesn't appear anyway on our substep completed character, so we can just remove it and reduce the flickering.
