### PR TITLE
Persist event loop across cls method execution

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -61,7 +61,7 @@ class UserException(Exception):
     pass
 
 
-class EventLoop:
+class SignalHandlingEventLoop:
     """Manage an event loop for executing coroutines while handling SIGINT/SIGTERM.
 
     Prevents stray cancellation errors from propagating up.
@@ -833,7 +833,7 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
     # Define a global app (need to do this before imports)
     container_app = function_io_manager.initialize_app()
 
-    with EventLoop() as event_loop, function_io_manager.heartbeats():
+    with SignalHandlingEventLoop() as event_loop, function_io_manager.heartbeats():
         # If this is a serialized function, fetch the definition from the server
         if container_args.function_def.definition_type == api_pb2.Function.DEFINITION_TYPE_SERIALIZED:
             ser_cls, ser_fun = function_io_manager.get_serialized_function()

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -61,20 +61,24 @@ class UserException(Exception):
     pass
 
 
-def run_with_signal_handler(coro):
-    """Execute coro in an event loop, with a signal handler that cancels
-    the task in the case of SIGINT or SIGTERM. Prevents stray cancellation errors
-    from propagating up."""
+class EventLoop:
+    """Manage an event loop for executing coroutines while handling SIGINT/SIGTERM.
 
-    loop = asyncio.new_event_loop()
-    task = asyncio.ensure_future(coro, loop=loop)
-    for s in [signal.SIGINT, signal.SIGTERM]:
-        loop.add_signal_handler(s, task.cancel)
-    try:
-        result = loop.run_until_complete(task)
-    finally:
-        loop.close()
-    return result
+    Prevents stray cancellation errors from propagating up.
+    """
+
+    def __enter__(self):
+        self.loop = asyncio.new_event_loop()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.loop.close()
+
+    def run(self, coro):
+        task = asyncio.ensure_future(coro, loop=self.loop)
+        for s in [signal.SIGINT, signal.SIGTERM]:
+            self.loop.add_signal_handler(s, task.cancel)
+        return self.loop.run_until_complete(task)
 
 
 class _FunctionIOManager:
@@ -829,7 +833,7 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
     # Define a global app (need to do this before imports)
     container_app = function_io_manager.initialize_app()
 
-    with function_io_manager.heartbeats():
+    with EventLoop() as event_loop, function_io_manager.heartbeats():
         # If this is a serialized function, fetch the definition from the server
         if container_args.function_def.definition_type == api_pb2.Function.DEFINITION_TYPE_SERIALIZED:
             ser_cls, ser_fun = function_io_manager.get_serialized_function()
@@ -851,7 +855,7 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
         # Identify all "enter" methods that need to run before we checkpoint
         if imp_fun.obj is not None and not imp_fun.is_auto_snapshot:
             pre_checkpoint_methods = _find_callables_for_obj(imp_fun.obj, _PartialFunctionFlags.ENTER_PRE_CHECKPOINT)
-            run_with_signal_handler(call_functions_for_setup(function_io_manager, pre_checkpoint_methods.values()))
+            event_loop.run(call_functions_for_setup(function_io_manager, pre_checkpoint_methods.values()))
 
         # Checkpoint container after imports. Checkpointed containers start from this point
         # onwards. This assumes that everything up to this point has run successfully,
@@ -867,12 +871,12 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
         # Identify the "enter" methods to run after we resume
         if imp_fun.obj is not None and not imp_fun.is_auto_snapshot:
             post_checkpoint_methods = _find_callables_for_obj(imp_fun.obj, _PartialFunctionFlags.ENTER_POST_CHECKPOINT)
-            run_with_signal_handler(call_functions_for_setup(function_io_manager, post_checkpoint_methods.values()))
+            event_loop.run(call_functions_for_setup(function_io_manager, post_checkpoint_methods.values()))
 
         if not imp_fun.is_async:
             call_function_sync(function_io_manager, imp_fun)
         else:
-            run_with_signal_handler(call_function_async(function_io_manager, imp_fun))
+            event_loop.run(call_function_async(function_io_manager, imp_fun))
 
         # Commit on exit to catch uncommitted volume changes and surface background
         # commit errors.

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -296,3 +296,14 @@ class CheckpointingCls:
     @method()
     def f(self, x):
         return "".join(self._vals) + x
+
+
+@stub.cls()
+class EventLoopCls:
+    @enter()
+    async def enter(self):
+        self.loop = asyncio.get_running_loop()
+
+    @method()
+    async def f(self):
+        return self.loop.is_running()

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -564,6 +564,17 @@ def test_checkpointing_cls_function(unix_servicer, event_loop):
 
 
 @skip_windows_unix_socket
+def test_cls_enter_uses_event_loop(unix_servicer):
+    ret = _run_container(
+        unix_servicer,
+        "modal_test_support.functions",
+        "EventLoopCls.f",
+        inputs=_get_inputs(((), {})),
+    )
+    assert _unwrap_scalar(ret) == True
+
+
+@skip_windows_unix_socket
 def test_container_heartbeats(unix_servicer, event_loop):
     _run_container(unix_servicer, "modal_test_support.functions", "square")
     assert any(isinstance(request, api_pb2.ContainerHeartbeatRequest) for request in unix_servicer.requests)


### PR DESCRIPTION
## Describe your changes

Fixes a regression in #1341 which caused different event loops to be used when executing `@enter` and `@method` methods. (Unrelated but we need an easier way to talk about the "@method method").

Now the event loop is persisted with a context manager.

- Resolves MOD-2383

## Changelog

- Fixes a regression from 0.57.40 where `@enter` methods used a separate event loop.