### PR TITLE
Drop from_id down to subclasses, remove AppLookupObject usage

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1496,6 +1496,13 @@ class _FunctionCall(_Object, type_prefix="fc"):
         assert self._client and self._client.stub
         await retry_transient_errors(self._client.stub.FunctionCallCancel, request)
 
+    @staticmethod
+    async def from_id(function_call_id: str, client: Optional[_Client] = None) -> "_FunctionCall":
+        if client is None:
+            client = await _Client.from_env()
+
+        return _FunctionCall._new_hydrated(function_call_id, client, None)
+
 
 FunctionCall = synchronize_api(_FunctionCall)
 

--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -7,7 +7,7 @@ from ._version_generated import build_number
 major_number = 0
 
 # Bump this manually on breaking changes, then reset the number in _version_generated.py
-minor_number = 60
+minor_number = 61
 
 # Right now, automatically increment the patch number in CI
 __version__ = f"{major_number}.{minor_number}.{max(build_number, 0)}"

--- a/modal_version/_version_generated.py
+++ b/modal_version/_version_generated.py
@@ -1,4 +1,4 @@
 # Copyright Modal Labs 2024
 
 # Note: Reset this value to -1 whenever you make a minor `0.X` release of the client.
-build_number = 15  # git: 01136e8
+build_number = -1

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -283,29 +283,6 @@ class MockClientServicer(api_grpc.ModalClientBase):
         request: api_pb2.AppGetByDeploymentNameRequest = await stream.recv_message()
         await stream.send_message(api_pb2.AppGetByDeploymentNameResponse(app_id=self.deployed_apps.get(request.name)))
 
-    async def AppLookupObject(self, stream):
-        # TODO(erikbern): remove soon
-        request: api_pb2.AppLookupObjectRequest = await stream.recv_message()
-        if not request.object_id:
-            app_id = self.deployed_apps.get(request.app_name)
-            if app_id is None:
-                raise GRPCError(Status.NOT_FOUND, f"can't find app {request.app_name}")
-            assert not request.object_tag
-            object_id = self.app_single_objects.get(app_id)
-            if object_id is None:
-                raise GRPCError(Status.NOT_FOUND, "can't find single object for app")
-        else:
-            app_id = None
-            object_id = request.object_id
-
-        if request.app_name:
-            assert request.object_entity
-            if object_id:
-                assert object_id.startswith(request.object_entity)
-
-        response = api_pb2.AppLookupObjectResponse(object=self.get_object_metadata(object_id), app_id=app_id)
-        await stream.send_message(response)
-
     async def AppHeartbeat(self, stream):
         request: api_pb2.AppHeartbeatRequest = await stream.recv_message()
         self.requests.append(request)

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -467,12 +467,6 @@ def test_from_id(client, servicer):
     assert function_id
     assert foo.web_url
 
-    rehydrated_function = Function.from_id(function_id, client=client)
-    assert isinstance(rehydrated_function, Function)
-
-    assert rehydrated_function.object_id == function_id
-    assert rehydrated_function.web_url == foo.web_url
-
     function_call = foo.spawn()
     assert function_call.object_id
     # Used in a few examples to construct FunctionCall objects


### PR DESCRIPTION
The `from_id` is only ever used by function calls (millions of times during the last week) and sandboxes (handful of times). There are some stray calls for other objects, but they are insanely rare (like, 1 function lookup for the entire last month).

I've dropped the implementation down to respective subclasses. I think we can pull this thread a bit further and get rid of the awkward overloaded handle_metadata stuff later, but it will take a bit more work.

This change gets rid of the remaining usage of `AppLookupObject` by the client so I'm bumping the client version – that way we can drop the old endpoint once 0.61 is the minimum version.