### PR TITLE
Remove unused container_id setting

### DIFF
--- a/modal/config.py
+++ b/modal/config.py
@@ -199,7 +199,6 @@ _SETTINGS = {
     "default_cloud": _Setting(None, transform=lambda x: x if x else None),
     "worker_id": _Setting(),  # For internal debugging use.
     "restore_state_path": _Setting("/opt/modal/restore-state.json"),
-    "container_id": _Setting(),
 }
 
 


### PR DESCRIPTION
I think @luiscape missed this in #1303 but `container_id` isn't a thing, we already have `task_id`
