### PR TITLE
Deprecate the singular form `secret` function parameter

### DIFF
--- a/modal/cli/secret.py
+++ b/modal/cli/secret.py
@@ -77,7 +77,7 @@ modal secret create my-credentials username=john password=-
     env_var_code = "\n    ".join(f'os.getenv("{name}")' for name in env_dict.keys()) if env_dict else "..."
 
     example_code = f"""
-@stub.function(secret=modal.Secret.from_name("{secret_name}"))
+@stub.function(secrets=[modal.Secret.from_name("{secret_name}")])
 def some_function():
     {env_var_code}
 """

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -66,6 +66,7 @@ from .exception import (
     NotFoundError,
     RemoteError,
     deprecation_error,
+    deprecation_warning,
 )
 from .gpu import GPU_T, parse_gpu_config
 from .image import _Image
@@ -606,6 +607,13 @@ class _Function(_Object, type_prefix="fu"):
         elif interactive and is_generator:
             raise InvalidError("Interactive mode not supported for generator functions")
 
+        if secret is not None:
+            deprecation_warning(
+                date(2024, 1, 31),
+                "The singular `secret` parameter is deprecated. Pass a list to `secrets` instead.",
+            )
+            secrets = [secret, *secrets]
+
         all_mounts = [
             _get_client_mount(),  # client
             *mounts,  # explicit mounts
@@ -615,9 +623,6 @@ class _Function(_Object, type_prefix="fu"):
             all_mounts.extend(stub._get_deduplicated_function_mounts(info.get_mounts()))  # implicit mounts
         else:
             all_mounts.extend(info.get_mounts().values())  # this would typically only happen for builder functions
-
-        if secret:
-            secrets = [secret, *secrets]
 
         retry_policy = _parse_retries(retries, raw_f)
 
@@ -639,7 +644,6 @@ class _Function(_Object, type_prefix="fu"):
                     snapshot_info,
                     stub=None,
                     image=image,
-                    secret=secret,
                     secrets=secrets,
                     gpu=gpu,
                     mounts=mounts,

--- a/modal/image.py
+++ b/modal/image.py
@@ -1067,7 +1067,7 @@ class _Image(_Object, type_prefix="im"):
         ```python
         modal.Image.from_gcp_artifact_registry(
             "us-east1-docker.pkg.dev/my-project-1234/my-repo/my-image:my-version",
-            secret=modal.Secret.from_name("my-gcp-secret"),
+            secrets=[modal.Secret.from_name("my-gcp-secret")],
             add_python="3.11",
         )
         ```
@@ -1108,7 +1108,7 @@ class _Image(_Object, type_prefix="im"):
         ```python
         modal.Image.from_aws_ecr(
             "000000000000.dkr.ecr.us-east-1.amazonaws.com/my-private-registry:my-version",
-            secret=modal.Secret.from_name("aws"),
+            secrets=[modal.Secret.from_name("aws")],
             add_python="3.11",
         )
         ```

--- a/modal/image.py
+++ b/modal/image.py
@@ -1261,8 +1261,7 @@ class _Image(_Object, type_prefix="im"):
         self,
         raw_f: Callable[[], Any],
         *,
-        secret: Optional[_Secret] = None,  # An optional Modal Secret with environment variables for the container
-        secrets: Sequence[_Secret] = (),  # Plural version of `secret` when multiple secrets are needed
+        secrets: Sequence[_Secret] = (),  # Optional Modal Secret objects with environment variables for the container
         gpu: GPU_T = None,  # GPU specification as string ("any", "T4", "A10G", ...) or object (`modal.GPU.A100()`, ...)
         mounts: Sequence[_Mount] = (),
         shared_volumes: Dict[Union[str, os.PathLike], _NetworkFileSystem] = {},
@@ -1271,6 +1270,7 @@ class _Image(_Object, type_prefix="im"):
         memory: Optional[int] = None,  # How much memory to request, in MiB. This is a soft limit.
         timeout: Optional[int] = 86400,  # Maximum execution time of the function in seconds.
         force_build: bool = False,
+        secret: Optional[_Secret] = None,  # Deprecated: use `secrets`
     ) -> "_Image":
         """Run user-defined function `raw_f` as an image build step. The function runs just like an ordinary Modal
         function, and any kwargs accepted by `@stub.function` (such as `Mount`s, `NetworkFileSystem`s, and resource requests) can

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -36,7 +36,7 @@ class _Secret(_StatefulObject, type_prefix="st"):
 
         Usage:
         ```python
-        @stub.function(secret=modal.Secret.from_dict({"FOO": "bar"})
+        @stub.function(secrets=[modal.Secret.from_dict({"FOO": "bar"}])
         def run():
             print(os.environ["FOO"])
         ```
@@ -80,7 +80,7 @@ class _Secret(_StatefulObject, type_prefix="st"):
         If called with an argument, it will use that as a starting point for finding `.env` files.
         In particular, you can call it like this:
         ```python
-        @stub.function(secret=modal.Secret.from_dotenv(__file__))
+        @stub.function(secrets=[modal.Secret.from_dotenv(__file__)])
         def run():
             print(os.environ["USERNAME"])  # Assumes USERNAME is defined in your .env file
         ```

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -96,7 +96,7 @@ class _Stub:
     stub = modal.Stub()
 
     @stub.function(
-        secret=modal.Secret.from_name("some_secret"),
+        secrets=[modal.Secret.from_name("some_secret")],
         schedule=modal.Period(days=1),
     )
     def foo():
@@ -445,8 +445,7 @@ class _Stub:
         *,
         image: Optional[_Image] = None,  # The image to run as the container for the function
         schedule: Optional[Schedule] = None,  # An optional Modal Schedule for the function
-        secret: Optional[_Secret] = None,  # An optional Modal Secret with environment variables for the container
-        secrets: Sequence[_Secret] = (),  # Plural version of `secret` when multiple secrets are needed
+        secrets: Sequence[_Secret] = (),  # Optional Modal Secret objects with environment variables for the container
         gpu: GPU_T = None,  # GPU specification as string ("any", "T4", "A10G", ...) or object (`modal.GPU.A100()`, ...)
         serialized: bool = False,  # Whether to send the function over using cloudpickle.
         mounts: Sequence[_Mount] = (),
@@ -477,6 +476,7 @@ class _Stub:
         cloud: Optional[str] = None,  # Cloud provider to run the function on. Possible values are aws, gcp, oci, auto.
         checkpointing_enabled: bool = False,  # Enable memory checkpointing for faster cold starts.
         block_network: bool = False,  # Whether to block network access
+        secret: Optional[_Secret] = None,  # Deprecated: use `secrets`
         _allow_background_volume_commits: bool = False,
     ) -> Callable[..., _Function]:
         """Decorator to register a new Modal function with this stub."""
@@ -572,8 +572,7 @@ class _Stub:
         _warn_parentheses_missing=None,
         *,
         image: Optional[_Image] = None,  # The image to run as the container for the function
-        secret: Optional[_Secret] = None,  # An optional Modal Secret with environment variables for the container
-        secrets: Sequence[_Secret] = (),  # Plural version of `secret` when multiple secrets are needed
+        secrets: Sequence[_Secret] = (),  # Optional Modal Secret objects with environment variables for the container
         gpu: GPU_T = None,  # GPU specification as string ("any", "T4", "A10G", ...) or object (`modal.GPU.A100()`, ...)
         serialized: bool = False,  # Whether to send the function over using cloudpickle.
         mounts: Sequence[_Mount] = (),
@@ -596,6 +595,7 @@ class _Stub:
         cloud: Optional[str] = None,  # Cloud provider to run the function on. Possible values are aws, gcp, oci, auto.
         checkpointing_enabled: bool = False,  # Enable memory checkpointing for faster cold starts.
         block_network: bool = False,  # Whether to block network access
+        secret: Optional[_Secret] = None,  # Deprecated: use `secrets`
     ) -> Callable[[CLS_T], _Cls]:
         if _warn_parentheses_missing:
             raise InvalidError("Did you forget parentheses? Suggestion: `@stub.cls()`.")

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -260,7 +260,7 @@ def test_ecr_install(servicer, client):
         image=Image.from_aws_ecr(
             image_tag,
             setup_dockerfile_commands=["RUN apt-get update"],
-            secret=Secret.from_dict({"AWS_ACCESS_KEY_ID": "", "AWS_SECRET_ACCESS_KEY": ""}),
+            secrets=[Secret.from_dict({"AWS_ACCESS_KEY_ID": "", "AWS_SECRET_ACCESS_KEY": ""})],
         )
     )
 

--- a/test/stub_test.py
+++ b/test/stub_test.py
@@ -326,7 +326,7 @@ def test_function_image_positional():
 @pytest.mark.asyncio
 async def test_deploy_disconnect(servicer, client):
     stub = Stub()
-    stub.function(secret=modal.Secret.from_name("nonexistent-secret"))(square)
+    stub.function(secrets=[modal.Secret.from_name("nonexistent-secret")])(square)
 
     with pytest.raises(NotFoundError):
         await deploy_stub.aio(stub, "my-app", client=client)


### PR DESCRIPTION
## Describe your changes

- Resolves MOD-2237

## Changelog

The singular form of the `secret` parameter in `Stub.function`, `Stub.cls`, and `Image.run_function` has been deprecated. Please update your code to use the plural form instead:`secrets=[Secret(...)]`.