### PR TITLE
Install `wheel` in Image.from_registry(add_python=)

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -962,12 +962,8 @@ class _Image(_Object, type_prefix="im"):
             *add_python_commands,
             *setup_dockerfile_commands,
             "COPY /modal_requirements.txt /modal_requirements.txt",
-            "RUN python -m pip install --upgrade pip",
+            "RUN python -m pip install --upgrade pip setuptools wheel",
             "RUN python -m pip install -r /modal_requirements.txt",
-            # TODO: We should add this next line at some point to clean up the image, but it would
-            # trigger a hash change, so batch it with the next rebuild-triggering change.
-            #
-            # "RUN rm /modal_requirements.txt",
         ]
 
     @staticmethod

--- a/modal/image.py
+++ b/modal/image.py
@@ -964,6 +964,7 @@ class _Image(_Object, type_prefix="im"):
             "COPY /modal_requirements.txt /modal_requirements.txt",
             "RUN python -m pip install --upgrade pip setuptools wheel",
             "RUN python -m pip install -r /modal_requirements.txt",
+            "RUN rm /modal_requirements.txt",
         ]
 
     @staticmethod


### PR DESCRIPTION
This fixes some issues with `pip_install` failing with PEP517-style installations, due to missing a wheel package, for the `torch` module and some others.

This will invalidate people's cache if they're using `Image.from_registry()`! Which is a bit concerning.


## Changelog

- Install the `wheel` package in `Image.from_registry()` constructors, resolving various installation issues. If you built an image before this version with `Image.from_registry()`, rerunning the app in this version will rebuild your image.