### PR TITLE
Show workspace username in `modal profile list`

### DIFF
--- a/modal/cli/profile.py
+++ b/modal/cli/profile.py
@@ -49,7 +49,7 @@ async def list(json: Optional[bool] = False):
             # Catch-all for other exceptions, like incorrect server url
             workspace = "Unknown (profile misconfigured)"
         else:
-            workspace = resp.workspace_name
+            workspace = resp.username
         content = ["•" if active else "", profile, workspace]
         rows.append((active, content))
 

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -2,6 +2,7 @@
 import json
 import os
 import pytest
+import re
 import sys
 import tempfile
 import traceback
@@ -534,10 +535,27 @@ def test_cls(servicer, set_env_client, test_dir):
     _run(["run", f"{stub_file.as_posix()}::AParametrized.some_method", "--x", "42", "--y", "1000"])
 
 
-def test_profile_list(servicer, server_url_env):
-    res = _run(["profile", "list"])
-    assert "Profile" in res.stdout
-    assert "Workspace" in res.stdout
+def test_profile_list(servicer, server_url_env, modal_config):
+    config = """
+    [test-profile]
+    token_id = "ak-abc"
+    token_secret = "as-xyz"
 
-    res = _run(["profile", "list", "--json"])
-    json.loads(res.stdout)
+    [other-profile]
+    token_id = "ak-abc"
+    token_secret = "as-xyz"
+    """
+
+    with modal_config(config):
+        res = _run(["profile", "list"])
+        table_rows = res.stdout.split("\n")
+        assert re.search("Profile .+ Workspace", table_rows[1])
+        assert re.search("test-profile .+ test-username", table_rows[3])
+        assert re.search("other-profile .+ test-username", table_rows[4])
+
+        res = _run(["profile", "list", "--json"])
+        json_data = json.loads(res.stdout)
+        assert json_data[0]["name"] == "test-profile"
+        assert json_data[0]["workspace"] == "test-username"
+        assert json_data[1]["name"] == "other-profile"
+        assert json_data[1]["workspace"] == "test-username"


### PR DESCRIPTION
## Describe your changes

- Resolves MOD-2220

## Changelog

In `modal profile list`, the user's GitHub username is now shown as the name for the "Personal" workspace.