### PR TITLE
Don't use `_run_stub` within `_serve_stub`

### DIFF
--- a/modal/runner.py
+++ b/modal/runner.py
@@ -195,7 +195,7 @@ async def _serve_update(
         )
 
         # Communicate to the parent process
-        is_ready.put(app.app_id)
+        is_ready.put((app.app_id, app.log_url()))
     except asyncio.exceptions.CancelledError:
         # Stopped by parent process
         pass

--- a/modal/serving.py
+++ b/modal/serving.py
@@ -12,7 +12,7 @@ from synchronicity import Interface
 from modal_utils.async_utils import TaskContext, asyncify, synchronize_api, synchronizer
 from modal_utils.logger import logger
 
-from ._output import OutputManager, get_app_logs_loop
+from ._output import OutputManager, get_app_logs_loop, step_completed, step_progress
 from ._watcher import watch
 from .cli.import_refs import import_stub
 from .client import HEARTBEAT_INTERVAL, _Client
@@ -34,15 +34,15 @@ def _run_serve(stub_ref: str, existing_app_id: Optional[str], is_ready: Queue, e
 
 async def _restart_serve(
     stub_ref: str, existing_app_id: str, environment_name: str, timeout: float = 5.0
-) -> Tuple[str, SpawnProcess]:
+) -> Tuple[str, str, SpawnProcess]:
     ctx = multiprocessing.get_context("spawn")  # Needed to reload the interpreter
     is_ready = ctx.Queue()
     p = ctx.Process(target=_run_serve, args=(stub_ref, existing_app_id, is_ready, environment_name))
     p.start()
-    app_id = is_ready.get(timeout)
+    (app_id, app_logs_url) = is_ready.get(timeout)
     # TODO(erikbern): we don't fail if the above times out, but that's somewhat intentional, since
     # the child process might build a huge image or similar
-    return app_id, p
+    return app_id, app_logs_url, p
 
 
 async def _terminate(proc: Optional[SpawnProcess], output_mgr: OutputManager, timeout: float = 5.0):
@@ -78,7 +78,9 @@ async def _run_watch_loop(
             async for trigger_files in watcher:
                 logger.debug(f"The following files triggered an app update: {', '.join(trigger_files)}")
                 await _terminate(curr_proc, output_mgr)
-                _, curr_proc = await _restart_serve(stub_ref, existing_app_id=app_id, environment_name=environment_name)
+                _, _, curr_proc = await _restart_serve(
+                    stub_ref, existing_app_id=app_id, environment_name=environment_name
+                )
         finally:
             await _terminate(curr_proc, output_mgr)
 
@@ -105,7 +107,16 @@ async def _serve_stub(
         watcher = watch(mounts_to_watch, output_mgr)
 
     async with TaskContext(grace=config["logs_timeout"]) as tc:
-        app_id, proc = await _restart_serve(stub_ref, existing_app_id=None, environment_name=environment_name)
+        # Start the stub the first time, and fetch the ID and logs URL.
+        app_id, app_logs_url, proc = await _restart_serve(
+            stub_ref, existing_app_id=None, environment_name=environment_name
+        )
+
+        with output_mgr.ctx_if_visible(output_mgr.make_live(step_progress("Initializing..."))):
+            initialized_msg = f"Initialized. [grey70]View run at [underline]{app_logs_url}[/underline][/grey70]"
+            output_mgr.print_if_visible(step_completed(initialized_msg))
+            output_mgr.update_app_page_url(app_logs_url)
+
         # Start heartbeats loop to keep the client alive
         tc.infinite_loop(lambda: _heartbeat(client, app_id), sleep=HEARTBEAT_INTERVAL)
 


### PR DESCRIPTION
Previously we had a complicated setup where we'd initially use `_run_stub` to initialize the stub the first time, but future updates would recreate the app within a separate process. This would leave the original `stub` in a weird state, where `LocalApp` would get set to `None` after the update. 

This PR moves all the necessary logic from `_run_stub` to `_serve_stub` — most of it was pretty unnecessary for this use case anyway. Note that it changes the interface for `serve_stub` so it now yields an `app_id` and not a `stub` object. That should probably be fine? (We have an internal integration test that relied on it, but we can update it)