### PR TITLE
Use sandbox to implement shell

### DIFF
--- a/modal/_container_exec.py
+++ b/modal/_container_exec.py
@@ -1,11 +1,6 @@
 # Copyright Modal Labs 2024
 import asyncio
-import contextlib
-import errno
-import os
 import platform
-import select
-import sys
 from typing import List, Optional
 
 import rich
@@ -16,17 +11,15 @@ from rich.console import Console
 
 from modal_proto import api_pb2
 
-from ._pty import get_pty_info, raw_terminal, set_nonblocking
-from ._utils.async_utils import TaskContext, asyncify
+from ._pty import get_pty_info
 from ._utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES, retry_transient_errors, unary_stream
+from ._utils.shell_utils import connect_to_terminal, write_to_fd
 from .client import _Client
 from .config import config
-from .exception import ExecutionError, InteractiveTimeoutError, NotFoundError
+from .exception import NotFoundError
 
 
-async def container_exec(
-    task_id: str, command: List[str], *, pty: bool, client: _Client, terminate_container_on_exit: bool = False
-):
+async def container_exec(task_id: str, command: List[str], *, pty: bool, client: _Client):
     """Execute a command inside an active container"""
     if platform.system() == "Windows":
         print("container exec is not currently supported on Windows.")
@@ -44,7 +37,6 @@ async def container_exec(
                 task_id=task_id,
                 command=command,
                 pty_info=get_pty_info(shell=True) if pty else None,
-                terminate_container_on_exit=terminate_container_on_exit,
                 runtime_debug=config.get("function_runtime_debug"),
             )
         )
@@ -66,82 +58,26 @@ async def connect_to_exec(exec_id: str, pty: bool = False, connecting_status: Op
 
     client = await _Client.from_env()
 
-    def stop_connecting_status():
-        if connecting_status:
-            connecting_status.stop()
+    async def _stream_to_stdout(on_connect: asyncio.Event) -> int:
+        return await _handle_exec_output(client, exec_id, on_connect)
 
-    on_connect = asyncio.Event()
-    async with TaskContext() as tc:
-        exec_output_task = tc.create_task(handle_exec_output(client, exec_id, on_connect=on_connect))
-        try:
-            # time out if we can't connect to the server fast enough
-            await asyncio.wait_for(on_connect.wait(), timeout=15)
-            stop_connecting_status()
+    async def _handle_input(data: bytes, message_index: int):
+        await retry_transient_errors(
+            client.stub.ContainerExecPutInput,
+            api_pb2.ContainerExecPutInputRequest(
+                exec_id=exec_id, input=api_pb2.RuntimeInputMessage(message=data, message_index=message_index)
+            ),
+            total_timeout=10,
+        )
 
-            async with handle_exec_input(client, exec_id, use_raw_terminal=pty):
-                exit_status = await exec_output_task
-
-            if exit_status != 0:
-                raise ExecutionError(f"Process exited with status code {exit_status}")
-
-        except (asyncio.TimeoutError, TimeoutError):
-            stop_connecting_status()
-            exec_output_task.cancel()
-            raise InteractiveTimeoutError("Failed to establish connection to container.")
+    await connect_to_terminal(_handle_input, _stream_to_stdout, pty, connecting_status)
 
 
-# note: this is very similar to code in _pty.py.
-@contextlib.asynccontextmanager
-async def handle_exec_input(client: _Client, exec_id: str, use_raw_terminal=False):
-    quit_pipe_read, quit_pipe_write = os.pipe()
-
-    set_nonblocking(sys.stdin.fileno())
-
-    @asyncify
-    def _read_stdin() -> Optional[bytes]:
-        nonlocal quit_pipe_read
-        # TODO: Windows support.
-        (readable, _, _) = select.select([sys.stdin.buffer, quit_pipe_read], [], [], 5)
-        if quit_pipe_read in readable:
-            return None
-        if sys.stdin.buffer in readable:
-            return sys.stdin.buffer.read()
-        # we had 5 seconds of no input. send an empty string as a "heartbeat" to the server.
-        return b""
-
-    async def _write():
-        message_index = 1
-        while True:
-            data = await _read_stdin()
-            if data is None:
-                return
-
-            await retry_transient_errors(
-                client.stub.ContainerExecPutInput,
-                api_pb2.ContainerExecPutInputRequest(
-                    exec_id=exec_id, input=api_pb2.RuntimeInputMessage(message=data, message_index=message_index)
-                ),
-                total_timeout=10,
-            )
-            message_index += 1
-
-    write_task = asyncio.create_task(_write())
-
-    if use_raw_terminal:
-        with raw_terminal():
-            yield
-    else:
-        yield
-
-    os.write(quit_pipe_write, b"\n")
-    write_task.cancel()
-
-
-async def handle_exec_output(client: _Client, exec_id: str, on_connect: Optional[asyncio.Event] = None) -> int:
+async def _handle_exec_output(client: _Client, exec_id: str, on_connect: Optional[asyncio.Event] = None) -> int:
     """
-    Streams exec output to stdout.
+    Streams exec output to current terminal's stdout.
 
-    If given, on_connect will be set when the client connects to the running process,
+    The on_connect event will be set when the client connects to the running process,
     and the event loop will be released.
 
     Returns the status code of the process.
@@ -156,7 +92,6 @@ async def handle_exec_output(client: _Client, exec_id: str, on_connect: Optional
 
     async def _get_output():
         nonlocal last_batch_index, exit_status, connected
-
         req = api_pb2.ContainerExecGetOutputRequest(
             exec_id=exec_id,
             timeout=55,
@@ -166,19 +101,17 @@ async def handle_exec_output(client: _Client, exec_id: str, on_connect: Optional
             for message in batch.items:
                 assert message.file_descriptor in [1, 2]
 
-                await _write_to_fd(message.file_descriptor, str.encode(message.message))
+                await write_to_fd(message.file_descriptor, str.encode(message.message))
 
             if not connected:
                 connected = True
-                if on_connect is not None:
-                    on_connect.set()
-                    # give up the event loop
-                    await asyncio.sleep(0)
+                on_connect.set()
+                # give up the event loop
+                await asyncio.sleep(0)
 
             if batch.HasField("exit_code"):
                 exit_status = batch.exit_code
                 break
-
             last_batch_index = batch.batch_index
 
     while exit_status is None:
@@ -193,21 +126,3 @@ async def handle_exec_output(client: _Client, exec_id: str, on_connect: Optional
             raise
 
     return exit_status
-
-
-def _write_to_fd(fd: int, data: bytes):
-    loop = asyncio.get_event_loop()
-    future = loop.create_future()
-
-    def try_write():
-        try:
-            nbytes = os.write(fd, data)
-            loop.remove_writer(fd)
-            future.set_result(nbytes)
-        except OSError as e:
-            if e.errno != errno.EAGAIN:
-                future.set_exception(e)
-                raise
-
-    loop.add_writer(fd, try_write)
-    return future

--- a/modal/_output.py
+++ b/modal/_output.py
@@ -32,8 +32,8 @@ from rich.text import Text
 
 from modal_proto import api_pb2
 
-from ._container_exec import handle_exec_input
-from ._utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES, unary_stream
+from ._utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES, retry_transient_errors, unary_stream
+from ._utils.shell_utils import stream_from_stdin
 from .client import _Client
 from .config import logger
 
@@ -382,7 +382,17 @@ async def stream_pty_shell_input(client: _Client, exec_id: str, finish_event: as
     """
     Streams stdin to the given exec id until finish_event is triggered
     """
-    async with handle_exec_input(client, exec_id, use_raw_terminal=True):
+
+    async def _handle_input(data: bytes, message_index: int):
+        await retry_transient_errors(
+            client.stub.ContainerExecPutInput,
+            api_pb2.ContainerExecPutInputRequest(
+                exec_id=exec_id, input=api_pb2.RuntimeInputMessage(message=data, message_index=message_index)
+            ),
+            total_timeout=10,
+        )
+
+    async with stream_from_stdin(_handle_input, use_raw_terminal=True):
         await finish_event.wait()
 
 

--- a/modal/_sandbox_shell.py
+++ b/modal/_sandbox_shell.py
@@ -36,7 +36,7 @@ async def _stream_logs_to_stdout(sandbox: _Sandbox, on_connect: asyncio.Event) -
     # slave. The PTY shell will then relay data from PTY master to stdout.
     # Therefore, we only need to stream from/to stdout here.
     async for message in sandbox.stdout:
-        await write_to_fd(1, str.encode(message))
+        await write_to_fd(1, message.encode("utf-8"))
 
         if not connected:
             connected = True

--- a/modal/_sandbox_shell.py
+++ b/modal/_sandbox_shell.py
@@ -1,0 +1,49 @@
+# Copyright Modal Labs 2024
+import asyncio
+
+from ._utils.shell_utils import connect_to_terminal, write_to_fd
+from .sandbox import _Sandbox
+
+
+async def connect_to_sandbox(sandbox: _Sandbox):
+    """
+    Connects the current terminal to the Sandbox process.
+    """
+
+    async def _handle_input(data: bytes, _):
+        sandbox.stdin.write(data)
+        await sandbox.stdin.drain.aio()  # type: ignore
+
+    async def _stream_to_stdout(on_connect: asyncio.Event) -> int:
+        return await _stream_logs_to_stdout(sandbox, on_connect)
+
+    await connect_to_terminal(_handle_input, _stream_to_stdout, pty=True)
+
+
+async def _stream_logs_to_stdout(sandbox: _Sandbox, on_connect: asyncio.Event) -> int:
+    """
+    Streams sandbox output logs to the current terminal's stdout.
+
+    The on_connect event will be set when the client connects to the running process,
+    and the event loop will be released.
+    """
+
+    # we are connected if we received at least one message from the server
+    # (the server will send an empty message when the process spawns)
+    connected = False
+
+    # Since the sandbox process will run in a PTY, stderr will go to the PTY
+    # slave. The PTY shell will then relay data from PTY master to stdout.
+    # Therefore, we only need to stream from/to stdout here.
+    async for message in sandbox.stdout:
+        await write_to_fd(1, str.encode(message))
+
+        if not connected:
+            connected = True
+            on_connect.set()
+            # give up the event loop
+            await asyncio.sleep(0)
+
+    # Right now we don't propagate the exit_status to the TaskLogs, so setting
+    # exit status to 0.
+    return 0

--- a/modal/_utils/shell_utils.py
+++ b/modal/_utils/shell_utils.py
@@ -81,7 +81,7 @@ async def connect_to_terminal(
     stream_to_stdio: Callable[[asyncio.Event], Coroutine[None, None, int]],
     pty: bool = False,
     connecting_status: Optional[rich.status.Status] = None,
-):
+) -> None:
     """
     Connect to the current terminal by streaming data from terminal's stdin to the running process
     and streaming output from running process into terminal's stdout.

--- a/modal/_utils/shell_utils.py
+++ b/modal/_utils/shell_utils.py
@@ -1,0 +1,113 @@
+# Copyright Modal Labs 2024
+import asyncio
+import contextlib
+import errno
+import os
+import select
+import sys
+from typing import Callable, Coroutine, Optional
+
+import rich.status
+
+from modal._pty import raw_terminal, set_nonblocking
+from modal.exception import ExecutionError, InteractiveTimeoutError
+
+from .async_utils import TaskContext, asyncify
+
+
+def write_to_fd(fd: int, data: bytes):
+    loop = asyncio.get_event_loop()
+    future = loop.create_future()
+
+    def try_write():
+        try:
+            nbytes = os.write(fd, data)
+            loop.remove_writer(fd)
+            future.set_result(nbytes)
+        except OSError as e:
+            if e.errno != errno.EAGAIN:
+                future.set_exception(e)
+                raise
+
+    loop.add_writer(fd, try_write)
+    return future
+
+
+@contextlib.asynccontextmanager
+async def stream_from_stdin(handle_input: Callable[[bytes, int], Coroutine], use_raw_terminal=False):
+    """Stream from terminal stdin to the handle_input provided by the method"""
+    quit_pipe_read, quit_pipe_write = os.pipe()
+
+    set_nonblocking(sys.stdin.fileno())
+
+    @asyncify
+    def _read_stdin() -> Optional[bytes]:
+        nonlocal quit_pipe_read
+        # TODO: Windows support.
+        (readable, _, _) = select.select([sys.stdin.buffer, quit_pipe_read], [], [], 5)
+        if quit_pipe_read in readable:
+            return None
+        if sys.stdin.buffer in readable:
+            return sys.stdin.buffer.read()
+        # we had 5 seconds of no input. send an empty string as a "heartbeat" to the server.
+        return b""
+
+    async def _write():
+        message_index = 1
+        while True:
+            data = await _read_stdin()
+            if data is None:
+                return
+
+            await handle_input(data, message_index)
+
+            message_index += 1
+
+    write_task = asyncio.create_task(_write())
+
+    if use_raw_terminal:
+        with raw_terminal():
+            yield
+    else:
+        yield
+    os.write(quit_pipe_write, b"\n")
+    write_task.cancel()
+
+
+async def connect_to_terminal(
+    # Handles data read from stdin. Inputs are the stdin data and message index.
+    handle_stdin: Callable[[bytes, int], Coroutine],
+    # Creates a coroutine that streams data to stdout/stderr. Returns the exit status.
+    stream_to_stdio: Callable[[asyncio.Event], Coroutine[None, None, int]],
+    pty: bool = False,
+    connecting_status: Optional[rich.status.Status] = None,
+):
+    """
+    Connect to the current terminal by streaming data from terminal's stdin to the running process
+    and streaming output from running process into terminal's stdout.
+
+    If connecting_status is given, this function will stop the status spinner upon connection or error.
+    """
+
+    def stop_connecting_status():
+        if connecting_status:
+            connecting_status.stop()
+
+    on_connect = asyncio.Event()
+    async with TaskContext() as tc:
+        exec_output_task = tc.create_task(stream_to_stdio(on_connect))
+        try:
+            # time out if we can't connect to the server fast enough
+            await asyncio.wait_for(on_connect.wait(), timeout=15)
+            stop_connecting_status()
+
+            async with stream_from_stdin(handle_stdin, use_raw_terminal=pty):
+                exit_status = await exec_output_task
+
+            if exit_status != 0:
+                raise ExecutionError(f"Process exited with status code {exit_status}")
+
+        except (asyncio.TimeoutError, TimeoutError):
+            stop_connecting_status()
+            exec_output_task.cancel()
+            raise InteractiveTimeoutError("Failed to establish connection to container.")

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -10,8 +10,9 @@ from rich.console import Console
 
 from modal_proto import api_pb2
 
-from ._container_exec import container_exec
 from ._output import OutputManager, get_app_logs_loop, step_completed, step_progress
+from ._pty import get_pty_info
+from ._sandbox_shell import connect_to_sandbox
 from ._utils.app_utils import is_valid_app_name
 from ._utils.async_utils import TaskContext, synchronize_api
 from ._utils.grpc_utils import retry_transient_errors
@@ -313,13 +314,12 @@ async def _interactive_shell(_stub: _Stub, cmd: List[str], environment_name: str
         loading_status = console.status("Starting container...")
         loading_status.start()
 
-        sb = await _stub.spawn_sandbox("sleep", "360000", **kwargs)
+        sb = await _stub.spawn_sandbox("bash", pty_info=get_pty_info(shell=True), **kwargs)
 
         for _ in range(40):
             await asyncio.sleep(0.5)
             resp = await sb._client.stub.SandboxGetTaskId(api_pb2.SandboxGetTaskIdRequest(sandbox_id=sb._object_id))
             if resp.task_id != "":
-                task_id = resp.task_id
                 break
             # else: sandbox hasn't been assigned a task yet
         else:
@@ -327,7 +327,7 @@ async def _interactive_shell(_stub: _Stub, cmd: List[str], environment_name: str
             raise InteractiveTimeoutError("Timed out while waiting for sandbox to start")
 
         loading_status.stop()
-        await container_exec(task_id, cmd, pty=True, client=client, terminate_container_on_exit=True)
+        await connect_to_sandbox(sb)
 
 
 run_stub = synchronize_api(_run_stub)

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -314,8 +314,8 @@ async def _interactive_shell(_stub: _Stub, cmd: List[str], environment_name: str
         loading_status = console.status("Starting container...")
         loading_status.start()
 
-        sb = await _stub.spawn_sandbox("bash", pty_info=get_pty_info(shell=True), **kwargs)
-
+        sandbox_cmds = cmd if len(cmd) > 0 else ["/bin/bash"]
+        sb = await _stub.spawn_sandbox(*sandbox_cmds, pty_info=get_pty_info(shell=True), **kwargs)
         for _ in range(40):
             await asyncio.sleep(0.5)
             resp = await sb._client.stub.SandboxGetTaskId(api_pb2.SandboxGetTaskIdRequest(sandbox_id=sb._object_id))

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -78,7 +78,7 @@ class _LogsReader:
         """mdmd:hidden
         Streams sandbox logs from the server to the reader.
 
-        When the stream receives an eof, it yields None. Once an EOF is received,
+        When the stream receives an EOF, it yields None. Once an EOF is received,
         subsequent invocations will not yield logs.
         """
         if self.eof:

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -47,7 +47,7 @@ class _LogsReader:
         self._client = client
         self._stream = None
         self._last_log_batch_entry_id = ""
-        # Whether the reader received an EOF. Once eof is True, it returns
+        # Whether the reader received an EOF. Once EOF is True, it returns
         # an empty string for any subsequent reads (including async for)
         self.eof = False
 
@@ -126,7 +126,7 @@ class _LogsReader:
         """mdmd:hidden"""
         value = await self._stream.__anext__()
 
-        # The stream yields None if it receives an eof batch.
+        # The stream yields None if it receives an EOF batch.
         if value is None:
             raise StopAsyncIteration
 

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
+import asyncio
 import os
-from typing import Dict, List, Optional, Sequence, Union
+from typing import AsyncIterator, Dict, List, Optional, Sequence, Union
 
 from google.protobuf.message import Message
 from grpclib.exceptions import GRPCError, StreamTerminatedError
@@ -34,6 +35,7 @@ class _LogsReader:
         self._file_descriptor = file_descriptor
         self._sandbox_id = sandbox_id
         self._client = client
+        self._stream = None
 
     async def read(self) -> str:
         """Fetch and return contents of the entire stream.
@@ -48,47 +50,63 @@ class _LogsReader:
         ```
 
         """
+        data = ""
+        # TODO: maybe combine this with get_app_logs_loop
+        async for message in self:
+            data += message
 
+        return data
+
+    async def _stream_logs(self) -> AsyncIterator[Optional[api_pb2.TaskLogs]]:
+        """mdmd:hidden The stream ends and yields None when it receives a
+        TaskLogsBatch with eof set to true.
+        """
         last_log_batch_entry_id = ""
         completed = False
-        data = ""
 
-        # TODO: maybe combine this with get_app_logs_loop
-
-        async def _get_logs():
-            nonlocal last_log_batch_entry_id, completed, data
-
+        retries_remaining = 10
+        while not completed:
             req = api_pb2.SandboxGetLogsRequest(
                 sandbox_id=self._sandbox_id,
                 file_descriptor=self._file_descriptor,
                 timeout=55,
                 last_entry_id=last_log_batch_entry_id,
             )
-            log_batch: api_pb2.TaskLogsBatch
-            async for log_batch in unary_stream(self._client.stub.SandboxGetLogs, req):
-                if log_batch.entry_id:
-                    # log_batch entry_id is empty for fd="server" messages from AppGetLogs
+            try:
+                async for log_batch in unary_stream(self._client.stub.SandboxGetLogs, req):
                     last_log_batch_entry_id = log_batch.entry_id
 
-                if log_batch.eof:
-                    completed = True
-                    break
-
-                for item in log_batch.items:
-                    data += item.data
-
-        while not completed:
-            try:
-                await _get_logs()
+                    for message in log_batch.items:
+                        yield message
+                    if log_batch.eof:
+                        completed = True
+                        yield None
+                        break
             except (GRPCError, StreamTerminatedError) as exc:
-                if isinstance(exc, GRPCError):
-                    if exc.status in RETRYABLE_GRPC_STATUS_CODES:
+                if retries_remaining > 0:
+                    retries_remaining -= 1
+                    if isinstance(exc, GRPCError):
+                        if exc.status in RETRYABLE_GRPC_STATUS_CODES:
+                            await asyncio.sleep(1.0)
+                            continue
+                    elif isinstance(exc, StreamTerminatedError):
                         continue
-                elif isinstance(exc, StreamTerminatedError):
-                    continue
                 raise
 
-        return data
+    def __aiter__(self):
+        """mdmd:hidden"""
+        self._stream = self._stream_logs()
+        return self
+
+    async def __anext__(self):
+        """mdmd:hidden"""
+        value = await self._stream.__anext__()
+
+        # The stream yields None if it receives an eof batch.
+        if value is None:
+            raise StopAsyncIteration
+
+        return value.data
 
 
 MAX_BUFFER_SIZE = 128 * 1024
@@ -164,6 +182,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         block_network: bool = False,
         volumes: Dict[Union[str, os.PathLike], Union[_Volume, _CloudBucketMount]] = {},
         allow_background_volume_commits: bool = False,
+        pty_info: Optional[api_pb2.PTYInfo] = None,
     ) -> "_Sandbox":
         """mdmd:hidden"""
 
@@ -223,6 +242,7 @@ class _Sandbox(_Object, type_prefix="sb"):
                 block_network=block_network,
                 cloud_bucket_mounts=cloud_bucket_mounts_to_proto(cloud_bucket_mounts),
                 volume_mounts=volume_mounts,
+                pty_info=pty_info,
             )
 
             create_req = api_pb2.SandboxCreateRequest(app_id=resolver.app_id, definition=definition)

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -32,7 +32,7 @@ class _LogsReader:
     As an asynchronous iterable, the object supports the async for statement.
     **Usage**
 
-    ```python
+    ```python notest
     sandbox = stub.app.spawn_sandbox("bash", "-c", "while true; do echo foo; sleep 1; done")
     async for message in sandbox.stdout:
         print(f"Message: {message}")

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -33,7 +33,7 @@ class _LogsReader:
     **Usage**
 
     ```python
-    sandbox = stub.app.spawn_sandbox("bash", "-c", "while true; do echo foo; sleep 1; done)
+    sandbox = stub.app.spawn_sandbox("bash", "-c", "while true; do echo foo; sleep 1; done")
     async for message in sandbox.stdout:
         print(f"Message: {message}")
     ```

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -28,7 +28,15 @@ from .secret import _Secret
 
 class _LogsReader:
     """Provides an interface to buffer and fetch logs from a sandbox stream (`stdout` or `stderr`).
+
     As an asynchronous iterable, the object supports the async for statement.
+    **Usage**
+
+    ```python
+    sandbox = stub.app.spawn_sandbox("bash", "-c", "while true; do echo foo; sleep 1; done)
+    async for message in sandbox.stdout:
+        print(f"Message: {message}")
+    ```
     """
 
     def __init__(self, file_descriptor: int, sandbox_id: str, client: _Client) -> None:

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -8,6 +8,7 @@ from typing import Any, AsyncGenerator, Callable, ClassVar, Dict, List, Optional
 from synchronicity.async_wrap import asynccontextmanager
 
 from modal._types import typechecked
+from modal_proto import api_pb2
 
 from ._ipython import is_notebook
 from ._output import OutputManager
@@ -699,6 +700,7 @@ class _Stub:
         block_network: bool = False,  # Whether to block network access
         volumes: Dict[Union[str, os.PathLike], _Volume] = {},  # Volumes to mount in the sandbox.
         _allow_background_volume_commits: bool = False,
+        pty_info: Optional[api_pb2.PTYInfo] = None,
     ) -> _Sandbox:
         """Sandboxes are a way to run arbitrary commands in dynamically defined environments.
 
@@ -737,6 +739,7 @@ class _Stub:
             block_network=block_network,
             volumes=volumes,
             allow_background_volume_commits=_allow_background_volume_commits,
+            pty_info=pty_info,
         )
         await resolver.load(obj)
         return obj

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1468,6 +1468,8 @@ message Sandbox {
   repeated CloudBucketMount cloud_bucket_mounts = 14;
 
   repeated VolumeMount volume_mounts = 13;
+
+  PTYInfo pty_info = 15;
 }
 
 message SandboxCreateRequest {

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -512,7 +512,8 @@ def test_environment_flag(test_dir, servicer, command):
     ):  # hacky - compatible with both argless modal run and interactive mode which always sends an arg...
         pass
 
-    servicer.add_shell_cmds([b"exit\n"])
+    # if command[0] == "shell":
+    #     servicer.add_shell_cmds([b"exit\n"])
     stub_file = test_dir / "supports" / "app_run_tests" / "app_with_lookups.py"
     with servicer.intercept() as ctx:
         ctx.add_response(

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -536,6 +536,7 @@ def test_volume_rm(servicer, set_env_client):
 
 @pytest.mark.parametrize("command", [["run"], ["deploy"], ["serve", "--timeout=1"], ["shell"]])
 @pytest.mark.usefixtures("set_env_client", "mock_shell_pty")
+@skip_windows("modal shell is not supported on Windows.")
 def test_environment_flag(test_dir, servicer, command):
     @servicer.function_body
     def nothing(
@@ -567,6 +568,7 @@ def test_environment_flag(test_dir, servicer, command):
 
 @pytest.mark.parametrize("command", [["run"], ["deploy"], ["serve", "--timeout=1"], ["shell"]])
 @pytest.mark.usefixtures("set_env_client", "mock_shell_pty")
+@skip_windows("modal shell is not supported on Windows.")
 def test_environment_noflag(test_dir, servicer, command, monkeypatch):
     monkeypatch.setenv("MODAL_ENVIRONMENT", "some_weird_default_env")
 

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -512,8 +512,8 @@ def test_environment_flag(test_dir, servicer, command):
     ):  # hacky - compatible with both argless modal run and interactive mode which always sends an arg...
         pass
 
-    # if command[0] == "shell":
-    #     servicer.add_shell_cmds([b"exit\n"])
+    if command[0] == "shell":
+        servicer.add_shell_cmds([b"exit\n"])
     stub_file = test_dir / "supports" / "app_run_tests" / "app_with_lookups.py"
     with servicer.intercept() as ctx:
         ctx.add_response(

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -512,6 +512,7 @@ def test_environment_flag(test_dir, servicer, command):
     ):  # hacky - compatible with both argless modal run and interactive mode which always sends an arg...
         pass
 
+    servicer.add_shell_cmds([b"exit\n"])
     stub_file = test_dir / "supports" / "app_run_tests" / "app_with_lookups.py"
     with servicer.intercept() as ctx:
         ctx.add_response(
@@ -546,7 +547,7 @@ def test_environment_noflag(test_dir, servicer, command, monkeypatch):
         pass
 
     stub_file = test_dir / "supports" / "app_run_tests" / "app_with_lookups.py"
-
+    servicer.add_shell_cmds([b"exit\n"])
     with servicer.intercept() as ctx:
         ctx.add_response(
             "MountGetOrCreate",

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -347,6 +347,7 @@ def mock_shell_pty():
             env_term=os.environ.get("TERM"),
             env_colorterm=os.environ.get("COLORTERM"),
             env_term_program=os.environ.get("TERM_PROGRAM"),
+            pty_type=api_pb2.PTYInfo.PTY_TYPE_SHELL,
         )
 
     captured_out = []
@@ -414,7 +415,8 @@ def test_shell_cmd(servicer, set_env_client, test_dir, mock_shell_pty):
     _, captured_out = mock_shell_pty
     _run(["shell", "--cmd", "pwd", stub_file.as_posix() + "::foo"])
     expected_output = subprocess.run(["pwd"], capture_output=True, check=True).stdout
-    assert captured_out == [(1, expected_output)]
+    shell_prompt = servicer.sandbox_shell_prompt.encode("utf-8")
+    assert captured_out == [(1, shell_prompt), (1, expected_output)]
 
 
 def test_app_descriptions(servicer, server_url_env, test_dir):

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -335,7 +335,7 @@ def test_serve(servicer, set_env_client, server_url_env, test_dir):
 
 
 @pytest.fixture
-def mock_shell_pty():
+def mock_shell_pty(servicer):
     def mock_get_pty_info(shell: bool) -> api_pb2.PTYInfo:
         rows, cols = (64, 128)
         return api_pb2.PTYInfo(
@@ -355,9 +355,9 @@ def mock_shell_pty():
 
     with mock.patch("rich.console.Console.is_terminal", True), mock.patch(
         "modal._pty.get_pty_info", mock_get_pty_info
-    ), mock.patch("modal._container_exec.get_pty_info", mock_get_pty_info), mock.patch(
-        "modal._container_exec.handle_exec_input", asyncnullcontext
-    ), mock.patch("modal._container_exec._write_to_fd", write_to_fd):
+    ), mock.patch("modal.runner.get_pty_info", mock_get_pty_info), mock.patch(
+        "modal._utils.shell_utils.stream_from_stdin", asyncnullcontext
+    ), mock.patch("modal._sandbox_shell.write_to_fd", write_to_fd):
         yield captured_out
 
 
@@ -366,19 +366,23 @@ def test_shell(servicer, set_env_client, test_dir, mock_shell_pty):
     stub_file = test_dir / "supports" / "app_run_tests" / "default_stub.py"
     webhook_stub_file = test_dir / "supports" / "app_run_tests" / "webhook.py"
 
+    # We need to send "exit\n" to the sandbox, otherwise sandbox.stdout.read() will not terminate
+    # as it hasn't received an EOF.
+    servicer.add_shell_cmds([b'echo "Hello World"\n', b"exit\n"])
     # Function is explicitly specified
     _run(["shell", stub_file.as_posix() + "::foo"])
-    assert mock_shell_pty == [(1, b"Hello World")]
+
+    assert mock_shell_pty == [(1, b"Hello World\n")]
     mock_shell_pty.clear()
 
     # Function is explicitly specified
     _run(["shell", webhook_stub_file.as_posix() + "::foo"])
-    assert mock_shell_pty == [(1, b"Hello World")]
+    assert mock_shell_pty == [(1, b"Hello World\n")]
     mock_shell_pty.clear()
 
     # Function must be inferred
     _run(["shell", webhook_stub_file.as_posix()])
-    assert mock_shell_pty == [(1, b"Hello World")]
+    assert mock_shell_pty == [(1, b"Hello World\n")]
     mock_shell_pty.clear()
 
 

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -391,18 +391,20 @@ def test_shell(servicer, set_env_client, test_dir, mock_shell_pty):
     # Function is explicitly specified
     _run(["shell", stub_file.as_posix() + "::foo"])
 
+    shell_prompt = servicer.sandbox_shell_prompt.encode("utf-8")
+
     # first captured message is the empty message the mock server sends
-    assert captured_out[1:] == [(1, b"Hello World\n")]
+    assert captured_out == [(1, shell_prompt), (1, b"Hello World\n")]
     captured_out.clear()
 
     # Function is explicitly specified
     _run(["shell", webhook_stub_file.as_posix() + "::foo"])
-    assert captured_out[1:] == [(1, b"Hello World\n")]
+    assert captured_out == [(1, shell_prompt), (1, b"Hello World\n")]
     captured_out.clear()
 
     # Function must be inferred
     _run(["shell", webhook_stub_file.as_posix()])
-    assert captured_out[1:] == [(1, b"Hello World\n")]
+    assert captured_out == [(1, shell_prompt), (1, b"Hello World\n")]
     captured_out.clear()
 
 
@@ -411,8 +413,7 @@ def test_shell_cmd(servicer, set_env_client, test_dir, mock_shell_pty):
     stub_file = test_dir / "supports" / "app_run_tests" / "default_stub.py"
     _, captured_out = mock_shell_pty
     _run(["shell", "--cmd", "pwd", stub_file.as_posix() + "::foo"])
-    p = subprocess.Popen("pwd", stdout=subprocess.PIPE)
-    expected_output = p.stdout.read()
+    expected_output = subprocess.run(["pwd"], capture_output=True, check=True).stdout
     assert captured_out == [(1, expected_output)]
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -844,7 +844,13 @@ class MockClientServicer(api_grpc.ModalClientBase):
         try:
             await asyncio.wait_for(self.sandbox.wait(), request.timeout)
         except asyncio.TimeoutError:
-            await stream.send_message(api_pb2.SandboxWaitResponse())
+            if self.sandbox.returncode:
+                res = api_pb2.GenericResult(
+                    status=api_pb2.GenericResult.GENERIC_STATUS_FAILURE, exitcode=self.sandbox.returncode
+                )
+                await stream.send_message(api_pb2.SandboxWaitResponse(result=res))
+            else:
+                await stream.send_message(api_pb2.SandboxWaitResponse())
             return
 
         if self.sandbox.returncode != 0:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -810,10 +810,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         await stream.send_message(api_pb2.SandboxCreateResponse(sandbox_id="sb-123"))
 
     def is_shell_cmds(self, cmds):
-        try:
-            return cmds[0] in ["bash", "sh", "/bin/bash"]
-        except KeyError:
-            return False
+        return len(cmds) == 1 and cmds[0] in ["bash", "sh", "/bin/bash"]
 
     async def SandboxGetLogs(self, stream):
         request: api_pb2.SandboxGetLogsRequest = await stream.recv_message()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -800,7 +800,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
     def add_shell_cmds(self, args: list[bytes]):
         self.pending_shell_cmds += args
 
-    def is_shell_cmds(self, cmds: list[str]):
+    def is_shell_cmds(self, cmds):
         shell_list = ["bash", "sh"]
         if len(cmds) == 1 and cmds[0] in shell_list:
             return True

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -29,6 +29,9 @@ def test_spawn_sandbox(client, servicer):
 
         assert sb.stdout.read() == "hi\n"
         assert sb.stderr.read() == "bye\n"
+        # read a second time
+        assert sb.stdout.read() == ""
+        assert sb.stderr.read() == ""
 
         assert sb.returncode == 42
         assert sb.poll() == 42

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -186,3 +186,7 @@ async def test_sandbox_async_for(client, servicer):
             err += message
 
         assert err == "bye\n"
+
+        # test reading after receiving EOF
+        assert sb.stdout.read() == ""
+        assert sb.stderr.read() == ""


### PR DESCRIPTION
This PR adds the ability to stream data out of a `Sandbox`'s `LogReader`. It also reimplements `modal shell` with `Sandbox API` (`stdin` and `async for`).

For example, you can now do:
```
import modal

stub = modal.Stub("examples")

@stub.local_entrypoint()
async def main():
    sandbox = stub.spawn_sandbox(
        "bash",
        "-c",
        "while true; do echo foo; sleep 1; done",
    )

    async for message in sandbox.stdout:
        print(f"Message: {message}")
```

The `async for` API is the same as `asyncio::StreamReader`:
```
process = await asyncio.create_subprocess_exec(
    'bash', '-c', 'echo foo', 
    stdout=asyncio.subprocess.PIPE
)
async for line in process.stdout:
    print(f'Output: {line.decode()}')
```


This PR does change the semantics of `read` for our Sandbox's `LogReader` to be more aligned with `asyncio`'s [StreamReader::Read](https://docs.python.org/3/library/asyncio-stream.html#asyncio.StreamReader.read) API. Before this PR, calling `sb.stdout.read()` would return the full stream content both times. Now, the second `read` would return an empty string.

Similarly, if you do an `async for` after a `read`, no messages would be streamed, as the reader has received an `EOF` already.
