### PR TITLE
Create a git tag for each release

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -128,9 +128,15 @@ jobs:
       - name: Update the changelog
         run: inv update-changelog
 
+      - name: Get the current client version
+        id: version
+        run: |
+          echo "client_version=`python -m modal_version`" >> "$GITHUB_OUTPUT"
+
       - uses: EndBug/add-and-commit@v9
         with:
           add: modal_version/_version_generated.py CHANGELOG.md
+          tag: v${{ steps.version.outputs.client_version }}
           message: "[auto-commit] [skip ci] Bump the build number"
           pull: "--rebase --autostash"
           default_author: github_actions

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -130,8 +130,7 @@ jobs:
 
       - name: Get the current client version
         id: version
-        run: |
-          echo "client_version=`python -m modal_version`" >> "$GITHUB_OUTPUT"
+        run: echo "client_version=`python -m modal_version`" >> "$GITHUB_OUTPUT"
 
       - uses: EndBug/add-and-commit@v9
         with:

--- a/modal_version/__main__.py
+++ b/modal_version/__main__.py
@@ -1,0 +1,4 @@
+from . import __version__
+
+if __name__ == "__main__":
+    print(__version__)

--- a/modal_version/__main__.py
+++ b/modal_version/__main__.py
@@ -1,3 +1,4 @@
+# Copyright Modal Labs 2024
 from . import __version__
 
 if __name__ == "__main__":


### PR DESCRIPTION
This should make it easier to track down the specific code / commit for each version that we publish to PyPI.

I've some mild concern about the burden of tags that we'll create doing this. I'm using "unannotated" tags to keep it lighter weight and hopefully it won't be more than O(100) before we reach a stable release. We can always prune tags if it becomes a problem.

Resolves MOD-2444