### PR TITLE
Rename TokenWorkspaceLookup -> WorkspaceLookup with empty request

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1571,17 +1571,6 @@ message TokenFlowWaitResponse {
   string workspace_username = 4;
 }
 
-
-message TokenWorkspaceLookupRequest{
-  string token_id = 1;
-}
-
-
-message TokenWorkspaceLookupResponse{
-  string workspace_name = 1;
-}
-
-
 message TunnelStartRequest {
   uint32 port = 1;
   bool unencrypted = 2;
@@ -1713,6 +1702,10 @@ message WebUrlInfo {
   bool truncated = 1;
   bool has_unique_hash = 2;
   bool label_stolen = 3;
+}
+
+message WorkspaceLookupResponse {
+  string workspace_name = 1;
 }
 
 // Used for `modal container exec`
@@ -1853,7 +1846,6 @@ service ModalClient {
   // Tokens (web auth flow)
   rpc TokenFlowCreate(TokenFlowCreateRequest) returns (TokenFlowCreateResponse);
   rpc TokenFlowWait(TokenFlowWaitRequest) returns (TokenFlowWaitResponse);
-  rpc TokenWorkspaceLookup(TokenWorkspaceLookupRequest) returns (TokenWorkspaceLookupResponse);
 
   // Tunnels
   rpc TunnelStart(TunnelStartRequest) returns (TunnelStartResponse);
@@ -1869,4 +1861,7 @@ service ModalClient {
   rpc VolumeReload(VolumeReloadRequest) returns (google.protobuf.Empty);
   rpc VolumeRemoveFile(VolumeRemoveFileRequest) returns (google.protobuf.Empty);
   rpc VolumeCopyFiles(VolumeCopyFilesRequest) returns (google.protobuf.Empty);
+
+// Workspaces
+  rpc WorkspaceLookup(google.protobuf.Empty) returns (WorkspaceLookupResponse);
 }


### PR DESCRIPTION
Reworking the approach to looking up the workspace associated with a profile so that we no longer need to pass a token in the request body. This removes protos that weren't in use so has no compatibility implications.