### PR TITLE
Fix bad default value for max_inputs in from_args

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -610,7 +610,7 @@ class _Function(_Object, type_prefix="fu"):
         checkpointing_enabled: bool = False,
         allow_background_volume_commits: bool = False,
         block_network: bool = False,
-        max_inputs: Optional[int] = True,
+        max_inputs: Optional[int] = None,
     ) -> None:
         """mdmd:hidden"""
         tag = info.get_tag()


### PR DESCRIPTION
Afaict, the `True` default value doesn't break anything - the only place the default value will be used is for `run_function`, in which case it's moot anyway.