### PR TITLE
Enhance `modal profile list` to show each profile's workspace

### DIFF
--- a/modal/cli/profile.py
+++ b/modal/cli/profile.py
@@ -3,11 +3,14 @@
 from typing import Optional
 
 import typer
+from rich.console import Console
+from rich.table import Table
 
-from modal.cli.utils import display_selection
-from modal.config import _profile, config_profiles, config_set_active_profile
+from modal.config import Config, _lookup_workspace, _profile, config_profiles, config_set_active_profile
+from modal.exception import AuthError
+from modal_utils.async_utils import synchronizer
 
-profile_cli = typer.Typer(name="profile", help="Set the active Modal profile.", no_args_is_help=True)
+profile_cli = typer.Typer(name="profile", help="Switch between Modal profiles.", no_args_is_help=True)
 
 
 @profile_cli.command(help="Change the active Modal profile.")
@@ -20,6 +23,24 @@ def current():
     typer.echo(_profile)
 
 
-@profile_cli.command(help="List all Modal profiles that are defined.")
-def list(json: Optional[bool] = False):
-    display_selection(config_profiles(), _profile, json)
+@profile_cli.command(name="list", help="Show all Modal profiles that are defined.")
+@synchronizer.create_blocking
+async def list(json: Optional[bool] = False):
+    config = Config()
+    column_names = ["", "Profile", "Workspace"]
+    rows = []
+    for profile in config_profiles():
+        try:
+            resp = await _lookup_workspace(config, profile)
+            workspace = resp.workspace_name
+        except AuthError:
+            workspace = "Unknown (authentication failed)"
+        except Exception:
+            workspace = "Unknown (profile misconfigured)"
+        rows.append(["*" if profile == _profile else "", profile, workspace])
+
+    console = Console()
+    table = Table(*column_names)
+    for row in rows:
+        table.add_row(*row, style="green" if row[0] == "*" else "dim")
+    console.print(table)

--- a/modal/config.py
+++ b/modal/config.py
@@ -79,6 +79,7 @@ from datetime import date
 
 import toml
 
+from modal_proto import api_pb2
 from modal_utils.logger import configure_logger
 
 from .exception import deprecation_error
@@ -97,6 +98,16 @@ def _read_user_config():
 
 
 _user_config = _read_user_config()
+
+
+async def _lookup_workspace(config: "Config", profile: str) -> api_pb2.TokenWorkspaceLookupResponse:
+    from .client import _Client
+
+    server_url = config.get("server_url", profile)
+    credentials = (config.get("token_id", profile), config.get("token_secret", profile))
+    async with _Client(server_url, api_pb2.CLIENT_TYPE_CLIENT, credentials) as client:
+        req = api_pb2.TokenWorkspaceLookupRequest(token_id=config.get("token_id", profile))
+        return await client.stub.TokenWorkspaceLookup(req)
 
 
 def config_profiles():

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1571,6 +1571,17 @@ message TokenFlowWaitResponse {
   string workspace_username = 4;
 }
 
+
+message TokenWorkspaceLookupRequest{
+  string token_id = 1;
+}
+
+
+message TokenWorkspaceLookupResponse{
+  string workspace_name = 1;
+}
+
+
 message TunnelStartRequest {
   uint32 port = 1;
   bool unencrypted = 2;
@@ -1842,6 +1853,7 @@ service ModalClient {
   // Tokens (web auth flow)
   rpc TokenFlowCreate(TokenFlowCreateRequest) returns (TokenFlowCreateResponse);
   rpc TokenFlowWait(TokenFlowWaitRequest) returns (TokenFlowWaitResponse);
+  rpc TokenWorkspaceLookup(TokenWorkspaceLookupRequest) returns (TokenWorkspaceLookupResponse);
 
   // Tunnels
   rpc TunnelStart(TunnelStartRequest) returns (TunnelStartResponse);

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -526,3 +526,11 @@ def test_cls(servicer, set_env_client, test_dir):
 
     _run(["run", stub_file.as_posix(), "--x", "42", "--y", "1000"])
     _run(["run", f"{stub_file.as_posix()}::AParametrized.some_method", "--x", "42", "--y", "1000"])
+
+
+def test_profile_list(servicer, server_url_env):
+    res = _run(["profile", "list"])
+    assert "Profile" in res.stdout
+    assert "Workspace" in res.stdout
+    assert "test-workspace" in res.stdout
+    print(res.stdout)

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -1,12 +1,13 @@
 # Copyright Modal Labs 2022
 import os
 import pathlib
+import pytest
 import subprocess
 import sys
 import tempfile
 
 import modal
-from modal.config import config
+from modal.config import _lookup_workspace, config
 
 
 def _cli(args, env={}):
@@ -102,3 +103,11 @@ def test_config_env_override_arbitrary_env():
     # Expect value to be overwritten.
     config.override_locally(key, value)
     assert os.getenv(key) == value
+
+
+@pytest.mark.asyncio
+async def test_workspace_lookup(servicer, server_url_env):
+    config.override_locally("token_id", "ak-abc")
+    config.override_locally("token_secret", "as-xyz")
+    resp = await _lookup_workspace(config, "test-profile")
+    assert resp.workspace_name == "test-workspace"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -818,6 +818,9 @@ class MockClientServicer(api_grpc.ModalClientBase):
             )
         )
 
+    async def TokenWorkspaceLookup(self, stream):
+        await stream.send_message(api_pb2.TokenWorkspaceLookupResponse(workspace_name="test-workspace"))
+
     ### Tunnel
 
     async def TunnelStart(self, stream):


### PR DESCRIPTION
## Describe your changes

- Resolves MOD-2154

## Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

## Changelog

The `modal profile list` command now shows the workspace associated with each profile.