### PR TITLE
Rename restrict_network to block_network

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -116,7 +116,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         cpu: Optional[float] = None,
         memory: Optional[int] = None,
         network_file_systems: Dict[Union[str, os.PathLike], _NetworkFileSystem] = {},
-        restrict_network: bool = False,
+        block_network: bool = False,
     ) -> "_Sandbox":
         """mdmd:hidden"""
 
@@ -153,7 +153,7 @@ class _Sandbox(_Object, type_prefix="sb"):
                 cloud_provider=cloud_provider,
                 nfs_mounts=network_file_system_mount_protos(validated_network_file_systems, False),
                 runtime_debug=config.get("function_runtime_debug"),
-                restrict_network=restrict_network,
+                block_network=block_network,
             )
 
             create_req = api_pb2.SandboxCreateRequest(app_id=resolver.app_id, definition=definition)

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -653,7 +653,7 @@ class _Stub:
         cloud: Optional[str] = None,
         cpu: Optional[float] = None,  # How many CPU cores to request. This is a soft limit.
         memory: Optional[int] = None,  # How much memory to request, in MiB. This is a soft limit.
-        restrict_network: bool = False,  # Whether to restrict network access
+        block_network: bool = False,  # Whether to block network access
     ) -> _Sandbox:
         """Sandboxes are a way to run arbitrary commands in dynamically defined environments.
 
@@ -689,7 +689,7 @@ class _Stub:
             cpu=cpu,
             memory=memory,
             network_file_systems=network_file_systems,
-            restrict_network=restrict_network,
+            block_network=block_network,
         )
         await resolver.load(obj)
         return obj

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1085,7 +1085,7 @@ message Sandbox {
 
   bool runtime_debug = 10; // For internal debugging use only.
 
-  bool restrict_network = 11;
+  bool block_network = 11;
 }
 
 message SandboxCreateRequest {


### PR DESCRIPTION
Question: Should I bump the `api.proto` number, or is this not necessary?