### PR TITLE
[MOD-2284] Implement ranged 'volume gets' on client side

### DIFF
--- a/modal/volume.py
+++ b/modal/volume.py
@@ -255,6 +255,8 @@ class _Volume(_StatefulObject, type_prefix="vo"):
         if n != len(response.data):
             raise IOError(f"failed to write {len(response.data)} bytes to output. Wrote {n}.")
         elif n == response.size:
+            if progress:
+                progress_bar.console.log(f"Wrote {n} bytes to '{path.decode()}'")
             return response.size
         elif n > response.size:
             raise RuntimeError(f"length of returned data exceeds reported filesize: {n} > {response.size}")

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -213,6 +213,7 @@ class _Volume(_StatefulObject, type_prefix="vo"):
             response = await retry_transient_errors(self._client.stub.VolumeGetFile, req)
         except GRPCError as exc:
             raise FileNotFoundError(exc.message) if exc.status == Status.NOT_FOUND else exc
+        # TODO(Jonathon): use ranged requests.
         if response.WhichOneof("data_oneof") == "data":
             yield response.data
             return
@@ -247,18 +248,20 @@ class _Volume(_StatefulObject, type_prefix="vo"):
             response = await retry_transient_errors(self._client.stub.VolumeGetFile, req)
         except GRPCError as exc:
             raise FileNotFoundError(exc.message) if exc.status == Status.NOT_FOUND else exc
-        if response.WhichOneof("data_oneof") == "data":
-            n = fileobj.write(response.data)
-            if n != len(response.data):
-                raise IOError(f"failed to write {len(response.data)} bytes to output. Wrote {n}.")
-            elif n == response.size:
-                return response.size
-            elif n > response.size:
-                raise RuntimeError(f"length of returned data exceeds reported filesize: {n} > {response.size}")
-            # else: there's more data to read. continue reading with further ranged GET requests.
-            start = n
-            file_size = response.size
-            written = n
+        if response.WhichOneof("data_oneof") != "data":
+            raise RuntimeError("expected to receive 'data' in response")
+
+        n = fileobj.write(response.data)
+        if n != len(response.data):
+            raise IOError(f"failed to write {len(response.data)} bytes to output. Wrote {n}.")
+        elif n == response.size:
+            return response.size
+        elif n > response.size:
+            raise RuntimeError(f"length of returned data exceeds reported filesize: {n} > {response.size}")
+        # else: there's more data to read. continue reading with further ranged GET requests.
+        start = n
+        file_size = response.size
+        written = n
 
         if progress:
             progress_bar.update(task_id, total=int(file_size))

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -997,7 +997,15 @@ class MockClientServicer(api_grpc.ModalClientBase):
         if vol_file.data_blob_id:
             await stream.send_message(api_pb2.VolumeGetFileResponse(data_blob_id=vol_file.data_blob_id))
         else:
-            await stream.send_message(api_pb2.VolumeGetFileResponse(data=vol_file.data))
+            size = len(vol_file.data)
+            if req.start or req.len:
+                start = req.start
+                len_ = req.len or len(vol_file.data)
+                await stream.send_message(
+                    api_pb2.VolumeGetFileResponse(data=vol_file.data[start : start + len_], size=size)
+                )
+            else:
+                await stream.send_message(api_pb2.VolumeGetFileResponse(data=vol_file.data, size=size))
 
     async def VolumeRemoveFile(self, stream):
         req = await stream.recv_message()


### PR DESCRIPTION
## Describe your changes

- MOD-2284

## Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


## Changelog

* `volume get` performance is improved for large (> 100MB) files
