### PR TITLE
Prevent installation on 3.12 for now

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.7, <3.12
 install_requires =
     aiohttp
     aiostream


### PR DESCRIPTION
Probably a bit cleaner than https://github.com/modal-labs/modal-client/pull/1095