### PR TITLE
Allow variadic parameters in scheduled functions

### DIFF
--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -321,7 +321,13 @@ class FunctionInfo:
         return self.function_name
 
     def is_nullary(self):
-        return all(param.default is not param.empty for param in self.signature.parameters.values())
+        for param in self.signature.parameters.values():
+            if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+                # variadic parameters are nullary
+                continue
+            if param.default is param.empty:
+                return False
+        return True
 
 
 def get_referred_objects(f: Callable) -> List[Object]:

--- a/test/function_utils_test.py
+++ b/test/function_utils_test.py
@@ -3,7 +3,7 @@
 from typing import List
 
 from modal import Queue
-from modal._function_utils import get_referred_objects
+from modal._function_utils import FunctionInfo, get_referred_objects
 from modal.object import Object
 
 q1 = Queue.new()
@@ -47,3 +47,26 @@ def refers_list():
 def test_refers_list():
     objs: List[Object] = get_referred_objects(refers_list)
     assert objs == []  # This may return [q1, q2] in the future
+
+
+def hasarg(a):
+    ...
+
+
+def noarg():
+    ...
+
+
+def defaultarg(a="hello"):
+    ...
+
+
+def wildcard_args(*wildcard_list, **wildcard_dict):
+    ...
+
+
+def test_is_nullary():
+    assert not FunctionInfo(hasarg).is_nullary()
+    assert FunctionInfo(noarg).is_nullary()
+    assert FunctionInfo(defaultarg).is_nullary()
+    assert FunctionInfo(wildcard_args).is_nullary()


### PR DESCRIPTION
Previously you couldn't do things like:

```
@stub.function(schedule=...)
def my_func(*args):
    ...
```

But this now works (the scheduled function will still be called without arguments, so args will be an empty tuple)

## Changelog

* Variadic parameters (e.g. *args and **kwargs) can now be used in scheduled functions as long as the function doesn't have any other parameters without a default value