### PR TITLE
Fix issue when default encoding can't open a source file

### DIFF
--- a/modal/_traceback.py
+++ b/modal/_traceback.py
@@ -224,10 +224,15 @@ def highlight_modal_deprecation_warnings() -> None:
             date = content[:10]
             message = content[11:].strip()
             try:
-                with open(filename) as f:
-                    source = f.readlines()[lineno - 1].strip()
+                try:
+                    with open(filename) as f:
+                        source = f.readlines()[lineno - 1].strip()
+                except UnicodeDecodeError:
+                    # mostly for convenience of Windows users w/ default encodings not using PYTHONUTF8=1
+                    with open(filename) as f:
+                        source = f.readlines()[lineno - 1].strip()
                 message = f"{message}\n\nSource: {filename}:{lineno}\n  {source}"
-            except OSError:
+            except (OSError, UnicodeDecodeError):
                 # e.g., when filename is "<unknown>"; raises FileNotFoundError on posix but OSError on windows
                 pass
             panel = Panel(

--- a/modal_utils/grpc_testing.py
+++ b/modal_utils/grpc_testing.py
@@ -3,7 +3,7 @@ import contextlib
 import inspect
 import logging
 from collections import Counter, defaultdict
-from typing import Any, Awaitable, Callable, Dict, List, Tuple
+from typing import Any, Callable, Dict, List, Tuple
 
 from grpclib import GRPCError, Status
 
@@ -100,7 +100,7 @@ class InterceptionContext:
         # adds one response to a queue of responses for requests of the specified type
         self.custom_responses[method_name].append((request_filter, [first_payload]))
 
-    def override_default(self, method_name: str, responder: Callable[[Any], Awaitable[Any]]):
+    def override_default(self, method_name: str, responder: Callable[[Any], Any]):
         """Replace the default handler for a method. E.g.
 
         ```python notest
@@ -130,7 +130,7 @@ class InterceptionContext:
             custom_default = self.custom_defaults.get(method_name)
             if not custom_default:
                 return None
-            return custom_default
+            next_response_messages = [custom_default(request)]
 
         async def responder(servicer_self, stream):
             try:

--- a/modal_utils/grpc_testing.py
+++ b/modal_utils/grpc_testing.py
@@ -3,7 +3,7 @@ import contextlib
 import inspect
 import logging
 from collections import Counter, defaultdict
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Any, Awaitable, Callable, Dict, List, Tuple
 
 from grpclib import GRPCError, Status
 
@@ -100,7 +100,7 @@ class InterceptionContext:
         # adds one response to a queue of responses for requests of the specified type
         self.custom_responses[method_name].append((request_filter, [first_payload]))
 
-    def override_default(self, method_name: str, responder: Callable[[Any], Any]):
+    def override_default(self, method_name: str, responder: Callable[[Any], Awaitable[Any]]):
         """Replace the default handler for a method. E.g.
 
         ```python notest
@@ -130,7 +130,7 @@ class InterceptionContext:
             custom_default = self.custom_defaults.get(method_name)
             if not custom_default:
                 return None
-            next_response_messages = [custom_default(request)]
+            return custom_default
 
         async def responder(servicer_self, stream):
             try:


### PR DESCRIPTION
Typically happens on windows when not running in UTF8 mode