### PR TITLE
volumes: Use os.sync before committing on exit

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -9,6 +9,7 @@ import importlib
 import inspect
 import json
 import math
+import os
 import pickle
 import signal
 import sys
@@ -24,6 +25,7 @@ from modal.stub import _Stub
 from modal_proto import api_pb2
 from modal_utils.async_utils import (
     TaskContext,
+    asyncify,
     synchronize_api,
     synchronizer,
 )
@@ -438,6 +440,7 @@ class _FunctionIOManager:
         """
         if not volume_ids:
             return
+        await asyncify(os.sync)()
         results = await asyncio.gather(
             *[
                 retry_transient_errors(


### PR DESCRIPTION
### Describe your changes

Follow up to https://github.com/modal-labs/modal-client/pull/1089#discussion_r1414511679

### Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

