### PR TITLE
Catch unhydrated object dependencies on deploy

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -848,6 +848,14 @@ class _Function(_Object, type_prefix="fu"):
                 for path, volume in validated_volumes
             ]
             loaded_mount_ids = {m.object_id for m in all_mounts}
+
+            # Get object dependencies
+            object_dependencies = []
+            for dep in _deps(only_explicit_mounts=True):
+                if not dep.object_id:
+                    raise Exception(f"Dependency {dep} isn't hydrated")
+                object_dependencies.append(api_pb2.ObjectDependency(object_id=dep.object_id))
+
             # Create function remotely
             function_definition = api_pb2.Function(
                 module_name=info.module_name or "",
@@ -883,9 +891,7 @@ class _Function(_Object, type_prefix="fu"):
                 is_method=bool(info.cls),
                 checkpointing_enabled=enable_memory_snapshot,
                 is_checkpointing_function=False,
-                object_dependencies=[
-                    api_pb2.ObjectDependency(object_id=dep.object_id) for dep in _deps(only_explicit_mounts=True)
-                ],
+                object_dependencies=object_dependencies,
                 block_network=block_network,
                 max_inputs=max_inputs or 0,
                 cloud_bucket_mounts=cloud_bucket_mounts_to_proto(cloud_bucket_mounts),


### PR DESCRIPTION
User reported an issue where one of `object_dependencies` is broken. This causes functions to fail to start up.

This doesn't fix the issue, but it adds an assertion that will trigger on deploy – at least this will prevent broken functions from deploying. And it will help us troubleshoot this.