### PR TITLE
Push `from_name` and `lookup` down into two intermediary temporary classes and change behavior slightly

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -18,7 +18,7 @@ from .functions import (
     _Function,
     _PartialFunctionFlags,
 )
-from .object import _Object
+from .object import _AppObject
 
 T = TypeVar("T")
 
@@ -122,7 +122,7 @@ class _Obj:
 Obj = synchronize_api(_Obj)
 
 
-class _Cls(_Object, type_prefix="cs"):
+class _Cls(_AppObject, type_prefix="cs"):
     _user_cls: Optional[type]
     _functions: Dict[str, _Function]
     _callables: Dict[str, Callable]
@@ -173,7 +173,7 @@ class _Cls(_Object, type_prefix="cs"):
         def _deps() -> List[_Function]:
             return list(functions.values())
 
-        async def _load(provider: _Object, resolver: Resolver, existing_object_id: Optional[str]):
+        async def _load(provider: "_Cls", resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.ClassCreateRequest(app_id=resolver.app_id, existing_class_id=existing_object_id)
             for f_name, f in functions.items():
                 req.methods.append(api_pb2.ClassMethod(function_name=f_name, function_id=f.object_id))

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -11,14 +11,14 @@ from ._serialization import deserialize, serialize
 from ._types import typechecked
 from .config import logger
 from .exception import deprecation_error
-from .object import _Object, live_method
+from .object import _StatefulObject, live_method
 
 
 def _serialize_dict(data):
     return [api_pb2.DictEntry(key=serialize(k), value=serialize(v)) for k, v in data.items()]
 
 
-class _Dict(_Object, type_prefix="di"):
+class _Dict(_StatefulObject, type_prefix="di"):
     """Distributed dictionary for storage in Modal apps.
 
     Keys and values can be essentially any object, so long as they can be

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -70,7 +70,7 @@ from .gpu import GPU_T, parse_gpu_config
 from .image import _Image
 from .mount import _get_client_mount, _Mount
 from .network_file_system import _NetworkFileSystem, network_file_system_mount_protos
-from .object import Object, _Object, live_method, live_method_gen
+from .object import Object, _AppObject, _Object, live_method, live_method_gen
 from .proxy import _Proxy
 from .retries import Retries
 from .schedule import Schedule
@@ -494,7 +494,7 @@ class FunctionStats:
     num_total_runners: int
 
 
-class _Function(_Object, type_prefix="fu"):
+class _Function(_AppObject, type_prefix="fu"):
     """Functions are the basic units of serverless execution on Modal.
 
     Generally, you will not construct a `Function` directly. Instead, use the
@@ -704,7 +704,7 @@ class _Function(_Object, type_prefix="fu"):
             # Update the precreated function handle (todo: hack until we merge providers/handles)
             provider._hydrate(response.function_id, resolver.client, response.handle_metadata)
 
-        async def _load(provider: _Object, resolver: Resolver, existing_object_id: Optional[str]):
+        async def _load(provider: _Function, resolver: Resolver, existing_object_id: Optional[str]):
             status_row = resolver.add_status_row()
             status_row.message(f"Creating {tag}...")
 

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -26,7 +26,7 @@ from ._blob_utils import FileUploadSpec, blob_upload_file, get_file_upload_spec
 from ._resolver import Resolver
 from .config import config, logger
 from .exception import NotFoundError
-from .object import _Object
+from .object import _StatefulObject
 
 MOUNT_PUT_FILE_CLIENT_TIMEOUT = 10 * 60  # 10 min max for transferring files
 
@@ -131,7 +131,7 @@ class _MountDir(_MountEntry):
         return self.local_dir, None
 
 
-class _Mount(_Object, type_prefix="mo"):
+class _Mount(_StatefulObject, type_prefix="mo"):
     """Create a mount for a local directory or file that can be attached
     to one or more Modal functions.
 

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -16,7 +16,7 @@ from modal_utils.hash_utils import get_sha256_hex
 from ._blob_utils import LARGE_FILE_LIMIT, blob_iter, blob_upload_file
 from ._resolver import Resolver
 from ._types import typechecked
-from .object import _Object, live_method, live_method_gen
+from .object import _StatefulObject, live_method, live_method_gen
 
 NETWORK_FILE_SYSTEM_PUT_FILE_CLIENT_TIMEOUT = (
     10 * 60
@@ -40,7 +40,7 @@ def network_file_system_mount_protos(
     return network_file_system_mounts
 
 
-class _NetworkFileSystem(_Object, type_prefix="sv"):
+class _NetworkFileSystem(_StatefulObject, type_prefix="sv"):
     """A shared, writable file system accessible by one or more Modal functions.
 
     By attaching this file system as a mount to one or more functions, they can

--- a/modal/object.py
+++ b/modal/object.py
@@ -1,6 +1,5 @@
 # Copyright Modal Labs 2022
 import uuid
-from datetime import date
 from functools import wraps
 from typing import Awaitable, Callable, ClassVar, Dict, List, Optional, Type, TypeVar
 
@@ -16,11 +15,20 @@ from ._deployments import deploy_single_object
 from ._resolver import Resolver
 from .client import _Client
 from .config import config
-from .exception import ExecutionError, InvalidError, NotFoundError, deprecation_error
+from .exception import ExecutionError, InvalidError, NotFoundError
 
 O = TypeVar("O", bound="_Object")
 
 _BLOCKING_O = synchronize_api(O)
+
+
+def _get_environment_name(environment_name: Optional[str], resolver: Optional[Resolver] = None) -> Optional[str]:
+    if environment_name:
+        return environment_name
+    elif resolver and resolver.environment_name:
+        return resolver.environment_name
+    else:
+        return config.get("environment")
 
 
 class _Object:
@@ -202,6 +210,13 @@ class _Object:
             resolver = Resolver()
             await resolver.load(self)
 
+
+class _StatefulObject(_Object):
+    # This base class is used for _Volume, _Dict, _Queue, _Secret, _NetworkFileSystem
+    # This is a temporary class needed until we rewrite AppLookupObject to be specific to each class.
+    # At that point, we can "push down" each of these methods into each class.
+    # These classes all have in common that they are always looked up using a single app name.
+
     async def _deploy(
         self,
         label: str,
@@ -212,33 +227,21 @@ class _Object:
         """
         Note: still considering this an "internal" method, but we'll make it "official" later
         """
-        if environment_name is None:
-            environment_name = config.get("environment")
-
         if client is None:
             client = await _Client.from_env()
 
-        await deploy_single_object(self, self._type_prefix, client, label, namespace, environment_name)
-
-    def persist(
-        self, label: str, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, environment_name: Optional[str] = None
-    ):
-        """`Object.persist` is deprecated for generic objects. See `NetworkFileSystem.persisted` or `Dict.persisted`."""
-        # Note: this method is overridden in SharedVolume and Dict to print a warning
-        deprecation_error(
-            date(2023, 6, 30),
-            self.persist.__doc__,
+        await deploy_single_object(
+            self, self._type_prefix, client, label, namespace, _get_environment_name(environment_name)
         )
 
     @typechecked
     def _persist(
         self, label: str, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, environment_name: Optional[str] = None
     ):
-        if environment_name is None:
-            environment_name = config.get("environment")
-
         async def _load_persisted(obj: _Object, resolver: Resolver, existing_object_id: Optional[str]):
-            await self._deploy(label, namespace, resolver.client, environment_name=environment_name)
+            await self._deploy(
+                label, namespace, resolver.client, environment_name=_get_environment_name(environment_name)
+            )
             obj._hydrate_from_other(self)
 
         cls = type(self)
@@ -249,11 +252,10 @@ class _Object:
     def from_name(
         cls: Type[O],
         app_name: str,
-        tag: Optional[str] = None,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
     ) -> O:
-        """Retrieve an object with a given name and tag.
+        """Retrieve an object with a given name.
 
         Useful for referencing secrets, as well as calling a function from a different app.
         Use this when attaching the object to a stub or function.
@@ -261,13 +263,7 @@ class _Object:
         **Examples**
 
         ```python notest
-        # Retrieve a secret
         stub.my_secret = Secret.from_name("my-secret")
-
-        # Retrieve a function from a different app
-        stub.other_function = Function.from_name("other-app", "function")
-
-        # Retrieve a persisted Volume, Queue, or Dict
         stub.my_volume = Volume.from_name("my-volume")
         stub.my_queue = Queue.from_name("my-queue")
         stub.my_dict = Dict.from_name("my-dict")
@@ -275,19 +271,101 @@ class _Object:
         """
 
         async def _load_remote(obj: _Object, resolver: Resolver, existing_object_id: Optional[str]):
-            nonlocal environment_name
-            if environment_name is None:
-                # fall back if no explicit environment was set in the call itself.
-                # If there is a current app setup, the resolver has the env name. If doing a .lookup
-                # with no associated app, must fetch environment from config.
-                environment_name = resolver.environment_name or config.get("environment")
+            request = api_pb2.AppLookupObjectRequest(
+                app_name=app_name,
+                namespace=namespace,
+                object_entity=cls._type_prefix,
+                environment_name=_get_environment_name(environment_name, resolver),
+            )
+            try:
+                response = await retry_transient_errors(resolver.client.stub.AppLookupObject, request)
+            except GRPCError as exc:
+                if exc.status == Status.NOT_FOUND:
+                    raise NotFoundError(exc.message)
+                else:
+                    raise
 
+            handle_metadata = get_proto_oneof(response.object, "handle_metadata_oneof")
+            obj._hydrate(response.object.object_id, resolver.client, handle_metadata)
+
+        rep = f"Ref({app_name})"
+        return cls._from_loader(_load_remote, rep, is_another_app=True)
+
+    @classmethod
+    async def lookup(
+        cls: Type[O],
+        app_name: str,
+        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        client: Optional[_Client] = None,
+        environment_name: Optional[str] = None,
+    ) -> O:
+        """Lookup an object with a given name.
+
+        This is a general-purpose method for objects like functions, network file systems,
+        and secrets. It gives a reference to the object in a running app.
+
+        **Examples**
+
+        ```python notest
+        my_secret = Secret.lookup("my-secret")
+        my_volume = Volume.lookup("my-volume")
+        my_queue = Queue.lookup("my-queue")
+        my_dict = Dict.lookup("my-dict")
+        ```
+        """
+        obj = cls.from_name(app_name, namespace=namespace, environment_name=environment_name)
+        if client is None:
+            client = await _Client.from_env()
+        resolver = Resolver(client=client)
+        await resolver.load(obj)
+        return obj
+
+    @classmethod
+    async def _exists(
+        cls: Type[O],
+        app_name: str,
+        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        client: Optional[_Client] = None,
+        environment_name: Optional[str] = None,
+    ) -> bool:
+        """Internal for now - will make this "public" later."""
+        try:
+            await cls.lookup(app_name, namespace, client, environment_name)
+            return True
+        except NotFoundError:
+            return False
+
+
+class _AppObject(_Object):
+    # Similar to _StatefulObject, this is a temporary class needed until we rewrite AppLookupObject
+    # to be specific to each class. This base class will only be used for _Function and _Cls
+    # Those are always looked up using an app name and a tag.
+
+    @classmethod
+    def from_name(
+        cls: Type[O],
+        app_name: str,
+        tag: Optional[str] = None,
+        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        environment_name: Optional[str] = None,
+    ) -> O:
+        """Retrieve a function/class with a given name and tag.
+
+        **Examples**
+
+        ```python notest
+        # Retrieve a function from a different app
+        stub.other_function = Function.from_name("other-app", "function")
+        ```
+        """
+
+        async def _load_remote(obj: _Object, resolver: Resolver, existing_object_id: Optional[str]):
             request = api_pb2.AppLookupObjectRequest(
                 app_name=app_name,
                 object_tag=tag,
                 namespace=namespace,
                 object_entity=cls._type_prefix,
-                environment_name=environment_name,
+                environment_name=_get_environment_name(environment_name, resolver),
             )
             try:
                 response = await retry_transient_errors(resolver.client.stub.AppLookupObject, request)
@@ -312,24 +390,12 @@ class _Object:
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
     ) -> O:
-        """Lookup an object with a given name and tag.
+        """Lookup a function/class with a given name and tag.
 
-        This is a general-purpose method for objects like functions, network file systems,
-        and secrets. It gives a reference to the object in a running app.
-
-        **Examples**
+        Example: Look up a function from a different app:
 
         ```python notest
-        # Lookup a secret
-        my_secret = Secret.lookup("my-secret")
-
-        # Lookup a function from a different app
         other_function = Function.lookup("other-app", "function")
-
-        # Lookup a persisted Volume, Queue, or Dict
-        my_volume = Volume.lookup("my-volume")
-        my_queue = Queue.lookup("my-queue")
-        my_dict = Dict.lookup("my-dict")
         ```
         """
         obj = cls.from_name(app_name, tag, namespace=namespace, environment_name=environment_name)
@@ -349,20 +415,9 @@ class _Object:
         environment_name: Optional[str] = None,
     ) -> bool:
         """Internal for now - will make this "public" later."""
-        if client is None:
-            client = await _Client.from_env()
-        if environment_name is None:
-            environment_name = config.get("environment")
-        request = api_pb2.AppLookupObjectRequest(
-            app_name=app_name,
-            object_tag=tag,
-            namespace=namespace,
-            object_entity=cls._type_prefix,
-            environment_name=environment_name,
-        )
         try:
-            response = await retry_transient_errors(client.stub.AppLookupObject, request)
-            return bool(response.object.object_id)  # old code path - change to `return True` shortly
+            await cls.lookup(app_name, tag, namespace, client, environment_name)
+            return True
         except GRPCError as exc:
             if exc.status == Status.NOT_FOUND:
                 return False
@@ -371,6 +426,8 @@ class _Object:
 
 
 Object = synchronize_api(_Object, target_module=__name__)
+StatefulObject = synchronize_api(_StatefulObject, target_module=__name__)
+AppObject = synchronize_api(_AppObject, target_module=__name__)
 
 
 def live_method(method):

--- a/modal/proxy.py
+++ b/modal/proxy.py
@@ -1,10 +1,10 @@
 # Copyright Modal Labs 2022
 from modal_utils.async_utils import synchronize_api
 
-from .object import _Object
+from .object import _StatefulObject
 
 
-class _Proxy(_Object, type_prefix="pr"):
+class _Proxy(_StatefulObject, type_prefix="pr"):
     """
     Proxy objects are used to setup secure tunnel connections to a private remote address, for example
     a database.

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -14,10 +14,10 @@ from modal_utils.grpc_utils import retry_transient_errors
 from ._resolver import Resolver
 from ._serialization import deserialize, serialize
 from .exception import deprecation_error
-from .object import _Object, live_method
+from .object import _StatefulObject, live_method
 
 
-class _Queue(_Object, type_prefix="qu"):
+class _Queue(_StatefulObject, type_prefix="qu"):
     """Distributed, FIFO queue for data flow in Modal apps.
 
     The queue can contain any object serializable by `cloudpickle`, including Modal objects.

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -10,12 +10,12 @@ from modal_utils.async_utils import synchronize_api
 
 from ._resolver import Resolver
 from .exception import InvalidError
-from .object import _Object
+from .object import _StatefulObject
 
 ENV_DICT_WRONG_TYPE_ERR = "the env_dict argument to Secret has to be a dict[str, Union[str, None]]"
 
 
-class _Secret(_Object, type_prefix="st"):
+class _Secret(_StatefulObject, type_prefix="st"):
     """Secrets provide a dictionary of environment variables for images.
 
     Secrets are a secure way to add credentials and other sensitive information

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -16,10 +16,10 @@ from ._blob_utils import blob_iter, blob_upload_file, get_file_upload_spec
 from ._resolver import Resolver
 from .config import logger
 from .mount import MOUNT_PUT_FILE_CLIENT_TIMEOUT
-from .object import _Object, live_method, live_method_gen
+from .object import _StatefulObject, live_method, live_method_gen
 
 
-class _Volume(_Object, type_prefix="vo"):
+class _Volume(_StatefulObject, type_prefix="vo"):
     """A writeable volume that can be used to share files between one or more Modal functions.
 
     The contents of a volume is exposed as a filesystem. You can use it to share data between different functions, or

--- a/test/lookup_test.py
+++ b/test/lookup_test.py
@@ -7,11 +7,9 @@ from modal.runner import deploy_stub
 
 
 def test_persistent_object(servicer, client):
-    stub = Stub()
-    stub["q_1"] = Queue.new()
-    deploy_stub(stub, "my-queue", client=client)
+    Queue.new()._deploy("my-queue", client=client)
 
-    q: Queue = Queue.lookup("my-queue", "q_1", client=client)
+    q: Queue = Queue.lookup("my-queue", client=client)
     assert isinstance(q, Queue)
     assert q.object_id == "qu-1"
 


### PR DESCRIPTION
This splits the way we do lookups into two ways based on the class

1. Functions and classes – these always require an object "tag"
2. All other objects – we assume these are always single-object apps

The intermediary classes are temporary – we're giong to push everything down into each specific subclass shortly. This is just some prep work that makes it easier.

It relies on some analytics I did which indicates that there's a strict correspondence between object types and lookup methods. If you analyze all calls to `AppLookupObject`, function & class lookups _always_ have the "tag" set, but all other entities _never_ have the "tag" set. This basically ends up _enforcing_ this, and is a step towards specializing the implementation of each class (which later will allow me to remove the single-object app code from the client)
