### PR TITLE
Show traceback from user code when local entrypoint function raises errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,13 @@ image = modal.Image.debian_slim().run_function(
 ## 0.58
 
 
+### 0.58.92 (2024-02-27)
+
+- Most errors raised through usage of the CLI will now print a simple error message rather than showing a traceback from inside the `modal` library.
+- Tracebacks originating from user code will include fewer frames from within `modal` itself.
+- The new `MODAL_TRACEBACK` environment variable (an `traceback` field in the Modal config file) can override these behaviors so that full tracebacks are always shown.
+
+
 ### 0.58.90 (2024-02-27)
 
 - Fixed a bug that could cause `cls`-based functions to to ignore timeout signals.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ image = modal.Image.debian_slim().run_function(
 
 - Most errors raised through usage of the CLI will now print a simple error message rather than showing a traceback from inside the `modal` library.
 - Tracebacks originating from user code will include fewer frames from within `modal` itself.
-- The new `MODAL_TRACEBACK` environment variable (an `traceback` field in the Modal config file) can override these behaviors so that full tracebacks are always shown.
+- The new `MODAL_TRACEBACK` environment variable (and `traceback` field in the Modal config file) can override these behaviors so that full tracebacks are always shown.
 
 
 ### 0.58.90 (2024-02-27)

--- a/modal/__main__.py
+++ b/modal/__main__.py
@@ -3,7 +3,7 @@ import sys
 
 from ._traceback import highlight_modal_deprecation_warnings, setup_rich_traceback
 from .cli.entry_point import entrypoint_cli
-from .cli.import_refs import CliUserExecutionError
+from .cli.import_refs import _CliUserExecutionError
 from .config import config
 
 
@@ -14,7 +14,9 @@ def main():
 
     try:
         entrypoint_cli()
-    except CliUserExecutionError as exc:
+    except _CliUserExecutionError as exc:
+        if config.get("traceback"):
+            raise exc
         # Try to step forward in the traceback until we get to the user code that failed to import
         tb = orig_tb = exc.__cause__.__traceback__
         if exc.user_source.endswith(".py"):

--- a/modal/__main__.py
+++ b/modal/__main__.py
@@ -16,7 +16,7 @@ def main():
         entrypoint_cli()
     except _CliUserExecutionError as exc:
         if config.get("traceback"):
-            raise exc
+            raise
         # Try to step forward in the traceback until we get to the user code that failed to import
         tb = orig_tb = exc.__cause__.__traceback__
         if exc.user_source.endswith(".py"):

--- a/modal/__main__.py
+++ b/modal/__main__.py
@@ -29,6 +29,8 @@ def main():
             # In case we didn't find a frame that matched the user source, revert to the original traceback
             tb = orig_tb
         sys.excepthook(type(exc.__cause__), exc.__cause__, tb)
+        sys.exit(1)
+
     except Exception as exc:
         if config.get("traceback"):
             raise

--- a/modal/__main__.py
+++ b/modal/__main__.py
@@ -14,9 +14,11 @@ def main():
 
     try:
         entrypoint_cli()
+
     except _CliUserExecutionError as exc:
         if config.get("traceback"):
             raise
+
         # Try to step forward in the traceback until we get to the user code that failed to import
         tb = orig_tb = exc.__cause__.__traceback__
         if exc.user_source.endswith(".py"):
@@ -34,14 +36,14 @@ def main():
     except Exception as exc:
         if config.get("traceback"):
             raise
-        else:
-            from rich.console import Console
-            from rich.panel import Panel
 
-            console = Console(stderr=True)
-            panel = Panel(str(exc), border_style="red", title="Error", title_align="left")
-            console.print(panel, highlight=False)
-            sys.exit(1)
+        from rich.console import Console
+        from rich.panel import Panel
+
+        console = Console(stderr=True)
+        panel = Panel(str(exc), border_style="red", title="Error", title_align="left")
+        console.print(panel, highlight=False)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/modal/cli/import_refs.py
+++ b/modal/cli/import_refs.py
@@ -19,6 +19,7 @@ from rich.console import Console
 from rich.markdown import Markdown
 
 import modal
+from modal.exception import _CliUserExecutionError
 from modal.functions import Function
 from modal.stub import LocalEntrypoint, Stub
 
@@ -38,18 +39,6 @@ def parse_import_ref(object_ref: str) -> ImportRef:
         file_or_module, object_path = object_ref, None
 
     return ImportRef(file_or_module, object_path)
-
-
-class CliUserExecutionError(Exception):
-    """Private wrapper for exceptions during stub imports in the CLI.
-
-    This intentionally does not inherit from `modal.exception.Error` because it
-    is a private type that should never bubble up to users. Exceptions raised in
-    the CLI at this stage will have tracebacks printed.
-    """
-
-    def __init__(self, user_source: str):
-        self.user_source = user_source
 
 
 DEFAULT_STUB_NAME = "stub"
@@ -75,12 +64,12 @@ def import_file_or_module(file_or_module: str):
         try:
             spec.loader.exec_module(module)
         except Exception as exc:
-            raise CliUserExecutionError(str(full_path)) from exc
+            raise _CliUserExecutionError(str(full_path)) from exc
     else:
         try:
             module = importlib.import_module(file_or_module)
         except Exception as exc:
-            raise CliUserExecutionError(file_or_module) from exc
+            raise _CliUserExecutionError(file_or_module) from exc
 
     return module
 

--- a/modal/exception.py
+++ b/modal/exception.py
@@ -92,6 +92,21 @@ class PendingDeprecationError(UserWarning):
     """Soon to be deprecated feature. Only used intermittently because of multi-repo concerns."""
 
 
+class _CliUserExecutionError(Exception):
+    """mdmd:hidden
+    Private wrapper for exceptions during when importing or running stubs from the CLI.
+
+    This intentionally does not inherit from `modal.exception.Error` because it
+    is a private type that should never bubble up to users. Exceptions raised in
+    the CLI at this stage will have tracebacks printed.
+    """
+
+    def __init__(self, user_source: str):
+        # `user_source` should be the filepath for the user code that is the source of the exception.
+        # This is used by our exception handler to show the traceback starting from that point.
+        self.user_source = user_source
+
+
 # TODO(erikbern): we have something similready in _function_utils.py
 _INTERNAL_MODULES = ["modal", "modal_utils", "synchronicity"]
 

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -18,7 +18,7 @@ from ._output import OutputManager, get_app_logs_loop, step_completed, step_prog
 from .app import _LocalApp, is_local
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, _Client
 from .config import config
-from .exception import InteractiveTimeoutError, InvalidError
+from .exception import InteractiveTimeoutError, InvalidError, _CliUserExecutionError
 
 if TYPE_CHECKING:
     from .stub import _Stub
@@ -151,7 +151,12 @@ async def _run_stub(
             else:
                 reason = api_pb2.APP_DISCONNECT_REASON_ENTRYPOINT_COMPLETED
 
-            exc_str = repr(exc_info) if exc_info else ""
+            if isinstance(exc_info, _CliUserExecutionError):
+                exc_str = repr(exc_info.__cause__)
+            elif exc_info:
+                exc_str = repr(exc_info)
+            else:
+                exc_str = ""
 
             await app.disconnect(reason, exc_str)
             stub._uncreate_all_objects()

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -230,7 +230,7 @@ def test_run_local_entrypoint_invalid_with_stub_run(servicer, set_env_client, te
     stub_file = test_dir / "supports" / "app_run_tests" / "local_entrypoint_invalid.py"
 
     res = _run(["run", stub_file.as_posix()], expected_exit_code=1)
-    assert "app is already running" in str(res.exception).lower()
+    assert "app is already running" in str(res.exception.__cause__).lower()
     assert "unreachable" not in res.stdout
     assert len(servicer.client_calls) == 0
 

--- a/test/supports/app_run_tests/raises_error.py
+++ b/test/supports/app_run_tests/raises_error.py
@@ -1,0 +1,9 @@
+# Copyright Modal Labs 2024
+import modal
+
+stub = modal.Stub()
+
+
+@stub.function(gpu="NOT_A_GPU")
+def f():
+    pass


### PR DESCRIPTION
Fixes an oversight in our recent change to traceback handling:

<img width="724" alt="image" src="https://github.com/modal-labs/modal-client/assets/315810/ebc3d4b6-e813-4b47-ac3b-032704b11e04">

Resolves MOD-2460