### PR TITLE
Protos for SecretGet

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1467,6 +1467,16 @@ message SecretCreateResponse {
   string secret_id = 1;
 }
 
+message SecretGetRequest {
+  string deployment_name = 1;
+  DeploymentNamespace namespace = 2;
+  string environment_name = 3;
+}
+
+message SecretGetResponse {
+  string secret_id = 1;
+}
+
 message SecretListItem {
   string label = 1;
   double created_at = 2;


### PR DESCRIPTION
Make it possible to look up deployed secrets without using `AppLookupObject`.

Not used yet, will implement it server-side next.