### PR TITLE
Adds test for sigint during input execution (e.g. timeouts)

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -158,6 +158,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.token_flow_localhost_port = None
         self.queue_max_len = 1_00
 
+        self.container_heartbeat_response = None
         self.container_heartbeat_abort = threading.Event()
 
         @self.function_body

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -1260,7 +1260,6 @@ def test_sigint_termination(servicer, method):
         os.kill(container_process.pid, signal.SIGINT)
 
     stdout, stderr = container_process.communicate(timeout=5)
-    print(stdout, stderr)
     assert container_process.returncode == 0
     assert f"[events:enter_sync,enter_async,{method},exit_sync,exit_async]" in stdout.decode()
     # assert "Traceback" not in stderr.decode()  # TODO (elias): fix sigint during an async function execution printing a long traceback from synchronicity

--- a/test/supports/functions.py
+++ b/test/supports/functions.py
@@ -230,6 +230,20 @@ class LifecycleCls:
         self.events.append("f_async")
         return self.events
 
+    @method()
+    def delay(self, duration: float):
+        self._print_at_exit()
+        self.events.append("delay")
+        time.sleep(duration)
+        return self.events
+
+    @method()
+    async def delay_async(self, duration: float):
+        self._print_at_exit()
+        self.events.append("delay_async")
+        await asyncio.sleep(duration)
+        return self.events
+
 
 @stub.function()
 def check_sibling_hydration(x):


### PR DESCRIPTION
TODO: fix async functions outputting a bunch of unactionable traceback spam when getting sigint:ed (commented out assertion for now)