### PR TITLE
add concurrency to reduce web endpoint latency

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -554,9 +554,9 @@ def call_function_sync(
                         item_count += 1
 
                     function_io_manager._queue_put(generator_queue, _FunctionIOManager._GENERATOR_STOP_SENTINEL)
-                    generator_output_task.result()  # Wait to finish sending generator outputs.
                     message = api_pb2.GeneratorDone(items_total=item_count)
                     function_io_manager.push_output(input_id, started_at, message, api_pb2.DATA_FORMAT_GENERATOR_DONE)
+                    generator_output_task.result()  # Wait to finish sending generator outputs.
                 else:
                     if inspect.iscoroutine(res) or inspect.isgenerator(res) or inspect.isasyncgen(res):
                         raise InvalidError(

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -618,7 +618,6 @@ async def call_function_async(
                         await function_io_manager._queue_put.aio(generator_queue, value)
                         item_count += 1
 
-                    message = api_pb2.GeneratorDone(items_total=item_count)
                     await function_io_manager._queue_put.aio(
                         generator_queue, _FunctionIOManager._GENERATOR_STOP_SENTINEL
                     )
@@ -629,6 +628,7 @@ async def call_function_async(
                     # Backend should not rely on a happens-before relationship between the
                     # last item and the 'generator done' message, only that the latter message
                     # will correctly report the total number of items to receive.
+                    message = api_pb2.GeneratorDone(items_total=item_count)
                     await asyncio.gather(
                         generator_output_task,
                         function_io_manager.push_output.aio(

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -619,19 +619,17 @@ async def call_function_async(
                         item_count += 1
 
                     message = api_pb2.GeneratorDone(items_total=item_count)
+                    await function_io_manager._queue_put.aio(
+                        generator_queue, _FunctionIOManager._GENERATOR_STOP_SENTINEL
+                    )
                     # Concurrently:
-                    #
-                    # 1. put stop sentinel to complete the generator outputs sending task
-                    # 2. wait to finish sending generator outputs
-                    # 3. send 'generator done' message with total item count
+                    # 1. wait to finish sending generator outputs
+                    # 2. send 'generator done' message with total item count
                     #
                     # Backend should not rely on a happens-before relationship between the
                     # last item and the 'generator done' message, only that the latter message
                     # will correctly report the total number of items to receive.
                     await asyncio.gather(
-                        function_io_manager._queue_put.aio(
-                            generator_queue, _FunctionIOManager._GENERATOR_STOP_SENTINEL
-                        ),
                         generator_output_task,
                         function_io_manager.push_output.aio(
                             input_id, started_at, message, api_pb2.DATA_FORMAT_GENERATOR_DONE


### PR DESCRIPTION
## Describe your changes


- In **local dev**, this reduces the high freq web endpoint's execution latency from ~9ms to ~3ms (66% latency reduction).  
- In **dev cluster**, this reduces the high freq web endpoint's execution latency from ~25ms to ~3ms (**88%** latency reduction). 
    - We can expect similar results in prod

### Repro

Take the highfreq `webhook.py` and deploy it with this change using `MODAL_SYNC_ENTRYPOINT=1`. Then hit it with `hyperfine` and observe the execution times in the app's logs. e.g.

`hyperfine -N --runs 100 'curl https://thundergolfer--highfreq-webhook-synthetic-monitor-webhook.modal-dev.run'`

### Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


## Changelog

* Performance optimization to web endpoints, reducing 5-10ms of overhead.