### PR TITLE
Add `_experimental_scheduler` flag to functions

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -583,6 +583,7 @@ class _Function(_Object, type_prefix="fu"):
         interactive: bool = False,
         cloud: Optional[str] = None,
         _experimental_boost: bool = False,
+        _experimental_scheduler: bool = False,
         is_builder_function: bool = False,
         cls: Optional[type] = None,
         is_auto_snapshot: bool = False,
@@ -849,6 +850,7 @@ class _Function(_Object, type_prefix="fu"):
                 max_inputs=max_inputs,
                 s3_mounts=s3_mounts_to_proto(s3_mounts),
                 _experimental_boost=_experimental_boost,
+                _experimental_scheduler=_experimental_scheduler,
             )
             request = api_pb2.FunctionCreateRequest(
                 app_id=resolver.app_id,

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -470,6 +470,7 @@ class _Stub:
             int
         ] = None,  # Limits the number of inputs a container handles before shutting down. Use `max_inputs = 1` for single-use containers.
         _experimental_boost: bool = False,  # Experimental flag for lower latency function execution (alpha).
+        _experimental_scheduler: bool = False,  # Experimental flag for more fine-grained scheduling (alpha).
     ) -> Callable[..., _Function]:
         """Decorator to register a new Modal function with this stub."""
         if isinstance(_warn_parentheses_missing, _Image):
@@ -551,6 +552,7 @@ class _Stub:
                 block_network=block_network,
                 max_inputs=max_inputs,
                 _experimental_boost=_experimental_boost,
+                _experimental_scheduler=_experimental_scheduler,
             )
 
             self._add_function(function)
@@ -592,6 +594,7 @@ class _Stub:
             int
         ] = None,  # Limits the number of inputs a container handles before shutting down. Use `max_inputs = 1` for single-use containers.
         _experimental_boost: bool = False,  # Experimental flag for lower latency function execution (alpha).
+        _experimental_scheduler: bool = False,  # Experimental flag for more fine-grained scheduling (alpha).
     ) -> Callable[[CLS_T], _Cls]:
         if _warn_parentheses_missing:
             raise InvalidError("Did you forget parentheses? Suggestion: `@stub.cls()`.")
@@ -623,6 +626,7 @@ class _Stub:
             _allow_background_volume_commits=_allow_background_volume_commits,
             max_inputs=max_inputs,
             _experimental_boost=_experimental_boost,
+            _experimental_scheduler=_experimental_scheduler,
         )
 
         def wrapper(user_cls: CLS_T) -> _Cls:

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -828,10 +828,11 @@ message Function {
   bool block_network = 44;
 
   uint32 max_inputs = 46;
-  
+
   repeated S3Mount s3_mounts = 47;
-  
+
   bool _experimental_boost = 48;
+  bool _experimental_scheduler = 49;
 }
 
 message FunctionHandleMetadata {
@@ -1828,7 +1829,7 @@ message RuntimeOutputMessage {
 
 message RuntimeOutputBatch {
   repeated RuntimeOutputMessage items = 1;
-  uint64 batch_index = 2; 
+  uint64 batch_index = 2;
   // if an exit code is given, this is the final message that will be sent.
   optional int32 exit_code = 3;
 }


### PR DESCRIPTION
We'll use this to gate task creations using different work-queue mechanisms behind the scenes. (Basically cargo culting 37b2e98835d537.)