### PR TITLE
Adds `AppState` to checkpoint info

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -758,6 +758,7 @@ message Function {
   message CheckpointInfo {
     string checksum = 1;
     CheckpointStatus status = 2;
+    AppState app_state = 3;
   }
   CheckpointInfo checkpoint = 42;
   repeated ObjectDependency object_dependencies = 43;


### PR DESCRIPTION
Allows for different system components to determine if a checkpoint should be created based on app state.
