### PR TITLE
Highlight client deprecation warnings in the CLI

### DIFF
--- a/modal/__main__.py
+++ b/modal/__main__.py
@@ -1,11 +1,12 @@
 # Copyright Modal Labs 2022
-from ._traceback import setup_rich_traceback
+from ._traceback import highlight_modal_deprecation_warnings, setup_rich_traceback
 from .cli.entry_point import entrypoint_cli
 
 
 def main():
     # Setup rich tracebacks, but only on user's end, when using the Modal CLI.
     setup_rich_traceback()
+    highlight_modal_deprecation_warnings()
     entrypoint_cli()
 
 

--- a/modal/_traceback.py
+++ b/modal/_traceback.py
@@ -221,11 +221,14 @@ def highlight_modal_deprecation_warnings() -> None:
             content = str(warning)
             date = content[:10]
             message = content[11:].strip()
-            with open(filename) as f:
-                source = f.readlines()[lineno - 1].strip()
-            print(filename, lineno, file, line)
+            try:
+                with open(filename) as f:
+                    source = f.readlines()[lineno - 1].strip()
+                message = f"{message}\n\nSource: {filename}:{lineno}\n  {source}"
+            except FileNotFoundError:
+                pass
             panel = Panel(
-                f"{message}\n\nSource: {filename}:{lineno}\n  {source}",
+                message,
                 style="yellow",
                 title=f"Deprecation Warning ({date})",
                 title_align="left",

--- a/modal/_traceback.py
+++ b/modal/_traceback.py
@@ -230,7 +230,7 @@ def highlight_modal_deprecation_warnings() -> None:
             panel = Panel(
                 message,
                 style="yellow",
-                title=f"Deprecation Warning ({date})",
+                title=f"Modal Deprecation Warning ({date})",
                 title_align="left",
             )
             Console().print(panel)

--- a/modal/_traceback.py
+++ b/modal/_traceback.py
@@ -221,8 +221,11 @@ def highlight_modal_deprecation_warnings() -> None:
             content = str(warning)
             date = content[:10]
             message = content[11:].strip()
+            with open(filename) as f:
+                source = f.readlines()[lineno - 1].strip()
+            print(filename, lineno, file, line)
             panel = Panel(
-                message,
+                f"{message}\n\nSource: {filename}:{lineno}\n  {source}",
                 style="yellow",
                 title=f"Deprecation Warning ({date})",
                 title_align="left",

--- a/modal/_traceback.py
+++ b/modal/_traceback.py
@@ -1,13 +1,17 @@
 # Copyright Modal Labs 2022
 import functools
 import traceback
+import warnings
 from typing import Any, Dict, Optional, Tuple
 
-from rich.console import RenderResult, group
+from rich.console import Console, RenderResult, group
+from rich.panel import Panel
 from rich.syntax import Syntax
 from rich.text import Text
 from rich.traceback import PathHighlighter, Stack, Traceback, install
 from tblib import Traceback as TBLibTraceback
+
+from .exception import DeprecationError
 
 TBDictType = Dict[str, Any]
 LineCacheType = Dict[Tuple[str, str], str]
@@ -206,3 +210,25 @@ def setup_rich_traceback() -> None:
     import modal_utils
 
     install(suppress=[synchronicity, modal_utils, grpclib], extra_lines=1)
+
+
+def highlight_modal_deprecation_warnings() -> None:
+    """Patch the warnings module to make client deprecation warnings more salient in the CLI."""
+    base_showwarning = warnings.showwarning
+
+    def showwarning(warning, category, filename, lineno, file=None, line=None):
+        if issubclass(category, DeprecationError):
+            content = str(warning)
+            date = content[:10]
+            message = content[11:].strip()
+            panel = Panel(
+                message,
+                style="yellow",
+                title=f"Deprecation Warning ({date})",
+                title_align="left",
+            )
+            Console().print(panel)
+        else:
+            base_showwarning(warning, category, filename, lineno, file=None, line=None)
+
+    warnings.showwarning = showwarning

--- a/modal/config.py
+++ b/modal/config.py
@@ -150,9 +150,6 @@ def _check_config() -> None:
         # But we want to give users time to activate one of their profiles without disruption
         message = dedent(
             """
-
-            WARNING:
-
             Support for using an implicit 'default' profile is deprecated.
             Please use `modal profile activate` to activate one of your profiles.
             (Use `modal profile list` to see the options.)

--- a/modal/config.py
+++ b/modal/config.py
@@ -157,7 +157,7 @@ def _check_config() -> None:
             This will become an error in a future update.
             """
         )
-        deprecation_warning(date(2024, 2, 6), message)
+        deprecation_warning(date(2024, 2, 6), message, show_source=False)
 
 
 if "MODAL_ENV" in os.environ:

--- a/modal/exception.py
+++ b/modal/exception.py
@@ -99,21 +99,23 @@ def deprecation_error(deprecated_on: date, msg: str):
     raise DeprecationError(f"Deprecated on {deprecated_on}: {msg}")
 
 
-def deprecation_warning(deprecated_on: date, msg: str, pending=False):
+def deprecation_warning(deprecated_on: date, msg: str, pending: bool = False, show_source: bool = True) -> None:
     """Utility for getting the proper stack entry.
 
     See the implementation of the built-in [warnings.warn](https://docs.python.org/3/library/warnings.html#available-functions).
     """
-    # Find the last non-Modal line that triggered the warning
-    try:
-        frame = sys._getframe()
-        while frame is not None and _is_internal_frame(frame):
-            frame = frame.f_back
-        filename = frame.f_code.co_filename
-        lineno = frame.f_lineno
-    except ValueError:
-        filename = "<unknown>"
-        lineno = 0
+    filename, lineno = "<unknown>", 0
+    if show_source:
+        # Find the last non-Modal line that triggered the warning
+        try:
+            frame = sys._getframe()
+            while frame is not None and _is_internal_frame(frame):
+                frame = frame.f_back
+            filename = frame.f_code.co_filename
+            lineno = frame.f_lineno
+        except ValueError:
+            # Use the defaults from above
+            pass
 
     warning_cls: type = PendingDeprecationError if pending else DeprecationError
 


### PR DESCRIPTION
## Describe your changes

This uses rich to make Modal deprecation warnings more salient in the CLI:

<img width="792" alt="image" src="https://github.com/modal-labs/modal-client/assets/315810/fc1d142c-981a-42aa-acf9-52874557a459">

Note that monkey-patching `warnings.showwarnings` is the [officially blessed](https://docs.python.org/3/library/warnings.html#warnings.showwarning) approach for customizing warning display. That said, I'm not totally sure how to write a unit test for this...

Open to suggestions about the formatting!

I've also enhanced our deprecation warning function to make it optional to include a source line. In some cases (e.g. commandline or config deprecation) the current logic attributes the warning to an asyncio entrypoint or some other unrelated line. Feels useful to supress when we know that will be the case.

## Changelog

- Modal client deprecation warnings are now highlighted in the CLI