### PR TITLE
Support exposing HTTP ports with the `@web_server` decorator

### DIFF
--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -20,7 +20,7 @@ try:
     from .image import Image
     from .mount import Mount, create_package_mounts
     from .network_file_system import NetworkFileSystem
-    from .partial_function import asgi_app, build, enter, exit, method, web_endpoint, wsgi_app
+    from .partial_function import asgi_app, build, enter, exit, method, web_endpoint, web_server, wsgi_app
     from .proxy import Proxy
     from .queue import Queue
     from .retries import Retries
@@ -75,6 +75,7 @@ __all__ = [
     "is_local",
     "method",
     "web_endpoint",
+    "web_server",
     "wsgi_app",
     "interact",
 ]

--- a/modal/_asgi.py
+++ b/modal/_asgi.py
@@ -280,7 +280,7 @@ async def _proxy_websocket_request(session: aiohttp.ClientSession, scope, receiv
             while True:
                 client_message = await receive()
                 if client_message["type"] == "websocket.disconnect":
-                    await upstream_ws.close(client_message.get("code", 1005))
+                    await upstream_ws.close(code=client_message.get("code", 1005))
                     break
                 elif client_message["type"] == "websocket.receive":
                     if client_message.get("text") is not None:

--- a/modal/_asgi.py
+++ b/modal/_asgi.py
@@ -1,10 +1,13 @@
 # Copyright Modal Labs 2022
 import asyncio
-from typing import Any, AsyncGenerator, Callable, Dict
+from typing import Any, AsyncGenerator, Callable, Dict, Optional, cast
+
+import aiohttp
 
 from ._utils.async_utils import TaskContext
 from ._utils.blob_utils import MAX_OBJECT_SIZE_BYTES
 from .config import logger
+from .exception import ExecutionError, InvalidError
 from .functions import current_function_call_id
 
 FIRST_MESSAGE_TIMEOUT_SECONDS = 5.0
@@ -157,3 +160,194 @@ def webhook_asgi_app(fn: Callable, method: str):
     )
     app.add_api_route("/", fn, methods=[method])
     return app
+
+
+def get_ip_address(ifname: bytes):
+    """Get the IP address associated with a network interface in Linux."""
+    import fcntl
+    import socket
+    import struct
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    return socket.inet_ntoa(
+        fcntl.ioctl(
+            s.fileno(),
+            0x8915,  # SIOCGIFADDR
+            struct.pack("256s", ifname[:15]),
+        )[20:24]
+    )
+
+
+def wait_for_web_server(host: str, port: int, *, timeout: float) -> None:
+    """Wait until a web server port starts accepting TCP connections."""
+    import socket
+    import time
+
+    start_time = time.monotonic()
+    while True:
+        try:
+            with socket.create_connection((host, port), timeout=timeout):
+                break
+        except OSError as ex:
+            time.sleep(0.01)
+            if time.monotonic() - start_time >= timeout:
+                raise TimeoutError(
+                    f"Waited too long for port {port} to start accepting connections. "
+                    + "Make sure the web server is listening on all interfaces, or adjust `startup_timeout`."
+                ) from ex
+
+
+async def _proxy_http_request(session: aiohttp.ClientSession, scope, receive, send) -> None:
+    proxy_response: Optional[aiohttp.ClientResponse] = None
+
+    async def request_generator():
+        while True:
+            message = await receive()
+            if message["type"] == "http.request":
+                body = message.get("body", b"")
+                if body:
+                    yield body
+                if not message.get("more_body", False):
+                    break
+            elif message["type"] == "http.disconnect":
+                proxy_response.connection.transport.abort()  # Abort the connection.
+                break
+            else:
+                raise ExecutionError(f"Unexpected message type: {message['type']}")
+
+    path = scope["path"]
+    if scope.get("query_string"):
+        path += scope["query_string"].decode()
+
+    proxy_response = await session.request(
+        method=scope["method"],
+        url=path,
+        headers=[(k.decode(), v.decode()) for k, v in scope["headers"]],
+        data=request_generator(),
+        allow_redirects=False,
+    )
+
+    async def send_response():
+        msg = {
+            "type": "http.response.start",
+            "status": proxy_response.status,
+            "headers": [(k.encode(), v.encode()) for k, v in proxy_response.headers.items()],
+        }
+        await send(msg)
+        async for data in proxy_response.content.iter_any():
+            msg = {
+                "type": "http.response.body",
+                "body": data,
+                "more_body": True,
+            }
+            await send(msg)
+        await send({"type": "http.response.body"})
+
+    async def listen_for_disconnect():
+        while True:
+            message = await receive()
+            if message["type"] == "http.disconnect":
+                proxy_response.connection.transport.abort()
+
+    try:
+        send_response_task = asyncio.create_task(send_response())
+        disconnect_task = asyncio.create_task(listen_for_disconnect())
+        await asyncio.wait([send_response_task, disconnect_task], return_when=asyncio.FIRST_COMPLETED)
+    finally:
+        send_response_task.cancel()
+        disconnect_task.cancel()
+
+
+async def _proxy_websocket_request(session: aiohttp.ClientSession, scope, receive, send) -> None:
+    first_message = await receive()  # Consume the initial "websocket.connect" message.
+    if first_message["type"] != "websocket.connect":
+        raise ExecutionError(f"Unexpected message type: {first_message['type']}")
+
+    path = scope["path"]
+    if scope.get("query_string"):
+        path += scope["query_string"].decode()
+
+    async with session.ws_connect(
+        url=path,
+        headers=[(k.decode(), v.decode()) for k, v in scope["headers"]],  # type: ignore
+        protocols=scope.get("subprotocols", []),
+    ) as upstream_ws:
+
+        async def client_to_upstream():
+            while True:
+                client_message = await receive()
+                if client_message["type"] == "websocket.disconnect":
+                    break
+                elif client_message["type"] == "websocket.receive":
+                    if client_message.get("text") is not None:
+                        await upstream_ws.send_str(client_message["text"])
+                    elif client_message.get("bytes") is not None:
+                        await upstream_ws.send_bytes(client_message["bytes"])
+                else:
+                    raise ExecutionError(f"Unexpected message type: {client_message['type']}")
+
+        async def upstream_to_client():
+            msg = {
+                "type": "websocket.accept",
+                "subprotocol": upstream_ws.protocol,
+            }
+            await send(msg)
+
+            while True:
+                upstream_message = await upstream_ws.receive()
+                if upstream_message.type == aiohttp.WSMsgType.closed:
+                    msg = {
+                        "type": "websocket.close",
+                        "code": cast(aiohttp.WSCloseCode, upstream_message.data).value,  # type: ignore
+                        "reason": upstream_message.extra,
+                    }
+                    await send(msg)
+                    break
+                elif upstream_message.type == aiohttp.WSMsgType.text:
+                    await send({"type": "websocket.send", "text": upstream_message.data})
+                elif upstream_message.type == aiohttp.WSMsgType.binary:
+                    await send({"type": "websocket.send", "bytes": upstream_message.data})
+                else:
+                    pass  # Ignore all other upstream WebSocket message types.
+
+        client_to_upstream_task = asyncio.create_task(client_to_upstream())
+        upstream_to_client_task = asyncio.create_task(upstream_to_client())
+        try:
+            await asyncio.wait([client_to_upstream_task, upstream_to_client_task], return_when=asyncio.FIRST_COMPLETED)
+        finally:
+            client_to_upstream_task.cancel()
+            upstream_to_client_task.cancel()
+
+
+def web_server_proxy(host: str, port: int):
+    """Return an ASGI app that proxies requests to a web server running on the same host."""
+    if not 0 < port < 65536:
+        raise InvalidError(f"Invalid port number: {port}")
+
+    base_url = f"http://{host}:{port}"
+    session: Optional[aiohttp.ClientSession] = None
+
+    async def web_server_proxy_app(scope, receive, send):
+        nonlocal session
+        if session is None:
+            # TODO: We currently create the ClientSession on container startup and never close it.
+            # This outputs an "Unclosed client session" warning during runner termination. We should
+            # properly close the session once we implement the ASGI lifespan protocol.
+            session = aiohttp.ClientSession(
+                base_url,
+                cookie_jar=aiohttp.DummyCookieJar(),
+                timeout=aiohttp.ClientTimeout(total=3600),
+                auto_decompress=False,
+                read_bufsize=1024 * 1024,  # 1 MiB
+            )
+
+        if scope["type"] == "lifespan":
+            pass  # Do nothing for lifespan events.
+        elif scope["type"] == "http":
+            await _proxy_http_request(session, scope, receive, send)
+        elif scope["type"] == "websocket":
+            await _proxy_websocket_request(session, scope, receive, send)
+        else:
+            raise NotImplementedError(f"Scope {scope} is not understood")
+
+    return web_server_proxy_app

--- a/modal/cli/import_refs.py
+++ b/modal/cli/import_refs.py
@@ -131,7 +131,7 @@ def _infer_function_or_help(
         function_name = sorted_function_choices[0]
     elif len(function_choices) == 0:
         if stub.registered_web_endpoints:
-            err_msg = "Modal stub has only webhook functions. Use `modal serve` instead of `modal run`."
+            err_msg = "Modal stub has only web endpoints. Use `modal serve` instead of `modal run`."
         else:
             err_msg = "Modal stub has no registered functions. Nothing to run."
         raise click.UsageError(err_msg)


### PR DESCRIPTION
This is another built-in type of web endpoint that exposes an external port on the container. Documentation is provided on the method.

We'll need to write a guide for this in the future, and we can [simplify some examples](https://github.com/modal-labs/modal-examples/pull/648).

**Usage:**

```python
import subprocess

from modal import Stub, web_server

stub = Stub()


@stub.function()
@web_server(8000)
def my_file_server():
    subprocess.Popen("python -m http.server -d / 8000", shell=True)
```


Resolves MOD-2504.

## Changelog

- Add the `@web_server` decorator, which exposes a server listening on a container port as a web endpoint.