### PR TITLE
Improve config file isolation in tests

### DIFF
--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -108,12 +108,14 @@ def test_secret_list(servicer, set_env_client):
     assert "dummy-secret-3" not in res.stdout
 
 
-def test_app_token_new(servicer, set_env_client, server_url_env):
-    _run(["token", "new", "--profile", "_test"])
+def test_app_token_new(servicer, set_env_client, server_url_env, modal_config):
+    with modal_config():
+        _run(["token", "new", "--profile", "_test"])
 
 
-def test_app_setup(servicer, set_env_client, server_url_env):
-    _run(["setup", "--profile", "_test"])
+def test_app_setup(servicer, set_env_client, server_url_env, modal_config):
+    with modal_config():
+        _run(["setup", "--profile", "_test"])
 
 
 def test_run(servicer, set_env_client, test_dir):

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -4,7 +4,6 @@ import pathlib
 import pytest
 import subprocess
 import sys
-import tempfile
 
 import modal
 from modal.config import _lookup_workspace, config
@@ -42,54 +41,48 @@ def test_config_env_override():
     assert config["server_url"] == "xyz.corp"
 
 
-def test_config_store_user(servicer):
-    # Can't reopen a TemporaryFile on windows if it's already open.
-    t = tempfile.NamedTemporaryFile(delete=False)
-    t.close()
+def test_config_store_user(servicer, modal_config):
 
-    env = {
-        "MODAL_CONFIG_PATH": t.name,
-        "MODAL_SERVER_URL": servicer.remote_addr,
-    }
+    with modal_config():
 
-    # No token by default
-    config = _get_config(env=env)
-    assert config["token_id"] is None
+        env = {"MODAL_SERVER_URL": servicer.remote_addr}
 
-    # Set creds to abc / xyz
-    _cli(["token", "set", "--token-id", "abc", "--token-secret", "xyz"], env=env)
+        # No token by default
+        config = _get_config(env=env)
+        assert config["token_id"] is None
 
-    # Set creds to foo / bar1 for the prof_1 profile
-    _cli(["token", "set", "--token-id", "foo", "--token-secret", "bar1", "--profile", "prof_1"], env=env)
+        # Set creds to abc / xyz
+        _cli(["token", "set", "--token-id", "abc", "--token-secret", "xyz"], env=env)
 
-    # Set creds to foo / bar2 for the prof_2 profile (given as an env var)
-    _cli(["token", "set", "--token-id", "foo", "--token-secret", "bar2"], env={"MODAL_PROFILE": "prof_2", **env})
+        # Set creds to foo / bar1 for the prof_1 profile
+        _cli(["token", "set", "--token-id", "foo", "--token-secret", "bar1", "--profile", "prof_1"], env=env)
 
-    # Now these should be stored in the user's home directory
-    config = _get_config(env=env)
-    assert config["token_id"] == "abc"
-    assert config["token_secret"] == "xyz"
+        # Set creds to foo / bar2 for the prof_2 profile (given as an env var)
+        _cli(["token", "set", "--token-id", "foo", "--token-secret", "bar2"], env={"MODAL_PROFILE": "prof_2", **env})
 
-    # Make sure it can be overridden too
-    config = _get_config(env={"MODAL_TOKEN_ID": "foo", **env})
-    assert config["token_id"] == "foo"
-    assert config["token_secret"] == "xyz"
+        # Now these should be stored in the user's home directory
+        config = _get_config(env=env)
+        assert config["token_id"] == "abc"
+        assert config["token_secret"] == "xyz"
 
-    # Check that we can get the prof_1 env creds too
-    config = _get_config(env={"MODAL_PROFILE": "prof_1", **env})
-    assert config["token_id"] == "foo"
-    assert config["token_secret"] == "bar1"
+        # Make sure it can be overridden too
+        config = _get_config(env={"MODAL_TOKEN_ID": "foo", **env})
+        assert config["token_id"] == "foo"
+        assert config["token_secret"] == "xyz"
 
-    # Check that we can get the prof_2 env creds too
-    config = _get_config(env={"MODAL_PROFILE": "prof_2", **env})
-    assert config["token_id"] == "foo"
-    assert config["token_secret"] == "bar2"
+        # Check that we can get the prof_1 env creds too
+        config = _get_config(env={"MODAL_PROFILE": "prof_1", **env})
+        assert config["token_id"] == "foo"
+        assert config["token_secret"] == "bar1"
 
-    # Check that an empty string falls back to the active profile
-    config = _get_config(env={"MODAL_PROFILE": "", **env})
-    assert config["token_secret"] == "xyz"
+        # Check that we can get the prof_2 env creds too
+        config = _get_config(env={"MODAL_PROFILE": "prof_2", **env})
+        assert config["token_id"] == "foo"
+        assert config["token_secret"] == "bar2"
 
-    os.remove(t.name)
+        # Check that an empty string falls back to the active profile
+        config = _get_config(env={"MODAL_PROFILE": "", **env})
+        assert config["token_secret"] == "xyz"
 
 
 def test_config_env_override_arbitrary_env():

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -12,6 +12,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import textwrap
 import traceback
 from collections import defaultdict
 from pathlib import Path
@@ -26,7 +27,7 @@ import pytest_asyncio
 from google.protobuf.empty_pb2 import Empty
 from grpclib import GRPCError, Status
 
-from modal import __version__
+from modal import __version__, config
 from modal.app import _ContainerApp
 from modal.client import Client
 from modal.image import _dockerhub_python_version
@@ -1106,3 +1107,32 @@ def test_dir(request):
     root_dir = Path(request.config.rootdir)
     test_dir = Path(os.getenv("PYTEST_CURRENT_TEST")).parent
     return root_dir / test_dir
+
+
+@pytest.fixture(scope="function")
+def modal_config():
+    """Return a context manager with a temporary modal.toml file"""
+
+    @contextlib.contextmanager
+    def mock_modal_toml(contents: str = ""):
+        # Some of the cli tests run within within the main process
+        # so we need to modify the config singletons to pick up any changes
+        orig_config_path_env = os.environ.get("MODAL_CONFIG_PATH")
+        orig_config_path = config.user_config_path
+        try:
+            with tempfile.NamedTemporaryFile(delete=False, suffix=".toml", mode="w") as t:
+                t.write(textwrap.dedent(contents.strip("\n")))
+            os.environ["MODAL_CONFIG_PATH"] = t.name
+            config.user_config_path = t.name
+            config._user_config = config._read_user_config()
+            yield
+        finally:
+            if orig_config_path_env:
+                os.environ["MODAL_CONFIG_PATH"] = orig_config_path_env
+            else:
+                del os.environ["MODAL_CONFIG_PATH"]
+            config.user_config_path = orig_config_path
+            config._user_config = config._read_user_config()
+            os.remove(t.name)
+
+    return mock_modal_toml


### PR DESCRIPTION
## Describe your changes

The CLI tests modify the main config file (`~/.modal.toml`) when run locally. Additionally, I want to be able to dump information into a config file so that I can test some of the `modal token` changes I am in the process of making. This PR adds a new fixture that sets up an isolated config file and uses it in (a) cli tests that are currently modifying `~/.modal.toml` and (b) an existing config test that sets up an isolated config in a non-reusable way.