### PR TITLE
Fix support for modal types in constructor args

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -1,6 +1,5 @@
 # Copyright Modal Labs 2022
 import os
-import pickle
 import typing
 from typing import Any, Callable, Collection, Dict, List, Optional, Type, TypeVar, Union
 
@@ -11,6 +10,7 @@ from modal_proto import api_pb2
 
 from ._output import OutputManager
 from ._resolver import Resolver
+from ._serialization import check_valid_cls_constructor_arg
 from ._utils.async_utils import synchronize_api, synchronizer
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.mount_utils import validate_volumes
@@ -44,15 +44,6 @@ class ClsMixin:
         deprecation_error((2023, 9, 1), "`ClsMixin` is deprecated and can be safely removed.")
 
 
-def check_picklability(key, arg):
-    try:
-        pickle.dumps(arg)
-    except Exception:
-        raise ValueError(
-            f"Only pickle-able types are allowed in remote class constructors: argument {key} of type {type(arg)}."
-        )
-
-
 class _Obj:
     """An instance of a `Cls`, i.e. `Cls("foo", 42)` returns an `Obj`.
 
@@ -75,9 +66,9 @@ class _Obj:
         kwargs,
     ):
         for i, arg in enumerate(args):
-            check_picklability(i + 1, arg)
+            check_valid_cls_constructor_arg(i + 1, arg)
         for key, kwarg in kwargs.items():
-            check_picklability(key, kwarg)
+            check_valid_cls_constructor_arg(key, kwarg)
 
         self._functions = {}
         for k, fun in base_functions.items():

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Callable, Dict
 
 from typing_extensions import assert_type
 
-from modal import Cls, Function, Image, Stub, build, enter, exit, method
+from modal import Cls, Function, Image, Queue, Stub, build, enter, exit, method
 from modal._serialization import deserialize
 from modal.app import ContainerApp
 from modal.cls import ClsMixin
@@ -98,6 +98,13 @@ def test_call_cls_remote_invalid_type(client):
 
         exc = excinfo.value
         assert "function" in str(exc)
+
+
+def test_call_cls_remote_modal_type(client):
+    with stub_remote.run(client=client):
+        with Queue.ephemeral(client) as q:
+            FooRemote(42, q)  # type: ignore
+
 
 
 stub_2 = Stub()


### PR DESCRIPTION
I didn't quite get it working in #1543 – this properly fixes it.

I don't love this, but let's revisit later.