### PR TITLE
Expand width of DataChunk index to 64-bit

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -52,7 +52,7 @@ message DataChunk {
     bytes data = 2;
     string data_blob_id = 3;
   }
-  uint32 index = 4; // Index of this data chunk in the stream.
+  uint64 index = 4; // Index of this data chunk in the stream.
 }
 
 message FunctionCallPutDataRequest {


### PR DESCRIPTION
This is just a precaution since u32s might be exhaustible in rare situations.

uint64 is wire-compatible with uint32