### PR TITLE
Deprecate dunder-hooks for class lifecycle methods

### DIFF
--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -115,7 +115,7 @@ def _find_callables_for_cls(user_cls: Type, flags: _PartialFunctionFlags) -> Dic
         if hasattr(user_cls, attr):
             suggested = attr.strip("_")
             if is_async := suggested.startswith("a"):
-                suggested = f"{suggested[1:]}"
+                suggested = suggested[1:]
             async_suggestion = " (on an async method)" if is_async else ""
             message = (
                 f"Using `{attr}` methods for class lifecycle management is deprecated."

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -113,7 +113,7 @@ def _find_callables_for_cls(user_cls: Type, flags: _PartialFunctionFlags) -> Dic
     # Grab legacy lifecycle methods
     for attr in check_attrs:
         if hasattr(user_cls, attr):
-            suggested = attr.strip("__")
+            suggested = attr.strip("_")
             if is_async := suggested.startswith("a"):
                 suggested = f"{suggested[1:]}"
             async_suggestion = " (on an async method)" if is_async else ""

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -1,5 +1,6 @@
 # Copyright Modal Labs 2023
 import enum
+from datetime import date
 from typing import (
     Any,
     Callable,
@@ -16,7 +17,7 @@ from modal_proto import api_pb2
 from modal_utils.async_utils import synchronize_api, synchronizer
 
 from .config import logger
-from .exception import InvalidError
+from .exception import InvalidError, deprecation_warning
 from .functions import _Function
 
 
@@ -112,6 +113,16 @@ def _find_callables_for_cls(user_cls: Type, flags: _PartialFunctionFlags) -> Dic
     # Grab legacy lifecycle methods
     for attr in check_attrs:
         if hasattr(user_cls, attr):
+            suggested = attr.strip("__")
+            if is_async := suggested.startswith("a"):
+                suggested = f"{suggested[1:]}"
+            async_suggestion = " (on an async method)" if is_async else ""
+            message = (
+                f"Using `{attr}` methods for class lifecycle management is deprecated."
+                f" Please try using the `modal.{suggested}` decorator{async_suggestion} instead."
+                " See https://modal.com/docs/guide/lifecycle-functions for more information."
+            )
+            deprecation_warning(date(2024, 2, 20), message, show_source=True)
             functions[attr] = getattr(user_cls, attr)
 
     # Grab new decorator-based methods

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -122,7 +122,7 @@ def _find_callables_for_cls(user_cls: Type, flags: _PartialFunctionFlags) -> Dic
                 f" Please try using the `modal.{suggested}` decorator{async_suggestion} instead."
                 " See https://modal.com/docs/guide/lifecycle-functions for more information."
             )
-            deprecation_warning(date(2024, 2, 20), message, show_source=True)
+            deprecation_warning(date(2024, 2, 21), message, show_source=True)
             functions[attr] = getattr(user_cls, attr)
 
     # Grab new decorator-based methods

--- a/modal_test_support/base_class.py
+++ b/modal_test_support/base_class.py
@@ -1,9 +1,10 @@
 # Copyright Modal Labs 2022
-from modal import method
+from modal import enter, method
 
 
 class BaseCls2:
-    def __enter__(self):
+    @enter()
+    def enter(self):
         self.x = 2
 
     @method()

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -147,7 +147,8 @@ class Cls:
     def __init__(self):
         self._k = 11
 
-    def __enter__(self):
+    @enter()
+    def enter(self):
         self._k += 100
 
     @method()
@@ -211,7 +212,8 @@ def unassociated_function(x):
 
 
 class BaseCls:
-    def __enter__(self):
+    @enter()
+    def enter(self):
         self.x = 2
 
     @method()

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -29,6 +29,7 @@ from modal._serialization import (
     serialize_data_format,
 )
 from modal.exception import InvalidError
+from modal.partial_function import enter
 from modal.stub import _Stub
 from modal_proto import api_pb2
 
@@ -518,7 +519,8 @@ def test_cls_web_endpoint(unix_servicer, event_loop):
 @skip_windows_unix_socket
 def test_serialized_cls(unix_servicer, event_loop):
     class Cls:
-        def __enter__(self):
+        @enter()
+        def enter(self):
             self.power = 5
 
         def method(self, x):

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -7,7 +7,7 @@ from tempfile import NamedTemporaryFile
 from typing import List
 from unittest import mock
 
-from modal import Image, Mount, NetworkFileSystem, Secret, Stub, gpu, method
+from modal import Image, Mount, NetworkFileSystem, Secret, Stub, build, gpu, method
 from modal.exception import DeprecationError, InvalidError, NotFoundError
 from modal.image import _dockerhub_python_version, _get_client_requirements_path
 from modal_proto import api_pb2
@@ -475,7 +475,8 @@ VARIABLE_6 = 1
     secrets=[Secret.from_dict({"xyz": "123"})],
 )
 class Foo:
-    def __build__(self):
+    @build()
+    def build_func(self):
         global VARIABLE_5
 
         print("foo!", VARIABLE_5)
@@ -499,13 +500,13 @@ def test_image_build_snapshot(client, servicer):
         globals = layers[0].build_function_globals
         assert b"VARIABLE_5" in globals
 
-        # Globals and def for the main function should not affect __enter__.
+        # Globals and def for the main function should not affect build step.
         assert "bar!" not in layers[0].build_function_def
         assert b"VARIABLE_6" not in globals
 
     function_id = servicer.image_build_function_ids[image_id]
     assert function_id
-    assert servicer.app_functions[function_id].function_name == "Foo.__build__"
+    assert servicer.app_functions[function_id].function_name == "Foo.build_func"
     assert len(servicer.app_functions[function_id].secret_ids) == 1
 
 


### PR DESCRIPTION
## Describe your changes

- Resolves MOD-2405

## Changelog

- The "dunder method" approach for class lifecycle management (`__build__`, `__enter__`, `__exit__`, etc.) is now deprecated in favor of the modal `@build`, `@enter`, and `@exit` decorators.