### PR TITLE
perf: intro --compile option to poetry installs

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -659,7 +659,7 @@ class _Image(_Object, type_prefix="im"):
 
         dockerfile_commands = [
             "FROM base",
-            "RUN python -m pip install poetry",
+            "RUN python -m pip install poetry~=1.7",
         ]
 
         if old_installer:
@@ -687,6 +687,7 @@ class _Image(_Object, type_prefix="im"):
 
         if only:
             install_cmd += f" --only {','.join(only)}"
+        install_cmd += " --compile"  # no .pyc compilation slows down cold-start.
 
         dockerfile_commands += [
             "COPY /.pyproject.toml /tmp/poetry/pyproject.toml",


### PR DESCRIPTION
## Describe your changes

Feb 27th 2023 a new Poetry version was release that **turned off** `.pyc` compilation on install: https://python-poetry.org/blog/announcing-poetry-1.4.0.

This speeds up installation a bit, and slows down the application's first run. Very bad tradeoff in our case.

This re-enables `.pyc` compilation, bringing cold start `import` perf back in line with non-poetry images. 

`sentence_transformers` package now imports in 5.1s, not 9.8s. 

**Aside:** I also introduce relaxed pinning of the Poetry version, as having not version range selection seems imprudent. 

## Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
