### PR TITLE
Restore arbitrary env vars

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -425,8 +425,10 @@ class _FunctionIOManager:
             restored_state = json.load(file)
 
         # State data is serialized with key-value pairs, example: {"task_id": "tk-000"}
+        # Empty string indicates that value does not need to be updated.
         for key, value in restored_state.items():
-            config.override_locally(key, value)
+            if value != "":
+                config.override_locally(key, value)
 
         self._client = await _Client.from_env()
         self._waiting_for_checkpoint = False

--- a/modal/config.py
+++ b/modal/config.py
@@ -194,7 +194,7 @@ class Config:
             self.get(key)
             os.environ["MODAL_" + key.upper()] = value
         except KeyError:
-            # Override env vars not available in config, e.g. NVIDIA_AVAILABLE_DEVICES.
+            # Override env vars not available in config, e.g. NVIDIA_VISIBLE_DEVICES.
             # This is used for restoring env vars from a checkpoint.
             os.environ[key.upper()] = value
 

--- a/modal/config.py
+++ b/modal/config.py
@@ -190,7 +190,13 @@ class Config:
         # Override setting in this process by overriding environment variable for the setting
         #
         # Does NOT write back to settings file etc.
-        os.environ["MODAL_" + key.upper()] = value
+        try:
+            self.get(key)
+            os.environ["MODAL_" + key.upper()] = value
+        except KeyError:
+            # Override env vars not available in config, e.g. NVIDIA_AVAILABLE_DEVICES.
+            # This is used for restoring env vars from a checkpoint.
+            os.environ[key.upper()] = value
 
     def __getitem__(self, key):
         return self.get(key)

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -87,15 +87,15 @@ def test_config_store_user(servicer):
 
     os.remove(t.name)
 
+
 def test_config_env_override_arbitrary_env():
     """config.override_locally() replaces existing env var if not part of config."""
     key = "NVIDIA_AVAILABLE_DEVICES"
     value = "0,1"
-    
+
     # Place old value in memory.
     os.environ[key] = "none"
 
     # Expect value to be overwritten.
     config.override_locally(key, value)
     assert os.getenv(key) == value
-

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -6,7 +6,6 @@ import sys
 import tempfile
 
 import modal
-
 from modal.config import config
 
 

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -7,6 +7,8 @@ import tempfile
 
 import modal
 
+from modal.config import config
+
 
 def _cli(args, env={}):
     lib_dir = pathlib.Path(modal.__file__).parent.parent
@@ -84,3 +86,16 @@ def test_config_store_user(servicer):
     assert config["token_secret"] == "bar2"
 
     os.remove(t.name)
+
+def test_config_env_override_arbitrary_env():
+    """config.override_locally() replaces existing env var if not part of config."""
+    key = "NVIDIA_AVAILABLE_DEVICES"
+    value = "0,1"
+    
+    # Place old value in memory.
+    os.environ[key] = "none"
+
+    # Expect value to be overwritten.
+    config.override_locally(key, value)
+    assert os.getenv(key) == value
+

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -89,7 +89,7 @@ def test_config_store_user(servicer):
 
 def test_config_env_override_arbitrary_env():
     """config.override_locally() replaces existing env var if not part of config."""
-    key = "NVIDIA_AVAILABLE_DEVICES"
+    key = "NVIDIA_VISIBLE_DEVICES"
     value = "0,1"
 
     # Place old value in memory.


### PR DESCRIPTION
Allows updating arbitrary env vars upon a restore from a checkpoint. This is useful for restoring system env vars such as `NVIDIA_AVAILABLE_DEVICES` which will be different on every restore.

For example, this restore config:

```json
{
    "task_id": "tk-0000",
    "nvidia_visible_devices":  "0",
}
```

Will update the following env vars: `MODAL_TASK_ID=tk-0000` and `nvidia_visible_devices=0`.