### PR TITLE
Change asyncify type to the broader Coroutine type, 

### DIFF
--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -7,7 +7,7 @@ import sys
 import time
 import typing
 from contextlib import asynccontextmanager
-from typing import Any, AsyncGenerator, Awaitable, Callable, Iterator, List, Optional, Set, TypeVar, cast
+from typing import Any, AsyncGenerator, Callable, Iterator, List, Optional, Set, TypeVar, cast
 
 import synchronicity
 from typing_extensions import ParamSpec
@@ -316,13 +316,13 @@ T = TypeVar("T")
 P = ParamSpec("P")
 
 
-def asyncify(f: Callable[P, T]) -> Callable[P, Awaitable[T]]:
+def asyncify(f: Callable[P, T]) -> Callable[P, typing.Coroutine[None, None, T]]:
     """Convert a blocking function into one that runs in the current loop's executor."""
 
     @functools.wraps(f)
-    def wrapper(*args: P.args, **kwargs: P.kwargs) -> Awaitable[T]:
+    async def wrapper(*args: P.args, **kwargs: P.kwargs):
         loop = asyncio.get_running_loop()
-        return loop.run_in_executor(None, functools.partial(f, *args, **kwargs))
+        return await loop.run_in_executor(None, functools.partial(f, *args, **kwargs))
 
     return wrapper
 


### PR DESCRIPTION
so using it as a decorator doesn't break abstract methods