### PR TITLE
Re-raise exception on Python 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ of how to use the library.
 
 ## Installation
 
-This requires Python 3.7 or later. Install the package with:
+**This requires Python 3.7 – 3.11.** Install the package with:
 
 ```bash
 pip install modal

--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -1,4 +1,12 @@
 # Copyright Modal Labs 2022
+import sys
+
+if sys.version_info >= (3, 12):
+    raise RuntimeError(
+        "This version of Modal does not support Python 3.12+. See https://github.com/modal-labs/modal-client/issues/1056"
+    )
+
+
 from modal_version import __version__
 
 try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.7, <3.12
+python_requires = >=3.7
 install_requires =
     aiohttp
     aiostream


### PR DESCRIPTION
Users installing the Modal client library on Python 3.12 would receive a backsolve to an older version of the library, which did not specify `python_version = <3.12`. This means their error message isn't helpful. We can get around this by raising an exception instead.

See this thread for prior discussion: https://discuss.python.org/t/requires-python-upper-limits/12663