### PR TITLE
Ephemeral dicts: support constructor args

### DIFF
--- a/modal/dict.py
+++ b/modal/dict.py
@@ -78,15 +78,18 @@ class _Dict(_Object, type_prefix="di"):
     @asynccontextmanager
     async def ephemeral(
         cls: Type["_Dict"],
+        data: Optional[dict] = None,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         _heartbeat_sleep: float = EPHEMERAL_OBJECT_HEARTBEAT_SLEEP,
     ) -> AsyncIterator["_Dict"]:
         if client is None:
             client = await _Client.from_env()
+        serialized = _serialize_dict(data if data is not None else {})
         request = api_pb2.DictGetOrCreateRequest(
             object_creation_type=api_pb2.OBJECT_CREATION_TYPE_EPHEMERAL,
             environment_name=_get_environment_name(environment_name),
+            data=serialized,
         )
         response = await client.stub.DictGetOrCreate(request)
         async with TaskContext() as tc:

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -100,6 +100,7 @@ class _Dict(_Object, type_prefix="di"):
     @staticmethod
     def from_name(
         label: str,
+        data: Optional[dict] = None,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
@@ -118,11 +119,13 @@ class _Dict(_Object, type_prefix="di"):
         """
 
         async def _load(self: _Dict, resolver: Resolver, existing_object_id: Optional[str]):
+            serialized = _serialize_dict(data if data is not None else {})
             req = api_pb2.DictGetOrCreateRequest(
                 deployment_name=label,
                 namespace=namespace,
                 environment_name=_get_environment_name(environment_name, resolver),
                 object_creation_type=(api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING if create_if_missing else None),
+                data=serialized,
             )
             response = await resolver.client.stub.DictGetOrCreate(req)
             logger.debug(f"Created dict with id {response.dict_id}")
@@ -141,6 +144,7 @@ class _Dict(_Object, type_prefix="di"):
     @staticmethod
     async def lookup(
         label: str,
+        data: Optional[dict] = None,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
@@ -154,7 +158,7 @@ class _Dict(_Object, type_prefix="di"):
         ```
         """
         obj = _Dict.from_name(
-            label, namespace=namespace, environment_name=environment_name, create_if_missing=create_if_missing
+            label, data=data, namespace=namespace, environment_name=environment_name, create_if_missing=create_if_missing
         )
         if client is None:
             client = await _Client.from_env()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -431,11 +431,11 @@ class MockClientServicer(api_grpc.ModalClientBase):
             dict_id = self.deployed_dicts[k]
         elif request.object_creation_type == api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING:
             dict_id = f"di-{len(self.dicts)}"
-            self.dicts[dict_id] = {}
+            self.dicts[dict_id] = {entry.key: entry.value for entry in request.data}
             self.deployed_dicts[k] = dict_id
         elif request.object_creation_type == api_pb2.OBJECT_CREATION_TYPE_EPHEMERAL:
             dict_id = f"di-{len(self.dicts)}"
-            self.dicts[dict_id] = {}
+            self.dicts[dict_id] = {entry.key: entry.value for entry in request.data}
         else:
             raise GRPCError(Status.NOT_FOUND, "Queue not found")
         await stream.send_message(api_pb2.DictGetOrCreateResponse(dict_id=dict_id))

--- a/test/dict_test.py
+++ b/test/dict_test.py
@@ -31,9 +31,10 @@ def test_dict_deploy(servicer, client):
 
 def test_dict_ephemeral(servicer, client):
     assert servicer.n_dict_heartbeats == 0
-    with Dict.ephemeral(client=client, _heartbeat_sleep=1) as d:
+    with Dict.ephemeral({"bar": 123}, client=client, _heartbeat_sleep=1) as d:
         d["foo"] = 42
-        assert d.len() == 1
+        assert d.len() == 2
         assert d["foo"] == 42
+        assert d["bar"] == 123
         time.sleep(1.5)  # Make time for 2 heartbeats
     assert servicer.n_dict_heartbeats == 2

--- a/test/dict_test.py
+++ b/test/dict_test.py
@@ -24,9 +24,11 @@ def test_dict_app(servicer, client):
         assert stub.d["foo"] is None
 
 
-def test_dict_deploy(servicer, client):
-    d = Dict.lookup("xyz", create_if_missing=True, client=client)
+def test_dict_lookup(servicer, client):
+    d = Dict.lookup("xyz", {"foo": "bar"}, create_if_missing=True, client=client)
     d["xyz"] = 123
+    assert d.len() == 2
+    assert d["foo"] == "bar"
 
 
 def test_dict_ephemeral(servicer, client):


### PR DESCRIPTION
Was broken server-side too

edit: realized it wasn't supported for from_name or lookup either, fixed that