### PR TITLE
Set low timeouts on Github Actions jobs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,6 +10,7 @@ env:
 jobs:
   client-test:
     name: Unit tests on ${{ matrix.python-version }} and ${{ matrix.os }} (protobuf=${{ matrix.proto-version }})
+    timeout-minutes: 30
 
     strategy:
       matrix:
@@ -57,6 +58,7 @@ jobs:
   container-dependencies:
     name: Check minimal container dependencies for ${{ matrix.python-version }}
     runs-on: ubuntu-20.04
+    timeout-minutes: 4
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
@@ -85,6 +87,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     needs: [client-test]
     runs-on: ubuntu-20.04
+    timeout-minutes: 5
     env:
       MODAL_LOGLEVEL: DEBUG
       MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
@@ -121,6 +124,7 @@ jobs:
     needs: [client-test]
     runs-on: ubuntu-20.04
     concurrency: publish-client
+    timeout-minutes: 5
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   client-test:
     name: Unit tests on ${{ matrix.python-version }} and ${{ matrix.os }} (protobuf=${{ matrix.proto-version }})
-    timeout-minutes: 30
+    timeout-minutes: 20
 
     strategy:
       matrix:


### PR DESCRIPTION
Github Actions change only. 

Recently one of @brianshih1's PRs had jobs get stuck running for 6hrs. 
