### PR TITLE
Don't synchronicity-translate input/outputs

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -266,6 +266,7 @@ class _FunctionIOManager:
                 if not yielded:
                     self._semaphore.release()
 
+    @synchronizer.no_io_translation
     async def run_inputs_outputs(self, input_concurrency: int = 1) -> AsyncIterator[tuple[str, str, Any, Any]]:
         # Ensure we do not fetch new inputs when container is too busy.
         # Before trying to fetch an input, acquire the semaphore:
@@ -285,6 +286,7 @@ class _FunctionIOManager:
             for _ in range(input_concurrency):
                 await self._semaphore.acquire()
 
+    @synchronizer.no_io_translation
     async def _push_output(
         self, input_id, started_at: float, gen_index: int, data_format=api_pb2.DATA_FORMAT_UNSPECIFIED, **kwargs
     ):
@@ -401,6 +403,7 @@ class _FunctionIOManager:
         self.calls_completed += 1
         self._semaphore.release()
 
+    @synchronizer.no_io_translation
     async def push_output(self, input_id, started_at: float, output_index: int, data: Any, data_format: int) -> None:
         await self._push_output(
             input_id,
@@ -412,6 +415,7 @@ class _FunctionIOManager:
         )
         await self.complete_call(started_at)
 
+    @synchronizer.no_io_translation
     async def push_generator_value(
         self, input_id, started_at: float, output_index: int, data: Any, data_format: int
     ) -> None:
@@ -425,6 +429,7 @@ class _FunctionIOManager:
             gen_status=api_pb2.GenericResult.GENERATOR_STATUS_INCOMPLETE,
         )
 
+    @synchronizer.no_io_translation
     async def push_generator_eof(self, input_id, started_at: float, output_index: int) -> None:
         await self._push_output(
             input_id,

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -30,6 +30,11 @@ def square(x):
 
 
 @stub.function()
+def ident(x):
+    return x
+
+
+@stub.function()
 def delay(t):
     time.sleep(t)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     importlib_metadata>=3.6.0
     protobuf>=3.19,<5.0,!=4.24.0
     rich>=12.0.0
-    synchronicity~=0.6.0
+    synchronicity~=0.6.2
     tblib>=1.7.0
     toml
     typer~=0.9.0

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -885,7 +885,7 @@ def test_function_io_doesnt_inspect_args_or_return_values(monkeypatch, unix_serv
     # pr.disable()
     # pr.print_stats()
     duration = time.perf_counter() - t0
-    assert duration < 0.0  # TODO (elias): should be able to get this down significantly more by improving serialization
+    assert duration < 1.0  # TODO (elias): migth be able to get this down significantly more by improving serialization
 
     # function_io_manager.serialize(large_data_list)
     in_translations = []

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -863,7 +863,7 @@ def test_multiple_build_decorator_cls(unix_servicer, event_loop):
 
 
 @skip_windows_unix_socket
-@pytest.mark.timeout(2)
+@pytest.mark.timeout(3.0)
 def test_function_io_doesnt_inspect_args_or_return_values(monkeypatch, unix_servicer):
     synchronizer = modal_utils.async_utils.synchronizer
 
@@ -885,7 +885,7 @@ def test_function_io_doesnt_inspect_args_or_return_values(monkeypatch, unix_serv
     # pr.disable()
     # pr.print_stats()
     duration = time.perf_counter() - t0
-    assert duration < 1.0  # TODO (elias): migth be able to get this down significantly more by improving serialization
+    assert duration < 2.0  # TODO (elias): migth be able to get this down significantly more by improving serialization
 
     # function_io_manager.serialize(large_data_list)
     in_translations = []

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -14,9 +14,11 @@ import tempfile
 import time
 from typing import Any, Dict, List, Optional, Tuple
 from unittest import mock
+from unittest.mock import MagicMock
 
 from grpclib.exceptions import GRPCError
 
+import modal_utils
 from modal import Client
 from modal._container_entrypoint import UserException, main
 from modal._serialization import deserialize, deserialize_data_format, serialize, serialize_data_format
@@ -117,10 +119,10 @@ def _run_container(
         temp_restore_file_path = tempfile.NamedTemporaryFile()
         if is_checkpointing_function:
             # State file is written to allow for a restore to happen.
-            tmep_file_name = temp_restore_file_path.name
-            with pathlib.Path(tmep_file_name).open("w") as target:
+            temp_file_name = temp_restore_file_path.name
+            with pathlib.Path(temp_file_name).open("w") as target:
                 json.dump({}, target)
-            env["MODAL_RESTORE_STATE_PATH"] = tmep_file_name
+            env["MODAL_RESTORE_STATE_PATH"] = temp_file_name
 
             # Override server URL to reproduce restore behavior.
             env["MODAL_SERVER_URL"] = servicer.remote_addr
@@ -850,3 +852,40 @@ def test_multiple_build_decorator_cls(unix_servicer, event_loop):
         is_auto_snapshot=True,
     )
     assert _unwrap_scalar(ret) == 1001
+
+
+@skip_windows_unix_socket
+@pytest.mark.timeout(2)
+def test_function_io_doesnt_inspect_args_or_return_values(monkeypatch, unix_servicer):
+    synchronizer = modal_utils.async_utils.synchronizer
+
+    # set up spys to track synchronicity calls to _translate_scalar_in/out
+    translate_in_spy = MagicMock(wraps=synchronizer._translate_scalar_in)
+    monkeypatch.setattr(synchronizer, "_translate_scalar_in", translate_in_spy)
+    translate_out_spy = MagicMock(wraps=synchronizer._translate_scalar_out)
+    monkeypatch.setattr(synchronizer, "_translate_scalar_out", translate_out_spy)
+
+    # don't do blobbing for this test
+    monkeypatch.setattr("modal._container_entrypoint.MAX_OBJECT_SIZE_BYTES", 1e100)
+
+    large_data_list = list(range(int(1e6)))  # large data set
+
+    t0 = time.perf_counter()
+    # pr = cProfile.Profile()
+    # pr.enable()
+    _run_container(unix_servicer, "modal_test_support.functions", "ident", inputs=_get_inputs(((large_data_list,), {})))
+    # pr.disable()
+    # pr.print_stats()
+    duration = time.perf_counter() - t0
+    assert duration < 0.0  # TODO (elias): should be able to get this down significantly more by improving serialization
+
+    # function_io_manager.serialize(large_data_list)
+    in_translations = []
+    out_translations = []
+    for call in translate_in_spy.call_args_list:
+        in_translations += list(call.args)
+    for call in translate_out_spy.call_args_list:
+        out_translations += list(call.args)
+
+    assert len(in_translations) < 200  # typically 136 or something
+    assert len(out_translations) < 200


### PR DESCRIPTION
This makes a significant performance difference in case of functions with large list structures in their arguments or return values.

Requires new synchronicity version 0.6.2 which is yet to be released: https://github.com/modal-labs/synchronicity/pull/126

- _Provide Linear issue reference (e.g. MOD-1234) if available._
Fixes MOD-1918

## Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
