### PR TITLE
Tell people to email support@modal.com if the installation is bad

### DIFF
--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -1,24 +1,41 @@
 # Copyright Modal Labs 2022
 from modal_version import __version__
 
-from ._tunnel import Tunnel, forward
-from .app import container_app, is_local
-from .client import Client
-from .cls import Cls
-from .dict import Dict
-from .exception import Error
-from .functions import Function, asgi_app, current_function_call_id, current_input_id, method, web_endpoint, wsgi_app
-from .image import Image
-from .mount import Mount, create_package_mounts
-from .network_file_system import NetworkFileSystem
-from .proxy import Proxy
-from .queue import Queue
-from .retries import Retries
-from .schedule import Cron, Period
-from .secret import Secret
-from .shared_volume import SharedVolume
-from .stub import Stub
-from .volume import Volume
+try:
+    from ._tunnel import Tunnel, forward
+    from .app import container_app, is_local
+    from .client import Client
+    from .cls import Cls
+    from .dict import Dict
+    from .exception import Error
+    from .functions import (
+        Function,
+        asgi_app,
+        current_function_call_id,
+        current_input_id,
+        method,
+        web_endpoint,
+        wsgi_app,
+    )
+    from .image import Image
+    from .mount import Mount, create_package_mounts
+    from .network_file_system import NetworkFileSystem
+    from .proxy import Proxy
+    from .queue import Queue
+    from .retries import Retries
+    from .schedule import Cron, Period
+    from .secret import Secret
+    from .shared_volume import SharedVolume
+    from .stub import Stub
+    from .volume import Volume
+except Exception:
+    print()
+    print("#" * 80)
+    print("#" + "Something with the Modal installation seems broken.".center(78) + "#")
+    print("#" + "Please email support@modal.com and we will try to help!".center(78) + "#")
+    print("#" * 80)
+    print()
+    raise
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
This is a bit of a test, but I think there's a bunch of user issues that go unreported because people don't get past the point of installing Modal successfully. Environment conflicts etc. So this is an attempt at catching user issues a bit more.

E.g. if protobuf is broken:

<img width="743" alt="image" src="https://github.com/modal-labs/modal-client/assets/1027979/25fff25f-bbc2-4404-b7ee-3331e076b986">
