### PR TITLE
Fix response for missing first ASGI message

### DIFF
--- a/modal/_asgi.py
+++ b/modal/_asgi.py
@@ -37,14 +37,16 @@ def asgi_app_wrapper(asgi_app, function_io_manager):
                             "body": b"Missing request, possibly due to cancellation or crash",
                         }
                     )
+                    await messages_to_app.put({"type": "http.disconnect"})
                 elif scope["type"] == "websocket":
-                    await messages_to_app.put(
+                    await messages_from_app.put(
                         {
                             "type": "websocket.close",
                             "code": 1011,
                             "reason": "Missing request, possibly due to cancellation or crash",
                         }
                     )
+                    await messages_to_app.put({"type": "websocket.disconnect"})
                 return
 
             await messages_to_app.put(first_message)

--- a/modal/_asgi.py
+++ b/modal/_asgi.py
@@ -30,8 +30,8 @@ def asgi_app_wrapper(asgi_app, function_io_manager):
                 first_message = await asyncio.wait_for(message_gen.__anext__(), 5.0)
             except asyncio.TimeoutError:
                 if scope["type"] == "http":
-                    await messages_to_app.put({"type": "http.response.start", "status": 502})
-                    await messages_to_app.put(
+                    await messages_from_app.put({"type": "http.response.start", "status": 502})
+                    await messages_from_app.put(
                         {
                             "type": "http.response.body",
                             "body": b"Missing request, possibly due to cancellation or crash",

--- a/modal/_serialization.py
+++ b/modal/_serialization.py
@@ -87,7 +87,7 @@ def _serialize_asgi(obj: Any) -> api_pb2.Asgi:
                 scheme=obj.get("scheme", "http"),
                 path=obj["path"],
                 query_string=obj.get("query_string"),
-                headers=flatten_headers(obj["headers"]),
+                headers=flatten_headers(obj.get("headers", [])),
                 client_host=obj["client"][0] if obj.get("client") else None,
                 client_port=obj["client"][1] if obj.get("client") else None,
             )
@@ -103,7 +103,7 @@ def _serialize_asgi(obj: Any) -> api_pb2.Asgi:
         return api_pb2.Asgi(
             http_response_start=api_pb2.Asgi.HttpResponseStart(
                 status=obj["status"],
-                headers=flatten_headers(obj["headers"]),
+                headers=flatten_headers(obj.get("headers", [])),
                 trailers=obj.get("trailers"),
             )
         )
@@ -117,7 +117,7 @@ def _serialize_asgi(obj: Any) -> api_pb2.Asgi:
     elif msg_type == "http.response.trailers":
         return api_pb2.Asgi(
             http_response_trailers=api_pb2.Asgi.HttpResponseTrailers(
-                headers=flatten_headers(obj["headers"]),
+                headers=flatten_headers(obj.get("headers", [])),
                 more_trailers=obj.get("more_trailers"),
             )
         )
@@ -131,7 +131,7 @@ def _serialize_asgi(obj: Any) -> api_pb2.Asgi:
                 scheme=obj.get("scheme", "ws"),
                 path=obj["path"],
                 query_string=obj.get("query_string"),
-                headers=flatten_headers(obj["headers"]),
+                headers=flatten_headers(obj.get("headers", [])),
                 client_host=obj["client"][0] if obj.get("client") else None,
                 client_port=obj["client"][1] if obj.get("client") else None,
                 subprotocols=obj.get("subprotocols"),


### PR DESCRIPTION
When the first message is missing, we need to send a `502` response in lieu of `FastAPI`. This fix places the response in the correct outgoing message queue.

Further, this fix adds an ingoing message to the `FastAPI` app to register the a client disconnect. This is not necessary but was useful to expose an issue in our ASGI serialization, where `headers` became optional in a variety of places in the 3.0 specification.