### PR TITLE
Remove references to -musl standalone Python

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -980,13 +980,12 @@ class _Image(_Object, type_prefix="im"):
     ) -> "_Image":
         """Build a Modal image from a public or private image registry, such as Docker Hub.
 
-        The image must be built for the `linux/amd64` platform and have Python 3.8 or above
-        installed and available on PATH as `python`. It should also have `pip`.
+        The image must be built for the `linux/amd64` platform.
 
         If your image does not come with Python installed, you can use the `add_python` parameter
         to specify a version of Python to add to the image. Supported versions are `3.8`, `3.9`,
-        `3.10`, `3.11`, and `3.12`. For Alpine-based images, use `3.8-musl` through `3.12-musl`, which
-        are statically-linked Python installations.
+        `3.10`, `3.11`, and `3.12`. Otherwise, the image is expected to have Python>3.8 available
+        on PATH as `python`, along with `pip`.
 
         You may also use `setup_dockerfile_commands` to run Dockerfile commands before the
         remaining commands run. This might be useful if you want a custom Python installation or to
@@ -1003,7 +1002,7 @@ class _Image(_Object, type_prefix="im"):
         ```python
         modal.Image.from_registry("python:3.11-slim-bookworm")
         modal.Image.from_registry("ubuntu:22.04", add_python="3.11")
-        modal.Image.from_registry("alpine:3.18.3", add_python="3.12-musl")
+        modal.Image.from_registry("nvcr.io/nvidia/pytorch:22.12-py3")
         ```
         """
         requirements_path = _get_client_requirements_path(add_python)
@@ -1141,8 +1140,7 @@ class _Image(_Object, type_prefix="im"):
 
         If your Dockerfile does not have Python installed, you can use the `add_python` parameter
         to specify a version of Python to add to the image. Supported versions are `3.8`, `3.9`,
-        `3.10`, `3.11`, and `3.12`. For Alpine-based images, use `3.8-musl` through `3.12-musl`, which
-        are statically-linked Python installations.
+        `3.10`, `3.11`, and `3.12`.
 
         **Example**
 

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -59,7 +59,7 @@ def python_standalone_mount_name(version: str) -> str:
         raise modal.exception.InvalidError(
             f"Unsupported standalone python version: {version}, supported values are {list(PYTHON_STANDALONE_VERSIONS.keys())}"
         )
-    if libc not in ("gnu", "musl"):
+    if libc != "gnu":
         raise modal.exception.InvalidError(f"Unsupported libc identifier: {libc}")
     release, full_version = PYTHON_STANDALONE_VERSIONS[version]
     return f"python-build-standalone.{release}.{full_version}-{libc}"

--- a/modal_base_images/base_mounts.py
+++ b/modal_base_images/base_mounts.py
@@ -29,13 +29,14 @@ def publish_client_mount(client):
     print(f"✅ Deployed client mount {name} to global namespace.")
 
 
-def publish_python_standalone(client, version: str, libc: str) -> None:
+def publish_python_standalone(client, version: str) -> None:
     release, full_version = PYTHON_STANDALONE_VERSIONS[version]
 
+    libc = "gnu"
     arch = "x86_64" if version == "3.8" else "x86_64_v3"
     url = (
         "https://github.com/indygreg/python-build-standalone/releases/download"
-        + f"/{release}/cpython-{full_version}+{release}-{arch}-unknown-linux-{libc}-install_only.tar.gz"
+        + f"/{release}/cpython-{full_version}+{release}-{arch}-unknown-linux-gnu-install_only.tar.gz"
     )
 
     profile_environment = config.get("environment")
@@ -62,8 +63,7 @@ def publish_python_standalone(client, version: str, libc: str) -> None:
 def main(client=None):
     publish_client_mount(client)
     for version in PYTHON_STANDALONE_VERSIONS:
-        publish_python_standalone(client, version, "gnu")
-        publish_python_standalone(client, version, "musl")
+        publish_python_standalone(client, version)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Describe your changes

We realized that images don't build properly on top of the `-musl` standalone Python builds, potentially due to a [bug](https://github.com/python/cpython/issues/81241) in CPython.

This PR deletes the suggestions to use `add_python=f"{version}-musl"` for Alpine Linux images, which I could not get to work.

I've also stopped building the `-musl` base mount. But otherwise preserved the flexibility to have alternate `libc` builds in the future.

- Resolves MOD-2419