### PR TITLE
Update pytest-markdown-docs to 0.5.0

### DIFF
--- a/modal/mount.py
+++ b/modal/mount.py
@@ -283,7 +283,7 @@ class _Mount(_StatefulObject, type_prefix="mo"):
         # Mount the DBT profile in user's home directory into container.
         dbt_profiles = modal.Mount.from_local_file(
             local_path="~/profiles.yml",
-            remote_path="/root/dbt_profile/profiles.yml"),
+            remote_path="/root/dbt_profile/profiles.yml",
         )
         ```
         """

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -36,7 +36,7 @@ class _Secret(_StatefulObject, type_prefix="st"):
 
         Usage:
         ```python
-        @stub.function(secrets=[modal.Secret.from_dict({"FOO": "bar"}])
+        @stub.function(secrets=[modal.Secret.from_dict({"FOO": "bar"})])
         def run():
             print(os.environ["FOO"])
         ```

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -12,7 +12,7 @@ pre-commit>=2.21,<4
 pytest~=7.4
 pytest-asyncio @ git+https://github.com/modal-labs/pytest-asyncio.git@b535db05f6e43019700483c442ab6686f132a415
 pytest-env~=0.6.2
-pytest-markdown-docs==0.4.3
+pytest-markdown-docs==0.5.0
 pytest-timeout~=2.1.0
 python-dotenv~=1.0.0;python_version>='3.8'
 requests~=2.31.0


### PR DESCRIPTION
Now catches syntax errors in docstrings which silently passed before

## Describe your changes

- _Provide Linear issue reference (e.g. MOD-1234) if available._


## Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
