### PR TITLE
Add MountDeploy rpc

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1249,6 +1249,13 @@ message MultiPartUpload {
   string completion_url = 3;
 }
 
+message MountDeployRequest {
+  string deployment_name = 1;
+  DeploymentNamespace namespace = 2;
+  string environment_name = 3;
+  string mount_id = 4;
+}
+
 message Object {
   string object_id = 1;
   oneof handle_metadata_oneof {
@@ -1891,6 +1898,7 @@ service ModalClient {
   // Mounts
   rpc MountPutFile(MountPutFileRequest) returns (MountPutFileResponse);
   rpc MountBuild(MountBuildRequest) returns (MountBuildResponse);
+  rpc MountDeploy(MountDeployRequest) returns (google.protobuf.Empty);
 
   // Queues
   rpc QueueCreate(QueueCreateRequest) returns (QueueCreateResponse);


### PR DESCRIPTION
There's some code in `modal_base_images` that deploys mounts. I'm taking a slightly different route than for dicts and queues since mounts are never deployed by normal users – just us. So I don't want to pollute the base methods with a bunch of stuff only used by us.

Adding this client-side so I can implement the server code
