### PR TITLE
Add protos for 'modal volume delete'

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1742,6 +1742,11 @@ message VolumeCommitResponse {
   bool skip_reload = 1;
 }
 
+message VolumeDeleteRequest {
+  string volume_id = 1;
+  string environment_name = 2;
+}
+
 message VolumeGetFileRequest {
   string volume_id = 1;
   bytes path = 2;
@@ -2003,6 +2008,7 @@ service ModalClient {
   // Volumes
   rpc VolumeCreate(VolumeCreateRequest) returns (VolumeCreateResponse);
   rpc VolumeCommit(VolumeCommitRequest) returns (VolumeCommitResponse);
+  rpc VolumeDelete(VolumeDeleteRequest) returns (google.protobuf.Empty);
   rpc VolumeGetFile(VolumeGetFileRequest) returns (VolumeGetFileResponse);
   rpc VolumeList(VolumeListRequest) returns (VolumeListResponse);
   rpc VolumeListFiles(VolumeListFilesRequest) returns (stream VolumeListFilesResponse);


### PR DESCRIPTION

### Backward/forward compatibility checks

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
