### PR TITLE
Fix error when getclosurevars() fails

### DIFF
--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -350,11 +350,18 @@ def get_referred_objects(f: Callable) -> List[Object]:
         elif isinstance(obj, Object):
             ret.append(obj)
         elif inspect.isfunction(obj):
-            for dep_obj in inspect.getclosurevars(obj).globals.values():
+            try:
+                closure_vars = inspect.getclosurevars(obj)
+            except ValueError:
+                logger.warning(
+                    f"Could not inspect closure vars of {f} - referenced global Modal objects may or may not work in that function"
+                )
+                continue
+
+            for dep_obj in closure_vars.globals.values():
                 if id(dep_obj) not in objs_seen:
                     objs_seen.add(id(dep_obj))
                     obj_queue.append(dep_obj)
-
     return ret
 
 


### PR DESCRIPTION
`getclosurevars()` can apparently fail with weird ValueErrors ("cell empty") which causes loading of the file to fail.

We'll probably get rid of getclosurevars usage soon anyways, but this should fix it in the meanwhile (at the cost of not being able to use things like `some_global = Dict.new()` in affected functions.

Repro for previous issue:
```python
from sqlalchemy import create_engine
@stub.function(image=modal.Image.debian_slim().pip_install('sqlalchemy')) def foo():
    if False:
        create_engine()
```

## Describe your changes

- _Provide Linear issue reference (e.g. MOD-1234) if available._


## Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
