### PR TITLE
Remove lookup option from protobuf

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -369,9 +369,6 @@ message AppLookupObjectRequest {
   string object_id = 5;
   string object_entity = 6;
   string environment_name = 7;
-
-  bool lookup_published = 8; // Lookup object on app published by another workspace
-  string workspace_name = 9;
 }
 
 message AppLookupObjectResponse {


### PR DESCRIPTION
These fields have never been used and will be moved to `ClassGet`