### PR TITLE
Add client support for current_function_call_id()

### DIFF
--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -7,7 +7,7 @@ from .client import Client
 from .cls import Cls
 from .dict import Dict
 from .exception import Error
-from .functions import Function, asgi_app, current_input_id, method, web_endpoint, wsgi_app
+from .functions import Function, asgi_app, current_function_call_id, current_input_id, method, web_endpoint, wsgi_app
 from .image import Image
 from .mount import Mount, create_package_mounts
 from .network_file_system import NetworkFileSystem
@@ -43,6 +43,7 @@ __all__ = [
     "asgi_app",
     "container_app",
     "create_package_mounts",
+    "current_function_call_id",
     "current_input_id",
     "forward",
     "is_local",

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -45,8 +45,8 @@ from .exception import InvalidError
 from .functions import (
     Function,
     _Function,  # type: ignore
-    _set_current_input_id,
     _set_current_function_call_id,
+    _set_current_input_id,
 )
 
 if TYPE_CHECKING:

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -16,7 +16,7 @@ import time
 import traceback
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, AsyncGenerator, AsyncIterator, Callable, List, Optional, Type
+from typing import TYPE_CHECKING, Any, AsyncGenerator, AsyncIterator, Callable, Optional, Type
 
 from grpclib import Status
 
@@ -189,7 +189,7 @@ class _FunctionIOManager:
 
         return math.ceil(RTT_S / max(self.get_average_call_time(), 1e-6))
 
-    async def _generate_inputs(self) -> AsyncIterator[tuple[str, api_pb2.FunctionInput]]:
+    async def _generate_inputs(self) -> AsyncIterator[tuple[str, str, api_pb2.FunctionInput]]:
         request = api_pb2.FunctionGetInputsRequest(function_id=self.function_id)
         eof_received = False
         iteration = 0
@@ -718,7 +718,7 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
 
         # Hydrate all function dependencies
         if imp_fun.function:
-            dep_object_ids: List[str] = [dep.object_id for dep in container_args.function_def.object_dependencies]
+            dep_object_ids: list[str] = [dep.object_id for dep in container_args.function_def.object_dependencies]
             container_app.hydrate_function_deps(imp_fun.function, dep_object_ids)
 
         # Checkpoint container after imports. Checkpointed containers start from this point

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1347,10 +1347,11 @@ gather = synchronize_api(_gather)
 
 
 _current_input_id: Optional[str] = None
+_current_function_call_id: Optional[str] = None
 
 
 def current_input_id() -> str:
-    """Returns the input ID for the currently processed input.
+    """Returns the input ID for the current input.
 
     Can only be called from Modal function (i.e. in a container context).
 
@@ -1366,9 +1367,31 @@ def current_input_id() -> str:
     return _current_input_id
 
 
+def current_function_call_id() -> str:
+    """Returns the function call ID for the current input.
+
+    Can only be called from Modal function (i.e. in a container context).
+
+    ```python
+    from modal import current_function_call_id
+
+    @stub.function()
+    def process_stuff():
+        print(f"Starting to process input from {current_function_call_id()}")
+    ```
+    """
+    global _current_function_call_id
+    return _current_function_call_id
+
+
 def _set_current_input_id(input_id: Optional[str]):
     global _current_input_id
     _current_input_id = input_id
+
+
+def _set_current_function_call_id(function_call_id: Optional[str]):
+    global _current_function_call_id
+    _current_function_call_id = function_call_id
 
 
 class _PartialFunction:

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -757,6 +757,7 @@ message FunctionGetInputsItem {
   FunctionInput input = 2;
   bool kill_switch = 3;
   reserved 4; // previously used
+  string function_call_id = 5;
 }
 
 message FunctionGetInputsRequest {


### PR DESCRIPTION
This PR adds client support for getting the function call ID of the currently-processing input.

Right now the caller of a function only knows its function call ID, but the callee only has the input ID. There's no way to connect the two. We should give the callee access to the function call ID as well.

This also helps implement data channels.