### PR TITLE
Fix for --env flag not propagating to all lookups when using `modal run`

### DIFF
--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -192,6 +192,11 @@ def _get_click_command_for_local_entrypoint(stub: Stub, entrypoint: LocalEntrypo
 
 class RunGroup(click.Group):
     def get_command(self, ctx, func_ref):
+        # note: get_command here is run before the "group logic" in the `run` logic below
+        # so to ensure that `env` has been globally populated before user code is loaded, it
+        # needs to be handled here, and not in the `run` logic below
+        ctx.ensure_object(dict)
+        ctx.obj["env"] = ensure_env(ctx.params["env"])
         function_or_entrypoint = import_function(func_ref, accept_local_entrypoint=True, base_cmd="modal run")
         stub: Stub = function_or_entrypoint.stub
         if stub.description is None:
@@ -246,7 +251,6 @@ def run(ctx, detach, quiet, env):
     ctx.ensure_object(dict)
     ctx.obj["detach"] = detach  # if subcommand would be a click command...
     ctx.obj["show_progress"] = False if quiet else True
-    ctx.obj["env"] = env
 
 
 def deploy(

--- a/modal/object.py
+++ b/modal/object.py
@@ -240,7 +240,7 @@ class _StatefulObject(_Object):
     ):
         async def _load_persisted(obj: _Object, resolver: Resolver, existing_object_id: Optional[str]):
             await self._deploy(
-                label, namespace, resolver.client, environment_name=_get_environment_name(environment_name)
+                label, namespace, resolver.client, environment_name=_get_environment_name(environment_name, resolver)
             )
             obj._hydrate_from_other(self)
 

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -506,25 +506,19 @@ def test_environment_noflag(test_dir, servicer, command, monkeypatch):
                     mount_handle_metadata=api_pb2.MountHandleMetadata(content_checksum_sha256_hex="abc123"),
                 )
             ),
-            request_filter=lambda req: req.app_name.startswith("modal-client-mount"),
+            request_filter=lambda req: req.app_name.startswith("modal-client-mount")
+            and req.namespace == api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL,
         )  # built-in client lookup
         ctx.add_response(
             "AppLookupObject",
             api_pb2.AppLookupObjectResponse(object=api_pb2.Object(object_id="sv-123")),
-            request_filter=lambda req: req.app_name == "volume_app",
+            request_filter=lambda req: req.app_name == "volume_app"
+            and req.environment_name == "some_weird_default_env",
         )
         _run(command + [str(stub_file)])
 
     app_create: api_pb2.AppCreateRequest = ctx.pop_request("AppCreate")
     assert app_create.environment_name == "some_weird_default_env"
-
-    app_lookup_object: api_pb2.AppLookupObjectRequest = ctx.pop_request("AppLookupObject")
-    assert app_lookup_object.app_name.startswith("modal-client-mount")
-    assert app_lookup_object.namespace == api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL
-
-    app_lookup_object2: api_pb2.AppLookupObjectRequest = ctx.pop_request("AppLookupObject")
-    assert app_lookup_object2.app_name == "volume_app"
-    assert app_lookup_object2.environment_name == "some_weird_default_env"
 
 
 def test_cls(servicer, set_env_client, test_dir):

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -470,25 +470,18 @@ def test_environment_flag(test_dir, servicer, command):
                     mount_handle_metadata=api_pb2.MountHandleMetadata(content_checksum_sha256_hex="abc123"),
                 )
             ),
-            request_filter=lambda req: req.app_name.startswith("modal-client-mount"),
+            request_filter=lambda req: req.app_name.startswith("modal-client-mount")
+            and req.namespace == api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL,
         )  # built-in client lookup
         ctx.add_response(
             "AppLookupObject",
             api_pb2.AppLookupObjectResponse(object=api_pb2.Object(object_id="sv-123")),
-            request_filter=lambda req: req.app_name == "volume_app",
+            request_filter=lambda req: req.app_name == "volume_app" and req.environment_name == "staging",
         )
         _run(command + ["--env=staging", str(stub_file)])
 
     app_create: api_pb2.AppCreateRequest = ctx.pop_request("AppCreate")
     assert app_create.environment_name == "staging"
-
-    app_lookup_object: api_pb2.AppLookupObjectRequest = ctx.pop_request("AppLookupObject")
-    assert app_lookup_object.app_name.startswith("modal-client-mount")
-    assert app_lookup_object.namespace == api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL
-
-    app_lookup_object2: api_pb2.AppLookupObjectRequest = ctx.pop_request("AppLookupObject")
-    assert app_lookup_object2.app_name == "volume_app"
-    assert app_lookup_object2.environment_name == "staging"
 
 
 @pytest.mark.parametrize("command", [["run"], ["deploy"], ["serve", "--timeout=1"], ["shell"]])

--- a/test/supports/app_run_tests/app_with_lookups.py
+++ b/test/supports/app_run_tests/app_with_lookups.py
@@ -3,7 +3,9 @@ import modal
 
 stub = modal.Stub("my-app")
 
+nfs = modal.NetworkFileSystem.lookup("volume_app")
 
-@stub.function(network_file_systems={"/vol": modal.NetworkFileSystem.from_name("volume_app")})
+
+@stub.function()
 def foo():
     print("foo")


### PR DESCRIPTION
* `ensure_env` wasn't being called for `modal run`
* there was a case where environment wasn't being propagated from the resolver to objects on the app being looked up

There was a test that was intended to catch this exact problem, but it happened to use one of the few lookup methods that were actually working. I changed it to use `modal.lookup()` in global scope now instead, which is entirely reliant on `ensure_env` being called.

## Changelog

- `modal run` cli command now properly propagates `--env` values to object lookups in global scope of user code