### PR TITLE
Task current inputs rpc

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1559,6 +1559,11 @@ message SharedVolumeMount {
   bool allow_cross_region = 4;
 }
 
+
+message TaskCurrentInputsResponse {
+  repeated string input_ids = 1;
+}
+
 message TaskInfo {
   string id = 1;
   double started_at = 2;
@@ -1610,6 +1615,7 @@ message TaskStats {
   string app_description = 3;
   double started_at = 4;
 }
+
 
 message TokenFlowCreateRequest {
   string utm_source = 3;
@@ -1916,6 +1922,9 @@ service ModalClient {
   // Tasks
   rpc TaskResult(TaskResultRequest) returns (google.protobuf.Empty);
   rpc TaskList(TaskListRequest) returns (TaskListResponse);
+
+  // Gets the inputs currently assigned to the requesting task, requires task metadata for auth
+  rpc TaskCurrentInputs(google.protobuf.Empty) returns (TaskCurrentInputsResponse);
 
   // Tokens (web auth flow)
   rpc TokenFlowCreate(TokenFlowCreateRequest) returns (TokenFlowCreateResponse);


### PR DESCRIPTION
To be used for confirming inputs of current task/container when cancelling inputs/function calls