### PR TITLE
Fix lifecycle-spec in SchedulerPlacement

### DIFF
--- a/modal/scheduler_placement.py
+++ b/modal/scheduler_placement.py
@@ -16,8 +16,12 @@ class SchedulerPlacement:
         spot: Optional[bool] = None,
     ):
         """mdmd:hidden"""
+        _lifecycle: Optional[str] = None
+        if spot is not None:
+            _lifecycle = "spot" if spot else "on-demand"
+
         self.proto = api_pb2.SchedulerPlacement(
             _region=region,
             _zone=zone,
-            _spot=spot,
+            _lifecycle=_lifecycle,
         )

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -848,7 +848,7 @@ message SchedulerPlacement {
   //   GPU types.
   optional string _region = 1;
   optional string _zone = 2;
-  optional bool _spot = 3;
+  optional string _lifecycle = 3; // "on-demand" or "spot", else ignored
 }
 
 message FunctionHandleMetadata {

--- a/test/scheduler_placement_test.py
+++ b/test/scheduler_placement_test.py
@@ -25,5 +25,5 @@ def test_scheduler_placement(servicer, client):
         assert fn._experimental_scheduler_placement == api_pb2.SchedulerPlacement(
             _region="us-east-1",
             _zone="us-east-1a",
-            _spot=False,
+            _lifecycle="on-demand",
         )


### PR DESCRIPTION
Forgot that proto3 does not support optional booleans, despite it's proto2-compatible syntax, so represent the requested lifecycle using a (nullable) string instead.