### PR TITLE
[mod 2017] modal shell loops spawn sh indefinitely with ASGI app functions

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -737,27 +737,28 @@ def import_function(
     else:
         obj = None
 
-    if function_def.webhook_config.type == api_pb2.WEBHOOK_TYPE_ASGI_APP:
-        # function returns an asgi_app, that we can use as a callable.
-        asgi_app = fun()
-        fun = asgi_app_wrapper(asgi_app, function_io_manager)
-        is_async = True
-        is_generator = True
-        data_format = api_pb2.DATA_FORMAT_ASGI
-    elif function_def.webhook_config.type == api_pb2.WEBHOOK_TYPE_WSGI_APP:
-        # function returns an wsgi_app, that we can use as a callable.
-        wsgi_app = fun()
-        fun = wsgi_app_wrapper(wsgi_app, function_io_manager)
-        is_async = True
-        is_generator = True
-        data_format = api_pb2.DATA_FORMAT_ASGI
-    elif function_def.webhook_config.type == api_pb2.WEBHOOK_TYPE_FUNCTION:
-        # function is webhook without an ASGI app. Create one for it.
-        asgi_app = webhook_asgi_app(fun, function_def.webhook_config.method)
-        fun = asgi_app_wrapper(asgi_app, function_io_manager)
-        is_async = True
-        is_generator = True
-        data_format = api_pb2.DATA_FORMAT_ASGI
+    if not pty_info.pty_type:  # do not wrap PTY-enabled functions
+        if function_def.webhook_config.type == api_pb2.WEBHOOK_TYPE_ASGI_APP:
+            # function returns an asgi_app, that we can use as a callable.
+            asgi_app = fun()
+            fun = asgi_app_wrapper(asgi_app, function_io_manager)
+            is_async = True
+            is_generator = True
+            data_format = api_pb2.DATA_FORMAT_ASGI
+        elif function_def.webhook_config.type == api_pb2.WEBHOOK_TYPE_WSGI_APP:
+            # function returns an wsgi_app, that we can use as a callable.
+            wsgi_app = fun()
+            fun = wsgi_app_wrapper(wsgi_app, function_io_manager)
+            is_async = True
+            is_generator = True
+            data_format = api_pb2.DATA_FORMAT_ASGI
+        elif function_def.webhook_config.type == api_pb2.WEBHOOK_TYPE_FUNCTION:
+            # function is webhook without an ASGI app. Create one for it.
+            asgi_app = webhook_asgi_app(fun, function_def.webhook_config.method)
+            fun = asgi_app_wrapper(asgi_app, function_io_manager)
+            is_async = True
+            is_generator = True
+            data_format = api_pb2.DATA_FORMAT_ASGI
 
     return ImportedFunction(
         obj,

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -506,6 +506,8 @@ class _Stub:
                 keep_warm = f.keep_warm or keep_warm
 
                 if webhook_config:
+                    if interactive:
+                        raise InvalidError(f"{interactive=} is not supported with web endpoint functions")
                     self._web_endpoints.append(info.get_tag())
             else:
                 info = FunctionInfo(f, serialized=serialized, name_override=name, cls=_cls)

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -507,7 +507,7 @@ class _Stub:
 
                 if webhook_config:
                     if interactive:
-                        raise InvalidError(f"{interactive=} is not supported with web endpoint functions")
+                        raise InvalidError("interactive=True is not supported with web endpoint functions")
                     self._web_endpoints.append(info.get_tag())
             else:
                 info = FunctionInfo(f, serialized=serialized, name_override=name, cls=_cls)

--- a/test/webhook_test.py
+++ b/test/webhook_test.py
@@ -125,7 +125,7 @@ async def test_webhook_decorator_with_interactivity(servicer, client):
         with pytest.raises(InvalidError) as excinfo:
 
             @stub.function(serialized=True, interactive=True)
-            @dec()
+            @dec()  # type: ignore
             def web():
                 pass
 

--- a/test/webhook_test.py
+++ b/test/webhook_test.py
@@ -117,6 +117,22 @@ async def test_webhook_decorator_in_wrong_order(servicer, client):
 
 
 @pytest.mark.asyncio
+async def test_webhook_decorator_with_interactivity(servicer, client):
+    stub = Stub()
+
+    # Debuggers can't work with Modal Functions triggered over HTTP.
+    for dec in [web_endpoint, asgi_app, wsgi_app]:
+        with pytest.raises(InvalidError) as excinfo:
+
+            @stub.function(serialized=True, interactive=True)
+            @dec()
+            def web():
+                pass
+
+        assert "not supported" in str(excinfo.value).lower()
+
+
+@pytest.mark.asyncio
 async def test_asgi_wsgi(servicer, client):
     stub = Stub()
 


### PR DESCRIPTION
### Describe your changes

- MOD-2017

Another bug that can be fixed in a follow-up: having `async def` with `@asgi_app` is invalid, but it's not caught by the client. 

### Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.
