### PR TITLE
Remove modal import machinery preamble from user code exceptions

### DIFF
--- a/modal/cli/import_refs.py
+++ b/modal/cli/import_refs.py
@@ -48,6 +48,9 @@ class CliUserExecutionError(Exception):
     the CLI at this stage will have tracebacks printed.
     """
 
+    def __init__(self, user_source: str):
+        self.user_source = user_source
+
 
 DEFAULT_STUB_NAME = "stub"
 
@@ -61,7 +64,8 @@ def import_file_or_module(file_or_module: str):
 
     if file_or_module.endswith(".py"):
         # when using a script path, that scripts directory should also be on the path as it is with `python some/script.py`
-        sys.path.insert(0, str(Path(file_or_module).resolve().parent))
+        full_path = Path(file_or_module).resolve()
+        sys.path.insert(0, str(full_path.parent))
 
         module_name = inspect.getmodulename(file_or_module)
         # Import the module - see https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly
@@ -71,12 +75,12 @@ def import_file_or_module(file_or_module: str):
         try:
             spec.loader.exec_module(module)
         except Exception as exc:
-            raise CliUserExecutionError() from exc
+            raise CliUserExecutionError(str(full_path)) from exc
     else:
         try:
             module = importlib.import_module(file_or_module)
         except Exception as exc:
-            raise CliUserExecutionError() from exc
+            raise CliUserExecutionError(file_or_module) from exc
 
     return module
 

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -301,6 +301,12 @@ def test_run_parse_args_function(servicer, set_env_client, test_dir):
         assert expected in res.stdout
 
 
+def test_run_user_script_exception(servicer, set_env_client, test_dir):
+    stub_file = test_dir / "supports" / "app_run_tests" / "raises_error.py"
+    res = _run(["run", stub_file.as_posix()], expected_exit_code=1)
+    assert res.exc_info[1].user_source == stub_file.as_posix()
+
+
 @pytest.fixture
 def fresh_main_thread_assertion_module(test_dir):
     modules_to_unload = [n for n in sys.modules.keys() if "main_thread_assertion" in n]

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -304,7 +304,7 @@ def test_run_parse_args_function(servicer, set_env_client, test_dir):
 def test_run_user_script_exception(servicer, set_env_client, test_dir):
     stub_file = test_dir / "supports" / "app_run_tests" / "raises_error.py"
     res = _run(["run", stub_file.as_posix()], expected_exit_code=1)
-    assert res.exc_info[1].user_source == stub_file.as_posix()
+    assert res.exc_info[1].user_source == str(stub_file.resolve())
 
 
 @pytest.fixture


### PR DESCRIPTION
Follow-on to #1422, this now modifies the traceback printed when we except on user code import to show the user's target script / module as the first frame.

AFAICT, we don't have any test framework that exercises `modal/__main__.py` (there is `cli_test`, but it uses the `cli_entrypoint` that is downstream of where we're doing this). I did add some robustness so that we fall back to the original traceback if we can't find the user's frame.

I still think it's sort of bad CLI UX that there's extra noise from the path taken inside modal for things like invalid argument values:

<img width="744" alt="image" src="https://github.com/modal-labs/modal-client/assets/315810/98cb3bc7-5fe4-4f73-9f03-a2191becf452">

And in some cases we end up with extra synchronicity frames after the line that actually triggered the exception, which is weird:

<img width="715" alt="image" src="https://github.com/modal-labs/modal-client/assets/315810/490e84f2-b80d-487a-9c11-456c41c9f0e9">

So probably more than we can do here. It's possible that `modal.exception.InvalidError` should be something like just an error panel with the invalid message and then maybe the relevant filename / line number in the user's codebase, but finding that could potentially be hard for more complex applications.