### PR TITLE
Freeze dataclasses in public API

### DIFF
--- a/modal/_tunnel.py
+++ b/modal/_tunnel.py
@@ -14,7 +14,7 @@ from .client import _Client
 from .exception import InvalidError, RemoteError
 
 
-@dataclass
+@dataclass(frozen=True)
 class Tunnel:
     """A port forwarded from within a running Modal container. Created by `modal.forward()`.
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -485,7 +485,7 @@ async def _map_invocation(
 
 
 # Wrapper type for api_pb2.FunctionStats
-@dataclass
+@dataclass(frozen=True)
 class FunctionStats:
     """Simple data structure storing stats for a running function."""
 

--- a/modal/gpu.py
+++ b/modal/gpu.py
@@ -8,7 +8,7 @@ from modal_proto import api_pb2
 from .exception import InvalidError, deprecation_error, deprecation_warning
 
 
-@dataclass
+@dataclass(frozen=True)
 class _GPUConfig:
     type: "api_pb2.GPUType.V"
     count: int

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -181,8 +181,10 @@ async def _serve_update(
         pass
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class DeployResult:
+    """Dataclass representing the result of deploying an app."""
+
     app_id: str
 
 


### PR DESCRIPTION
This is to eliminate unexpected behavior in the client library. I'm also adding documentation to DeployResult.

<img width="640" alt="image" src="https://github.com/modal-labs/modal-client/assets/7550632/53687efb-4b1d-4bcf-a9a6-3fe2b8e8e5fb">
