### PR TITLE
Remove outputs_timeout config variable

### DIFF
--- a/modal/config.py
+++ b/modal/config.py
@@ -148,7 +148,6 @@ _SETTINGS = {
     "serve_timeout": _Setting(transform=float),
     "sync_entrypoint": _Setting(),
     "logs_timeout": _Setting(10, float),
-    "outputs_timeout": _Setting(55.0, float),
     "image_python_version": _Setting(),
     "image_id": _Setting(),
     "automount": _Setting(True, transform=lambda x: x not in ("", "0")),

--- a/modal_utils/grpc_utils.py
+++ b/modal_utils/grpc_utils.py
@@ -60,8 +60,7 @@ class ChannelPool(grpclib.client.Channel):
     """Use multiple channels under the hood. A drop-in replacement for the grpclib Channel.
 
     The main reason is to get around limitations with TCP connections over the internet,
-    in particular idle timeouts, but also the fact that ALBs in AWS limits the number of
-    streams per connection to 128.
+    in particular idle timeouts.
 
     The algorithm is very simple. It reuses the last subchannel as long as it has had less
     than 64 requests or if it was created less than 30s ago. It closes any subchannel that


### PR DESCRIPTION
This configuration variable is unused and undocumented. If a user changes the value, it might lead to problems since it's tuned to our internal infrastructure.
