### PR TITLE
Support app-associated mounts and secrets

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -143,6 +143,7 @@ enum ObjectCreationType {
   OBJECT_CREATION_TYPE_CREATE_IF_MISSING = 1;
   OBJECT_CREATION_TYPE_CREATE_FAIL_IF_EXISTS = 2;
   OBJECT_CREATION_TYPE_CREATE_OVERWRITE_IF_EXISTS = 3;
+  OBJECT_CREATION_TYPE_ANONYMOUS_OWNED_BY_APP = 4;  // deprecate at some point
 }
 
 enum ProgressType {
@@ -1248,6 +1249,7 @@ message MountGetOrCreateRequest {
   string environment_name = 3;
   ObjectCreationType object_creation_type = 4;
   repeated MountFile files = 5;
+  string app_id = 6;  // only used with OBJECT_CREATION_TYPE_ANONYMOUS_OWNED_BY_APP
 }
 
 message MountGetOrCreateResponse {
@@ -1504,6 +1506,7 @@ message SecretGetOrCreateRequest {
   string environment_name = 3;
   ObjectCreationType object_creation_type = 4;  // Not used atm
   map<string, string> env_dict = 5;
+  string app_id = 6;  // only used with OBJECT_CREATION_TYPE_ANONYMOUS_OWNED_BY_APP
 }
 
 message SecretGetOrCreateResponse {


### PR DESCRIPTION
We want to deprecate and remove app-associated mounts and secrets eventually, but treating it as a special object creation mode will let us get rid of the old endpoints (`SecretCreate` and `MountBuild`) much sooner, so that seems useful.

