### PR TITLE
Create/lookup NFS using SharedVolumeGetOrCreate

### DIFF
--- a/modal/cli/network_file_system.py
+++ b/modal/cli/network_file_system.py
@@ -73,8 +73,7 @@ def create(
     env: Optional[str] = ENV_OPTION,
 ):
     ensure_env(env)
-    volume = modal.NetworkFileSystem.new()
-    volume._deploy(name, environment_name=env)
+    modal.NetworkFileSystem.create_deployed(name, environment_name=env)
     console = Console()
     console.print(f"Created volume '{name}'. \n\nCode example:\n")
     usage = Syntax(gen_usage_code(name), "python")

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -193,6 +193,25 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         await resolver.load(obj)
         return obj
 
+    @staticmethod
+    async def create_deployed(
+        deployment_name: str,
+        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        client: Optional[_Client] = None,
+        environment_name: Optional[str] = None,
+    ) -> str:
+        """mdmd:hidden"""
+        if client is None:
+            client = await _Client.from_env()
+        request = api_pb2.SharedVolumeGetOrCreateRequest(
+            deployment_name=deployment_name,
+            namespace=namespace,
+            environment_name=_get_environment_name(environment_name),
+            object_creation_type=api_pb2.OBJECT_CREATION_TYPE_CREATE_FAIL_IF_EXISTS,
+        )
+        resp = await retry_transient_errors(client.stub.SharedVolumeGetOrCreate, request)
+        return resp.shared_volume_id
+
     @live_method
     async def write_file(self, remote_path: str, fp: BinaryIO) -> int:
         """Write from a file object to a path on the network file system, atomically.

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -15,8 +15,9 @@ from modal_utils.hash_utils import get_sha256_hex
 from ._blob_utils import LARGE_FILE_LIMIT, blob_iter, blob_upload_file
 from ._resolver import Resolver
 from ._types import typechecked
+from .client import _Client
 from .exception import deprecation_warning
-from .object import _StatefulObject, live_method, live_method_gen
+from .object import _get_environment_name, _Object, live_method, live_method_gen
 
 NETWORK_FILE_SYSTEM_PUT_FILE_CLIENT_TIMEOUT = (
     10 * 60
@@ -40,7 +41,7 @@ def network_file_system_mount_protos(
     return network_file_system_mounts
 
 
-class _NetworkFileSystem(_StatefulObject, type_prefix="sv"):
+class _NetworkFileSystem(_Object, type_prefix="sv"):
     """A shared, writable file system accessible by one or more Modal functions.
 
     By attaching this file system as a mount to one or more functions, they can
@@ -107,6 +108,29 @@ class _NetworkFileSystem(_StatefulObject, type_prefix="sv"):
         return _NetworkFileSystem._from_loader(_load, "NetworkFileSystem()")
 
     @staticmethod
+    def from_name(
+        label: str,
+        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        environment_name: Optional[str] = None,
+        create_if_missing: bool = False,
+    ) -> "_NetworkFileSystem":
+        """Create a reference to a persisted network filesystem
+
+        """
+
+        async def _load(self: _NetworkFileSystem, resolver: Resolver, existing_object_id: Optional[str]):
+            req = api_pb2.SharedVolumeGetOrCreateRequest(
+                deployment_name=label,
+                namespace=namespace,
+                environment_name=_get_environment_name(environment_name, resolver),
+                object_creation_type=(api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING if create_if_missing else None),
+            )
+            response = await resolver.client.stub.SharedVolumeGetOrCreate(req)
+            self._hydrate(response.shared_volume_id, resolver.client, None)
+
+        return _NetworkFileSystem._from_loader(_load, "NetworkFileSystem()")
+
+    @staticmethod
     def persisted(
         label: str,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
@@ -132,7 +156,7 @@ class _NetworkFileSystem(_StatefulObject, type_prefix="sv"):
             pass
         ```
         """
-        return _NetworkFileSystem.new(cloud)._persist(label, namespace, environment_name)
+        return _NetworkFileSystem.from_name(label, namespace, environment_name, create_if_missing=True)
 
     def persist(
         self,
@@ -144,6 +168,30 @@ class _NetworkFileSystem(_StatefulObject, type_prefix="sv"):
         """`NetworkFileSystem().persist("my-volume")` is deprecated. Use `NetworkFileSystem.persisted("my-volume")` instead."""
         deprecation_warning((2024, 2, 29), _NetworkFileSystem.persist.__doc__)
         return self.persisted(label, namespace, environment_name, cloud)
+
+    @staticmethod
+    async def lookup(
+        label: str,
+        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        client: Optional[_Client] = None,
+        environment_name: Optional[str] = None,
+        create_if_missing: bool = False,
+    ) -> "_NetworkFileSystem":
+        """Lookup a network file system with a given name and tag.
+
+        ```python
+        n = modal.NetworkFileSystem.lookup("my-nfs")
+        print(n.listdir("/"))
+        ```
+        """
+        obj = _NetworkFileSystem.from_name(
+            label, namespace=namespace, environment_name=environment_name, create_if_missing=create_if_missing
+        )
+        if client is None:
+            client = await _Client.from_env()
+        resolver = Resolver(client=client)
+        await resolver.load(obj)
+        return obj
 
     @live_method
     async def write_file(self, remote_path: str, fp: BinaryIO) -> int:

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -520,9 +520,9 @@ def test_environment_flag(test_dir, servicer, command):
             and req.namespace == api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL,
         )  # built-in client lookup
         ctx.add_response(
-            "AppLookupObject",
-            api_pb2.AppLookupObjectResponse(object=api_pb2.Object(object_id="sv-123")),
-            request_filter=lambda req: req.app_name == "volume_app" and req.environment_name == "staging",
+            "SharedVolumeGetOrCreate",
+            api_pb2.SharedVolumeGetOrCreateResponse(shared_volume_id="sv-123"),
+            request_filter=lambda req: req.deployment_name == "volume_app" and req.environment_name == "staging",
         )
         _run(command + ["--env=staging", str(stub_file)])
 
@@ -554,9 +554,9 @@ def test_environment_noflag(test_dir, servicer, command, monkeypatch):
             and req.namespace == api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL,
         )  # built-in client lookup
         ctx.add_response(
-            "AppLookupObject",
-            api_pb2.AppLookupObjectResponse(object=api_pb2.Object(object_id="sv-123")),
-            request_filter=lambda req: req.app_name == "volume_app"
+            "SharedVolumeGetOrCreate",
+            api_pb2.SharedVolumeGetOrCreateResponse(shared_volume_id="sv-123"),
+            request_filter=lambda req: req.deployment_name == "volume_app"
             and req.environment_name == "some_weird_default_env",
         )
         _run(command + [str(stub_file)])

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -904,14 +904,25 @@ class MockClientServicer(api_grpc.ModalClientBase):
     async def SharedVolumeGetOrCreate(self, stream):
         request: api_pb2.SharedVolumeGetOrCreateRequest = await stream.recv_message()
         k = (request.deployment_name, request.namespace, request.environment_name)
-        if k in self.deployed_nfss:
+        if request.object_creation_type == api_pb2.OBJECT_CREATION_TYPE_UNSPECIFIED:
+            if k not in self.deployed_nfss:
+                raise GRPCError(Status.NOT_FOUND, "NFS not found")
             nfs_id = self.deployed_nfss[k]
         elif request.object_creation_type == api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING:
+            if k not in self.deployed_nfss:
+                nfs_id = f"sv-{len(self.nfs_files)}"
+                self.nfs_files[nfs_id] = {}
+                self.deployed_nfss[k] = nfs_id
+            nfs_id = self.deployed_nfss[k]
+        elif request.object_creation_type == api_pb2.OBJECT_CREATION_TYPE_CREATE_FAIL_IF_EXISTS:
+            if k in self.deployed_nfss:
+                raise GRPCError(Status.ALREADY_EXISTS, "NFS already exists")
             nfs_id = f"sv-{len(self.nfs_files)}"
             self.nfs_files[nfs_id] = {}
             self.deployed_nfss[k] = nfs_id
         else:
-            raise GRPCError(Status.NOT_FOUND, "Nfs not found")
+            raise GRPCError(Status.INVALID_ARGUMENT, "unsupported object creation type")
+
         await stream.send_message(api_pb2.SharedVolumeGetOrCreateResponse(shared_volume_id=nfs_id))
 
     async def SharedVolumePutFile(self, stream):

--- a/test/network_file_system_test.py
+++ b/test/network_file_system_test.py
@@ -3,7 +3,7 @@ import pytest
 from unittest import mock
 
 import modal
-from modal.exception import DeprecationError, InvalidError
+from modal.exception import DeprecationError, InvalidError, NotFoundError
 from modal.runner import deploy_stub
 
 
@@ -159,3 +159,15 @@ def test_write_file(client, tmp_path, servicer):
 
         # Make sure we can write through the provider too
         stub.vol.write_file("remote_path.txt", open(local_file_path, "rb"))
+
+
+def test_persisted(servicer, client):
+    # Lookup should fail since it doesn't exist
+    with pytest.raises(NotFoundError):
+        modal.NetworkFileSystem.lookup("xyz", client=client)
+
+    # Create it
+    modal.NetworkFileSystem.lookup("xyz", create_if_missing=True, client=client)
+
+    # Lookup should succeed now
+    modal.NetworkFileSystem.lookup("xyz", client=client)


### PR DESCRIPTION
This switches the client to use the new endpoint for non-ephemeral NFS

Lots of code duplication that we'll be able to reduce later. Also a bunch of this is just tests + fixtures.