### PR TITLE
Use stdlib importlib.metadata

### DIFF
--- a/modal_utils/package_utils.py
+++ b/modal_utils/package_utils.py
@@ -2,9 +2,8 @@
 import importlib
 import importlib.util
 import typing
+from importlib.metadata import PackageNotFoundError, files
 from pathlib import Path
-
-from importlib_metadata import PackageNotFoundError, files
 
 from modal.exception import ModuleNotMountable
 
@@ -24,7 +23,7 @@ def get_module_mount_info(module_name: str) -> typing.List[typing.Tuple[bool, Pa
     """Returns a list of tuples [(is_dir, path)] describing how to mount a given module."""
     file_formats = get_file_formats(module_name)
     if set(BINARY_FORMATS) & set(file_formats):
-        raise ModuleNotMountable(f"{module_name} can't be mounted because it contains a binary file.")
+        raise ModuleNotMountable(f"{module_name} can't be mounted because it contains binary file(s).")
     try:
         spec = importlib.util.find_spec(module_name)
     except Exception as exc:

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ install_requires =
     click>=8.1.0
     fastapi
     grpclib==0.4.7
-    importlib_metadata>=3.6.0
     protobuf>=3.19,<5.0,!=4.24.0
     rich>=12.0.0
     synchronicity~=0.6.2

--- a/test/package_utils_test.py
+++ b/test/package_utils_test.py
@@ -1,8 +1,9 @@
 # Copyright Modal Labs 2022
+import platform
 import pytest
 
-from modal_utils.package_utils import get_module_mount_info
 from modal.exception import ModuleNotMountable
+from modal_utils.package_utils import get_module_mount_info
 
 
 def test_get_module_mount_info():
@@ -18,5 +19,7 @@ def test_get_module_mount_info():
     assert len(res) == 1
     assert res[0][0] == False
 
-    with pytest.raises(ModuleNotMountable, match="aiohttp can't be mounted because it contains binary file"):
-        get_module_mount_info("aiohttp")
+    if platform.system() != "Windows":
+        # TODO This assertion fails on windows; I assume that compiled file formats are different there?
+        with pytest.raises(ModuleNotMountable, match="aiohttp can't be mounted because it contains binary file"):
+            get_module_mount_info("aiohttp")

--- a/test/package_utils_test.py
+++ b/test/package_utils_test.py
@@ -1,6 +1,8 @@
 # Copyright Modal Labs 2022
+import pytest
 
 from modal_utils.package_utils import get_module_mount_info
+from modal.exception import ModuleNotMountable
 
 
 def test_get_module_mount_info():
@@ -15,3 +17,6 @@ def test_get_module_mount_info():
     res = get_module_mount_info("six")
     assert len(res) == 1
     assert res[0][0] == False
+
+    with pytest.raises(ModuleNotMountable, match="aiohttp can't be mounted because it contains binary file"):
+        get_module_mount_info("aiohttp")


### PR DESCRIPTION
We use a third-party `importlib_metadata` package but `importlib.metadata` was [added to to the stdlib in 3.8](https://docs.python.org/3/library/importlib.metadata.html) (it was originally marked as "provisional", but blessed in 3.10).

Converting our (very simple) usage of this package to the stdlib version will allow us to remove another container dependency.

Resolves MOD-2451