### PR TITLE
Add username to WorkspaceNameLookupResponse proto

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1712,6 +1712,7 @@ message WebUrlInfo {
 
 message WorkspaceNameLookupResponse {
   string workspace_name = 1;
+  string username = 2;
 }
 
 // Used for `modal container exec`


### PR DESCRIPTION
- Part of MOD-2168, this will let us show the user's GitHub username rather than "Personal"