### PR TITLE
[MOD 2035] automatically handle resource exhausted input rate limiting

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package modal.client;
 
 import "modal_proto/options.proto";
+import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/wrappers.proto";
 
@@ -1267,6 +1268,14 @@ message Resources {
   uint32 memory_mb = 2;
   uint32 milli_cpu = 3;
   GPUConfig gpu_config = 4;
+}
+
+// Used in RESOURCE_EXHAUSTED errors to differentiate
+// retryable and non-retryable version of that error status.
+// Idea taken from googleapis:
+// github.com/googleapis/googleapis/blob/8781c9414dc1543ae0198f727b4d15020eceabf6/google/rpc/error_details.proto#L91C9-L91C18
+message RetryInfo {
+  google.protobuf.Duration retry_delay = 1;
 }
 
 message Sandbox {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1272,8 +1272,8 @@ message Resources {
 
 // Used in RESOURCE_EXHAUSTED errors to differentiate
 // retryable and non-retryable version of that error status.
-// Idea taken from googleapis:
-// github.com/googleapis/googleapis/blob/8781c9414dc1543ae0198f727b4d15020eceabf6/google/rpc/error_details.proto#L91C9-L91C18
+// Lifted from googleapis as an alternative to using the google-common-protos PyPi package.
+// ref: github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto
 message RetryInfo {
   google.protobuf.Duration retry_delay = 1;
 }

--- a/modal_utils/grpc_utils.py
+++ b/modal_utils/grpc_utils.py
@@ -220,7 +220,7 @@ async def unary_stream(
             yield item
 
 
-def get_grpc_error_retry_delay(e: GRPCError) -> int | None:
+def get_grpc_error_retry_delay(e: GRPCError) -> Optional[int]:
     """Returns the recommended retry delay in secs if error is retryable. Otherwise, `None`."""
     if not e.details:
         return None

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ install_requires =
     cloudpickle>=2.2.0,<2.3.0;python_version>='3.11'
     click>=8.1.0
     fastapi
+    googleapis-common-protos
     grpclib==0.4.3
     importlib_metadata>=3.6.0
     protobuf>=3.19,<5.0,!=4.24.0

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -309,8 +309,8 @@ class MockClientServicer(api_grpc.ModalClientBase):
         # This is used to test retry_transient_errors, see grpc_utils_test.py
         self.blob_create_metadata = stream.metadata
         if len(self.fail_blob_create) > 0:
-            status_code = self.fail_blob_create.pop()
-            raise GRPCError(status_code, "foobar")
+            err = self.fail_blob_create.pop()
+            raise err
         elif req.content_length > self.blob_multipart_threshold:
             self.n_blobs += 1
             blob_id = f"bl-{self.n_blobs}"

--- a/test/grpc_utils_test.py
+++ b/test/grpc_utils_test.py
@@ -105,26 +105,26 @@ async def test_retry_transient_errors(servicer):
     req = api_pb2.BlobCreateRequest()
 
     # Fail 3 times -> should still succeed
-    servicer.fail_blob_create = [Status.UNAVAILABLE] * 3
+    servicer.fail_blob_create = [GRPCError(Status.UNAVAILABLE, "foobar")] * 3
     assert await retry_transient_errors(client_stub.BlobCreate, req)
     assert servicer.blob_create_metadata.get("x-idempotency-key")
     assert servicer.blob_create_metadata.get("x-retry-attempt") == "3"
 
     # Fail 4 times -> should fail
-    servicer.fail_blob_create = [Status.UNAVAILABLE] * 4
+    servicer.fail_blob_create = [GRPCError(Status.UNAVAILABLE, "foobar")] * 4
     with pytest.raises(GRPCError):
         await retry_transient_errors(client_stub.BlobCreate, req)
     assert servicer.blob_create_metadata.get("x-idempotency-key")
     assert servicer.blob_create_metadata.get("x-retry-attempt") == "3"
 
     # Fail 5 times, but set max_retries to infinity
-    servicer.fail_blob_create = [Status.UNAVAILABLE] * 5
+    servicer.fail_blob_create = [GRPCError(Status.UNAVAILABLE, "foobar")] * 5
     assert await retry_transient_errors(client_stub.BlobCreate, req, max_retries=None, base_delay=0)
     assert servicer.blob_create_metadata.get("x-idempotency-key")
     assert servicer.blob_create_metadata.get("x-retry-attempt") == "5"
 
     # Not a transient error.
-    servicer.fail_blob_create = [Status.PERMISSION_DENIED]
+    servicer.fail_blob_create = [GRPCError(Status.PERMISSION_DENIED, "foobar")]
     with pytest.raises(GRPCError):
         assert await retry_transient_errors(client_stub.BlobCreate, req, max_retries=None, base_delay=0)
     assert servicer.blob_create_metadata.get("x-idempotency-key")
@@ -132,7 +132,7 @@ async def test_retry_transient_errors(servicer):
 
     # Make sure to respect total_timeout
     t0 = time.time()
-    servicer.fail_blob_create = [Status.UNAVAILABLE] * 99
+    servicer.fail_blob_create = [GRPCError(Status.UNAVAILABLE, "foobar")] * 99
     with pytest.raises(GRPCError):
         assert await retry_transient_errors(client_stub.BlobCreate, req, max_retries=None, total_timeout=3)
     total_time = time.time() - t0


### PR DESCRIPTION
### Describe your changes

- MOD-2035

This turned into a bit of a rabbit hole. We previously did actually retry `RESOURCE_EXHAUSTED` status codes, until Richard used that code for the "Workspace billing limit" issue (legit) and in that case `RESOURCE_EXHAUSTED` is _not_ retryable. So he removed the retrying.

The crux is that some `RESOURCE_EXHAUSTED` errors are retryable and some aren't. The client needs some way to differentiate them. The best way to do that appears to be the `details` part of a gRPCError and the accompanying `RetryInfo` message.

Here are some examples of others discussing or dealing with this issue. 

- https://groups.google.com/g/remote-execution-apis/c/drAQ6N1pNbQ (Bazel devs discussed how to tell when to retry `RESOURCE_EXHAUSTED`)
- https://github.com/open-telemetry/opentelemetry-collector/pull/5147 (Using `RetryInfo` with `RESOURCE_EXHAUSTED`
- https://grpclib.readthedocs.io/en/latest/errors.html#error-details

This PR adds the client-side changes to make `RESOURCE_EXHAUSTED` errors conditionally retryable on the presence of `RetryInfo`. 

There's also some annoying `grpclib` -> `grpcio` data munging required on the server to get this working. Please check out that PR as well (PR #9700)


### Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
    - yes, the client will get no error details and just error immediately like it currently does.
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
