### PR TITLE
Track objects based on id

### DIFF
--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -312,7 +312,7 @@ def get_referred_objects(f: Callable) -> List[Object]:
 
     ret: List[Object] = []
     obj_queue: deque[Callable] = deque([f])
-    objs_seen: Set[Callable] = set([f])
+    objs_seen: Set[int] = set([id(f)])
     while obj_queue:
         obj = obj_queue.popleft()
         if isinstance(obj, (Function, Cls)):
@@ -322,8 +322,8 @@ def get_referred_objects(f: Callable) -> List[Object]:
             ret.append(obj)
         elif inspect.isfunction(obj):
             for dep_obj in inspect.getclosurevars(obj).globals.values():
-                if dep_obj not in objs_seen:
-                    objs_seen.add(dep_obj)
+                if id(dep_obj) not in objs_seen:
+                    objs_seen.add(id(dep_obj))
                     obj_queue.append(dep_obj)
 
     return ret

--- a/test/function_utils_test.py
+++ b/test/function_utils_test.py
@@ -35,3 +35,15 @@ def recursive():
 
 def test_recursive():
     get_referred_objects(recursive)
+
+
+l = [q1, q2]
+
+
+def refers_list():
+    return len(l)
+
+
+def test_refers_list():
+    objs: List[Object] = get_referred_objects(refers_list)
+    assert objs == []  # This may return [q1, q2] in the future


### PR DESCRIPTION
Fixes this error: 

```
            elif inspect.isfunction(obj):
                for dep_obj in inspect.getclosurevars(obj).globals.values():
>                   if dep_obj not in objs_seen:
E                   TypeError: unhashable type: 'list'
```

This happens any time closurevars refers to any unhashable type. Tracking these dependencies using ids instead.