### PR TITLE
Add size to VolumeGet

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1514,6 +1514,7 @@ message VolumeGetFileResponse {
     bytes data = 1;
     string data_blob_id = 2;
   }
+  uint64 size = 3;
 }
 
 message VolumeListFilesEntry {


### PR DESCRIPTION
For reporting download progress.

- [ ] ~TODO: maybe do this in `BlobGet`~ (don't want to add a HEAD request round trip for `BlobGetResponse` to add size)