### PR TITLE
Don't use `MountBuild` in the client

### DIFF
--- a/modal/mount.py
+++ b/modal/mount.py
@@ -388,8 +388,12 @@ class _Mount(_StatefulObject, type_prefix="mo"):
 
         # Build mounts
         status_row.message(f"Creating mount {message_label}: Building mount")
-        req = api_pb2.MountBuildRequest(app_id=resolver.app_id, existing_mount_id=existing_object_id, files=files)
-        resp = await retry_transient_errors(resolver.client.stub.MountBuild, req, base_delay=1)
+        req = api_pb2.MountGetOrCreateRequest(
+            files=files,
+            object_creation_type=api_pb2.OBJECT_CREATION_TYPE_ANONYMOUS_OWNED_BY_APP,
+            app_id=resolver.app_id
+        )
+        resp = await retry_transient_errors(resolver.client.stub.MountGetOrCreate, req, base_delay=1)
         status_row.finish(f"Created mount {message_label}")
 
         logger.debug(f"Uploaded {len(uploaded_hashes)}/{n_files} files and {total_bytes} bytes in {time.time() - t0}s")


### PR DESCRIPTION
This replaces `MountBuild` with `MountGetOrCreate` for ephemeral mounts, which will let us delete the server endpoint in 4-6 months.

In a subsequent PR I'll leverage this in order to change how we _deploy_ mounts so that we don't rely on single-object apps on the client side