### PR TITLE
Use workspace as name for profiles created by `modal token` CLI

### DIFF
--- a/modal/cli/entry_point.py
+++ b/modal/cli/entry_point.py
@@ -6,6 +6,8 @@ import typer
 from rich.console import Console
 from rich.rule import Rule
 
+from modal_utils.async_utils import synchronizer
+
 from . import run
 from .app import app_cli
 from .config import config_cli
@@ -71,11 +73,12 @@ def check_path():
     console.print(Rule(style="white"))
 
 
-def setup(profile: Optional[str] = None):
+@synchronizer.create_blocking
+async def setup(profile: Optional[str] = None):
     check_path()
 
     # Fetch a new token (same as `modal token new` but redirect to /home once finishes)
-    _new_token(profile=profile, next_url="/home")
+    await _new_token(profile=profile, next_url="/home")
 
 
 entrypoint_cli_typer.add_typer(app_cli)

--- a/modal/cli/profile.py
+++ b/modal/cli/profile.py
@@ -30,9 +30,15 @@ def current():
 async def list(json: Optional[bool] = False):
     config = Config()
     profiles = config_profiles()
-    responses = await asyncio.gather(
-        *(_lookup_workspace(config, profile) for profile in profiles), return_exceptions=True
-    )
+    lookup_coros = [
+        _lookup_workspace(
+            config.get("server_url", profile),
+            config.get("token_id", profile),
+            config.get("token_secret", profile),
+        )
+        for profile in profiles
+    ]
+    responses = await asyncio.gather(*lookup_coros, return_exceptions=True)
 
     rows = []
     for profile, resp in zip(profiles, responses):

--- a/modal/cli/token.py
+++ b/modal/cli/token.py
@@ -10,7 +10,7 @@ import typer
 from rich.console import Console
 
 from modal.client import _Client
-from modal.config import _lookup_workspace, _store_user_config, config, user_config_path
+from modal.config import _lookup_workspace, _store_user_config, config, config_profiles, user_config_path
 from modal.token_flow import _TokenFlow
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronizer
@@ -52,7 +52,10 @@ async def set(
         profile = workspace.username
 
     # TODO add activate as a parameter?
-    _store_user_config({"token_id": token_id, "token_secret": token_secret}, profile=profile)
+    config_data = {"token_id": token_id, "token_secret": token_secret}
+    if not config_profiles():  # TODO or use activate flag?
+        config_data["active"] = True
+    _store_user_config(config_data, profile=profile)
     # TODO unify formatting with new_token output
     rich.print(f"Token written to {user_config_path} in profile {profile}")
 
@@ -126,7 +129,11 @@ async def _new_token(
         profile = workspace.username
 
     with console.status("Storing token", spinner="dots"):
-        _store_user_config({"token_id": result.token_id, "token_secret": result.token_secret}, profile=profile)
+        # TODO copy-pasted from token-set; need to refactor
+        config_data = {"token_id": result.token_id, "token_secret": result.token_secret}
+        if not config_profiles():  # TODO or use activate flag?
+            config_data["active"] = True
+        _store_user_config(config_data, profile=profile)
         # TODO print profile name like we do for token set
         console.print(f"[green]Token written to [white]{user_config_path}[/white] successfully![/green]")
 

--- a/modal/cli/token.py
+++ b/modal/cli/token.py
@@ -1,18 +1,13 @@
 # Copyright Modal Labs 2022
 import getpass
-import itertools
-import os
-import webbrowser
 from typing import Optional
 
 import rich
 import typer
-from rich.console import Console
 
 from modal.client import _Client
 from modal.config import _lookup_workspace, _store_user_config, config, config_profiles, user_config_path
-from modal.token_flow import _TokenFlow
-from modal_proto import api_pb2
+from modal.token_flow import _new_token
 from modal_utils.async_utils import synchronizer
 
 token_cli = typer.Typer(name="token", help="Manage tokens.", no_args_is_help=True)
@@ -60,85 +55,7 @@ async def set(
     rich.print(f"Token written to {user_config_path} in profile {profile}")
 
 
-def _open_url(url: str) -> bool:
-    """Opens url in web browser, making sure we use a modern one (not Lynx etc)"""
-    if "PYTEST_CURRENT_TEST" in os.environ:
-        return False
-    try:
-        browser = webbrowser.get()
-        # zpresto defines `BROWSER=open` by default on macOS, which causes `webbrowser` to return `GenericBrowser`.
-        if isinstance(browser, webbrowser.GenericBrowser) and browser.name != "open":
-            return False
-        else:
-            return browser.open_new_tab(url)
-    except webbrowser.Error:
-        return False
-
-
-async def _new_token(
-    profile: Optional[str] = None, no_verify: bool = False, source: Optional[str] = None, next_url: Optional[str] = None
-):
-    server_url = config.get("server_url", profile=profile)
-
-    console = Console()
-
-    result: Optional[api_pb2.TokenFlowWaitResponse] = None
-    client = await _Client.unauthenticated_client(server_url)
-    async with client:
-        token_flow = _TokenFlow(client)
-
-        async with token_flow.start(source, next_url) as (_, web_url, code):
-            with console.status("Waiting for authentication in the web browser", spinner="dots"):
-                # Open the web url in the browser
-                if _open_url(web_url):
-                    console.print(
-                        "The web browser should have opened for you to authenticate and get an API token.\n"
-                        "If it didn't, please copy this URL into your web browser manually:\n"
-                    )
-                else:
-                    console.print(
-                        "[red]Was not able to launch web browser[/red]\n"
-                        "Please go to this URL manually and complete the flow:\n"
-                    )
-                console.print(f"[link={web_url}]{web_url}[/link]\n")
-                if code:
-                    console.print(f"Enter this code: [yellow]{code}[/yellow]\n")
-
-            with console.status("Waiting for token flow to complete...", spinner="dots") as status:
-                for attempt in itertools.count():
-                    result = await token_flow.finish()
-                    if result is not None:
-                        break
-                    status.update(f"Waiting for token flow to complete... (attempt {attempt+2})")
-
-        console.print("[green]Web authentication finished successfully![/green]")
-
-    assert result is not None
-
-    if result.workspace_username:
-        console.print(f"[green]Token is connected to the [white]{result.workspace_username}[/white] workspace.[/green]")
-
-    if not no_verify:
-        with console.status(f"Verifying token against [blue]{server_url}[/blue]", spinner="dots"):
-            await _Client.verify(server_url, (result.token_id, result.token_secret))
-            console.print("[green]Token verified successfully![/green]")
-
-    if profile is None:
-        # TODO what if this fails verification but no_verify was False?
-        workspace = await _lookup_workspace(server_url, result.token_id, result.token_secret)
-        profile = workspace.username
-
-    with console.status("Storing token", spinner="dots"):
-        # TODO copy-pasted from token-set; need to refactor
-        config_data = {"token_id": result.token_id, "token_secret": result.token_secret}
-        if not config_profiles():  # TODO or use activate flag?
-            config_data["active"] = True
-        _store_user_config(config_data, profile=profile)
-        # TODO print profile name like we do for token set
-        console.print(f"[green]Token written to [white]{user_config_path}[/white] successfully![/green]")
-
-
 @token_cli.command(name="new", help="Creates a new token by using an authenticated web session.")
 @synchronizer.create_blocking
 async def new(profile: Optional[str] = profile_option, no_verify: bool = False, source: Optional[str] = None):
-    await _new_token(profile, no_verify, source)
+    await _new_token(profile=profile, no_verify=no_verify, source=source)

--- a/modal/cli/token.py
+++ b/modal/cli/token.py
@@ -11,7 +11,13 @@ token_cli = typer.Typer(name="token", help="Manage tokens.", no_args_is_help=Tru
 
 profile_option = typer.Option(
     None,
-    help="Modal profile to set credentials for. You can switch the currently active Modal profile with the `modal profile` command. If unspecified, uses `default` profile.",
+    help=(
+        "Modal profile to set credentials for. If unspecified (and MODAL_PROFILE environment variable is not set), uses the workspace name associated with the credentials."
+    ),
+)
+activate_option = typer.Option(
+    False,
+    help="Activate the profile that this token.",
 )
 
 
@@ -24,16 +30,22 @@ async def set(
     token_id: Optional[str] = typer.Option(None, help="Account token ID."),
     token_secret: Optional[str] = typer.Option(None, help="Account token secret."),
     profile: Optional[str] = profile_option,
+    activate: bool = activate_option,
     no_verify: bool = False,
 ):
     if token_id is None:
         token_id = getpass.getpass("Token ID:")
     if token_secret is None:
         token_secret = getpass.getpass("Token secret:")
-    await _set_token(token_id, token_secret, profile=profile, no_verify=no_verify)
+    await _set_token(token_id, token_secret, profile=profile, activate=activate, no_verify=no_verify)
 
 
-@token_cli.command(name="new", help="Creates a new token by using an authenticated web session.")
+@token_cli.command(name="new", help="Create a new token by using an authenticated web session.")
 @synchronizer.create_blocking
-async def new(profile: Optional[str] = profile_option, no_verify: bool = False, source: Optional[str] = None):
-    await _new_token(profile=profile, no_verify=no_verify, source=source)
+async def new(
+    profile: Optional[str] = profile_option,
+    activate: bool = activate_option,
+    no_verify: bool = False,
+    source: Optional[str] = None,
+):
+    await _new_token(profile=profile, activate=activate, no_verify=no_verify, source=source)

--- a/modal/cli/token.py
+++ b/modal/cli/token.py
@@ -2,12 +2,9 @@
 import getpass
 from typing import Optional
 
-import rich
 import typer
 
-from modal.client import _Client
-from modal.config import _lookup_workspace, _store_user_config, config, config_profiles, user_config_path
-from modal.token_flow import _new_token
+from modal.token_flow import _new_token, _set_token
 from modal_utils.async_utils import synchronizer
 
 token_cli = typer.Typer(name="token", help="Manage tokens.", no_args_is_help=True)
@@ -33,26 +30,7 @@ async def set(
         token_id = getpass.getpass("Token ID:")
     if token_secret is None:
         token_secret = getpass.getpass("Token secret:")
-
-    # TODO add server_url as a parameter for verification?
-    server_url = config.get("server_url", profile=profile)
-    if not no_verify:
-        rich.print(f"Verifying token against [blue]{server_url}[/blue]")
-        await _Client.verify(server_url, (token_id, token_secret))
-        rich.print("[green]Token verified successfully[/green]")
-
-    if profile is None:
-        # TODO what if this fails verification but no_verify was False?
-        workspace = await _lookup_workspace(server_url, token_id, token_secret)
-        profile = workspace.username
-
-    # TODO add activate as a parameter?
-    config_data = {"token_id": token_id, "token_secret": token_secret}
-    if not config_profiles():  # TODO or use activate flag?
-        config_data["active"] = True
-    _store_user_config(config_data, profile=profile)
-    # TODO unify formatting with new_token output
-    rich.print(f"Token written to {user_config_path} in profile {profile}")
+    await _set_token(token_id, token_secret, profile=profile, no_verify=no_verify)
 
 
 @token_cli.command(name="new", help="Creates a new token by using an authenticated web session.")

--- a/modal/cli/token.py
+++ b/modal/cli/token.py
@@ -17,7 +17,7 @@ profile_option = typer.Option(
 )
 activate_option = typer.Option(
     False,
-    help="Activate the profile that this token.",
+    help="Activate the profile containing this token after creation.",
 )
 
 

--- a/modal/config.py
+++ b/modal/config.py
@@ -101,11 +101,10 @@ def _read_user_config():
 _user_config = _read_user_config()
 
 
-async def _lookup_workspace(config: "Config", profile: str) -> api_pb2.WorkspaceNameLookupResponse:
+async def _lookup_workspace(server_url: str, token_id: str, token_secret: str) -> api_pb2.WorkspaceNameLookupResponse:
     from .client import _Client
 
-    server_url = config.get("server_url", profile)
-    credentials = (config.get("token_id", profile), config.get("token_secret", profile))
+    credentials = (token_id, token_secret)
     async with _Client(server_url, api_pb2.CLIENT_TYPE_CLIENT, credentials) as client:
         return await client.stub.WorkspaceNameLookup(Empty())
 

--- a/modal/config.py
+++ b/modal/config.py
@@ -76,6 +76,7 @@ import os
 import typing
 import warnings
 from datetime import date
+from typing import Any, Dict, Optional
 
 import toml
 from google.protobuf.empty_pb2 import Empty
@@ -230,12 +231,20 @@ configure_logger(logger, config["loglevel"], config["log_format"])
 # Utils to write config
 
 
-def _store_user_config(new_settings, profile=None):
+def _store_user_config(
+    new_settings: Dict[str, Any], profile: Optional[str] = None, active_profile: Optional[str] = None
+):
     """Internal method, used by the CLI to set tokens."""
     if profile is None:
         profile = _profile
     user_config = _read_user_config()
     user_config.setdefault(profile, {}).update(**new_settings)
+    if active_profile is not None:
+        for prof_name, prof_config in user_config.items():
+            if prof_name == active_profile:
+                prof_config["active"] = True
+            else:
+                prof_config.pop("active", None)
     _write_user_config(user_config)
 
 

--- a/modal/token_flow.py
+++ b/modal/token_flow.py
@@ -127,8 +127,8 @@ async def _set_token(
     no_verify: bool = False,
 ):
     # TODO add server_url as a parameter for verification?
-    console = Console()
     server_url = config.get("server_url", profile=profile)
+    console = Console()
     if not no_verify:
         console.print(f"Verifying token against [blue]{server_url}[/blue]")
         await _Client.verify(server_url, (token_id, token_secret))

--- a/modal/token_flow.py
+++ b/modal/token_flow.py
@@ -131,9 +131,12 @@ async def _set_token(
         rich.print("[green]Token verified successfully![/green]")
 
     if profile is None:
-        # TODO what if this fails verification but no_verify was False?
-        workspace = await _lookup_workspace(server_url, token_id, token_secret)
-        profile = workspace.username
+        if "MODAL_PROFILE" in os.environ:
+            profile = os.environ["MODAL_PROFILE"]
+        else:
+            # TODO what if this fails verification but no_verify was False?
+            workspace = await _lookup_workspace(server_url, token_id, token_secret)
+            profile = workspace.username
 
     # TODO add activate as a parameter?
     config_data: Dict[str, Any] = {"token_id": token_id, "token_secret": token_secret}

--- a/modal/token_flow.py
+++ b/modal/token_flow.py
@@ -6,7 +6,6 @@ from contextlib import asynccontextmanager
 from typing import Any, AsyncGenerator, Dict, Optional, Tuple
 
 import aiohttp.web
-import rich
 from rich.console import Console
 
 from modal_proto import api_pb2
@@ -110,7 +109,9 @@ async def _new_token(
     assert result is not None
 
     if result.workspace_username:
-        console.print(f"[green]Token is connected to the [white]{result.workspace_username}[/white] workspace.[/green]")
+        console.print(
+            f"[green]Token is connected to the [magenta]{result.workspace_username}[/magenta] workspace.[/green]"
+        )
 
     await _set_token(result.token_id, result.token_secret, profile=profile, no_verify=no_verify)
 
@@ -126,9 +127,9 @@ async def _set_token(
     console = Console()
     server_url = config.get("server_url", profile=profile)
     if not no_verify:
-        rich.print(f"Verifying token against [blue]{server_url}[/blue]")
+        console.print(f"Verifying token against [blue]{server_url}[/blue]")
         await _Client.verify(server_url, (token_id, token_secret))
-        rich.print("[green]Token verified successfully![/green]")
+        console.print("[green]Token verified successfully![/green]")
 
     if profile is None:
         if "MODAL_PROFILE" in os.environ:
@@ -144,8 +145,9 @@ async def _set_token(
         config_data["active"] = True
     with console.status("Storing token", spinner="dots"):
         _store_user_config(config_data, profile=profile)
-    # TODO highlight config path and profile
-    rich.print(f"[green]Token written to {user_config_path} in profile {profile}![/green]")
+    console.print(
+        f"[green]Token written to [magenta]{user_config_path}[/magenta] in profile [magenta]{profile}[/magenta].[/green]"
+    )
 
 
 def _open_url(url: str) -> bool:

--- a/modal/token_flow.py
+++ b/modal/token_flow.py
@@ -1,14 +1,19 @@
 # Copyright Modal Labs 2023
+import itertools
+import os
+import webbrowser
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator, Optional, Tuple
 
 import aiohttp.web
+from rich.console import Console
 
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronize_api
 from modal_utils.http_utils import run_temporary_http_server
 
 from .client import _Client
+from .config import _lookup_workspace, _store_user_config, config, config_profiles, user_config_path
 
 
 class _TokenFlow:
@@ -57,3 +62,97 @@ class _TokenFlow:
 
 
 TokenFlow = synchronize_api(_TokenFlow)
+
+
+async def _new_token(
+    *,
+    profile: Optional[str] = None,
+    no_verify: bool = False,
+    source: Optional[str] = None,
+    next_url: Optional[str] = None,
+):
+    server_url = config.get("server_url", profile=profile)
+
+    console = Console()
+
+    result: Optional[api_pb2.TokenFlowWaitResponse] = None
+    client = await _Client.unauthenticated_client(server_url)
+    async with client:
+        token_flow = _TokenFlow(client)
+
+        async with token_flow.start(source, next_url) as (_, web_url, code):
+            with console.status("Waiting for authentication in the web browser", spinner="dots"):
+                # Open the web url in the browser
+                if _open_url(web_url):
+                    console.print(
+                        "The web browser should have opened for you to authenticate and get an API token.\n"
+                        "If it didn't, please copy this URL into your web browser manually:\n"
+                    )
+                else:
+                    console.print(
+                        "[red]Was not able to launch web browser[/red]\n"
+                        "Please go to this URL manually and complete the flow:\n"
+                    )
+                console.print(f"[link={web_url}]{web_url}[/link]\n")
+                if code:
+                    console.print(f"Enter this code: [yellow]{code}[/yellow]\n")
+
+            with console.status("Waiting for token flow to complete...", spinner="dots") as status:
+                for attempt in itertools.count():
+                    result = await token_flow.finish()
+                    if result is not None:
+                        break
+                    status.update(f"Waiting for token flow to complete... (attempt {attempt+2})")
+
+        console.print("[green]Web authentication finished successfully![/green]")
+
+    assert result is not None
+
+    if result.workspace_username:
+        console.print(f"[green]Token is connected to the [white]{result.workspace_username}[/white] workspace.[/green]")
+
+    if not no_verify:
+        with console.status(f"Verifying token against [blue]{server_url}[/blue]", spinner="dots"):
+            await _Client.verify(server_url, (result.token_id, result.token_secret))
+            console.print("[green]Token verified successfully![/green]")
+
+    if profile is None:
+        # TODO what if this fails verification but no_verify was False?
+        workspace = await _lookup_workspace(server_url, result.token_id, result.token_secret)
+        profile = workspace.username
+
+    with console.status("Storing token", spinner="dots"):
+        # TODO copy-pasted from token-set; need to refactor
+        config_data = {"token_id": result.token_id, "token_secret": result.token_secret}
+        if not config_profiles():  # TODO or use activate flag?
+            config_data["active"] = True
+        _store_user_config(config_data, profile=profile)
+        # TODO print profile name like we do for token set
+        console.print(f"[green]Token written to [white]{user_config_path}[/white] for profile successfully![/green]")
+
+
+async def _set_token(
+    token_id: str,
+    token_secret: str,
+    *,
+    profile: Optional[str] = None,
+    no_verify: bool = False,
+    source: Optional[str] = None,
+    next_url: Optional[str] = None,
+):
+    ...
+
+
+def _open_url(url: str) -> bool:
+    """Opens url in web browser, making sure we use a modern one (not Lynx etc)"""
+    if "PYTEST_CURRENT_TEST" in os.environ:
+        return False
+    try:
+        browser = webbrowser.get()
+        # zpresto defines `BROWSER=open` by default on macOS, which causes `webbrowser` to return `GenericBrowser`.
+        if isinstance(browser, webbrowser.GenericBrowser) and browser.name != "open":
+            return False
+        else:
+            return browser.open_new_tab(url)
+    except webbrowser.Error:
+        return False

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -11,6 +11,7 @@ from unittest import mock
 import click
 import click.testing
 import pytest_asyncio
+import toml
 
 from modal import Client
 from modal.cli.entry_point import entrypoint_cli
@@ -109,13 +110,15 @@ def test_secret_list(servicer, set_env_client):
 
 
 def test_app_token_new(servicer, set_env_client, server_url_env, modal_config):
-    with modal_config():
+    with modal_config() as config_file_path:
         _run(["token", "new", "--profile", "_test"])
+        assert "_test" in toml.load(config_file_path)
 
 
 def test_app_setup(servicer, set_env_client, server_url_env, modal_config):
-    with modal_config():
+    with modal_config() as config_file_path:
         _run(["setup", "--profile", "_test"])
+        assert "_test" in toml.load(config_file_path)
 
 
 def test_run(servicer, set_env_client, test_dir):

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -98,7 +98,5 @@ def test_config_env_override_arbitrary_env():
 
 @pytest.mark.asyncio
 async def test_workspace_lookup(servicer, server_url_env):
-    config.override_locally("token_id", "ak-abc")
-    config.override_locally("token_secret", "as-xyz")
-    resp = await _lookup_workspace(config, "test-profile")
+    resp = await _lookup_workspace(servicer.remote_addr, "ak-abc", "as-xyz")
     assert resp.workspace_name == "test-workspace"

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -100,6 +100,17 @@ def test_config_store_user(servicer, modal_config):
         _cli(["token", "set", "--token-id", "ABC", "--token-secret", "XYZ"], env=env)
         assert toml.load(config_file_path)["test-username"]["token_id"] == "ABC"
 
+        # Check that we can activate a profile while setting a token
+        _cli(
+            ["token", "set", "--token-id", "foo", "--token-secret", "bar3", "--profile", "prof_3", "--activate"],
+            env=env,
+        )
+        for profile, profile_config in toml.load(config_file_path).items():
+            if profile == "prof_3":
+                assert profile_config["active"] is True
+            else:
+                assert "active" not in profile_config
+
 
 def test_config_env_override_arbitrary_env():
     """config.override_locally() replaces existing env var if not part of config."""

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -42,7 +42,7 @@ def test_config_env_override():
 
 
 def test_config_store_user(servicer, modal_config):
-    with modal_config():
+    with modal_config(show_on_error=True):
         env = {"MODAL_SERVER_URL": servicer.remote_addr}
 
         # No token by default

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -68,6 +68,11 @@ def test_config_store_user(servicer, modal_config):
         assert config["token_id"] == "foo"
         assert config["token_secret"] == "xyz"
 
+        # Check that the profile is named after the workspace username by default
+        config = _get_config(env={"MODAL_PROFILE": "test-username", **env})
+        assert config["token_id"] == "abc"
+        assert config["token_secret"] == "xyz"
+
         # Check that we can get the prof_1 env creds too
         config = _get_config(env={"MODAL_PROFILE": "prof_1", **env})
         assert config["token_id"] == "foo"
@@ -81,6 +86,12 @@ def test_config_store_user(servicer, modal_config):
         # Check that an empty string falls back to the active profile
         config = _get_config(env={"MODAL_PROFILE": "", **env})
         assert config["token_secret"] == "xyz"
+
+        # Check that we can overwrite the default profile
+        _cli(["token", "set", "--token-id", "ABC", "--token-secret", "XYZ"], env=env)
+        config = _get_config(env={"MODAL_PROFILE": "test-username", **env})
+        assert config["token_id"] == "ABC"
+        assert config["token_secret"] == "XYZ"
 
 
 def test_config_env_override_arbitrary_env():

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -820,7 +820,9 @@ class MockClientServicer(api_grpc.ModalClientBase):
         )
 
     async def WorkspaceNameLookup(self, stream):
-        await stream.send_message(api_pb2.WorkspaceNameLookupResponse(workspace_name="test-workspace"))
+        await stream.send_message(
+            api_pb2.WorkspaceNameLookupResponse(workspace_name="test-workspace", username="test-username")
+        )
 
     ### Tunnel
 
@@ -1114,7 +1116,7 @@ def modal_config():
     """Return a context manager with a temporary modal.toml file"""
 
     @contextlib.contextmanager
-    def mock_modal_toml(contents: str = ""):
+    def mock_modal_toml(contents: str = "", show_on_error: bool = False):
         # Some of the cli tests run within within the main process
         # so we need to modify the config singletons to pick up any changes
         orig_config_path_env = os.environ.get("MODAL_CONFIG_PATH")
@@ -1126,6 +1128,11 @@ def modal_config():
             config.user_config_path = t.name
             config._user_config = config._read_user_config()
             yield
+        except Exception:
+            if show_on_error:
+                with open(t.name) as f:
+                    print(f"Test config file contents:\n\n{f.read()}", file=sys.stderr)
+            raise
         finally:
             if orig_config_path_env:
                 os.environ["MODAL_CONFIG_PATH"] = orig_config_path_env

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1127,7 +1127,7 @@ def modal_config():
             os.environ["MODAL_CONFIG_PATH"] = t.name
             config.user_config_path = t.name
             config._user_config = config._read_user_config()
-            yield
+            yield t.name
         except Exception:
             if show_on_error:
                 with open(t.name) as f:


### PR DESCRIPTION
## Describe your changes

A few things are happening in this PR:

First, I refactored the existing code underlying `modal token new` and `modal token set`:
  - I moved the underlying functions into `modal/token_flow.py` so the CLI code stays very thin.
  - `_new_token` now calls into `_set_token` after grabbing credentials from the server, to reduce duplicated code and ensure consistent console logging.
  - I converted the underlying functions to be async as they call into an async function for fetching the workspace name

Then, I changed the behavior of these functions to let us move away from having a "default" profile concept:
- The default profile that is created / updated by these functions will be named after the workspace that the token points to, rather than being named `"default"`
- If no profiles currently exist, the new profile will have its `active` metadata set to `True`
- There's a new `--activate` flag for both CLI commands that will activate the profile that gets created / modified
 
Open questions:
- Should `_new_token` and `_set_token` be public functions in the API?
    - One thing to consider is that the functions as written won't modify the config state in the active process, so I think we'd want to make them reload the config if we do that.
- Maybe `modal/token_flow.py` should be `modal/token.py` now? This is safe to do as it does not currently contain public interfaces.
- Would it make more sense to have `activate=True` by default?

Part of MOD-2168

## Changelog

The `modal token new` and `modal token set` commands now create profiles that are more closely associated with workspaces, and they have more explicit profile activation behavior:

- By default, these commands will create/update a profile named after the workspace that the token points to, rather than a profile named "default"
- Both commands now have an `--activate` flag that will activate the profile associated with the new token
- If no other profiles exist at the time of creation, the new profile will have its `active` metadata set to True

With these changes, we are moving away from the concept of a "default" profile. Implicit usage of the "default" profile will be deprecated in a future update.