### PR TITLE
Disallow stacking lifecycle decorators on top of primary @method

### DIFF
--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -571,7 +571,7 @@ def test_build_image(client, servicer):
 
 @pytest.mark.parametrize("decorator", [build, enter, exit])
 def test_disallow_lifecycle_decorators_with_method(decorator):
-    name = decorator.__name__.removeprefix("blocking__")
+    name = decorator.__name__.split("_")[-1]  # remove synchronicity prefix
     with pytest.raises(InvalidError, match=f"Cannot use `@{name}` decorator with `@method`."):
 
         class ClsDecoratorMethodStack:

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -10,7 +10,7 @@ from modal import Cls, Function, Image, Stub, build, enter, exit, method
 from modal._serialization import deserialize
 from modal.app import ContainerApp
 from modal.cls import ClsMixin
-from modal.exception import DeprecationError, ExecutionError
+from modal.exception import DeprecationError, ExecutionError, InvalidError
 from modal.partial_function import (
     _find_callables_for_obj,
     _find_partial_methods_for_cls,
@@ -569,6 +569,18 @@ def test_build_image(client, servicer):
         assert f_image.base_images[0].image_id == image.object_id
 
 
+@pytest.mark.parametrize("decorator", [build, enter, exit])
+def test_disallow_lifecycle_decorators_with_method(decorator):
+    name = decorator.__name__.removeprefix("blocking__")
+    with pytest.raises(InvalidError, match=f"Cannot use `@{name}` decorator with `@method`."):
+
+        class ClsDecoratorMethodStack:
+            @decorator()
+            @method()
+            def f(self):
+                pass
+
+
 def test_deprecated_sync_methods():
     class ClsWithDeprecatedSyncMethods:
         def __enter__(self):
@@ -601,7 +613,7 @@ def test_deprecated_sync_methods():
 
 
 @pytest.mark.asyncio
-async def test_legacy_async_methods():
+async def test_deprecated_async_methods():
     class ClsWithDeprecatedAsyncMethods:
         async def __aenter__(self):
             return 42


### PR DESCRIPTION
## Describe your changes

This raises an `InvalidError` when users stack lifecycle decorators (`@build`, `@enter`, or `@exit`) on top of `@method`. Currently, doing that will either by silently ignored, cause confusing errors, or make a function multiple times (depending on method and client version).

While there may be some valid use-cases that can be solved by stacking these decorators, there are other ways to achieve the same result. And we suspect that users sometimes get confused and habitually add the `@method` decorator on methods that they "want modal to know about" even when they don't intend to use it as a primary method.

- Resolves MOD-2393

## Changelog

- An `InvalidError` is now raised when a lifecycle decorator (`@build`, `@enter`, or `@exit`) is used in conjunction with `@method`. Previously, this was undefined and could produce confusing failures.