### PR TITLE
Update DictGetOrCreateRequest

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -136,6 +136,11 @@ enum GPUType {
   GPU_TYPE_L4 = 9;
 }
 
+enum ObjectCreationType {
+  OBJECT_CREATION_TYPE_UNSPECIFIED = 0;  // just lookup
+  OBJECT_CREATION_TYPE_CREATE_IF_MISSING = 1;
+}
+
 enum ProgressType {
   IMAGE_SNAPSHOT_UPLOAD = 0;  // TODO(erikbern): shouldn't be zero, and needs prefix
   FUNCTION_QUEUED = 1;  // TODO(erikbern): needs_prefix
@@ -611,12 +616,11 @@ message DictCreateResponse {  // Will be superseded by DictGetOrCreateResponse
 }
 
 message DictGetOrCreateRequest {
-  string app_id = 1;
-  string deployment_name = 2;
-  DeploymentNamespace namespace = 3;
-  string environment_name = 4;
-  bool create_if_missing = 5;
-  repeated DictEntry data = 6;
+  string deployment_name = 1;
+  DeploymentNamespace namespace = 2;
+  string environment_name = 3;
+  ObjectCreationType object_creation_type = 4;
+  repeated DictEntry data = 5;
 }
 
 message DictGetOrCreateResponse {


### PR DESCRIPTION
I realized we probably want to get rid of the `.new` methods anyway, so let's leave the old `DictCreate` alone and let's not support attaching dicts to apps in `DictGetOrCreate`.

Thinking through it I also realized it might be useful to support more than 2 ways to create an object in the future, so I turned the bool in to an enum instead. Off the top of my head I think we might want to support modes like this:

1. Only lookup
2. Lookup, create if missing
3. Always create, fail if exists
4. Create ephemeral

Right now we only support the first two.
