### PR TITLE
[MOD-2582] fix multipart upload concurrency

### DIFF
--- a/modal/_utils/blob_utils.py
+++ b/modal/_utils/blob_utils.py
@@ -32,6 +32,9 @@ LARGE_FILE_LIMIT = 4 * 1024 * 1024  # 4 MiB
 # Max parallelism during map calls
 BLOB_MAX_PARALLELISM = 10
 
+# read ~16MiB chunks by default
+DEFAULT_SEGMENT_CHUNK_SIZE = 2**24
+
 
 class BytesIOSegmentPayload(BytesIOPayload):
     """Modified bytes payload for concurrent sends of chunks from the same file
@@ -51,7 +54,7 @@ class BytesIOSegmentPayload(BytesIOPayload):
         read_lock: asyncio.Lock,
         segment_start: int,
         segment_length: int,
-        chunk_size: int = 2**24,  # read ~16MiB chunks by default
+        chunk_size: int = DEFAULT_SEGMENT_CHUNK_SIZE,
     ):
         # not thread safe constructor!
         super().__init__(bytes_io)
@@ -247,6 +250,7 @@ async def _blob_upload(upload_hashes: UploadHashes, data: Union[bytes, BinaryIO]
             max_part_size=resp.multipart.part_length,
             part_urls=resp.multipart.upload_urls,
             completion_url=resp.multipart.completion_url,
+            upload_chunk_size=DEFAULT_SEGMENT_CHUNK_SIZE,
         )
     else:
         lock = asyncio.Lock()  # not strictly necessary here

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -26,9 +26,9 @@ from .client import _Client
 from .config import logger
 from .object import _get_environment_name, _Object, live_method, live_method_gen
 
-# 15 min max for uploading to volumes files
+# Max duration for uploading to volumes files
 # As a guide, files >40GiB will take >10 minutes to upload.
-VOLUME_PUT_FILE_CLIENT_TIMEOUT = 15 * 60
+VOLUME_PUT_FILE_CLIENT_TIMEOUT = 30 * 60
 
 
 class _Volume(_Object, type_prefix="vo"):
@@ -513,6 +513,7 @@ class _VolumeUploadContextManager:
         request = api_pb2.MountPutFileRequest(sha256_hex=file_spec.sha256_hex)
         response = await retry_transient_errors(self._client.stub.MountPutFile, request, base_delay=1)
 
+        start_time = time.monotonic()
         if not response.exists:
             if file_spec.use_blob:
                 logger.debug(f"Creating blob file for {file_spec.source_description} ({file_spec.size} bytes)")
@@ -526,8 +527,7 @@ class _VolumeUploadContextManager:
                 )
                 request2 = api_pb2.MountPutFileRequest(data=file_spec.content, sha256_hex=file_spec.sha256_hex)
 
-            start_time = time.monotonic()
-            while time.monotonic() - start_time < VOLUME_PUT_FILE_CLIENT_TIMEOUT:
+            while (time.monotonic() - start_time) < VOLUME_PUT_FILE_CLIENT_TIMEOUT:
                 response = await retry_transient_errors(self._client.stub.MountPutFile, request2, base_delay=1)
                 if response.exists:
                     break

--- a/test/blob_test.py
+++ b/test/blob_test.py
@@ -10,6 +10,8 @@ from modal._utils.blob_utils import (
 )
 from modal.exception import ExecutionError
 
+from .supports.skip import skip_old_py
+
 blob_upload = synchronize_api(_blob_upload)
 blob_download = synchronize_api(_blob_download)
 blob_upload_file = synchronize_api(_blob_upload_file)
@@ -44,6 +46,7 @@ async def test_blob_large(servicer, blob_server, client):
     assert await blob_download.aio(blob_id, client.stub) == data
 
 
+@skip_old_py("random.randbytes() was introduced in python 3.9", (3, 9))
 @pytest.mark.asyncio
 async def test_blob_multipart(servicer, blob_server, client, monkeypatch, tmp_path):
     monkeypatch.setattr("modal._utils.blob_utils.DEFAULT_SEGMENT_CHUNK_SIZE", 128)

--- a/test/blob_test.py
+++ b/test/blob_test.py
@@ -1,12 +1,18 @@
 # Copyright Modal Labs 2022
 import pytest
+import random
 
 from modal._utils.async_utils import synchronize_api
-from modal._utils.blob_utils import blob_download as _blob_download, blob_upload as _blob_upload
+from modal._utils.blob_utils import (
+    blob_download as _blob_download,
+    blob_upload as _blob_upload,
+    blob_upload_file as _blob_upload_file,
+)
 from modal.exception import ExecutionError
 
 blob_upload = synchronize_api(_blob_upload)
 blob_download = synchronize_api(_blob_download)
+blob_upload_file = synchronize_api(_blob_upload_file)
 
 
 @pytest.mark.asyncio
@@ -39,8 +45,20 @@ async def test_blob_large(servicer, blob_server, client):
 
 
 @pytest.mark.asyncio
-async def test_blob_multipart(servicer, blob_server, client):
-    servicer.blob_multipart_threshold = 2_000_000
-    data = b"*" * 10_000_020
+async def test_blob_multipart(servicer, blob_server, client, monkeypatch, tmp_path):
+    monkeypatch.setattr("modal._utils.blob_utils.DEFAULT_SEGMENT_CHUNK_SIZE", 128)
+    multipart_threshold = 1024
+    servicer.blob_multipart_threshold = multipart_threshold
+    # - set high # of parts, to test concurrency correctness
+    # - make last part significantly shorter than rest, creating uneven upload time.
+    data_len = (256 * multipart_threshold) + (multipart_threshold // 2)
+    data = random.randbytes(data_len)  # random data will not hide byte re-ordering corruption
     blob_id = await blob_upload.aio(data, client.stub)
+    assert await blob_download.aio(blob_id, client.stub) == data
+
+    data_len = (256 * multipart_threshold) + (multipart_threshold // 2)
+    data = random.randbytes(data_len)  # random data will not hide byte re-ordering corruption
+    data_filepath = tmp_path / "temp.bin"
+    data_filepath.write_bytes(data)
+    blob_id = await blob_upload_file.aio(data_filepath.open("rb"), client.stub)
     assert await blob_download.aio(blob_id, client.stub) == data

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -27,7 +27,7 @@ def test_app_name():
 @pytest.mark.asyncio
 async def test_file_segment_payloads():
     data = io.BytesIO(b"abc123")
-    lock = asyncio.Lock()
+    data2 = io.BytesIO(data.getbuffer())
 
     class DummyOutput:  # AbstractStreamWriter
         def __init__(self):
@@ -38,8 +38,8 @@ async def test_file_segment_payloads():
 
     out1 = DummyOutput()
     out2 = DummyOutput()
-    p1 = BytesIOSegmentPayload(data, lock, 0, 3)
-    p2 = BytesIOSegmentPayload(data, lock, 3, 3)
+    p1 = BytesIOSegmentPayload(data, 0, 3)
+    p2 = BytesIOSegmentPayload(data2, 3, 3)
 
     # "out of order" writes
     await p2.write(out2)  # type: ignore
@@ -49,11 +49,10 @@ async def test_file_segment_payloads():
     assert p1.md5_checksum().digest() == hashlib.md5(b"abc").digest()
     assert p2.md5_checksum().digest() == hashlib.md5(b"123").digest()
 
-    assert data.read() == b"abc123"
-    data.seek(0)
+    data = io.BytesIO(b"abc123")
 
     # test reset_on_error
-    all_data = BytesIOSegmentPayload(data, lock, 0, 6)
+    all_data = BytesIOSegmentPayload(data, 0, 6)
 
     class DummyExc(Exception):
         pass
@@ -72,7 +71,7 @@ async def test_file_segment_payloads():
 @pytest.mark.asyncio
 async def test_file_segment_payloads_concurrency():
     data = io.BytesIO((b"123" * 1024 * 350)[: 1024 * 1024])  # 1 MiB
-    lock = asyncio.Lock()
+    data2 = io.BytesIO(data.getbuffer())
 
     class DummyOutput:  # AbstractStreamWriter
         def __init__(self):
@@ -83,7 +82,7 @@ async def test_file_segment_payloads_concurrency():
 
     out1 = DummyOutput()
     out2 = DummyOutput()
-    p1 = BytesIOSegmentPayload(data, lock, 0, len(data.getvalue()) // 2, chunk_size=100 * 1024)  # 100 KiB chunks
-    p2 = BytesIOSegmentPayload(data, lock, len(data.getvalue()) // 2, len(data.getvalue()) // 2, chunk_size=100 * 1024)
+    p1 = BytesIOSegmentPayload(data, 0, len(data.getvalue()) // 2, chunk_size=100 * 1024)  # 100 KiB chunks
+    p2 = BytesIOSegmentPayload(data2, len(data.getvalue()) // 2, len(data.getvalue()) // 2, chunk_size=100 * 1024)
     await asyncio.gather(p2.write(out2), p1.write(out1))  # type: ignore
     assert out1.value + out2.value == data.getvalue()


### PR DESCRIPTION
## Describe your changes

- MOD-2582

### Problem

At some point after I last looked at `volume put` reliability, something changed to surface this concurrency bug in our multi-part upload code. When I was testing against prod with a 30 GiB file, I got three hash mismatch errors in a row, each caused by corrupted data being uploaded to S3.

There's plenty of details in the referenced Linear ticket, but the crux of this issue is that this piece of code was making an unsynchronized mutation to the shared file position pointer, and it was doing so whenever a part upload finished, not just on error: 

```
    @contextmanager
    def reset_on_error(self):
        try:
            yield
        finally:
            self.reset_state()
```

This caused upload parts to read from the start of the file instead of the intended read position, corrupting the upload. 

### Fix

The chosen fix is to do away with the lock altogether and just have each upload part use it's own file position pointer. For files a part gets its own file descriptor; for in-memory `BinaryIO` objects we create N copies which reference the original using memory view and don't copy the underlying buffer.

## Backward/forward compatibility checks

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
