### PR TITLE
Remove a false suggestion from the `modal shell` help

### DIFF
--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -356,8 +356,6 @@ def shell(
     modal shell hello_world.py::my_function
     ```
 
-    Note that you can select the function interactively if you omit the function name.
-
     Start a `python` shell:
 
     ```bash


### PR DESCRIPTION
Maybe this was a feature at some point but currently does not seem to be one:

```
╭─ Error ──────────────────────────────────────────────────────────────────────╮
│ You need to specify a Modal function or local entrypoint to run, e.g.                                                                        │
│                                                                                                                                              │
│ modal run app.py::my_function [...args]                                                                                                      │
│                                                                                                                                              │
│ Registered functions and local entrypoints on the selected stub are:                                                                         │
│ cpu                                                                                                                                          │
│ gpu                                                                                                                                          │
│                                                                                                                                              │
╰───────────────────────────────────────────────────────────────────────────────╯
```

cc @ekzhang you have the blame on this line, maybe you know?