### PR TITLE
Allow for None as a secret value

### DIFF
--- a/modal/secret.py
+++ b/modal/secret.py
@@ -31,7 +31,6 @@ class _Secret(_Object, type_prefix="st"):
         env_dict: Dict[
             str, Union[str, None]
         ] = {},  # dict of entries to be inserted as environment variables in functions using the secret
-        template_type="",  # internal use only
     ):
         """Create a secret from a str-str dictionary. Values can also be `None`, which is ignored.
 
@@ -55,7 +54,6 @@ class _Secret(_Object, type_prefix="st"):
             req = api_pb2.SecretCreateRequest(
                 app_id=resolver.app_id,
                 env_dict=env_dict_filtered,
-                template_type=template_type,
                 existing_secret_id=existing_object_id,
             )
             try:

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -33,7 +33,7 @@ class _Secret(_Object, type_prefix="st"):
         ] = {},  # dict of entries to be inserted as environment variables in functions using the secret
         template_type="",  # internal use only
     ):
-        """Create a secret from a str-str dictionary.
+        """Create a secret from a str-str dictionary. Values can also be `None`, which is ignored.
 
         Usage:
         ```python

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -1,6 +1,6 @@
 # Copyright Modal Labs 2022
 import os
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 from grpclib import GRPCError, Status
 
@@ -12,7 +12,7 @@ from ._resolver import Resolver
 from .exception import InvalidError
 from .object import _Object
 
-ENV_DICT_WRONG_TYPE_ERR = "the env_dict argument to Secret has to be a dict[str, str]"
+ENV_DICT_WRONG_TYPE_ERR = "the env_dict argument to Secret has to be a dict[str, Union[str, None]]"
 
 
 class _Secret(_Object, type_prefix="st"):
@@ -29,7 +29,7 @@ class _Secret(_Object, type_prefix="st"):
     @staticmethod
     def from_dict(
         env_dict: Dict[
-            str, str
+            str, Union[str, None]
         ] = {},  # dict of entries to be inserted as environment variables in functions using the secret
         template_type="",  # internal use only
     ):
@@ -42,15 +42,19 @@ class _Secret(_Object, type_prefix="st"):
             print(os.environ["FOO"])
         ```
         """
-        if not isinstance(env_dict, dict) or not all(
-            isinstance(k, str) and isinstance(v, str) for k, v in env_dict.items()
-        ):
+        if not isinstance(env_dict, dict):
+            raise InvalidError(ENV_DICT_WRONG_TYPE_ERR)
+
+        env_dict_filtered: dict[str, str] = {k: v for k, v in env_dict.items() if v is not None}
+        if not all(isinstance(k, str) for k in env_dict_filtered.keys()):
+            raise InvalidError(ENV_DICT_WRONG_TYPE_ERR)
+        if not all(isinstance(v, str) for v in env_dict_filtered.values()):
             raise InvalidError(ENV_DICT_WRONG_TYPE_ERR)
 
         async def _load(provider: _Secret, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.SecretCreateRequest(
                 app_id=resolver.app_id,
-                env_dict=env_dict,
+                env_dict=env_dict_filtered,
                 template_type=template_type,
                 existing_secret_id=existing_object_id,
             )

--- a/test/secret_test.py
+++ b/test/secret_test.py
@@ -11,10 +11,10 @@ from .supports.skip import skip_old_py
 
 def test_secret_from_dict(servicer, client):
     stub = Stub()
-    stub.secret = Secret.from_dict({"FOO": "hello, world", "BAR": None})
+    stub.secret = Secret.from_dict({"FOO": "hello, world"})
     with stub.run(client=client):
         assert stub.secret.object_id == "st-0"
-        assert servicer.secrets["st-0"].env_dict == {"FOO": "hello, world"}  # None is ignored
+        assert servicer.secrets["st-0"].env_dict == {"FOO": "hello, world"}
 
 
 @skip_old_py("python-dotenv requires python3.8 or higher", (3, 8))
@@ -32,3 +32,10 @@ def test_secret_from_dotenv(servicer, client):
 def test_init_types():
     with pytest.raises(InvalidError):
         Secret.from_dict({"foo": 1.0})  # type: ignore
+
+
+def test_secret_from_dict_none(servicer, client):
+    stub = Stub()
+    stub.secret = Secret.from_dict({"FOO": os.getenv("xyz"), "BAR": os.environ.get("abc"), "BAZ": "baz"})
+    with stub.run(client=client):
+        assert servicer.secrets["st-0"].env_dict == {"BAZ": "baz"}

--- a/test/secret_test.py
+++ b/test/secret_test.py
@@ -11,10 +11,10 @@ from .supports.skip import skip_old_py
 
 def test_secret_from_dict(servicer, client):
     stub = Stub()
-    stub.secret = Secret.from_dict({"FOO": "hello, world"})
+    stub.secret = Secret.from_dict({"FOO": "hello, world", "BAR": None})
     with stub.run(client=client):
         assert stub.secret.object_id == "st-0"
-        assert servicer.secrets["st-0"].env_dict == {"FOO": "hello, world"}
+        assert servicer.secrets["st-0"].env_dict == {"FOO": "hello, world"}  # None is ignored
 
 
 @skip_old_py("python-dotenv requires python3.8 or higher", (3, 8))
@@ -31,4 +31,4 @@ def test_secret_from_dotenv(servicer, client):
 
 def test_init_types():
     with pytest.raises(InvalidError):
-        Secret.from_dict({"foo": None})  # type: ignore
+        Secret.from_dict({"foo": 1.0})  # type: ignore


### PR DESCRIPTION
This is useful for defining things that may not be available in the container, e.g.

`my_secret = modal.Secret.from_dict({"FOO": os.getenv("xyz")})`

separately, we should probably add another constructor that copies local environment variables