### PR TITLE
Add option to restrict network for sandboxed containers

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -116,6 +116,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         cpu: Optional[float] = None,
         memory: Optional[int] = None,
         network_file_systems: Dict[Union[str, os.PathLike], _NetworkFileSystem] = {},
+        restrict_network: Optional[bool] = False,
     ) -> "_Sandbox":
         """mdmd:hidden"""
 
@@ -152,6 +153,7 @@ class _Sandbox(_Object, type_prefix="sb"):
                 cloud_provider=cloud_provider,
                 nfs_mounts=network_file_system_mount_protos(validated_network_file_systems, False),
                 runtime_debug=config.get("function_runtime_debug"),
+                restrict_network=restrict_network,
             )
 
             create_req = api_pb2.SandboxCreateRequest(app_id=resolver.app_id, definition=definition)

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -116,7 +116,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         cpu: Optional[float] = None,
         memory: Optional[int] = None,
         network_file_systems: Dict[Union[str, os.PathLike], _NetworkFileSystem] = {},
-        restrict_network: Optional[bool] = False,
+        restrict_network: bool = False,
     ) -> "_Sandbox":
         """mdmd:hidden"""
 

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -653,7 +653,7 @@ class _Stub:
         cloud: Optional[str] = None,
         cpu: Optional[float] = None,  # How many CPU cores to request. This is a soft limit.
         memory: Optional[int] = None,  # How much memory to request, in MiB. This is a soft limit.
-        restrict_network: Optional[bool] = False,  # Whether to restrict network access
+        restrict_network: bool = False,  # Whether to restrict network access
     ) -> _Sandbox:
         """Sandboxes are a way to run arbitrary commands in dynamically defined environments.
 

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -653,6 +653,7 @@ class _Stub:
         cloud: Optional[str] = None,
         cpu: Optional[float] = None,  # How many CPU cores to request. This is a soft limit.
         memory: Optional[int] = None,  # How much memory to request, in MiB. This is a soft limit.
+        restrict_network: Optional[bool] = False,  # Whether to restrict network access
     ) -> _Sandbox:
         """Sandboxes are a way to run arbitrary commands in dynamically defined environments.
 
@@ -688,6 +689,7 @@ class _Stub:
             cpu=cpu,
             memory=memory,
             network_file_systems=network_file_systems,
+            restrict_network=restrict_network,
         )
         await resolver.load(obj)
         return obj

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1084,6 +1084,8 @@ message Sandbox {
   repeated SharedVolumeMount nfs_mounts = 9;
 
   bool runtime_debug = 10; // For internal debugging use only.
+
+  bool restrict_network = 11;
 }
 
 message SandboxCreateRequest {


### PR DESCRIPTION
## Describe your changes

- Linear: MOD-1752
- Adds a `restrict_network` flag to `spawn_sandbox` that turns off internet access for the sandbox.

## Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers (unsure)

---

Also see https://github.com/modal-labs/modal/pull/9577