### PR TITLE
Improve error handling on windows when warning source is unknown

### DIFF
--- a/modal/_traceback.py
+++ b/modal/_traceback.py
@@ -225,7 +225,8 @@ def highlight_modal_deprecation_warnings() -> None:
                 with open(filename) as f:
                     source = f.readlines()[lineno - 1].strip()
                 message = f"{message}\n\nSource: {filename}:{lineno}\n  {source}"
-            except FileNotFoundError:
+            except OSError:
+                # e.g., when filename is "<unknown>"; raises FileNotFoundError on posix but OSError on windows
                 pass
             panel = Panel(
                 message,


### PR DESCRIPTION
## Describe your changes

Fixes a user-reported issue on windows, as the malformed filename raises a more general error on windows. (`FileNotFoundError` is a subclass of `OSError` so this will continue to work on Posix).


## Changelog

Fixed an issue with displaying deprecation warnings on Windows systems.