### PR TITLE
[MOD-2551] Add runtime_debug to 'modal exec'

### DIFF
--- a/modal/_container_exec.py
+++ b/modal/_container_exec.py
@@ -20,6 +20,7 @@ from ._pty import get_pty_info, raw_terminal, set_nonblocking
 from ._utils.async_utils import TaskContext, asyncify
 from ._utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES, retry_transient_errors, unary_stream
 from .client import _Client
+from .config import config
 from .exception import ExecutionError, InteractiveTimeoutError, NotFoundError
 
 
@@ -44,6 +45,7 @@ async def container_exec(
                 command=command,
                 pty_info=get_pty_info(shell=True) if pty else None,
                 terminate_container_on_exit=terminate_container_on_exit,
+                runtime_debug=config.get("function_runtime_debug"),
             )
         )
     except GRPCError as err:

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -591,6 +591,7 @@ message ContainerExecRequest {
   PTYInfo pty_info = 3;
   // Send SIGTERM to running container on exit of exec command.
   bool terminate_container_on_exit = 4;
+  bool runtime_debug = 5; // For internal debugging use only.
 }
 
 message ContainerExecGetOutputRequest {


### PR DESCRIPTION
## Describe your changes

- _Provide Linear issue reference (e.g. MOD-1234) if available._


## Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
    - old servers will just ignore new field 
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
