### PR TITLE
Renames checkpoints to "memory snapshots"

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -607,6 +607,7 @@ class _Function(_Object, type_prefix="fu"):
         is_builder_function: bool = False,
         is_auto_snapshot: bool = False,
         enable_memory_snapshot: bool = False,
+        checkpointing_enabled: Optional[bool] = None,
         allow_background_volume_commits: bool = False,
         block_network: bool = False,
         max_inputs: Optional[int] = None,
@@ -628,6 +629,13 @@ class _Function(_Object, type_prefix="fu"):
                 "The singular `secret` parameter is deprecated. Pass a list to `secrets` instead.",
             )
             secrets = [secret, *secrets]
+
+        if checkpointing_enabled is not None:
+            deprecation_warning(
+                (2024, 4, 4),
+                "The argument `checkpointing_enabled` is now deprecated. Use `enable_memory_snapshot` instead.",
+            )
+            enable_memory_snapshot = checkpointing_enabled
 
         explicit_mounts = mounts
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -883,7 +883,7 @@ class _Function(_Object, type_prefix="fu"):
                 worker_id=config.get("worker_id"),
                 is_auto_snapshot=is_auto_snapshot,
                 is_method=bool(info.cls),
-                enable_memory_snapshot=enable_memory_snapshot,
+                checkpointing_enabled=enable_memory_snapshot,
                 is_checkpointing_function=False,
                 object_dependencies=[
                     api_pb2.ObjectDependency(object_id=dep.object_id) for dep in _deps(only_explicit_mounts=True)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -607,7 +607,7 @@ class _Function(_Object, type_prefix="fu"):
         _experimental_scheduler_placement: Optional[SchedulerPlacement] = None,
         is_builder_function: bool = False,
         is_auto_snapshot: bool = False,
-        checkpointing_enabled: bool = False,
+        enable_memory_snapshot: bool = False,
         allow_background_volume_commits: bool = False,
         block_network: bool = False,
         max_inputs: Optional[int] = None,
@@ -883,7 +883,7 @@ class _Function(_Object, type_prefix="fu"):
                 worker_id=config.get("worker_id"),
                 is_auto_snapshot=is_auto_snapshot,
                 is_method=bool(info.cls),
-                checkpointing_enabled=checkpointing_enabled,
+                enable_memory_snapshot=enable_memory_snapshot,
                 is_checkpointing_function=False,
                 object_dependencies=[
                     api_pb2.ObjectDependency(object_id=dep.object_id) for dep in _deps(only_explicit_mounts=True)

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -407,7 +407,7 @@ def _build(
 def _enter(
     _warn_parentheses_missing=None,
     *,
-    checkpoint: bool = False,
+    memory_snapshot: bool = False,
 ) -> Callable[[Union[Callable[[Any], Any], _PartialFunction]], _PartialFunction]:
     """Decorator for methods which should be executed when a new container is started.
 
@@ -415,7 +415,7 @@ def _enter(
     if _warn_parentheses_missing:
         raise InvalidError("Positional arguments are not allowed. Did you forget parentheses? Suggestion: `@enter()`.")
 
-    if checkpoint:
+    if memory_snapshot:
         flag = _PartialFunctionFlags.ENTER_PRE_CHECKPOINT
     else:
         flag = _PartialFunctionFlags.ENTER_POST_CHECKPOINT

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -407,7 +407,7 @@ def _build(
 def _enter(
     _warn_parentheses_missing=None,
     *,
-    memory_snapshot: bool = False,
+    snap: bool = False,
 ) -> Callable[[Union[Callable[[Any], Any], _PartialFunction]], _PartialFunction]:
     """Decorator for methods which should be executed when a new container is started.
 
@@ -415,7 +415,7 @@ def _enter(
     if _warn_parentheses_missing:
         raise InvalidError("Positional arguments are not allowed. Did you forget parentheses? Suggestion: `@enter()`.")
 
-    if memory_snapshot:
+    if snap:
         flag = _PartialFunctionFlags.ENTER_PRE_CHECKPOINT
     else:
         flag = _PartialFunctionFlags.ENTER_POST_CHECKPOINT

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -551,7 +551,7 @@ class _Stub:
                 keep_warm=keep_warm,
                 cloud=cloud,
                 webhook_config=webhook_config,
-                checkpointing_enabled=enable_memory_snapshot,
+                enable_memory_snapshot=enable_memory_snapshot,
                 allow_background_volume_commits=_allow_background_volume_commits,
                 block_network=block_network,
                 max_inputs=max_inputs,

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -474,6 +474,7 @@ class _Stub:
         ] = None,  # Set this to True if it's a non-generator function returning a [sync/async] generator object
         cloud: Optional[str] = None,  # Cloud provider to run the function on. Possible values are aws, gcp, oci, auto.
         enable_memory_snapshot: bool = False,  # Enable memory checkpointing for faster cold starts.
+        checkpointing_enabled: Optional[bool] = None,   # Deprecated
         block_network: bool = False,  # Whether to block network access
         secret: Optional[_Secret] = None,  # Deprecated: use `secrets`
         _allow_background_volume_commits: bool = False,
@@ -565,6 +566,7 @@ class _Stub:
                 cloud=cloud,
                 webhook_config=webhook_config,
                 enable_memory_snapshot=enable_memory_snapshot,
+                checkpointing_enabled=checkpointing_enabled,
                 allow_background_volume_commits=_allow_background_volume_commits,
                 block_network=block_network,
                 max_inputs=max_inputs,
@@ -605,6 +607,7 @@ class _Stub:
         keep_warm: Optional[int] = None,  # An optional number of containers to always keep warm.
         cloud: Optional[str] = None,  # Cloud provider to run the function on. Possible values are aws, gcp, oci, auto.
         enable_memory_snapshot: bool = False,  # Enable memory checkpointing for faster cold starts.
+        checkpointing_enabled: Optional[bool] = None,  # Deprecated
         block_network: bool = False,  # Whether to block network access
         secret: Optional[_Secret] = None,  # Deprecated: use `secrets`
         _allow_background_volume_commits: bool = False,
@@ -643,6 +646,7 @@ class _Stub:
             keep_warm=keep_warm,
             cloud=cloud,
             enable_memory_snapshot=enable_memory_snapshot,
+            checkpointing_enabled=checkpointing_enabled,
             block_network=block_network,
             _allow_background_volume_commits=_allow_background_volume_commits,
             max_inputs=max_inputs,

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -551,7 +551,7 @@ class _Stub:
                 keep_warm=keep_warm,
                 cloud=cloud,
                 webhook_config=webhook_config,
-                enable_memory_snapshot=enable_memory_snapshot,
+                checkpointing_enabled=enable_memory_snapshot,
                 allow_background_volume_commits=_allow_background_volume_commits,
                 block_network=block_network,
                 max_inputs=max_inputs,

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -464,7 +464,7 @@ class _Stub:
             bool
         ] = None,  # Set this to True if it's a non-generator function returning a [sync/async] generator object
         cloud: Optional[str] = None,  # Cloud provider to run the function on. Possible values are aws, gcp, oci, auto.
-        checkpointing_enabled: bool = False,  # Enable memory checkpointing for faster cold starts.
+        enable_memory_snapshot: bool = False,  # Enable memory checkpointing for faster cold starts.
         block_network: bool = False,  # Whether to block network access
         secret: Optional[_Secret] = None,  # Deprecated: use `secrets`
         _allow_background_volume_commits: bool = False,
@@ -551,7 +551,7 @@ class _Stub:
                 keep_warm=keep_warm,
                 cloud=cloud,
                 webhook_config=webhook_config,
-                checkpointing_enabled=checkpointing_enabled,
+                enable_memory_snapshot=enable_memory_snapshot,
                 allow_background_volume_commits=_allow_background_volume_commits,
                 block_network=block_network,
                 max_inputs=max_inputs,
@@ -591,7 +591,7 @@ class _Stub:
         interactive: bool = False,  # Whether to run the function in interactive mode.
         keep_warm: Optional[int] = None,  # An optional number of containers to always keep warm.
         cloud: Optional[str] = None,  # Cloud provider to run the function on. Possible values are aws, gcp, oci, auto.
-        checkpointing_enabled: bool = False,  # Enable memory checkpointing for faster cold starts.
+        enable_memory_snapshot: bool = False,  # Enable memory checkpointing for faster cold starts.
         block_network: bool = False,  # Whether to block network access
         secret: Optional[_Secret] = None,  # Deprecated: use `secrets`
         _allow_background_volume_commits: bool = False,
@@ -629,7 +629,7 @@ class _Stub:
             interactive=interactive,
             keep_warm=keep_warm,
             cloud=cloud,
-            checkpointing_enabled=checkpointing_enabled,
+            enable_memory_snapshot=enable_memory_snapshot,
             block_network=block_network,
             _allow_background_volume_commits=_allow_background_volume_commits,
             max_inputs=max_inputs,

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -832,7 +832,7 @@ message Function {
 
   // Checkpoint and restore
 
-  bool enable_memory_snapshot = 41;
+  bool checkpointing_enabled = 41;
 
   CheckpointInfo checkpoint = 42;
   repeated ObjectDependency object_dependencies = 43;

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -832,7 +832,7 @@ message Function {
 
   // Checkpoint and restore
 
-  bool checkpointing_enabled = 41;
+  bool enable_memory_snapshot = 41;
 
   CheckpointInfo checkpoint = 42;
   repeated ObjectDependency object_dependencies = 43;

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -294,11 +294,11 @@ class CheckpointingCls:
     def __init__(self):
         self._vals = []
 
-    @enter(memory_snapshot=True)
+    @enter(snap=True)
     def enter1(self):
         self._vals.append("A")
 
-    @enter(memory_snapshot=True)
+    @enter(snap=True)
     def enter2(self):
         self._vals.append("B")
 

--- a/modal_test_support/functions.py
+++ b/modal_test_support/functions.py
@@ -289,16 +289,16 @@ class BuildCls:
         return self._k * x
 
 
-@stub.cls(checkpointing_enabled=True)
+@stub.cls(enable_memory_snapshot=True)
 class CheckpointingCls:
     def __init__(self):
         self._vals = []
 
-    @enter(checkpoint=True)
+    @enter(memory_snapshot=True)
     def enter1(self):
         self._vals.append("A")
 
-    @enter(checkpoint=True)
+    @enter(memory_snapshot=True)
     def enter2(self):
         self._vals.append("B")
 

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -510,7 +510,7 @@ class ClsWithHandlers:
     def my_build(self):
         pass
 
-    @enter(memory_snapshot=True)
+    @enter(snap=True)
     def my_memory_snapshot(self):
         pass
 

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -510,8 +510,8 @@ class ClsWithHandlers:
     def my_build(self):
         pass
 
-    @enter(checkpoint=True)
-    def my_checkpoint(self):
+    @enter(memory_snapshot=True)
+    def my_memory_snapshot(self):
         pass
 
     @enter()

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -535,7 +535,7 @@ def test_handlers():
     assert list(pfs.keys()) == ["my_build", "my_build_and_enter"]
 
     pfs = _find_partial_methods_for_cls(ClsWithHandlers, _PartialFunctionFlags.ENTER_PRE_CHECKPOINT)
-    assert list(pfs.keys()) == ["my_checkpoint"]
+    assert list(pfs.keys()) == ["my_memory_snapshot"]
 
     pfs = _find_partial_methods_for_cls(ClsWithHandlers, _PartialFunctionFlags.ENTER_POST_CHECKPOINT)
     assert list(pfs.keys()) == ["my_enter", "my_build_and_enter"]


### PR DESCRIPTION
Renames the client interface for making checkpoints to "memory snapshots". That's easier to understand and avoid confusion with weight checkpoints. 