### PR TITLE
fix: restore volume.read_file liveness

### DIFF
--- a/modal/stub.py
+++ b/modal/stub.py
@@ -464,7 +464,7 @@ class _Stub:
         allow_concurrent_inputs: Optional[int] = None,  # Number of inputs the container may fetch to run concurrently.
         container_idle_timeout: Optional[int] = None,  # Timeout for idle containers waiting for inputs to shut down.
         timeout: Optional[int] = None,  # Maximum execution time of the function in seconds.
-        interactive: bool = False,  # Whether to run the function in interactive mode./
+        interactive: bool = False,  # Whether to run the function in interactive mode.
         keep_warm: Optional[
             int
         ] = None,  # An optional minimum number of containers to always keep warm (use concurrency_limit for maximum).

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -182,7 +182,8 @@ class _Volume(_Object, type_prefix="vo"):
         """
         return [entry async for entry in self.iterdir(path)]
 
-    async def read_file(self, path: Union[str, bytes]) -> Union[AsyncIterator[bytes], None]:
+    @live_method_gen
+    async def read_file(self, path: Union[str, bytes]) -> AsyncIterator[bytes]:
         """
         Read a file from the modal.Volume.
 


### PR DESCRIPTION
Erroneously removed in https://github.com/modal-labs/modal-client/pull/1118