### PR TITLE
Update image.py

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -353,11 +353,13 @@ class _Image(_Object, type_prefix="im"):
                 'RUN echo "hello world" > hello.txt',
             ],
             secrets=[secret1, secret2],
+            gpu="T4",
         )
         ```
         """
-            gpu_config = parse_gpu_config(gpu)
-            return _Image._from_args(base_images={"base": self}, gpu_config=gpu_config, **kwargs)
+        
+        gpu_config = parse_gpu_config(gpu)
+        return _Image._from_args(base_images={"base": self}, gpu_config=gpu_config, **kwargs)
 
     @typechecked
     def copy_mount(self, mount: _Mount, remote_path: Union[str, Path] = ".") -> "_Image":

--- a/modal/image.py
+++ b/modal/image.py
@@ -337,7 +337,7 @@ class _Image(_Object, type_prefix="im"):
         obj.force_build = force_build
         return obj
 
-    def extend(self, **kwargs) -> "_Image":
+    def extend(self, gpu: GPU_T = None, **kwargs) -> "_Image":
         """Extend an image (named "base") with additional options or commands.
 
         This is a low-level command. Generally, you should prefer using functions
@@ -356,8 +356,8 @@ class _Image(_Object, type_prefix="im"):
         )
         ```
         """
-
-        return _Image._from_args(base_images={"base": self}, **kwargs)
+            gpu_config = parse_gpu_config(gpu)
+            return _Image._from_args(base_images={"base": self}, gpu_config=gpu_config, **kwargs)
 
     @typechecked
     def copy_mount(self, mount: _Mount, remote_path: Union[str, Path] = ".") -> "_Image":


### PR DESCRIPTION
expose GPU for `image.extend` function

## Describe your changes

- expose the `gpu` parameter for `image.extend` similar to `image.pip_install`

## Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
Let's a user enable a `gpu` when extending
