### PR TITLE
Add github_token to environment that publish-client workflow runs under

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -96,6 +96,8 @@ jobs:
     needs: [client-test]
     runs-on: ubuntu-20.04
     concurrency: publish-client
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Generate token for Github PR Bot
         id: generate_token


### PR DESCRIPTION
## Describe your changes

Fixes a bug in #1191