### PR TITLE
Mark 3.8 as min version in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     aiohttp
     aiostream


### PR DESCRIPTION
### Describe your changes

Follow up to https://github.com/modal-labs/modal-client/pull/1204. Thanks @aksh-at 

### Backward/forward compatibility checks

- [x] Client+Server: this change is compatible with old servers
    - This isn't related to servers sending data to the client.
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
