### PR TITLE
Relax assertion in flaky test

### DIFF
--- a/test/container_test.py
+++ b/test/container_test.py
@@ -963,7 +963,7 @@ def test_multiple_build_decorator_cls(unix_servicer, event_loop):
 
 
 @skip_windows_unix_socket
-@pytest.mark.timeout(3.0)
+@pytest.mark.timeout(10.0)
 def test_function_io_doesnt_inspect_args_or_return_values(monkeypatch, unix_servicer):
     synchronizer = modal_utils.async_utils.synchronizer
 
@@ -990,7 +990,7 @@ def test_function_io_doesnt_inspect_args_or_return_values(monkeypatch, unix_serv
     # pr.disable()
     # pr.print_stats()
     duration = time.perf_counter() - t0
-    assert duration < 2.0  # TODO (elias): might be able to get this down significantly more by improving serialization
+    assert duration < 5.0  # TODO (elias): might be able to get this down significantly more by improving serialization
 
     # function_io_manager.serialize(large_data_list)
     in_translations = []


### PR DESCRIPTION
This test is flaking on 10–15% of builds (kinda weird but my impression is that it's consistently on Python 3.10?). This relaxes the assertion based on @freider's suggestion for what's still acceptable.

- Resolves MOD-2384