### PR TITLE
Add debug-mode to @web_endpoint

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -758,7 +758,7 @@ def import_function(
         data_format = api_pb2.DATA_FORMAT_ASGI
     elif function_def.webhook_config.type == api_pb2.WEBHOOK_TYPE_FUNCTION:
         # function is webhook without an ASGI app. Create one for it.
-        asgi_app = webhook_asgi_app(fun, function_def.webhook_config.method)
+        asgi_app = webhook_asgi_app(fun, function_def.webhook_config.method, function_def.webhook_config.debug)
         fun = asgi_app_wrapper(asgi_app, function_io_manager)
         is_async = True
         is_generator = True

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1630,6 +1630,7 @@ def _web_endpoint(
     custom_domains: Optional[
         Iterable[str]
     ] = None,  # Create an endpoint using a custom domain fully-qualified domain name.
+    debug: bool = False,  # Enable debug logging features on the endpoint.
 ) -> Callable[[Callable[..., Any]], _PartialFunction]:
     """Register a basic web endpoint with this application.
 
@@ -1665,8 +1666,6 @@ def _web_endpoint(
         else:
             _response_mode = api_pb2.WEBHOOK_ASYNC_MODE_AUTO  # the default
 
-        # self._loose_webhook_configs.add(raw_f)
-
         return _PartialFunction(
             raw_f,
             _PartialFunctionFlags.FUNCTION,
@@ -1676,6 +1675,7 @@ def _web_endpoint(
                 requested_suffix=label,
                 async_mode=_response_mode,
                 custom_domains=_parse_custom_domains(custom_domains),
+                debug=debug,
             ),
         )
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1626,6 +1626,7 @@ message WebhookConfig {
   string requested_suffix = 4;
   WebhookAsyncMode async_mode = 5;
   repeated CustomDomainConfig custom_domains = 6;
+  bool debug = 7;
 }
 
 message WebUrlInfo {


### PR DESCRIPTION
### Describe your changes

![image](https://github.com/modal-labs/modal-client/assets/12058921/c8e4aa6e-3ee4-4075-bd12-692f0839cede)

Something I've wanted on occasion when being temporarily baffled by a 422.

- _Provide Linear issue reference (e.g. MOD-1234) if available._


## Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.
