### PR TITLE
Remove task-cancellation log spam already cancelled

### DIFF
--- a/modal_utils/async_utils.py
+++ b/modal_utils/async_utils.py
@@ -3,6 +3,7 @@ import asyncio
 import concurrent.futures
 import functools
 import inspect
+import sys
 import time
 import typing
 from contextlib import asynccontextmanager
@@ -142,7 +143,13 @@ class TaskContext:
                 if task.done() or task in self._loops:
                     continue
 
-                logger.warning(f"Canceling remaining unfinished task {task}")
+                already_cancelling = False
+                if sys.version_info >= (3, 11):
+                    already_cancelling = task.cancelling() > 0
+
+                if not already_cancelling:
+                    logger.warning(f"Canceling remaining unfinished task: {task}")
+
                 task.cancel()
 
     async def __aexit__(self, exc_type, value, tb):

--- a/tasks.py
+++ b/tasks.py
@@ -13,6 +13,7 @@ import datetime
 import os
 import sys
 from pathlib import Path
+from typing import Optional
 
 from invoke import task
 
@@ -73,10 +74,10 @@ def check_copyright(ctx, fix=False):
 
 
 @task
-def update_build_number(ctx, new_build_number):
-    new_build_number = int(new_build_number)
+def update_build_number(ctx, new_build_number: Optional[int] = None):
     from modal_version import build_number as current_build_number
 
+    new_build_number = new_build_number or current_build_number + 1
     assert new_build_number > current_build_number
     with open("modal_version/_version_generated.py", "w") as f:
         f.write(


### PR DESCRIPTION
Noticing a lot of log spam of the following sort for ASGI apps, after upgrading modal-client.
```
  2023-12-20T19:43:01+0000 Canceling remaining unfinished task <Task
  cancelling name='Task-44'
  coro=<asgi_app_wrapper.<locals>.fn.<locals>.fetch_data_in() running at
  /pkg/modal/_asgi.py:30> wait_for=<Future pending
  cb=[Task.task_wakeup()]> cb=[set.discard()]>
```
This started happened 0b5f834 when we stopped using grace period in the surrounding task context. So we stopped running the unfinished (but marked-for-cancellation) tasks on the event loop when closing the TaskContext. These tasks were therefore not done(), and we logged the above. We can check for pending cancellations using the task object - so just do that before logging.