### PR TITLE
[MOD 1731] vol get progress display

### DIFF
--- a/modal/_output.py
+++ b/modal/_output.py
@@ -25,6 +25,7 @@ from rich.progress import (
     TextColumn,
     TimeElapsedColumn,
     TimeRemainingColumn,
+    TransferSpeedColumn,
 )
 from rich.spinner import Spinner
 from rich.text import Text
@@ -75,6 +76,25 @@ def step_completed(message: str, is_substep: bool = False) -> RenderableType:
 
     symbol = SUBSTEP_COMPLETED if is_substep else STEP_COMPLETED
     return f"{symbol} {message}"
+
+
+def download_progress_bar():
+    """
+    Returns a progress bar suitable for showing file download progress.
+    Requires passing a `path: str` data field for rendering.
+    """
+    return Progress(
+        TextColumn("[bold white]{task.fields[path]}", justify="right"),
+        BarColumn(bar_width=None),
+        "[progress.percentage]{task.percentage:>3.1f}%",
+        "•",
+        DownloadColumn(),
+        "•",
+        TransferSpeedColumn(),
+        "•",
+        TimeRemainingColumn(),
+        transient=True,
+    )
 
 
 class LineBufferedOutput(io.StringIO):

--- a/modal/_output.py
+++ b/modal/_output.py
@@ -78,7 +78,7 @@ def step_completed(message: str, is_substep: bool = False) -> RenderableType:
     return f"{symbol} {message}"
 
 
-def download_progress_bar():
+def download_progress_bar() -> Progress:
     """
     Returns a progress bar suitable for showing file download progress.
     Requires passing a `path: str` data field for rendering.

--- a/modal/_output.py
+++ b/modal/_output.py
@@ -143,7 +143,6 @@ class OutputManager:
     _task_states: dict[str, int]
     _task_progress_items: dict[tuple[str, int], TaskID]
     _current_render_group: Optional[Group]
-    _file_download_progress: Optional[Progress]
     _function_progress: Optional[Progress]
     _function_queueing_progress: Optional[Progress]
     _snapshot_progress: Optional[Progress]
@@ -160,7 +159,6 @@ class OutputManager:
         self._task_states = {}
         self._task_progress_items = {}
         self._current_render_group = None
-        self._file_download_progress = None
         self._function_progress = None
         self._function_queueing_progress = None
         self._snapshot_progress = None
@@ -187,28 +185,6 @@ class OutputManager:
 
     def enable_image_logs(self):
         self._show_image_logs = True
-
-    @property
-    def file_download_progress(self) -> Progress:
-        """Creates a `rich.Progress` instance with custom columns for file download progress,
-        and adds it to the current render group."""
-        if not self._file_download_progress:
-            self._file_download_progress = Progress(
-                TextColumn("[bold white]{task.fields[path]}", justify="right"),
-                BarColumn(bar_width=None),
-                "[progress.percentage]{task.percentage:>3.1f}%",
-                "•",
-                DownloadColumn(),
-                "•",
-                TransferSpeedColumn(),
-                "•",
-                TimeRemainingColumn(),
-                transient=True,
-                console=self._console,
-            )
-            if self._current_render_group:
-                self._current_render_group.renderables.append(Panel(self._file_download_progress, style="gray50"))
-        return self._file_download_progress
 
     @property
     def function_progress(self) -> Progress:
@@ -334,21 +310,6 @@ class OutputManager:
                 self.snapshot_progress.remove_task(progress_task_id)
         except KeyError:
             # Rich throws a KeyError if the task has already been removed.
-            pass
-
-    def update_file_download_progress(self, path: str, advance: int, total: Optional[int] = None) -> None:
-        task_key = (path, "file_download")
-        if task_key in self._task_progress_items:
-            progress_task_id = self._task_progress_items[task_key]
-        else:
-            progress_task_id = self.file_download_progress.add_task(f"[yellow]Downloading {path}", total=total)
-            self._task_progress_items[task_key] = progress_task_id
-            self.file_download_progress.start_task(progress_task_id)
-        if total is not None:
-            self.file_download_progress.update(progress_task_id, total=int(total))
-        try:
-            self.file_download_progress.update(progress_task_id, advance=advance)
-        except KeyError:
             pass
 
     def update_queueing_progress(

--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -17,7 +17,7 @@ from rich.table import Table
 from typer import Argument, Option, Typer
 
 import modal
-from modal._output import OutputManager, step_completed, step_progress
+from modal._output import step_completed, step_progress
 from modal.cli._download import _glob_download
 from modal.cli.utils import ENV_OPTION, display_table
 from modal.client import _Client
@@ -133,11 +133,8 @@ async def get(
             shutil.move(fp.name, destination)
 
     try:
-        path = remote_path.lstrip("/")
         with _destination_stream() as fp:
-            output_mgr = OutputManager(stdout=None, show_progress=True, status_spinner_text=f"Downloading {path}")
-            progress = destination != PIPE_PATH
-            await volume.read_file_into_fileobj(path, fileobj=fp, progress=progress, output_mgr=output_mgr)
+            await volume.read_file_into_fileobj(remote_path.lstrip("/"), fileobj=fp, progress=destination != PIPE_PATH)
     except FileNotFoundError as exc:
         raise UsageError(str(exc))
     except GRPCError as exc:

--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -17,7 +17,7 @@ from rich.table import Table
 from typer import Argument, Option, Typer
 
 import modal
-from modal._output import step_completed, step_progress
+from modal._output import OutputManager, step_completed, step_progress
 from modal.cli._download import _glob_download
 from modal.cli.utils import ENV_OPTION, display_table
 from modal.client import _Client
@@ -133,8 +133,11 @@ async def get(
             shutil.move(fp.name, destination)
 
     try:
+        path = remote_path.lstrip("/")
         with _destination_stream() as fp:
-            await volume.read_file_into_fileobj(remote_path.lstrip("/"), fileobj=fp, progress=destination != PIPE_PATH)
+            output_mgr = OutputManager(stdout=None, show_progress=True, status_spinner_text=f"Downloading {path}")
+            progress = destination != PIPE_PATH
+            await volume.read_file_into_fileobj(path, fileobj=fp, progress=progress, output_mgr=output_mgr)
     except FileNotFoundError as exc:
         raise UsageError(str(exc))
     except GRPCError as exc:

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -1,8 +1,9 @@
 # Copyright Modal Labs 2023
 import asyncio
 import time
+from contextlib import nullcontext
 from pathlib import Path, PurePosixPath
-from typing import IO, AsyncIterator, List, Literal, Optional, Union, overload
+from typing import IO, AsyncIterator, List, Optional, Union
 
 from grpclib import GRPCError, Status
 
@@ -173,18 +174,7 @@ class _Volume(_Object, type_prefix="vo"):
         """
         return [entry async for entry in self.iterdir(path)]
 
-    @overload
-    async def read_file(self, path: Union[str, bytes], output: Literal[None] = ...) -> AsyncIterator[bytes]:
-        ...
-
-    @overload
-    async def read_file(self, path: Union[str, bytes], output: IO[bytes]) -> None:
-        ...
-
-    @live_method_gen
-    async def read_file(
-        self, path: Union[str, bytes], output: Optional[IO[bytes]] = None
-    ) -> Union[AsyncIterator[bytes], None]:
+    async def read_file(self, path: Union[str, bytes]) -> Union[AsyncIterator[bytes], None]:
         """
         Read a file from the modal.Volume.
 
@@ -207,9 +197,59 @@ class _Volume(_Object, type_prefix="vo"):
             raise FileNotFoundError(exc.message) if exc.status == Status.NOT_FOUND else exc
         if response.WhichOneof("data_oneof") == "data":
             yield response.data
+            return
         else:
             async for data in blob_iter(response.data_blob_id, self._client.stub):
                 yield data
+
+    @live_method
+    async def read_file_into_fileobj(self, path: Union[str, bytes], fileobj: IO[bytes], progress: bool = False) -> int:
+        """mdmd:hidden
+
+        Read volume file into file-like IO object, with support for progress display.
+        Used by modal CLI. In future will replace current generator implementation of `read_file` method.
+        """
+        if isinstance(path, str):
+            path = path.encode("utf-8")
+
+        if progress:
+            from ._output import download_progress_bar
+
+            progress_bar = download_progress_bar()
+            task_id = progress_bar.add_task("download", path=path.decode(), start=False)
+            progress_bar.console.log(f"Requesting {path.decode()}")
+        else:
+            progress_bar = nullcontext()
+            task_id = None
+
+        req = api_pb2.VolumeGetFileRequest(volume_id=self.object_id, path=path)
+        try:
+            response = await retry_transient_errors(self._client.stub.VolumeGetFile, req)
+        except GRPCError as exc:
+            raise FileNotFoundError(exc.message) if exc.status == Status.NOT_FOUND else exc
+        if response.WhichOneof("data_oneof") == "data":
+            n = fileobj.write(response.data)
+            if n != len(response.data):
+                raise IOError(f"failed to write {len(response.data)} bytes to output. Wrote {n}.")
+            return len(response.data)
+
+        written = 0
+        if progress:
+            progress_bar.update(task_id, total=int(response.size))
+            progress_bar.start_task(task_id)
+        with progress_bar:
+            async for data in blob_iter(response.data_blob_id, self._client.stub):
+                n = fileobj.write(data)
+                if n != len(data):
+                    raise IOError(f"failed to write {len(data)} bytes to output. Wrote {n}.")
+                written += n
+                if progress:
+                    progress_bar.update(task_id, advance=n)
+            if written != response.size:
+                raise IOError(f"truncated read. expected to read {response.size} total but only read {written}")
+            if progress:
+                progress_bar.console.log(f"Wrote {written} bytes to '{path.decode()}'")
+        return written
 
     @live_method
     async def remove_file(self, path: Union[str, bytes], recursive: bool = False) -> None:

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2023
 import asyncio
 import time
+from contextlib import nullcontext
 from pathlib import Path, PurePosixPath
 from typing import IO, AsyncIterator, List, Optional, Union
 
@@ -202,9 +203,7 @@ class _Volume(_Object, type_prefix="vo"):
                 yield data
 
     @live_method
-    async def read_file_into_fileobj(
-        self, path: Union[str, bytes], fileobj: IO[bytes], progress: bool = False, output_mgr=None
-    ) -> int:
+    async def read_file_into_fileobj(self, path: Union[str, bytes], fileobj: IO[bytes], progress: bool = False) -> int:
         """mdmd:hidden
 
         Read volume file into file-like IO object, with support for progress display.
@@ -213,16 +212,15 @@ class _Volume(_Object, type_prefix="vo"):
         if isinstance(path, str):
             path = path.encode("utf-8")
 
-        output_mgr.file_download_progress.console.log("Foo bar")
-        # if progress:
-        #     from ._output import download_progress_bar
+        if progress:
+            from ._output import download_progress_bar
 
-        #     progress_bar = download_progress_bar()
-        #     task_id = progress_bar.add_task("download", path=path.decode(), start=False)
-        #     progress_bar.console.log(f"Requesting {path.decode()}")
-        # else:
-        #     progress_bar = nullcontext()
-        #     task_id = None
+            progress_bar = download_progress_bar()
+            task_id = progress_bar.add_task("download", path=path.decode(), start=False)
+            progress_bar.console.log(f"Requesting {path.decode()}")
+        else:
+            progress_bar = nullcontext()
+            task_id = None
 
         req = api_pb2.VolumeGetFileRequest(volume_id=self.object_id, path=path)
         try:
@@ -237,24 +235,20 @@ class _Volume(_Object, type_prefix="vo"):
 
         written = 0
         if progress:
-            # progress_bar.update(task_id, total=int(response.size))
-            # progress_bar.start_task(task_id)
-            output_mgr.update_file_download_progress(path, advance=0, total=response.size)
-        # with progress_bar:
-        async for data in blob_iter(response.data_blob_id, self._client.stub):
-            n = fileobj.write(data)
-            if n != len(data):
-                raise IOError(f"failed to write {len(data)} bytes to output. Wrote {n}.")
-            written += n
+            progress_bar.update(task_id, total=int(response.size))
+            progress_bar.start_task(task_id)
+        with progress_bar:
+            async for data in blob_iter(response.data_blob_id, self._client.stub):
+                n = fileobj.write(data)
+                if n != len(data):
+                    raise IOError(f"failed to write {len(data)} bytes to output. Wrote {n}.")
+                written += n
+                if progress:
+                    progress_bar.update(task_id, advance=n)
+            if written != response.size:
+                raise IOError(f"truncated read. expected to read {response.size} total but only read {written}")
             if progress:
-                # progress_bar.update(task_id, advance=n)
-                output_mgr.update_file_download_progress(path, advance=n)
-        if written != response.size:
-            raise IOError(f"truncated read. expected to read {response.size} total but only read {written}")
-        if progress:
-            ...
-            # progress_bar.console.log(f"Wrote {written} bytes to '{path.decode()}'")
-            output_mgr.file_download_progress.console.log(f"Wrote {written} bytes to '{path.decode()}'")
+                progress_bar.console.log(f"Wrote {written} bytes to '{path.decode()}'")
         return written
 
     @live_method

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -2,7 +2,7 @@
 import asyncio
 import time
 from pathlib import Path, PurePosixPath
-from typing import AsyncIterator, List, Optional, Union
+from typing import IO, AsyncIterator, List, Literal, Optional, Union, overload
 
 from grpclib import GRPCError, Status
 
@@ -173,8 +173,18 @@ class _Volume(_Object, type_prefix="vo"):
         """
         return [entry async for entry in self.iterdir(path)]
 
+    @overload
+    async def read_file(self, path: Union[str, bytes], output: Literal[None] = ...) -> AsyncIterator[bytes]:
+        ...
+
+    @overload
+    async def read_file(self, path: Union[str, bytes], output: IO[bytes]) -> None:
+        ...
+
     @live_method_gen
-    async def read_file(self, path: Union[str, bytes]) -> AsyncIterator[bytes]:
+    async def read_file(
+        self, path: Union[str, bytes], output: Optional[IO[bytes]] = None
+    ) -> Union[AsyncIterator[bytes], None]:
         """
         Read a file from the modal.Volume.
 

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -1,4 +1,5 @@
 # Copyright Modal Labs 2023
+import io
 import pytest
 from unittest import mock
 
@@ -78,6 +79,10 @@ async def test_volume_get(servicer, client, tmp_path):
     for chunk in vol.read_file(file_path):
         data += chunk
     assert data == file_contents
+
+    output = io.BytesIO()
+    vol.read_file_into_fileobj(file_path, output)
+    assert output.getvalue() == file_contents
 
     with pytest.raises(FileNotFoundError):
         for _ in vol.read_file("/abc/def/i-dont-exist-at-all"):


### PR DESCRIPTION
### Describe your changes

- MOD-1731

Initially started off an evolution of the `read_file` method to support returning either and async iterator or just writing into an IO object. But this doesn't work because this function is a generator and can only be called as a generator.

So this change add a new fn, `read_file_into_fileobj`, initially used in the CLI to handle writing to disk and displaying download progress. Not having download progress visible is really not good when attempting to `get` 50+ GB. 

<kbd>
<img width="1501" alt="image" src="https://github.com/modal-labs/modal-client/assets/12058921/3cd96b37-f0aa-4080-825d-35f7df22bb4e">
</kbd>

### Backward/forward compatibility checks

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.
