### PR TITLE
Freider/stop on app done

### DIFF
--- a/modal/_blob_utils.py
+++ b/modal/_blob_utils.py
@@ -288,10 +288,10 @@ async def _download_from_url(download_url) -> bytes:
             return await resp.read()
 
 
-async def blob_download(blob_id, stub) -> bytes:
+async def blob_download(blob_id, grpc_api) -> bytes:
     # convenience function reading all of the downloaded file into memory
     req = api_pb2.BlobGetRequest(blob_id=blob_id)
-    resp = await retry_transient_errors(stub.BlobGet, req)
+    resp = await retry_transient_errors(grpc_api.BlobGet, req)
 
     return await _download_from_url(resp.download_url)
 

--- a/modal/exception.py
+++ b/modal/exception.py
@@ -88,6 +88,12 @@ class DeprecationError(UserWarning):
     # Overloading it to evade the default filter, which excludes __main__.
 
 
+class AppStopped(Error):
+    """Raised by function result pollers (.remote() etc) if an app is stopped during execution"""
+
+    pass
+
+
 class PendingDeprecationError(UserWarning):
     """Soon to be deprecated feature. Only used intermittently because of multi-repo concerns."""
 

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -1,4 +1,5 @@
 # Copyright Modal Labs 2022
+import asyncio
 import inspect
 import os
 import typing
@@ -119,6 +120,8 @@ class _Stub:
     _local_app: Optional[_LocalApp]
     _all_stubs: ClassVar[Dict[str, List["_Stub"]]] = {}
 
+    _terminating: asyncio.Event
+
     @typechecked
     def __init__(
         self,
@@ -174,6 +177,7 @@ class _Stub:
         self._web_endpoints = []
         self._local_app = None  # when this is the launcher process
         self._container_app = None  # when this is inside a container
+        self._terminating = asyncio.Event()
 
         string_name = self._name or ""
 
@@ -717,6 +721,12 @@ class _Stub:
         )
         await resolver.load(obj)
         return obj
+
+    def _termination_event(self) -> asyncio.Event:
+        return self._terminating
+
+    def _set_terminating(self):
+        self._terminating.set()
 
 
 Stub = synchronize_api(_Stub)

--- a/modal_utils/grpc_testing.py
+++ b/modal_utils/grpc_testing.py
@@ -3,7 +3,7 @@ import contextlib
 import inspect
 import logging
 from collections import Counter, defaultdict
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Any, Awaitable, Callable, Dict, List, Tuple
 
 from grpclib import GRPCError, Status
 
@@ -100,7 +100,7 @@ class InterceptionContext:
         # adds one response to a queue of responses for requests of the specified type
         self.custom_responses[method_name].append((request_filter, [first_payload]))
 
-    def override_default(self, method_name: str, responder: Callable[[Any], Any]):
+    def override_default(self, method_name: str, responder: Callable[[Any], Awaitable[Any]]):
         """Replace the default handler for a method. E.g.
 
         ```python notest
@@ -130,7 +130,7 @@ class InterceptionContext:
             custom_default = self.custom_defaults.get(method_name)
             if not custom_default:
                 return None
-            next_response_messages = [custom_default(request)]
+            return custom_default
 
         async def responder(servicer_self, stream):
             try:

--- a/modal_utils/grpc_testing.py
+++ b/modal_utils/grpc_testing.py
@@ -114,7 +114,6 @@ class InterceptionContext:
 
     def next_custom_responder(self, method_name, request):
         method_responses = self.custom_responses[method_name]
-
         for i, (request_filter, response_messages) in enumerate(method_responses):
             try:
                 request_matches = request_filter(request)

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -124,16 +124,16 @@ def test_app_setup(servicer, set_env_client, server_url_env, modal_config):
 
 
 def test_run(servicer, set_env_client, test_dir):
-    # stub_file = test_dir / "supports" / "app_run_tests" / "default_stub.py"
-    # _run(["run", stub_file.as_posix()])
-    # _run(["run", stub_file.as_posix() + "::stub"])
-    # _run(["run", stub_file.as_posix() + "::stub.foo"])
-    # _run(["run", stub_file.as_posix() + "::foo"])
-    # _run(["run", stub_file.as_posix() + "::bar"], expected_exit_code=1, expected_stderr=None)
+    stub_file = test_dir / "supports" / "app_run_tests" / "default_stub.py"
+    _run(["run", stub_file.as_posix()])
+    _run(["run", stub_file.as_posix() + "::stub"])
+    _run(["run", stub_file.as_posix() + "::stub.foo"])
+    _run(["run", stub_file.as_posix() + "::foo"])
+    _run(["run", stub_file.as_posix() + "::bar"], expected_exit_code=1, expected_stderr=None)
     file_with_entrypoint = test_dir / "supports" / "app_run_tests" / "local_entrypoint.py"
     _run(["run", file_with_entrypoint.as_posix()])
-    # _run(["run", file_with_entrypoint.as_posix() + "::main"])
-    # _run(["run", file_with_entrypoint.as_posix() + "::stub.main"])
+    _run(["run", file_with_entrypoint.as_posix() + "::main"])
+    _run(["run", file_with_entrypoint.as_posix() + "::stub.main"])
 
 
 def test_run_async(servicer, set_env_client, test_dir):

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -124,16 +124,16 @@ def test_app_setup(servicer, set_env_client, server_url_env, modal_config):
 
 
 def test_run(servicer, set_env_client, test_dir):
-    stub_file = test_dir / "supports" / "app_run_tests" / "default_stub.py"
-    _run(["run", stub_file.as_posix()])
-    _run(["run", stub_file.as_posix() + "::stub"])
-    _run(["run", stub_file.as_posix() + "::stub.foo"])
-    _run(["run", stub_file.as_posix() + "::foo"])
-    _run(["run", stub_file.as_posix() + "::bar"], expected_exit_code=1, expected_stderr=None)
+    # stub_file = test_dir / "supports" / "app_run_tests" / "default_stub.py"
+    # _run(["run", stub_file.as_posix()])
+    # _run(["run", stub_file.as_posix() + "::stub"])
+    # _run(["run", stub_file.as_posix() + "::stub.foo"])
+    # _run(["run", stub_file.as_posix() + "::foo"])
+    # _run(["run", stub_file.as_posix() + "::bar"], expected_exit_code=1, expected_stderr=None)
     file_with_entrypoint = test_dir / "supports" / "app_run_tests" / "local_entrypoint.py"
     _run(["run", file_with_entrypoint.as_posix()])
-    _run(["run", file_with_entrypoint.as_posix() + "::main"])
-    _run(["run", file_with_entrypoint.as_posix() + "::stub.main"])
+    # _run(["run", file_with_entrypoint.as_posix() + "::main"])
+    # _run(["run", file_with_entrypoint.as_posix() + "::stub.main"])
 
 
 def test_run_async(servicer, set_env_client, test_dir):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -57,6 +57,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
     fc_data_out: defaultdict[str, asyncio.Queue[api_pb2.DataChunk]]
 
     def __init__(self, blob_host, blobs):
+        self.log_sleep = 0.5
         self.put_outputs_barrier = threading.Barrier(
             1, timeout=10
         )  # set to non-1 to get lock-step of output pushing within a test
@@ -245,7 +246,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
             last_entry_id = "1"
         else:
             last_entry_id = str(int(request.last_entry_id) + 1)
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(self.log_sleep)
         log = api_pb2.TaskLogs(data=f"hello, world ({last_entry_id})\n", file_descriptor=api_pb2.FILE_DESCRIPTOR_STDOUT)
         await stream.send_message(api_pb2.TaskLogsBatch(entry_id=last_entry_id, items=[log]))
         if self.done:

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -257,10 +257,11 @@ async def test_volume_upload_large_file(client, tmp_path, servicer, blob_server,
 async def test_volume_upload_file_timeout(client, tmp_path, servicer, blob_server, *args):
     call_count = 0
 
-    def mount_put_file(_request):
+    async def mount_put_file(self, stream):
+        await stream.recv_message()
         nonlocal call_count
         call_count += 1
-        return api_pb2.MountPutFileResponse(exists=False)
+        await stream.send_message(api_pb2.MountPutFileResponse(exists=False))
 
     with servicer.intercept() as ctx:
         ctx.override_default("MountPutFile", mount_put_file)


### PR DESCRIPTION
Refactor of how we "cancel" ongoing function runs when an app shuts down.

Previously we had a `_mute_cancellations` which just made us mute some errors that were spit out on interpreter shutdown when ongoing function polling got cancelled.

Now we instead add a Future that gets resolved with an Exception object when the local stub gets a termination call, which we in turn trigger from both KeyboardInterrupt (which was the old case of muted cancellations) and now also from the log loop when it receieves `app_done=True`, indicating that no results will ever come in on the polled functions.

We could extend this with more failure states in other parts of the code (e.g. the app heartbeat loop), but to be truly rigorous about this we should add support in our longpolling backend calls (like FunctionGetOutput) for catching app terminations and similar and return immediately with an error indicating it so no long-pollers sit around unecessarily/forever. 
