### PR TITLE
Deprecate `.persisted` in favor of `.from_name(..., create_if_missing=True)`

### DIFF
--- a/modal/dict.py
+++ b/modal/dict.py
@@ -10,7 +10,7 @@ from ._serialization import deserialize, serialize
 from ._types import typechecked
 from .client import _Client
 from .config import logger
-from .exception import deprecation_error
+from .exception import deprecation_error, deprecation_warning
 from .object import _get_environment_name, _Object, live_method
 
 
@@ -111,8 +111,8 @@ class _Dict(_Object, type_prefix="di"):
     def persisted(
         label: str, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, environment_name: Optional[str] = None
     ) -> "_Dict":
-        """Create a persisted modal.Dict which as a lifetime beyond the app it was created in.
-        The object will persist until it is deleted by the user."""
+        """Deprecated! Use `Dict.from_name(name, create_if_missing=True)`."""
+        deprecation_warning((2024, 3, 1), _Dict.persisted.__doc__)
         return _Dict.from_name(label, namespace, environment_name, create_if_missing=True)
 
     @staticmethod

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -114,8 +114,17 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
     ) -> "_NetworkFileSystem":
-        """Create a reference to a persisted network filesystem
+        """Create a reference to a persisted network filesystem, optionally creating it lazily.
 
+        **Examples**
+
+        ```python notest
+        volume = NetworkFileSystem.from_name("my-volume", create_if_missing=True)
+
+        @stub.function(network_file_systems={"/vol": volume})
+        def f():
+            pass
+        ```
         """
 
         async def _load(self: _NetworkFileSystem, resolver: Resolver, existing_object_id: Optional[str]):
@@ -137,25 +146,8 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         environment_name: Optional[str] = None,
         cloud: Optional[str] = None,
     ) -> "_NetworkFileSystem":
-        """Deploy a Modal app containing this object.
-
-        The deployed object can then be imported from other apps, or by calling
-        `NetworkFileSystem.from_name(label)` from that same app.
-
-        **Examples**
-
-        ```python notest
-        # In one app:
-        volume = NetworkFileSystem.persisted("my-volume")
-
-        # Later, in another app or Python file:
-        volume = NetworkFileSystem.from_name("my-volume")
-
-        @stub.function(network_file_systems={"/vol": volume})
-        def f():
-            pass
-        ```
-        """
+        """Deprecated! Use `NetworkFileSystem.from_name(name, create_if_missing=True)`."""
+        deprecation_warning((2024, 3, 1), _NetworkFileSystem.persisted.__doc__)
         return _NetworkFileSystem.from_name(label, namespace, environment_name, create_if_missing=True)
 
     def persist(
@@ -165,7 +157,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         environment_name: Optional[str] = None,
         cloud: Optional[str] = None,
     ):
-        """`NetworkFileSystem().persist("my-volume")` is deprecated. Use `NetworkFileSystem.persisted("my-volume")` instead."""
+        """`NetworkFileSystem().persist("my-volume")` is deprecated. Use `NetworkFileSystem.from_name("my-volume", create_if_missing=True)` instead."""
         deprecation_warning((2024, 2, 29), _NetworkFileSystem.persist.__doc__)
         return self.persisted(label, namespace, environment_name, cloud)
 

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -13,7 +13,7 @@ from modal_utils.grpc_utils import retry_transient_errors
 from ._resolver import Resolver
 from ._serialization import deserialize, serialize
 from .client import _Client
-from .exception import deprecation_error
+from .exception import deprecation_error, deprecation_warning
 from .object import _get_environment_name, _Object, live_method
 
 
@@ -97,6 +97,8 @@ class _Queue(_Object, type_prefix="qu"):
     def persisted(
         label: str, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, environment_name: Optional[str] = None
     ) -> "_Queue":
+        """Deprecated! Use `Queue.from_name(name, create_if_missing=True)`."""
+        deprecation_warning((2024, 3, 1), _Queue.persisted.__doc__)
         return _Queue.from_name(label, namespace, environment_name, create_if_missing=True)
 
     @staticmethod

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -9,7 +9,7 @@ from typing import IO, AsyncGenerator, AsyncIterator, BinaryIO, Callable, Genera
 import aiostream
 from grpclib import GRPCError, Status
 
-from modal.exception import VolumeUploadTimeoutError
+from modal.exception import VolumeUploadTimeoutError, deprecation_warning
 from modal_proto import api_pb2
 from modal_utils.async_utils import asyncnullcontext, synchronize_api
 from modal_utils.grpc_utils import retry_transient_errors, unary_stream
@@ -105,8 +105,22 @@ class _Volume(_Object, type_prefix="vo"):
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
     ) -> "_Volume":
-        """Create a reference to a persisted volume
+        """Create a reference to a persisted volume. Optionally create it lazily.
 
+        **Example Usage**
+
+        ```python
+        import modal
+
+        volume = modal.Volume.from_name("my-volume", create_if_missing=True)
+
+        stub = modal.Stub()
+
+        # Volume refers to the same object, even across instances of `stub`.
+        @stub.function(volumes={"/vol": volume})
+        def f():
+            pass
+        ```
         """
 
         async def _load(self: _Volume, resolver: Resolver, existing_object_id: Optional[str]):
@@ -128,26 +142,8 @@ class _Volume(_Object, type_prefix="vo"):
         environment_name: Optional[str] = None,
         cloud: Optional[str] = None,
     ) -> "_Volume":
-        """Deploy a Modal app containing this object. This object can then be imported from other apps using
-        the returned reference, or by calling `modal.Volume.from_name(label)` (or the equivalent method
-        on respective class).
-
-        **Example Usage**
-
-        ```python
-        import modal
-
-        volume = modal.Volume.persisted("my-volume")
-
-        stub = modal.Stub()
-
-        # Volume refers to the same object, even across instances of `stub`.
-        @stub.function(volumes={"/vol": volume})
-        def f():
-            pass
-        ```
-
-        """
+        """Deprecated! Use `Volume.from_name(name, create_if_missing=True)`."""
+        deprecation_warning((2024, 3, 1), _Volume.persisted.__doc__)
         return _Volume.from_name(label, namespace, environment_name, create_if_missing=True)
 
     @staticmethod

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -7,7 +7,7 @@ from tempfile import NamedTemporaryFile
 from typing import List
 from unittest import mock
 
-from modal import Image, Mount, NetworkFileSystem, Secret, Stub, build, gpu, method
+from modal import Image, Mount, Secret, Stub, build, gpu, method
 from modal._serialization import serialize
 from modal.exception import DeprecationError, InvalidError, NotFoundError
 from modal.image import _dockerhub_python_version, _get_client_requirements_path
@@ -278,7 +278,6 @@ def run_f():
 
 def test_image_run_function(client, servicer):
     stub = Stub()
-    NetworkFileSystem.persisted("test-vol")
     stub["image"] = (
         Image.debian_slim().pip_install("pandas").run_function(run_f, secrets=[Secret.from_dict({"xyz": "123"})])
     )
@@ -299,7 +298,6 @@ def test_image_run_function(client, servicer):
 
 def test_image_run_function_interactivity(client, servicer):
     stub = Stub()
-    NetworkFileSystem.persisted("test-vol")
     stub["image"] = Image.debian_slim().pip_install("pandas").run_function(run_f)
 
     from modal.runner import run_stub


### PR DESCRIPTION
These methods are almost the same at this point, so let's merge.

We'll merge `.lookup` as well later.

Before we merge this, we need to update examples, integration tests, and docs. Otherwise those will fail.