### PR TITLE
perf: remove 1 FunctionCallPutDataRequest RPC request from webhooks

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -202,6 +202,10 @@ class _FunctionIOManager:
             message = await message_rx.get()
             if message is self._GENERATOR_STOP_SENTINEL:
                 break
+            # ASGI 'http.response.start' and 'http.response.body' msgs are observed to be separated by 1ms.
+            # If we don't sleep here for 1ms we end up with an extra call to .put_data_out().
+            if index == 1:
+                await asyncio.sleep(0.001)
             messages_bytes = [serialize_data_format(message, data_format)]
             total_size = len(messages_bytes[0]) + 512
             while total_size < 16 * 1024 * 1024:  # 16 MiB, maximum size in a single message


### PR DESCRIPTION
### Describe your changes

Example of the ~1ms latency between ASGI messages:

```
# Emitting from asgi_app_wrapper
1708486469.33347 msg={'type': 'http.response.start', 'status': 200, 'headers': [(b'content-length', b'14'), (b'content-type', b'application/json')]}    GET / -> 200 OK  (duration: 1.75 s)
1708486469.33355 msg={'type': 'http.response.body', 'body': b'{"name":"foo"}'}
# Emitting from `async for value in res
1708486469.33368 value={'type': 'http.response.start', 'status': 200, 'headers': [(b'content-length', b'14'), (b'content-type', b'application/json')]}
1708486469.33480 value={'type': 'http.response.body', 'body': b'{"name":"foo"}'}
```

☝️ body emitted 1.12ms later, even though it was pushed out of the wrapper only 0.08ms later

