### PR TITLE
Suppress click/typer context when showing the traceback

### DIFF
--- a/modal/_traceback.py
+++ b/modal/_traceback.py
@@ -204,12 +204,14 @@ def setup_rich_traceback() -> None:
     Traceback._render_stack = _render_stack  # type: ignore
     Traceback.from_exception = _from_exception  # type: ignore
 
+    import click
     import grpclib
     import synchronicity
+    import typer
 
     import modal_utils
 
-    install(suppress=[synchronicity, modal_utils, grpclib], extra_lines=1)
+    install(suppress=[synchronicity, modal_utils, grpclib, click, typer], extra_lines=1)
 
 
 def highlight_modal_deprecation_warnings() -> None:


### PR DESCRIPTION
## Describe your changes

Adds `click` and `typer` to the list of modules that are shown with a minimum amount of context when we print a traceback.

I think there's a a *lot* more we could do to improve the tracebacks that we show. But we already suppress some "wrapper" libraries in our tracebacks and have at least half-a-dozen frames in every traceback just from the CLI, so this is some marginal improvement.

## Changelog

- The amount of context from modal's CLI framework is now reduced when showing a traceback.