### PR TITLE
Improve error display (with @mwaskom)

### DIFF
--- a/modal/__main__.py
+++ b/modal/__main__.py
@@ -1,13 +1,35 @@
 # Copyright Modal Labs 2022
+import sys
+
 from ._traceback import highlight_modal_deprecation_warnings, setup_rich_traceback
 from .cli.entry_point import entrypoint_cli
+from .cli.import_refs import CliUserExecutionError
+from .config import config
 
 
 def main():
     # Setup rich tracebacks, but only on user's end, when using the Modal CLI.
     setup_rich_traceback()
     highlight_modal_deprecation_warnings()
-    entrypoint_cli()
+
+    if config.get("traceback"):
+        try:
+            entrypoint_cli()
+        except CliUserExecutionError as exc:
+            raise exc.__cause__ from None
+    else:
+        try:
+            entrypoint_cli()
+        except CliUserExecutionError as exc:
+            raise exc.__cause__ from None
+        except Exception as exc:
+            from rich.console import Console
+            from rich.panel import Panel
+
+            console = Console(stderr=True)
+            panel = Panel(str(exc), border_style="red", title="Error", title_align="left")
+            console.print(panel, highlight=False)
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/modal/__main__.py
+++ b/modal/__main__.py
@@ -12,17 +12,14 @@ def main():
     setup_rich_traceback()
     highlight_modal_deprecation_warnings()
 
-    if config.get("traceback"):
-        try:
-            entrypoint_cli()
-        except CliUserExecutionError as exc:
-            raise exc.__cause__ from None
-    else:
-        try:
-            entrypoint_cli()
-        except CliUserExecutionError as exc:
-            raise exc.__cause__ from None
-        except Exception as exc:
+    try:
+        entrypoint_cli()
+    except CliUserExecutionError as exc:
+        raise exc.__cause__ from None
+    except Exception as exc:
+        if config.get("traceback"):
+            raise
+        else:
             from rich.console import Console
             from rich.panel import Panel
 

--- a/modal/config.py
+++ b/modal/config.py
@@ -4,15 +4,15 @@ r"""Modal intentionally keeps configurability to a minimum.
 The main configuration options are the API tokens: the token id and the token secret.
 These can be configured in two ways:
 
-1. By running the ``modal token set`` command.
-   This writes the tokens to ``.modal.toml`` file in your home directory.
-2. By setting the environment variables ``MODAL_TOKEN_ID`` and ``MODAL_TOKEN_SECRET``.
+1. By running the `modal token set` command.
+   This writes the tokens to `.modal.toml` file in your home directory.
+2. By setting the environment variables `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET`.
    This takes precedence over the previous method.
 
 .modal.toml
 ---------------
 
-The ``.modal.toml`` file is generally stored in your home directory.
+The `.modal.toml` file is generally stored in your home directory.
 It should look like this::
 
 ```toml
@@ -21,7 +21,7 @@ token_id = "ak-12345..."
 token_secret = "as-12345..."
 ```
 
-You can create this file manually, or you can run the ``modal token set ...``
+You can create this file manually, or you can run the `modal token set ...`
 command (see below).
 
 Setting tokens using the CLI
@@ -35,9 +35,9 @@ modal token set \
   --token-secret <token secret>
 ```
 
-This will write the token id and secret to ``.modal.toml``.
+This will write the token id and secret to `.modal.toml`.
 
-If the token id or secret is provided as the string ``-`` (a single dash),
+If the token id or secret is provided as the string `-` (a single dash),
 then it will be read in a secret way from stdin instead.
 
 Other configuration options
@@ -45,29 +45,28 @@ Other configuration options
 
 Other possible configuration options are:
 
-* ``loglevel`` (in the .toml file) / ``MODAL_LOGLEVEL`` (as an env var).
-  Defaults to ``WARNING``.
-  Set this to ``DEBUG`` to see a bunch of internal output.
-* ``logs_timeout`` (in the .toml file) / ``MODAL_LOGS_TIMEOUT`` (as an env var).
+* `loglevel` (in the .toml file) / `MODAL_LOGLEVEL` (as an env var).
+  Defaults to `WARNING`. Set this to `DEBUG` to see internal messages.
+* `logs_timeout` (in the .toml file) / `MODAL_LOGS_TIMEOUT` (as an env var).
   Defaults to 10.
   Number of seconds to wait for logs to drain when closing the session,
   before giving up.
-* ``automount`` (in the .toml file) / ``MODAL_AUTOMOUNT`` (as an env var).
+* `automount` (in the .toml file) / `MODAL_AUTOMOUNT` (as an env var).
   Defaults to True.
   By default, Modal automatically mounts modules imported in the current scope, that
   are deemed to be "local". This can be turned off by setting this to False.
-* ``server_url`` (in the .toml file) / ``MODAL_SERVER_URL`` (as an env var).
-  Defaults to ``https://api.modal.com``.
-  Not typically meant to be used.
+* `traceback` (in the .toml file) / `MODAL_TRACEBACK` (as an env var).
+  Defaults to False. Enables printing full tracebacks on unexpected CLI
+  errors, which can be useful for debugging client issues.
 
 Meta-configuration
 ------------------
 
 Some "meta-options" are set using environment variables only:
 
-* ``MODAL_CONFIG_PATH`` lets you override the location of the .toml file,
-  by default ``~/.modal.toml``.
-* ``MODAL_PROFILE`` lets you use multiple sections in the .toml file
+* `MODAL_CONFIG_PATH` lets you override the location of the .toml file,
+  by default `~/.modal.toml`.
+* `MODAL_PROFILE` lets you use multiple sections in the .toml file
   and switch between them. It defaults to "default".
 """
 
@@ -194,6 +193,7 @@ _SETTINGS = {
     "worker_id": _Setting(),  # For internal debugging use.
     "restore_state_path": _Setting("/__modal/restore-state.json"),
     "force_build": _Setting(False, transform=lambda x: x not in ("", "0")),
+    "traceback": _Setting(False, transform=lambda x: x not in ("", "0")),
 }
 
 

--- a/test/cli_imports_test.py
+++ b/test/cli_imports_test.py
@@ -145,6 +145,7 @@ def test_get_by_object_path():
 
     # simple
     assert get_by_object_path(NS(foo="bar"), "foo") == "bar"
+    assert get_by_object_path(NS(foo="bar"), "bar") is None
 
     # nested simple
     assert get_by_object_path(NS(foo=NS(bar="baz")), "foo.bar") == "baz"

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -82,13 +82,6 @@ def test_app_deploy_with_name(servicer, mock_dir, set_env_client):
     assert "my_app_foo" in servicer.deployed_apps
 
 
-def test_app_deploy_no_such_module():
-    res = _run(["deploy", "does_not_exist.py"], 1)
-    assert "No such file or directory" in str(res.exception)
-    res = _run(["deploy", "does.not.exist"], 1)
-    assert "No module named 'does'" in str(res.exception)
-
-
 def test_secret_create(servicer, set_env_client):
     # fail without any keys
     _run(["secret", "create", "foo"], 2, None)


### PR DESCRIPTION
This splits up errors into two classes: user errors and CLI errors.

## CLI errors

Before, CLI errors displayed a long traceback.

<img width="924" alt="image" src="https://github.com/modal-labs/modal-client/assets/7550632/d94230ee-f178-44a8-85fe-c8faa84d3cf8">

Now they display just the error message, relevant to the user, but the original behavior can be restored by running with the `MODAL_TRACEBACK=1` config option.

<img width="938" alt="image" src="https://github.com/modal-labs/modal-client/assets/7550632/30058f32-e109-4c14-9486-899d3ad093ee">


## User errors

Before, user code errors in a file loaded by Modal printed out a long traceback.

<img width="789" alt="image" src="https://github.com/modal-labs/modal-client/assets/7550632/38ba28e2-e8d0-47d6-9ad4-d53e38b16860">

Now, they print out a shorter traceback.

<img width="809" alt="image" src="https://github.com/modal-labs/modal-client/assets/7550632/6b4a9254-04d2-4e9e-8787-4c2709e6cca5">