### PR TITLE
Unit-consistency: don't use 'memory' to mean an non-adjustable amount of GiB

### DIFF
--- a/modal/gpu.py
+++ b/modal/gpu.py
@@ -68,23 +68,24 @@ class A100(_GPUConfig):
         self,
         *,
         count: int = 1,  # Number of GPUs per container. Defaults to 1. Useful if you have very large models that don't fit on a single GPU.
-        memory: int = 0,  # Deprecated. Use `memory_gb` instead.
-        memory_gb: Union[str, None] = None,  # Select GiB configuration of GPU device: "40" or "80". Defaults to "40".
+        memory: int = 0,  # Deprecated. Use `size` instead.
+        size: Union[str, None] = None,  # Select GiB configuration of GPU device: "40GB" or "80GB". Defaults to "40GB".
     ):
         allowed_memory_values = {40, 80}
+        allowed_size_values = {"40GB", "80GB"}
         if memory == 20:
             raise ValueError("A100 20GB is unsupported, consider `modal.A10G` or `modal.A100(memory_gb='40')` instead")
-        elif memory and memory_gb:
-            raise ValueError("Cannot specify both `memory` and `memory_gb`. Just specify `memory_gb`.")
+        elif memory and size:
+            raise ValueError("Cannot specify both `memory` and `size`. Just specify `size`.")
         elif memory:
             if memory not in allowed_memory_values:
                 raise ValueError(f"A100s can only have memory values of {allowed_memory_values} => memory={memory}")
-        elif memory_gb:
-            if memory_gb not in {str(m) for m in allowed_memory_values}:
+        elif size:
+            if size not in allowed_size_values:
                 raise ValueError(
-                    f"memory_mb='{memory_gb}' is invalid. A100s can only have memory values of {allowed_memory_values}."
+                    f"size='{size}' is invalid. A100s can only have memory values of {allowed_size_values}."
                 )
-            memory = int(memory_gb)
+            memory = int(size.replace("GB", ""))
         else:
             memory = 40
 
@@ -177,9 +178,9 @@ def _parse_gpu_config(value: GPU_T, raise_on_true: bool = True) -> Optional[_GPU
         if value.lower() == "a100-20g":
             return A100(memory=20, count=count)  # Triggers unsupported error underneath.
         elif value.lower() == "a100-40gb":
-            return A100(memory_gb="40", count=count)
+            return A100(size="40GB", count=count)
         elif value.lower() == "a100-80gb":
-            return A100(memory_gb="80", count=count)
+            return A100(size="80GB", count=count)
         elif value.lower() not in STRING_TO_GPU_CONFIG:
             raise InvalidError(
                 f"Invalid GPU type: {value}. Value must be one of {list(STRING_TO_GPU_CONFIG.keys())} (case-insensitive)."

--- a/modal/gpu.py
+++ b/modal/gpu.py
@@ -179,6 +179,8 @@ def _parse_gpu_config(value: GPU_T, raise_on_true: bool = True) -> Optional[_GPU
 
         if value.lower() == "a100-20g":
             return A100(memory=20, count=count)  # Triggers unsupported error underneath.
+        elif value.lower() == "a100-40gb":
+            return A100(memory_gb="40", count=count)
         elif value.lower() == "a100-80gb":
             return A100(memory_gb="80", count=count)
         elif value.lower() not in STRING_TO_GPU_CONFIG:

--- a/modal/gpu.py
+++ b/modal/gpu.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 from dataclasses import dataclass
 from datetime import date
-from typing import Literal, Optional, Union
+from typing import Optional, Union
 
 from modal_proto import api_pb2
 
@@ -69,9 +69,7 @@ class A100(_GPUConfig):
         *,
         count: int = 1,  # Number of GPUs per container. Defaults to 1. Useful if you have very large models that don't fit on a single GPU.
         memory: int = 0,  # Deprecated. Use `memory_gb` instead.
-        memory_gb: Union[
-            Literal["80"], Literal["40"], None
-        ] = None,  # Select GiB configuration of GPU device. Defaults to 40GiB.
+        memory_gb: Union[str, None] = None,  # Select GiB configuration of GPU device: "40" or "80". Defaults to "40".
     ):
         allowed_memory_values = {40, 80}
         if memory == 20:

--- a/modal/gpu.py
+++ b/modal/gpu.py
@@ -69,7 +69,9 @@ class A100(_GPUConfig):
         *,
         count: int = 1,  # Number of GPUs per container. Defaults to 1. Useful if you have very large models that don't fit on a single GPU.
         memory: int = 0,  # Deprecated. Use `memory_gb` instead.
-        memory_gb: Union[Literal["80"], Literal["40"], None] = None,  # Select GiB configuration of GPU device.
+        memory_gb: Union[
+            Literal["80"], Literal["40"], None
+        ] = None,  # Select GiB configuration of GPU device. Defaults to 40GiB.
     ):
         if memory == 20:
             raise ValueError("A100 20GB is unsupported, consider `modal.A10G` or `modal.A100(memory_gb='40')` instead")

--- a/modal/gpu.py
+++ b/modal/gpu.py
@@ -73,23 +73,22 @@ class A100(_GPUConfig):
             Literal["80"], Literal["40"], None
         ] = None,  # Select GiB configuration of GPU device. Defaults to 40GiB.
     ):
+        allowed_memory_values = {40, 80}
         if memory == 20:
             raise ValueError("A100 20GB is unsupported, consider `modal.A10G` or `modal.A100(memory_gb='40')` instead")
         elif memory and memory_gb:
             raise ValueError("Cannot specify both `memory` and `memory_gb`. Just specify `memory_gb`.")
-
-        memory = memory or 40
-        memory_gb = memory_gb or "40"
-        allowed_memory_values = {40, 80}
-
-        if memory not in allowed_memory_values:
-            raise ValueError(f"A100s can only have memory values of {allowed_memory_values} => memory={memory}")
-        if memory_gb not in {str(m) for m in allowed_memory_values}:
-            raise ValueError(
-                f"memory_mb='{memory_gb}' is invalid. A100s can only have memory values of {allowed_memory_values}."
-            )
-        else:
+        elif memory:
+            if memory not in allowed_memory_values:
+                raise ValueError(f"A100s can only have memory values of {allowed_memory_values} => memory={memory}")
+        elif memory_gb:
+            if memory_gb not in {str(m) for m in allowed_memory_values}:
+                raise ValueError(
+                    f"memory_mb='{memory_gb}' is invalid. A100s can only have memory values of {allowed_memory_values}."
+                )
             memory = int(memory_gb)
+        else:
+            memory = 40
 
         if memory == 80:
             super().__init__(api_pb2.GPU_TYPE_A100_80GB, count, memory)

--- a/test/gpu_test.py
+++ b/test/gpu_test.py
@@ -141,7 +141,7 @@ def test_a100_20gb_gpu_unsupported():
 
     with pytest.raises(ValueError) as err:
         stub.function(gpu=modal.gpu.A100(memory=20))(dummy)
-    assert err.value.args[0].startswith("A100 20GB is unsupported, consider A10 or A100 40GB instead")
+    assert err.value.args[0].startswith("A100 20GB is unsupported, consider")
 
 
 A100_GPU_COUNT_MAPPING = {1: api_pb2.GPU_TYPE_A100, **{i: api_pb2.GPU_TYPE_A100 for i in range(2, 5)}}

--- a/test/gpu_test.py
+++ b/test/gpu_test.py
@@ -138,9 +138,8 @@ def test_a100_20gb_gpu_unsupported():
 
     stub = Stub()
 
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError, match="A100 20GB is unsupported, consider"):
         stub.function(gpu=modal.gpu.A100(memory=20))(dummy)
-    assert err.value.args[0].startswith("A100 20GB is unsupported, consider")
 
 
 A100_GPU_COUNT_MAPPING = {1: api_pb2.GPU_TYPE_A100, **{i: api_pb2.GPU_TYPE_A100 for i in range(2, 5)}}


### PR DESCRIPTION
~`modal.gpu.A100(memory=40)` → `modal.gpu.A100(memory_gb="40")`~

`modal.gpu.A100(memory=40)` → `modal.gpu.A100(size="40GB")`

### Describe your changes

Putting this up as a result of some discussion in `#client` Slack channel. 

Currently a `memory: int` parameter is dominantly used to provide way to specify a integer amount of MiB in some allowed range. But in the `gpu.py` module `memory: int` is used to provide a way to specify _only two possible_ integer values of _GiB_, not MiB.

This change proposes that: 

1. when measurement parameters have names that do not include the unit (e.g. `memory`, `timeout`), we should consistently use only one unit for that measurement. (And where possible, sue the SI base unit, which is seconds in the case of time.)
2. A `int` parameter shouldn't be used when the set of valid integers is very small.
    - But what should be used? A `Enum` is a bit clunky, but most correct. 

2 is more contentious than 1. 

### Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


## Changelog

- `gpu.A100` class now supports specifying GiB memory configuration using a `size: str` parameter. The `memory: int` parameter is deprecated.
