### PR TITLE
Add error (and deprecation warning) for invalid profile configuration

### DIFF
--- a/modal/__main__.py
+++ b/modal/__main__.py
@@ -1,11 +1,47 @@
 # Copyright Modal Labs 2022
+import os
+import sys
+from textwrap import dedent
+
+from rich.console import Console
+from rich.panel import Panel
+
 from ._traceback import setup_rich_traceback
 from .cli.entry_point import entrypoint_cli
+from .config import _profile, _user_config
+from .exception import InvalidError
+
+
+def check_profile():
+    if ("MODAL_PROFILE" in os.environ) or (len(sys.argv) == 1) or (sys.argv[1] in {"setup", "profile"}):
+        return
+
+    num_profiles = len(_user_config)
+    num_active = sum(v.get("active", False) for v in _user_config.values())
+    if num_active > 1:
+        raise InvalidError(
+            "More than one Modal profile is active. "
+            "Please fix with `modal profile activate` or by editing your Modal config file."
+        )
+    elif num_profiles > 1 and num_active == 0 and _profile == "default":
+        # Eventually we plan to have num_profiles > 1 with num_active = 0 be an error
+        # But we want to give users time to activate one of their profiles without disruption
+        console = Console()
+        message = dedent(
+            """\
+        Support for using an implicit 'default' profile is deprecated.
+        Please use `modal profile activate` to activate one of your profiles.
+        (Use `modal profile list` to see the options.)
+
+        This will become an error in a future update."""
+        )
+        console.print(Panel(message, style="yellow", title="Warning", title_align="left"))
 
 
 def main():
     # Setup rich tracebacks, but only on user's end, when using the Modal CLI.
     setup_rich_traceback()
+    check_profile()
     entrypoint_cli()
 
 

--- a/modal/__main__.py
+++ b/modal/__main__.py
@@ -1,47 +1,11 @@
 # Copyright Modal Labs 2022
-import os
-import sys
-from textwrap import dedent
-
-from rich.console import Console
-from rich.panel import Panel
-
 from ._traceback import setup_rich_traceback
 from .cli.entry_point import entrypoint_cli
-from .config import _profile, _user_config
-from .exception import InvalidError
-
-
-def check_profile():
-    if ("MODAL_PROFILE" in os.environ) or (len(sys.argv) == 1) or (sys.argv[1] in {"setup", "profile"}):
-        return
-
-    num_profiles = len(_user_config)
-    num_active = sum(v.get("active", False) for v in _user_config.values())
-    if num_active > 1:
-        raise InvalidError(
-            "More than one Modal profile is active. "
-            "Please fix with `modal profile activate` or by editing your Modal config file."
-        )
-    elif num_profiles > 1 and num_active == 0 and _profile == "default":
-        # Eventually we plan to have num_profiles > 1 with num_active = 0 be an error
-        # But we want to give users time to activate one of their profiles without disruption
-        console = Console()
-        message = dedent(
-            """\
-            Support for using an implicit 'default' profile is deprecated.
-            Please use `modal profile activate` to activate one of your profiles.
-            (Use `modal profile list` to see the options.)
-
-            This will become an error in a future update."""
-        )
-        console.print(Panel(message, style="yellow", title="Warning", title_align="left"))
 
 
 def main():
     # Setup rich tracebacks, but only on user's end, when using the Modal CLI.
     setup_rich_traceback()
-    check_profile()
     entrypoint_cli()
 
 

--- a/modal/__main__.py
+++ b/modal/__main__.py
@@ -29,11 +29,11 @@ def check_profile():
         console = Console()
         message = dedent(
             """\
-        Support for using an implicit 'default' profile is deprecated.
-        Please use `modal profile activate` to activate one of your profiles.
-        (Use `modal profile list` to see the options.)
+            Support for using an implicit 'default' profile is deprecated.
+            Please use `modal profile activate` to activate one of your profiles.
+            (Use `modal profile list` to see the options.)
 
-        This will become an error in a future update."""
+            This will become an error in a future update."""
         )
         console.print(Panel(message, style="yellow", title="Warning", title_align="left"))
 

--- a/modal/client.py
+++ b/modal/client.py
@@ -16,7 +16,7 @@ from modal_utils.http_utils import http_client_with_tls
 from modal_version import __version__
 
 from ._tracing import inject_tracing_context
-from .config import config, logger
+from .config import _check_config, config, logger
 from .exception import AuthError, ConnectionError, DeprecationError, VersionError
 
 HEARTBEAT_INTERVAL: float = config.get("heartbeat_interval")
@@ -141,6 +141,7 @@ class _Client:
 
     async def _verify(self):
         logger.debug("Client: Starting")
+        _check_config()
         try:
             req = empty_pb2.Empty()
             resp = await retry_transient_errors(

--- a/modal/config.py
+++ b/modal/config.py
@@ -142,7 +142,8 @@ def _check_config() -> None:
     if num_active > 1:
         raise InvalidError(
             "More than one Modal profile is active. "
-            "Please fix with `modal profile activate` or by editing your Modal config file."
+            "Please fix with `modal profile activate` or by editing your Modal config file "
+            f"({user_config_path})."
         )
     elif num_profiles > 1 and num_active == 0 and _profile == "default":
         # Eventually we plan to have num_profiles > 1 with num_active = 0 be an error

--- a/modal/config.py
+++ b/modal/config.py
@@ -76,6 +76,7 @@ import os
 import typing
 import warnings
 from datetime import date
+from textwrap import dedent
 from typing import Any, Dict, Optional
 
 import toml
@@ -84,7 +85,7 @@ from google.protobuf.empty_pb2 import Empty
 from modal_proto import api_pb2
 from modal_utils.logger import configure_logger
 
-from .exception import deprecation_error
+from .exception import InvalidError, deprecation_error, deprecation_warning
 
 # Locate config file and read it
 
@@ -133,6 +134,32 @@ def config_set_active_profile(env: str) -> None:
 
     _user_config[env]["active"] = True
     _write_user_config(_user_config)
+
+
+def _check_config() -> None:
+    num_profiles = len(_user_config)
+    num_active = sum(v.get("active", False) for v in _user_config.values())
+    if num_active > 1:
+        raise InvalidError(
+            "More than one Modal profile is active. "
+            "Please fix with `modal profile activate` or by editing your Modal config file."
+        )
+    elif num_profiles > 1 and num_active == 0 and _profile == "default":
+        # Eventually we plan to have num_profiles > 1 with num_active = 0 be an error
+        # But we want to give users time to activate one of their profiles without disruption
+        message = dedent(
+            """
+
+            WARNING:
+
+            Support for using an implicit 'default' profile is deprecated.
+            Please use `modal profile activate` to activate one of your profiles.
+            (Use `modal profile list` to see the options.)
+
+            This will become an error in a future update.
+            """
+        )
+        deprecation_warning(date(2024, 2, 6), message)
 
 
 if "MODAL_ENV" in os.environ:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1172,12 +1172,14 @@ def modal_config():
         # so we need to modify the config singletons to pick up any changes
         orig_config_path_env = os.environ.get("MODAL_CONFIG_PATH")
         orig_config_path = config.user_config_path
+        orig_profile = config._profile
         try:
             with tempfile.NamedTemporaryFile(delete=False, suffix=".toml", mode="w") as t:
                 t.write(textwrap.dedent(contents.strip("\n")))
             os.environ["MODAL_CONFIG_PATH"] = t.name
             config.user_config_path = t.name
             config._user_config = config._read_user_config()
+            config._profile = config._config_active_profile()
             yield t.name
         except Exception:
             if show_on_error:
@@ -1191,6 +1193,7 @@ def modal_config():
                 del os.environ["MODAL_CONFIG_PATH"]
             config.user_config_path = orig_config_path
             config._user_config = config._read_user_config()
+            config._profile = orig_profile
             os.remove(t.name)
 
     return mock_modal_toml


### PR DESCRIPTION
## Describe your changes

This adds some checks that enforce the following rule for profile configuration: if more than one profile is defined in `.modal.toml`, exactly one must be explicitly marked as active.

We are deprecating the legacy behavior where we implicitly fall back to a profile named 'default' if one exists. There's a deprecation warning, and we'll start enforcing that in a future release.

I've also added an error when more than one profile is explicitly marked as active. Currently we just silently use the first profile; this feels "wrong" enough to break without a gradual deprecation, but I'm happy to make this a warning if others feel differently.

- Resolves MOD-2211
- Resolves MOD-2228

## Changelog

- Support for an implicit 'default' profile is now deprecated. If you have more than one profile in your Modal config file, one must be explicitly set to `active` (use `modal profile activate` or edit your `.modal.toml` file to resolve).
- An error is now raised when more than one profile is set to `active`.