### PR TITLE
[Feature] add blocking modal.Queue.put to handle full queues

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -143,6 +143,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.sandbox: subprocess.Popen = None
 
         self.token_flow_localhost_port = None
+        self.queue_max_len = 1_00
 
         @self.function_body
         def default_function_body(*args, **kwargs):
@@ -665,6 +666,8 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def QueuePut(self, stream):
         request: api_pb2.QueuePutRequest = await stream.recv_message()
+        if len(self.queue) >= self.queue_max_len:
+            raise GRPCError(Status.RESOURCE_EXHAUSTED, f"Hit servicer's max len for Queues: {self.queue_max_len}")
         self.queue += request.values
         await stream.send_message(Empty())
 

--- a/test/queue_test.py
+++ b/test/queue_test.py
@@ -5,6 +5,8 @@ import time
 
 from modal import Queue, Stub
 
+from .supports.skip import skip_windows
+
 
 def test_queue(servicer, client):
     stub = Stub()
@@ -20,6 +22,7 @@ def test_queue(servicer, client):
         assert stub.q.len() == 0
 
 
+@skip_windows("TODO(Jonathon): figure out why timeouts don't occur on Windows.")
 @pytest.mark.parametrize(
     ["put_timeout_secs", "min_queue_full_exc_count", "max_queue_full_exc_count"],
     [

--- a/test/queue_test.py
+++ b/test/queue_test.py
@@ -1,8 +1,11 @@
 # Copyright Modal Labs 2022
 import pytest
 import queue
+import time
 
 from modal import Queue, Stub
+
+from .supports.skip import skip_windows
 
 
 def test_queue(servicer, client):
@@ -17,3 +20,72 @@ def test_queue(servicer, client):
         with pytest.raises(queue.Empty):
             stub.q.get(timeout=0)
         assert stub.q.len() == 0
+
+
+@skip_windows("TODO(Jonathon): figure out why timeouts don't occur on Windows.")
+@pytest.mark.parametrize(
+    ["put_timeout_secs", "min_queue_full_exc_count", "max_queue_full_exc_count"],
+    [
+        (0.02, 1, 100),  # a low timeout causes some exceptions
+        (10.0, 0, 0),  # a high timeout causes zero exceptions
+        (0.00, 1, 100),  # zero-len timeout causes some exceptions
+        (None, 0, 0),  # no timeout causes zero exceptions
+    ],
+)
+def test_queue_blocking_put(put_timeout_secs, min_queue_full_exc_count, max_queue_full_exc_count, servicer, client):
+    import queue
+    import threading
+
+    stub = Stub()
+    stub.q = Queue.new()
+    producer_delay = 0.001
+    consumer_delay = producer_delay * 5
+
+    queue_full_exceptions = 0
+    with stub.run(client=client):
+
+        def producer():
+            nonlocal queue_full_exceptions
+            for i in range(servicer.queue_max_len * 2):
+                item = f"Item {i}"
+                try:
+                    stub.q.put(item, block=True, timeout=put_timeout_secs)  # type: ignore
+                except queue.Full:
+                    queue_full_exceptions += 1
+                time.sleep(producer_delay)
+
+        def consumer():
+            while True:
+                time.sleep(consumer_delay)
+                item = stub.q.get(block=True)  # type: ignore
+                if item is None:
+                    break  # Exit if a None item is received
+
+        producer_thread = threading.Thread(target=producer)
+        consumer_thread = threading.Thread(target=consumer)
+        producer_thread.start()
+        consumer_thread.start()
+        producer_thread.join()
+        # Stop the consumer by sending a None item
+        stub.q.put(None)  # type: ignore
+        consumer_thread.join()
+
+        assert queue_full_exceptions >= min_queue_full_exc_count
+        assert queue_full_exceptions <= max_queue_full_exc_count
+
+
+def test_queue_nonblocking_put(
+    servicer,
+    client,
+):
+    stub = Stub()
+    stub.q = Queue.new()
+
+    with stub.run(client=client):
+        # Non-blocking PUTs don't tolerate a full queue and will raise exception.
+        with pytest.raises(queue.Full) as excinfo:
+            for i in range(servicer.queue_max_len + 1):
+                stub.q.put(i, block=False)  # type: ignore
+
+    assert str(servicer.queue_max_len) in str(excinfo.value)
+    assert i == servicer.queue_max_len

--- a/test/queue_test.py
+++ b/test/queue_test.py
@@ -5,8 +5,6 @@ import time
 
 from modal import Queue, Stub
 
-from .supports.skip import skip_windows
-
 
 def test_queue(servicer, client):
     stub = Stub()
@@ -22,7 +20,6 @@ def test_queue(servicer, client):
         assert stub.q.len() == 0
 
 
-@skip_windows("TODO(Jonathon): figure out why timeouts don't occur on Windows.")
 @pytest.mark.parametrize(
     ["put_timeout_secs", "min_queue_full_exc_count", "max_queue_full_exc_count"],
     [


### PR DESCRIPTION
- [ ] **TODO:** ~find out why the tests are failing on MacOS and Windows~

### Describe your changes

This functionality became a lot more relevant when we introduced `modal.Queue` size limits.

**Issues in this change:**

1. `RESOURCE_EXHAUSTED` may in future be an overloaded GRPC status for this RPC.
2. Returning `queue.Full` instead of `GRPCError` exception is a breaking change, unfortunately. 

### Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] ~Client+Server: this change is compatible with old servers~
- [ ] _Client forward compatibility: this change ensures client can accept data intended for later versions of itself_ ⚠️ see above, if in future this client gets `RESOURCE_EXHAUSTED` for a reason other than queue size..
