### PR TITLE
Add FunctionCallGetDataOut to client protos

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1810,6 +1810,7 @@ service ModalClient {
   rpc FunctionCallCancel(FunctionCallCancelRequest) returns (google.protobuf.Empty);
   rpc FunctionCallList(FunctionCallListRequest) returns (FunctionCallListResponse);
   rpc FunctionCallGetDataIn(FunctionCallGetDataRequest) returns (stream DataChunk);
+  rpc FunctionCallGetDataOut(FunctionCallGetDataRequest) returns (stream DataChunk);
   rpc FunctionCallPutDataOut(FunctionCallPutDataRequest) returns (google.protobuf.Empty);
 
   // Images


### PR DESCRIPTION
This is needed on the server to implement generators and web endpoint outputs using the faster data channel.