### PR TITLE
[MOD-2209] Add force flag for volume uploads

### DIFF
--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -221,7 +221,7 @@ async def put(
     volume_name: str,
     local_path: str = Argument(),
     remote_path: str = Argument(default="/"),
-    clobber: bool = Option(False, "--clobber", help="Overwrite existing files."),
+    force: bool = Option(False, "-f", "--force", help="Overwrite existing files."),
     env: Optional[str] = ENV_OPTION,
 ):
     ensure_env(env)
@@ -237,7 +237,7 @@ async def put(
         spinner = step_progress(f"Uploading directory '{local_path}' to '{remote_path}'...")
         with Live(spinner, console=console):
             try:
-                async with _VolumeUploadContextManager(vol.object_id, vol._client, clobber=clobber) as batch:
+                async with _VolumeUploadContextManager(vol.object_id, vol._client, force=force) as batch:
                     batch.put_directory(local_path, remote_path)
             except FileExistsError as exc:
                 raise UsageError(str(exc))
@@ -248,7 +248,7 @@ async def put(
         spinner = step_progress(f"Uploading file '{local_path}' to '{remote_path}'...")
         with Live(spinner, console=console):
             try:
-                async with _VolumeUploadContextManager(vol.object_id, vol._client, clobber=clobber) as batch:
+                async with _VolumeUploadContextManager(vol.object_id, vol._client, force=force) as batch:
                     batch.put_file(local_path, remote_path)
             except FileExistsError as exc:
                 raise UsageError(str(exc))

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -291,9 +291,12 @@ class _Volume(_StatefulObject, type_prefix="vo"):
         await retry_transient_errors(self._client.stub.VolumeCopyFiles, request, base_delay=1)
 
     @live_method
-    async def batch_upload(self) -> "_VolumeUploadContextManager":
+    async def batch_upload(self, clobber: bool = False) -> "_VolumeUploadContextManager":
         """
         Initiate a batched upload to a volume.
+
+        To allow overwriting existing files, set `clobber` to `True` (you cannot overwrite existing directories with
+        files regardless).
 
         **Example:**
 
@@ -306,7 +309,7 @@ class _Volume(_StatefulObject, type_prefix="vo"):
             batch.put_file(io.BytesIO(b"some data"), "/foobar")
         ```
         """
-        return _VolumeUploadContextManager(self.object_id, self._client)
+        return _VolumeUploadContextManager(self.object_id, self._client, clobber=clobber)
 
 
 class _VolumeUploadContextManager:
@@ -314,13 +317,15 @@ class _VolumeUploadContextManager:
 
     _volume_id: str
     _client: _Client
+    _clobber: bool
     _upload_generators: List[Generator[Callable[[], FileUploadSpec], None, None]]
 
-    def __init__(self, volume_id: str, client: _Client):
+    def __init__(self, volume_id: str, client: _Client, clobber: bool = False):
         """mdmd:hidden"""
         self._volume_id = volume_id
         self._client = client
         self._upload_generators = []
+        self._clobber = clobber
 
     async def __aenter__(self):
         return self
@@ -347,8 +352,13 @@ class _VolumeUploadContextManager:
             uploads_stream = aiostream.stream.map(files_stream, self._upload_file, task_limit=20)
             files: List[api_pb2.MountFile] = await aiostream.stream.list(uploads_stream)
 
-            request = api_pb2.VolumePutFilesRequest(volume_id=self._volume_id, files=files)
-            await retry_transient_errors(self._client.stub.VolumePutFiles, request, base_delay=1)
+            request = api_pb2.VolumePutFilesRequest(
+                volume_id=self._volume_id, files=files, no_clobber=not self._clobber
+            )
+            try:
+                await retry_transient_errors(self._client.stub.VolumePutFiles, request, base_delay=1)
+            except GRPCError as exc:
+                raise FileExistsError(exc.message) if exc.status == Status.ALREADY_EXISTS else exc
 
     def put_file(
         self,

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1722,8 +1722,8 @@ message VolumePutFilesRequest {
   // TODO(staffan): This is obviously unfortunately named, but provides what we need - consider renaming.
   repeated MountFile files = 2;
   // If set to true, prevent overwriting existing files. (Note that we don't allow overwriting
-  // existing directories with uploaded files even when clobbering is allowed.)
-  bool no_clobber = 3;
+  // existing directories with uploaded files regardless.)
+  bool disallow_overwrite_existing_files = 3;
 }
 
 message VolumeRemoveFileRequest {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1721,6 +1721,9 @@ message VolumePutFilesRequest {
   string volume_id = 1;
   // TODO(staffan): This is obviously unfortunately named, but provides what we need - consider renaming.
   repeated MountFile files = 2;
+  // If set to true, prevent overwriting existing files. (Note that we don't allow overwriting
+  // existing directories with uploaded files even when clobbering is allowed.)
+  bool no_clobber = 3;
 }
 
 message VolumeRemoveFileRequest {

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -460,16 +460,22 @@ def test_volume_put_force(servicer, set_env_client):
             f.flush()
 
         # File upload
-        _run(["volume", "put", vol_name, upload_path, file_path])
+        _run(["volume", "put", vol_name, upload_path, file_path])  # Seed the volume
+        with servicer.intercept() as ctx:
+            _run(["volume", "put", vol_name, upload_path, file_path], expected_exit_code=2, expected_stderr=None)
+            assert ctx.pop_request("VolumePutFiles").disallow_overwrite_existing_files
 
-        _run(["volume", "put", vol_name, upload_path, file_path], expected_exit_code=2, expected_stderr=None)
-        _run(["volume", "put", vol_name, upload_path, file_path, "--force"])
+            _run(["volume", "put", vol_name, upload_path, file_path, "--force"])
+            assert not ctx.pop_request("VolumePutFiles").disallow_overwrite_existing_files
 
         # Dir upload
-        _run(["volume", "put", vol_name, tmpdir])
+        _run(["volume", "put", vol_name, tmpdir])  # Seed the volume
+        with servicer.intercept() as ctx:
+            _run(["volume", "put", vol_name, tmpdir], expected_exit_code=2, expected_stderr=None)
+            assert ctx.pop_request("VolumePutFiles").disallow_overwrite_existing_files
 
-        _run(["volume", "put", vol_name, tmpdir], expected_exit_code=2, expected_stderr=None)
-        _run(["volume", "put", vol_name, tmpdir, "--force"])
+            _run(["volume", "put", vol_name, tmpdir, "--force"])
+            assert not ctx.pop_request("VolumePutFiles").disallow_overwrite_existing_files
 
 
 def test_volume_rm(servicer, set_env_client):

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -448,6 +448,30 @@ def test_volume_get(servicer, set_env_client):
             assert f.read() == file_contents
 
 
+def test_volume_put_clobber(servicer, set_env_client):
+    vol_name = "my-test-vol"
+    _run(["volume", "create", vol_name])
+    file_path = "test.txt"
+    file_contents = b"foo bar baz"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        upload_path = os.path.join(tmpdir, "upload.txt")
+        with open(upload_path, "wb") as f:
+            f.write(file_contents)
+            f.flush()
+
+        # File upload
+        _run(["volume", "put", vol_name, upload_path, file_path])
+
+        _run(["volume", "put", vol_name, upload_path, file_path], expected_exit_code=2, expected_stderr=None)
+        _run(["volume", "put", vol_name, upload_path, file_path, "--clobber"])
+
+        # Dir upload
+        _run(["volume", "put", vol_name, tmpdir])
+
+        _run(["volume", "put", vol_name, tmpdir], expected_exit_code=2, expected_stderr=None)
+        _run(["volume", "put", vol_name, tmpdir, "--clobber"])
+
+
 def test_volume_rm(servicer, set_env_client):
     vol_name = "my-test-vol"
     _run(["volume", "create", vol_name])

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -448,7 +448,7 @@ def test_volume_get(servicer, set_env_client):
             assert f.read() == file_contents
 
 
-def test_volume_put_clobber(servicer, set_env_client):
+def test_volume_put_force(servicer, set_env_client):
     vol_name = "my-test-vol"
     _run(["volume", "create", vol_name])
     file_path = "test.txt"
@@ -463,13 +463,13 @@ def test_volume_put_clobber(servicer, set_env_client):
         _run(["volume", "put", vol_name, upload_path, file_path])
 
         _run(["volume", "put", vol_name, upload_path, file_path], expected_exit_code=2, expected_stderr=None)
-        _run(["volume", "put", vol_name, upload_path, file_path, "--clobber"])
+        _run(["volume", "put", vol_name, upload_path, file_path, "--force"])
 
         # Dir upload
         _run(["volume", "put", vol_name, tmpdir])
 
         _run(["volume", "put", vol_name, tmpdir], expected_exit_code=2, expected_stderr=None)
-        _run(["volume", "put", vol_name, tmpdir, "--clobber"])
+        _run(["volume", "put", vol_name, tmpdir, "--force"])
 
 
 def test_volume_rm(servicer, set_env_client):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -943,6 +943,10 @@ class MockClientServicer(api_grpc.ModalClientBase):
         req = await stream.recv_message()
         for file in req.files:
             blob_data = self.files_sha2data[file.sha256_hex]
+
+            if file.filename in self.volume_files[req.volume_id] and req.no_clobber:
+                raise GRPCError(Status.ALREADY_EXISTS, f"{file.filename}: already exists (no_clobber={req.no_clobber}")
+
             self.volume_files[req.volume_id][file.filename] = VolumeFile(
                 data=blob_data["data"],
                 data_blob_id=blob_data["data_blob_id"],

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -944,8 +944,11 @@ class MockClientServicer(api_grpc.ModalClientBase):
         for file in req.files:
             blob_data = self.files_sha2data[file.sha256_hex]
 
-            if file.filename in self.volume_files[req.volume_id] and req.no_clobber:
-                raise GRPCError(Status.ALREADY_EXISTS, f"{file.filename}: already exists (no_clobber={req.no_clobber}")
+            if file.filename in self.volume_files[req.volume_id] and req.disallow_overwrite_existing_files:
+                raise GRPCError(
+                    Status.ALREADY_EXISTS,
+                    f"{file.filename}: already exists (disallow_overwrite_existing_files={req.disallow_overwrite_existing_files}",
+                )
 
             self.volume_files[req.volume_id][file.filename] = VolumeFile(
                 data=blob_data["data"],

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -186,6 +186,26 @@ async def test_volume_batch_upload(servicer, client, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_volume_batch_upload_clobber(servicer, client, tmp_path):
+    stub = modal.Stub()
+    stub.vol = modal.Volume.new()
+
+    local_file_path = tmp_path / "some_file"
+    local_file_path.write_text("hello world")
+
+    with stub.run(client=client):
+        with stub.vol.batch_upload() as batch:
+            batch.put_file(local_file_path, "/some_file")
+
+        with pytest.raises(FileExistsError):
+            with stub.vol.batch_upload() as batch:
+                batch.put_file(local_file_path, "/some_file")
+
+        with stub.vol.batch_upload(clobber=True) as batch:
+            batch.put_file(local_file_path, "/some_file")
+
+
+@pytest.mark.asyncio
 async def test_volume_upload_removed_file(servicer, client, tmp_path):
     stub = modal.Stub()
     stub.vol = modal.Volume.new()

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -186,7 +186,7 @@ async def test_volume_batch_upload(servicer, client, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_volume_batch_upload_clobber(servicer, client, tmp_path):
+async def test_volume_batch_upload_force(servicer, client, tmp_path):
     stub = modal.Stub()
     stub.vol = modal.Volume.new()
 
@@ -201,7 +201,7 @@ async def test_volume_batch_upload_clobber(servicer, client, tmp_path):
             with stub.vol.batch_upload() as batch:
                 batch.put_file(local_file_path, "/some_file")
 
-        with stub.vol.batch_upload(clobber=True) as batch:
+        with stub.vol.batch_upload(force=True) as batch:
             batch.put_file(local_file_path, "/some_file")
 
 


### PR DESCRIPTION
Previously, we silently overwrite any existing files. This is error-prone so we're changing the default behaviour to not overwrite existing files.

This adds a `force` flag which you can use to explicitly allow overwriting existing files.

Even with `force=True` we will not allow overwriting existing _directories_ with uploaded files.