### PR TITLE
Checks that `custom_domains` is `Iterable[str]` to prevent confusion

### DIFF
--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -162,6 +162,7 @@ def _method(
 
 
 def _parse_custom_domains(custom_domains: Optional[Iterable[str]] = None) -> List[api_pb2.CustomDomainConfig]:
+    assert not isinstance(custom_domains, str), "custom_domains must be `Iterable[str]` but is `str` instead."
     _custom_domains: List[api_pb2.CustomDomainConfig] = []
     if custom_domains is not None:
         for custom_domain in custom_domains:
@@ -179,7 +180,7 @@ def _web_endpoint(
     wait_for_response: bool = True,  # Whether requests should wait for and return the function response.
     custom_domains: Optional[
         Iterable[str]
-    ] = None,  # Create an endpoint using a custom domain fully-qualified domain name.
+    ] = None,  # Create an endpoint using a custom domain fully-qualified domain name (FQDN).
 ) -> Callable[[Callable[..., Any]], _PartialFunction]:
     """Register a basic web endpoint with this application.
 

--- a/test/stub_test.py
+++ b/test/stub_test.py
@@ -351,6 +351,7 @@ def test_redeploy_from_name_change(servicer, client):
     # This should not fail because the object_id changed - it's a different app
     deploy_stub(stub, "my-app", client=client)
 
+
 def test_parse_custom_domains():
     assert len(_parse_custom_domains(None)) == 0
     assert len(_parse_custom_domains(["foo.com", "bar.com"])) == 2

--- a/test/stub_test.py
+++ b/test/stub_test.py
@@ -9,10 +9,10 @@ from grpclib import GRPCError, Status
 import modal.app
 from modal import Dict, Image, Queue, Stub, web_endpoint
 from modal.exception import DeprecationError, ExecutionError, InvalidError, NotFoundError
+from modal.partial_function import _parse_custom_domains
 from modal.runner import deploy_stub
 from modal_proto import api_pb2
 from modal_test_support import module_1, module_2
-from modal.partial_function import _parse_custom_domains
 
 
 @pytest.mark.asyncio

--- a/test/stub_test.py
+++ b/test/stub_test.py
@@ -12,6 +12,7 @@ from modal.exception import DeprecationError, ExecutionError, InvalidError, NotF
 from modal.runner import deploy_stub
 from modal_proto import api_pb2
 from modal_test_support import module_1, module_2
+from modal.partial_function import _parse_custom_domains
 
 
 @pytest.mark.asyncio
@@ -349,3 +350,9 @@ def test_redeploy_from_name_change(servicer, client):
     # Redeploy app
     # This should not fail because the object_id changed - it's a different app
     deploy_stub(stub, "my-app", client=client)
+
+def test_parse_custom_domains():
+    assert len(_parse_custom_domains(None)) == 0
+    assert len(_parse_custom_domains(["foo.com", "bar.com"])) == 2
+    with pytest.raises(AssertionError):
+        assert _parse_custom_domains("foo.com")


### PR DESCRIPTION
Users may accidentally pass:

```python
@modal.web_endpoint(custom_domains="example.com")
...
```
to a function, triggering the following error:

```shell
InvalidError: Exceeded number of custom domains per function: 10 domains maximum
```

This fails earlier with a clearer error:

```shell
custom_domains must be `Iterable[str]` but is `str` instead.
```