### PR TITLE
Remove task-cancellation log spam for python version < 3.11

### DIFF
--- a/modal_utils/async_utils.py
+++ b/modal_utils/async_utils.py
@@ -143,12 +143,10 @@ class TaskContext:
                 if task.done() or task in self._loops:
                     continue
 
-                already_cancelling = False
                 if sys.version_info >= (3, 11):
                     already_cancelling = task.cancelling() > 0
-
-                if not already_cancelling:
-                    logger.warning(f"Canceling remaining unfinished task: {task}")
+                    if not already_cancelling:
+                        logger.warning(f"Canceling remaining unfinished task: {task}")
 
                 task.cancel()
 


### PR DESCRIPTION
Users running python version < 3.11 were still seeing log spam of the following sort, for the reasons described in 3193b106eefe. Since this warning is just that, a warning, and the unfinished task check is accurate using only python 3.11+ task APIs, only warn for python 3.11+.
```
  2024-01-24T18:05:18+0000 Canceling remaining unfinished task: <Task
  pending name='Task-15'
  coro=<asgi_app_wrapper.<locals>.fn.<locals>.fetch_data_in() running at
  /pkg/modal/_asgi.py:30> wait_for=<Future pending
  cb=[Task.task_wakeup()]> cb=[set.discard()]>
```