### PR TITLE
Track and hydrate object dependencies of functions using closurevars

### DIFF
--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -310,7 +310,7 @@ def get_referred_objects(f: Callable) -> List[Object]:
     for obj in inspect.getclosurevars(f).globals.values():
         if isinstance(obj, Object):
             ret.append(obj)
-        elif callable(obj):
+        elif inspect.isfunction(obj):
             ret += get_referred_objects(obj)
 
     return ret

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -306,9 +306,15 @@ def get_referred_objects(f: Callable) -> List[Object]:
     TODO: this does not yet support Object contained by another object,
     e.g. a list of Objects in global scope.
     """
+    from .cls import Cls
+    from .functions import Function
+
     ret: List[Object] = []
     for obj in inspect.getclosurevars(f).globals.values():
-        if isinstance(obj, Object):
+        if isinstance(obj, (Function, Cls)):
+            # These are always attached to stubs, so we shouldn't do anything
+            pass
+        elif isinstance(obj, Object):
             ret.append(obj)
         elif inspect.isfunction(obj):
             ret += get_referred_objects(obj)

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -231,6 +231,6 @@ other_volume = Volume.new()
 @stub.function(image=image, volumes={"/tmp/xyz": volume})
 def check_dep_hydration(x):
     assert image.is_hydrated
-    assert not other_image.is_hydrated
+    assert other_image.is_hydrated
     assert volume.is_hydrated
-    assert not other_volume.is_hydrated
+    assert other_volume.is_hydrated

--- a/modal_test_support/package_mount.py
+++ b/modal_test_support/package_mount.py
@@ -3,9 +3,8 @@ from modal import Mount, Stub
 
 stub = Stub()
 
-mount = Mount.from_local_python_packages("module_1")
-
 
 @stub.function()
 def num_mounts(_x):
+    mount = Mount.from_local_python_packages("module_1")
     return len(mount.entries)

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -851,5 +851,10 @@ def test_volume_commit_on_exit_doesnt_fail_container(unix_servicer, event_loop):
 @skip_windows_unix_socket
 def test_function_dep_hydration(unix_servicer):
     deploy_stub_externally(unix_servicer, "modal_test_support.functions", "stub")
-    ret = _run_container(unix_servicer, "modal_test_support.functions", "check_dep_hydration", deps=["im-1", "vo-1"])
+    ret = _run_container(
+        unix_servicer,
+        "modal_test_support.functions",
+        "check_dep_hydration",
+        deps=["im-1", "vo-1", "im-1", "im-2", "vo-1", "vo-2"],
+    )
     assert _unwrap_scalar(ret) is None

--- a/test/function_utils_test.py
+++ b/test/function_utils_test.py
@@ -26,4 +26,12 @@ def test_referred_objects():
 
 def test_referred_objects_recursive():
     objs: List[Object] = get_referred_objects(f2)
-    assert objs == [q1, q2]
+    assert set(objs) == set([q1, q2])
+
+
+def recursive():
+    recursive()
+
+
+def test_recursive():
+    get_referred_objects(recursive)

--- a/test/function_utils_test.py
+++ b/test/function_utils_test.py
@@ -1,0 +1,29 @@
+# Copyright Modal Labs 2023
+
+from typing import List
+
+from modal import Queue
+from modal._function_utils import get_referred_objects
+from modal.object import Object
+
+q1 = Queue.new()
+q2 = Queue.new()
+
+
+def f1():
+    q1.get()
+
+
+def f2():
+    f1()
+    q2.get()
+
+
+def test_referred_objects():
+    objs: List[Object] = get_referred_objects(f1)
+    assert objs == [q1]
+
+
+def test_referred_objects_recursive():
+    objs: List[Object] = get_referred_objects(f2)
+    assert objs == [q1, q2]


### PR DESCRIPTION
This PR:
1. Adds a utility helper that takes a callable (a user function) and returns a list of Modal objects in global scope that it refers.
2. Tracks all such dependencies of user functions, which will cause those objects to be hydrated in the container as well

The point is to obviate stub assignments since this takes care of most/all cases where it's still needed. We don't yet support a bunch of weird cases (wrapping objects in data structures etc) but neither does the current stub assignment logic so I think it's fine.

It lets us get rid of remaining needs for stub assignments, which at this point is really just weird ones:
1. Ephemeral Dict/Queues (for other ephemeral objects, they are already referred to by functions, so there's no need for stub assignments)
4. References to objects in other apps.
5. Quasi-deployed objects by tying volumes to an app (vs using a separate single-object app). I did some analytics and this is very rare.

In case 1 and 2, this code will make it work without the assignment i.e. you can just refer to the object itself from inside the function and it will by hydrated.

For case 3, we should encourage people to use persisted objects instead.