### PR TITLE
Increase retry count for volume requests

### DIFF
--- a/modal/volume.py
+++ b/modal/volume.py
@@ -210,7 +210,7 @@ class _Volume(_StatefulObject, type_prefix="vo"):
             path = path.encode("utf-8")
         req = api_pb2.VolumeGetFileRequest(volume_id=self.object_id, path=path)
         try:
-            response = await retry_transient_errors(self._client.stub.VolumeGetFile, req)
+            response = await retry_transient_errors(self._client.stub.VolumeGetFile, req, max_retries=10)
         except GRPCError as exc:
             raise FileNotFoundError(exc.message) if exc.status == Status.NOT_FOUND else exc
         if response.WhichOneof("data_oneof") == "data":
@@ -242,7 +242,7 @@ class _Volume(_StatefulObject, type_prefix="vo"):
 
         req = api_pb2.VolumeGetFileRequest(volume_id=self.object_id, path=path)
         try:
-            response = await retry_transient_errors(self._client.stub.VolumeGetFile, req)
+            response = await retry_transient_errors(self._client.stub.VolumeGetFile, req, max_retries=10)
         except GRPCError as exc:
             raise FileNotFoundError(exc.message) if exc.status == Status.NOT_FOUND else exc
         if response.WhichOneof("data_oneof") == "data":


### PR DESCRIPTION
A user is reporting issues with receiving `StreamTerminatedError` after downloading large files from a `modal volume get` request.

Not sure if this will resolve the issue — just making the branch in case it's a transient disconnect.

It sounds more likely to me that the user is just trying to download a file that is too large, so it's timing out our max gRPC duration internally when passing through the presigned URL path.