### PR TITLE
Do not warn when TaskContext cancels unfinished tasks

### DIFF
--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -143,11 +143,7 @@ class TaskContext:
                 if task.done() or task in self._loops:
                     continue
 
-                if sys.version_info >= (3, 11):
-                    already_cancelling = task.cancelling() > 0
-                    if not already_cancelling:
-                        logger.warning(f"Canceling remaining unfinished task: {task}")
-
+                # Cancel any remaining unfinished tasks.
                 task.cancel()
 
     async def __aexit__(self, exc_type, value, tb):

--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -98,7 +98,7 @@ class TaskContext:
 
     ```python notest
     async with TaskContext() as task_context:
-        task = task_context.create(coro())
+        task = task_context.create_task(coro())
     ```
     """
 

--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -85,11 +85,21 @@ def retry(direct_fn=None, *, n_attempts=3, base_delay=0, delay_factor=2, timeout
 
 
 class TaskContext:
-    """Simple thing to make sure we don't have stray tasks.
+    """A structured group that helps manage stray tasks.
+
+    This differs from the standard library `asyncio.TaskGroup` in that it cancels all tasks still
+    running after exiting the context manager, rather than waiting for them to finish.
+
+    A `TaskContext` can have an optional `grace` period in seconds, which will wait for a certain
+    amount of time before cancelling all remaining tasks. This is useful for allowing tasks to
+    gracefully exit when they determine that the context is shutting down.
 
     Usage:
+
+    ```python
     async with TaskContext() as task_context:
         task = task_context.create(coro())
+    ```
     """
 
     _loops: Set[asyncio.Task]

--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -3,7 +3,6 @@ import asyncio
 import concurrent.futures
 import functools
 import inspect
-import sys
 import time
 import typing
 from contextlib import asynccontextmanager

--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -96,7 +96,7 @@ class TaskContext:
 
     Usage:
 
-    ```python
+    ```python notest
     async with TaskContext() as task_context:
         task = task_context.create(coro())
     ```


### PR DESCRIPTION
See https://github.com/modal-labs/modal-client/pull/1522#issuecomment-1999782348

The history of this is that @irfansharif silenced the warning for Python versions up to 3.10 and below, two months ago. But it's still been happening for version 3.11, and it's a bit of an unhelpful warning in our case.

Note: `asyncio.TaskGroup` from the Python standard library waits for all tasks to finish when it exits normally. It only cancels tasks when it sees that one of its subtasks throws an exception other than `CancelledError`. However, our `async_utils.TaskContext` object is quite different in behavior, since it actually cancels _all_ tasks when it exits after a short grace period.

Code that is written for `TaskContext` will not work with `asyncio.TaskGroup`, and vice versa.
