### PR TITLE
Generalize resolver deduplication

### DIFF
--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -92,7 +92,11 @@ class Resolver:
             await obj._preload(obj, self, existing_object_id)
 
     async def load(self, obj: "_Object", existing_object_id: Optional[str] = None):
-        deduplication_key = await obj._deduplication_key()
+        if obj._deduplication_key:
+            deduplication_key = await obj._deduplication_key()
+        else:
+            deduplication_key = None
+
         cached_future = self._local_uuid_to_future.get(obj.local_uuid)
 
         if not cached_future and deduplication_key is not None:
@@ -101,14 +105,9 @@ class Resolver:
             # the same content
             cached_future = self._deduplication_cache.get(deduplication_key)
             if cached_future:
-
-                def hydrate_copy(fut):
-                    # in case an object is omitted due to content duplication, make sure the copy is
-                    # is still hydrated using hydration data from the original
-                    hydrated_object = fut.result()
-                    obj._hydrate(hydrated_object.object_id, self._client, hydrated_object._get_metadata())
-
-                cached_future.add_done_callback(hydrate_copy)
+                hydrated_object = await cached_future
+                obj._hydrate(hydrated_object.object_id, self._client, hydrated_object._get_metadata())
+                return obj
 
         if not cached_future:
             # don't run any awaits within this if-block to prevent race conditions
@@ -142,9 +141,6 @@ class Resolver:
             self._local_uuid_to_future[obj.local_uuid] = cached_future
             if deduplication_key is not None:
                 self._deduplication_cache[deduplication_key] = cached_future
-
-        if cached_future.done():
-            return cached_future.result()
 
         return await cached_future
 


### PR DESCRIPTION
Allow injection of deduplication key logic in constructor instead of using class method. This will be used in followup PR to deduplicate `from_name()` object references.

Also fixes a newly surfaced issue where duplicate objects weren't necessarily hydrated immediately after their `load()` method returned. This is due to `add_done_callback()` not necessarily running before an awaiter gets the result of a future even though it's guaranteed to *be scheduled* before that...
