### PR TITLE
Add warning for threads on container exit

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -98,7 +98,7 @@ def publish_base_mounts(ctx, no_confirm=False):
         answer = input(f"Modal server URL is '{server_url}' not localhost. Continue operation? [y/N]: ")
         if answer.upper() not in ["Y", "YES"]:
             exit("Aborting task.")
-    for mount in ["client", "python_standalone"]:
+    for mount in ["modal_client_package", "python_standalone"]:
         ctx.run(f"{sys.executable} {Path(__file__).parent}/modal_global_objects/mounts/{mount}.py", pty=True)
 
 


### PR DESCRIPTION
Resolves MOD-2388.

## Changelog

- Modal containers now display a warning message if lingering threads are present at container exit, which prevents runner shutdown.