### PR TITLE
Deprecate gpu=True

### DIFF
--- a/modal/gpu.py
+++ b/modal/gpu.py
@@ -5,7 +5,7 @@ from typing import Optional, Union
 
 from modal_proto import api_pb2
 
-from .exception import InvalidError, deprecation_error
+from .exception import InvalidError, deprecation_error, deprecation_warning
 
 
 @dataclass
@@ -175,6 +175,11 @@ def _parse_gpu_config(value: GPU_T, raise_on_true: bool = True) -> Optional[_GPU
         if raise_on_true:
             deprecation_error(
                 date(2022, 12, 19), 'Setting gpu=True is deprecated. Use `gpu="any"` or `gpu=modal.gpu.Any()` instead.'
+            )
+        else:
+            # We didn't support targeting a GPU type for run_function until 2023-12-12
+            deprecation_warning(
+                date(2023, 12, 13), 'Setting gpu=True is deprecated. Use `gpu="any"` or `gpu=modal.gpu.Any()` instead.'
             )
         return Any()
     elif value is None or value is False:

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -8,7 +8,7 @@ from typing import List
 from unittest import mock
 
 from modal import Image, Mount, NetworkFileSystem, Secret, Stub, gpu, method
-from modal.exception import InvalidError, NotFoundError
+from modal.exception import DeprecationError, InvalidError, NotFoundError
 from modal.image import _dockerhub_python_version
 from modal_proto import api_pb2
 
@@ -426,9 +426,8 @@ def test_image_gpu(client, servicer):
         layers = get_image_layers(stub["image"].object_id, servicer)
         assert layers[0].gpu_config.type == api_pb2.GPU_TYPE_UNSPECIFIED
 
-    # TODO(erikbern): reenable this warning when we actually support different GPU types
-    # with pytest.warns(DeprecationError):
-    stub = Stub(image=Image.debian_slim().run_commands("echo 1", gpu=True))
+    with pytest.warns(DeprecationError):
+        stub = Stub(image=Image.debian_slim().run_commands("echo 1", gpu=True))
     with stub.run(client=client):
         layers = get_image_layers(stub["image"].object_id, servicer)
         assert layers[0].gpu_config.type == api_pb2.GPU_TYPE_ANY


### PR DESCRIPTION
We stopped supporting `gpu=True` for functions a long time ago, but we've been supporting it for `run_function` since we didn't have the ability to target a gpu anyway.

Now we have, so let's turn it into a deprecation warning. In a few months we can remove support for it altogether.

Note that we still support `gpu="any"` so we'll just tell people to change to that if they don't care about the GPU type.