### PR TITLE
Restrict toml usage / imports to local environment

### DIFF
--- a/container_requirements.txt
+++ b/container_requirements.txt
@@ -10,4 +10,3 @@ grpclib==0.4.7
 protobuf>=3.19.0
 rich==12.3.0
 tblib==1.7.0
-toml==0.10.2

--- a/modal/config.py
+++ b/modal/config.py
@@ -82,7 +82,6 @@ from google.protobuf.empty_pb2 import Empty
 from modal_proto import api_pb2
 from modal_utils.logger import configure_logger
 
-from .app import is_local
 from .exception import ExecutionError, InvalidError, deprecation_error, deprecation_warning
 
 # Locate config file and read it
@@ -91,6 +90,8 @@ user_config_path: str = os.environ.get("MODAL_CONFIG_PATH") or os.path.expanduse
 
 
 def _read_user_config():
+    from .app import is_local
+
     if is_local() and os.path.exists(user_config_path):
         # Defer toml import so we don't need it in the container runtime environment
         import toml
@@ -275,6 +276,8 @@ def _store_user_config(
 
 
 def _write_user_config(user_config):
+    from .app import is_local
+
     if not is_local():
         raise ExecutionError("Can't update config file in remote environment.")
 

--- a/modal/config.py
+++ b/modal/config.py
@@ -82,7 +82,7 @@ from google.protobuf.empty_pb2 import Empty
 from modal_proto import api_pb2
 from modal_utils.logger import configure_logger
 
-from .exception import ExecutionError, InvalidError, deprecation_error, deprecation_warning
+from .exception import InvalidError, deprecation_error, deprecation_warning
 
 # Locate config file and read it
 
@@ -279,7 +279,7 @@ def _write_user_config(user_config):
     from .app import is_local
 
     if not is_local():
-        raise ExecutionError("Can't update config file in remote environment.")
+        raise InvalidError("Can't update config file in remote environment.")
 
     # Defer toml import so we don't need it in the container runtime environment
     import toml

--- a/modal/config.py
+++ b/modal/config.py
@@ -282,7 +282,7 @@ def _store_user_config(
 
 
 def _write_user_config(user_config):
-    if not _is_remote():
+    if _is_remote():
         raise InvalidError("Can't update config file in remote environment.")
 
     # Defer toml import so we don't need it in the container runtime environment

--- a/modal/config.py
+++ b/modal/config.py
@@ -93,12 +93,8 @@ def _is_remote() -> bool:
     # We want to prevent read/write on a modal config file in the container
     # environment, both because that doesn't make sense and might cause weird
     # behavior, and because we want to keep the `toml` dependency out of the
-    # container runtime. Ideally we would use `modal.app.is_local` here, but
-    # we currently need to read the config before setting up the container app.
-    # So we're taking the somewhat hacky route of checking for env variables
-    # that we know will be set in the container environment and are unlikely
-    # to be set in the local environment.
-    return {"MODAL_TASK_ID", "MODAL_IMAGE_ID"} <= set(os.environ)
+    # container runtime.
+    return os.environ.get("MODAL_IS_REMOTE") == "1"
 
 
 def _read_user_config():

--- a/modal/image.py
+++ b/modal/image.py
@@ -9,7 +9,6 @@ from inspect import isfunction
 from pathlib import Path, PurePosixPath
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
-import toml
 from google.protobuf.message import Message
 from grpclib.exceptions import GRPCError, StreamTerminatedError
 
@@ -602,6 +601,9 @@ class _Image(_Object, type_prefix="im"):
         # Don't re-run inside container.
         if not is_local():
             return self
+
+        # Defer toml import so we don't need it in the container runtime environment
+        import toml
 
         pyproject_toml = os.path.expanduser(pyproject_toml)
 


### PR DESCRIPTION
We don't need `toml` in the container runtime: the two places where it's currently used are only relevant locally, so it makes sense to gate the codepaths by `MODAL_IS_REMOTE` and then defer the `toml` import. It's not optimal to have deferred imports, but it provides  a lower maintenance burden than vendoring. We can explore the stdlib `tomllib` once we roll up to 3.11+ (although I think that is read-only).

- Resolves MOD-2456
