### PR TITLE
New attempt: Skip synchronicity inspection of arguments/return values

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Build protobuf
         run: inv protoc
 
+      - name: Install package + deps
+        run: pip install -e .  # Makes sure doc generation doesn't break on client imports etc.
+
       - name: Generate reference docs
         run: python -m modal_docs.gen_reference_docs reference_docs_output
 

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -152,6 +152,7 @@ class _FunctionIOManager:
     def deserialize(self, data: bytes) -> Any:
         return deserialize(data, self._client)
 
+    @synchronizer.no_io_translation
     def serialize_data_format(self, obj: Any, data_format: int) -> bytes:
         return serialize_data_format(obj, data_format)
 
@@ -241,6 +242,7 @@ class _FunctionIOManager:
 
         return math.ceil(RTT_S / max(self.get_average_call_time(), 1e-6))
 
+    @synchronizer.no_io_translation
     async def _generate_inputs(self) -> AsyncIterator[tuple[str, str, api_pb2.FunctionInput]]:
         request = api_pb2.FunctionGetInputsRequest(function_id=self.function_id)
         eof_received = False
@@ -292,6 +294,7 @@ class _FunctionIOManager:
                 if not yielded:
                     self._semaphore.release()
 
+    @synchronizer.no_io_translation
     async def run_inputs_outputs(self, input_concurrency: int = 1) -> AsyncIterator[tuple[str, str, Any, Any]]:
         # Ensure we do not fetch new inputs when container is too busy.
         # Before trying to fetch an input, acquire the semaphore:
@@ -421,6 +424,7 @@ class _FunctionIOManager:
         self.calls_completed += 1
         self._semaphore.release()
 
+    @synchronizer.no_io_translation
     async def push_output(self, input_id, started_at: float, data: Any, data_format: int) -> None:
         await self._push_output(
             input_id,

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1225,8 +1225,9 @@ class _Function(_Object, type_prefix="fu"):
         async for item in self._map(input_stream, order_outputs, return_exceptions, kwargs):
             yield item
 
+    @synchronizer.no_io_translation
     @live_method
-    async def remote(self, *args, **kwargs) -> Awaitable[Any]:
+    async def remote(self, *args, **kwargs) -> Any:
         """
         Calls the function remotely, executing it with the given arguments and returning the execution's result.
         """
@@ -1243,6 +1244,7 @@ class _Function(_Object, type_prefix="fu"):
 
         return await self._call_function(args, kwargs)
 
+    @synchronizer.no_io_translation
     @live_method_gen
     async def remote_gen(self, *args, **kwargs) -> AsyncGenerator[Any, None]:
         """
@@ -1272,6 +1274,7 @@ class _Function(_Object, type_prefix="fu"):
         else:
             deprecation_error(date(2023, 8, 16), "`f.call(...)` is deprecated. It has been renamed to `f.remote(...)`")
 
+    @synchronizer.no_io_translation
     @live_method
     async def shell(self, *args, **kwargs) -> None:
         if self._is_generator:
@@ -1347,6 +1350,7 @@ class _Function(_Object, type_prefix="fu"):
                 " a Modal container in the cloud",
             )
 
+    @synchronizer.no_input_translation
     @live_method
     async def spawn(self, *args, **kwargs) -> Optional["_FunctionCall"]:
         """Calls the function with the given arguments, without waiting for the results.

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1135,13 +1135,13 @@ class _Function(_Object, type_prefix="fu"):
         async for res in invocation.run_generator():
             yield res
 
-    @synchronizer.no_io_translation  # TODO (elias): test spawn w/ generators
+    @synchronizer.no_io_translation
     async def _call_generator_nowait(self, args, kwargs):
         return await _Invocation.create(self.object_id, args, kwargs, self._client)
 
     @warn_if_generator_is_not_consumed
     @live_method_gen
-    @synchronizer.no_input_translation  # TODO (elias) test that outputs from the map still behave correctly
+    @synchronizer.no_input_translation
     async def map(
         self,
         *input_iterators,  # one input iterator per argument in the mapped-over function/generator

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1129,16 +1129,19 @@ class _Function(_Object, type_prefix="fu"):
 
     @warn_if_generator_is_not_consumed
     @live_method_gen
+    @synchronizer.no_input_translation
     async def _call_generator(self, args, kwargs):
         invocation = await _Invocation.create(self.object_id, args, kwargs, self._client)
         async for res in invocation.run_generator():
             yield res
 
+    @synchronizer.no_io_translation  # TODO (elias): test spawn w/ generators
     async def _call_generator_nowait(self, args, kwargs):
         return await _Invocation.create(self.object_id, args, kwargs, self._client)
 
     @warn_if_generator_is_not_consumed
     @live_method_gen
+    @synchronizer.no_input_translation  # TODO (elias) test that outputs from the map still behave correctly
     async def map(
         self,
         *input_iterators,  # one input iterator per argument in the mapped-over function/generator
@@ -1187,6 +1190,7 @@ class _Function(_Object, type_prefix="fu"):
         async for item in self._map(input_stream, order_outputs, return_exceptions, kwargs):
             yield item
 
+    @synchronizer.no_input_translation
     async def for_each(self, *input_iterators, kwargs={}, ignore_exceptions: bool = False):
         """Execute function for all inputs, ignoring outputs.
 
@@ -1202,6 +1206,7 @@ class _Function(_Object, type_prefix="fu"):
 
     @warn_if_generator_is_not_consumed
     @live_method_gen
+    @synchronizer.no_input_translation
     async def starmap(
         self, input_iterator, kwargs={}, order_outputs: bool = True, return_exceptions: bool = False
     ) -> AsyncGenerator[Any, None]:

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -862,9 +862,6 @@ def test_multiple_build_decorator_cls(unix_servicer, event_loop):
     assert _unwrap_scalar(ret) == 1001
 
 
-@pytest.mark.skip(
-    "we need to find a way to still let users pass Modal objects, or have a deprecation path before we disable inspection"
-)
 @skip_windows_unix_socket
 @pytest.mark.timeout(3.0)
 def test_function_io_doesnt_inspect_args_or_return_values(monkeypatch, unix_servicer):
@@ -888,7 +885,7 @@ def test_function_io_doesnt_inspect_args_or_return_values(monkeypatch, unix_serv
     # pr.disable()
     # pr.print_stats()
     duration = time.perf_counter() - t0
-    assert duration < 2.0  # TODO (elias): migth be able to get this down significantly more by improving serialization
+    assert duration < 2.0  # TODO (elias): might be able to get this down significantly more by improving serialization
 
     # function_io_manager.serialize(large_data_list)
     in_translations = []

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -895,5 +895,5 @@ def test_function_io_doesnt_inspect_args_or_return_values(monkeypatch, unix_serv
     for call in translate_out_spy.call_args_list:
         out_translations += list(call.args)
 
-    assert len(in_translations) < 200  # typically 136 or something
-    assert len(out_translations) < 200
+    assert len(in_translations) < 1000  # typically 136 or something
+    assert len(out_translations) < 1000

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -648,7 +648,7 @@ def test_interactive_mode():
 
 
 def assert_is_wrapped_dict(some_arg):
-    assert isinstance(some_arg, modal.Dict)
+    assert type(some_arg) == modal.Dict  # this should not be a modal._Dict unwrapped instance!
 
 
 def test_calls_should_not_unwrap_modal_objects(servicer, client):
@@ -661,10 +661,10 @@ def test_calls_should_not_unwrap_modal_objects(servicer, client):
     with stub.run(client=client):
         foo.remote(stub.some_modal_object)
         foo.spawn(stub.some_modal_object)
-        # for _ in foo.map([stub.some_modal_object]):
-        #     pass
-        # for _ in foo.starmap([stub.some_modal_object]):
-        #     pass
+        for _ in foo.map([stub.some_modal_object]):
+            pass
+        for _ in foo.starmap([stub.some_modal_object]):
+            pass
 
     # make sure the serialized object is an actual Dict and not a _Dict
     assert len(servicer.client_calls) == 2


### PR DESCRIPTION
The previous patch broke since the `modal.functions.Function` methods didn't have no-wrap, so Modal objects passed to `Function.remote()` or similar would become the "internal" represenation of the object, i.e. async without a separate event loop.

This also adds some more tests w/ assertions of data types going in and out of the user-level API