### PR TITLE
Fix signal handling for modal.Cls functions

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -91,7 +91,7 @@ class SignalHandlingEventLoop:
 
         res = self.loop.run_until_complete(task)
 
-        # Remove the signal handlers so we can interrupt subsequent tasks
+        # Reset the signal handlers so we can interrupt the container
         for s in [signal.SIGINT, signal.SIGTERM, signal.SIGUSR1]:
             self.loop.remove_signal_handler(s)
 

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -88,7 +88,14 @@ class SignalHandlingEventLoop:
             global _ignore_cancellation
             _ignore_cancellation = True
             self.loop.add_signal_handler(signal.SIGUSR1, task.cancel)
-        return self.loop.run_until_complete(task)
+
+        res = self.loop.run_until_complete(task)
+
+        # Remove the signal handlers so we can interrupt subsequent tasks
+        for s in [signal.SIGINT, signal.SIGTERM, signal.SIGUSR1]:
+            self.loop.remove_signal_handler(s)
+
+        return res
 
 
 class _FunctionIOManager:


### PR DESCRIPTION
Fixes a bug where the container was not responsive to termination signals when using a `modal.Cls` following a recent PR that made the event loop persist over multiple inputs.

## Changelog

- Fixed a bug that could cause `cls`-based functions to to ignore timeout signals.