### PR TITLE
Raise when a class uses snap methods without enabling memory snapshots

### DIFF
--- a/modal/stub.py
+++ b/modal/stub.py
@@ -26,7 +26,7 @@ from .image import _Image
 from .mount import _Mount
 from .network_file_system import _NetworkFileSystem
 from .object import _Object
-from .partial_function import PartialFunction, _PartialFunction
+from .partial_function import PartialFunction, _find_callables_for_cls, _PartialFunction, _PartialFunctionFlags
 from .proxy import _Proxy
 from .retries import Retries
 from .runner import _run_stub
@@ -663,6 +663,12 @@ class _Stub:
 
         def wrapper(user_cls: CLS_T) -> _Cls:
             cls: _Cls = _Cls.from_local(user_cls, self, decorator)
+
+            if (
+                _find_callables_for_cls(user_cls, _PartialFunctionFlags.ENTER_PRE_CHECKPOINT)
+                and not enable_memory_snapshot
+            ):
+                raise InvalidError("A class must have `enable_memory_snapshot=True` to use `snap=True` on its methods.")
 
             if len(cls._functions) > 1 and keep_warm is not None:
                 deprecation_warning(

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -647,3 +647,18 @@ async def test_deprecated_async_methods():
     stub = Stub("deprecated-async-cls")
     with pytest.warns(DeprecationError):
         stub.cls()(ClsWithDeprecatedAsyncMethods)()
+
+
+class HasSnapMethod:
+    @enter(snap=True)
+    def enter(self):
+        pass
+
+    @method()
+    def f(self):
+        pass
+
+
+def test_snap_method_without_snapshot_enabled():
+    with pytest.raises(InvalidError, match="A class must have `enable_memory_snapshot=True`"):
+        stub.cls(enable_memory_snapshot=False)(HasSnapMethod)


### PR DESCRIPTION
Prevents users from doing only `@enter(snap=True)`, which has no effect unless the class was also defined with `enable_memory_snapshot=True`

Note that we may continue revising the terminology here prior to officially releasing this feature.

Resolves MOD-2563