### PR TITLE
Add reuse_containers flag to function definition

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -613,6 +613,7 @@ class _Function(_Object, type_prefix="fu"):
         checkpointing_enabled: bool = False,
         allow_background_volume_commits: bool = False,
         block_network: bool = False,
+        reuse_containers: bool = True,
     ) -> None:
         """mdmd:hidden"""
         tag = info.get_tag()
@@ -872,6 +873,7 @@ class _Function(_Object, type_prefix="fu"):
                     api_pb2.ObjectDependency(object_id=dep.object_id) for dep in _deps(only_explicit_mounts=True)
                 ],
                 block_network=block_network,
+                reuse_containers=reuse_containers,
             )
             request = api_pb2.FunctionCreateRequest(
                 app_id=resolver.app_id,

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -478,6 +478,7 @@ class _Stub:
         block_network: bool = False,  # Whether to block network access
         secret: Optional[_Secret] = None,  # Deprecated: use `secrets`
         _allow_background_volume_commits: bool = False,
+        reuse_containers: bool = True,  # Allow subsequent requests to run in the same container
     ) -> Callable[..., _Function]:
         """Decorator to register a new Modal function with this stub."""
         if isinstance(_warn_parentheses_missing, _Image):
@@ -560,6 +561,7 @@ class _Stub:
                 checkpointing_enabled=checkpointing_enabled,
                 allow_background_volume_commits=_allow_background_volume_commits,
                 block_network=block_network,
+                reuse_containers=reuse_containers,
             )
 
             self._add_function(function)
@@ -596,6 +598,7 @@ class _Stub:
         checkpointing_enabled: bool = False,  # Enable memory checkpointing for faster cold starts.
         block_network: bool = False,  # Whether to block network access
         secret: Optional[_Secret] = None,  # Deprecated: use `secrets`
+        reuse_containers: bool = True,  # Allow subsequent requests to run in the same container
     ) -> Callable[[CLS_T], _Cls]:
         if _warn_parentheses_missing:
             raise InvalidError("Did you forget parentheses? Suggestion: `@stub.cls()`.")
@@ -624,6 +627,7 @@ class _Stub:
             cloud=cloud,
             checkpointing_enabled=checkpointing_enabled,
             block_network=block_network,
+            reuse_containers=reuse_containers,
         )
 
         def wrapper(user_cls: CLS_T) -> _Cls:

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -821,6 +821,8 @@ message Function {
   repeated ObjectDependency object_dependencies = 43;
 
   bool block_network = 44;
+
+  bool reuse_containers = 45;
 }
 
 message FunctionHandleMetadata {


### PR DESCRIPTION
Using

```
@stub.function(reuse_containers=False, ...)
def foo():
    ...
```

will force each instance of `foo()` to run in a new container.