### PR TITLE
Fix for potential dying container heartbeat loop (!)

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -141,9 +141,10 @@ class _FunctionIOManager:
             # pre Python3.8, CancelledErrors were a subclass of exception
             except asyncio.CancelledError:
                 raise
-            except Exception as exc:
+            except Exception:
                 # don't stop heartbeat loop if there are transient exceptions!
-                logger.warning("Heartbeat failure", exc_info=exc)
+                time_elapsed = time.monotonic() - t0
+                logger.exception(f"Heartbeat attempt failed (time_elapsed={time_elapsed})")
 
             heartbeat_duration = time.monotonic() - t0
             time_until_next_hearbeat = max(0.0, HEARTBEAT_INTERVAL - heartbeat_duration)

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -129,16 +129,24 @@ class _FunctionIOManager:
     async def _run_heartbeat_loop(self):
         while 1:
             t0 = time.monotonic()
-            if await self._heartbeat():
-                # got a cancellation event, fine to start another heartbeat immediately
-                # since the cancellation queue should be empty on the worker server
-                # however, we wait at least 1s to prevent short-circuiting the heartbeat loop
-                # in case there is ever a bug. This means it will take at least 1s between
-                # two subsequent cancellations on the same task at the moment
-                time_until_next_hearbeat = 1.0
-            else:
-                heartbeat_duration = time.monotonic() - t0
-                time_until_next_hearbeat = max(0.0, HEARTBEAT_INTERVAL - heartbeat_duration)
+            try:
+                if await self._heartbeat():
+                    # got a cancellation event, fine to start another heartbeat immediately
+                    # since the cancellation queue should be empty on the worker server
+                    # however, we wait at least 1s to prevent short-circuiting the heartbeat loop
+                    # in case there is ever a bug. This means it will take at least 1s between
+                    # two subsequent cancellations on the same task at the moment
+                    await asyncio.sleep(1.0)
+                    continue
+            # pre Python3.8, CancelledErrors were a subclass of exception
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                # don't stop heartbeat loop if there are transient exceptions!
+                logger.warning("Heartbeat failure", exc_info=exc)
+
+            heartbeat_duration = time.monotonic() - t0
+            time_until_next_hearbeat = max(0.0, HEARTBEAT_INTERVAL - heartbeat_duration)
             await asyncio.sleep(time_until_next_hearbeat)
 
     async def _heartbeat(self) -> bool:


### PR DESCRIPTION
Realized there might have been a regression in error resilience in our heartbeat loop as part of the long polling refactor of container heartbeats a couple of weeks ago!