### PR TITLE
Use VolumeGetOrCreate client-side

### DIFF
--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -64,8 +64,7 @@ def create(
     env: Optional[str] = ENV_OPTION,
 ):
     env_name = ensure_env(env)
-    volume = modal.Volume.new()
-    volume._deploy(name, environment_name=env)
+    modal.Volume.create_deployed(name, environment_name=env)
     usage_code = f"""
 @stub.function(volumes={{"/my_vol": modal.Volume.from_name("{name}")}})
 def some_func():

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -177,7 +177,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
     ) -> "_NetworkFileSystem":
-        """Lookup a network file system with a given name and tag.
+        """Lookup a network file system with a given name
 
         ```python
         n = modal.NetworkFileSystem.lookup("my-nfs")

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -105,7 +105,7 @@ class _Volume(_Object, type_prefix="vo"):
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
     ) -> "_Volume":
-        """Create a reference to a persisted network filesystem
+        """Create a reference to a persisted volume
 
         """
 
@@ -158,10 +158,10 @@ class _Volume(_Object, type_prefix="vo"):
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
     ) -> "_Volume":
-        """Lookup a network file system with a given name and tag.
+        """Lookup a volume with a given name
 
         ```python
-        n = modal.Volume.lookup("my-nfs")
+        n = modal.Volume.lookup("my-volume")
         print(n.listdir("/"))
         ```
         """

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -9,7 +9,7 @@ from typing import IO, AsyncGenerator, AsyncIterator, BinaryIO, Callable, Genera
 import aiostream
 from grpclib import GRPCError, Status
 
-import modal.exception
+from modal.exception import VolumeUploadTimeoutError
 from modal_proto import api_pb2
 from modal_utils.async_utils import asyncnullcontext, synchronize_api
 from modal_utils.grpc_utils import retry_transient_errors, unary_stream
@@ -25,10 +25,10 @@ from ._resolver import Resolver
 from .client import _Client
 from .config import logger
 from .mount import MOUNT_PUT_FILE_CLIENT_TIMEOUT
-from .object import _StatefulObject, live_method, live_method_gen
+from .object import _get_environment_name, _Object, live_method, live_method_gen
 
 
-class _Volume(_StatefulObject, type_prefix="vo"):
+class _Volume(_Object, type_prefix="vo"):
     """A writeable volume that can be used to share files between one or more Modal functions.
 
     The contents of a volume is exposed as a filesystem. You can use it to share data between different functions, or
@@ -99,10 +99,34 @@ class _Volume(_StatefulObject, type_prefix="vo"):
         return _Volume._from_loader(_load, "Volume()")
 
     @staticmethod
+    def from_name(
+        label: str,
+        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        environment_name: Optional[str] = None,
+        create_if_missing: bool = False,
+    ) -> "_Volume":
+        """Create a reference to a persisted network filesystem
+
+        """
+
+        async def _load(self: _Volume, resolver: Resolver, existing_object_id: Optional[str]):
+            req = api_pb2.VolumeGetOrCreateRequest(
+                deployment_name=label,
+                namespace=namespace,
+                environment_name=_get_environment_name(environment_name, resolver),
+                object_creation_type=(api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING if create_if_missing else None),
+            )
+            response = await resolver.client.stub.VolumeGetOrCreate(req)
+            self._hydrate(response.volume_id, resolver.client, None)
+
+        return _Volume._from_loader(_load, "Volume()")
+
+    @staticmethod
     def persisted(
         label: str,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
+        cloud: Optional[str] = None,
     ) -> "_Volume":
         """Deploy a Modal app containing this object. This object can then be imported from other apps using
         the returned reference, or by calling `modal.Volume.from_name(label)` (or the equivalent method
@@ -124,7 +148,50 @@ class _Volume(_StatefulObject, type_prefix="vo"):
         ```
 
         """
-        return _Volume.new()._persist(label, namespace, environment_name)
+        return _Volume.from_name(label, namespace, environment_name, create_if_missing=True)
+
+    @staticmethod
+    async def lookup(
+        label: str,
+        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        client: Optional[_Client] = None,
+        environment_name: Optional[str] = None,
+        create_if_missing: bool = False,
+    ) -> "_Volume":
+        """Lookup a network file system with a given name and tag.
+
+        ```python
+        n = modal.Volume.lookup("my-nfs")
+        print(n.listdir("/"))
+        ```
+        """
+        obj = _Volume.from_name(
+            label, namespace=namespace, environment_name=environment_name, create_if_missing=create_if_missing
+        )
+        if client is None:
+            client = await _Client.from_env()
+        resolver = Resolver(client=client)
+        await resolver.load(obj)
+        return obj
+
+    @staticmethod
+    async def create_deployed(
+        deployment_name: str,
+        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        client: Optional[_Client] = None,
+        environment_name: Optional[str] = None,
+    ) -> str:
+        """mdmd:hidden"""
+        if client is None:
+            client = await _Client.from_env()
+        request = api_pb2.VolumeGetOrCreateRequest(
+            deployment_name=deployment_name,
+            namespace=namespace,
+            environment_name=_get_environment_name(environment_name),
+            object_creation_type=api_pb2.OBJECT_CREATION_TYPE_CREATE_FAIL_IF_EXISTS,
+        )
+        resp = await retry_transient_errors(client.stub.VolumeGetOrCreate, request)
+        return resp.volume_id
 
     @live_method
     async def _do_reload(self, lock=True):
@@ -467,7 +534,7 @@ class _VolumeUploadContextManager:
                     break
 
             if not response.exists:
-                raise modal.exception.VolumeUploadTimeoutError(f"Uploading of {file_spec.source_description} timed out")
+                raise VolumeUploadTimeoutError(f"Uploading of {file_spec.source_description} timed out")
 
         return api_pb2.MountFile(
             filename=remote_filename,

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from unittest import mock
 
 import modal
-from modal.exception import InvalidError, VolumeUploadTimeoutError
+from modal.exception import InvalidError, NotFoundError, VolumeUploadTimeoutError
 from modal.runner import deploy_stub
 from modal_proto import api_pb2
 
@@ -71,11 +71,7 @@ def test_volume_commit(client, servicer, skip_reload):
 
 @pytest.mark.asyncio
 async def test_volume_get(servicer, client, tmp_path):
-    stub = modal.Stub()
-    vol = modal.Volume.persisted("my-vol")
-    stub.vol = vol
-    await vol._deploy.aio("my-vol", client=client)
-    assert await modal.Volume._exists.aio("my-vol", client=client)  # type: ignore
+    await modal.Volume.create_deployed.aio("my-vol", client=client)
     vol = await modal.Volume.lookup.aio("my-vol", client=client)  # type: ignore
 
     file_contents = b"hello world"
@@ -330,3 +326,15 @@ async def test_volume_copy(client, tmp_path, servicer):
     }
     assert returned_file_data[Path("test_dir/file1.txt")].data == b"test copy"
     assert returned_file_data[Path("test_dir/file2.txt")].data == b"test copy"
+
+
+def test_persisted(servicer, client):
+    # Lookup should fail since it doesn't exist
+    with pytest.raises(NotFoundError):
+        modal.Volume.lookup("xyz", client=client)
+
+    # Create it
+    modal.Volume.lookup("xyz", create_if_missing=True, client=client)
+
+    # Lookup should succeed now
+    modal.Volume.lookup("xyz", client=client)


### PR DESCRIPTION
This is the final one of all the RPC changes to objects. This one is mostly copy paste from `NetworkFileSystem` (aka `SharedVolume`) and similar to other PRs, adds quite a lot of redundant code in the short and medium term.

Once this is merged, we can start to delete some amount of code. Sadly not a ton initially, because a lot of it will require deprecations. But we can at least delete `_StatefulObject` a few more things
