### PR TITLE
Change Mount.from_local_python_packages remote path to /root

### DIFF
--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -15,10 +15,8 @@ from modal_proto import api_pb2
 from ._serialization import serialize
 from .config import config, logger
 from .exception import InvalidError
-from .mount import _Mount
+from .mount import ROOT_DIR, _Mount
 from .object import Object
-
-ROOT_DIR = PurePosixPath("/root")
 
 # Expand symlinks in paths (homebrew Python paths are all symlinks).
 SYS_PREFIXES = set(

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -395,7 +395,7 @@ class _Mount(_StatefulObject, type_prefix="mo"):
         provider._hydrate(resp.mount_id, resolver.client, resp.handle_metadata)
 
     @staticmethod
-    def from_local_python_packages(*module_names: str, remote_dir=ROOT_DIR) -> "_Mount":
+    def from_local_python_packages(*module_names: str, remote_dir: Union[str, PurePosixPath] = ROOT_DIR) -> "_Mount":
         """Returns a `modal.Mount` that makes local modules listed in `module_names` available inside the container.
         This works by mounting the local path of each module's package to a directory inside the container that's on `PYTHONPATH`.
 
@@ -422,6 +422,7 @@ class _Mount(_StatefulObject, type_prefix="mo"):
         if not is_local():
             return mount
 
+        remote_dir = PurePosixPath(remote_dir)
         for module_name in module_names:
             mount_infos = get_module_mount_info(module_name)
 

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -396,7 +396,7 @@ class _Mount(_StatefulObject, type_prefix="mo"):
 
     @staticmethod
     def from_local_python_packages(
-        *module_names: str, remote_dir: Union[str, PurePosixPath] = str(ROOT_DIR)
+        *module_names: str, remote_dir: Union[str, PurePosixPath] = ROOT_DIR.as_posix()
     ) -> "_Mount":
         """Returns a `modal.Mount` that makes local modules listed in `module_names` available inside the container.
         This works by mounting the local path of each module's package to a directory inside the container that's on `PYTHONPATH`.

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -28,7 +28,7 @@ from .config import config, logger
 from .exception import NotFoundError
 from .object import _StatefulObject
 
-ROOT_DIR = PurePosixPath("/root")
+ROOT_DIR: PurePosixPath = PurePosixPath("/root")
 MOUNT_PUT_FILE_CLIENT_TIMEOUT = 10 * 60  # 10 min max for transferring files
 
 # Supported releases and versions for python-build-standalone.
@@ -395,7 +395,9 @@ class _Mount(_StatefulObject, type_prefix="mo"):
         provider._hydrate(resp.mount_id, resolver.client, resp.handle_metadata)
 
     @staticmethod
-    def from_local_python_packages(*module_names: str, remote_dir: Union[str, PurePosixPath] = ROOT_DIR) -> "_Mount":
+    def from_local_python_packages(
+        *module_names: str, remote_dir: Union[str, PurePosixPath] = str(ROOT_DIR)
+    ) -> "_Mount":
         """Returns a `modal.Mount` that makes local modules listed in `module_names` available inside the container.
         This works by mounting the local path of each module's package to a directory inside the container that's on `PYTHONPATH`.
 

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -28,6 +28,7 @@ from .config import config, logger
 from .exception import NotFoundError
 from .object import _StatefulObject
 
+ROOT_DIR = PurePosixPath("/root")
 MOUNT_PUT_FILE_CLIENT_TIMEOUT = 10 * 60  # 10 min max for transferring files
 
 # Supported releases and versions for python-build-standalone.
@@ -394,7 +395,7 @@ class _Mount(_StatefulObject, type_prefix="mo"):
         provider._hydrate(resp.mount_id, resolver.client, resp.handle_metadata)
 
     @staticmethod
-    def from_local_python_packages(*module_names: str) -> "_Mount":
+    def from_local_python_packages(*module_names: str, remote_dir=ROOT_DIR) -> "_Mount":
         """Returns a `modal.Mount` that makes local modules listed in `module_names` available inside the container.
         This works by mounting the local path of each module's package to a directory inside the container that's on `PYTHONPATH`.
 
@@ -432,12 +433,12 @@ class _Mount(_StatefulObject, type_prefix="mo"):
                 if is_package:
                     mount = mount.add_local_dir(
                         base_path,
-                        remote_path=f"/pkg/{module_name}",
+                        remote_path=remote_dir / module_name,
                         condition=module_mount_condition,
                         recursive=True,
                     )
                 else:
-                    remote_path = PurePosixPath("/pkg") / Path(base_path).name
+                    remote_path = remote_dir / Path(base_path).name
                     mount = mount.add_local_file(
                         base_path,
                         remote_path=remote_path,

--- a/test/mount_test.py
+++ b/test/mount_test.py
@@ -92,14 +92,25 @@ def test_from_local_python_packages(servicer, client, test_dir):
     stub.function(mounts=[Mount.from_local_python_packages("pkg_a", "pkg_b", "standalone_file")])(dummy)
 
     with stub.run(client=client):
-        files = servicer.files_name2sha.keys()
-        assert any(["/pkg/pkg_a/a.py" in f for f in files])
-        assert any(["/pkg/pkg_a/b/c.py" in f for f in files])
-        assert any(["/pkg/pkg_b/f.py" in f for f in files])
-        assert any(["/pkg/pkg_b/g/h.py" in f for f in files])
-        assert any(["/pkg/standalone_file.py" in f for f in files])
-        assert not any(["/pkg/pkg_c/i.py" in f for f in files])
-        assert not any(["/pkg/pkg_c/j/k.py" in f for f in files])
+        files = set(servicer.files_name2sha.keys())
+        assert {
+            # files that should be added
+            "/root/pkg_a/a.py",
+            "/root/pkg_a/b/c.py",
+            "/root/pkg_b/f.py",
+            "/root/pkg_b/g/h.py",
+            "/root/standalone_file.py",
+        } - files == set()
+
+        assert (
+            files
+            & {
+                # files that should not be added
+                "/root/pkg_c/i.py",
+                "/root/pkg_c/j/k.py",
+            }
+            == set()
+        )
 
 
 def test_stub_mounts(servicer, client, test_dir):
@@ -110,13 +121,15 @@ def test_stub_mounts(servicer, client, test_dir):
     stub.function(mounts=[Mount.from_local_python_packages("pkg_a")])(dummy)
 
     with stub.run(client=client):
-        files = servicer.files_name2sha.keys()
-        assert any(["pkg/pkg_a/a.py" in f for f in files])
-        assert any(["pkg/pkg_a/b/c.py" in f for f in files])
-        assert any(["pkg/pkg_b/f.py" in f for f in files])
-        assert any(["pkg/pkg_b/g/h.py" in f for f in files])
-        assert not any(["pkg/pkg_c/i.py" in f for f in files])
-        assert not any(["pkg/pkg_c/j/k.py" in f for f in files])
+        files = set(servicer.files_name2sha.keys())
+        assert {
+            "/root/pkg_a/a.py",
+            "/root/pkg_a/b/c.py",
+            "/root/pkg_b/f.py",
+            "/root/pkg_b/g/h.py",
+        } - files == set()
+
+        assert {"/root/pkg_c/i.py", "/root/pkg_c/j/k.py"} & files == set()
 
 
 def test_from_local_python_packages_missing_module(servicer, client, test_dir):


### PR DESCRIPTION
## Describe your changes
Was previously /pkg, which differed from where auto-mounted packages were put (/root). This makes it consistent, so that explicit mounting is put at the same location as auto-mounting, which is probably what users want most of the time, e.g. when manually adding static content to packages that isn't being picked up by the auto mounting logic.

Fixes MOD-2102

## Backward/forward compatibility checks

If users mount packages and then refer to their location using `/pkg` this would be a breaking change once they upgrade to this new client version.

## Changelog

* `Mount.from_local_python_packages` now places mounted packages at `/root` in the Modal runtime by default (used to be `/pkg`). To override this behavior, the function now takes a `remote_dir: Union[str, PurePosixPath]` argument.