### PR TITLE
Pin pytest on 8.0.x until we update pytest-markdown-docs

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -9,7 +9,7 @@ invoke~=2.2
 mypy~=1.8.0
 mypy-protobuf~=3.3.0  # TODO: can't use mypy-protobuf>=3.4 because of protobuf==3.19 support
 pre-commit>=2.21,<4
-pytest~=8.0
+pytest~=8.0.0
 pytest-asyncio @ git+https://github.com/modal-labs/pytest-asyncio.git@b535db05f6e43019700483c442ab6686f132a415
 pytest-env~=0.6.2
 pytest-markdown-docs==0.5.0


### PR DESCRIPTION
Looks like the pytest 8.1.0 release broke something with our `pytest-markdown-docs` plugin. I'm pinning on us 8.0.x until we can sort that out.