### PR TITLE
Makes `checkpoint_id` optional in `ContainerArguments`

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -546,7 +546,7 @@ message ContainerArguments {  // This is used to pass data from the worker to th
   bytes serialized_params = 10;
   string runtime = 11;
   string environment_name = 13;
-  string checkpoint_id = 14;
+  optional string checkpoint_id = 14;
 }
 
 message ContainerHeartbeatRequest {

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -773,7 +773,7 @@ def test_checkpoint_and_restore_success(unix_servicer, event_loop):
     assert any(isinstance(request, api_pb2.ContainerCheckpointRequest) for request in unix_servicer.requests)
     for request in unix_servicer.requests:
         if isinstance(request, api_pb2.ContainerCheckpointRequest):
-            assert request.checkpoint_id != ""
+            assert request.checkpoint_id
 
     assert _unwrap_scalar(ret) == 42**2
 


### PR DESCRIPTION
`checkpoint_id` is only available in functions that have checkpointing enabled. This makes the `ContainerArgument` property optional to reflect that. 