### PR TITLE
`modal.experimental.stop_fetching_inputs`

### DIFF
--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -74,7 +74,6 @@ __all__ = [
     "forward",
     "is_local",
     "method",
-    "stop_fetching_inputs",
     "web_endpoint",
     "wsgi_app",
     "interact",

--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -74,6 +74,7 @@ __all__ = [
     "forward",
     "is_local",
     "method",
+    "stop_fetching_inputs",
     "web_endpoint",
     "wsgi_app",
     "interact",

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -325,7 +325,7 @@ class _FunctionIOManager:
         request = api_pb2.FunctionGetInputsRequest(function_id=self.function_id)
         eof_received = False
         iteration = 0
-        while not eof_received:
+        while not eof_received and _container_app.fetching_inputs:
             request.average_call_time = self.get_average_call_time()
             request.max_values = self.get_max_inputs_to_fetch()  # Deprecated; remove.
             request.input_concurrency = self._input_concurrency

--- a/modal/app.py
+++ b/modal/app.py
@@ -251,6 +251,7 @@ class _ContainerApp:
     # if true, there's an active PTY shell session connected to this process.
     _is_interactivity_enabled: bool
     _function_def: Optional[api_pb2.Function]
+    _fetching_inputs: bool
 
     def __init__(self):
         self._client = None
@@ -261,6 +262,7 @@ class _ContainerApp:
         self._tag_to_object_id = {}
         self._object_handle_metadata = {}
         self._is_interactivity_enabled = False
+        self._fetching_inputs = True
 
     @property
     def client(self) -> Optional[_Client]:
@@ -271,6 +273,10 @@ class _ContainerApp:
     def app_id(self) -> Optional[str]:
         """A unique identifier for this running App."""
         return self._app_id
+
+    @property
+    def fetching_inputs(self) -> bool:
+        return self._fetching_inputs
 
     def _associate_stub_container(self, stub):
         if self._associated_stub:
@@ -365,6 +371,9 @@ class _ContainerApp:
         global _is_container_app, _container_app
         _is_container_app = False
         _container_app.__init__()  # type: ignore
+
+    def stop_fetching_inputs(self):
+        self._fetching_inputs = False
 
 
 LocalApp = synchronize_api(_LocalApp)

--- a/modal/experimental.py
+++ b/modal/experimental.py
@@ -1,3 +1,6 @@
+# Copyright Modal Labs 2022
+
+
 def stop_fetching_inputs():
     """Don't fetch any more inputs from the server, after the current one.
     The container will exit gracefully after the current input is processed."""

--- a/modal/experimental.py
+++ b/modal/experimental.py
@@ -1,0 +1,7 @@
+def stop_fetching_inputs():
+    """Don't fetch any more inputs from the server, after the current one.
+    The container will exit gracefully after the current input is processed."""
+
+    from .app import _container_app
+
+    _container_app.stop_fetching_inputs()

--- a/modal_test_support/experimental.py
+++ b/modal_test_support/experimental.py
@@ -1,0 +1,27 @@
+# Copyright Modal Labs 2022
+from __future__ import annotations
+
+import modal.experimental
+from modal import (
+    Stub,
+    enter,
+    method,
+)
+
+stub = Stub()
+
+
+@stub.cls()
+class StopFetching:
+    @enter()
+    def init(self):
+        self.counter = 0
+
+    @method()
+    def after_two(self, x):
+        self.counter += 1
+
+        if self.counter >= 2:
+            modal.experimental.stop_fetching_inputs()
+
+        return x * x

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -41,14 +41,16 @@ FUNCTION_CALL_ID = "fc-123"
 SLEEP_DELAY = 0.1
 
 
-def _get_inputs(args: Tuple[Tuple, Dict] = ((42,), {}), n: int = 1) -> List[api_pb2.FunctionGetInputsResponse]:
+def _get_inputs(
+    args: Tuple[Tuple, Dict] = ((42,), {}), n: int = 1, kill_switch=True
+) -> List[api_pb2.FunctionGetInputsResponse]:
     input_pb = api_pb2.FunctionInput(args=serialize(args), data_format=api_pb2.DATA_FORMAT_PICKLE)
     inputs = [
         *(
             api_pb2.FunctionGetInputsItem(input_id=f"in-xyz{i}", function_call_id="fc-123", input=input_pb)
             for i in range(n)
         ),
-        api_pb2.FunctionGetInputsItem(kill_switch=True),
+        *([api_pb2.FunctionGetInputsItem(kill_switch=True)] if kill_switch else []),
     ]
     return [api_pb2.FunctionGetInputsResponse(inputs=[x]) for x in inputs]
 
@@ -1192,3 +1194,19 @@ def test_lifecycle_full(servicer):
     stdout, _ = container_process.communicate(timeout=5)
     assert container_process.returncode == 0
     assert "[events:enter_sync,enter_async,f_async,exit_sync,exit_async]" in stdout.decode()
+
+
+## modal.experimental functionality ##
+
+
+@skip_windows_unix_socket
+def test_stop_fetching_inputs(unix_servicer, event_loop):
+    ret = _run_container(
+        unix_servicer,
+        "modal_test_support.experimental",
+        "StopFetching.after_two",
+        inputs=_get_inputs(((42,), {}), n=4, kill_switch=False),
+    )
+
+    assert len(ret.items) == 2
+    assert ret.items[0].result.status == api_pb2.GenericResult.GENERIC_STATUS_SUCCESS


### PR DESCRIPTION

## Changelog

When called from within a container, `modal.experimental.stop_fetching_inputs()` causes it to gracefully exit after the current input has been processed. 

