### PR TITLE
Add `block_network` flag to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ We appreciate your patience while we speedily work towards a stable release of t
 
 <!-- NEW CONTENT GENERATED BELOW. PLEASE PRESERVE THIS COMMENT. -->
 
+### 0.56.4620 (2024-01-16)
+
+* modal.Stub.function now takes a `block_network` argument.
+
+
+
 ### 0.56.4616 (2024-01-16)
 
 * modal.Stub now takes a `volumes` argument for setting the default volumes of all the stub's functions, similarly to the `mounts` and `secrets` argument.


### PR DESCRIPTION
I forgot to fill out the changelog in my previous PR, so I'm filling it out manually in CHANGELOG.md