### PR TITLE
Simplify type signatures for deprecation_warning and deprecation_error

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -1,5 +1,4 @@
 # Copyright Modal Labs 2022
-from datetime import date
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypeVar
 
 from google.protobuf.message import Message
@@ -285,9 +284,7 @@ class _ContainerApp:
         deprecation_error((2023, 8, 10), "`app[...]` is no longer supported. Use the stub to get objects instead.")
 
     def __contains__(self, tag: str) -> bool:
-        deprecation_error(
-            date(2023, 8, 10), "`obj in app` is no longer supported. Use the stub to get objects instead."
-        )
+        deprecation_error((2023, 8, 10), "`obj in app` is no longer supported. Use the stub to get objects instead.")
 
     def __getattr__(self, tag: str) -> _Object:
         if tag.startswith("__"):

--- a/modal/app.py
+++ b/modal/app.py
@@ -144,17 +144,15 @@ class _LocalApp:
         return self._app_page_url
 
     def __getitem__(self, tag: str) -> _Object:
-        deprecation_error(date(2023, 8, 10), "`app[...]` is no longer supported. Use the stub to get objects instead.")
+        deprecation_error((2023, 8, 10), "`app[...]` is no longer supported. Use the stub to get objects instead.")
 
     def __contains__(self, tag: str) -> bool:
-        deprecation_error(
-            date(2023, 8, 10), "`obj in app` is no longer supported. Use the stub to get objects instead."
-        )
+        deprecation_error((2023, 8, 10), "`obj in app` is no longer supported. Use the stub to get objects instead.")
 
     def __getattr__(self, tag: str) -> _Object:
         if tag.startswith("__"):
             raise AttributeError(f"No such attribute `{tag}`")  # Dumb workaround for doc thing
-        deprecation_error(date(2023, 8, 10), "`app.obj` is no longer supported. Use the stub to get objects instead.")
+        deprecation_error((2023, 8, 10), "`app.obj` is no longer supported. Use the stub to get objects instead.")
 
     @staticmethod
     async def _init_existing(client: _Client, existing_app_id: str) -> "_LocalApp":
@@ -232,7 +230,7 @@ class _LocalApp:
         **kwargs,
     ):
         """Deprecated. Use `Stub.spawn_sandbox` instead."""
-        deprecation_error(date(2023, 9, 11), _LocalApp.spawn_sandbox.__doc__)
+        deprecation_error((2023, 9, 11), _LocalApp.spawn_sandbox.__doc__)
 
 
 class _ContainerApp:
@@ -284,7 +282,7 @@ class _ContainerApp:
                     obj._hydrate(object_id, self._client, handle_metadata)
 
     def __getitem__(self, tag: str) -> _Object:
-        deprecation_error(date(2023, 8, 10), "`app[...]` is no longer supported. Use the stub to get objects instead.")
+        deprecation_error((2023, 8, 10), "`app[...]` is no longer supported. Use the stub to get objects instead.")
 
     def __contains__(self, tag: str) -> bool:
         deprecation_error(
@@ -294,7 +292,7 @@ class _ContainerApp:
     def __getattr__(self, tag: str) -> _Object:
         if tag.startswith("__"):
             raise AttributeError(f"No such attribute `{tag}`")  # Dumb workaround for doc thing
-        deprecation_error(date(2023, 8, 10), "`app.obj` is no longer supported. Use the stub to get objects instead.")
+        deprecation_error((2023, 8, 10), "`app.obj` is no longer supported. Use the stub to get objects instead.")
 
     def _has_object(self, tag: str) -> bool:
         return tag in self._tag_to_object_id
@@ -342,7 +340,7 @@ class _ContainerApp:
         **kwargs,
     ):
         """Deprecated. Use `Stub.spawn_sandbox` instead."""
-        deprecation_error(date(2023, 9, 11), _ContainerApp.spawn_sandbox.__doc__)
+        deprecation_error((2023, 9, 11), _ContainerApp.spawn_sandbox.__doc__)
 
     @staticmethod
     def _reset_container():

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -37,7 +37,7 @@ T = TypeVar("T")
 
 class ClsMixin:
     def __init_subclass__(cls):
-        deprecation_error(date(2023, 9, 1), "`ClsMixin` is deprecated and can be safely removed.")
+        deprecation_error((2023, 9, 1), "`ClsMixin` is deprecated and can be safely removed.")
 
 
 def check_picklability(key, arg):

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2022
 import os
 import pickle
-from datetime import date
 from typing import Any, Callable, Collection, Dict, List, Optional, Type, TypeVar, Union
 
 from google.protobuf.message import Message
@@ -340,9 +339,7 @@ class _Cls(_Object, type_prefix="cs"):
         )
 
     async def remote(self, *args, **kwargs):
-        deprecation_error(
-            date(2023, 9, 1), "`Cls.remote(...)` on classes is deprecated. Use the constructor: `Cls(...)`."
-        )
+        deprecation_error((2023, 9, 1), "`Cls.remote(...)` on classes is deprecated. Use the constructor: `Cls(...)`.")
 
     def __getattr__(self, k):
         # Used by CLI and container entrypoint

--- a/modal/config.py
+++ b/modal/config.py
@@ -75,7 +75,6 @@ import logging
 import os
 import typing
 import warnings
-from datetime import date
 from textwrap import dedent
 from typing import Any, Dict, Optional
 
@@ -157,11 +156,11 @@ def _check_config() -> None:
             This will become an error in a future update.
             """
         )
-        deprecation_warning(date(2024, 2, 6), message, show_source=False)
+        deprecation_warning((2024, 2, 6), message, show_source=False)
 
 
 if "MODAL_ENV" in os.environ:
-    deprecation_error(date(2023, 5, 24), "MODAL_ENV has been replaced with MODAL_PROFILE")
+    deprecation_error((2023, 5, 24), "MODAL_ENV has been replaced with MODAL_PROFILE")
 
 _profile = os.environ.get("MODAL_PROFILE") or _config_active_profile()
 

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -1,5 +1,4 @@
 # Copyright Modal Labs 2022
-from datetime import date
 from typing import Any, Optional
 
 from modal_proto import api_pb2
@@ -71,7 +70,7 @@ class _Dict(_Object, type_prefix="di"):
 
     def __init__(self, data={}):
         """mdmd:hidden"""
-        deprecation_error(date(2023, 6, 27), "`Dict({...})` is deprecated. Please use `Dict.new({...})` instead.")
+        deprecation_error((2023, 6, 27), "`Dict({...})` is deprecated. Please use `Dict.new({...})` instead.")
         obj = _Dict.new(data)
         self._init_from_other(obj)
 

--- a/modal/exception.py
+++ b/modal/exception.py
@@ -4,6 +4,7 @@ import signal
 import sys
 import warnings
 from datetime import date
+from typing import Tuple
 
 
 class Error(Exception):
@@ -95,12 +96,12 @@ def _is_internal_frame(frame):
     return module in _INTERNAL_MODULES
 
 
-def deprecation_error(deprecated_on: tuple[int, int, int], msg: str):
+def deprecation_error(deprecated_on: Tuple[int, int, int], msg: str):
     raise DeprecationError(f"Deprecated on {date(*deprecated_on)}: {msg}")
 
 
 def deprecation_warning(
-    deprecated_on: tuple[int, int, int], msg: str, pending: bool = False, show_source: bool = True
+    deprecated_on: Tuple[int, int, int], msg: str, pending: bool = False, show_source: bool = True
 ) -> None:
     """Utility for getting the proper stack entry.
 

--- a/modal/exception.py
+++ b/modal/exception.py
@@ -95,11 +95,13 @@ def _is_internal_frame(frame):
     return module in _INTERNAL_MODULES
 
 
-def deprecation_error(deprecated_on: date, msg: str):
-    raise DeprecationError(f"Deprecated on {deprecated_on}: {msg}")
+def deprecation_error(deprecated_on: tuple[int, int, int], msg: str):
+    raise DeprecationError(f"Deprecated on {date(*deprecated_on)}: {msg}")
 
 
-def deprecation_warning(deprecated_on: date, msg: str, pending: bool = False, show_source: bool = True) -> None:
+def deprecation_warning(
+    deprecated_on: tuple[int, int, int], msg: str, pending: bool = False, show_source: bool = True
+) -> None:
     """Utility for getting the proper stack entry.
 
     See the implementation of the built-in [warnings.warn](https://docs.python.org/3/library/warnings.html#available-functions).
@@ -120,7 +122,7 @@ def deprecation_warning(deprecated_on: date, msg: str, pending: bool = False, sh
     warning_cls: type = PendingDeprecationError if pending else DeprecationError
 
     # This is a lower-level function that warnings.warn uses
-    warnings.warn_explicit(f"{deprecated_on}: {msg}", warning_cls, filename, lineno)
+    warnings.warn_explicit(f"{date(*deprecated_on)}: {msg}", warning_cls, filename, lineno)
 
 
 def _simulate_preemption_interrupt(signum, frame):

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -7,7 +7,6 @@ import time
 import warnings
 from contextvars import ContextVar
 from dataclasses import dataclass
-from datetime import date
 from pathlib import PurePosixPath
 from typing import (
     TYPE_CHECKING,
@@ -605,7 +604,7 @@ class _Function(_Object, type_prefix="fu"):
 
         if secret is not None:
             deprecation_warning(
-                date(2024, 1, 31),
+                (2024, 1, 31),
                 "The singular `secret` parameter is deprecated. Pass a list to `secrets` instead.",
             )
             secrets = [secret, *secrets]
@@ -1267,11 +1266,9 @@ class _Function(_Object, type_prefix="fu"):
         """Deprecated. Use `f.remote` or `f.remote_gen` instead."""
         # TODO: Generics/TypeVars
         if self._is_generator:
-            deprecation_error(
-                date(2023, 8, 16), "`f.call(...)` is deprecated. It has been renamed to `f.remote_gen(...)`"
-            )
+            deprecation_error((2023, 8, 16), "`f.call(...)` is deprecated. It has been renamed to `f.remote_gen(...)`")
         else:
-            deprecation_error(date(2023, 8, 16), "`f.call(...)` is deprecated. It has been renamed to `f.remote(...)`")
+            deprecation_error((2023, 8, 16), "`f.call(...)` is deprecated. It has been renamed to `f.remote(...)`")
 
     @synchronizer.no_io_translation
     @live_method
@@ -1337,13 +1334,13 @@ class _Function(_Object, type_prefix="fu"):
     def __call__(self, *args, **kwargs) -> Any:  # TODO: Generics/TypeVars
         if self._get_is_remote_cls_method():
             deprecation_error(
-                date(2023, 9, 1),
+                (2023, 9, 1),
                 "Calling remote class methods like `obj.f(...)` is deprecated. Use `obj.f.remote(...)` for remote calls"
                 " and `obj.f.local(...)` for local calls",
             )
         else:
             deprecation_error(
-                date(2023, 8, 16),
+                (2023, 8, 16),
                 "Calling Modal functions like `f(...)` is deprecated. Use `f.local(...)` if you want to call the"
                 " function in the same Python process. Use `f.remote(...)` if you want to call the function in"
                 " a Modal container in the cloud",

--- a/modal/gpu.py
+++ b/modal/gpu.py
@@ -1,6 +1,5 @@
 # Copyright Modal Labs 2022
 from dataclasses import dataclass
-from datetime import date
 from typing import Optional, Union
 
 from modal_proto import api_pb2
@@ -213,12 +212,12 @@ def _parse_gpu_config(value: GPU_T, raise_on_true: bool = True) -> Optional[_GPU
     elif value is True:
         if raise_on_true:
             deprecation_error(
-                date(2022, 12, 19), 'Setting gpu=True is deprecated. Use `gpu="any"` or `gpu=modal.gpu.Any()` instead.'
+                (2022, 12, 19), 'Setting gpu=True is deprecated. Use `gpu="any"` or `gpu=modal.gpu.Any()` instead.'
             )
         else:
             # We didn't support targeting a GPU type for run_function until 2023-12-12
             deprecation_warning(
-                date(2023, 12, 13), 'Setting gpu=True is deprecated. Use `gpu="any"` or `gpu=modal.gpu.Any()` instead.'
+                (2023, 12, 13), 'Setting gpu=True is deprecated. Use `gpu="any"` or `gpu=modal.gpu.Any()` instead.'
             )
         return Any()
     elif value is None or value is False:

--- a/modal/image.py
+++ b/modal/image.py
@@ -5,7 +5,6 @@ import shlex
 import sys
 import typing
 import warnings
-from datetime import date
 from inspect import isfunction
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
@@ -1037,9 +1036,7 @@ class _Image(_Object, type_prefix="im"):
         **kwargs,
     ):
         """`Image.from_dockerhub` is deprecated. Use `Image.from_registry` instead."""
-        deprecation_error(
-            date(2023, 8, 25), "`Image.from_dockerhub` is deprecated. Use `Image.from_registry` instead."
-        )
+        deprecation_error((2023, 8, 25), "`Image.from_dockerhub` is deprecated. Use `Image.from_registry` instead.")
 
     @staticmethod
     @typechecked
@@ -1403,7 +1400,7 @@ class _Image(_Object, type_prefix="im"):
             import torch
         ```
         """
-        deprecation_warning(date(2023, 12, 15), Image.run_inside.__doc__)
+        deprecation_warning((2023, 12, 15), Image.run_inside.__doc__)
         return self.imports()
 
 

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -7,7 +7,6 @@ import functools
 import os
 import time
 import typing
-from datetime import date
 from pathlib import Path, PurePosixPath
 from typing import AsyncGenerator, Callable, List, Optional, Sequence, Tuple, Type, Union
 
@@ -538,7 +537,7 @@ _create_package_mounts_deprecation_msg = (
 def _create_package_mounts(module_names: Sequence[str]):
     f"""{_create_package_mounts_deprecation_msg}"""
     modal.exception.deprecation_error(
-        date(2023, 7, 19),
+        (2023, 7, 19),
         _create_package_mounts_deprecation_msg,
     )
 

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2023
 import os
 import time
-from datetime import date
 from pathlib import Path, PurePosixPath
 from typing import AsyncIterator, BinaryIO, List, Optional, Tuple, Union
 
@@ -97,7 +96,7 @@ class _NetworkFileSystem(_StatefulObject, type_prefix="sv"):
                 return
 
             if cloud:
-                deprecation_warning(date(2024, 1, 17), "Argument `cloud` is deprecated (has no effect).")
+                deprecation_warning((2024, 1, 17), "Argument `cloud` is deprecated (has no effect).")
 
             status_row.message("Creating network file system...")
             req = api_pb2.SharedVolumeCreateRequest(app_id=resolver.app_id)

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -1,6 +1,5 @@
 # Copyright Modal Labs 2023
 import enum
-from datetime import date
 from typing import (
     Any,
     Callable,
@@ -122,7 +121,7 @@ def _find_callables_for_cls(user_cls: Type, flags: _PartialFunctionFlags) -> Dic
                 f" Please try using the `modal.{suggested}` decorator{async_suggestion} instead."
                 " See https://modal.com/docs/guide/lifecycle-functions for more information."
             )
-            deprecation_warning(date(2024, 2, 21), message, show_source=True)
+            deprecation_warning((2024, 2, 21), message, show_source=True)
             functions[attr] = getattr(user_cls, attr)
 
     # Grab new decorator-based methods

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -2,7 +2,6 @@
 import queue  # The system library
 import time
 import warnings
-from datetime import date
 from typing import Any, List, Optional
 
 from grpclib import GRPCError, Status
@@ -58,7 +57,7 @@ class _Queue(_Object, type_prefix="qu"):
 
     def __init__(self):
         """mdmd:hidden"""
-        deprecation_error(date(2023, 6, 27), "`Queue()` is deprecated. Please use `Queue.new()` instead.")
+        deprecation_error((2023, 6, 27), "`Queue()` is deprecated. Please use `Queue.new()` instead.")
         obj = _Queue.new()
         self._init_from_other(obj)
 

--- a/modal/shared_volume.py
+++ b/modal/shared_volume.py
@@ -1,5 +1,4 @@
 # Copyright Modal Labs 2023
-from datetime import date
 
 from modal_utils.async_utils import synchronize_api
 
@@ -9,17 +8,17 @@ from .exception import deprecation_error
 class _SharedVolume:
     def __init__(self, *args, **kwargs):
         """`SharedVolume(...)` is deprecated. Please use `NetworkFileSystem.new(...)` instead."""
-        deprecation_error(date(2023, 7, 5), _SharedVolume.__init__.__doc__)
+        deprecation_error((2023, 7, 5), _SharedVolume.__init__.__doc__)
 
     @staticmethod
     def new(*args, **kwargs):
         """`SharedVolume.new(...)` is deprecated. Please use `NetworkFileSystem.new(...)` instead."""
-        deprecation_error(date(2023, 7, 5), _SharedVolume.new.__doc__)
+        deprecation_error((2023, 7, 5), _SharedVolume.new.__doc__)
 
     @staticmethod
     def persisted(*args, **kwargs):
         """`SharedVolume.persisted(...)` is deprecated. Please use `NetworkFileSystem.persisted(...)` instead."""
-        deprecation_error(date(2023, 7, 5), _SharedVolume.persisted.__doc__)
+        deprecation_error((2023, 7, 5), _SharedVolume.persisted.__doc__)
 
 
 SharedVolume = synchronize_api(_SharedVolume)

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -2,7 +2,6 @@
 import inspect
 import os
 import typing
-from datetime import date
 from pathlib import PurePosixPath
 from typing import Any, AsyncGenerator, Callable, ClassVar, Dict, List, Optional, Sequence, Tuple, Union
 
@@ -156,7 +155,7 @@ class _Stub:
 
         if indexed_objects:
             deprecation_warning(
-                date(2023, 12, 13),
+                (2023, 12, 13),
                 "Passing **kwargs to a stub is deprecated. In most cases, you can just define the objects in global scope.",
             )
 
@@ -195,7 +194,7 @@ class _Stub:
         """`stub.app` is deprecated: use e.g. `stub.obj` instead of `stub.app.obj`
         if you need to access objects on the running app.
         """
-        deprecation_error(date(2023, 9, 11), _Stub.app.__doc__)
+        deprecation_error((2023, 9, 11), _Stub.app.__doc__)
 
     @property
     def app_id(self) -> Optional[str]:
@@ -278,7 +277,7 @@ class _Stub:
             import torch
         ```
         """
-        deprecation_error(date(2023, 11, 8), _Stub.is_inside.__doc__)
+        deprecation_error((2023, 11, 8), _Stub.is_inside.__doc__)
 
     @asynccontextmanager
     async def _set_local_app(self, app: _LocalApp) -> AsyncGenerator[None, None]:
@@ -486,7 +485,7 @@ class _Stub:
 
         if shared_volumes:
             deprecation_error(
-                date(2023, 7, 5),
+                (2023, 7, 5),
                 "`shared_volumes` is deprecated. Use the argument `network_file_systems` instead.",
             )
 
@@ -631,7 +630,7 @@ class _Stub:
 
             if len(cls._functions) > 1 and keep_warm is not None:
                 deprecation_warning(
-                    date(2023, 10, 20),
+                    (2023, 10, 20),
                     "`@stub.cls(keep_warm=...)` is deprecated when there is more than 1 method."
                     " Use `@method(keep_warm=...)` on each method instead!",
                 )

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import asyncio
 import time
-from datetime import date
 
 from modal import (
     Image,
@@ -76,7 +75,7 @@ def gen_n_fail_on_m(n, m):
 
 
 def deprecated_function(x):
-    deprecation_warning(date(2000, 1, 1), "This function is deprecated")
+    deprecation_warning((2000, 1, 1), "This function is deprecated")
     return x**2
 
 


### PR DESCRIPTION
## Describe your changes

Small internal quality-of-life thing: our `deprecation_warning` and `deprecation_error` helpers accept a `date` parameter, and it's annoying to have to import `datetime` when doing a new deprecation. This PR changes the functions to accept `tuple[int, int, int]` and then coerce the data to a `datetime.date` internally.