### PR TITLE
Checks for open connections before checkpointing

### DIFF
--- a/modal/_checkpointing_utils.py
+++ b/modal/_checkpointing_utils.py
@@ -1,0 +1,23 @@
+import psutil
+
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class NetworkConnection:
+    remote_addr: str
+    status: str
+
+
+def get_open_connections() -> list[NetworkConnection]:
+    open_connections:list[NetworkConnection] = []
+    for kind in ["tcp", "udp"]:
+        for conn in psutil.net_connections(kind=kind):
+            if conn.status == "ESTABLISHED":
+                remote_address, remote_port = conn.raddr if conn.raddr else ("Unknown", "Unknown")
+                open_connections.append(
+                    NetworkConnection(
+                        remote_addr=f"{remote_address}:{remote_port}",
+                        status=conn.status,
+                    ))
+        
+    return open_connections

--- a/modal/_checkpointing_utils.py
+++ b/modal/_checkpointing_utils.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import List
 
 import psutil
 
@@ -9,7 +10,7 @@ class NetworkConnection:
     status: str
 
 
-def get_open_connections() -> list[NetworkConnection]:
+def get_open_connections() -> List[NetworkConnection]:
     open_connections:list[NetworkConnection] = []
     for kind in ["tcp", "udp"]:
         for conn in psutil.net_connections(kind=kind):

--- a/modal/_checkpointing_utils.py
+++ b/modal/_checkpointing_utils.py
@@ -16,7 +16,7 @@ def get_open_connections() -> List[NetworkConnection]:
     open_connections:list[NetworkConnection] = []
     for kind in ["tcp", "udp"]:
         for conn in psutil.net_connections(kind=kind):
-            if conn.status == "ESTABLISHED":
+            if conn.status in ("ESTABLISHED", "CLOSING", "CLOSE_WAIT"):
                 remote_address, remote_port = conn.raddr if conn.raddr else ("Unknown", "Unknown")
                 open_connections.append(
                     NetworkConnection(

--- a/modal/_checkpointing_utils.py
+++ b/modal/_checkpointing_utils.py
@@ -1,3 +1,5 @@
+# Copyright Modal Labs 2022
+
 from dataclasses import dataclass
 from typing import List
 

--- a/modal/_checkpointing_utils.py
+++ b/modal/_checkpointing_utils.py
@@ -1,6 +1,7 @@
+from dataclasses import dataclass
+
 import psutil
 
-from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class NetworkConnection:
@@ -19,5 +20,5 @@ def get_open_connections() -> list[NetworkConnection]:
                         remote_addr=f"{remote_address}:{remote_port}",
                         status=conn.status,
                     ))
-        
+
     return open_connections

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -484,7 +484,7 @@ class _FunctionIOManager:
                 logger.error(f"Remote Address: {conn.remote_addr}, Status: {conn.status}")
 
             raise ConnectionError(
-                "Cannot checkpoint container with open TCP connections. "
+                "Cannot checkpoint container with open network connections. "
                 "Are you closing connections before checkpointing?"
             )
         else:

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -479,7 +479,7 @@ class _FunctionIOManager:
             logger.debug(f"Checkpoint ID: {self.checkpoint_id}")
 
         if connections := get_open_connections():
-            logger.error(f"Found {len(connections)} open network connections:")
+            logger.error(f"Found {len(connections)} open network connection(s):")
             for conn in connections:
                 logger.error(f"Remote Address: {conn.remote_addr}, Status: {conn.status}")
 

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -479,11 +479,11 @@ class _FunctionIOManager:
             logger.debug(f"Checkpoint ID: {self.checkpoint_id}")
 
         if connections := get_open_connections():
-            logger.error(f"Found {len(connections)} open TCP connections:")
+            logger.error(f"Found {len(connections)} open network connections:")
             for conn in connections:
                 logger.error(f"Remote Address: {conn.remote_addr}, Status: {conn.status}")
 
-            raise ValueError(
+            raise ConnectionError(
                 "Cannot checkpoint container with open TCP connections. "
                 "Are you closing connections before checkpointing?"
             )

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -35,12 +35,12 @@ from modal_utils.grpc_utils import retry_transient_errors
 
 from ._asgi import asgi_app_wrapper, webhook_asgi_app, wsgi_app_wrapper
 from ._blob_utils import MAX_OBJECT_SIZE_BYTES, blob_download, blob_upload
+from ._checkpointing_utils import get_open_connections
 from ._function_utils import LocalFunctionError, is_async as get_is_async, is_global_function
 from ._proxy_tunnel import proxy_tunnel
 from ._serialization import deserialize, deserialize_data_format, serialize, serialize_data_format
 from ._traceback import extract_traceback
 from ._tracing import extract_tracing_context, set_span_tag, trace, wrap
-from ._checkpointing_utils import get_open_connections, NetworkConnection
 from .app import _container_app, _ContainerApp
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, Client, _Client
 from .cls import Cls

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
 from __future__ import annotations
 
+import socket
 import asyncio
 import time
 from datetime import date
@@ -296,3 +297,14 @@ class CheckpointingCls:
     @method()
     def f(self, x):
         return "".join(self._vals) + x
+
+
+@stub.cls(checkpointing_enabled=True)
+class CheckpointingClsNetworkConnectionOpen:
+    def __init__(self):
+        self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        
+    @enter(checkpoint=True)
+    def open_connection(self):
+        remote_ip = socket.gethostbyname("google.com")
+        self._socket.connect((remote_ip, 80))

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -1,8 +1,8 @@
 # Copyright Modal Labs 2022
 from __future__ import annotations
 
-import socket
 import asyncio
+import socket
 import time
 from datetime import date
 
@@ -303,7 +303,7 @@ class CheckpointingCls:
 class CheckpointingClsNetworkConnectionOpen:
     def __init__(self):
         self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        
+
     @enter(checkpoint=True)
     def open_connection(self):
         remote_ip = socket.gethostbyname("google.com")

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -306,5 +306,5 @@ class CheckpointingClsNetworkConnectionOpen:
 
     @enter(checkpoint=True)
     def open_connection(self):
-        remote_ip = socket.gethostbyname("google.com")
+        remote_ip = socket.gethostbyname("modal.com")
         self._socket.connect((remote_ip, 80))

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     typer~=0.9.0
     types-certifi
     types-toml
+    psutil
     watchfiles
     typing_extensions~=4.6
 

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -35,7 +35,7 @@ from modal.stub import _Stub
 from modal_proto import api_pb2
 
 from .helpers import deploy_stub_externally
-from .supports.skip import skip_windows_unix_socket
+from .supports.skip import skip_windows_unix_socket, skip_macos, skip_windows
 
 EXTRA_TOLERANCE_DELAY = 2.0 if sys.platform == "linux" else 5.0
 FUNCTION_CALL_ID = "fc-123"
@@ -549,7 +549,8 @@ def test_cls_generator(unix_servicer, event_loop):
     assert exc is None
 
 
-@skip_windows_unix_socket
+@skip_macos
+@skip_windows
 def test_checkpointing_cls_function(unix_servicer, event_loop):
 
     # Monkey-patched to prevent side effects with other existing connections.
@@ -821,7 +822,8 @@ def test_call_function_that_calls_method(unix_servicer, event_loop):
     assert _unwrap_scalar(ret) == 123**2  # servicer's implementation of function calling
 
 
-@skip_windows_unix_socket
+@skip_macos
+@skip_windows
 def test_checkpoint_and_restore_success(unix_servicer, event_loop):
     """Functions send a checkpointing request and continue to execute normally,
     simulating a restore operation."""
@@ -842,7 +844,8 @@ def test_checkpoint_and_restore_success(unix_servicer, event_loop):
 
 
 
-@skip_windows_unix_socket
+@skip_macos
+@skip_windows
 def test_error_open_connection(unix_servicer, event_loop):
     """Functions fail to checkpoint if connections are open."""
     with pytest.raises(ConnectionError):

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -825,12 +825,14 @@ def test_call_function_that_calls_method(unix_servicer, event_loop):
 def test_checkpoint_and_restore_success(unix_servicer, event_loop):
     """Functions send a checkpointing request and continue to execute normally,
     simulating a restore operation."""
-    ret = _run_container(
-        unix_servicer,
-        "modal_test_support.functions",
-        "square",
-        is_checkpointing_function=True,
-    )
+    with mock.patch("modal._container_entrypoint.get_open_connections", lambda: []):
+        ret = _run_container(
+            unix_servicer,
+            "modal_test_support.functions",
+            "square",
+            is_checkpointing_function=True,
+        )
+
     assert any(isinstance(request, api_pb2.ContainerCheckpointRequest) for request in unix_servicer.requests)
     for request in unix_servicer.requests:
         if isinstance(request, api_pb2.ContainerCheckpointRequest):
@@ -850,7 +852,6 @@ def test_error_open_connection(unix_servicer, event_loop):
             "CheckpointingClsNetworkConnectionOpen.open_connection",
             is_checkpointing_function=True,
         )
-        assert not any(isinstance(request, api_pb2.ContainerCheckpointRequest) for request in unix_servicer.requests)
 
 @skip_windows_unix_socket
 def test_get_open_connections():

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -40,6 +40,7 @@ from .supports.skip import skip_macos, skip_windows, skip_windows_unix_socket
 EXTRA_TOLERANCE_DELAY = 2.0 if sys.platform == "linux" else 5.0
 FUNCTION_CALL_ID = "fc-123"
 SLEEP_DELAY = 0.1
+CONNECTION_CHECK_CHECKPOINTING_MESSAGE = "connection check only runs inside containers"
 
 
 def _get_inputs(args: Tuple[Tuple, Dict] = ((42,), {}), n: int = 1) -> List[api_pb2.FunctionGetInputsResponse]:
@@ -549,8 +550,8 @@ def test_cls_generator(unix_servicer, event_loop):
     assert exc is None
 
 
-@skip_macos
-@skip_windows
+@skip_macos(CONNECTION_CHECK_CHECKPOINTING_MESSAGE)
+@skip_windows(CONNECTION_CHECK_CHECKPOINTING_MESSAGE)
 def test_checkpointing_cls_function(unix_servicer, event_loop):
 
     # Monkey-patched to prevent side effects with other existing connections.
@@ -822,8 +823,8 @@ def test_call_function_that_calls_method(unix_servicer, event_loop):
     assert _unwrap_scalar(ret) == 123**2  # servicer's implementation of function calling
 
 
-@skip_macos
-@skip_windows
+@skip_macos(CONNECTION_CHECK_CHECKPOINTING_MESSAGE)
+@skip_windows(CONNECTION_CHECK_CHECKPOINTING_MESSAGE)
 def test_checkpoint_and_restore_success(unix_servicer, event_loop):
     """Functions send a checkpointing request and continue to execute normally,
     simulating a restore operation."""
@@ -844,8 +845,8 @@ def test_checkpoint_and_restore_success(unix_servicer, event_loop):
 
 
 
-@skip_macos
-@skip_windows
+@skip_macos(CONNECTION_CHECK_CHECKPOINTING_MESSAGE)
+@skip_windows(CONNECTION_CHECK_CHECKPOINTING_MESSAGE)
 def test_error_open_connection(unix_servicer, event_loop):
     """Functions fail to checkpoint if connections are open."""
     with pytest.raises(ConnectionError):

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -856,7 +856,7 @@ def test_error_open_connection(unix_servicer, event_loop):
 @skip_windows_unix_socket
 def test_get_open_connections():
     new_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    remote_ip = socket.gethostbyname("google.com")
+    remote_ip = socket.gethostbyname("modal.com")
     new_socket.connect((remote_ip, 80))
 
     connections = get_open_connections()

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -857,7 +857,8 @@ def test_error_open_connection(unix_servicer, event_loop):
             is_checkpointing_function=True,
         )
 
-@skip_windows_unix_socket
+@skip_macos(CONNECTION_CHECK_CHECKPOINTING_MESSAGE)
+@skip_windows(CONNECTION_CHECK_CHECKPOINTING_MESSAGE)
 def test_get_open_connections():
     new_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     remote_ip = socket.gethostbyname("modal.com")

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -8,9 +8,9 @@ import os
 import pathlib
 import pickle
 import pytest
+import socket
 import subprocess
 import sys
-import socket
 import tempfile
 import time
 import uuid
@@ -22,8 +22,8 @@ from grpclib.exceptions import GRPCError
 
 import modal_utils
 from modal import Client
-from modal._container_entrypoint import UserException, main
 from modal._checkpointing_utils import get_open_connections
+from modal._container_entrypoint import UserException, main
 from modal._serialization import (
     deserialize,
     deserialize_data_format,

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -35,7 +35,7 @@ from modal.stub import _Stub
 from modal_proto import api_pb2
 
 from .helpers import deploy_stub_externally
-from .supports.skip import skip_windows_unix_socket, skip_macos, skip_windows
+from .supports.skip import skip_macos, skip_windows, skip_windows_unix_socket
 
 EXTRA_TOLERANCE_DELAY = 2.0 if sys.platform == "linux" else 5.0
 FUNCTION_CALL_ID = "fc-123"


### PR DESCRIPTION
Adds a check for remote connections. This informs user that checkpointing isn't possible if connections are open. It also shows which targets currently have connections open.

This is what users will see:
```python
@stub.cls(checkpointing_enabled=True,
          concurrency_limit=1, retries=0, container_idle_timeout=2)
class ConnectionOpen:
    def __init__(self):
        self.new_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
    
    @modal.enter(checkpoint=True)
    def open_connection(self):
        remote_ip = socket.gethostbyname("modal.com")
        self.new_socket.connect((remote_ip, 80))
    
    @modal.method()
    def foo(self):
        print("hello from remote function")
        return "done"    
```

```shell
$ modal run .local/hello_checkpoint.py 
✓ Initialized. View run at http://localhost:7601/luiscape/apps/ap-4kH9suzabkIPSdNZtRIeIt
✓ Created objects.
├── 🔨 Created mount /home/ubuntu/modal/.local/hello_checkpoint.py
├── 🔨 Created ConnectionOpen.foo.
└── 🔨 Created f.
Starting function memory checkpointing. Worker fingerprint 37616ec2dbf3210613d0f1916a3236610c64845ebb6dc68c36299b8ddfba0f65
2024-02-13T20:48:54+0000 Found 1 open network connections:
2024-02-13T20:48:54+0000 Remote Address: 54.167.233.8:80, Status: ESTABLISHED
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/pkg/modal/_container_entrypoint.py", line 916, in <module>
    main(container_args, client)
  File "/usr/local/lib/python3.11/contextlib.py", line 222, in __aexit__
    await self.gen.athrow(typ, value, traceback)
  File "/pkg/modal/_container_entrypoint.py", line 136, in heartbeats
    yield
  File "/pkg/modal/_container_entrypoint.py", line 874, in main
    function_io_manager.checkpoint()
  File "/pkg/synchronicity/synchronizer.py", line 526, in proxy_method
    return wrapped_method(instance, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/pkg/synchronicity/combined_types.py", line 28, in __call__
    raise uc_exc.exc from None
  File "/pkg/modal/_container_entrypoint.py", line 486, in checkpoint
    raise ConnectionError(
ConnectionError: Cannot checkpoint container with open TCP connections. Are you closing connections before checkpointing?
Runner failed with exit code: 1
```