### PR TITLE
Revert "Revert recent changes to mounts to unbreak integration tests"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ We appreciate your patience while we speedily work towards a stable release of t
 
 <!-- NEW CONTENT GENERATED BELOW. PLEASE PRESERVE THIS COMMENT. -->
 
+### 0.61.26 (2024-03-07)
+
+* Stubs/apps can now be "composed" from several smaller stubs using `stub.include(...)`. This allows more ergonomic setup of multi-file Modal apps.
+
+
 
 ### 0.61.24 (2024-03-06)
 

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -15,7 +15,7 @@ from modal_proto import api_pb2
 from ._serialization import serialize
 from .config import config, logger
 from .exception import InvalidError, ModuleNotMountable
-from .mount import ROOT_DIR, _Mount, module_mount_condition
+from .mount import ROOT_DIR, _Mount
 from .object import Object
 
 # Expand symlinks in paths (homebrew Python paths are all symlinks).
@@ -211,16 +211,10 @@ class FunctionInfo:
         # make sure the function's own entrypoint is included:
         if self.type == FunctionInfoType.PACKAGE:
             if config.get("automount"):
-                return [
-                    _Mount.from_local_dir(
-                        self.base_dir,
-                        remote_path=self.remote_dir,
-                        recursive=True,
-                        condition=module_mount_condition,
-                    )
-                ]
+                return [_Mount.from_local_python_packages(self.module_name)]
             elif self.definition_type == api_pb2.Function.DEFINITION_TYPE_FILE:
                 # mount only relevant file and __init__.py:s
+                # TODO: This might lead to an "extra" in case another mount has both this file and others and is loaded *after* this one
                 return [
                     _Mount.from_local_dir(
                         self.base_dir,

--- a/modal/_function_utils.py
+++ b/modal/_function_utils.py
@@ -214,7 +214,6 @@ class FunctionInfo:
                 return [_Mount.from_local_python_packages(self.module_name)]
             elif self.definition_type == api_pb2.Function.DEFINITION_TYPE_FILE:
                 # mount only relevant file and __init__.py:s
-                # TODO: This might lead to an "extra" in case another mount has both this file and others and is loaded *after* this one
                 return [
                     _Mount.from_local_dir(
                         self.base_dir,

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -92,8 +92,6 @@ class Resolver:
             await obj._preload(obj, self, existing_object_id)
 
     async def load(self, obj: "_Object", existing_object_id: Optional[str] = None):
-        breakpoint()
-        print("LOADING", obj, existing_object_id, "DEDUP", self._deduplication_cache)
         deduplication_key = await obj._deduplication_key()
         cached_future = self._local_uuid_to_future.get(obj.local_uuid)
 
@@ -139,8 +137,6 @@ class Resolver:
         def hydrate_original(fut):
             # in case an object is omitted due to content duplication, make sure the original reference
             # is still hydrated
-            if obj.is_hydrated:
-                return  # already hydrated, probably the original object
             hydrated_object = fut.result()
             obj._hydrate(hydrated_object.object_id, self._client, hydrated_object._get_metadata())
 

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -148,7 +148,7 @@ class Resolver:
         return await cached_future
 
     def objects(self) -> List["_Object"]:
-        unique_objects = {}
+        unique_objects: Dict[str, "_Object"] = {}
         for fut in self._local_uuid_to_future.values():
             if not fut.done():
                 # this will raise an exception if not all loads have been awaited, but that *should* never happen

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -2,7 +2,7 @@
 import asyncio
 import contextlib
 from asyncio import Future
-from typing import TYPE_CHECKING, Dict, List, Optional, TypeVar
+from typing import TYPE_CHECKING, Dict, Hashable, List, Optional, TypeVar
 
 from grpclib import GRPCError, Status
 
@@ -11,6 +11,8 @@ from modal_proto import api_pb2
 if TYPE_CHECKING:
     from rich.spinner import Spinner
     from rich.tree import Tree
+
+    from modal.object import _Object
 else:
     Spinner = TypeVar("Spinner")
     Tree = TypeVar("Tree")
@@ -51,6 +53,7 @@ class Resolver:
     _local_uuid_to_future: Dict[str, Future]
     _environment_name: Optional[str]
     _app_id: Optional[str]
+    _deduplication_cache: Dict[Hashable, Future]
 
     def __init__(
         self,
@@ -70,6 +73,7 @@ class Resolver:
         self._client = client
         self._app_id = app_id
         self._environment_name = environment_name
+        self._deduplication_cache = {}
 
     @property
     def app_id(self) -> str:
@@ -89,8 +93,14 @@ class Resolver:
         if obj._preload is not None:
             await obj._preload(obj, self, existing_object_id)
 
-    async def load(self, obj, existing_object_id: Optional[str] = None):
-        cached_future = self._local_uuid_to_future.get(obj.local_uuid)
+    async def load(self, obj: "_Object", existing_object_id: Optional[str] = None):
+        deduplication_key = await obj._deduplication_key()
+        cached_future = None
+        if deduplication_key is not None:
+            cached_future = self._deduplication_cache.get(deduplication_key)
+
+        if not cached_future:
+            cached_future = self._local_uuid_to_future.get(obj.local_uuid)
 
         if not cached_future:
             # don't run any awaits within this if-block to prevent race conditions
@@ -122,6 +132,18 @@ class Resolver:
 
             cached_future = asyncio.create_task(loader())
             self._local_uuid_to_future[obj.local_uuid] = cached_future
+            if deduplication_key:
+                self._deduplication_cache[deduplication_key] = cached_future
+
+        def hydrate_original(fut):
+            # in case an object is omitted due to content duplication, make sure the original reference
+            # is still hydrated
+            if obj.object_id:
+                return  # already hydrated, probably the original object
+            hydrated_object = fut.result()
+            obj._hydrate(hydrated_object.object_id, self._client, hydrated_object._get_metadata())
+
+        cached_future.add_done_callback(hydrate_original)
 
         if cached_future.done():
             return cached_future.result()

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
 import os
 import pickle
+import typing
 from typing import Any, Callable, Collection, Dict, List, Optional, Type, TypeVar, Union
 
 from google.protobuf.message import Message
@@ -32,6 +33,10 @@ from .secret import _Secret
 from .volume import _Volume
 
 T = TypeVar("T")
+
+
+if typing.TYPE_CHECKING:
+    import modal.stub
 
 
 class ClsMixin:
@@ -146,6 +151,7 @@ class _Cls(_Object, type_prefix="cs"):
     _options: Optional[api_pb2.FunctionOptions]
     _callables: Dict[str, Callable]
     _from_other_workspace: Optional[bool]  # Functions require FunctionBindParams before invocation.
+    _stub: Optional["modal.stub._Stub"] = None  # not set for lookups
 
     def _initialize_from_empty(self):
         self._user_cls = None

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -71,7 +71,7 @@ from .exception import (
 )
 from .gpu import GPU_T, parse_gpu_config
 from .image import _Image
-from .mount import _get_client_mount, _Mount, _MountCache
+from .mount import _get_client_mount, _Mount
 from .network_file_system import _NetworkFileSystem, network_file_system_mount_protos
 from .object import Object, _get_environment_name, _Object, live_method, live_method_gen
 from .proxy import _Proxy
@@ -752,11 +752,7 @@ class _Function(_Object, type_prefix="fu"):
                 # worker runtime
                 deps += list(explicit_mounts)
             else:
-                mount_cache = (
-                    stub._mount_cache if stub else _MountCache()
-                )  # builder functions don't have stubs at this point
-                optimized_mounts = mount_cache.get_many(all_mounts)
-                deps += list(optimized_mounts)
+                deps += list(all_mounts)
             if proxy:
                 deps.append(proxy)
             if image:
@@ -851,16 +847,20 @@ class _Function(_Object, type_prefix="fu"):
                 )
                 for path, volume in validated_volumes
             ]
-            mount_cache = (
-                stub._mount_cache if stub else _MountCache()
-            )  # builder functions don't have stubs at this point
-            optimized_mounts = mount_cache.get_many(all_mounts)
+            loaded_mount_ids = {m.object_id for m in all_mounts}
+
+            # Get object dependencies
+            object_dependencies = []
+            for dep in _deps(only_explicit_mounts=True):
+                if not dep.object_id:
+                    raise Exception(f"Dependency {dep} isn't hydrated")
+                object_dependencies.append(api_pb2.ObjectDependency(object_id=dep.object_id))
 
             # Create function remotely
             function_definition = api_pb2.Function(
                 module_name=info.module_name or "",
                 function_name=info.function_name,
-                mount_ids=[mount.object_id for mount in optimized_mounts],
+                mount_ids=loaded_mount_ids,
                 secret_ids=[secret.object_id for secret in secrets],
                 image_id=(image.object_id if image else ""),
                 definition_type=info.definition_type,
@@ -891,9 +891,7 @@ class _Function(_Object, type_prefix="fu"):
                 is_method=bool(info.cls),
                 checkpointing_enabled=enable_memory_snapshot,
                 is_checkpointing_function=False,
-                object_dependencies=[
-                    api_pb2.ObjectDependency(object_id=dep.object_id) for dep in _deps(only_explicit_mounts=True)
-                ],
+                object_dependencies=object_dependencies,
                 block_network=block_network,
                 max_inputs=max_inputs or 0,
                 cloud_bucket_mounts=cloud_bucket_mounts_to_proto(cloud_bucket_mounts),

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -82,6 +82,7 @@ class _MountEntry(metaclass=abc.ABCMeta):
 
 
 def _select_files(entries: List[_MountEntry]) -> List[Tuple[Path, PurePosixPath]]:
+    # TODO: make this async
     all_files: typing.Set[Tuple[Path, PurePosixPath]] = set()
     for entry in entries:
         all_files |= set(entry.get_files_to_upload())
@@ -582,6 +583,19 @@ class _Mount(_Object, type_prefix="mo"):
         resolver = Resolver(client=client)
         await resolver.load(self)
 
+    async def _deduplication_key(self):
+        try:
+            included_files = await asyncio.get_event_loop().run_in_executor(None, _select_files, self.entries)
+        except NonLocalMountError:
+            return None
+        return frozenset(included_files)
+
+    def _get_metadata(self) -> api_pb2.MountHandleMetadata:
+        if self._content_checksum_sha256_hex is None:
+            raise ValueError("Trying to access checksum of unhydrated mount")
+
+        return api_pb2.MountHandleMetadata(content_checksum_sha256_hex=self._content_checksum_sha256_hex)
+
 
 Mount = synchronize_api(_Mount)
 
@@ -628,30 +642,6 @@ def _get_client_mount():
 _create_package_mounts_deprecation_msg = (
     "modal.create_package_mounts() is being deprecated, use modal.Mount.from_local_python_packages() instead"
 )
-
-
-class _MountCache:
-    # used for deduplicating Mounts
-    cache: typing.Dict[typing.FrozenSet[Tuple[Path, PurePosixPath]], _Mount]
-
-    def __init__(self):
-        self.cache = {}
-
-    def _cache_key(self, mount: _Mount) -> typing.FrozenSet[Tuple[Path, PurePosixPath]]:
-        return frozenset(_select_files(mount.entries))
-
-    def get(self, mount: _Mount) -> _Mount:
-        # return the mount itself or an equivalent one that has already been added
-        try:
-            return self.cache.setdefault(self._cache_key(mount), mount)
-        except NonLocalMountError:
-            return mount
-
-    def get_many(self, mounts: typing.Collection[_Mount]) -> List[_Mount]:
-        result = []
-        for m in mounts:
-            result.append(self.get(m))
-        return result
 
 
 @typechecked

--- a/modal/object.py
+++ b/modal/object.py
@@ -204,7 +204,7 @@ class _Object:
                 " wasn't defined in global scope."
             )
         else:
-            resolver = Resolver()
+            resolver = Resolver()  # TODO: this resolver has no attached Client!
             await resolver.load(self)
 
     async def _deduplication_key(self) -> Optional[Hashable]:

--- a/modal/object.py
+++ b/modal/object.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 import uuid
 from functools import wraps
-from typing import Awaitable, Callable, ClassVar, Dict, List, Optional, Type, TypeVar
+from typing import Awaitable, Callable, ClassVar, Dict, Hashable, List, Optional, Type, TypeVar
 
 from google.protobuf.message import Message
 
@@ -206,6 +206,9 @@ class _Object:
         else:
             resolver = Resolver()
             await resolver.load(self)
+
+    async def _deduplication_key(self) -> Optional[Hashable]:
+        return None
 
 
 Object = synchronize_api(_Object, target_module=__name__)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1318,6 +1318,11 @@ def modal_config():
     return mock_modal_toml
 
 
+@pytest.fixture
+def supports_dir(test_dir):
+    return test_dir / Path("supports")
+
+
 @pytest.fixture()
 def modal_test_support_dir(request):
     # TODO: merge this with test/supports dir?

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -7,14 +7,23 @@ from typing import Optional
 
 
 def deploy_stub_externally(
-    servicer, file_or_module: str, stub_variable: Optional[str] = None, deployment_name="Deployment", cwd=None, env={}
-):
+    servicer,
+    file_or_module: str,
+    stub_variable: Optional[str] = None,
+    deployment_name="Deployment",
+    cwd=None,
+    env={},
+    capture_output=True,
+) -> Optional[str]:
     # deploys a stub from another interpreter to prevent leaking state from client into a container process (apart from what goes through the servicer)
     # also has the advantage that no modules imported by the test files themselves will be added to sys.modules and included in mounts etc.
     windows_support: dict[str, str] = {}
 
     if sys.platform == "win32":
-        windows_support = {**os.environ.copy(), **{"PYTHONUTF8": "1"}}  # windows apparently needs a bunch of env vars to start python...
+        windows_support = {
+            **os.environ.copy(),
+            **{"PYTHONUTF8": "1"},
+        }  # windows apparently needs a bunch of env vars to start python...
 
     env = {**windows_support, "MODAL_SERVER_URL": servicer.remote_addr, **env}
     if cwd is None:
@@ -22,9 +31,12 @@ def deploy_stub_externally(
 
     stub_ref = file_or_module if stub_variable is None else f"{file_or_module}::{stub_variable}"
 
-    return subprocess.check_output(
+    p = subprocess.Popen(
         [sys.executable, "-m", "modal.cli.entry_point", "deploy", stub_ref, "--name", deployment_name],
         cwd=cwd,
         env=env,
         stderr=subprocess.STDOUT,
-    ).decode("utf8")
+        stdout=subprocess.PIPE if capture_output else None,
+    )
+    stdout, _ = p.communicate()
+    return stdout.decode("utf8")

--- a/test/mounted_files_test.py
+++ b/test/mounted_files_test.py
@@ -28,11 +28,6 @@ def venv_path(tmp_path):
 script_path = "pkg_a/script.py"
 
 
-@pytest.fixture
-def supports_dir(test_dir):
-    return test_dir / Path("supports")
-
-
 def f():
     pass
 

--- a/test/stub_composition_test.py
+++ b/test/stub_composition_test.py
@@ -1,0 +1,10 @@
+# Copyright Modal Labs 2024
+from test.helpers import deploy_stub_externally
+
+
+def test_stub_composition_includes_all_functions(servicer, supports_dir, monkeypatch, client):
+    print(deploy_stub_externally(servicer, "main.py", cwd=supports_dir / "multifile_project"))
+    assert servicer.n_functions == 3
+    assert {"/root/main.py", "/root/a.py", "/root/b.py", "/root/c.py"} == set(servicer.files_name2sha.keys())
+    assert len(servicer.secrets) == 1  # secret from B should be included
+    assert servicer.n_mounts == 4  # mounts should not be duplicated

--- a/test/supports/multifile_project/a.py
+++ b/test/supports/multifile_project/a.py
@@ -1,0 +1,16 @@
+# Copyright Modal Labs 2024
+import c
+
+import modal
+
+stub = modal.Stub()
+
+d = modal.Dict.from_name("my-queue", create_if_missing=True)
+
+
+@stub.function()
+def a_func():
+    d["foo"] = "bar"
+
+
+stub.include(c.stub)

--- a/test/supports/multifile_project/b.py
+++ b/test/supports/multifile_project/b.py
@@ -1,0 +1,14 @@
+# Copyright Modal Labs 2024
+import c
+
+import modal
+
+stub = modal.Stub()
+
+
+@stub.function(secrets=[modal.Secret.from_dict({"foo": "bar"})])
+def b_func():
+    pass
+
+
+stub.include(c.stub)

--- a/test/supports/multifile_project/c.py
+++ b/test/supports/multifile_project/c.py
@@ -1,0 +1,9 @@
+# Copyright Modal Labs 2024
+import modal
+
+stub = modal.Stub("c")
+
+
+@stub.function()
+def c_func():
+    pass

--- a/test/supports/multifile_project/main.py
+++ b/test/supports/multifile_project/main.py
@@ -1,0 +1,9 @@
+# Copyright Modal Labs 2024
+import a
+import b
+
+import modal
+
+stub = modal.Stub()
+stub.include(a.stub)
+stub.include(b.stub)


### PR DESCRIPTION
Reverts modal-labs/modal-client#1500

Work in progress to fix the integration tests breaking

## Changelog

* Stubs/apps can now be "composed" from several smaller stubs using `stub.include(...)`. This allows more ergonomic setup of multi-file Modal apps.
