### PR TITLE
Change last_index to a uint64

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -719,7 +719,7 @@ message FunctionCallPutDataRequest {
 
 message FunctionCallGetDataRequest {
   string function_call_id = 1;
-  uint32 last_index = 2;
+  uint64 last_index = 2;
 }
 
 message Function {


### PR DESCRIPTION
This is a minor inconsistency with DataChunk's index field.

It remains backwards-compatible because uint32 and uint64 have the same wire protocol. https://protobuf.dev/programming-guides/encoding/

I needed to do this because it creates a type error later on.

## Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
