### PR TITLE
Add versioned requirements files to package data

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ console_scripts =
 
 [options.package_data]
 modal =
-    requirements.txt
+    requirements*.txt
     py.typed
     *.pyi
 modal_proto =


### PR DESCRIPTION
Fixes an oversight from the py312 compatibility work where the versioned requirements file was not included with the distributed package. Missed it in testing due to using an editable install. I'll think a little bit about how we can improve the testing to catch this in the future, but pushing out a quick fix now.