### PR TITLE
[MOD-2343] volume support for sandboxes and 'modal shell'

### DIFF
--- a/modal/_container_exec.py
+++ b/modal/_container_exec.py
@@ -22,7 +22,9 @@ from modal_utils.async_utils import TaskContext, asyncify
 from modal_utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES, retry_transient_errors, unary_stream
 
 
-async def container_exec(task_id: str, command: List[str], *, pty: bool, client: _Client):
+async def container_exec(
+    task_id: str, command: List[str], *, pty: bool, client: _Client, terminate_container_on_exit: bool = False
+):
     """Execute a command inside an active container"""
     if platform.system() == "Windows":
         print("container exec is not currently supported on Windows.")
@@ -37,7 +39,10 @@ async def container_exec(task_id: str, command: List[str], *, pty: bool, client:
     try:
         res: api_pb2.ContainerExecResponse = await client.stub.ContainerExec(
             api_pb2.ContainerExecRequest(
-                task_id=task_id, command=command, pty_info=get_pty_info(shell=True) if pty else None
+                task_id=task_id,
+                command=command,
+                pty_info=get_pty_info(shell=True) if pty else None,
+                terminate_container_on_exit=terminate_container_on_exit,
             )
         )
     except GRPCError as err:

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -376,14 +376,9 @@ def shell(
         assert isinstance(function, Function)
         function_env: FunctionEnv = function.env
         if any(isinstance(v, _Volume) for v in function_env.volumes.values()):
-            if function_env.allow_background_volume_commits:
-                print(
-                    "Warning: allow_background_volume_commits with `modal shell` is still in beta. Please verify that any changes to volumes have committed successfully (ex. by launching another shell and checking that all modified files are there) before exiting."
-                )
-            else:
-                print(
-                    "Warning: changes to volumes in `modal shell` will not persist after exiting. Use _allow_background_volume_commits=True to persist changes."
-                )
+            print(
+                "Warning: please verify that any changes to volumes have committed successfully (ex. by launching another shell and checking that all modified files are there) before exiting."
+            )
         start_shell = partial(
             interactive_shell,
             image=function_env.image,
@@ -395,7 +390,7 @@ def shell(
             cpu=function_env.cpu,
             memory=function_env.memory,
             volumes=function_env.volumes,
-            _allow_background_volume_commits=function_env.allow_background_volume_commits,
+            _allow_background_volume_commits=True,
         )
     else:
         modal_image = Image.from_registry(image, add_python=add_python) if image else None

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -378,10 +378,12 @@ def shell(
         if any(isinstance(v, _Volume) for v in function_env.volumes.values()):
             if function_env.allow_background_volume_commits:
                 print(
-                    "Warning: allow_background_volume_commits with `modal shell` is still in beta. Please verify that any modifications you make to mounted volumes have successfully been committed before exiting."
+                    "Warning: allow_background_volume_commits with `modal shell` is still in beta. Please verify that any changes to volumes have committed successfully (ex. by launching another shell and checking that all modified files are there) before exiting."
                 )
             else:
-                print("Warning: changes to volumes in `modal shell` will not persist after exit.")
+                print(
+                    "Warning: changes to volumes in `modal shell` will not persist after exiting. Use _allow_background_volume_commits=True to persist changes."
+                )
         start_shell = partial(
             interactive_shell,
             image=function_env.image,

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -375,10 +375,10 @@ def shell(
         function = import_function(func_ref, accept_local_entrypoint=False, accept_webhook=True, base_cmd="modal shell")
         assert isinstance(function, Function)
         function_env: FunctionEnv = function.env
-        if any(isinstance(v, _Volume) for v in function_env.volumes):
-            if function_env._allow_background_volume_commits:
+        if any(isinstance(v, _Volume) for v in function_env.volumes.values()):
+            if function_env.allow_background_volume_commits:
                 print(
-                    "Warning: _allow_background_volume_commits with `modal shell` is still in beta. Changes in mounted volumes may not persist after exit."
+                    "Warning: allow_background_volume_commits with `modal shell` is still in beta. Please verify that any modifications you make to mounted volumes have successfully been committed before exiting."
                 )
             else:
                 print("Warning: changes to volumes in `modal shell` will not persist after exit.")

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -13,8 +13,6 @@ import typer
 from rich.console import Console
 from typing_extensions import TypedDict
 
-from modal.volume import _Volume
-
 from ..config import config
 from ..environments import ensure_env
 from ..exception import ExecutionError, InvalidError
@@ -375,10 +373,6 @@ def shell(
         function = import_function(func_ref, accept_local_entrypoint=False, accept_webhook=True, base_cmd="modal shell")
         assert isinstance(function, Function)
         function_env: FunctionEnv = function.env
-        if any(isinstance(v, _Volume) for v in function_env.volumes.values()):
-            print(
-                "Warning: please verify that any changes to volumes have committed successfully (ex. by launching another shell and checking that all modified files are there) before exiting."
-            )
         start_shell = partial(
             interactive_shell,
             image=function_env.image,

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -531,6 +531,7 @@ class FunctionEnv:
     secrets: Sequence[_Secret]
     network_file_systems: Dict[Union[str, PurePosixPath], _NetworkFileSystem]
     volumes: Dict[Union[str, os.PathLike], Union[_Volume, _S3Mount]]
+    allow_background_volume_commits: bool
     gpu: GPU_T
     cloud: Optional[str]
     cpu: Optional[float]
@@ -634,6 +635,7 @@ class _Function(_Object, type_prefix="fu"):
             gpu=gpu,
             network_file_systems=network_file_systems,
             volumes=volumes,
+            allow_background_volume_commits=allow_background_volume_commits,
             image=image,
             cloud=cloud,
             cpu=cpu,

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -531,7 +531,6 @@ class FunctionEnv:
     secrets: Sequence[_Secret]
     network_file_systems: Dict[Union[str, PurePosixPath], _NetworkFileSystem]
     volumes: Dict[Union[str, os.PathLike], Union[_Volume, _S3Mount]]
-    allow_background_volume_commits: bool
     gpu: GPU_T
     cloud: Optional[str]
     cpu: Optional[float]
@@ -635,7 +634,6 @@ class _Function(_Object, type_prefix="fu"):
             gpu=gpu,
             network_file_systems=network_file_systems,
             volumes=volumes,
-            allow_background_volume_commits=allow_background_volume_commits,
             image=image,
             cloud=cloud,
             cpu=cpu,

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -323,7 +323,7 @@ async def _interactive_shell(_stub: _Stub, cmd: List[str], environment_name: str
             return
 
         loading_status.stop()
-        await container_exec(task_id, cmd, pty=True, client=client)
+        await container_exec(task_id, cmd, pty=True, client=client, terminate_container_on_exit=True)
 
 
 run_stub = synchronize_api(_run_stub)

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -119,8 +119,8 @@ class _Sandbox(_Object, type_prefix="sb"):
         memory: Optional[int] = None,
         network_file_systems: Dict[Union[str, os.PathLike], _NetworkFileSystem] = {},
         block_network: bool = False,
-        # Note: Only _S3Mounts are supported right now.
         volumes: Dict[Union[str, os.PathLike], Union[_Volume, _S3Mount]] = {},
+        allow_background_volume_commits: bool = False,
     ) -> "_Sandbox":
         """mdmd:hidden"""
 
@@ -136,12 +136,11 @@ class _Sandbox(_Object, type_prefix="sb"):
         s3_mounts = [(k, v) for k, v in validated_volumes if isinstance(v, _S3Mount)]
         validated_volumes = [(k, v) for k, v in validated_volumes if isinstance(v, _Volume)]
 
-        if len(validated_volumes) > 0:
-            raise InvalidError("sandboxes currently only support S3Mount volumes")
-
         def _deps() -> List[_Object]:
             deps: List[_Object] = [image] + list(mounts) + list(secrets)
             for _, vol in validated_network_file_systems:
+                deps.append(vol)
+            for _, vol in validated_volumes:
                 deps.append(vol)
             for _, s3_mount in s3_mounts:
                 if s3_mount.secret:
@@ -157,6 +156,16 @@ class _Sandbox(_Object, type_prefix="sb"):
                 raise InvalidError(f"Invalid fractional CPU value {cpu}. Cannot have less than 0.25 CPU resources.")
             milli_cpu = int(1000 * cpu) if cpu is not None else None
 
+            # Relies on dicts being ordered (true as of Python 3.6).
+            volume_mounts = [
+                api_pb2.VolumeMount(
+                    mount_path=path,
+                    volume_id=volume.object_id,
+                    allow_background_commits=allow_background_volume_commits,
+                )
+                for path, volume in validated_volumes
+            ]
+
             definition = api_pb2.Sandbox(
                 entrypoint_args=entrypoint_args,
                 image_id=image.object_id,
@@ -170,6 +179,7 @@ class _Sandbox(_Object, type_prefix="sb"):
                 runtime_debug=config.get("function_runtime_debug"),
                 block_network=block_network,
                 s3_mounts=s3_mounts_to_proto(s3_mounts),
+                volume_mounts=volume_mounts,
             )
 
             create_req = api_pb2.SandboxCreateRequest(app_id=resolver.app_id, definition=definition)

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -30,7 +30,6 @@ from .partial_function import PartialFunction, _PartialFunction
 from .proxy import _Proxy
 from .retries import Retries
 from .runner import _run_stub
-from .s3mount import _S3Mount
 from .sandbox import _Sandbox
 from .schedule import Schedule
 from .secret import _Secret
@@ -663,7 +662,7 @@ class _Stub:
         cpu: Optional[float] = None,  # How many CPU cores to request. This is a soft limit.
         memory: Optional[int] = None,  # How much memory to request, in MiB. This is a soft limit.
         block_network: bool = False,  # Whether to block network access
-        volumes: Dict[Union[str, os.PathLike], _S3Mount] = {},  # Volumes to mount in the sandbox.
+        volumes: Dict[Union[str, os.PathLike], _Volume] = {},  # Volumes to mount in the sandbox.
         _allow_background_volume_commits: bool = False,
     ) -> _Sandbox:
         """Sandboxes are a way to run arbitrary commands in dynamically defined environments.

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -663,9 +663,8 @@ class _Stub:
         cpu: Optional[float] = None,  # How many CPU cores to request. This is a soft limit.
         memory: Optional[int] = None,  # How much memory to request, in MiB. This is a soft limit.
         block_network: bool = False,  # Whether to block network access
-        volumes: Dict[
-            Union[str, os.PathLike], _S3Mount
-        ] = {},  # Volumes to mount in the sandbox. Currently, only S3 mounts are supported in sandboxes.
+        volumes: Dict[Union[str, os.PathLike], _S3Mount] = {},  # Volumes to mount in the sandbox.
+        _allow_background_volume_commits: bool = False,
     ) -> _Sandbox:
         """Sandboxes are a way to run arbitrary commands in dynamically defined environments.
 
@@ -703,6 +702,7 @@ class _Stub:
             network_file_systems=network_file_systems,
             block_network=block_network,
             volumes=volumes,
+            allow_background_volume_commits=_allow_background_volume_commits,
         )
         await resolver.load(obj)
         return obj


### PR DESCRIPTION
## Describe your changes

Fixing `modal shell`'s ability to interact with volumes.

This PR relies on merging a server-side PR to support 'commit on exit'.

## Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
    - API change was merged yesterday, all servers have been rolled over
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


## Changelog

- Support attaching `modal.Volume` volumes to `modal.Sandbox` containers.
