### PR TITLE
web endpoint optimization: or, the unreasonable effectiveness of asyncio.gather?

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -596,9 +596,7 @@ async def call_function_async(
             started_at = time.time()
             reset_context = _set_current_context_ids(input_id, function_call_id)
             async with function_io_manager.handle_input_exception.aio(input_id, started_at):
-                print(f"{time.time() - started_at:.5f}s before calling fn")
                 res = imp_fun.fun(*args, **kwargs)
-                print(f"{time.time() - started_at:.5f}s after calling fn")
 
                 # TODO(erikbern): any exception below shouldn't be considered a user exception
                 if imp_fun.is_generator:
@@ -619,9 +617,7 @@ async def call_function_async(
                     async for value in res:
                         await function_io_manager._queue_put.aio(generator_queue, value)
                         item_count += 1
-                    print(f"{time.time() - started_at:.5f}s after putting all values")
 
-                    print(f"{time.time() - started_at:.5f}s before waiting on generator")
                     asyncio.gather(
                         function_io_manager._queue_put.aio(
                             generator_queue, _FunctionIOManager._GENERATOR_STOP_SENTINEL
@@ -629,7 +625,6 @@ async def call_function_async(
                         generator_output_task,  # Wait to finish sending generator outputs.
                     )
                     message = api_pb2.GeneratorDone(items_total=item_count)
-                    print(f"{time.time() - started_at:.5f}s for output to be produced")
                     await function_io_manager.push_output.aio(
                         input_id, started_at, message, api_pb2.DATA_FORMAT_GENERATOR_DONE
                     )

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -596,7 +596,9 @@ async def call_function_async(
             started_at = time.time()
             reset_context = _set_current_context_ids(input_id, function_call_id)
             async with function_io_manager.handle_input_exception.aio(input_id, started_at):
+                print(f"{time.time() - started_at:.5f}s before calling fn")
                 res = imp_fun.fun(*args, **kwargs)
+                print(f"{time.time() - started_at:.5f}s after calling fn")
 
                 # TODO(erikbern): any exception below shouldn't be considered a user exception
                 if imp_fun.is_generator:
@@ -617,12 +619,17 @@ async def call_function_async(
                     async for value in res:
                         await function_io_manager._queue_put.aio(generator_queue, value)
                         item_count += 1
+                    print(f"{time.time() - started_at:.5f}s after putting all values")
 
-                    await function_io_manager._queue_put.aio(
-                        generator_queue, _FunctionIOManager._GENERATOR_STOP_SENTINEL
+                    print(f"{time.time() - started_at:.5f}s before waiting on generator")
+                    asyncio.gather(
+                        function_io_manager._queue_put.aio(
+                            generator_queue, _FunctionIOManager._GENERATOR_STOP_SENTINEL
+                        ),
+                        generator_output_task,  # Wait to finish sending generator outputs.
                     )
-                    await generator_output_task  # Wait to finish sending generator outputs.
                     message = api_pb2.GeneratorDone(items_total=item_count)
+                    print(f"{time.time() - started_at:.5f}s for output to be produced")
                     await function_io_manager.push_output.aio(
                         input_id, started_at, message, api_pb2.DATA_FORMAT_GENERATOR_DONE
                     )


### PR DESCRIPTION
### Describe your changes

- In **local dev**, this reduces the high freq web endpoint's execution latency from ~9ms to ~3ms (66% latency reduction).  
- In **dev cluster**, this reduces the high freq web endpoint's execution latency from ~25ms to ~3ms (**88%** latency reduction). 
    - We can expect similar results in prod

There's no behavior change in this PR. The `generator_output_task` will still not exit until it receives `_GENERATOR_STOP_SENTINEL`. But with the concurrent coro creation, the sentinel receive happens more or less instantly.

### Repro

Take the highfreq `webhook.py` and deploy it with this change using `MODAL_SYNC_ENTRYPOINT=1`. Then hit it with `hyperfine` and observe the execution times in the app's logs. 

`hyperfine -N --runs 100 'curl https://thundergolfer--highfreq-webhook-synthetic-monitor-webhook.modal-dev.run'`

### Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


## Changelog

* Performance optimization to web endpoints, reducing 5-10ms of overhead.
