### PR TITLE
Use latest ruff

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -16,7 +16,7 @@ pytest-markdown-docs==0.5.0
 pytest-timeout~=2.1.0
 python-dotenv~=1.0.0;python_version>='3.8'
 requests~=2.31.0
-ruff==0.0.277
+ruff==0.2.1
 types-croniter~=1.0.8
 types-python-dateutil~=2.8.10
 types-requests~=2.31.0


### PR DESCRIPTION
We had an old version for some reason? Things started breaking?

https://github.com/modal-labs/modal-client/actions/runs/7878189786/job/21495899574?pr=1338

I had the same issue locally and it went away when I installed the newest version