### PR TITLE
Add CI job to test minimal container dependencies

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -67,7 +67,7 @@ jobs:
         run: pip install -r container_requirements.txt
 
       - name: Compile protos
-        run: inv protoc
+        run: python -m grpc_tools.protoc --python_out=. --grpclib_python_out=. --grpc_python_out=. --mypy_out=. --mypy_grpc_out=.
 
       - name: Check entrypoint import
         run: python -c 'import modal._container_entrypoint'

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -70,8 +70,11 @@ jobs:
 
       - name: Compile protos
         run: |
+          python -m venv venv
+          source venv/bin/activate
           pip install grpcio-tools
           python -m grpc_tools.protoc --python_out=. --grpclib_python_out=. --grpc_python_out=. -I . modal_proto/api.proto modal_proto/options.proto
+          deactivate
 
       - name: Check entrypoint import
         run: python -c 'import modal._container_entrypoint'

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -67,7 +67,9 @@ jobs:
         run: pip install -r container_requirements.txt
 
       - name: Compile protos
-        run: python -m grpc_tools.protoc --python_out=. --grpclib_python_out=. --grpc_python_out=. --mypy_out=. --mypy_grpc_out=.
+        run: |
+          pip install grpcio-tools
+          python -m grpc_tools.protoc --python_out=. --grpclib_python_out=. --grpc_python_out=. --mypy_out=. --mypy_grpc_out=.
 
       - name: Check entrypoint import
         run: python -c 'import modal._container_entrypoint'

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Compile protos
         run: |
           pip install grpcio-tools
-          python -m grpc_tools.protoc --python_out=. --grpclib_python_out=. --grpc_python_out=. --mypy_out=. --mypy_grpc_out=.
+          python -m grpc_tools.protoc --python_out=. --grpclib_python_out=. --grpc_python_out=. --mypy_out=. --mypy_grpc_out=. -I . modal_proto/api.proto modal_proto/options.proto
 
       - name: Check entrypoint import
         run: python -c 'import modal._container_entrypoint'

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -64,7 +64,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install dependencies
-        run: pip install -r container_requirements.txt
+        run: |
+          pip install -r container_requirements.txt
+          pip install synchronicity
 
       - name: Compile protos
         run: |

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Compile protos
         run: |
           pip install grpcio-tools
-          python -m grpc_tools.protoc --python_out=. --grpclib_python_out=. --grpc_python_out=. --mypy_out=. --mypy_grpc_out=. -I . modal_proto/api.proto modal_proto/options.proto
+          python -m grpc_tools.protoc --python_out=. --grpclib_python_out=. --grpc_python_out=. -I . modal_proto/api.proto modal_proto/options.proto
 
       - name: Check entrypoint import
         run: python -c 'import modal._container_entrypoint'

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Install dependencies
         run: pip install -r container_requirements.txt
 
+      - name: Compile protos
+        run: inv protoc
+
       - name: Check entrypoint import
         run: python -c 'import modal._container_entrypoint'
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -54,6 +54,21 @@ jobs:
       - name: Run docstring tests
         run: pytest -s --markdown-docs -m markdown-docs modal
 
+  container-dependencies:
+    name: Check minimal container dependencies for ${{ matrix.python-version }}
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: pip install -r container_requirements.txt
+
+      - name: Check entrypoint import
+        run: python -c 'import modal._container_entrypoint'
+
   publish-base-images:
     name: |
       Publish base images for ${{ matrix.image-name }} ${{ matrix.python-version }}

--- a/container_requirements.txt
+++ b/container_requirements.txt
@@ -1,15 +1,12 @@
 # Requirements file for testing the minimal client dependency set in the container environment
 # Not currently used in production; exists for CI usage until we remove modal/requirements.txt
-aiohttp==3.8.3;python_version<'3.12'
-aiohttp==3.9.1;python_version>='3.12'
+aiohttp==3.9.1
 aiostream==0.4.4
 asgiref==3.5.2
 certifi>=2022.12.07
-cloudpickle==2.0.0;python_version<'3.11'
-cloudpickle==2.2.0;python_version>='3.11'
+cloudpickle==2.2.0
 fastapi==0.88.0
-grpclib==0.4.3;python_version<'3.12'
-grpclib==0.4.7;python_version>='3.12'
+grpclib==0.4.7
 protobuf>=3.19.0
 rich==12.3.0
 tblib==1.7.0

--- a/container_requirements.txt
+++ b/container_requirements.txt
@@ -10,7 +10,6 @@ cloudpickle==2.2.0;python_version>='3.11'
 fastapi==0.88.0
 grpclib==0.4.3;python_version<'3.12'
 grpclib==0.4.7;python_version>='3.12'
-importlib_metadata==4.8.1
 protobuf>=3.19.0
 rich==12.3.0
 tblib==1.7.0

--- a/container_requirements.txt
+++ b/container_requirements.txt
@@ -1,0 +1,17 @@
+# Requirements file for testing the minimal client dependency set in the container environment
+# Not currently used in production; exists for CI usage until we remove modal/requirements.txt
+aiohttp==3.8.3;python_version<'3.12'
+aiohttp==3.9.1;python_version>='3.12'
+aiostream==0.4.4
+asgiref==3.5.2
+certifi>=2022.12.07
+cloudpickle==2.0.0;python_version<'3.11'
+cloudpickle==2.2.0;python_version>='3.11'
+fastapi==0.88.0
+grpclib==0.4.3;python_version<'3.12'
+grpclib==0.4.7;python_version>='3.12'
+importlib_metadata==4.8.1
+protobuf>=3.19.0
+rich==12.3.0
+tblib==1.7.0
+toml==0.10.2


### PR DESCRIPTION
We're undertaking an effort to reduce the set of client dependencies that are required in the container runtime, and we want a way to automatically check the known set (and to prevent future regressions). This PR adds a new CI job to do that. The steps are:

1) Install the dependencies specified by `container_requirements.txt` (a new file currently used only for CI)
2) Activate a venv, install some additional gRPC utilities; compile the client protos, and then deactivate
3) Try to import `modal._container_entrypoint`

The actual verification is a little bit lightweight but I think that this should catch most cases where unwanted dependencies are included on the codepaths that get imported when we run a container.

Resolves MOD-2449