### PR TITLE
Add 'Latest' header to changelog and don't break on comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,6 @@ The client library is still in pre-1.0 development, and sometimes breaking chang
 
 We appreciate your patience while we speedily work towards a stable release of the client.
 
+## Latest
+
 <!-- NEW CONTENT GENERATED BELOW. PLEASE PRESERVE THIS COMMENT. -->

--- a/tasks.py
+++ b/tasks.py
@@ -183,7 +183,7 @@ def update_changelog(ctx):
     comment_pattern = r"<!--.+?-->"
     pr_description = re.sub(comment_pattern, "", pr_description, flags=re.DOTALL)
 
-    changelog_pattern = r"## Changelog\s*(.+?)(?:^#|$)"
+    changelog_pattern = r"## Changelog\s*(.+)$"
     m = re.search(changelog_pattern, pr_description, flags=re.DOTALL)
     if m:
         update = m.group(1).strip()


### PR DESCRIPTION
## Describe your changes

Two improvements to the changelog setup:

- I put a "Latest" H2 header at the top of the changelog to align with the plan to (manually) add H2 headers for each 0.YY version bump.
- I modified the regex for extracting the changelog from the PR description. Originally I terminated on `^#` with the idea that people might add additional markdown headers after the changelog section. It occurred to me that this will also terminate if people write Python code examples with comments. It feels safer to extract from the "Changelog" header to the end of the description for now.