### PR TITLE
Use QueueGetOrCreate client-side

### DIFF
--- a/modal/dict.py
+++ b/modal/dict.py
@@ -67,7 +67,7 @@ class _Dict(_Object, type_prefix="di"):
             logger.debug(f"Created dict with id {response.dict_id}")
             provider._hydrate(response.dict_id, resolver.client, None)
 
-        return _Dict._from_loader(_load, "Dict()")
+        return _Dict._from_loader(_load, "Dict()", is_another_app=True)
 
     def __init__(self, data={}):
         """mdmd:hidden"""

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -92,7 +92,7 @@ class _Queue(_Object, type_prefix="qu"):
             response = await resolver.client.stub.QueueGetOrCreate(req)
             provider._hydrate(response.queue_id, resolver.client, None)
 
-        return _Queue._from_loader(_load, "Queue()")
+        return _Queue._from_loader(_load, "Queue()", is_another_app=True)
 
     @staticmethod
     def persisted(

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -111,8 +111,8 @@ class _Queue(_Object, type_prefix="qu"):
         """Lookup a queue with a given name and tag.
 
         ```python
-        d = modal.Queue.lookup("my-queue")
-        d["xyz"] = 123
+        q = modal.Queue.lookup("my-queue")
+        q.put(123)
         ```
         """
         obj = _Queue.from_name(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -71,7 +71,6 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.queue = []
         self.deployed_apps = {
             client_mount_name(): "ap-x",
-            "foo-queue": "ap-y",
             f"debian-slim-{_dockerhub_python_version()}-{__version__}": "ap-z",
             f"conda-{__version__}": "ap-c",
             "my-proxy": "ap-proxy",
@@ -82,7 +81,6 @@ class MockClientServicer(api_grpc.ModalClientBase):
         }
         self.app_single_objects = {
             "ap-x": "mo-123",
-            "ap-y": "qu-foo",
             "ap-proxy": "pr-123",
         }
         self.app_unindexed_objects = {
@@ -431,10 +429,12 @@ class MockClientServicer(api_grpc.ModalClientBase):
         k = (request.deployment_name, request.namespace, request.environment_name)
         if k in self.deployed_dicts:
             dict_id = self.deployed_dicts[k]
-        else:
+        elif request.object_creation_type == api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING:
             dict_id = f"di-{len(self.dicts)}"
             self.dicts[dict_id] = {}
             self.deployed_dicts[k] = dict_id
+        else:
+            raise GRPCError(Status.NOT_FOUND, "Queue not found")
         await stream.send_message(api_pb2.DictGetOrCreateResponse(dict_id=dict_id))
 
     async def DictClear(self, stream):
@@ -731,10 +731,12 @@ class MockClientServicer(api_grpc.ModalClientBase):
         k = (request.deployment_name, request.namespace, request.environment_name)
         if k in self.deployed_queues:
             queue_id = self.deployed_queues[k]
-        else:
+        elif request.object_creation_type == api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING:
             self.n_queues += 1
             queue_id = f"qu-{self.n_queues}"
             self.deployed_queues[k] = queue_id
+        else:
+            raise GRPCError(Status.NOT_FOUND, "Queue not found")
         await stream.send_message(api_pb2.QueueGetOrCreateResponse(queue_id=queue_id))
 
     async def QueuePut(self, stream):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -129,6 +129,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
         self.dicts = {}
         self.deployed_dicts = {}
+        self.deployed_queues = {}
 
         self.cleared_function_calls = set()
 
@@ -724,6 +725,17 @@ class MockClientServicer(api_grpc.ModalClientBase):
             self.n_queues += 1
             queue_id = f"qu-{self.n_queues}"
         await stream.send_message(api_pb2.QueueCreateResponse(queue_id=queue_id))
+
+    async def QueueGetOrCreate(self, stream):
+        request: api_pb2.QueueGetOrCreateRequest = await stream.recv_message()
+        k = (request.deployment_name, request.namespace, request.environment_name)
+        if k in self.deployed_queues:
+            queue_id = self.deployed_queues[k]
+        else:
+            self.n_queues += 1
+            queue_id = f"qu-{self.n_queues}"
+            self.deployed_queues[k] = queue_id
+        await stream.send_message(api_pb2.QueueGetOrCreateResponse(queue_id=queue_id))
 
     async def QueuePut(self, stream):
         request: api_pb2.QueuePutRequest = await stream.recv_message()

--- a/test/lookup_test.py
+++ b/test/lookup_test.py
@@ -1,20 +1,20 @@
 # Copyright Modal Labs 2023
 import pytest
 
-from modal import Function, Queue, Stub, web_endpoint
+from modal import Function, Stub, Volume, web_endpoint
 from modal.exception import DeprecationError, ExecutionError, NotFoundError
 from modal.runner import deploy_stub
 
 
 def test_persistent_object(servicer, client):
-    Queue.new()._deploy("my-queue", client=client)
+    Volume.new()._deploy("my-volume", client=client)
 
-    q: Queue = Queue.lookup("my-queue", client=client)
-    assert isinstance(q, Queue)
-    assert q.object_id == "qu-1"
+    v: Volume = Volume.lookup("my-volume", client=client)
+    assert isinstance(v, Volume)
+    assert v.object_id == "vo-1"
 
     with pytest.raises(NotFoundError):
-        Queue.lookup("bazbazbaz", client=client)
+        Volume.lookup("bazbazbaz", client=client)
 
 
 def square(x):
@@ -60,17 +60,17 @@ def test_webhook_lookup(servicer, client):
 
 
 def test_deploy_exists(servicer, client):
-    assert not Queue._exists("my-queue", client=client)
-    q1: Queue = Queue.new()
-    q1._deploy("my-queue", client=client)
-    assert Queue._exists("my-queue", client=client)
-    q2: Queue = Queue.lookup("my-queue", client=client)
-    assert q1.object_id == q2.object_id
+    assert not Volume._exists("my-volume", client=client)
+    v1: Volume = Volume.new()
+    v1._deploy("my-volume", client=client)
+    assert Volume._exists("my-volume", client=client)
+    v2: Volume = Volume.lookup("my-volume", client=client)
+    assert v1.object_id == v2.object_id
 
 
 def test_deploy_retain_id(servicer, client):
-    q1: Queue = Queue.new()
-    q2: Queue = Queue.new()
-    q1._deploy("my-queue", client=client)
-    q2._deploy("my-queue", client=client)
-    assert q1.object_id == q2.object_id
+    v1: Volume = Volume.new()
+    v2: Volume = Volume.new()
+    v1._deploy("my-volume", client=client)
+    v2._deploy("my-volume", client=client)
+    assert v1.object_id == v2.object_id

--- a/test/object_test.py
+++ b/test/object_test.py
@@ -18,12 +18,16 @@ async def test_async_factory(client):
 
 @pytest.mark.asyncio
 async def test_use_object(client):
+    # Deploy object
+    q = await Queue.lookup.aio("foo-queue", create_if_missing=True, client=client)
+
+    # Use object
     stub = Stub()
     q = Queue.from_name("foo-queue")
     assert isinstance(q, Queue)
     stub["my_q"] = q
     async with stub.run(client=client):
-        assert stub["my_q"].object_id == "qu-foo"
+        assert stub["my_q"].object_id == "qu-1"
         with pytest.raises(DeprecationError):
             stub.app["my_q"]
 

--- a/test/queue_test.py
+++ b/test/queue_test.py
@@ -90,3 +90,8 @@ def test_queue_nonblocking_put(
 
     assert str(servicer.queue_max_len) in str(excinfo.value)
     assert i == servicer.queue_max_len
+
+
+def test_queue_deploy(servicer, client):
+    d = Queue.lookup("xyz", create_if_missing=True, client=client)
+    d.put(123)

--- a/test/stub_test.py
+++ b/test/stub_test.py
@@ -319,14 +319,18 @@ async def test_deploy_disconnect(servicer, client):
 
 
 def test_redeploy_from_name_change(servicer, client):
+    # Deploy queue
+    modal.Queue.lookup("foo-queue", create_if_missing=True, client=client)
+
+    # Use it from stub
     stub = Stub()
     stub.q = modal.Queue.from_name("foo-queue")
     deploy_stub(stub, "my-app", client=client)
 
     # Change the object id of foo-queue
-    q_app_id = servicer.deployed_apps["foo-queue"]
-    servicer.app_single_objects[q_app_id]
-    servicer.app_single_objects[q_app_id] = "qu-baz123"
+    k = ("foo-queue", api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, "main")
+    assert servicer.deployed_queues[k]
+    servicer.deployed_queues[k] = "qu-baz123"
 
     # Redeploy app
     # This should not fail because the object_id changed - it's a different app

--- a/test/stub_test.py
+++ b/test/stub_test.py
@@ -8,6 +8,7 @@ from grpclib import GRPCError, Status
 
 import modal.app
 from modal import Dict, Image, Queue, Stub, web_endpoint
+from modal.config import config
 from modal.exception import DeprecationError, ExecutionError, InvalidError, NotFoundError
 from modal.partial_function import _parse_custom_domains
 from modal.runner import deploy_stub
@@ -328,7 +329,7 @@ def test_redeploy_from_name_change(servicer, client):
     deploy_stub(stub, "my-app", client=client)
 
     # Change the object id of foo-queue
-    k = ("foo-queue", api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, "main")
+    k = ("foo-queue", api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, config.get("environment"))
     assert servicer.deployed_queues[k]
     servicer.deployed_queues[k] = "qu-baz123"
 


### PR DESCRIPTION
This starts to use the new endpoint. Still uses `QueueCreate` for ephemeral queues though (might delete this later)

A bit of copy paste with dict but I think we need to do it to get to the other side of the river. We can simplify a lot later (will take some deprecation pain)