### PR TITLE
fix: incorrect example docs in modal.Image

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -1065,11 +1065,13 @@ class _Image(_Object, type_prefix="im"):
         ```python
         modal.Image.from_gcp_artifact_registry(
             "us-east1-docker.pkg.dev/my-project-1234/my-repo/my-image:my-version",
-            secrets=[modal.Secret.from_name("my-gcp-secret")],
+            secret=modal.Secret.from_name("my-gcp-secret"),
             add_python="3.11",
         )
         ```
         """
+        if "secrets" in kwargs:
+            raise ValueError("Passing a list of 'secrets' is not supported; use the singular 'secret' argument.")
         image_registry_config = _ImageRegistryConfig(api_pb2.REGISTRY_AUTH_TYPE_GCP, secret)
         return _Image.from_registry(
             tag,
@@ -1106,11 +1108,13 @@ class _Image(_Object, type_prefix="im"):
         ```python
         modal.Image.from_aws_ecr(
             "000000000000.dkr.ecr.us-east-1.amazonaws.com/my-private-registry:my-version",
-            secrets=[modal.Secret.from_name("aws")],
+            secret=modal.Secret.from_name("aws"),
             add_python="3.11",
         )
         ```
         """
+        if "secrets" in kwargs:
+            raise ValueError("Passing a list of 'secrets' is not supported; use the singular 'secret' argument.")
         image_registry_config = _ImageRegistryConfig(api_pb2.REGISTRY_AUTH_TYPE_AWS, secret)
         return _Image.from_registry(
             tag,

--- a/modal/image.py
+++ b/modal/image.py
@@ -1071,7 +1071,7 @@ class _Image(_Object, type_prefix="im"):
         ```
         """
         if "secrets" in kwargs:
-            raise ValueError("Passing a list of 'secrets' is not supported; use the singular 'secret' argument.")
+            raise TypeError("Passing a list of 'secrets' is not supported; use the singular 'secret' argument.")
         image_registry_config = _ImageRegistryConfig(api_pb2.REGISTRY_AUTH_TYPE_GCP, secret)
         return _Image.from_registry(
             tag,
@@ -1114,7 +1114,7 @@ class _Image(_Object, type_prefix="im"):
         ```
         """
         if "secrets" in kwargs:
-            raise ValueError("Passing a list of 'secrets' is not supported; use the singular 'secret' argument.")
+            raise TypeError("Passing a list of 'secrets' is not supported; use the singular 'secret' argument.")
         image_registry_config = _ImageRegistryConfig(api_pb2.REGISTRY_AUTH_TYPE_AWS, secret)
         return _Image.from_registry(
             tag,

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -260,7 +260,7 @@ def test_ecr_install(servicer, client):
         image=Image.from_aws_ecr(
             image_tag,
             setup_dockerfile_commands=["RUN apt-get update"],
-            secrets=[Secret.from_dict({"AWS_ACCESS_KEY_ID": "", "AWS_SECRET_ACCESS_KEY": ""})],
+            secret=Secret.from_dict({"AWS_ACCESS_KEY_ID": "", "AWS_SECRET_ACCESS_KEY": ""}),
         )
     )
 


### PR DESCRIPTION
## Describe your changes

Broken in https://github.com/modal-labs/modal-client/pull/1269. 

It still may be dubious to fully reject the `secrets` value. But I've explicitly rejected it to make things less confusing. 
