### PR TITLE
Add TTY support to `modal container exec`

### DIFF
--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -50,8 +50,15 @@ async def list():
 
 @container_cli.command("exec")
 @synchronizer.create_blocking
-async def exec(task_id: str, command: str, tty: bool = False):
+async def exec(
+    container_id: str = typer.Argument(
+        help="The ID of the container to run the command in",
+    ),
+    command: str = typer.Argument(help="The command to run"),
+    tty: bool = typer.Option(is_flag=True, default=True, help="Whether to run the command inside a TTY."),
+):
     """Execute a command inside an active container"""
+    task_id = container_id
     if platform.system() == "Windows":
         print("container exec is not currently supported on Windows.")
         return

--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -55,7 +55,7 @@ async def exec(
         help="The ID of the container to run the command in",
     ),
     command: str = typer.Argument(help="The command to run"),
-    tty: bool = typer.Option(is_flag=True, default=True, help="Whether to run the command inside a TTY."),
+    tty: bool = typer.Option(is_flag=True, default=True, help="Run the command inside a TTY"),
 ):
     """Execute a command inside an active container"""
     task_id = container_id


### PR DESCRIPTION
Depends on https://github.com/modal-labs/modal/pull/9859


## Changelog

Adds tty support to `modal container exec` for fully-interactive commands. Example: `modal container exec [container-id] /bin/bash`