### PR TITLE
[MOD-1980] Add skip_reload flag to VolumeCommit RPC response

### DIFF
--- a/modal/volume.py
+++ b/modal/volume.py
@@ -136,9 +136,10 @@ class _Volume(_Object, type_prefix="vo"):
             req = api_pb2.VolumeCommitRequest(volume_id=self.object_id)
             try:
                 # TODO(gongy): only apply indefinite retries on 504 status.
-                _ = await retry_transient_errors(self._client.stub.VolumeCommit, req, max_retries=90)
-                # Reload changes on successful commit.
-                await self._do_reload(lock=False)
+                resp = await retry_transient_errors(self._client.stub.VolumeCommit, req, max_retries=90)
+                if not resp.omit_reload:
+                    # Reload changes on successful commit.
+                    await self._do_reload(lock=False)
             except GRPCError as exc:
                 raise RuntimeError(exc.message) if exc.status in (Status.FAILED_PRECONDITION, Status.NOT_FOUND) else exc
 

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -137,7 +137,7 @@ class _Volume(_Object, type_prefix="vo"):
             try:
                 # TODO(gongy): only apply indefinite retries on 504 status.
                 resp = await retry_transient_errors(self._client.stub.VolumeCommit, req, max_retries=90)
-                if not resp.omit_reload:
+                if not resp.skip_reload:
                     # Reload changes on successful commit.
                     await self._do_reload(lock=False)
             except GRPCError as exc:

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -126,7 +126,7 @@ class _Volume(_Object, type_prefix="vo"):
     async def commit(self):
         """Commit changes to the volume and fetch any other changes made to the volume by other containers.
 
-        Committing always triggers a reload after saving changes.
+        Unless background commits are enabled, committing always triggers a reload after saving changes.
 
         If successful, the changes made are now persisted in durable storage and available to other containers accessing the volume.
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1509,7 +1509,7 @@ message VolumeCommitRequest {
 }
 
 message VolumeCommitResponse {
-  bool omit_reload = 1;
+  bool skip_reload = 1;
 }
 
 message VolumeGetFileRequest {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1508,6 +1508,10 @@ message VolumeCommitRequest {
   string volume_id = 1 [ (modal.options.audit_target_attr) = true ];
 }
 
+message VolumeCommitResponse {
+  bool omit_reload = 1;
+}
+
 message VolumeGetFileRequest {
   string volume_id = 1;
   bytes path = 2;
@@ -1723,7 +1727,7 @@ service ModalClient {
 
   // Volumes
   rpc VolumeCreate(VolumeCreateRequest) returns (VolumeCreateResponse);
-  rpc VolumeCommit(VolumeCommitRequest) returns (google.protobuf.Empty);
+  rpc VolumeCommit(VolumeCommitRequest) returns (VolumeCommitResponse);
   rpc VolumeGetFile(VolumeGetFileRequest) returns (VolumeGetFileResponse);
   rpc VolumeList(VolumeListRequest) returns (VolumeListResponse);
   rpc VolumeListFiles(VolumeListFilesRequest) returns (stream VolumeListFilesResponse);

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -803,7 +803,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         if not req.volume_id.startswith("vo-"):
             raise GRPCError(Status.NOT_FOUND, f"invalid volume ID {req.volume_id}")
         self.volume_commits[req.volume_id] += 1
-        await stream.send_message(Empty())
+        await stream.send_message(api_pb2.VolumeCommitResponse(omit_reload=False))
 
     async def VolumeReload(self, stream):
         req = await stream.recv_message()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -803,7 +803,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         if not req.volume_id.startswith("vo-"):
             raise GRPCError(Status.NOT_FOUND, f"invalid volume ID {req.volume_id}")
         self.volume_commits[req.volume_id] += 1
-        await stream.send_message(api_pb2.VolumeCommitResponse(omit_reload=False))
+        await stream.send_message(api_pb2.VolumeCommitResponse(skip_reload=False))
 
     async def VolumeReload(self, stream):
         req = await stream.recv_message()

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -45,14 +45,14 @@ def test_volume_duplicate_mount():
         stub.function(volumes={"/foo": volume, "/bar": volume})(dummy)
 
 
-@pytest.mark.parametrize("omit_reload", [False, True])
-def test_volume_commit(client, servicer, omit_reload):
+@pytest.mark.parametrize("skip_reload", [False, True])
+def test_volume_commit(client, servicer, skip_reload):
     stub = modal.Stub()
     stub.vol = modal.Volume.new()
 
     with servicer.intercept() as ctx:
-        ctx.add_response("VolumeCommit", api_pb2.VolumeCommitResponse(omit_reload=omit_reload))
-        ctx.add_response("VolumeCommit", api_pb2.VolumeCommitResponse(omit_reload=omit_reload))
+        ctx.add_response("VolumeCommit", api_pb2.VolumeCommitResponse(skip_reload=skip_reload))
+        ctx.add_response("VolumeCommit", api_pb2.VolumeCommitResponse(skip_reload=skip_reload))
 
         with stub.run(client=client):
             # Note that in practice this will not work unless run in a task.
@@ -64,8 +64,8 @@ def test_volume_commit(client, servicer, omit_reload):
             assert ctx.pop_request("VolumeCommit").volume_id == stub.vol.object_id
             assert ctx.pop_request("VolumeCommit").volume_id == stub.vol.object_id
 
-            # commit should implicitly reload on successful commit if omit_reload=False
-            assert servicer.volume_reloads[stub.vol.object_id] == 0 if omit_reload else 2
+            # commit should implicitly reload on successful commit if skip_reload=False
+            assert servicer.volume_reloads[stub.vol.object_id] == 0 if skip_reload else 2
 
 
 @pytest.mark.asyncio

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -6,6 +6,7 @@ from unittest import mock
 import modal
 from modal.exception import InvalidError
 from modal.runner import deploy_stub
+from modal_proto import api_pb2
 
 
 def dummy():
@@ -44,20 +45,27 @@ def test_volume_duplicate_mount():
         stub.function(volumes={"/foo": volume, "/bar": volume})(dummy)
 
 
-def test_volume_commit(client, servicer):
+@pytest.mark.parametrize("omit_reload", [False, True])
+def test_volume_commit(client, servicer, omit_reload):
     stub = modal.Stub()
     stub.vol = modal.Volume.new()
 
-    with stub.run(client=client):
-        # Note that in practice this will not work unless run in a task.
-        stub.vol.commit()
+    with servicer.intercept() as ctx:
+        ctx.add_response("VolumeCommit", api_pb2.VolumeCommitResponse(omit_reload=omit_reload))
+        ctx.add_response("VolumeCommit", api_pb2.VolumeCommitResponse(omit_reload=omit_reload))
 
-        # Make sure we can commit through the provider too
-        stub.vol.commit()
+        with stub.run(client=client):
+            # Note that in practice this will not work unless run in a task.
+            stub.vol.commit()
 
-        assert servicer.volume_commits[stub.vol.object_id] == 2
-        # commit should implicitly reload on successful commit
-        assert servicer.volume_reloads[stub.vol.object_id] == 2
+            # Make sure we can commit through the provider too
+            stub.vol.commit()
+
+            assert ctx.pop_request("VolumeCommit").volume_id == stub.vol.object_id
+            assert ctx.pop_request("VolumeCommit").volume_id == stub.vol.object_id
+
+            # commit should implicitly reload on successful commit if omit_reload=False
+            assert servicer.volume_reloads[stub.vol.object_id] == 0 if omit_reload else 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Reloading on commit for volumes where background commits are enabled makes no sense. This allows us to avoid the reload-on-commit in those cases.

## Backward/forward compatibility checks

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
