### PR TITLE
Protos for image builder version lookups

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1242,6 +1242,7 @@ message ImageGetOrCreateRequest {
   string build_function_id = 6;
   bool force_build = 7;
   DeploymentNamespace namespace = 8;
+  string builder_version = 9;
 }
 
 message ImageGetOrCreateResponse {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1226,6 +1226,10 @@ message Image {
   BuildFunction build_function = 21;
 }
 
+message ImageBuilderVersionLookupResponse {
+  string version = 1;
+}
+
 message ImageContextFile {
   string filename = 1;
   bytes data = 2;
@@ -2052,6 +2056,7 @@ service ModalClient {
   // Images
   rpc ImageGetOrCreate(ImageGetOrCreateRequest) returns (ImageGetOrCreateResponse);
   rpc ImageJoinStreaming(ImageJoinStreamingRequest) returns (stream ImageJoinStreamingResponse);
+  rpc ImageBuilderVersionLookup(google.protobuf.Empty) returns (ImageBuilderVersionLookupResponse);
 
   // Mounts
   rpc MountPutFile(MountPutFileRequest) returns (MountPutFileResponse);


### PR DESCRIPTION
Very simple for now; could imagine expanding this in the future to send back the list of currently-supported versions, e.g. for generating deprecation warnings or errors.

Since the image builder version is a workspace-level setting, we don't need to pass any information in the request, since the workspace id will be available server-side.