### PR TITLE
Returns default value when using `Modal.Dict.get()`

### DIFF
--- a/modal/dict.py
+++ b/modal/dict.py
@@ -143,8 +143,9 @@ class _Dict(_Object, type_prefix="di"):
 
         This function only works in a synchronous context.
         """
-        value = await self.get(key)
-        if value is None:
+        NOT_FOUND = object()
+        value = await self.get(key, NOT_FOUND)
+        if value is NOT_FOUND:
             raise KeyError(f"KeyError: {key} not in dict {self.object_id}")
 
         return value

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -115,7 +115,7 @@ class _Dict(_Object, type_prefix="di"):
     async def get(self, key: Any, default: Optional[Any] = None) -> Any:
         """Get the value associated with a key.
 
-        Returns `default` if key does not exist. 
+        Returns `default` if key does not exist.
         """
         req = api_pb2.DictGetRequest(dict_id=self.object_id, key=serialize(key))
         resp = await retry_transient_errors(self._client.stub.DictGet, req)

--- a/test/dict_test.py
+++ b/test/dict_test.py
@@ -19,3 +19,5 @@ def test_dict(servicer, client):
             _ = stub.d["foo"]
 
         assert stub.d.get("foo", default=True)
+        stub.d["foo"] = None
+        assert stub.d["foo"] is None

--- a/test/dict_test.py
+++ b/test/dict_test.py
@@ -17,3 +17,5 @@ def test_dict(servicer, client):
         assert stub.d.len() == 0
         with pytest.raises(KeyError):
             _ = stub.d["foo"]
+
+        assert stub.d.get("foo", default=True)


### PR DESCRIPTION
Mimics the behavior of Python's [**dict**](https://docs.python.org/3/library/stdtypes.html?highlight=dict#dict.get). 

> Return the value for key if key is in the dictionary, else default. If default is not given, it defaults to None, so that this method never raises a [KeyError](https://docs.python.org/3/library/exceptions.html#KeyError).