### PR TITLE
DictGetOrCreate - use new endpoint client side 

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -306,9 +306,8 @@ class _Cls(_Object, type_prefix="cs"):
 
         return cls
 
-    @classmethod
+    @staticmethod
     async def lookup(
-        cls: Type["_Cls"],
         app_name: str,
         tag: Optional[str] = None,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
@@ -322,7 +321,7 @@ class _Cls(_Object, type_prefix="cs"):
         Class = modal.Cls.lookup("other-app", "Class")
         ```
         """
-        obj = cls.from_name(app_name, tag, namespace=namespace, environment_name=environment_name, workspace=workspace)
+        obj = _Cls.from_name(app_name, tag, namespace=namespace, environment_name=environment_name, workspace=workspace)
         if client is None:
             client = await _Client.from_env()
         resolver = Resolver(client=client)

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -12,14 +12,14 @@ from ._types import typechecked
 from .client import _Client
 from .config import logger
 from .exception import deprecation_error
-from .object import _get_environment_name, _StatefulObject, live_method
+from .object import _get_environment_name, _Object, live_method
 
 
 def _serialize_dict(data):
     return [api_pb2.DictEntry(key=serialize(k), value=serialize(v)) for k, v in data.items()]
 
 
-class _Dict(_StatefulObject, type_prefix="di"):
+class _Dict(_Object, type_prefix="di"):
     """Distributed dictionary for storage in Modal apps.
 
     Keys and values can be essentially any object, so long as they can be

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -9,9 +9,10 @@ from modal_utils.grpc_utils import retry_transient_errors
 from ._resolver import Resolver
 from ._serialization import deserialize, serialize
 from ._types import typechecked
+from .client import _Client
 from .config import logger
 from .exception import deprecation_error
-from .object import _StatefulObject, live_method
+from .object import _get_environment_name, _StatefulObject, live_method
 
 
 def _serialize_dict(data):
@@ -75,13 +76,13 @@ class _Dict(_StatefulObject, type_prefix="di"):
         self._init_from_other(obj)
 
     @staticmethod
-    def persisted(
-        label: str, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, environment_name: Optional[str] = None
+    def from_name(
+        label: str,
+        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        environment_name: Optional[str] = None,
+        create_if_missing: bool = False,
     ) -> "_Dict":
-        """Deploy a Modal app containing this object.
-
-        The deployed object can then be imported from other apps, or by calling
-        `Dict.from_name(label)` from that same app.
+        """Create a reference to a persisted Dict
 
         **Examples**
 
@@ -93,17 +94,49 @@ class _Dict(_StatefulObject, type_prefix="di"):
         stub.dict = Dict.from_name("my-dict")
         ```
         """
-        return _Dict.new()._persist(label, namespace, environment_name)
 
-    def persist(
-        self, label: str, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, environment_name: Optional[str] = None
+        async def _load(provider: _Dict, resolver: Resolver, existing_object_id: Optional[str]):
+            req = api_pb2.DictGetOrCreateRequest(
+                deployment_name=label,
+                namespace=namespace,
+                environment_name=_get_environment_name(environment_name),
+                object_creation_type=(api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING if create_if_missing else None),
+            )
+            response = await resolver.client.stub.DictGetOrCreate(req)
+            logger.debug("Created dict with id %s" % response.dict_id)
+            provider._hydrate(response.dict_id, resolver.client, None)
+
+        return _Dict._from_loader(_load, "Dict()")
+
+    @staticmethod
+    def persisted(
+        label: str, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, environment_name: Optional[str] = None
     ) -> "_Dict":
-        """mdmd:hidden"""
-        deprecation_error(
-            date(2023, 6, 30),
-            """`Dict.new().persist("my-dict")` is deprecated. Use `Dict.persisted("my-dict")` instead.""",
+        return _Dict.from_name(label, namespace, environment_name, create_if_missing=True)
+
+    @staticmethod
+    async def lookup(
+        label: str,
+        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        client: Optional[_Client] = None,
+        environment_name: Optional[str] = None,
+        create_if_missing: bool = False,
+    ) -> "_Dict":
+        """Lookup a dict with a given name and tag.
+
+        ```python
+        d = modal.Dict.lookup("my-dict")
+        d["xyz"] = 123
+        ```
+        """
+        obj = _Dict.from_name(
+            label, namespace=namespace, environment_name=environment_name, create_if_missing=create_if_missing
         )
-        return self.persisted(label, namespace, environment_name)
+        if client is None:
+            client = await _Client.from_env()
+        resolver = Resolver(client=client)
+        await resolver.load(obj)
+        return obj
 
     @live_method
     async def clear(self) -> None:

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -978,9 +978,8 @@ class _Function(_Object, type_prefix="fu"):
         rep = f"Ref({app_name})"
         return cls._from_loader(_load_remote, rep, is_another_app=True)
 
-    @classmethod
+    @staticmethod
     async def lookup(
-        cls: Type["_Function"],
         app_name: str,
         tag: Optional[str] = None,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
@@ -993,7 +992,7 @@ class _Function(_Object, type_prefix="fu"):
         other_function = modal.Function.lookup("other-app", "function")
         ```
         """
-        obj = cls.from_name(app_name, tag, namespace=namespace, environment_name=environment_name)
+        obj = _Function.from_name(app_name, tag, namespace=namespace, environment_name=environment_name)
         if client is None:
             client = await _Client.from_env()
         resolver = Resolver(client=client)

--- a/modal/object.py
+++ b/modal/object.py
@@ -234,7 +234,7 @@ class _Object:
 
 
 class _StatefulObject(_Object):
-    # This base class is used for _Volume, _Dict, _Queue, _Secret, _NetworkFileSystem
+    # This base class is used for _Volume, _Queue, _Secret, _NetworkFileSystem
     # This is a temporary class needed until we rewrite AppLookupObject to be specific to each class.
     # At that point, we can "push down" each of these methods into each class.
     # These classes all have in common that they are always looked up using a single app name.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -128,6 +128,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.client_hello_metadata = None
 
         self.dicts = {}
+        self.deployed_dicts = {}
 
         self.cleared_function_calls = set()
 
@@ -406,6 +407,17 @@ class MockClientServicer(api_grpc.ModalClientBase):
             dict_id = f"di-{len(self.dicts)}"
             self.dicts[dict_id] = {}
         await stream.send_message(api_pb2.DictCreateResponse(dict_id=dict_id))
+
+    async def DictGetOrCreate(self, stream):
+        request: api_pb2.DictGetOrCreateRequest = await stream.recv_message()
+        k = (request.deployment_name, request.namespace, request.environment_name)
+        if k in self.deployed_dicts:
+            dict_id = self.deployed_dicts[k]
+        else:
+            dict_id = f"di-{len(self.dicts)}"
+            self.dicts[dict_id] = {}
+            self.deployed_dicts[k] = dict_id
+        await stream.send_message(api_pb2.DictGetOrCreateResponse(dict_id=dict_id))
 
     async def DictClear(self, stream):
         request: api_pb2.DictGetRequest = await stream.recv_message()

--- a/test/dict_test.py
+++ b/test/dict_test.py
@@ -4,7 +4,7 @@ import pytest
 from modal import Dict, Stub
 
 
-def test_dict(servicer, client):
+def test_dict_app(servicer, client):
     stub = Stub()
     stub.d = Dict.new()
     with stub.run(client=client):
@@ -21,3 +21,8 @@ def test_dict(servicer, client):
         assert stub.d.get("foo", default=True)
         stub.d["foo"] = None
         assert stub.d["foo"] is None
+
+
+def test_dict_deploy(servicer, client):
+    d = Dict.lookup("xyz", create_if_missing=True, client=client)
+    d["xyz"] = 123

--- a/test/stub_test.py
+++ b/test/stub_test.py
@@ -251,25 +251,6 @@ def test_set_image_on_stub_as_attribute():
     assert stub._get_default_image() == custom_img
 
 
-@pytest.mark.asyncio
-async def test_redeploy_persist(servicer, client):
-    stub = Stub(image=Image.debian_slim().pip_install("pandas"))
-    stub.function()(square)
-
-    stub.d = Dict.new()
-
-    # Deploy app
-    app = await deploy_stub.aio(stub, "my-app", client=client)
-    assert app.app_id == "ap-1"
-    assert servicer.app_objects["ap-1"]["d"] == "di-0"
-
-    stub.d = Dict.persisted("my-dict")
-    # Redeploy, make sure all ids are the same
-    app = await deploy_stub.aio(stub, "my-app", client=client)
-    assert app.app_id == "ap-1"
-    assert servicer.app_objects["ap-1"]["d"] == "di-1"
-
-
 def test_redeploy_delete_objects(servicer, client):
     # Deploy an app with objects d1 and d2
     stub = Stub()


### PR DESCRIPTION
This starts using `DictGetOrCreate` on the client side for `persisted`, `from_name`, and `lookup` (but not `new`)

A lot of redundant code right now but once this is done we should be able to clean up quite a lot