### PR TITLE
Setup a changelog that pulls from PR description

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,3 +12,8 @@ Check these boxes or delete any item (or this section) if not relevant for this 
 
 Note on protobuf: protobuf message changes in one place may have impact to
 multiple entities (client, server, worker, database). See points above.
+
+
+## Changelog
+
+<!-- If relevant, include a brief user-facing description of what's new in this version. -->

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -115,6 +115,9 @@ jobs:
       - name: Bump the version number
         run: inv update-build-number -n $GITHUB_RUN_NUMBER
 
+      - name: Update the changelog
+        run: inv update-changelog
+
       - uses: EndBug/add-and-commit@v9
         with:
           add: modal_version/_version_generated.py

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -120,7 +120,7 @@ jobs:
 
       - uses: EndBug/add-and-commit@v9
         with:
-          add: modal_version/_version_generated.py
+          add: modal_version/_version_generated.py CHANGELOG.md
           message: "[auto-commit] [skip ci] Bump the build number"
           pull: "--rebase --autostash"
           default_author: github_actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
-This changelog documents user-facing changes (features, fixes, and deprecations) in `modal`.
+This changelog documents user-facing updates (features, enhancements, fixes, and deprecations) to the `modal` client library. Patch releases are made on every change.
+
+The client library is still in pre-1.0 development, and sometimes breaking changes are necessary. We try to minimize them and publish deprecation warnings / migration guides in advance, typically providing a transition window of several months.
+
+We appreciate your patience while we speedily work towards a stable release of the client.
 
 <!-- NEW CONTENT GENERATED BELOW. PLEASE PRESERVE THIS COMMENT. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+This changelog documents user-facing changes (features, fixes, and deprecations) in `modal`.
+
+<!-- NEW CONTENT GENERATED BELOW. PLEASE PRESERVE THIS COMMENT. -->

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -18,6 +18,7 @@ requests~=2.31.0
 ruff==0.0.277
 types-croniter~=1.0.8
 types-python-dateutil~=2.8.10
+types-requests~=2.31.0
 types-setuptools~=57.4.11
 types-six==1.16.21
 types-toml~=0.10.4

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -14,6 +14,7 @@ pytest-env~=0.6.2
 pytest-markdown-docs==0.4.3
 pytest-timeout~=2.1.0
 python-dotenv~=1.0.0;python_version>='3.8'
+requests~=2.31.0
 ruff==0.0.277
 types-croniter~=1.0.8
 types-python-dateutil~=2.8.10

--- a/tasks.py
+++ b/tasks.py
@@ -209,7 +209,7 @@ def update_changelog(ctx):
     # Build the new changelog and write it out
     from modal_version import __version__
 
-    date = datetime.now().strftime("%Y-%m-%d")
+    date = datetime.datetime.now().strftime("%Y-%m-%d")
     new_section = f"### {__version__} ({date})\n\n{update}"
     final_content = f"{header}\n\n{new_section}\n\n{previous_changelog}"
     with open("CHANGELOG.md", "w") as fid:

--- a/tasks.py
+++ b/tasks.py
@@ -197,7 +197,6 @@ def update_changelog(ctx):
     # Read the existing changelog and split after the header so we can prepend new content
     with open("CHANGELOG.md", "r") as fid:
         content = fid.read()
-
     token_pattern = "<!-- NEW CONTENT GENERATED BELOW. PLEASE PRESERVE THIS COMMENT. -->"
     m = re.search(token_pattern, content)
     if m:
@@ -211,7 +210,7 @@ def update_changelog(ctx):
     from modal_version import __version__
 
     date = datetime.now().strftime("%Y-%m-%d")
-    new_section = f"## {__version__} ({date})\n\n{update}"
+    new_section = f"### {__version__} ({date})\n\n{update}"
     final_content = f"{header}\n\n{new_section}\n\n{previous_changelog}"
     with open("CHANGELOG.md", "w") as fid:
         fid.write(final_content)

--- a/tasks.py
+++ b/tasks.py
@@ -181,9 +181,9 @@ def update_changelog(ctx):
 
     # Parse the PR description to get a changelog update
     comment_pattern = r"<!--.+?-->"
-    pr_description = re.sub(comment_pattern, "", pr_description)
+    pr_description = re.sub(comment_pattern, "", pr_description, flags=re.DOTALL)
 
-    changelog_pattern = r"## Changelog\s*(.+?)(?:<!--|#|$)"
+    changelog_pattern = r"## Changelog\s*(.+?)(?:^#|$)"
     m = re.search(changelog_pattern, pr_description, flags=re.DOTALL)
     if m:
         update = m.group(1).strip()


### PR DESCRIPTION
## Describe your changes

This sets up the basic infrastructure to start recording changes in the client on a per-version basis. Once this is merged, the PR template will include a "Changelog" section. For user-facing changes (new features, bug fixes, deprecations, etc.), we can add a short description in this section. Once the PR is merged, the action that triggers on a push to main will fetch the PR description and insert it into `CHANGELOG.md`. The section is optional, and the action should abort if you delete the "Changelog" section or simply leave it empty.

The changelog is currently organized with h3 headers (containing the modal version and date) for each micro release. Because the action simply prepends new information, we can revise the existing content or add new content manually if necessary (provided that we are careful to preserve the token that marks where new content should be inserted!)

Please review carefully: I developed this in a test repo and everything looked good, but we won't be able to exercise it in the modal-client repo until it's actually merged, and it could break the automatic release process if it fails on an edge case.

Resolves MOD-2054