### PR TITLE
Deprecate parameterized exit methods

### DIFF
--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -15,6 +15,7 @@ from modal._types import typechecked
 from modal_proto import api_pb2
 from modal_utils.async_utils import synchronize_api, synchronizer
 
+from ._function_utils import method_has_params
 from .config import logger
 from .exception import InvalidError, deprecation_warning
 from .functions import _Function
@@ -422,12 +423,12 @@ def _exit(_warn_parentheses_missing=None) -> Callable[[ExitHandlerType], _Partia
     def wrapper(f: ExitHandlerType) -> _PartialFunction:
         if isinstance(f, _PartialFunction):
             _disallow_wrapping_method(f, "exit")
-        # if method_has_params(f):
-        #     message = (
-        #         "Support for wrapping parameterized methods with `@exit` has been deprecated."
-        #         " To avoid future errors, please update your code and remove the parameters."
-        #     )
-        #     deprecation_warning((2024, 2, 23), message)
+        if method_has_params(f):
+            message = (
+                "Support for decorating parameterized methods with `@exit` has been deprecated."
+                " To avoid future errors, please update your code by removing the parameters."
+            )
+            deprecation_warning((2024, 2, 23), message)
         return _PartialFunction(f, _PartialFunctionFlags.EXIT)
 
     return wrapper

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -582,20 +582,22 @@ def test_disallow_lifecycle_decorators_with_method(decorator):
 
 
 def test_deprecated_sync_methods():
-    class ClsWithDeprecatedSyncMethods:
-        def __enter__(self):
-            return 42
+    with pytest.warns(DeprecationError, match="Support for decorating parameterized methods with `@exit`"):
 
-        @enter()
-        def my_enter(self):
-            return 43
+        class ClsWithDeprecatedSyncMethods:
+            def __enter__(self):
+                return 42
 
-        def __exit__(self, exc_type, exc, tb):
-            return 44
+            @enter()
+            def my_enter(self):
+                return 43
 
-        @exit()
-        def my_exit(self, exc_type, exc, tb):
-            return 45
+            def __exit__(self, exc_type, exc, tb):
+                return 44
+
+            @exit()
+            def my_exit(self, exc_type, exc, tb):
+                return 45
 
     obj = ClsWithDeprecatedSyncMethods()
 
@@ -614,20 +616,22 @@ def test_deprecated_sync_methods():
 
 @pytest.mark.asyncio
 async def test_deprecated_async_methods():
-    class ClsWithDeprecatedAsyncMethods:
-        async def __aenter__(self):
-            return 42
+    with pytest.warns(DeprecationError, match="Support for decorating parameterized methods with `@exit`"):
 
-        @enter()
-        async def my_enter(self):
-            return 43
+        class ClsWithDeprecatedAsyncMethods:
+            async def __aenter__(self):
+                return 42
 
-        async def __aexit__(self, exc_type, exc, tb):
-            return 44
+            @enter()
+            async def my_enter(self):
+                return 43
 
-        @exit()
-        async def my_exit(self, exc_type, exc, tb):
-            return 45
+            async def __aexit__(self, exc_type, exc, tb):
+                return 44
+
+            @exit()
+            async def my_exit(self, exc_type, exc, tb):
+                return 45
 
     obj = ClsWithDeprecatedAsyncMethods()
 
@@ -642,17 +646,3 @@ async def test_deprecated_async_methods():
     stub = Stub("deprecated-async-cls")
     with pytest.warns(DeprecationError):
         stub.cls()(ClsWithDeprecatedAsyncMethods)()
-
-
-def test_exit_parameter_deprecation():
-    return  # Disabling test until we enforce the deprecation
-    with pytest.warns(DeprecationError, match="Support for wrapping parameterized methods with `@exit`"):
-
-        class ClsWithExitParams:
-            @method()
-            def f(self, x):
-                pass
-
-            @exit()
-            def teardown(self, exc_type, exc, tback):
-                pass


### PR DESCRIPTION
## Describe your changes

Follow-on to #1404; this PR activates the deprecation warning for parameterized exit methods.

- Resolves MOD-2417

## Changelog

- Support for function parameters in methods decorated with `@exit` has been deprecated. Previously, exit methods were required to accept three arguments containing exception information (akin to `__exit__` in the context manager protocol). However, due to a bug, these arguments were always null. Going forward, `@exit` methods are expected to have no parameters.