### PR TITLE
Pdm cache fix

### DIFF
--- a/modal/mount.py
+++ b/modal/mount.py
@@ -97,7 +97,7 @@ class _MountFile(_MountEntry):
         return str(self.local_file)
 
     def get_files_to_upload(self):
-        local_file = self.local_file.expanduser().absolute()
+        local_file = self.local_file.resolve().expanduser()
         if not local_file.exists():
             raise FileNotFoundError(local_file)
 
@@ -105,11 +105,11 @@ class _MountFile(_MountEntry):
         yield local_file, rel_filename
 
     def watch_entry(self):
-        parent = self.local_file.absolute().parent
-        return parent, self.local_file.absolute()
+        safe_path = self.local_file.resolve().expanduser()
+        return safe_path.parent, safe_path
 
     def top_level_paths(self) -> List[Tuple[Path, PurePosixPath]]:
-        return [(self.local_file.absolute(), self.remote_path)]
+        return [(self.local_file, self.remote_path)]
 
 
 @dataclasses.dataclass
@@ -120,10 +120,10 @@ class _MountDir(_MountEntry):
     recursive: bool
 
     def description(self):
-        return str(self.local_dir)
+        return str(self.local_dir.resolve().expanduser())
 
     def get_files_to_upload(self):
-        local_dir = self.local_dir.expanduser().absolute()
+        local_dir = self.local_dir.resolve().expanduser()
 
         if not local_dir.exists():
             raise FileNotFoundError(local_dir)
@@ -138,15 +138,15 @@ class _MountDir(_MountEntry):
 
         for local_filename in gen:
             if self.condition(local_filename):
-                local_relpath = Path(local_filename).absolute().relative_to(local_dir)
+                local_relpath = Path(local_filename).resolve().relative_to(local_dir)
                 mount_path = self.remote_path / local_relpath.as_posix()
                 yield local_filename, mount_path
 
     def watch_entry(self):
-        return self.local_dir.absolute(), None
+        return self.local_dir.resolve().expanduser(), None
 
     def top_level_paths(self) -> List[Tuple[Path, PurePosixPath]]:
-        return [(self.local_dir.absolute(), self.remote_path)]
+        return [(self.local_dir, self.remote_path)]
 
 
 def module_mount_condition(f: str):
@@ -491,7 +491,7 @@ class _Mount(_Object, type_prefix="mo"):
             req = api_pb2.MountGetOrCreateRequest(
                 object_creation_type=api_pb2.OBJECT_CREATION_TYPE_ANONYMOUS_OWNED_BY_APP,
                 files=files,
-                app_id=resolver.app_id
+                app_id=resolver.app_id,
             )
         resp = await retry_transient_errors(resolver.client.stub.MountGetOrCreate, req, base_delay=1)
         status_row.finish(f"Created mount {message_label}")

--- a/modal_utils/package_utils.py
+++ b/modal_utils/package_utils.py
@@ -33,12 +33,12 @@ def get_module_mount_info(module_name: str) -> typing.List[typing.Tuple[bool, Pa
     if spec is None:
         raise ModuleNotMountable(f"{module_name} has no spec - might not be installed?")
     elif spec.submodule_search_locations:
-        entries = [(True, Path(path).resolve()) for path in spec.submodule_search_locations if Path(path).exists()]
+        entries = [(True, Path(path)) for path in spec.submodule_search_locations if Path(path).exists()]
     else:
         # Individual file
         filename = spec.origin
         if filename is not None and Path(filename).exists():
-            entries = [(False, Path(filename).resolve())]
+            entries = [(False, Path(filename))]
     if not entries:
         raise ModuleNotMountable(f"{module_name} has no mountable paths")
     return entries

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -29,3 +29,4 @@ nbclient==0.6.8
 notebook==6.5.1
 jupytext==1.14.1
 pyright==1.1.351
+pdm==2.12.4  # used for testing pdm cache behavior w/ automounts

--- a/test/cli_imports_test.py
+++ b/test/cli_imports_test.py
@@ -1,6 +1,5 @@
 # Copyright Modal Labs 2023
 import pytest
-from pathlib import Path
 
 from modal.cli.import_refs import (
     DEFAULT_STUB_NAME,
@@ -113,7 +112,7 @@ def test_import_object(dir_structure, ref, expected_object_type, mock_dir):
         assert isinstance(_translated_obj, expected_object_type)
 
 
-def test_import_package_and_module_names(monkeypatch):
+def test_import_package_and_module_names(monkeypatch, modal_test_support_dir):
     # We try to reproduce the package/module naming standard that the `python` command line tool uses,
     # i.e. when loading using a module path (-m flag w/ python) you get a fully qualified package/module name
     # but when loading using a filename, some/mod.py it will not have a __package__
@@ -121,8 +120,6 @@ def test_import_package_and_module_names(monkeypatch):
     # The biggest difference is that __name__ of the imported "entrypoint" script
     # is __main__ when using `python` but in the Modal runtime it's the name of the
     # file minus the ".py", since Modal has its own __main__
-
-    modal_test_support_dir = Path(__file__).parent.parent / "modal_test_support"
     monkeypatch.chdir(modal_test_support_dir)
     mod1 = import_file_or_module("assert_package")
     assert mod1.__package__ == ""

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1316,3 +1316,10 @@ def modal_config():
             os.remove(t.name)
 
     return mock_modal_toml
+
+
+@pytest.fixture()
+def modal_test_support_dir(request):
+    # TODO: merge this with test/supports dir?
+    root_dir = Path(request.config.rootdir)
+    return root_dir / "modal_test_support"

--- a/test/mounted_files_test.py
+++ b/test/mounted_files_test.py
@@ -253,6 +253,7 @@ def test_mount_dedupe_explicit(servicer, test_dir, server_url_env):
     assert "/root/pkg_a/normally_not_included.pyc" in custom_pkg_a_mount.keys()
 
 
+@skip_windows("pip-installed pdm seems somewhat broken on windows")
 def test_pdm_cache_automount_exclude(tmp_path, monkeypatch, supports_dir, servicer, server_url_env):
     # check that `pdm`'s cached packages are not included in automounts
     project_dir = Path(__file__).parent.parent

--- a/test/mounted_files_test.py
+++ b/test/mounted_files_test.py
@@ -251,3 +251,23 @@ def test_mount_dedupe_explicit(servicer, test_dir, server_url_env):
     custom_pkg_a_mount = servicer.mount_contents["mo-3"]
     assert len(custom_pkg_a_mount) == len(pkg_a_mount) + 1
     assert "/root/pkg_a/normally_not_included.pyc" in custom_pkg_a_mount.keys()
+
+
+def test_pdm_cache_automount_exclude(tmp_path, monkeypatch, supports_dir, servicer, server_url_env):
+    # check that `pdm`'s cached packages are not included in automounts
+    project_dir = Path(__file__).parent.parent
+    monkeypatch.chdir(tmp_path)
+    subprocess.run(["pdm", "init", "-n"], check=True)
+    subprocess.run(
+        ["pdm", "add", "--dev", project_dir], check=True
+    )  # install workdir modal into venv, not using cache...
+    subprocess.run(["pdm", "config", "--local", "install.cache", "on"], check=True)
+    subprocess.run(["pdm", "add", "six"], check=True)  # single file module
+    subprocess.run(
+        ["pdm", "run", "modal", "deploy", supports_dir / "imports_six.py"], check=True
+    )  # deploy a basically empty function
+
+    files = set(servicer.files_name2sha.keys())
+    assert files == {
+        "/root/imports_six.py",
+    }

--- a/test/supports/imports_six.py
+++ b/test/supports/imports_six.py
@@ -1,0 +1,10 @@
+import six  # noqa
+
+import modal
+
+stub = modal.Stub("imports_six")
+
+
+@stub.function()
+def some_func():
+    pass

--- a/test/supports/imports_six.py
+++ b/test/supports/imports_six.py
@@ -1,3 +1,4 @@
+# Copyright Modal Labs 2024
 import six  # noqa
 
 import modal


### PR DESCRIPTION
## Describe your changes
Fix issue where all pdm cached packages would be automounted (MOD-2485)

The underlying issue was that pdm with cache symlinks the actual package data into site-packages, and we called `resolve()` on the package paths before comparing them with SYS_PREFIXES.

This patch changes the logic to preserve the un-expanded symlink paths for purposes of automount evaluation, but still resolves paths for serve/watch and deduplication

## Changelog

* Fix issue with pdm where all installed packages would be automounted when using package cache (MOD-2485)