### PR TITLE
Drop synchronicity frames when showing tracebacks from user code

### DIFF
--- a/modal/__main__.py
+++ b/modal/__main__.py
@@ -19,8 +19,19 @@ def main():
         if config.get("traceback"):
             raise
 
-        # Try to step forward in the traceback until we get to the user code that failed to import
-        tb = orig_tb = exc.__cause__.__traceback__
+        tb = tb_root = exc.__cause__.__traceback__
+
+        # Step forward all the way through the traceback and drop any synchronicity frames
+        while tb is not None:
+            while tb.tb_next is not None:
+                if "/site-packages/synchronicity/" in tb.tb_next.tb_frame.f_code.co_filename:
+                    tb.tb_next = tb.tb_next.tb_next
+                else:
+                    break
+            tb = tb.tb_next
+        tb = tb_root
+
+        # Now step forward again until we get to first frame of user code
         if exc.user_source.endswith(".py"):
             while tb is not None and tb.tb_frame.f_code.co_filename != exc.user_source:
                 tb = tb.tb_next
@@ -28,8 +39,9 @@ def main():
             while tb is not None and tb.tb_frame.f_code.co_name != "<module>":
                 tb = tb.tb_next
         if tb is None:
-            # In case we didn't find a frame that matched the user source, revert to the original traceback
-            tb = orig_tb
+            # In case we didn't find a frame that matched the user source, revert to the original root
+            tb = tb_root
+
         sys.excepthook(type(exc.__cause__), exc.__cause__, tb)
         sys.exit(1)
 


### PR DESCRIPTION
A little additional traceback improvement: synchronicity, in its endless weirdness, sometimes has frames show up _after_ the line of user code that actually triggered an exception. As a result, we don't strip them with the existing logic that walks through the stack until we get to user code. This PR adds an additional step that walks all the way through the stack and drops any synchronicity frames. The result is even cleaner.