### PR TITLE
Adds `checkpoint_id` to `CheckpointInfo`

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -682,6 +682,7 @@ message ObjectDependency {
 message CheckpointInfo {
   string checksum = 1;
   CheckpointStatus status = 2;
+  checkpoint_id string = 3;
 }
 
 message Function {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -682,7 +682,7 @@ message ObjectDependency {
 message CheckpointInfo {
   string checksum = 1;
   CheckpointStatus status = 2;
-  checkpoint_id string = 3;
+  string checkpoint_id = 3;
 }
 
 message Function {


### PR DESCRIPTION
Allows for keeping a consistent reference throughput execution lifecycle. 