### PR TITLE
Remove deprecated fields from AppGetObjectsItem and AppLookupObjectResponse

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -335,12 +335,6 @@ message AppGetObjectsRequest {
 
 message AppGetObjectsItem {
   string tag = 1;
-  string object_id = 2 [deprecated=true]; // needed by 0.51
-  oneof handle_metadata_oneof {
-    FunctionHandleMetadata function_handle_metadata = 3 [deprecated=true]; // needed by 0.51
-    MountHandleMetadata mount_handle_metadata = 4 [deprecated=true]; // needed by 0.51
-    ClassHandleMetadata class_handle_metadata = 5 [deprecated=true]; // needed by 0.51
-  }
   Object object = 6;
 }
 
@@ -378,13 +372,6 @@ message AppLookupObjectRequest {
 }
 
 message AppLookupObjectResponse {
-  string object_id = 1 [deprecated=true]; // needed by 0.51
-  string error_message = 2 [deprecated=true]; // needed by 0.55
-  oneof handle_metadata_oneof {
-    FunctionHandleMetadata function_handle_metadata = 3 [deprecated=true]; // needed by 0.51
-    MountHandleMetadata mount_handle_metadata = 4 [deprecated=true]; // needed by 0.51
-    ClassHandleMetadata class_handle_metadata = 5 [deprecated=true]; // needed by 0.51
-  }
   Object object = 6;
   string app_id = 7;
 }


### PR DESCRIPTION
About to remove them from the server