### PR TITLE
Attach decorator-level options to parameterized functions

### DIFF
--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -157,7 +157,7 @@ def _get_click_command_for_function(stub: Stub, function_tag):
                 # TODO(erikbern): this code is a bit hacky
                 cls_kwargs = {k: kwargs[k] for k in cls_signature}
                 fun_kwargs = {k: kwargs[k] for k in fun_signature}
-                method = function.from_parametrized(None, False, tuple(), cls_kwargs)
+                method = function.from_parametrized(None, False, None, tuple(), cls_kwargs)
                 method.remote(**fun_kwargs)
 
     with_click_options = _add_click_options(f, signature)

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -274,10 +274,6 @@ class _Cls(_Object, type_prefix="cs"):
         keep_warm: Optional[int] = None,
         allow_background_volume_commits: bool = False,
     ) -> "_Cls":
-        # TODO(gongy): figure out a cleaner way to clone a _Cls
-        cls = _Cls._from_other(self)
-        cls._initialize_from_other(self)
-
         retry_policy = _parse_retries(retries)
         resources = api_pb2.Resources(gpu_config=parse_gpu_config(gpu)) if gpu else None
 
@@ -291,6 +287,7 @@ class _Cls(_Object, type_prefix="cs"):
         ]
         replace_volume_mounts = len(volume_mounts) > 0
 
+        cls = _Cls._from_other(self)
         cls._options = api_pb2.FunctionOptions(
             replace_secret_ids=bool(secrets),
             secret_ids=[secret.object_id for secret in secrets],

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -287,7 +287,7 @@ class _Cls(_Object, type_prefix="cs"):
         ]
         replace_volume_mounts = len(volume_mounts) > 0
 
-        cls = _Cls._from_other(self)
+        cls = self.clone()
         cls._options = api_pb2.FunctionOptions(
             replace_secret_ids=bool(secrets),
             secret_ids=[secret.object_id for secret in secrets],

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -2,7 +2,7 @@
 import os
 import pickle
 from datetime import date
-from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union
+from typing import Any, Callable, Collection, Dict, List, Optional, Type, TypeVar, Union
 
 from google.protobuf.message import Message
 from grpclib import GRPCError, Status
@@ -29,6 +29,7 @@ from .partial_function import (
     _PartialFunctionFlags,
 )
 from .retries import Retries
+from .secret import _Secret
 from .volume import _Volume
 
 T = TypeVar("T")
@@ -263,6 +264,7 @@ class _Cls(_Object, type_prefix="cs"):
     def with_options(
         self: "_Cls",
         gpu: GPU_T = None,
+        secrets: Collection[_Secret] = (),
         volumes: Dict[Union[str, os.PathLike], _Volume] = {},
         retries: Optional[Union[int, Retries]] = None,
         timeout: Optional[int] = None,
@@ -290,6 +292,8 @@ class _Cls(_Object, type_prefix="cs"):
         replace_volume_mounts = len(volume_mounts) > 0
 
         cls._options = api_pb2.FunctionOptions(
+            replace_secret_ids=bool(secrets),
+            secret_ids=[secret.object_id for secret in secrets],
             resources=resources,
             retry_policy=retry_policy,
             concurrency_limit=concurrency_limit,

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -160,6 +160,7 @@ class _Cls(_Object, type_prefix="cs"):
         self._functions = other._functions
         self._options = other._options
         self._callables = other._callables
+        self._from_other_workspace = other._from_other_workspace
         self._output_mgr: Optional[OutputManager] = other._output_mgr
 
     def _set_output_mgr(self, output_mgr: OutputManager):
@@ -272,7 +273,7 @@ class _Cls(_Object, type_prefix="cs"):
         allow_background_volume_commits: bool = False,
     ) -> "_Cls":
         # TODO(gongy): figure out a cleaner way to clone a _Cls
-        cls = _Cls.from_other(self)
+        cls = _Cls._from_other(self)
         cls._initialize_from_other(self)
 
         retry_policy = _parse_retries(retries)

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -262,7 +262,7 @@ class _Cls(_Object, type_prefix="cs"):
         return cls
 
     def with_options(
-        self: Type["_Cls"],
+        self: "_Cls",
         secrets: Collection[_Secret] = (),
         gpu: GPU_T = None,
         mounts: Collection[_Mount] = (),
@@ -276,7 +276,7 @@ class _Cls(_Object, type_prefix="cs"):
         allow_background_volume_commits: bool = False,
     ) -> "_Cls":
         # TODO(gongy): figure out a cleaner way to clone a _Cls
-        cls = _Cls._from_loader(self, self._load, self._rep)
+        cls = _Cls.from_other(self)
         cls._initialize_from_other(self)
 
         validated_volumes = _validate_volumes(volumes)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -22,6 +22,7 @@ from typing import (
     List,
     Optional,
     Set,
+    Tuple,
     Type,
     Union,
 )
@@ -493,6 +494,48 @@ class FunctionStats:
     num_total_runners: int
 
 
+def _parse_retries(
+    retries: Optional[Union[int, Retries]],
+    raw_f: Optional[Callable] = None,
+) -> Optional[api_pb2.FunctionRetryPolicy]:
+    if isinstance(retries, int):
+        return Retries(
+            max_retries=retries,
+            initial_delay=1.0,
+            backoff_coefficient=1.0,
+        )._to_proto()
+    elif isinstance(retries, Retries):
+        return retries._to_proto()
+    elif retries is None:
+        return None
+    else:
+        err_object = f"Function {raw_f}" if raw_f else "Function"
+        raise InvalidError(
+            f"{err_object} retries must be an integer or instance of modal.Retries. Found: {type(retries)}"
+        )
+
+
+def _validate_volumes(
+    volumes: Dict[Union[str, os.PathLike], _Volume]
+) -> List[Tuple[str, Union[_Volume, _NetworkFileSystem]]]:
+    if not isinstance(volumes, dict):
+        raise InvalidError("volumes must be a dict[str, Volume] where the keys are paths")
+
+    validated_volumes = validate_mount_points("Volume", volumes)
+    # We don't support mounting a volume in more than one location
+    volume_to_paths: Dict[_Volume, List[str]] = {}
+    for path, volume in validated_volumes:
+        volume_to_paths.setdefault(volume, []).append(path)
+    for paths in volume_to_paths.values():
+        if len(paths) > 1:
+            conflicting = ", ".join(paths)
+            raise InvalidError(
+                f"The same Volume cannot be mounted in multiple locations for the same function: {conflicting}"
+            )
+
+    return validated_volumes
+
+
 class _Function(_Object, type_prefix="fu"):
     """Functions are the basic units of serverless execution on Modal.
 
@@ -574,20 +617,7 @@ class _Function(_Object, type_prefix="fu"):
         if secret:
             secrets = [secret, *secrets]
 
-        if isinstance(retries, int):
-            retry_policy = Retries(
-                max_retries=retries,
-                initial_delay=1.0,
-                backoff_coefficient=1.0,
-            )._to_proto()
-        elif isinstance(retries, Retries):
-            retry_policy = retries._to_proto()
-        elif retries is None:
-            retry_policy = None
-        else:
-            raise InvalidError(
-                f"Function {raw_f} retries must be an integer or instance of modal.Retries. Found: {type(retries)}"
-            )
+        retry_policy = _parse_retries(retries, raw_f)
 
         gpu_config = parse_gpu_config(gpu)
 
@@ -647,19 +677,7 @@ class _Function(_Object, type_prefix="fu"):
                 raise InvalidError("Webhooks cannot be generators")
 
         # Validate volumes
-        if not isinstance(volumes, dict):
-            raise InvalidError("volumes must be a dict[str, Volume] where the keys are paths")
-        validated_volumes = validate_mount_points("Volume", volumes)
-        # We don't support mounting a volume in more than one location
-        volume_to_paths: Dict[_Volume, List[str]] = {}
-        for path, volume in validated_volumes:
-            volume_to_paths.setdefault(volume, []).append(path)
-        for paths in volume_to_paths.values():
-            if len(paths) > 1:
-                conflicting = ", ".join(paths)
-                raise InvalidError(
-                    f"The same Volume cannot be mounted in multiple locations for the same function: {conflicting}"
-                )
+        validated_volumes = _validate_volumes(volumes)
 
         # Validate NFS
         if not isinstance(network_file_systems, dict):
@@ -882,7 +900,12 @@ class _Function(_Object, type_prefix="fu"):
         return obj
 
     def from_parametrized(
-        self, obj, from_other_workspace: bool, args: Iterable[Any], kwargs: Dict[str, Any]
+        self,
+        obj,
+        from_other_workspace: bool,
+        options: Optional[api_pb2.FunctionOptions],
+        args: Iterable[Any],
+        kwargs: Dict[str, Any],
     ) -> "_Function":
         async def _load(provider: _Function, resolver: Resolver, existing_object_id: Optional[str]):
             if not self.is_hydrated:
@@ -892,9 +915,11 @@ class _Function(_Object, type_prefix="fu"):
                     " created because it wasn't defined in global scope."
                 )
             serialized_params = pickle.dumps((args, kwargs))  # TODO(erikbern): use modal._serialization?
+            print(f"Sending FunctionBindParams with {options}!")
             req = api_pb2.FunctionBindParamsRequest(
                 function_id=self._object_id,
                 serialized_params=serialized_params,
+                function_options=options,
             )
             response = await retry_transient_errors(self._client.stub.FunctionBindParams, req)
             provider._hydrate(response.bound_function_id, self._client, response.handle_metadata)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -915,7 +915,6 @@ class _Function(_Object, type_prefix="fu"):
                     " created because it wasn't defined in global scope."
                 )
             serialized_params = pickle.dumps((args, kwargs))  # TODO(erikbern): use modal._serialization?
-            print(f"Sending FunctionBindParams with {options}!")
             req = api_pb2.FunctionBindParamsRequest(
                 function_id=self._object_id,
                 serialized_params=serialized_params,

--- a/modal/object.py
+++ b/modal/object.py
@@ -90,6 +90,10 @@ class _Object:
         # default implementation, can be overriden in subclasses
         pass
 
+    def _initialize_from_other(self, other):
+        # default implementation, can be overriden in subclasses
+        pass
+
     def _hydrate(self, object_id: str, client: _Client, metadata: Optional[Message]):
         assert isinstance(object_id, str)
         if not object_id.startswith(self._type_prefix):
@@ -247,6 +251,17 @@ class _StatefulObject(_Object):
         cls = type(self)
         rep = f"PersistedRef<{self}>({label})"
         return cls._from_loader(_load_persisted, rep, is_another_app=True)
+
+    @classmethod
+    def from_other(cls: Type[O], other: _Object):
+        """Clone a given hydrated object."""
+
+        # Object to clone must already be hydrated, otherwise from_loader is more suitable.
+        assert other._hydrated
+
+        obj = _Object.__new__(cls)
+        obj._initialize_from_other(other)
+        return obj
 
     @classmethod
     def from_name(

--- a/modal/object.py
+++ b/modal/object.py
@@ -121,7 +121,7 @@ class _Object:
         # Transient use case, see Dict, Queue, and SharedVolume
         self._init(other._rep, other._load, other._is_another_app, other._preload)
 
-    def clone(self) -> O:
+    def clone(self: O) -> O:
         """Clone a given hydrated object."""
 
         # Object to clone must already be hydrated, otherwise from_loader is more suitable.

--- a/modal/object.py
+++ b/modal/object.py
@@ -121,15 +121,14 @@ class _Object:
         # Transient use case, see Dict, Queue, and SharedVolume
         self._init(other._rep, other._load, other._is_another_app, other._preload)
 
-    @classmethod
-    def _from_other(cls: Type[O], other: "_Object"):
+    def clone(self) -> O:
         """Clone a given hydrated object."""
 
         # Object to clone must already be hydrated, otherwise from_loader is more suitable.
-        assert other._is_hydrated
+        assert self._is_hydrated
 
-        obj = _Object.__new__(cls)
-        obj._initialize_from_other(other)
+        obj = _Object.__new__(type(self))
+        obj._initialize_from_other(self)
         return obj
 
     @classmethod

--- a/modal/object.py
+++ b/modal/object.py
@@ -122,6 +122,17 @@ class _Object:
         self._init(other._rep, other._load, other._is_another_app, other._preload)
 
     @classmethod
+    def _from_other(cls: Type[O], other: "_Object"):
+        """Clone a given hydrated object."""
+
+        # Object to clone must already be hydrated, otherwise from_loader is more suitable.
+        assert other._is_hydrated
+
+        obj = _Object.__new__(cls)
+        obj._initialize_from_other(other)
+        return obj
+
+    @classmethod
     def _from_loader(
         cls,
         load: Callable[[O, Resolver, Optional[str]], Awaitable[None]],
@@ -251,17 +262,6 @@ class _StatefulObject(_Object):
         cls = type(self)
         rep = f"PersistedRef<{self}>({label})"
         return cls._from_loader(_load_persisted, rep, is_another_app=True)
-
-    @classmethod
-    def from_other(cls: Type[O], other: _Object):
-        """Clone a given hydrated object."""
-
-        # Object to clone must already be hydrated, otherwise from_loader is more suitable.
-        assert other._hydrated
-
-        obj = _Object.__new__(cls)
-        obj._initialize_from_other(other)
-        return obj
 
     @classmethod
     def from_name(


### PR DESCRIPTION
Look up and execute a parametrized function that is published by another workspace.

Syntax:

```python
modal.Cls.lookup(
  workspace="modal-labs", "vllm-inference", "Model"
).with_options(
  volumes={"/data": Volume.lookup("my-llama-weights")},
  allow_concurrent_inputs=10,
  concurrency_limit=3,
) # Attachs a api_pb2.FunctionOptions object
```