### PR TITLE
blueprint -> indexed_objects

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -62,7 +62,7 @@ class _LocalApp:
 
     async def _create_all_objects(
         self,
-        blueprint: Dict[str, _Object],
+        indexed_objects: Dict[str, _Object],
         new_app_state: int,
         environment_name: str,
         shell: bool = False,
@@ -82,7 +82,7 @@ class _LocalApp:
             self._tag_to_object_id = {}
 
             # Assign all objects
-            for tag, obj in blueprint.items():
+            for tag, obj in indexed_objects.items():
                 # Reset object_id in case the app runs twice
                 # TODO(erikbern): clean up the interface
                 obj._unhydrate()
@@ -92,7 +92,7 @@ class _LocalApp:
             # functions have ids assigned to them when the function is serialized.
             # Note: when handles/objs are merged, all objects will need to get ids pre-assigned
             # like this in order to be referrable within serialized functions
-            for tag, obj in blueprint.items():
+            for tag, obj in indexed_objects.items():
                 existing_object_id = tag_to_object_id.get(tag)
                 # Note: preload only currently implemented for Functions, returns None otherwise
                 # this is to ensure that directly referenced functions from the global scope has
@@ -101,7 +101,7 @@ class _LocalApp:
                 if obj.object_id is not None:
                     tag_to_object_id[tag] = obj.object_id
 
-            for tag, obj in blueprint.items():
+            for tag, obj in indexed_objects.items():
                 existing_object_id = tag_to_object_id.get(tag)
                 await resolver.load(obj, existing_object_id)
                 self._tag_to_object_id[tag] = obj.object_id

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -92,7 +92,7 @@ async def _run_stub(
         try:
             # Create all members
             await app._create_all_objects(
-                stub._blueprint, app_state, environment_name, shell=shell, output_mgr=output_mgr
+                stub._indexed_objects, app_state, environment_name, shell=shell, output_mgr=output_mgr
             )
 
             # Update all functions client-side to have the output mgr
@@ -171,7 +171,7 @@ async def _serve_update(
         # Create objects
         output_mgr = OutputManager(None, True)
         await app._create_all_objects(
-            stub._blueprint, api_pb2.APP_STATE_UNSPECIFIED, environment_name, output_mgr=output_mgr
+            stub._indexed_objects, api_pb2.APP_STATE_UNSPECIFIED, environment_name, output_mgr=output_mgr
         )
 
         # Communicate to the parent process
@@ -253,7 +253,7 @@ async def _deploy_stub(
         try:
             # Create all members
             await app._create_all_objects(
-                stub._blueprint, post_init_state, environment_name=environment_name, output_mgr=output_mgr
+                stub._indexed_objects, post_init_state, environment_name=environment_name, output_mgr=output_mgr
             )
 
             # Deploy app


### PR DESCRIPTION
This just unifies the terminology between the server and the client (and the RPC) by referring to these objects as "indexed_objects" consistently.

Zero behavioral change.

Will start to clean up crap on the stub class next.