### PR TITLE
Adds `CloudBucketMount` proto to support multiple cloud bucket providers

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1421,6 +1421,19 @@ message S3Mount {
   bool read_only = 4;
 }
 
+message CloudBucketMount {
+  string bucket_name = 1;
+  string mount_path = 2;
+  string credentials_secret_id = 3;
+  bool read_only = 4;
+
+  enum BucketType {
+    UNSPECIFIED = 0;
+    S3 = 1;
+  }
+  BucketType bucket_type = 5;
+}
+
 message Sandbox {
   repeated string entrypoint_args = 1;
   repeated string mount_ids = 2;

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -83,6 +83,19 @@ enum ClientType {
   CLIENT_TYPE_WEB_SERVER = 5;
 }
 
+message CloudBucketMount {
+  string bucket_name = 1;
+  string mount_path = 2;
+  string credentials_secret_id = 3;
+  bool read_only = 4;
+
+  enum BucketType {
+    UNSPECIFIED = 0;
+    S3 = 1;
+  }
+  BucketType bucket_type = 5;
+}
+
 enum CloudProvider {
   CLOUD_PROVIDER_UNSPECIFIED = 0;
   CLOUD_PROVIDER_AWS = 1;
@@ -1419,19 +1432,6 @@ message S3Mount {
   string mount_path = 2;
   string credentials_secret_id = 3;
   bool read_only = 4;
-}
-
-message CloudBucketMount {
-  string bucket_name = 1;
-  string mount_path = 2;
-  string credentials_secret_id = 3;
-  bool read_only = 4;
-
-  enum BucketType {
-    UNSPECIFIED = 0;
-    S3 = 1;
-  }
-  BucketType bucket_type = 5;
 }
 
 message Sandbox {


### PR DESCRIPTION
This adds `CloudBucketMount` as a super interface to `S3Mount` in order to add support for multiple cloud providers.
