### PR TITLE
Allow JSON log format for client logger

### DIFF
--- a/modal/config.py
+++ b/modal/config.py
@@ -79,6 +79,8 @@ from datetime import date
 
 import toml
 
+from modal_utils.logger import configure_logger
+
 from .exception import deprecation_error
 
 # Locate config file and read it
@@ -137,6 +139,7 @@ class _Setting(typing.NamedTuple):
 
 _SETTINGS = {
     "loglevel": _Setting("WARNING", lambda s: s.upper()),
+    "log_format": _Setting("STRING", lambda s: s.upper()),
     "server_url": _Setting("https://api.modal.com"),
     "token_id": _Setting(),
     "token_secret": _Setting(),
@@ -213,12 +216,7 @@ config = Config()
 # Logging
 
 logger = logging.getLogger("modal-client")
-ch = logging.StreamHandler()
-log_level_numeric = logging.getLevelName(config["loglevel"])
-logger.setLevel(log_level_numeric)
-ch.setLevel(log_level_numeric)
-ch.setFormatter(logging.Formatter("%(asctime)s %(message)s", datefmt="%Y-%m-%dT%H:%M:%S%z"))
-logger.addHandler(ch)
+configure_logger(logger, config["loglevel"], config["log_format"])
 
 # Utils to write config
 

--- a/modal_utils/logger.py
+++ b/modal_utils/logger.py
@@ -2,13 +2,36 @@
 import logging
 import os
 
-# TODO: set this from env.
+
+def configure_logger(logger: logging.Logger, log_level: str, log_format: str):
+    ch = logging.StreamHandler()
+    log_level_numeric = logging.getLevelName(log_level.upper())
+    logger.setLevel(log_level_numeric)
+    ch.setLevel(log_level_numeric)
+
+    if log_format.upper() == "JSON":
+        # This is primarily for modal internal use.
+        # pythonjsonlogger is already installed in the environment.
+        from pythonjsonlogger import jsonlogger
+
+        json_formatter = jsonlogger.JsonFormatter(
+            fmt=(
+                "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] "
+                "[dd.service=%(dd.service)s dd.env=%(dd.env)s dd.version=%(dd.version)s dd.trace_id=%(dd.trace_id)s dd.span_id=%(dd.span_id)s] "
+                "- %(message)s"
+            ),
+            datefmt="%Y-%m-%dT%H:%M:%S%z",
+        )
+
+        ch.setFormatter(json_formatter)
+    else:
+        ch.setFormatter(logging.Formatter("%(asctime)s %(message)s", datefmt="%Y-%m-%dT%H:%M:%S%z"))
+
+    logger.addHandler(ch)
+
+
+log_level = os.environ.get("MODAL_LOGLEVEL", "WARNING")
+log_format = os.environ.get("MODAL_LOG_FORMAT", "STRING")
+
 logger = logging.getLogger("modal-utils")
-
-ch = logging.StreamHandler()
-
-log_level_numeric = logging.getLevelName(os.environ.get("MODAL_LOGLEVEL", "WARNING").upper())
-logger.setLevel(log_level_numeric)
-ch.setLevel(log_level_numeric)
-ch.setFormatter(logging.Formatter("%(asctime)s %(message)s", datefmt="%Y-%m-%dT%H:%M:%S%z"))
-logger.addHandler(ch)
+configure_logger(logger, log_level, log_format)


### PR DESCRIPTION
`MODAL_LOG_FORMAT=JSON` configures the client loggers to use a JSON formatter instead of the string one.

This fixes an issue with log handling in our internal server logs (since we use `modal_utils` there).