### PR TITLE
Remove MODAL_IMAGE_PYTHON_VERSION

### DIFF
--- a/modal/config.py
+++ b/modal/config.py
@@ -159,7 +159,6 @@ _SETTINGS = {
     "serve_timeout": _Setting(transform=float),
     "sync_entrypoint": _Setting(),
     "logs_timeout": _Setting(10, float),
-    "image_python_version": _Setting(),
     "image_id": _Setting(),
     "automount": _Setting(True, transform=lambda x: x not in ("", "0")),
     "tracing_enabled": _Setting(False, transform=lambda x: x not in ("", "0")),

--- a/modal/image.py
+++ b/modal/image.py
@@ -48,8 +48,6 @@ def _validate_python_version(version: str) -> None:
 
 def _dockerhub_python_version(python_version=None):
     if python_version is None:
-        python_version = config["image_python_version"]
-    if python_version is None:
         python_version = "%d.%d" % sys.version_info[:2]
 
     parts = python_version.split(".")


### PR DESCRIPTION
This is a legacy configuration option that was once used in integration tests. It seems like not a useful configuration for users; they should override the python_version of their image manually.

## Changelog

- The legacy `image_python_version` config option has been removed. Use the `python_version=` parameter on your image definition instead.