### PR TITLE
Simplify token verification option by removing double negative

### DIFF
--- a/modal/cli/token.py
+++ b/modal/cli/token.py
@@ -20,6 +20,11 @@ activate_option = typer.Option(
     help="Activate the profile containing this token after creation.",
 )
 
+verify_option = typer.Option(
+    True,
+    help="Make a test request to verify the new credentials.",
+)
+
 
 @token_cli.command(
     name="set",
@@ -31,13 +36,13 @@ async def set(
     token_secret: Optional[str] = typer.Option(None, help="Account token secret."),
     profile: Optional[str] = profile_option,
     activate: bool = activate_option,
-    no_verify: bool = False,
+    verify: bool = verify_option,
 ):
     if token_id is None:
         token_id = getpass.getpass("Token ID:")
     if token_secret is None:
         token_secret = getpass.getpass("Token secret:")
-    await _set_token(token_id, token_secret, profile=profile, activate=activate, no_verify=no_verify)
+    await _set_token(token_id, token_secret, profile=profile, activate=activate, verify=verify)
 
 
 @token_cli.command(name="new", help="Create a new token by using an authenticated web session.")
@@ -45,7 +50,7 @@ async def set(
 async def new(
     profile: Optional[str] = profile_option,
     activate: bool = activate_option,
-    no_verify: bool = False,
+    verify: bool = verify_option,
     source: Optional[str] = None,
 ):
-    await _new_token(profile=profile, activate=activate, no_verify=no_verify, source=source)
+    await _new_token(profile=profile, activate=activate, verify=verify, source=source)

--- a/modal/token_flow.py
+++ b/modal/token_flow.py
@@ -68,8 +68,8 @@ TokenFlow = synchronize_api(_TokenFlow)
 async def _new_token(
     *,
     profile: Optional[str] = None,
-    activate: bool = False,
-    no_verify: bool = False,
+    activate: bool = True,
+    verify: bool = True,
     source: Optional[str] = None,
     next_url: Optional[str] = None,
 ):
@@ -115,7 +115,7 @@ async def _new_token(
             f"[green]Token is connected to the [magenta]{result.workspace_username}[/magenta] workspace.[/green]"
         )
 
-    await _set_token(result.token_id, result.token_secret, profile=profile, activate=activate, no_verify=no_verify)
+    await _set_token(result.token_id, result.token_secret, profile=profile, activate=activate, verify=verify)
 
 
 async def _set_token(
@@ -123,13 +123,13 @@ async def _set_token(
     token_secret: str,
     *,
     profile: Optional[str] = None,
-    activate: bool = False,
-    no_verify: bool = False,
+    activate: bool = True,
+    verify: bool = True,
 ):
     # TODO add server_url as a parameter for verification?
     server_url = config.get("server_url", profile=profile)
     console = Console()
-    if not no_verify:
+    if verify:
         console.print(f"Verifying token against [blue]{server_url}[/blue]")
         await _Client.verify(server_url, (token_id, token_secret))
         console.print("[green]Token verified successfully![/green]")
@@ -141,7 +141,7 @@ async def _set_token(
             try:
                 workspace = await _lookup_workspace(server_url, token_id, token_secret)
             except AuthError as exc:
-                if no_verify:
+                if not verify:
                     # Improve the error message for verification failure with --no-verify to reduce surprise
                     msg = "No profile name given, but could not authenticate client to look up workspace name."
                     raise AuthError(msg) from exc


### PR DESCRIPTION
## Describe your changes

Previously the `modal token new` and `modal token set` CLI had `no_verify` as a parameter so type created `--no-verify` and `--no-no-verify-flags`. That's a little silly so this changes the parameter to `verify` and inverts the default.

This is technically an API break but I sort of doubt that anyone is explicitly adding `--no-no-verify` just to get the default behavior?

Additionally, I changed the default value for `activate` on the internal API to match a previous change to the CLI (#1288).

## Changelog

- In `modal token new` and `modal token set`, the `--no-no-verify` flag has been removed in favor of a `--verify` flag. This remains the default behavior.