### PR TITLE
Add max_entries to VolumesListFilesRequest

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1884,6 +1884,7 @@ message VolumeListFilesEntry {
 message VolumeListFilesRequest {
   string volume_id = 1;
   string path = 2;
+  optional int32 max_entries = 3;
 }
 
 message VolumeListFilesResponse {


### PR DESCRIPTION
Adds an optional field `max_entries` to VolumesListFilesRequest for volume viewer (refer to original suggestion [here](https://github.com/modal-labs/modal/pull/11022#discussion_r1520411269)).