### PR TITLE
Re-run newly pinned black version

### DIFF
--- a/test/config_test.py
+++ b/test/config_test.py
@@ -42,9 +42,7 @@ def test_config_env_override():
 
 
 def test_config_store_user(servicer, modal_config):
-
     with modal_config():
-
         env = {"MODAL_SERVER_URL": servicer.remote_addr}
 
         # No token by default


### PR DESCRIPTION
Fixes an issue with the `check` CI step introduced by the timing of https://github.com/modal-labs/modal-client/pull/1252 and https://github.com/modal-labs/modal-client/pull/1251