### PR TITLE
Indicate when token is active in env vars in `modal profile list`

### DIFF
--- a/modal/cli/profile.py
+++ b/modal/cli/profile.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
 
 import asyncio
+import os
 from typing import Optional
 
 import typer
@@ -33,8 +34,8 @@ async def list(json: Optional[bool] = False):
     lookup_coros = [
         _lookup_workspace(
             config.get("server_url", profile),
-            config.get("token_id", profile),
-            config.get("token_secret", profile),
+            config.get("token_id", profile, use_env=False),
+            config.get("token_secret", profile, use_env=False),
         )
         for profile in profiles
     ]
@@ -53,7 +54,20 @@ async def list(json: Optional[bool] = False):
         content = ["•" if active else "", profile, workspace]
         rows.append((active, content))
 
+    env_based_workspace: Optional[str] = None
+    if "MODAL_TOKEN_ID" in os.environ:
+        try:
+            env_based_resp = await _lookup_workspace(
+                config.get("server_url", _profile),
+                os.environ.get("MODAL_TOKEN_ID"),
+                os.environ.get("MODAL_TOKEN_SECRET"),
+            )
+            env_based_workspace = env_based_resp.username
+        except AuthError:
+            env_based_workspace = "Unknown (authentication failure)"
+
     console = Console()
+    highlight = "bold green" if env_based_workspace is None else "yellow"
     if json:
         json_data = []
         for active, content in rows:
@@ -62,5 +76,10 @@ async def list(json: Optional[bool] = False):
     else:
         table = Table(" ", "Profile", "Workspace")
         for active, content in rows:
-            table.add_row(*content, style="bold green" if active else "dim")
+            table.add_row(*content, style=highlight if active else "dim")
         console.print(table)
+
+    if env_based_workspace is not None:
+        console.print(
+            f"Using [bold]{env_based_workspace}[/bold] workspace based on environment variables", style="yellow"
+        )

--- a/modal/config.py
+++ b/modal/config.py
@@ -180,11 +180,11 @@ class Config:
     def __init__(self):
         pass
 
-    def get(self, key, profile=None):
+    def get(self, key, profile=None, use_env=True):
         """Looks up a configuration value.
 
         Will check (in decreasing order of priority):
-        1. Any environment variable of the form MODAL_FOO_BAR
+        1. Any environment variable of the form MODAL_FOO_BAR (when use_env is True)
         2. Settings in the user's .toml configuration file
         3. The default value of the setting
         """
@@ -192,7 +192,7 @@ class Config:
             profile = _profile
         s = _SETTINGS[key]
         env_var_key = "MODAL_" + key.upper()
-        if env_var_key in os.environ:
+        if use_env and env_var_key in os.environ:
             return s.transform(os.environ[env_var_key])
         elif profile in _user_config and key in _user_config[profile]:
             return s.transform(_user_config[profile][key])

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -542,8 +542,9 @@ def test_profile_list(servicer, server_url_env, modal_config):
     token_secret = "as-xyz"
 
     [other-profile]
-    token_id = "ak-abc"
-    token_secret = "as-xyz"
+    token_id = "ak-123"
+    token_secret = "as-789"
+    active = true
     """
 
     with modal_config(config):
@@ -559,3 +560,20 @@ def test_profile_list(servicer, server_url_env, modal_config):
         assert json_data[0]["workspace"] == "test-username"
         assert json_data[1]["name"] == "other-profile"
         assert json_data[1]["workspace"] == "test-username"
+
+        orig_env_token_id = os.environ.get("MODAL_TOKEN_ID")
+        orig_env_token_secret = os.environ.get("MODAL_TOKEN_SECRET")
+        os.environ["MODAL_TOKEN_ID"] = "ak-abc"
+        os.environ["MODAL_TOKEN_SECRET"] = "as-xyz"
+        try:
+            res = _run(["profile", "list"])
+            assert "Using test-username workspace based on environment variables" in res.stdout
+        finally:
+            if orig_env_token_id:
+                os.environ["MODAL_TOKEN_ID"] = orig_env_token_id
+            else:
+                del os.environ["MODAL_TOKEN_ID"]
+            if orig_env_token_secret:
+                os.environ["MODAL_TOKEN_SECRET"] = orig_env_token_secret
+            else:
+                del os.environ["MODAL_TOKEN_SECRET"]


### PR DESCRIPTION
## Describe your changes

<img width="422" alt="image" src="https://github.com/modal-labs/modal-client/assets/315810/73836048-c82c-4107-ad22-86cf0727e1a1">

- Resolves MOD-2194

## Changelog

The `modal profile list` output now indicates when the workspace is determined by a token stored in environment variables.