### PR TITLE
Proto changes for implementing Shell With Sandbox

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1468,6 +1468,8 @@ message Sandbox {
   repeated CloudBucketMount cloud_bucket_mounts = 14;
 
   repeated VolumeMount volume_mounts = 13;
+
+  PTYInfo pty_info = 15;
 }
 
 message SandboxCreateRequest {


### PR DESCRIPTION
Proto changes for this [PR](https://github.com/modal-labs/modal-client/pull/1534).

We need to add PTY info to `Sandbox` because the sandbox created for `modal shell` needs to run with a PTY.