### PR TITLE
Deploy persisted mounts directly

### DIFF
--- a/test/mount_test.py
+++ b/test/mount_test.py
@@ -60,7 +60,7 @@ def test_create_mount(servicer, client):
 
     m._deploy("my-mount", client=client)
 
-    assert m.object_id == "mo-123"
+    assert m.object_id == "mo-1"
     assert f"/foo/{cur_filename}" in servicer.files_name2sha
     sha256_hex = servicer.files_name2sha[f"/foo/{cur_filename}"]
     assert sha256_hex in servicer.files_sha2data

--- a/test/mounted_files_test.py
+++ b/test/mounted_files_test.py
@@ -221,8 +221,8 @@ def test_mount_dedupe(servicer, test_dir, server_url_env):
         )
     )
     assert servicer.n_mounts == 2
-    assert servicer.mount_contents["mo-123"].keys() == {"/root/mount_dedupe.py"}
-    pkg_a_mount = servicer.mount_contents["mo-124"]
+    assert servicer.mount_contents["mo-1"].keys() == {"/root/mount_dedupe.py"}
+    pkg_a_mount = servicer.mount_contents["mo-2"]
     for fn in pkg_a_mount.keys():
         assert fn.startswith("/root/pkg_a")
     assert "/root/pkg_a/normally_not_included.pyc" not in pkg_a_mount.keys()
@@ -242,12 +242,12 @@ def test_mount_dedupe_explicit(servicer, test_dir, server_url_env):
         )
     )
     assert servicer.n_mounts == 3
-    assert servicer.mount_contents["mo-123"].keys() == {"/root/mount_dedupe.py"}
-    pkg_a_mount = servicer.mount_contents["mo-124"]
+    assert servicer.mount_contents["mo-1"].keys() == {"/root/mount_dedupe.py"}
+    pkg_a_mount = servicer.mount_contents["mo-2"]
     for fn in pkg_a_mount.keys():
         assert fn.startswith("/root/pkg_a")
     assert "/root/pkg_a/normally_not_included.pyc" not in pkg_a_mount.keys()
 
-    custom_pkg_a_mount = servicer.mount_contents["mo-125"]
+    custom_pkg_a_mount = servicer.mount_contents["mo-3"]
     assert len(custom_pkg_a_mount) == len(pkg_a_mount) + 1
     assert "/root/pkg_a/normally_not_included.pyc" in custom_pkg_a_mount.keys()


### PR DESCRIPTION
`_Mount` previously inherited from `_StatefulObject`, which is an intermediate object we've needed for deploying single-object apps client-side. But with this change, we deploy mounts directly using `MountGetOrCreate`, and we don't rely on the client code to construct an app etc – this logic will happen server-side instead.

Mounts are only deployed by our own code, in `modal_base_images`, so this hopefully shouldn't affect users.

