### PR TITLE
Use MountGetOrCreate for mount lookups

### DIFF
--- a/modal/mount.py
+++ b/modal/mount.py
@@ -9,7 +9,7 @@ import time
 import typing
 from datetime import date
 from pathlib import Path, PurePosixPath
-from typing import AsyncGenerator, Callable, List, Optional, Sequence, Tuple, Union
+from typing import AsyncGenerator, Callable, List, Optional, Sequence, Tuple, Type, Union
 
 import aiostream
 from google.protobuf.message import Message
@@ -471,8 +471,9 @@ class _Mount(_StatefulObject, type_prefix="mo"):
 
         return _Mount._from_loader(_load, "Mount()")
 
-    @staticmethod
+    @classmethod
     async def lookup(
+        cls: Type["_Mount"],
         label: str,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         client: Optional[_Client] = None,

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -514,14 +514,12 @@ def test_environment_flag(test_dir, servicer, command):
     stub_file = test_dir / "supports" / "app_run_tests" / "app_with_lookups.py"
     with servicer.intercept() as ctx:
         ctx.add_response(
-            "AppLookupObject",
-            api_pb2.AppLookupObjectResponse(
-                object=api_pb2.Object(
-                    object_id="mo-123",
-                    mount_handle_metadata=api_pb2.MountHandleMetadata(content_checksum_sha256_hex="abc123"),
-                )
+            "MountGetOrCreate",
+            api_pb2.MountGetOrCreateResponse(
+                mount_id="mo-123",
+                handle_metadata=api_pb2.MountHandleMetadata(content_checksum_sha256_hex="abc123"),
             ),
-            request_filter=lambda req: req.app_name.startswith("modal-client-mount")
+            request_filter=lambda req: req.deployment_name.startswith("modal-client-mount")
             and req.namespace == api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL,
         )  # built-in client lookup
         ctx.add_response(
@@ -550,14 +548,12 @@ def test_environment_noflag(test_dir, servicer, command, monkeypatch):
 
     with servicer.intercept() as ctx:
         ctx.add_response(
-            "AppLookupObject",
-            api_pb2.AppLookupObjectResponse(
-                object=api_pb2.Object(
-                    object_id="mo-123",
-                    mount_handle_metadata=api_pb2.MountHandleMetadata(content_checksum_sha256_hex="abc123"),
-                )
+            "MountGetOrCreate",
+            api_pb2.MountGetOrCreateResponse(
+                mount_id="mo-123",
+                handle_metadata=api_pb2.MountHandleMetadata(content_checksum_sha256_hex="abc123"),
             ),
-            request_filter=lambda req: req.app_name.startswith("modal-client-mount")
+            request_filter=lambda req: req.deployment_name.startswith("modal-client-mount")
             and req.namespace == api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL,
         )  # built-in client lookup
         ctx.add_response(


### PR DESCRIPTION
This implements half of the client changes. We're still using `Mount._deploy` in `modal_base_images` so I need to change that too.

This passes all integration test (and I'm able to run this client against prod).

Similar to other changes, this adds quite a bit of code, although once we're across the bridge we should be able to clean up quite a lot of it.