### PR TITLE
Fix minor version and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ We appreciate your patience while we speedily work towards a stable release of t
 
 <!-- NEW CONTENT GENERATED BELOW. PLEASE PRESERVE THIS COMMENT. -->
 
-### 0.59.0 (2024-02-29)
+### 0.60.0 (2024-02-29)
 
 - `Image.run_function` now allows you to pass args and kwargs to the function. Usage:
 
@@ -26,12 +26,18 @@ image = modal.Image.debian_slim().run_function(
 
 
 
+## 0.59
+
+
 ### 0.59.0 (2024-02-28)
 
 * Mounted packages are now deduplicated across functions in the same stub
 * Mounting of local Python packages are now marked as such in the mount creation output, e.g. `PythonPackage:my_package`
 * Automatic mounting now includes packages outside of the function file's own directory. Mounted packages are mounted in /root/<module path>
 
+
+
+## 0.58
 
 
 ### 0.58.90 (2024-02-27)

--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -7,7 +7,7 @@ from ._version_generated import build_number
 major_number = 0
 
 # Bump this manually on breaking changes, then reset the number in _version_generated.py
-minor_number = 59
+minor_number = 60
 
 # Right now, automatically increment the patch number in CI
 __version__ = f"{major_number}.{minor_number}.{max(build_number, 0)}"


### PR DESCRIPTION
We had an error in our version metadata that caused the deployments of versions 0.60.0 and 0.60.1 to error out. This PR fixes things so that the version is correct going forward.