### PR TITLE
Adds `MODAL_CHECKPOINT_ID` to container entrypoint

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -466,8 +466,11 @@ class _FunctionIOManager:
 
     async def checkpoint(self) -> None:
         """Message server indicating that function is ready to be checkpointed."""
+        checkpoint_id = os.getenv("MODAL_CHECKPOINT_ID")
         await self._client.stub.ContainerCheckpoint(
-            api_pb2.ContainerCheckpointRequest(checkpoint_id=os.getenv("MODAL_CHECKPOINT_ID", ""))
+            api_pb2.ContainerCheckpointRequest(checkpoint_id=checkpoint_id)
+            if checkpoint_id
+            else api_pb2.ContainerCheckpointRequest()
         )
 
         self._waiting_for_checkpoint = True

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -466,7 +466,9 @@ class _FunctionIOManager:
 
     async def checkpoint(self) -> None:
         """Message server indicating that function is ready to be checkpointed."""
-        await self._client.stub.ContainerCheckpoint(api_pb2.ContainerCheckpointRequest())
+        await self._client.stub.ContainerCheckpoint(api_pb2.ContainerCheckpointRequest(
+            checkpoint_id=os.getenv("MODAL_CHECKPOINT_ID", "")
+        ))
 
         self._waiting_for_checkpoint = True
         await self._client._close()

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -466,9 +466,9 @@ class _FunctionIOManager:
 
     async def checkpoint(self) -> None:
         """Message server indicating that function is ready to be checkpointed."""
-        await self._client.stub.ContainerCheckpoint(api_pb2.ContainerCheckpointRequest(
-            checkpoint_id=os.getenv("MODAL_CHECKPOINT_ID", "")
-        ))
+        await self._client.stub.ContainerCheckpoint(
+            api_pb2.ContainerCheckpointRequest(checkpoint_id=os.getenv("MODAL_CHECKPOINT_ID", ""))
+        )
 
         self._waiting_for_checkpoint = True
         await self._client._close()

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -553,7 +553,9 @@ message ContainerHeartbeatRequest {
   double current_input_started_at = 2;
 }
 
-message ContainerCheckpointRequest {}
+message ContainerCheckpointRequest {
+  string checkpoint_id = 1;
+}
 
 message ContainerExecRequest {
   string task_id = 1;

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2022
 
 import asyncio
-import uuid
 import base64
 import dataclasses
 import json
@@ -13,6 +12,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import uuid
 from typing import Any, Dict, List, Optional, Tuple
 from unittest import mock
 

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
 
 import asyncio
+import uuid
 import base64
 import dataclasses
 import json
@@ -119,10 +120,11 @@ def _run_container(
         temp_restore_file_path = tempfile.NamedTemporaryFile()
         if is_checkpointing_function:
             # State file is written to allow for a restore to happen.
-            tmep_file_name = temp_restore_file_path.name
-            with pathlib.Path(tmep_file_name).open("w") as target:
+            tmp_file_name = temp_restore_file_path.name
+            with pathlib.Path(tmp_file_name).open("w") as target:
                 json.dump({}, target)
-            env["MODAL_RESTORE_STATE_PATH"] = tmep_file_name
+            env["MODAL_RESTORE_STATE_PATH"] = tmp_file_name
+            env["MODAL_CHECKPOINT_ID"] = f"ch-{uuid.uuid4()}"
 
             # Override server URL to reproduce restore behavior.
             env["MODAL_SERVER_URL"] = servicer.remote_addr
@@ -765,6 +767,10 @@ def test_checkpoint_and_restore_success(unix_servicer, event_loop):
     simulating a restore operation."""
     ret = _run_container(unix_servicer, "modal_test_support.functions", "square", is_checkpointing_function=True)
     assert any(isinstance(request, api_pb2.ContainerCheckpointRequest) for request in unix_servicer.requests)
+    for request in unix_servicer.requests:
+        if isinstance(request, api_pb2.ContainerCheckpointRequest):
+            assert request.checkpoint_id != ""
+
     assert _unwrap_scalar(ret) == 42**2
 
 


### PR DESCRIPTION
Allows for keeping a consistent reference for the creation and usage of checkpoint images.
