### PR TITLE
Revert "Remove task-cancellation log spam already cancelled (#1143)"

### DIFF
--- a/modal_utils/async_utils.py
+++ b/modal_utils/async_utils.py
@@ -3,7 +3,6 @@ import asyncio
 import concurrent.futures
 import functools
 import inspect
-import sys
 import time
 import typing
 from contextlib import asynccontextmanager
@@ -143,13 +142,7 @@ class TaskContext:
                 if task.done() or task in self._loops:
                     continue
 
-                already_cancelling = False
-                if sys.version_info >= (3, 11):
-                    already_cancelling = task.cancelling() > 0
-
-                if not already_cancelling:
-                    logger.warning(f"Canceling remaining unfinished task: {task}")
-
+                logger.warning(f"Canceling remaining unfinished task {task}")
                 task.cancel()
 
     async def __aexit__(self, exc_type, value, tb):

--- a/tasks.py
+++ b/tasks.py
@@ -13,7 +13,6 @@ import datetime
 import os
 import sys
 from pathlib import Path
-from typing import Optional
 
 from invoke import task
 
@@ -74,10 +73,10 @@ def check_copyright(ctx, fix=False):
 
 
 @task
-def update_build_number(ctx, new_build_number: Optional[int] = None):
+def update_build_number(ctx, new_build_number):
+    new_build_number = int(new_build_number)
     from modal_version import build_number as current_build_number
 
-    new_build_number = new_build_number or current_build_number + 1
     assert new_build_number > current_build_number
     with open("modal_version/_version_generated.py", "w") as f:
         f.write(


### PR DESCRIPTION
Reverting for now, since the change to `update_build_number` was preventing package deploys to PyPI.