### PR TITLE
Mini cleanup: Remove unused `name` function arg in internal method

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -581,7 +581,6 @@ class _Function(_Object, type_prefix="fu"):
         cpu: Optional[float] = None,
         keep_warm: Optional[int] = None,
         interactive: bool = False,
-        name: Optional[str] = None,
         cloud: Optional[str] = None,
         is_builder_function: bool = False,
         cls: Optional[type] = None,

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -554,7 +554,6 @@ class _Stub:
                 cpu=cpu,
                 interactive=interactive,
                 keep_warm=keep_warm,
-                name=name,
                 cloud=cloud,
                 webhook_config=webhook_config,
                 cls=_cls,


### PR DESCRIPTION
Name can still be specified in the @ function decorator, but it's propagated through FunctionInfo, and not through from_args
