### PR TITLE
Remove beta commentary from modal volume CLI help

### DIFF
--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -35,12 +35,9 @@ volume_cli = Typer(
     name="volume",
     no_args_is_help=True,
     help="""
-    [Beta] Read and edit `modal.Volume` volumes.
+    Read and edit `modal.Volume` volumes.
 
-    This command is in preview and may change in the future.
-
-    Previous users of `modal.NetworkFileSystem` should replace their usage with
-    the `modal nfs` command instead.
+    Note: users of `modal.NetworkFileSystem` should use the `modal nfs` command instead.
     """,
 )
 


### PR DESCRIPTION
We removed the "beta" designation from `modal.Volume` in the docs a little while back (https://github.com/modal-labs/modal/pull/9871); this PR makes corresponding updates to the `modal volume --help` headnote.