### PR TITLE
Deprecate Dict.new and Queue.new

### DIFF
--- a/modal/dict.py
+++ b/modal/dict.py
@@ -57,7 +57,7 @@ class _Dict(_Object, type_prefix="di"):
     def new(data: Optional[dict] = None) -> "_Dict":
         """`Dict.new` is deprecated.
 
-        Please use `Dict.from_name` (for persisted) or `Dict.ephemeral` (for ephemeral) queues.
+        Please use `Dict.from_name` (for persisted) or `Dict.ephemeral` (for ephemeral) dicts.
         """
         deprecation_warning((2024, 3, 19), Dict.new.__doc__)
 
@@ -89,7 +89,7 @@ class _Dict(_Object, type_prefix="di"):
 
         Usage:
         ```python
-        with Dict.ephemeral() as :
+        with Dict.ephemeral() as d:
             d["foo"] = "bar"
 
         async with Dict.ephemeral.aio() as d:

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -28,27 +28,25 @@ class _Dict(_Object, type_prefix="di"):
 
     **Lifetime of a Dict and its items**
 
-    A `Dict` matches the lifetime of the app it is attached to, but an individual entry will expire 30 days after it was last added to its Dict object.
+    An individual dict entry will expire 30 days after it was last added to its Dict object.
     Because of this, `Dict`s are best not used for
     long-term storage. All data is deleted when the app is stopped.
 
     **Usage**
 
-    Create a new `Dict` with `Dict.new()`, then assign it to a stub or function.
-
     ```python
     from modal import Dict, Stub
 
     stub = Stub()
-    stub.my_dict = Dict.new()
+    my_dict = Dict.from_name("my-persisted_dict", create_if_missing=True)
 
     @stub.local_entrypoint()
     def main():
-        stub.my_dict["some key"] = "some value"
-        stub.my_dict[123] = 456
+        my_dict["some key"] = "some value"
+        my_dict[123] = 456
 
-        assert stub.my_dict["some key"] == "some value"
-        assert stub.my_dict[123] == 456
+        assert my_dict["some key"] == "some value"
+        assert my_dict[123] == 456
     ```
 
     For more examples, see the [guide](/docs/guide/dicts-and-queues#modal-dicts).
@@ -57,7 +55,11 @@ class _Dict(_Object, type_prefix="di"):
     @typechecked
     @staticmethod
     def new(data: Optional[dict] = None) -> "_Dict":
-        """Create a new Dict, optionally with initial data."""
+        """`Dict.new` is deprecated.
+
+        Please use `Dict.from_name` (for persisted) or `Dict.ephemeral` (for ephemeral) queues.
+        """
+        deprecation_warning((2024, 3, 19), Dict.new.__doc__)
 
         async def _load(self: _Dict, resolver: Resolver, existing_object_id: Optional[str]):
             serialized = _serialize_dict(data if data is not None else {})
@@ -83,6 +85,17 @@ class _Dict(_Object, type_prefix="di"):
         environment_name: Optional[str] = None,
         _heartbeat_sleep: float = EPHEMERAL_OBJECT_HEARTBEAT_SLEEP,
     ) -> AsyncIterator["_Dict"]:
+        """Creates a new ephemeral dict within a context manager:
+
+        Usage:
+        ```python
+        with Dict.ephemeral() as :
+            d["foo"] = "bar"
+
+        async with Dict.ephemeral.aio() as d:
+            await d.put.aio("foo", "bar")
+        ```
+        """
         if client is None:
             client = await _Client.from_env()
         serialized = _serialize_dict(data if data is not None else {})

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -31,21 +31,19 @@ class _Queue(_Object, type_prefix="qu"):
 
     **Usage**
 
-    Create a new `Queue` with `Queue.new()`, then assign it to a stub or function.
-
     ```python
     from modal import Queue, Stub
 
     stub = Stub()
-    stub.my_queue = Queue.new()
+    my_queue = Queue.from_name("my-persisted-queue", create_if_missing=True)
 
     @stub.local_entrypoint()
     def main():
-        stub.my_queue.put("some value")
-        stub.my_queue.put(123)
+        my_queue.put("some value")
+        my_queue.put(123)
 
-        assert stub.my_queue.get() == "some value"
-        assert stub.my_queue.get() == 123
+        assert my_queue.get() == "some value"
+        assert my_queue.get() == 123
     ```
 
     For more examples, see the [guide](/docs/guide/dicts-and-queues#modal-queues).
@@ -53,7 +51,11 @@ class _Queue(_Object, type_prefix="qu"):
 
     @staticmethod
     def new():
-        """Create an empty Queue."""
+        """`Queue.new` is deprecated.
+
+        Please use `Queue.from_name` (for persisted) or `Queue.ephemeral` (for ephemeral) queues.
+        """
+        deprecation_warning((2024, 3, 19), Queue.new.__doc__)
 
         async def _load(self: _Queue, resolver: Resolver, existing_object_id: Optional[str]):
             request = api_pb2.QueueCreateRequest(app_id=resolver.app_id, existing_queue_id=existing_object_id)
@@ -64,9 +66,7 @@ class _Queue(_Object, type_prefix="qu"):
 
     def __init__(self):
         """mdmd:hidden"""
-        deprecation_error((2023, 6, 27), "`Queue()` is deprecated. Please use `Queue.new()` instead.")
-        obj = _Queue.new()
-        self._init_from_other(obj)
+        deprecation_error((2023, 6, 27), "`Queue()` is deprecated. Please use `Queue.ephemeral()` instead.")
 
     @classmethod
     @asynccontextmanager
@@ -76,6 +76,17 @@ class _Queue(_Object, type_prefix="qu"):
         environment_name: Optional[str] = None,
         _heartbeat_sleep: float = EPHEMERAL_OBJECT_HEARTBEAT_SLEEP,
     ) -> AsyncIterator["_Queue"]:
+        """Creates a new ephemeral queue within a context manager:
+
+        Usage:
+        ```python
+        with Queue.ephemeral() as q:
+            q.put(123)
+
+        async with Queue.ephemeral.aio() as q:
+            await q.put.aio(123)
+        ```
+        """
         if client is None:
             client = await _Client.from_env()
         request = api_pb2.QueueGetOrCreateRequest(

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -7,7 +7,7 @@ from unittest import mock
 import modal.secret
 from modal import Dict, Stub
 from modal.app import container_app
-from modal.exception import InvalidError
+from modal.exception import DeprecationError, InvalidError
 from modal_proto import api_pb2
 
 from .supports.skip import skip_windows_unix_socket
@@ -34,7 +34,8 @@ async def test_container_function_lazily_imported(unix_servicer, container_clien
     assert await my_f_container.remote.aio(42) == 1764  # type: ignore
 
     # Also make sure dicts work
-    my_d_container = Dict.new()
+    with pytest.warns(DeprecationError):
+        my_d_container = Dict.new()
     stub.my_d = my_d_container  # should trigger id assignment
     assert my_d_container.object_id == "di-123"
 

--- a/test/dict_test.py
+++ b/test/dict_test.py
@@ -3,11 +3,13 @@ import pytest
 import time
 
 from modal import Dict, Stub
+from modal.exception import DeprecationError
 
 
 def test_dict_app(servicer, client):
     stub = Stub()
-    stub.d = Dict.new()
+    with pytest.warns(DeprecationError):
+        stub.d = Dict.new()
     with stub.run(client=client):
         stub.d["foo"] = 42
         stub.d["foo"] += 5

--- a/test/function_utils_test.py
+++ b/test/function_utils_test.py
@@ -7,8 +7,8 @@ from modal._utils.function_utils import FunctionInfo, get_referred_objects, meth
 from modal.exception import InvalidError
 from modal.object import Object
 
-q1 = Queue.new()
-q2 = Queue.new()
+q1 = Queue.from_name("q1", create_if_missing=True)
+q2 = Queue.from_name("q2", create_if_missing=True)
 
 
 def f1():

--- a/test/object_test.py
+++ b/test/object_test.py
@@ -8,7 +8,8 @@ from modal.exception import DeprecationError, InvalidError
 @pytest.mark.asyncio
 async def test_async_factory(client):
     stub = Stub()
-    stub["my_factory"] = Queue.new()
+    with pytest.warns(DeprecationError):
+        stub["my_factory"] = Queue.new()
     async with stub.run(client=client):
         assert isinstance(stub["my_factory"], Queue)
         assert stub["my_factory"].object_id == "qu-1"

--- a/test/queue_test.py
+++ b/test/queue_test.py
@@ -4,13 +4,15 @@ import queue
 import time
 
 from modal import Queue, Stub
+from modal.exception import DeprecationError
 
 from .supports.skip import skip_macos, skip_windows
 
 
 def test_queue(servicer, client):
     stub = Stub()
-    stub.q = Queue.new()
+    with pytest.warns(DeprecationError):
+        stub.q = Queue.new()
     with stub.run(client=client):
         assert isinstance(stub.q, Queue)
         assert stub.q.len() == 0
@@ -47,20 +49,18 @@ def test_queue_blocking_put(put_timeout_secs, min_queue_full_exc_count, max_queu
     import queue
     import threading
 
-    stub = Stub()
-    stub.q = Queue.new()
     producer_delay = 0.001
     consumer_delay = producer_delay * 5
 
     queue_full_exceptions = 0
-    with stub.run(client=client):
+    with Queue.ephemeral(client=client) as q:
 
         def producer():
             nonlocal queue_full_exceptions
             for i in range(servicer.queue_max_len * 2):
                 item = f"Item {i}"
                 try:
-                    stub.q.put(item, block=True, timeout=put_timeout_secs)  # type: ignore
+                    q.put(item, block=True, timeout=put_timeout_secs)  # type: ignore
                 except queue.Full:
                     queue_full_exceptions += 1
                 time.sleep(producer_delay)
@@ -68,7 +68,7 @@ def test_queue_blocking_put(put_timeout_secs, min_queue_full_exc_count, max_queu
         def consumer():
             while True:
                 time.sleep(consumer_delay)
-                item = stub.q.get(block=True)  # type: ignore
+                item = q.get(block=True)  # type: ignore
                 if item is None:
                     break  # Exit if a None item is received
 
@@ -78,25 +78,19 @@ def test_queue_blocking_put(put_timeout_secs, min_queue_full_exc_count, max_queu
         consumer_thread.start()
         producer_thread.join()
         # Stop the consumer by sending a None item
-        stub.q.put(None)  # type: ignore
+        q.put(None)  # type: ignore
         consumer_thread.join()
 
         assert queue_full_exceptions >= min_queue_full_exc_count
         assert queue_full_exceptions <= max_queue_full_exc_count
 
 
-def test_queue_nonblocking_put(
-    servicer,
-    client,
-):
-    stub = Stub()
-    stub.q = Queue.new()
-
-    with stub.run(client=client):
+def test_queue_nonblocking_put(servicer, client):
+    with Queue.ephemeral(client=client) as q:
         # Non-blocking PUTs don't tolerate a full queue and will raise exception.
         with pytest.raises(queue.Full) as excinfo:
             for i in range(servicer.queue_max_len + 1):
-                stub.q.put(i, block=False)  # type: ignore
+                q.put(i, block=False)  # type: ignore
 
     assert str(servicer.queue_max_len) in str(excinfo.value)
     assert i == servicer.queue_max_len

--- a/test/serialization_test.py
+++ b/test/serialization_test.py
@@ -2,22 +2,17 @@
 import pytest
 import random
 
-from modal import Queue, Stub
+from modal import Queue
 from modal._serialization import deserialize, deserialize_data_format, serialize, serialize_data_format
 from modal._utils.rand_pb_testing import rand_pb
 from modal_proto import api_pb2
 
 from .supports.skip import skip_old_py
 
-stub = Stub()
-
-stub.q = Queue.new()
-
 
 @pytest.mark.asyncio
 async def test_roundtrip(servicer, client):
-    async with stub.run(client=client):
-        q = stub.q
+    async with Queue.ephemeral(client=client) as q:
         data = serialize(q)
         # TODO: strip synchronizer reference from synchronicity entities!
         assert len(data) < 350  # Used to be 93...


### PR DESCRIPTION
This deprecates the `new` method for `Dict` and `Queue` in favor of `from_name` and `ephemeral`

It's still not deprecated for `Volume` and `NetworkFileSystem`

Need to update an internal integration test before merging this.