### PR TITLE
Add types to most of modal_utils

### DIFF
--- a/modal_utils/async_utils.py
+++ b/modal_utils/async_utils.py
@@ -7,7 +7,7 @@ import sys
 import time
 import typing
 from contextlib import asynccontextmanager
-from typing import Any, AsyncGenerator, Awaitable, Callable, Iterator, List, Optional, Set, TypeVar, Union
+from typing import Any, AsyncGenerator, Awaitable, Callable, Iterator, List, Optional, Set, TypeVar, Union, cast
 
 import synchronicity
 from typing_extensions import ParamSpec
@@ -327,7 +327,7 @@ def asyncify(f: Callable[P, T]) -> Callable[P, Awaitable[T]]:
     return wrapper
 
 
-async def iterate_blocking(iterator: Iterator[T]) -> AsyncGenerator[Union[T, object], None]:
+async def iterate_blocking(iterator: Iterator[T]) -> AsyncGenerator[T, None]:
     """Iterate over a blocking iterator in an async context."""
 
     loop = asyncio.get_running_loop()
@@ -336,7 +336,7 @@ async def iterate_blocking(iterator: Iterator[T]) -> AsyncGenerator[Union[T, obj
         obj = await loop.run_in_executor(None, next, iterator, DONE)
         if obj is DONE:
             break
-        yield obj
+        yield cast(T, obj)
 
 
 class ConcurrencyPool:

--- a/modal_utils/async_utils.py
+++ b/modal_utils/async_utils.py
@@ -7,7 +7,7 @@ import sys
 import time
 import typing
 from contextlib import asynccontextmanager
-from typing import Any, AsyncIterator, Awaitable, Callable, Iterator, List, Optional, Set, TypeVar
+from typing import Any, AsyncGenerator, Awaitable, Callable, Iterator, List, Optional, Set, TypeVar, Union
 
 import synchronicity
 from typing_extensions import ParamSpec
@@ -327,7 +327,7 @@ def asyncify(f: Callable[P, T]) -> Callable[P, Awaitable[T]]:
     return wrapper
 
 
-async def iterate_blocking(iterator: Iterator[T]) -> AsyncIterator[T]:
+async def iterate_blocking(iterator: Iterator[T]) -> AsyncGenerator[Union[T, object], None]:
     """Iterate over a blocking iterator in an async context."""
 
     loop = asyncio.get_running_loop()

--- a/modal_utils/package_utils.py
+++ b/modal_utils/package_utils.py
@@ -23,7 +23,7 @@ def get_file_formats(module):
 BINARY_FORMATS = ["so", "S", "s", "asm"]  # TODO
 
 
-def get_module_mount_info(module_name: str) -> typing.List[typing.Tuple[bool, Path]]:
+def get_module_mount_info(module_name: str) -> typing.Sequence[typing.Tuple[bool, Path]]:
     """Returns a list of tuples [(is_dir, path)] describing how to mount a given module."""
     file_formats = get_file_formats(module_name)
     if set(BINARY_FORMATS) & set(file_formats):

--- a/tasks.py
+++ b/tasks.py
@@ -51,8 +51,6 @@ def type_check(ctx):
         "modal_utils/http_utils.py",
         "modal_utils/logger.py",
         "modal_utils/package_utils.py",
-        "modal_version/__init__.py",
-        "modal_version/_version_generated.py",
     ]
 
     ctx.run(f"pyright {' '.join(pyright_allowlist)}", pty=True)

--- a/tasks.py
+++ b/tasks.py
@@ -44,6 +44,15 @@ def type_check(ctx):
     # use pyright for checking implementation of those files
     pyright_allowlist = [
         "modal/functions.py",
+        "modal_utils/__init__.py",
+        "modal_utils/app_utils.py",
+        "modal_utils/async_utils.py",
+        "modal_utils/grpc_testing.py",
+        "modal_utils/http_utils.py",
+        "modal_utils/logger.py",
+        "modal_utils/package_utils.py",
+        "modal_version/__init__.py",
+        "modal_version/_version_generated.py",
     ]
 
     ctx.run(f"pyright {' '.join(pyright_allowlist)}", pty=True)


### PR DESCRIPTION
## Describe your changes

This PR adds mypy types to `modal_version` and `modal_utils`, as per https://github.com/modal-labs/modal-client/issues/1372.

```
modal_utils/__init__.py
modal_utils/app_utils.py
modal_utils/async_utils.py
modal_utils/grpc_testing.py
modal_utils/http_utils.py
modal_utils/logger.py
modal_utils/package_utils.py
```