### PR TITLE
Support `modal container exec`

### DIFF
--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -52,9 +52,8 @@ async def exec(task_id: str, command: str):
     res: api_pb2.ContainerExecResponse = await client.stub.ContainerExec(
         api_pb2.ContainerExecRequest(task_id=task_id, command=command, pty_info=get_pty_info(shell=True))
     )
-    if res.exec_id is None:
-        # todo(nathan): proper error message?
-        print("failed to execute command, unclear why")
+    if res.exec_id == "":
+        print(f"Failed to execute command. Is the container ID ({task_id}) correct?")
         return
 
     async with handle_exec_input(client, res.exec_id):

--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import errno
 import os
+import platform
 import select
 import sys
 from typing import List, Optional, Union
@@ -48,6 +49,10 @@ async def list():
 @synchronizer.create_blocking
 async def exec(task_id: str, command: str):
     """Execute a command inside an active container"""
+    if platform.system() == "Windows":
+        print("container exec is not currently supported on Windows.")
+        return
+
     client = await _Client.from_env()
     res: api_pb2.ContainerExecResponse = await client.stub.ContainerExec(
         api_pb2.ContainerExecRequest(task_id=task_id, command=command, pty_info=get_pty_info(shell=True))

--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -12,7 +12,7 @@ import typer
 from grpclib.exceptions import GRPCError, StreamTerminatedError
 from rich.text import Text
 
-from modal._pty import get_pty_info, raw_terminal, set_nonblocking
+from modal._pty import get_pty_info, set_nonblocking
 from modal.cli.utils import display_table, timestamp_to_local
 from modal.client import _Client
 from modal_proto import api_pb2
@@ -88,8 +88,9 @@ async def handle_exec_input(client: _Client, exec_id: str):
             )
 
     write_task = asyncio.create_task(_write())
-    with raw_terminal():
-        yield
+
+    yield
+
     os.write(quit_pipe_write, b"\n")
     write_task.cancel()
 
@@ -127,7 +128,6 @@ async def handle_exec_output(client: _Client, exec_id: str):
         async for batch in unary_stream(client.stub.ContainerExecGetOutput, req):
             for message in batch.items:
                 assert message.file_descriptor in [1, 2]
-                assert message.file_descriptor == 1
 
                 await write_data(message.file_descriptor, str.encode(message.message))
 

--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -103,7 +103,7 @@ async def handle_exec_output(client: _Client, exec_id: str):
 
         req = api_pb2.ContainerExecGetOutputRequest(
             exec_id=exec_id,
-            timeout=0.5,
+            timeout=55,
             last_entry_id=last_entry_id,
         )
         async for message in unary_stream(client.stub.ContainerExecGetOutput, req):

--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -33,3 +33,14 @@ async def list():
         )
 
     display_table(column_names, rows, json=False, title="Active Containers")
+
+
+@container_cli.command("exec")
+@synchronizer.create_blocking
+async def exec(task_id: str, command: str):
+    """Execute a command inside an active container"""
+    client = await _Client.from_env()
+    res: api_pb2.ContainerExecResponse = await client.stub.ContainerExec(
+        api_pb2.ContainerExecRequest(task_id=task_id, command=command)
+    )
+    print(res)

--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -82,3 +82,51 @@ async def exec(task_id: str, command: str):
             elif isinstance(exc, StreamTerminatedError):
                 continue
             raise
+
+
+@container_cli.command("connect")
+@synchronizer.create_blocking
+async def connect(task_id: str):
+    """Connects to a container and spawns /bin/bash."""
+    # todo(nathan): get rid of repeated code from above
+    client = await _Client.from_env()
+    res: api_pb2.ContainerExecResponse = await client.stub.ContainerExec(
+        api_pb2.ContainerExecRequest(task_id=task_id, command="/bin/bash")
+    )
+    if res.exec_id is None:
+        # todo(nathan): proper error message?
+        print("failed to execute command, unclear why")
+        return
+
+    last_entry_id = ""
+
+    async def _get_output():
+        nonlocal last_entry_id
+
+        req = api_pb2.ContainerExecGetOutputRequest(
+            exec_id=res.exec_id,
+            timeout=55,
+            last_entry_id=last_entry_id,
+        )
+        async for message in unary_stream(client.stub.ContainerExecGetOutput, req):
+            print(f"[{message.file_descriptor}] {message.message}")
+            # todo(nathan): ugh need to actually implement entry id's as well...
+            # if log_batch.entry_id:
+            #     # log_batch entry_id is empty for fd="server" messages from AppGetLogs
+            #     last_entry_id = log_batch.entry_id
+
+            # if log_batch.eof:
+            #     completed = True
+            #     break
+
+    while True:
+        try:
+            await _get_output()
+        except (GRPCError, StreamTerminatedError) as exc:
+            # todo(nathan): consider debounce?
+            if isinstance(exc, GRPCError):
+                if exc.status in RETRYABLE_GRPC_STATUS_CODES:
+                    continue
+            elif isinstance(exc, StreamTerminatedError):
+                continue
+            raise

--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -3,12 +3,14 @@
 from typing import List, Union
 
 import typer
+from grpclib.exceptions import GRPCError, StreamTerminatedError
 from rich.text import Text
 
 from modal.cli.utils import display_table, timestamp_to_local
 from modal.client import _Client
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronizer
+from modal_utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES, unary_stream
 
 container_cli = typer.Typer(name="container", help="Manage running containers.", no_args_is_help=True)
 
@@ -43,4 +45,40 @@ async def exec(task_id: str, command: str):
     res: api_pb2.ContainerExecResponse = await client.stub.ContainerExec(
         api_pb2.ContainerExecRequest(task_id=task_id, command=command)
     )
-    print(res)
+    if res.exec_id is None:
+        # todo(nathan): proper error message?
+        print("failed to execute command, unclear why")
+        return
+
+    last_entry_id = ""
+
+    async def _get_output():
+        nonlocal last_entry_id
+
+        req = api_pb2.ContainerExecGetOutputRequest(
+            exec_id=res.exec_id,
+            timeout=55,
+            last_entry_id=last_entry_id,
+        )
+        async for message in unary_stream(client.stub.ContainerExecGetOutput, req):
+            print(f"[{message.file_descriptor}] {message.message}")
+            # todo(nathan): ugh need to actually implement entry id's as well...
+            # if log_batch.entry_id:
+            #     # log_batch entry_id is empty for fd="server" messages from AppGetLogs
+            #     last_entry_id = log_batch.entry_id
+
+            # if log_batch.eof:
+            #     completed = True
+            #     break
+
+    while True:
+        try:
+            await _get_output()
+        except (GRPCError, StreamTerminatedError) as exc:
+            # todo(nathan): consider debounce?
+            if isinstance(exc, GRPCError):
+                if exc.status in RETRYABLE_GRPC_STATUS_CODES:
+                    continue
+            elif isinstance(exc, StreamTerminatedError):
+                continue
+            raise

--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -60,7 +60,7 @@ async def exec(task_id: str, command: str):
         await handle_exec_output(client, res.exec_id)
 
 
-# todo(nathan): duplicated code in _pty.py
+# note: this is very similar to code in _pty.py.
 @contextlib.asynccontextmanager
 async def handle_exec_input(client: _Client, exec_id: str):
     quit_pipe_read, quit_pipe_write = os.pipe()
@@ -147,10 +147,3 @@ async def handle_exec_output(client: _Client, exec_id: str):
             elif isinstance(exc, StreamTerminatedError):
                 continue
             raise
-
-
-@container_cli.command("connect")
-@synchronizer.create_blocking
-async def connect(task_id: str):
-    """Connects to a container and spawns /bin/bash."""
-    # todo(nathan): copy code from above

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -545,9 +545,14 @@ message ContainerExecRequest {
   string command = 2;
 }
 
+message ContainerExecGetOutputRequest {
+  string exec_id = 1;
+  float timeout = 2;
+  string last_entry_id = 3;
+}
+
 message ContainerExecResponse {
-  // todo(nathan): maybe add a status field to signal container not found?
-  string message = 1;
+  string exec_id = 1;
 }
 
 message TaskStats {
@@ -1677,6 +1682,13 @@ message WebUrlInfo {
   bool label_stolen = 3;
 }
 
+// Used for `modal container exec`
+message RuntimeOutputMessage {
+  // only stdout / stderr is used
+  FileDescriptor file_descriptor = 1;
+  string message = 2;
+}
+
 
 service ModalClient {
   // Apps
@@ -1708,7 +1720,9 @@ service ModalClient {
 
   // Container
   rpc ContainerHeartbeat(ContainerHeartbeatRequest) returns (google.protobuf.Empty);
+  // todo(nathan): should both of these just be renamed to Task?
   rpc ContainerExec(ContainerExecRequest) returns (ContainerExecResponse);
+  rpc ContainerExecGetOutput(ContainerExecGetOutputRequest) returns (stream RuntimeOutputMessage);
 
   // Checkpointing
   rpc ContainerCheckpoint(ContainerCheckpointRequest) returns (google.protobuf.Empty);

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1698,7 +1698,10 @@ message RuntimeOutputMessage {
 }
 
 message RuntimeInputMessage {
+  // todo(nathan): make sure to also support resizing window, etc
   string message = 1;
+  // this is filled in by the server
+  string entry_id = 2;
 }
 
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1685,8 +1685,11 @@ message WebUrlInfo {
 // Used for `modal container exec`
 message RuntimeOutputMessage {
   // only stdout / stderr is used
-  FileDescriptor file_descriptor = 1;
-  string message = 2;
+  string entry_id = 1;
+  double timestamp = 2;
+  FileDescriptor file_descriptor = 3;
+  string message = 4;
+  bool eof = 5;
 }
 
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1753,7 +1753,6 @@ service ModalClient {
 
   // Container
   rpc ContainerHeartbeat(ContainerHeartbeatRequest) returns (google.protobuf.Empty);
-  // todo(nathan): should both of these just be renamed to Task?
   rpc ContainerExec(ContainerExecRequest) returns (ContainerExecResponse);
   rpc ContainerExecGetOutput(ContainerExecGetOutputRequest) returns (stream RuntimeOutputBatch);
   rpc ContainerExecPutInput(ContainerExecPutInputRequest) returns (google.protobuf.Empty);

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -551,6 +551,11 @@ message ContainerExecGetOutputRequest {
   string last_entry_id = 3;
 }
 
+message ContainerExecPutInputRequest {
+  string exec_id = 1;
+  RuntimeInputMessage input = 2;
+}
+
 message ContainerExecResponse {
   string exec_id = 1;
 }
@@ -1692,6 +1697,10 @@ message RuntimeOutputMessage {
   bool eof = 5;
 }
 
+message RuntimeInputMessage {
+  string message = 1;
+}
+
 
 service ModalClient {
   // Apps
@@ -1726,6 +1735,7 @@ service ModalClient {
   // todo(nathan): should both of these just be renamed to Task?
   rpc ContainerExec(ContainerExecRequest) returns (ContainerExecResponse);
   rpc ContainerExecGetOutput(ContainerExecGetOutputRequest) returns (stream RuntimeOutputMessage);
+  rpc ContainerExecPutInput(ContainerExecPutInputRequest) returns (google.protobuf.Empty);
 
   // Checkpointing
   rpc ContainerCheckpoint(ContainerCheckpointRequest) returns (google.protobuf.Empty);

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -540,6 +540,16 @@ message ContainerHeartbeatRequest {
 
 message ContainerCheckpointRequest {}
 
+message ContainerExecRequest {
+  string task_id = 1;
+  string command = 2;
+}
+
+message ContainerExecResponse {
+  // todo(nathan): maybe add a status field to signal container not found?
+  string message = 1;
+}
+
 message TaskStats {
   string task_id = 1;
   string app_id = 2;
@@ -1698,6 +1708,7 @@ service ModalClient {
 
   // Container
   rpc ContainerHeartbeat(ContainerHeartbeatRequest) returns (google.protobuf.Empty);
+  rpc ContainerExec(ContainerExecRequest) returns (ContainerExecResponse);
 
   // Checkpointing
   rpc ContainerCheckpoint(ContainerCheckpointRequest) returns (google.protobuf.Empty);

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1717,8 +1717,7 @@ message RuntimeOutputBatch {
 }
 
 message RuntimeInputMessage {
-  // todo(nathan): make sure to also support resizing window, etc
-  string message = 1;
+  bytes message = 1;
   // this is filled in by the server
   string entry_id = 2;
 }

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -543,6 +543,7 @@ message ContainerCheckpointRequest {}
 message ContainerExecRequest {
   string task_id = 1;
   string command = 2;
+  PTYInfo pty_info = 3;
 }
 
 message ContainerExecGetOutputRequest {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1690,11 +1690,14 @@ message WebUrlInfo {
 // Used for `modal container exec`
 message RuntimeOutputMessage {
   // only stdout / stderr is used
+  FileDescriptor file_descriptor = 1;
+  string message = 2;
+}
+
+message RuntimeOutputBatch {
   string entry_id = 1;
-  double timestamp = 2;
-  FileDescriptor file_descriptor = 3;
-  string message = 4;
-  bool eof = 5;
+  repeated RuntimeOutputMessage items = 2;
+  bool eof = 3;
 }
 
 message RuntimeInputMessage {
@@ -1737,7 +1740,7 @@ service ModalClient {
   rpc ContainerHeartbeat(ContainerHeartbeatRequest) returns (google.protobuf.Empty);
   // todo(nathan): should both of these just be renamed to Task?
   rpc ContainerExec(ContainerExecRequest) returns (ContainerExecResponse);
-  rpc ContainerExecGetOutput(ContainerExecGetOutputRequest) returns (stream RuntimeOutputMessage);
+  rpc ContainerExecGetOutput(ContainerExecGetOutputRequest) returns (stream RuntimeOutputBatch);
   rpc ContainerExecPutInput(ContainerExecPutInputRequest) returns (google.protobuf.Empty);
 
   // Checkpointing


### PR DESCRIPTION
MOD-2064

See https://github.com/modal-labs/modal/pull/9600

## Changelog

You can now execute commands in running containers with `modal container exec [container-id] [command]`.