### PR TITLE
Fix passing exception info to @exit method

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -66,8 +66,7 @@ if TYPE_CHECKING:
     else:
         TracebackType = Any
 
-
-ExceptionInfo = Tuple[Optional[Type[BaseException]], Optional[BaseException], Optional[TracebackType]]
+    ExceptionInfo = Tuple[Optional[Type[BaseException]], Optional[BaseException], Optional[TracebackType]]
 
 MAX_OUTPUT_BATCH_SIZE: int = 49
 

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -59,7 +59,13 @@ from .functions import Function, _Function, _set_current_context_ids, _stream_fu
 from .partial_function import _find_callables_for_obj, _PartialFunctionFlags
 
 if TYPE_CHECKING:
-    from types import ModuleType, TracebackType
+    from types import ModuleType
+
+    if sys.version_info > (3, 8):
+        from types import TracebackType
+    else:
+        TracebackType = Any
+
 
 ExceptionInfo = Tuple[Optional[Type[BaseException]], Optional[BaseException], Optional[TracebackType]]
 


### PR DESCRIPTION
## Describe your changes

We claim to support `__exit__` style exception propagation but because we have already handled any user-code exceptions `sys.exc_info` is null in the `finally` block where we use it. This is a fairly naive fix and there's a lot of complexity here (concurrent inputs, etc.) so I'm not totally confident about it.

I'm also pretty uncertain about how to unit test it. AFAICT we don't really exercise the `exit()` behavior anywhere in the tests, and even in our integration tests, we have a note about not being able to. Open to suggestions.

- Fixes MOD-2417

## Changelog

- Fixed a bug where exception info was not propagated to `@exit` lifecycle methods