### PR TITLE
SecretGet -> SecretGetOrCreate

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1467,13 +1467,14 @@ message SecretCreateResponse {
   string secret_id = 1;
 }
 
-message SecretGetRequest {
+message SecretGetOrCreateRequest {
   string deployment_name = 1;
   DeploymentNamespace namespace = 2;
   string environment_name = 3;
+  ObjectCreationType object_creation_type = 4;  // Not used atm
 }
 
-message SecretGetResponse {
+message SecretGetOrCreateResponse {
   string secret_id = 1;
 }
 
@@ -1931,7 +1932,7 @@ service ModalClient {
 
   // Secrets
   rpc SecretCreate(SecretCreateRequest) returns (SecretCreateResponse);
-  rpc SecretGet(SecretGetRequest) returns (SecretGetResponse);
+  rpc SecretGetOrCreate(SecretGetOrCreateRequest) returns (SecretGetOrCreateResponse);
   rpc SecretList(SecretListRequest) returns (SecretListResponse);
 
   // SharedVolumes


### PR DESCRIPTION
Realized it's better since
1. We might actually want to create secrets lazily later (through a web thing)
2. It's more consistent with other object types
3. It helps us avoid some mypy warnings in the server