### PR TITLE
Add `list_apps` function

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -6,7 +6,7 @@ from google.protobuf.message import Message
 from grpclib import GRPCError, Status
 
 from modal_proto import api_pb2
-from modal_utils.async_utils import synchronize_api, synchronizer
+from modal_utils.async_utils import synchronize_api
 from modal_utils.grpc_utils import get_proto_oneof, retry_transient_errors
 
 from ._output import OutputManager
@@ -377,10 +377,12 @@ def is_local() -> bool:
     return not _is_container_app
 
 
-@synchronizer.create_blocking
-async def list_apps(env: str, client: Optional[_Client] = None) -> List[api_pb2.AppStats]:
+async def _list_apps(env: str, client: Optional[_Client] = None) -> List[api_pb2.AppStats]:
     """List apps in a given Modal environment."""
     if client is None:
         client = await _Client.from_env()
     resp: api_pb2.AppListResponse = await client.stub.AppList(api_pb2.AppListRequest(environment_name=env))
     return list(resp.apps)
+
+
+list_apps = synchronize_api(_list_apps)

--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -8,7 +8,7 @@ from grpclib import GRPCError, Status
 from rich.text import Text
 
 from modal._output import OutputManager, get_app_logs_loop
-from modal.app import list_apps
+from modal.app import _list_apps
 from modal.cli.utils import ENV_OPTION, display_table, timestamp_to_local
 from modal.client import _Client
 from modal.environments import ensure_env
@@ -37,7 +37,8 @@ async def list(env: Optional[str] = ENV_OPTION, json: Optional[bool] = False):
 
     column_names = ["App ID", "Name", "State", "Creation time", "Stop time"]
     rows: List[List[Union[Text, str]]] = []
-    for app_stats in list_apps(env=env, client=client):
+    apps = await _list_apps(env=env, client=client)
+    for app_stats in apps:
         state = APP_STATE_TO_MESSAGE.get(app_stats.state, Text("unknown", style="gray"))
 
         rows.append(

--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -8,6 +8,7 @@ from grpclib import GRPCError, Status
 from rich.text import Text
 
 from modal._output import OutputManager, get_app_logs_loop
+from modal.app import list_apps
 from modal.cli.utils import ENV_OPTION, display_table, timestamp_to_local
 from modal.client import _Client
 from modal.environments import ensure_env
@@ -33,11 +34,10 @@ async def list(env: Optional[str] = ENV_OPTION, json: Optional[bool] = False):
     """List all running or recently running Modal apps for the current account"""
     client = await _Client.from_env()
     env = ensure_env(env)
-    res: api_pb2.AppListResponse = await client.stub.AppList(api_pb2.AppListRequest(environment_name=env))
 
     column_names = ["App ID", "Name", "State", "Creation time", "Stop time"]
     rows: List[List[Union[Text, str]]] = []
-    for app_stats in res.apps:
+    for app_stats in list_apps(env=env, client=client):
         state = APP_STATE_TO_MESSAGE.get(app_stats.state, Text("unknown", style="gray"))
 
         rows.append(


### PR DESCRIPTION
## Describe your changes

A user we have was using a subprocess to do `modal app list --json`. They're doing this because we're violating the "CLI is a thin wrapper over API" rule. So I'm alleviating this here. 

The sync/async thing feels weird though? How should we be exposing both an async and a sync implementation of the same function? 

Another this is we don't currently provide reference documentation at http://modal.com/docs/reference for `modal.app` and `modal.environment`, but it seems like we should?


### Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
