### PR TITLE
Rename `run_inside` to `imports`

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -24,7 +24,7 @@ from ._resolver import Resolver
 from ._serialization import serialize
 from .app import is_local
 from .config import config, logger
-from .exception import InvalidError, NotFoundError, RemoteError, deprecation_error
+from .exception import InvalidError, NotFoundError, RemoteError, deprecation_error, deprecation_warning
 from .gpu import GPU_T, parse_gpu_config
 from .mount import _Mount, python_standalone_mount_name
 from .network_file_system import _NetworkFileSystem
@@ -1367,6 +1367,8 @@ class _Image(_Object, type_prefix="im"):
                 # Image is already initialized (we can remove this case later
                 # when we don't hydrate objects so early)
                 raise
+            if not isinstance(exc, ImportError):
+                warnings.warn(f"Warning: caught a non-ImportError exception in an `imports()` block: {repr(exc)}")
 
     def run_inside(self):
         """`Image.run_inside` is deprecated - use `Image.imports` instead.
@@ -1377,7 +1379,8 @@ class _Image(_Object, type_prefix="im"):
             import torch
         ```
         """
-        deprecation_error(date(2023, 12, 15), Image.run_inside.__doc__, pending=True)
+        deprecation_warning(date(2023, 12, 15), Image.run_inside.__doc__, pending=True)
+        return self.imports()
 
 
 Image = synchronize_api(_Image)

--- a/modal/image.py
+++ b/modal/image.py
@@ -1355,7 +1355,7 @@ class _Image(_Object, type_prefix="im"):
     # Live handle methods
 
     @contextlib.contextmanager
-    def run_inside(self):
+    def imports(self):
         env_image_id = config.get("image_id")
         try:
             yield
@@ -1367,6 +1367,17 @@ class _Image(_Object, type_prefix="im"):
                 # Image is already initialized (we can remove this case later
                 # when we don't hydrate objects so early)
                 raise
+
+    def run_inside(self):
+        """`Image.run_inside` is deprecated - use `Image.imports` instead.
+
+        Usage:
+        ```
+        with image.imports():
+            import torch
+        ```
+        """
+        deprecation_error(date(2023, 12, 15), Image.run_inside.__doc__, pending=True)
 
 
 Image = synchronize_api(_Image)

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -264,10 +264,10 @@ class _Stub:
 
     @typechecked
     def is_inside(self, image: Optional[_Image] = None):
-        """Deprecated: use `Image.run_inside()` instead! Usage:
+        """Deprecated: use `Image.imports()` instead! Usage:
         ```
         my_image = modal.Image.debian_slim().pip_install("torch")
-        with my_image.run_inside():
+        with my_image.imports():
             import torch
         ```
         """

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -516,11 +516,11 @@ def test_inside_ctx_unhydrated(client):
 
     with mock.patch.dict(os.environ, {"MODAL_IMAGE_ID": "im-123"}):
         # This should initially swallow the exception
-        with image_1.run_inside():
+        with image_1.imports():
             raise Exception("foo")
 
         # This one too
-        with image_2.run_inside():
+        with image_2.imports():
             raise Exception("bar")
 
         # Hydration of the image should raise the exception
@@ -542,9 +542,9 @@ def test_inside_ctx_hydrated(client):
 
         # Ctx manager should now raise right away
         with pytest.raises(Exception, match="baz"):
-            with image_1.run_inside():
+            with image_1.imports():
                 raise Exception("baz")
 
         # We're not inside this image so this should be swallowed
-        with image_2.run_inside():
+        with image_2.imports():
             raise Exception("bar")

--- a/test/queue_test.py
+++ b/test/queue_test.py
@@ -5,7 +5,7 @@ import time
 
 from modal import Queue, Stub
 
-from .supports.skip import skip_windows
+from .supports.skip import skip_macos, skip_windows
 
 
 def test_queue(servicer, client):
@@ -22,6 +22,7 @@ def test_queue(servicer, client):
         assert stub.q.len() == 0
 
 
+@skip_macos("TODO(erikbern): this consistently fails on OSX. Unclear why.")
 @skip_windows("TODO(Jonathon): figure out why timeouts don't occur on Windows.")
 @pytest.mark.parametrize(
     ["put_timeout_secs", "min_queue_full_exc_count", "max_queue_full_exc_count"],

--- a/test/stub_test.py
+++ b/test/stub_test.py
@@ -139,7 +139,7 @@ def test_run_function_without_app_error():
 
 def test_is_inside_basic():
     stub = Stub()
-    with pytest.raises(DeprecationError, match="run_inside"):
+    with pytest.raises(DeprecationError, match="imports()"):
         stub.is_inside()
 
 

--- a/test/supports/skip.py
+++ b/test/supports/skip.py
@@ -6,10 +6,11 @@ import sys
 
 
 def skip_windows(msg: str):
-    return pytest.mark.skipif(
-        platform.system() == "Windows",
-        reason=msg,
-    )
+    return pytest.mark.skipif(platform.system() == "Windows", reason=msg)
+
+
+def skip_macos(msg: str):
+    return pytest.mark.skipif(platform.system() == "Darwin", reason=msg)
 
 
 skip_windows_unix_socket = skip_windows("Windows doesn't have UNIX sockets")


### PR DESCRIPTION
The reason we make this change is that it's confusing with behavior like this:

```python
with image.run_inside():
    print("hello")  # this will be printed regardless!
```

Renaming it `imports()` makes it harder to mis-use the function and run into unexpected behavior.

This adds a _pending_ deprecation warning for any usage of `run_inside` since I want to clean up all uses of `run_inside` from integration tests and examples first. After that's done, I'll go back and remove `pending=True`

As a part of the rename, I also made a minor change so that there's a warning if the block triggers any non-`ImportError` exception. We still swallow it, but I think it's helpful to warn. We probably don't want to re-raise it since sometimes import problem manifest themselves as non-`ImportError` exceptions – I have encountered that in third party libraries.