### PR TITLE
De-flake resolver test

### DIFF
--- a/test/resolver_test.py
+++ b/test/resolver_test.py
@@ -52,5 +52,5 @@ async def test_multi_resolve_concurrent_loads_once():
     obj = _DumbObject._from_loader(_load, "DumbObject()")
     t0 = time.monotonic()
     await asyncio.gather(resolver.load(obj), resolver.load(obj))
-    assert 0.08 < time.monotonic() - t0 < 0.15
+    assert 0.08 < time.monotonic() - t0 < 0.17
     assert load_count == 1


### PR DESCRIPTION
This tripped up in the macos CI suite, see [1].

[1]: https://github.com/modal-labs/modal-client/actions/runs/7304357946/job/19906410509?pr=1143