### PR TITLE
Fix license metadata that gets sent to PyPI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ keywords = modal, client, cloud, serverless, infrastructure
 classifiers =
     Topic :: System :: Distributed Computing
     Operating System :: OS Independent
-    License :: OSI Approved :: MIT License
+    License :: OSI Approved :: Apache Software License
     Programming Language :: Python :: 3
 
 [options]


### PR DESCRIPTION
Out `setup.cfg` metadata had us as MIT licensed, but the repo has an Apache license file in it.