### PR TITLE
Exit from container_exec with modal exceptions

### DIFF
--- a/modal/_container_exec.py
+++ b/modal/_container_exec.py
@@ -10,13 +10,13 @@ from typing import List, Optional
 
 import rich
 import rich.status
-import typer
 from grpclib import Status
 from grpclib.exceptions import GRPCError, StreamTerminatedError
 from rich.console import Console
 
 from modal._pty import get_pty_info, raw_terminal, set_nonblocking
 from modal.client import _Client
+from modal.exception import ExecutionError, NotFoundError, TimeoutError as ModalTimeoutError
 from modal_proto import api_pb2
 from modal_utils.async_utils import TaskContext, asyncify
 from modal_utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES, retry_transient_errors, unary_stream
@@ -48,8 +48,7 @@ async def container_exec(
     except GRPCError as err:
         connecting_status.stop()
         if err.status == Status.NOT_FOUND:
-            rich.print(f"Container ID {task_id} not found", file=sys.stderr)
-            raise typer.Exit(code=1)
+            raise NotFoundError(f"Container ID {task_id} not found")
         raise
 
     await connect_to_exec(res.exec_id, pty, connecting_status)
@@ -80,14 +79,12 @@ async def connect_to_exec(exec_id: str, pty: bool = False, connecting_status: Op
                 exit_status = await exec_output_task
 
             if exit_status != 0:
-                rich.print(f"Process exited with status code {exit_status}", file=sys.stderr)
-                raise typer.Exit(code=1)
+                raise ExecutionError(f"Process exited with status code {exit_status}")
 
         except (asyncio.TimeoutError, TimeoutError):
             stop_connecting_status()
-            rich.print("Failed to establish connection to process", file=sys.stderr)
             exec_output_task.cancel()
-            raise typer.Exit(code=1)
+            raise ModalTimeoutError("Failed to establish connection to container.")
 
 
 # note: this is very similar to code in _pty.py.

--- a/modal/_container_exec.py
+++ b/modal/_container_exec.py
@@ -16,7 +16,7 @@ from rich.console import Console
 
 from modal._pty import get_pty_info, raw_terminal, set_nonblocking
 from modal.client import _Client
-from modal.exception import ExecutionError, NotFoundError, TimeoutError as ModalTimeoutError
+from modal.exception import ExecutionError, InteractiveTimeoutError, NotFoundError
 from modal_proto import api_pb2
 from modal_utils.async_utils import TaskContext, asyncify
 from modal_utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES, retry_transient_errors, unary_stream
@@ -84,7 +84,7 @@ async def connect_to_exec(exec_id: str, pty: bool = False, connecting_status: Op
         except (asyncio.TimeoutError, TimeoutError):
             stop_connecting_status()
             exec_output_task.cancel()
-            raise ModalTimeoutError("Failed to establish connection to container.")
+            raise InteractiveTimeoutError("Failed to establish connection to container.")
 
 
 # note: this is very similar to code in _pty.py.

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -390,9 +390,4 @@ def shell(
         modal_image = Image.from_registry(image, add_python=add_python) if image else None
         start_shell = partial(interactive_shell, image=modal_image, cpu=cpu, memory=memory, gpu=gpu, cloud=cloud)
 
-    start_shell(
-        stub,
-        cmd=[cmd],
-        environment_name=env,
-        timeout=3600,
-    )
+    start_shell(stub, cmd=[cmd], environment_name=env, timeout=3600)

--- a/modal/exception.py
+++ b/modal/exception.py
@@ -53,6 +53,10 @@ class VolumeUploadTimeoutError(TimeoutError):
     """Raised when a Volume upload times out."""
 
 
+class InteractiveTimeoutError(TimeoutError):
+    """Raised when interactive frontends time out while trying to connect to a container."""
+
+
 class AuthError(Error):
     """Raised when a client has missing or invalid authentication."""
 

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -3,11 +3,9 @@ import asyncio
 import contextlib
 import dataclasses
 import os
-import sys
 from multiprocessing.synchronize import Event
 from typing import TYPE_CHECKING, AsyncGenerator, List, Optional, TypeVar
 
-import rich
 from rich.console import Console
 
 from modal_proto import api_pb2
@@ -20,7 +18,7 @@ from ._output import OutputManager, get_app_logs_loop, step_completed, step_prog
 from .app import _LocalApp, is_local
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, _Client
 from .config import config
-from .exception import InvalidError
+from .exception import InvalidError, TimeoutError
 
 if TYPE_CHECKING:
     from .stub import _Stub
@@ -319,8 +317,7 @@ async def _interactive_shell(_stub: _Stub, cmd: List[str], environment_name: str
             # else: sandbox hasn't been assigned a task yet
         else:
             loading_status.stop()
-            rich.print("Error: timed out waiting for sandbox to start", file=sys.stderr)
-            return
+            raise TimeoutError("Timed out while waiting for sandbox to start")
 
         loading_status.stop()
         await container_exec(task_id, cmd, pty=True, client=client, terminate_container_on_exit=True)

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -18,7 +18,7 @@ from ._output import OutputManager, get_app_logs_loop, step_completed, step_prog
 from .app import _LocalApp, is_local
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, _Client
 from .config import config
-from .exception import InvalidError, TimeoutError
+from .exception import InteractiveTimeoutError, InvalidError
 
 if TYPE_CHECKING:
     from .stub import _Stub
@@ -317,7 +317,7 @@ async def _interactive_shell(_stub: _Stub, cmd: List[str], environment_name: str
             # else: sandbox hasn't been assigned a task yet
         else:
             loading_status.stop()
-            raise TimeoutError("Timed out while waiting for sandbox to start")
+            raise InteractiveTimeoutError("Timed out while waiting for sandbox to start")
 
         loading_status.stop()
         await container_exec(task_id, cmd, pty=True, client=client, terminate_container_on_exit=True)


### PR DESCRIPTION
## Describe your changes

This updates some error handling in the function(s) underlying `modal container exec` and `modal shell` to raise modal exceptions rather than using `typer.Exit` or doing `rich.print` and returning.

The primary goal was to keep the use of `typer` limited to `modal/cli`, but I also think it's more Pythonic to handle errors this way in library functions.

Originally I was hoping to remove `rich` from the libarary functions too; I think that ideally the rich display would be completely owned by the CLI, but that's tricker here; we at least would need to pass in callbacks or some other way of terminating the status spinner when it's time to hand over the terminal to the shell. I tried a few larger refactors but the current situation with these functions being used by both `modal container exec` and `modal shell` left me unable to come up with a satisfactory solution.

- Resolves MOD-2435