### PR TITLE
Grpc testing responders

### DIFF
--- a/modal/_utils/grpc_testing.py
+++ b/modal/_utils/grpc_testing.py
@@ -2,10 +2,15 @@
 import contextlib
 import inspect
 import logging
+import typing
 from collections import Counter, defaultdict
 from typing import Any, Awaitable, Callable, Dict, List, Tuple
 
+import grpclib.server
 from grpclib import GRPCError, Status
+
+if typing.TYPE_CHECKING:
+    from test.conftest import MockClientServicer
 
 
 def patch_mock_servicer(cls):
@@ -50,29 +55,33 @@ def patch_mock_servicer(cls):
     cls.intercept = intercept
     cls.interception_context = None
 
-    def make_interceptable(method_name, original_method):
-        async def intercepted_method(servicer_self, stream):
-            ctx = servicer_self.interception_context
-            if ctx:
-                intercepted_stream = await InterceptedStream(ctx, method_name, stream).initialize()
-                custom_responder = ctx.next_custom_responder(method_name, intercepted_stream.request_message)
-                if custom_responder:
-                    return await custom_responder(servicer_self, intercepted_stream)
+    def patch_grpc_method(method_name, original_method):
+        async def patched_method(servicer_self, stream):
+            try:
+                ctx = servicer_self.interception_context
+                if ctx:
+                    intercepted_stream = await InterceptedStream(ctx, method_name, stream).initialize()
+                    custom_responder = ctx.next_custom_responder(method_name, intercepted_stream.request_message)
+                    if custom_responder:
+                        return await custom_responder(servicer_self, intercepted_stream)
+                    else:
+                        # use default servicer, but intercept messages for assertions
+                        return await original_method(servicer_self, intercepted_stream)
                 else:
-                    # use default servicer, but intercept messages for assertions
-                    return await original_method(servicer_self, intercepted_stream)
-            else:
-                return await original_method(servicer_self, stream)
+                    return await original_method(servicer_self, stream)
+            except Exception:
+                logging.exception("Error in mock servicer responder:")
+                raise
 
-        return intercepted_method
+        return patched_method
 
     # Fill in the remaining methods on the class
     for name in dir(cls):
         method = getattr(cls, name)
         if getattr(method, "__isabstractmethod__", False):
-            setattr(cls, name, make_interceptable(name, fallback))
+            setattr(cls, name, patch_grpc_method(name, fallback))
         elif name[0].isupper() and inspect.isfunction(method):
-            setattr(cls, name, make_interceptable(name, method))
+            setattr(cls, name, patch_grpc_method(name, method))
 
     cls.__abstractmethods__ = frozenset()
     return cls
@@ -89,7 +98,7 @@ class InterceptionContext:
     def __init__(self):
         self.calls: List[Tuple[str, Any]] = []  # List[Tuple[method_name, message]]
         self.custom_responses: Dict[str, List[Tuple[Callable[[Any], bool], List[Any]]]] = defaultdict(list)
-        self.custom_defaults: Dict[str, Callable[[Any], Any]] = {}
+        self.custom_defaults: Dict[str, Callable[["MockClientServicer", grpclib.server.Stream], Awaitable[None]]] = {}
 
     def add_recv(self, method_name: str, msg):
         self.calls.append((method_name, msg))
@@ -100,12 +109,18 @@ class InterceptionContext:
         # adds one response to a queue of responses for requests of the specified type
         self.custom_responses[method_name].append((request_filter, [first_payload]))
 
-    def override_default(self, method_name: str, responder: Callable[[Any], Awaitable[Any]]):
-        """Replace the default handler for a method. E.g.
+    def set_responder(
+        self, method_name: str, responder: Callable[["MockClientServicer", grpclib.server.Stream], Awaitable[None]]
+    ):
+        """Replace the default responder method. E.g.
 
         ```python notest
+        def custom_responder(servicer, stream):
+            request = stream.recv_message()
+            await stream.send_message(api_pb2.SomeMethodResponse(foo=123))
+
         with servicer.intercept() as ctx:
-            ctx.add_response("SomeMethod", lambda _req: api_pb2.SomeMethodResponse(foo=123))
+            ctx.set_responder("SomeMethod", custom_responder)
         ```
 
         Responses added via `.add_response()` take precedence.
@@ -131,14 +146,11 @@ class InterceptionContext:
                 return None
             return custom_default
 
+        # build a new temporary responder based on the next queued response messages (added via add_response)
         async def responder(servicer_self, stream):
-            try:
-                await stream.recv_message()  # get the input message so we can track that
-                for msg in next_response_messages:
-                    await stream.send_message(msg)
-            except Exception:
-                logging.exception("Error when sending response")
-                raise
+            await stream.recv_message()  # get the input message so we can track that
+            for msg in next_response_messages:
+                await stream.send_message(msg)
 
         return responder
 

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -410,7 +410,7 @@ def test_logs(servicer, server_url_env):
         await stream.send_message(api_pb2.TaskLogsBatch(app_done=True))
 
     with servicer.intercept() as ctx:
-        ctx.override_default("AppGetLogs", app_done)
+        ctx.set_responder("AppGetLogs", app_done)
         res = _run(["app", "logs", "ap-123"], expected_exit_code=0)
         assert res.stdout == "hello\n"
 

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -253,13 +253,14 @@ async def test_volume_upload_large_file(client, tmp_path, servicer, blob_server,
 async def test_volume_upload_file_timeout(client, tmp_path, servicer, blob_server, *args):
     call_count = 0
 
-    def mount_put_file(_request):
+    async def mount_put_file(self, stream):
+        await stream.recv_message()
         nonlocal call_count
         call_count += 1
-        return api_pb2.MountPutFileResponse(exists=False)
+        await stream.send_message(api_pb2.MountPutFileResponse(exists=False))
 
     with servicer.intercept() as ctx:
-        ctx.override_default("MountPutFile", mount_put_file)
+        ctx.set_responder("MountPutFile", mount_put_file)
         with mock.patch("modal._utils.blob_utils.LARGE_FILE_LIMIT", 10):
             with mock.patch("modal.volume.VOLUME_PUT_FILE_CLIENT_TIMEOUT", 0.5):
                 stub = modal.Stub()


### PR DESCRIPTION
Needed for some tests I'm working on

Makes overriding servicer functions a bit more flexible:
* override_default (now set_responder) now allows setting an async responder function with the same signature as the original method, instead of a blocking one
* errors in the mock servicer methods are now caught and logged properly, regardless how/when they are added