### PR TITLE
Support entrypoint parameters annotated as optional

### DIFF
--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -126,7 +126,7 @@ def _get_click_command_for_function(stub: Stub, function_tag):
     if function.is_generator:
         raise InvalidError("`modal run` is not supported for generator functions")
 
-    signature: Dict[str, inspect.Parameter]
+    signature: Dict[str, ParameterMetadata]
     if function.info.cls is not None:
         cls_signature = _get_signature(function.info.cls)
         fun_signature = _get_signature(function.info.raw_f, is_method=True)

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -5,11 +5,12 @@ import inspect
 import re
 import sys
 import time
-from typing import Any, Callable, Dict, Optional, TypedDict, get_type_hints
+from typing import Any, Callable, Dict, Optional, get_type_hints
 
 import click
 import typer
 from rich.console import Console
+from typing_extensions import TypedDict
 
 from ..config import config
 from ..environments import ensure_env

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -59,6 +59,9 @@ def _get_param_type_as_str(annot: Any) -> str:
     m = re.match(r"typing.Optional\[([\w.]+)\]", annot_str)
     if m is not None:
         return m.group(1)
+    m = re.match(r"typing.Union\[([\w.]+), NoneType\]", annot_str)
+    if m is not None:
+        return m.group(1)
     m = re.match(r"([\w.]+) \| None", annot_str)
     if m is not None:
         return m.group(1)

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -3,6 +3,7 @@ import asyncio
 import datetime
 import functools
 import inspect
+import re
 import sys
 import time
 from typing import Any, Callable, Dict, Optional
@@ -65,10 +66,15 @@ def _add_click_options(func, signature: Dict[str, inspect.Parameter]):
     """
     for param in signature.values():
         param_type = Any if param.annotation is inspect.Signature.empty else param.annotation
+        param_is_optional = str(param_type).startswith("typing.Optional")
         param_name = param.name.replace("_", "-")
         cli_name = "--" + param_name
         if param_type in (bool, "bool"):
             cli_name += "/--no-" + param_name
+        if param_is_optional:
+            m = re.match(r"typing.Optional\[(\w+)\]", str(param_type))
+            if m is not None:
+                param_type = m.group(1)
         parser = option_parsers.get(param_type)
         if parser is None:
             raise NoParserAvailable(repr(param_type))

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -56,18 +56,16 @@ def _get_param_type_as_str(annot: Any) -> str:
     if annot is inspect.Signature.empty:
         return "Any"
     annot_str = str(annot)
-    m = re.match(r"typing.Optional\[([\w.]+)\]", annot_str)
-    if m is not None:
-        return m.group(1)
-    m = re.match(r"typing.Union\[([\w.]+), NoneType\]", annot_str)
-    if m is not None:
-        return m.group(1)
-    m = re.match(r"([\w.]+) \| None", annot_str)
-    if m is not None:
-        return m.group(1)
-    m = re.match(r"<class '([\w\.]+)'>", annot_str)
-    if m is not None:
-        return m.group(1)
+    annot_patterns = [
+        r"typing.Optional\[([\w.]+)\]",
+        r"typing.Union\[([\w.]+), NoneType\]",
+        r"([\w.]+) \| None",
+        r"<class '([\w\.]+)'>",
+    ]
+    for pat in annot_patterns:
+        m = re.match(pat, annot_str)
+        if m is not None:
+            return m.group(1)
     return annot_str
 
 

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -53,7 +53,13 @@ class NoParserAvailable(InvalidError):
 
 
 def _get_signature(f: Callable, is_method: bool = False) -> Dict[str, ParameterMetadata]:
-    type_hints = get_type_hints(f)
+    try:
+        type_hints = get_type_hints(f)
+    except Exception as exc:
+        # E.g., if entrypoint type hints cannot be evaluated by local Python runtime
+        msg = "Unable to generate command line interface for app entrypoint. See traceback above for details."
+        raise RuntimeError(msg) from exc
+
     if is_method:
         self = None  # Dummy, doesn't matter
         f = functools.partial(f, self)

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -5,7 +5,7 @@ import inspect
 import re
 import sys
 import time
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, Optional
 
 import click
 import typer
@@ -51,8 +51,8 @@ def _get_signature(f: Callable, is_method: bool = False) -> Dict[str, inspect.Pa
     return {param.name: param for param in inspect.signature(f).parameters.values()}
 
 
-def _get_param_type_as_str(annot: Any) -> Tuple[str, bool]:
-    """Return param type as a string, handling various spellings for optional types."""
+def _get_param_type_as_str(annot: Any) -> str:
+    """Return annotation as a string, handling various spellings for optional types."""
     if annot is inspect.Signature.empty:
         return "Any"
     annot_str = str(annot)

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -81,7 +81,8 @@ def _add_click_options(func, signature: Dict[str, inspect.Parameter]):
             cli_name += "/--no-" + param_name
         parser = option_parsers.get(param_type_str)
         if parser is None:
-            raise NoParserAvailable(repr(param.annotation))
+            msg = f"Parameter `{param_name}` has unparseable annotation: {param.annotation!r}"
+            raise NoParserAvailable(msg)
         kwargs: Any = {
             "type": parser,
         }

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -267,6 +267,10 @@ def test_run_parse_args_entrypoint(servicer, set_env_client, test_dir):
         res = _run(["run", f"{stub_file.as_posix()}::unparseable_annot", "--i=20"], expected_exit_code=1)
         assert "Parameter `i` has unparseable annotation: typing.Union[int, str]" in str(res.exception)
 
+    if sys.version_info <= (3, 10):
+        res = _run(["run", f"{stub_file.as_posix()}::optional_arg_pep604"], expected_exit_code=1)
+        assert "Unable to generate command line interface for app entrypoint." in str(res.exception)
+
 
 def test_run_parse_args_function(servicer, set_env_client, test_dir):
     stub_file = test_dir / "supports" / "app_run_tests" / "cli_args.py"

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -247,6 +247,8 @@ def test_run_parse_args_entrypoint(servicer, set_env_client, test_dir):
         (["run", f"{stub_file.as_posix()}::default_arg"], "10 <class 'int'>"),
         (["run", f"{stub_file.as_posix()}::unannotated_arg", "--i=2022-10-31"], "'2022-10-31' <class 'str'>"),
         (["run", f"{stub_file.as_posix()}::unannotated_default_arg"], "10 <class 'int'>"),
+        (["run", f"{stub_file.as_posix()}::optional_arg", "--i=20"], "20 <class 'int'>"),
+        (["run", f"{stub_file.as_posix()}::optional_arg"], "None <class 'NoneType'>"),
     ]
     for args, expected in valid_call_args:
         res = _run(args)

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -272,6 +272,7 @@ def test_run_parse_args_function(servicer, set_env_client, test_dir):
         (["run", f"{stub_file.as_posix()}::int_arg_fn", "--i=200"], "200 <class 'int'>"),
         (["run", f"{stub_file.as_posix()}::ALifecycle.some_method", "--i=hello"], "'hello' <class 'str'>"),
         (["run", f"{stub_file.as_posix()}::ALifecycle.some_method_int", "--i=42"], "42 <class 'int'>"),
+        (["run", f"{stub_file.as_posix()}::optional_arg_fn"], "None <class 'NoneType'>"),
     ]
     for args, expected in valid_call_args:
         res = _run(args)

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -250,9 +250,14 @@ def test_run_parse_args_entrypoint(servicer, set_env_client, test_dir):
         (["run", f"{stub_file.as_posix()}::optional_arg", "--i=20"], "20 <class 'int'>"),
         (["run", f"{stub_file.as_posix()}::optional_arg"], "None <class 'NoneType'>"),
         (["run", f"{stub_file.as_posix()}::optional_arg_postponed"], "None <class 'NoneType'>"),
-        (["run", f"{stub_file.as_posix()}::optional_arg_pep604", "--i=20"], "20 <class 'int'>"),
-        (["run", f"{stub_file.as_posix()}::optional_arg_pep604"], "None <class 'NoneType'>"),
     ]
+    if sys.version_info >= (3, 10):
+        valid_call_args.extend(
+            [
+                (["run", f"{stub_file.as_posix()}::optional_arg_pep604", "--i=20"], "20 <class 'int'>"),
+                (["run", f"{stub_file.as_posix()}::optional_arg_pep604"], "None <class 'NoneType'>"),
+            ]
+        )
     for args, expected in valid_call_args:
         res = _run(args)
         assert expected in res.stdout

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -263,8 +263,9 @@ def test_run_parse_args_entrypoint(servicer, set_env_client, test_dir):
         assert expected in res.stdout
         assert len(servicer.client_calls) == 0
 
-    res = _run(["run", f"{stub_file.as_posix()}::unparseable_annot", "--i=20"], expected_exit_code=1)
-    assert "Parameter `i` has unparseable annotation: 'int | str'" in str(res.exception)
+    if sys.version_info >= (3, 10):
+        res = _run(["run", f"{stub_file.as_posix()}::unparseable_annot", "--i=20"], expected_exit_code=1)
+        assert "Parameter `i` has unparseable annotation: typing.Union[int, str]" in str(res.exception)
 
 
 def test_run_parse_args_function(servicer, set_env_client, test_dir):

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -257,6 +257,9 @@ def test_run_parse_args_entrypoint(servicer, set_env_client, test_dir):
         assert expected in res.stdout
         assert len(servicer.client_calls) == 0
 
+    res = _run(["run", f"{stub_file.as_posix()}::unparseable_annot", "--i=20"], expected_exit_code=1)
+    assert "Parameter `i` has unparseable annotation: 'int | str'" in str(res.exception)
+
 
 def test_run_parse_args_function(servicer, set_env_client, test_dir):
     stub_file = test_dir / "supports" / "app_run_tests" / "cli_args.py"

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -249,6 +249,8 @@ def test_run_parse_args_entrypoint(servicer, set_env_client, test_dir):
         (["run", f"{stub_file.as_posix()}::unannotated_default_arg"], "10 <class 'int'>"),
         (["run", f"{stub_file.as_posix()}::optional_arg", "--i=20"], "20 <class 'int'>"),
         (["run", f"{stub_file.as_posix()}::optional_arg"], "None <class 'NoneType'>"),
+        (["run", f"{stub_file.as_posix()}::optional_arg_pep604", "--i=20"], "20 <class 'int'>"),
+        (["run", f"{stub_file.as_posix()}::optional_arg_pep604"], "None <class 'NoneType'>"),
     ]
     for args, expected in valid_call_args:
         res = _run(args)

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -249,6 +249,7 @@ def test_run_parse_args_entrypoint(servicer, set_env_client, test_dir):
         (["run", f"{stub_file.as_posix()}::unannotated_default_arg"], "10 <class 'int'>"),
         (["run", f"{stub_file.as_posix()}::optional_arg", "--i=20"], "20 <class 'int'>"),
         (["run", f"{stub_file.as_posix()}::optional_arg"], "None <class 'NoneType'>"),
+        (["run", f"{stub_file.as_posix()}::optional_arg_postponed"], "None <class 'NoneType'>"),
         (["run", f"{stub_file.as_posix()}::optional_arg_pep604", "--i=20"], "20 <class 'int'>"),
         (["run", f"{stub_file.as_posix()}::optional_arg_pep604"], "None <class 'NoneType'>"),
     ]

--- a/test/supports/app_run_tests/cli_args.py
+++ b/test/supports/app_run_tests/cli_args.py
@@ -56,3 +56,8 @@ def optional_arg(i: Optional[int] = None):
 @stub.local_entrypoint()
 def optional_arg_pep604(i: "int | None" = None):
     print(repr(i), type(i))
+
+
+@stub.function()
+def optional_arg_fn(i: Optional[int] = None):
+    print(repr(i), type(i))

--- a/test/supports/app_run_tests/cli_args.py
+++ b/test/supports/app_run_tests/cli_args.py
@@ -61,3 +61,8 @@ def optional_arg_pep604(i: "int | None" = None):
 @stub.function()
 def optional_arg_fn(i: Optional[int] = None):
     print(repr(i), type(i))
+
+
+@stub.local_entrypoint()
+def unparseable_annot(i: "int | str"):
+    pass

--- a/test/supports/app_run_tests/cli_args.py
+++ b/test/supports/app_run_tests/cli_args.py
@@ -51,3 +51,8 @@ class ALifecycle:
 @stub.local_entrypoint()
 def optional_arg(i: Optional[int] = None):
     print(repr(i), type(i))
+
+
+@stub.local_entrypoint()
+def optional_arg_pep604(i: "int | None" = None):
+    print(repr(i), type(i))

--- a/test/supports/app_run_tests/cli_args.py
+++ b/test/supports/app_run_tests/cli_args.py
@@ -1,5 +1,6 @@
 # Copyright Modal Labs 2022
 from datetime import datetime
+from typing import Optional
 
 from modal import Stub, method
 
@@ -45,3 +46,8 @@ class ALifecycle:
     @method()
     def some_method_int(self, i: int):
         print(repr(i), type(i))
+
+
+@stub.local_entrypoint()
+def optional_arg(i: Optional[int] = None):
+    print(repr(i), type(i))

--- a/test/supports/app_run_tests/cli_args.py
+++ b/test/supports/app_run_tests/cli_args.py
@@ -58,6 +58,11 @@ def optional_arg_pep604(i: "int | None" = None):
     print(repr(i), type(i))
 
 
+@stub.local_entrypoint()
+def optional_arg_postponed(i: "Optional[int]" = None):
+    print(repr(i), type(i))
+
+
 @stub.function()
 def optional_arg_fn(i: Optional[int] = None):
     print(repr(i), type(i))

--- a/test/supports/app_run_tests/cli_args.py
+++ b/test/supports/app_run_tests/cli_args.py
@@ -1,6 +1,6 @@
 # Copyright Modal Labs 2022
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Union
 
 from modal import Stub, method
 
@@ -69,5 +69,5 @@ def optional_arg_fn(i: Optional[int] = None):
 
 
 @stub.local_entrypoint()
-def unparseable_annot(i: "int | str"):
+def unparseable_annot(i: Union[int, str]):
     pass


### PR DESCRIPTION
Previously, we would fail to build a CLI for entrypoints with parameters annotated as `Optional[T]`. This PR improves the logic of the parsing from type annotations -> click options to handle both `Optional[T]`, and `T | None` spellings for optional arguments.

In implementing this change, I also modified some of the existing approach for handling pre/post evaluation annotations and slightly improved the error message that is generated when an annotation cannot be parsed.

- MOD-1251