### PR TITLE
Deprecation warning for NFS.persist

### DIFF
--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -142,6 +142,7 @@ class _NetworkFileSystem(_StatefulObject, type_prefix="sv"):
         cloud: Optional[str] = None,
     ):
         """`NetworkFileSystem().persist("my-volume")` is deprecated. Use `NetworkFileSystem.persisted("my-volume")` instead."""
+        deprecation_warning((2024, 2, 29), _NetworkFileSystem.persist.__doc__)
         return self.persisted(label, namespace, environment_name, cloud)
 
     @live_method


### PR DESCRIPTION
The deprecation warning is in the docstring, but we never actually emitted the warning! My bad! I don't think anyone uses this method though.
