### PR TITLE
Fix mounted directories with symlinked files

### DIFF
--- a/modal/mount.py
+++ b/modal/mount.py
@@ -98,7 +98,7 @@ class _MountFile(_MountEntry):
         return str(self.local_file)
 
     def get_files_to_upload(self):
-        local_file = self.local_file.resolve().expanduser()
+        local_file = self.local_file.expanduser().absolute()
         if not local_file.exists():
             raise FileNotFoundError(local_file)
 
@@ -106,7 +106,7 @@ class _MountFile(_MountEntry):
         yield local_file, rel_filename
 
     def watch_entry(self):
-        safe_path = self.local_file.resolve().expanduser()
+        safe_path = self.local_file.expanduser().absolute()
         return safe_path.parent, safe_path
 
     def top_level_paths(self) -> List[Tuple[Path, PurePosixPath]]:
@@ -121,10 +121,10 @@ class _MountDir(_MountEntry):
     recursive: bool
 
     def description(self):
-        return str(self.local_dir.resolve().expanduser())
+        return str(self.local_dir.expanduser().absolute())
 
     def get_files_to_upload(self):
-        local_dir = self.local_dir.resolve().expanduser()
+        local_dir = self.local_dir.expanduser().absolute()
 
         if not local_dir.exists():
             raise FileNotFoundError(local_dir)
@@ -139,7 +139,7 @@ class _MountDir(_MountEntry):
 
         for local_filename in gen:
             if self.condition(local_filename):
-                local_relpath = Path(local_filename).resolve().relative_to(local_dir)
+                local_relpath = Path(local_filename).expanduser().absolute().relative_to(local_dir)
                 mount_path = self.remote_path / local_relpath.as_posix()
                 yield local_filename, mount_path
 


### PR DESCRIPTION
We introduced a bug in https://github.com/modal-labs/modal-client/pull/1470 while trying to address an edge case in automounting behavior that arises with `pdm`. The consequence of the bug is that symlinks get dropped when we mount a local directory. This PR attempts to fix that problem but in a fairly naive way — I just replaced calls to `Path.resolve` (which resolves symlinks) with `Path.absolute` (which does not).

This fixes my test case for the bug and passes our test suite, but I am a little concerned that it is going to reintroduce the issue we tried to fix in #1470  — I am not sure I have enough context there to say.

## Changelog

- Fixed an bug where` Mount` was failing to include symbolic links.