### PR TITLE
Build base images using corresponding Python version

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -71,7 +71,7 @@ jobs:
 
       - uses: ./.github/actions/setup-cached-python
         with:
-          version: "3.10"
+          version: ${{ matrix.python-version }}
 
       - name: Build protobuf
         run: inv protoc

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -65,6 +65,14 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         image-name: ["debian_slim", "conda", "micromamba"]
+        exclude:
+          # Exclude base images that currently fail to build becasue multidict,
+          # a transitive dependency, has not published wheels for Python 3.12:
+          # https://github.com/aio-libs/multidict/issues/887
+          - python-version: 3.12
+            image-name: conda
+          - python-version: 3.12
+            image-name: micromamba
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@ We appreciate your patience while we speedily work towards a stable release of t
 
 ### 0.56.4707 (2024-01-23)
 
-The Modal client library is now compatible with Python 3.12.
+The Modal client library is now compatible with Python 3.12, although there are a few limitations:
+
+- Images that use Python 3.12 without explicitly specifing it through `python_version` or `add_python` will not build
+  properly unless the modal client is also running on Python 3.12.
+- The `conda` and `microconda` base images currently do not support Python 3.12 because an upstream dependency is not yet compatible.
 
 
 


### PR DESCRIPTION
Fixes an issue in our CI introduced by #1207. See [here](https://github.com/modal-labs/modal-client/actions/runs/7630968826/job/20788017328) for an example of what is now failing.

The problem is that when we set up the base images for conda/miniconda, the images already contain a Python so we don't explicitly specify a `add_python` version. That means the logic that selects the "versioned" requirements file falls back to the version that is running the client process. This is an underlying defect that is hard to solve in general; but for CI we can work around it by making sure that we run the process that generates the base images using the correct Python version.

Additionally, it looks like we can't install modal's base requirements on top of the `conda` or `micromamba` images because a transitive dependency ([multidict](https://github.com/aio-libs/multidict/issues/887)) has not published wheels for 3.12. I've excluded those from the build for now to unbreak CI.