### PR TITLE
Don't warn about not turning partial function into function for build/enter/exit

### DIFF
--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -62,7 +62,7 @@ class _PartialFunction:
         return function
 
     def __del__(self):
-        if self.wrapped is False:
+        if (self.flags & _PartialFunctionFlags.FUNCTION) and self.wrapped is False:
             logger.warning(
                 f"Method or web function {self.raw_f} was never turned into a function."
                 " Did you forget a @stub.function or @stub.cls decorator?"


### PR DESCRIPTION
Got some sporadic test flake due to these warnings popping up in destructors that sometimes trigger later during a test that asserts on output.