### PR TITLE
Raise error if generator functions are called with .map(...)

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -470,7 +470,7 @@ async def _map_invocation(
             async for idx, output in streamer:
                 if count_update_callback is not None:
                     count_update_callback(num_outputs, num_inputs)
-                elif not order_outputs:
+                if not order_outputs:
                     yield _OutputValue(output)
                 else:
                     # hold on to outputs for function maps, so we can reorder them correctly.

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -247,6 +247,26 @@ async def test_generator(client, servicer):
 
 
 @pytest.mark.asyncio
+async def test_generator_map_invalid(client, servicer):
+    stub = Stub()
+
+    later_gen_modal = stub.function()(later_gen)
+
+    def dummy(x):
+        yield x
+
+    servicer.function_body(dummy)
+
+    with stub.run(client=client):
+        with pytest.raises(InvalidError):
+            # Support for .map() on generators was removed in version 0.57
+            for _ in later_gen_modal.map([1, 2, 3]):
+                pass
+        with pytest.raises(InvalidError):
+            later_gen_modal.for_each([1, 2, 3])
+
+
+@pytest.mark.asyncio
 async def test_generator_async(client, servicer):
     stub = Stub()
 


### PR DESCRIPTION
Resolves MOD-2283

## Changelog

- Improve error message when generator functions are called with `.map(...)`.