### PR TITLE
Add types to modal_version and modal_utils

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -196,7 +196,7 @@ async def _stream_function_call_data(
     while True:
         req = api_pb2.FunctionCallGetDataRequest(function_call_id=function_call_id, last_index=last_index)
         try:
-            async for chunk in unary_stream(stub_fn, req):
+            async for chunk in unary_stream(stub_fn, req):  # type: ignore[var-annotated]
                 if chunk.index <= last_index:
                     continue
                 last_index = chunk.index

--- a/tasks.py
+++ b/tasks.py
@@ -43,6 +43,18 @@ def lint(ctx):
 def mypy(ctx):
     mypy_allowlist = [
         "modal/functions.py",
+        "modal_utils/__init__.py",
+        "modal_utils/app_utils.py",
+        "modal_utils/async_utils.py",
+        "modal_utils/grpc_testing.py",
+        "modal_utils/grpc_utils.py",
+        "modal_utils/hash_utils.py",
+        "modal_utils/http_utils.py",
+        "modal_utils/logger.py",
+        "modal_utils/package_utils.py",
+        "modal_utils/rand_pb_testing.py",
+        "modal_version/__init__.py",
+        "modal_version/_version_generated.py",
     ]
 
     ctx.run("mypy .", pty=True)


### PR DESCRIPTION
## Describe your changes

This PR adds mypy types to `modal_version` and `modal_utils`, as per https://github.com/modal-labs/modal-client/issues/1372.

```
modal_utils/__init__.py
modal_utils/app_utils.py
modal_utils/async_utils.py
modal_utils/grpc_testing.py
modal_utils/grpc_utils.py
modal_utils/hash_utils.py
modal_utils/http_utils.py
modal_utils/logger.py
modal_utils/package_utils.py
modal_utils/rand_pb_testing.py
modal_version/__init__.py
modal_version/_version_generated.py
```