### PR TITLE
Adds `volumes` argument to Stub

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -8,6 +8,7 @@ import warnings
 from contextvars import ContextVar
 from dataclasses import dataclass
 from datetime import date
+from pathlib import PurePosixPath
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -516,7 +517,7 @@ def _parse_retries(
 
 
 def _validate_volumes(
-    volumes: Dict[Union[str, os.PathLike], _Volume]
+    volumes: Dict[Union[str, PurePosixPath], _Volume]
 ) -> List[Tuple[str, Union[_Volume, _NetworkFileSystem]]]:
     if not isinstance(volumes, dict):
         raise InvalidError("volumes must be a dict[str, Volume] where the keys are paths")


### PR DESCRIPTION
## Describe your changes

Similarly to `mounts` and `secrets`, this sets a baseline of volumes for all of the stub's functions


## Backward/forward compatibility checks

Minor incompatibility for apps using the name `volumes` as a general Modal object assigned through a stub constructor (and such assignments has been deprecated for a while afaik)

## Changelog

* modal.Stub now takes a `volumes` argument for setting the default volumes of all the stub's functions, similarly to the `mounts` and `secrets` argument.