### PR TITLE
Show build logs when running `modal shell`

### DIFF
--- a/modal/_container_exec.py
+++ b/modal/_container_exec.py
@@ -30,8 +30,6 @@ async def container_exec(
         print("container exec is not currently supported on Windows.")
         return
 
-    client = await _Client.from_env()
-
     console = Console()
     connecting_status = console.status("Connecting...")
     connecting_status.start()
@@ -51,17 +49,17 @@ async def container_exec(
             raise NotFoundError(f"Container ID {task_id} not found")
         raise
 
-    await connect_to_exec(res.exec_id, pty, connecting_status)
+    await connect_to_exec(client, res.exec_id, pty, connecting_status)
 
 
-async def connect_to_exec(exec_id: str, pty: bool = False, connecting_status: Optional[rich.status.Status] = None):
+async def connect_to_exec(
+    client: _Client, exec_id: str, pty: bool = False, connecting_status: Optional[rich.status.Status] = None
+):
     """
     Connects the current terminal to the given exec id.
 
     If connecting_status is given, this function will stop the status spinner upon connection or error.
     """
-
-    client = await _Client.from_env()
 
     def stop_connecting_status():
         if connecting_status:

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -291,14 +291,15 @@ async def _interactive_shell(_stub: _Stub, cmd: List[str], environment_name: str
     **kwargs will be passed into spawn_sandbox().
     """
 
+    client = await _Client.from_env()
     output_mgr = OutputManager(None, show_progress=True, status_spinner_text="Starting shell...")
 
     client = await _Client.from_env()
     async with _run_stub(_stub, environment_name=environment_name, output_mgr=output_mgr):
-        sb = await _stub.spawn_sandbox("sleep", "360000", **kwargs)
         console = Console()
         loading_status = console.status("Starting container...")
         loading_status.start()
+        sb = await _stub.spawn_sandbox("sleep", "360000", **kwargs)
 
         for _ in range(40):
             await asyncio.sleep(0.5)


### PR DESCRIPTION
I had previously hidden all extra output logs from `modal shell`. This PR reverts this behavior. Example with this PR:

```
✓ Initialized. View run at http://localhost:7601/thecodingwizard/apps/ap-KXB4kwBbgtvuEsReqRW1Ha
✓ Created objects.
root@modal:/# exit
exit
Stopping app - local entrypoint completed.
✓ App completed. View run at http://localhost:7601/thecodingwizard/apps/ap-KXB4kwBbgtvuEsReqRW1Ha
```

Example without this PR:

```
root@modal:/# exit
exit
```

Notably, build logs are now visible, so the user can see what's going on while `modal shell` boots up. Unfortunately S3 mount failures don't seem to show up :/

Demo: https://asciinema.org/a/vasxtLEDRKeyMXDZWogAYqG9l

This PR depends on #1279 .
