### PR TITLE
Add experimental `SchedulerPlacement` class

### DIFF
--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -24,6 +24,7 @@ try:
     from .s3mount import S3Mount
     from .sandbox import Sandbox
     from .schedule import Cron, Period
+    from .scheduler_placement import SchedulerPlacement
     from .secret import Secret
     from .shared_volume import SharedVolume
     from .stub import Stub
@@ -54,6 +55,7 @@ __all__ = [
     "Retries",
     "S3Mount",
     "Sandbox",
+    "SchedulerPlacement",
     "Secret",
     "SharedVolume",
     "Stub",

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -77,6 +77,7 @@ from .proxy import _Proxy
 from .retries import Retries
 from .s3mount import _S3Mount, s3_mounts_to_proto
 from .schedule import Schedule
+from .scheduler_placement import SchedulerPlacement
 from .secret import _Secret
 from .volume import _Volume
 
@@ -588,6 +589,7 @@ class _Function(_Object, type_prefix="fu"):
         cloud: Optional[str] = None,
         _experimental_boost: bool = False,
         _experimental_scheduler: bool = False,
+        _experimental_scheduler_placement: Optional[SchedulerPlacement] = None,
         is_builder_function: bool = False,
         cls: Optional[type] = None,
         is_auto_snapshot: bool = False,
@@ -666,6 +668,7 @@ class _Function(_Object, type_prefix="fu"):
                     cpu=cpu,
                     is_builder_function=True,
                     is_auto_snapshot=True,
+                    _experimental_scheduler_placement=_experimental_scheduler_placement,
                 )
                 image = image.extend(build_function=snapshot_function, force_build=image.force_build)
 
@@ -855,6 +858,9 @@ class _Function(_Object, type_prefix="fu"):
                 s3_mounts=s3_mounts_to_proto(s3_mounts),
                 _experimental_boost=_experimental_boost,
                 _experimental_scheduler=_experimental_scheduler,
+                _experimental_scheduler_placement=_experimental_scheduler_placement.proto
+                if _experimental_scheduler_placement
+                else None,
             )
             request = api_pb2.FunctionCreateRequest(
                 app_id=resolver.app_id,

--- a/modal/scheduler_placement.py
+++ b/modal/scheduler_placement.py
@@ -1,0 +1,23 @@
+# Copyright Modal Labs 2024
+from typing import Optional
+
+from modal_proto import api_pb2
+
+
+class SchedulerPlacement:
+    """mdmd:hidden This is an experimental feature."""
+
+    proto: api_pb2.SchedulerPlacement
+
+    def __init__(
+        self,
+        region: Optional[str] = None,
+        zone: Optional[str] = None,
+        spot: Optional[bool] = None,
+    ):
+        """mdmd:hidden"""
+        self.proto = api_pb2.SchedulerPlacement(
+            _region=region,
+            _zone=zone,
+            _spot=spot,
+        )

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -32,6 +32,7 @@ from .retries import Retries
 from .runner import _run_stub
 from .sandbox import _Sandbox
 from .schedule import Schedule
+from .scheduler_placement import SchedulerPlacement
 from .secret import _Secret
 from .volume import _Volume
 
@@ -470,6 +471,9 @@ class _Stub:
         ] = None,  # Limits the number of inputs a container handles before shutting down. Use `max_inputs = 1` for single-use containers.
         _experimental_boost: bool = False,  # Experimental flag for lower latency function execution (alpha).
         _experimental_scheduler: bool = False,  # Experimental flag for more fine-grained scheduling (alpha).
+        _experimental_scheduler_placement: Optional[
+            SchedulerPlacement
+        ] = None,  # Experimental controls over fine-grained scheduling (alpha).
     ) -> Callable[..., _Function]:
         """Decorator to register a new Modal function with this stub."""
         if isinstance(_warn_parentheses_missing, _Image):
@@ -552,6 +556,7 @@ class _Stub:
                 max_inputs=max_inputs,
                 _experimental_boost=_experimental_boost,
                 _experimental_scheduler=_experimental_scheduler,
+                _experimental_scheduler_placement=_experimental_scheduler_placement,
             )
 
             self._add_function(function)
@@ -594,6 +599,9 @@ class _Stub:
         ] = None,  # Limits the number of inputs a container handles before shutting down. Use `max_inputs = 1` for single-use containers.
         _experimental_boost: bool = False,  # Experimental flag for lower latency function execution (alpha).
         _experimental_scheduler: bool = False,  # Experimental flag for more fine-grained scheduling (alpha).
+        _experimental_scheduler_placement: Optional[
+            SchedulerPlacement
+        ] = None,  # Experimental controls over fine-grained scheduling (alpha).
     ) -> Callable[[CLS_T], _Cls]:
         if _warn_parentheses_missing:
             raise InvalidError("Did you forget parentheses? Suggestion: `@stub.cls()`.")
@@ -626,6 +634,7 @@ class _Stub:
             max_inputs=max_inputs,
             _experimental_boost=_experimental_boost,
             _experimental_scheduler=_experimental_scheduler,
+            _experimental_scheduler_placement=_experimental_scheduler_placement,
         )
 
         def wrapper(user_cls: CLS_T) -> _Cls:

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -834,7 +834,21 @@ message Function {
   repeated S3Mount s3_mounts = 47;
 
   bool _experimental_boost = 48;
+
+  // If set, tasks will be scheduled using the new scheduler, which also knows
+  // to look at fine-grained placement constraints.
   bool _experimental_scheduler = 49;
+  optional SchedulerPlacement _experimental_scheduler_placement = 50;
+}
+
+message SchedulerPlacement {
+  // TODO(irfansharif):
+  // - Fold in cloud, resource needs here too.
+  // - Allow specifying list of regions, zones, cloud, fallback and alternative
+  //   GPU types.
+  optional string _region = 1;
+  optional string _zone = 2;
+  optional bool _spot = 3;
 }
 
 message FunctionHandleMetadata {

--- a/tasks.py
+++ b/tasks.py
@@ -35,8 +35,8 @@ def protoc(ctx):
 
 
 @task
-def lint(ctx):
-    ctx.run("ruff .", pty=True)
+def lint(ctx, fix=False):
+    ctx.run(f"ruff . {'--fix' if fix else ''}", pty=True)
 
 
 @task

--- a/test/scheduler_placement_test.py
+++ b/test/scheduler_placement_test.py
@@ -1,0 +1,29 @@
+# Copyright Modal Labs 2024
+from modal import SchedulerPlacement, Stub
+from modal_proto import api_pb2
+
+stub = Stub()
+
+
+@stub.function(
+    _experimental_scheduler=True,
+    _experimental_scheduler_placement=SchedulerPlacement(
+        region="us-east-1",
+        zone="us-east-1a",
+        spot=False,
+    ),
+)
+def f():
+    pass
+
+
+def test_scheduler_placement(servicer, client):
+    with stub.run(client=client):
+        assert len(servicer.app_functions) == 1
+        fn = servicer.app_functions["fu-1"]
+        assert fn._experimental_scheduler
+        assert fn._experimental_scheduler_placement == api_pb2.SchedulerPlacement(
+            _region="us-east-1",
+            _zone="us-east-1a",
+            _spot=False,
+        )


### PR DESCRIPTION
It's hidden in docs, etc. We're going to use it in the new scheduler to very selectively place where tasks can run. Export zone + spot for now too, we can get rid of it or disable it later.