### PR TITLE
Build conda / micromamba base images on Python 3.12

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -93,14 +93,6 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         image-name: ["debian_slim", "conda", "micromamba"]
-        exclude:
-          # Exclude base images that currently fail to build becasue multidict,
-          # a transitive dependency, has not published wheels for Python 3.12:
-          # https://github.com/aio-libs/multidict/issues/887
-          - python-version: 3.12
-            image-name: conda
-          - python-version: 3.12
-            image-name: micromamba
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The upstream blocker ([`multidict` wheels](https://github.com/aio-libs/multidict/issues/887)) has resolved, so we should be able to build these images now.