### PR TITLE
Force utf-8 and squash errors when reading code for warnings

### DIFF
--- a/modal/_traceback.py
+++ b/modal/_traceback.py
@@ -224,8 +224,8 @@ def highlight_modal_deprecation_warnings() -> None:
             date = content[:10]
             message = content[11:].strip()
             try:
-                with open(filename) as f:
-                    source = f.readlines()[lineno - 1].strip()
+                with open(filename, "rt", encoding="utf-8", errors="replace") as code_file:
+                    source = code_file.readlines()[lineno - 1].strip()
                 message = f"{message}\n\nSource: {filename}:{lineno}\n  {source}"
             except OSError:
                 # e.g., when filename is "<unknown>"; raises FileNotFoundError on posix but OSError on windows


### PR DESCRIPTION
Should fix an issue reported by a user on Windows. I can't reproduce to test, but I am copying what we do elsewhere in some related traceback handling.