### PR TITLE
Updates local state when restoring containers 

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -462,9 +462,9 @@ class _FunctionIOManager:
 
         # Local FunctionIOManager state.
         for key in ["task_id", "function_id"]:
-            value = restored_state[key]
-            logger.debug(f"Updating FunctionIOManager.{key} = {value}")
-            setattr(self, key, restored_state[key])
+            if value := restored_state.get(key):
+                logger.debug(f"Updating FunctionIOManager.{key} = {value}")
+                setattr(self, key, restored_state[key])
 
         # Env vars and global state.
         for key, value in restored_state.items():

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -453,7 +453,7 @@ class _FunctionIOManager:
             await asyncio.sleep(0.01)
             continue
 
-        logger.debug(f"Container restored.")
+        logger.debug("Container restored.")
 
         # Look for state file and create new client with updated credentials.
         # State data is serialized with key-value pairs, example: {"task_id": "tk-000"}

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -442,23 +442,33 @@ class _FunctionIOManager:
         self._waiting_for_checkpoint = True
         await self._client._close()
 
-        logger.debug("checkpointing request sent and connection closed")
+        logger.debug("Checkpointing request sent. Connection closed.")
 
         # Busy-wait for restore. `/opt/modal/restore-state.json` is created
         # by the worker process with updates to the container config.
         restored_path = Path(config.get("restore_state_path"))
+        start = time.perf_counter()
         while not restored_path.exists():
-            logger.debug("waiting for restore ...")
+            logger.debug(f"Waiting for restore (elapsed={time.perf_counter() - start:.3f}s)")
             await asyncio.sleep(0.01)
             continue
+            
+        logger.debug(f"Container restored.")
 
         # Look for state file and create new client with updated credentials.
+        # State data is serialized with key-value pairs, example: {"task_id": "tk-000"}
         with restored_path.open("r") as file:
             restored_state = json.load(file)
 
-        # State data is serialized with key-value pairs, example: {"task_id": "tk-000"}
-        # Empty string indicates that value does not need to be updated.
+        # Local FunctionIOManager state.
+        for key in ["task_id", "function_id"]:
+            value = restored_state[key]
+            logger.debug(f"Updating FunctionIOManager.{key} = {value}")
+            setattr(self, key, restored_state[key])
+
+        # Env vars and global state.
         for key, value in restored_state.items():
+            # Empty string indicates that value does not need to be updated.
             if value != "":
                 config.override_locally(key, value)
 

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -452,7 +452,7 @@ class _FunctionIOManager:
             logger.debug(f"Waiting for restore (elapsed={time.perf_counter() - start:.3f}s)")
             await asyncio.sleep(0.01)
             continue
-            
+
         logger.debug(f"Container restored.")
 
         # Look for state file and create new client with updated credentials.

--- a/modal_utils/grpc_utils.py
+++ b/modal_utils/grpc_utils.py
@@ -181,7 +181,8 @@ def create_channel(
     else:
         raise Exception(f"Unknown scheme: {o.scheme}")
 
-    logger.debug(f"Connecting to {o.netloc} using scheme {o.scheme}")
+    target = o.path if o.scheme == "unix" else o.netloc
+    logger.debug(f"Connecting to {target} using scheme {o.scheme}")
 
     # Inject metadata for the client.
     async def send_request(event: grpclib.events.SendRequest) -> None:


### PR DESCRIPTION
In order to support ephemeral app checkpointing and restore operations, we need to update FunctionIOManager's local variables `task_id` and `function_id`. Those are used to get inputs for a function.

This is not needed for deployed apps because the function ID doesn't change between checkpointing and restore.

This eventually allows for a checkpoint created with an ephemeral function to be used in restore operations by deployed apps.