### PR TITLE
Make loader take `self`

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -204,12 +204,12 @@ class _Cls(_Object, type_prefix="cs"):
         def _deps() -> List[_Function]:
             return list(functions.values())
 
-        async def _load(provider: "_Cls", resolver: Resolver, existing_object_id: Optional[str]):
+        async def _load(self: "_Cls", resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.ClassCreateRequest(app_id=resolver.app_id, existing_class_id=existing_object_id)
             for f_name, f in functions.items():
                 req.methods.append(api_pb2.ClassMethod(function_name=f_name, function_id=f.object_id))
             resp = await resolver.client.stub.ClassCreate(req)
-            provider._hydrate(resp.class_id, resolver.client, resp.handle_metadata)
+            self._hydrate(resp.class_id, resolver.client, resp.handle_metadata)
 
         rep = f"Cls({user_cls.__name__})"
         cls = _Cls._from_loader(_load, rep, deps=_deps)

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -57,14 +57,14 @@ class _Dict(_Object, type_prefix="di"):
     def new(data: Optional[dict] = None) -> "_Dict":
         """Create a new Dict, optionally with initial data."""
 
-        async def _load(provider: _Dict, resolver: Resolver, existing_object_id: Optional[str]):
+        async def _load(self: _Dict, resolver: Resolver, existing_object_id: Optional[str]):
             serialized = _serialize_dict(data if data is not None else {})
             req = api_pb2.DictCreateRequest(
                 app_id=resolver.app_id, data=serialized, existing_dict_id=existing_object_id
             )
             response = await resolver.client.stub.DictCreate(req)
             logger.debug(f"Created dict with id {response.dict_id}")
-            provider._hydrate(response.dict_id, resolver.client, None)
+            self._hydrate(response.dict_id, resolver.client, None)
 
         return _Dict._from_loader(_load, "Dict()", is_another_app=True)
 
@@ -94,7 +94,7 @@ class _Dict(_Object, type_prefix="di"):
         ```
         """
 
-        async def _load(provider: _Dict, resolver: Resolver, existing_object_id: Optional[str]):
+        async def _load(self: _Dict, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.DictGetOrCreateRequest(
                 deployment_name=label,
                 namespace=namespace,
@@ -103,7 +103,7 @@ class _Dict(_Object, type_prefix="di"):
             )
             response = await resolver.client.stub.DictGetOrCreate(req)
             logger.debug(f"Created dict with id {response.dict_id}")
-            provider._hydrate(response.dict_id, resolver.client, None)
+            self._hydrate(response.dict_id, resolver.client, None)
 
         return _Dict._from_loader(_load, "Dict()")
 

--- a/modal/image.py
+++ b/modal/image.py
@@ -207,7 +207,7 @@ class _Image(_Object, type_prefix="im"):
                 deps.append(image_registry_config.secret)
             return deps
 
-        async def _load(provider: _Image, resolver: Resolver, existing_object_id: Optional[str]):
+        async def _load(self: _Image, resolver: Resolver, existing_object_id: Optional[str]):
             base_images_pb2s = [
                 api_pb2.BaseImage(
                     docker_tag=docker_tag,
@@ -327,7 +327,7 @@ class _Image(_Object, type_prefix="im"):
             else:
                 raise RemoteError("Unknown status %s!" % result.status)
 
-            provider._hydrate(image_id, resolver.client, None)
+            self._hydrate(image_id, resolver.client, None)
 
         rep = f"Image({dockerfile_commands})"
         obj = _Image._from_loader(_load, rep, deps=_deps)

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -88,11 +88,11 @@ class _NetworkFileSystem(_StatefulObject, type_prefix="sv"):
     def new(cloud: Optional[str] = None) -> "_NetworkFileSystem":
         """Construct a new network file system, which is empty by default."""
 
-        async def _load(provider: _NetworkFileSystem, resolver: Resolver, existing_object_id: Optional[str]):
+        async def _load(self: _NetworkFileSystem, resolver: Resolver, existing_object_id: Optional[str]):
             status_row = resolver.add_status_row()
             if existing_object_id:
                 # Volume already exists; do nothing.
-                provider._hydrate(existing_object_id, resolver.client, None)
+                self._hydrate(existing_object_id, resolver.client, None)
                 return
 
             if cloud:
@@ -102,7 +102,7 @@ class _NetworkFileSystem(_StatefulObject, type_prefix="sv"):
             req = api_pb2.SharedVolumeCreateRequest(app_id=resolver.app_id)
             resp = await retry_transient_errors(resolver.client.stub.SharedVolumeCreate, req)
             status_row.finish("Created network file system.")
-            provider._hydrate(resp.shared_volume_id, resolver.client, None)
+            self._hydrate(resp.shared_volume_id, resolver.client, None)
 
         return _NetworkFileSystem._from_loader(_load, "NetworkFileSystem()")
 

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -48,10 +48,10 @@ class _Queue(_Object, type_prefix="qu"):
     def new():
         """Create an empty Queue."""
 
-        async def _load(provider: _Queue, resolver: Resolver, existing_object_id: Optional[str]):
+        async def _load(self: _Queue, resolver: Resolver, existing_object_id: Optional[str]):
             request = api_pb2.QueueCreateRequest(app_id=resolver.app_id, existing_queue_id=existing_object_id)
             response = await resolver.client.stub.QueueCreate(request)
-            provider._hydrate(response.queue_id, resolver.client, None)
+            self._hydrate(response.queue_id, resolver.client, None)
 
         return _Queue._from_loader(_load, "Queue()")
 
@@ -81,7 +81,7 @@ class _Queue(_Object, type_prefix="qu"):
         ```
         """
 
-        async def _load(provider: _Queue, resolver: Resolver, existing_object_id: Optional[str]):
+        async def _load(self: _Queue, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.QueueGetOrCreateRequest(
                 deployment_name=label,
                 namespace=namespace,
@@ -89,7 +89,7 @@ class _Queue(_Object, type_prefix="qu"):
                 object_creation_type=(api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING if create_if_missing else None),
             )
             response = await resolver.client.stub.QueueGetOrCreate(req)
-            provider._hydrate(response.queue_id, resolver.client, None)
+            self._hydrate(response.queue_id, resolver.client, None)
 
         return _Queue._from_loader(_load, "Queue()", is_another_app=True)
 

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -147,7 +147,7 @@ class _Sandbox(_Object, type_prefix="sb"):
                     deps.append(s3_mount.secret)
             return deps
 
-        async def _load(provider: _Sandbox, resolver: Resolver, _existing_object_id: Optional[str]):
+        async def _load(self: _Sandbox, resolver: Resolver, _existing_object_id: Optional[str]):
             gpu_config = parse_gpu_config(gpu)
 
             cloud_provider = parse_cloud_provider(cloud) if cloud else None
@@ -186,7 +186,7 @@ class _Sandbox(_Object, type_prefix="sb"):
             create_resp = await retry_transient_errors(resolver.client.stub.SandboxCreate, create_req)
 
             sandbox_id = create_resp.sandbox_id
-            provider._hydrate(sandbox_id, resolver.client, None)
+            self._hydrate(sandbox_id, resolver.client, None)
 
         return _Sandbox._from_loader(_load, "Sandbox()", deps=_deps)
 

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -52,7 +52,7 @@ class _Secret(_Object, type_prefix="st"):
         if not all(isinstance(v, str) for v in env_dict_filtered.values()):
             raise InvalidError(ENV_DICT_WRONG_TYPE_ERR)
 
-        async def _load(provider: _Secret, resolver: Resolver, existing_object_id: Optional[str]):
+        async def _load(self: _Secret, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.SecretGetOrCreateRequest(
                 object_creation_type=api_pb2.OBJECT_CREATION_TYPE_ANONYMOUS_OWNED_BY_APP,
                 env_dict=env_dict_filtered,
@@ -66,7 +66,7 @@ class _Secret(_Object, type_prefix="st"):
                 if exc.status == Status.FAILED_PRECONDITION:
                     raise InvalidError(exc.message)
                 raise
-            provider._hydrate(resp.secret_id, resolver.client, None)
+            self._hydrate(resp.secret_id, resolver.client, None)
 
         rep = f"Secret.from_dict([{', '.join(env_dict.keys())}])"
         return _Secret._from_loader(_load, rep)
@@ -91,7 +91,7 @@ class _Secret(_Object, type_prefix="st"):
         starting point for finding the `.env` file.
         """
 
-        async def _load(provider: _Secret, resolver: Resolver, existing_object_id: Optional[str]):
+        async def _load(self: _Secret, resolver: Resolver, existing_object_id: Optional[str]):
             try:
                 from dotenv import dotenv_values, find_dotenv
                 from dotenv.main import _walk_to_root
@@ -124,7 +124,7 @@ class _Secret(_Object, type_prefix="st"):
             )
             resp = await resolver.client.stub.SecretGetOrCreate(req)
 
-            provider._hydrate(resp.secret_id, resolver.client, None)
+            self._hydrate(resp.secret_id, resolver.client, None)
 
         return _Secret._from_loader(_load, "Secret.from_dotenv()")
 
@@ -145,7 +145,7 @@ class _Secret(_Object, type_prefix="st"):
         ```
         """
 
-        async def _load(provider: _Secret, resolver: Resolver, existing_object_id: Optional[str]):
+        async def _load(self: _Secret, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.SecretGetOrCreateRequest(
                 deployment_name=label,
                 namespace=namespace,
@@ -158,7 +158,7 @@ class _Secret(_Object, type_prefix="st"):
                     raise NotFoundError(exc.message)
                 else:
                     raise
-            provider._hydrate(response.secret_id, resolver.client, None)
+            self._hydrate(response.secret_id, resolver.client, None)
 
         return _Secret._from_loader(_load, "Secret()")
 

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -83,18 +83,18 @@ class _Volume(_StatefulObject, type_prefix="vo"):
     def new() -> "_Volume":
         """Construct a new volume, which is empty by default."""
 
-        async def _load(provider: _Volume, resolver: Resolver, existing_object_id: Optional[str]):
+        async def _load(self: _Volume, resolver: Resolver, existing_object_id: Optional[str]):
             status_row = resolver.add_status_row()
             if existing_object_id:
                 # Volume already exists; do nothing.
-                provider._hydrate(existing_object_id, resolver.client, None)
+                self._hydrate(existing_object_id, resolver.client, None)
                 return
 
             status_row.message("Creating volume...")
             req = api_pb2.VolumeCreateRequest(app_id=resolver.app_id)
             resp = await retry_transient_errors(resolver.client.stub.VolumeCreate, req)
             status_row.finish("Created volume.")
-            provider._hydrate(resp.volume_id, resolver.client, None)
+            self._hydrate(resp.volume_id, resolver.client, None)
 
         return _Volume._from_loader(_load, "Volume()")
 


### PR DESCRIPTION
The load method used to be a class method that would take the "provider" as the first argument and return a "handle".

But since Aug 2023, the load method just mutates the provider directly. So we might as well rename it to `self` and let it behave like a regular method.

In particular this lets us define the loader function on the class itself, and use it as a normal bound method. This is roughly happening `_Mount._load_mount` already, so we can simplify this a bit and get rid of a usage of `functools.partial`.

(The reason I created this PR was that I needed to add a bunch of extra arguments to the partial, and I realized it's unnecessarily complex)

In the future this lets us move more loader functions to sit on the class instead. This will let us get rid of the nested initialization code.