### PR TITLE
Add `modal container list` command

### DIFF
--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -1,7 +1,11 @@
 # Copyright Modal Labs 2022
 
-import typer
+from typing import List, Union
 
+import typer
+from rich.text import Text
+
+from modal.cli.utils import display_table, timestamp_to_local
 from modal.client import _Client
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronizer
@@ -16,5 +20,16 @@ async def list():
     client = await _Client.from_env()
     res: api_pb2.ContainerListResponse = await client.stub.ContainerList(api_pb2.ContainerListRequest())
 
-    print("Hello World!")
-    print(res)
+    column_names = ["Container ID", "App ID", "App Name", "Start time"]
+    rows: List[List[Union[Text, str]]] = []
+    for container_stats in res.containers:
+        rows.append(
+            [
+                container_stats.container_id,
+                container_stats.app_id,
+                container_stats.app_description,
+                timestamp_to_local(container_stats.started_at) if container_stats.started_at else "Pending",
+            ]
+        )
+
+    display_table(column_names, rows, json=False, title="Active Containers")

--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -18,17 +18,17 @@ container_cli = typer.Typer(name="container", help="Manage running containers.",
 async def list():
     """List all containers that are currently running"""
     client = await _Client.from_env()
-    res: api_pb2.ContainerListResponse = await client.stub.ContainerList(api_pb2.ContainerListRequest())
+    res: api_pb2.TaskListResponse = await client.stub.TaskList(api_pb2.TaskListRequest())
 
     column_names = ["Container ID", "App ID", "App Name", "Start time"]
     rows: List[List[Union[Text, str]]] = []
-    for container_stats in res.containers:
+    for task_stats in res.tasks:
         rows.append(
             [
-                container_stats.container_id,
-                container_stats.app_id,
-                container_stats.app_description,
-                timestamp_to_local(container_stats.started_at) if container_stats.started_at else "Pending",
+                task_stats.task_id,
+                task_stats.app_id,
+                task_stats.app_description,
+                timestamp_to_local(task_stats.started_at) if task_stats.started_at else "Pending",
             ]
         )
 

--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -1,0 +1,20 @@
+# Copyright Modal Labs 2022
+
+import typer
+
+from modal.client import _Client
+from modal_proto import api_pb2
+from modal_utils.async_utils import synchronizer
+
+container_cli = typer.Typer(name="container", help="Manage running containers.", no_args_is_help=True)
+
+
+@container_cli.command("list")
+@synchronizer.create_blocking
+async def list():
+    """List all containers that are currently running"""
+    client = await _Client.from_env()
+    res: api_pb2.ContainerListResponse = await client.stub.ContainerList(api_pb2.ContainerListRequest())
+
+    print("Hello World!")
+    print(res)

--- a/modal/cli/entry_point.py
+++ b/modal/cli/entry_point.py
@@ -9,6 +9,7 @@ from rich.rule import Rule
 from . import run
 from .app import app_cli
 from .config import config_cli
+from .container import container_cli
 from .environment import environment_cli
 from .launch import launch_cli
 from .network_file_system import nfs_cli
@@ -79,6 +80,7 @@ def setup(profile: Optional[str] = None):
 
 entrypoint_cli_typer.add_typer(app_cli)
 entrypoint_cli_typer.add_typer(config_cli)
+entrypoint_cli_typer.add_typer(container_cli)
 entrypoint_cli_typer.add_typer(environment_cli)
 entrypoint_cli_typer.add_typer(launch_cli)
 entrypoint_cli_typer.add_typer(nfs_cli)

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -540,17 +540,17 @@ message ContainerHeartbeatRequest {
 
 message ContainerCheckpointRequest {}
 
-message ContainerStats {
-  string container_id = 1;
+message TaskStats {
+  string task_id = 1;
   string app_id = 2;
   string app_description = 3;
   double started_at = 4;
 }
 
-message ContainerListRequest {}
+message TaskListRequest {}
 
-message ContainerListResponse {
-  repeated ContainerStats containers = 1;
+message TaskListResponse {
+  repeated TaskStats tasks = 1;
 }
 
 message DictClearRequest {
@@ -1695,7 +1695,6 @@ service ModalClient {
   rpc ClientHeartbeat(ClientHeartbeatRequest) returns (google.protobuf.Empty);
 
   // Container
-  rpc ContainerList(ContainerListRequest) returns (ContainerListResponse);
   rpc ContainerHeartbeat(ContainerHeartbeatRequest) returns (google.protobuf.Empty);
 
   // Checkpointing
@@ -1777,6 +1776,7 @@ service ModalClient {
 
   // Tasks
   rpc TaskResult(TaskResultRequest) returns (google.protobuf.Empty);
+  rpc TaskList(TaskListRequest) returns (TaskListResponse);
 
   // Tokens (web auth flow)
   rpc TokenFlowCreate(TokenFlowCreateRequest) returns (TokenFlowCreateResponse);

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -540,6 +540,21 @@ message ContainerHeartbeatRequest {
 
 message ContainerCheckpointRequest {}
 
+message ContainerStats {
+  string app_id = 1;
+  string worker_id = 2;
+  string id = 3;
+  // todo(nathan): ??
+}
+
+message ContainerListRequest {
+  // todo(nathan): add env or something?
+}
+
+message ContainerListResponse {
+  repeated ContainerStats containers = 1;
+}
+
 message DictClearRequest {
   string dict_id = 1;
 }
@@ -1682,6 +1697,7 @@ service ModalClient {
   rpc ClientHeartbeat(ClientHeartbeatRequest) returns (google.protobuf.Empty);
 
   // Container
+  rpc ContainerList(ContainerListRequest) returns (ContainerListResponse);
   rpc ContainerHeartbeat(ContainerHeartbeatRequest) returns (google.protobuf.Empty);
 
   // Checkpointing

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -543,7 +543,6 @@ message ContainerCheckpointRequest {}
 message ContainerStats {
   string app_id = 1;
   string worker_id = 2;
-  string id = 3;
   // todo(nathan): ??
 }
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -541,14 +541,13 @@ message ContainerHeartbeatRequest {
 message ContainerCheckpointRequest {}
 
 message ContainerStats {
-  string app_id = 1;
-  string worker_id = 2;
-  // todo(nathan): ??
+  string container_id = 1;
+  string app_id = 2;
+  string app_description = 3;
+  double started_at = 4;
 }
 
-message ContainerListRequest {
-  // todo(nathan): add env or something?
-}
+message ContainerListRequest {}
 
 message ContainerListResponse {
   repeated ContainerStats containers = 1;


### PR DESCRIPTION
Also see https://github.com/modal-labs/modal/pull/9582

## Describe your changes

- Linear MOD-2067
- Adds a `modal container list` command that shows list of running containers

![image](https://github.com/modal-labs/modal-client/assets/7865976/2f0a2e92-ba1e-45a6-8993-8a774b712b70)

## Backward/forward compatibility checks

- [ ] Client+Server: this change is compatible with old servers: unsure
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself: unsure
