### PR TITLE
No need to pass client to .delete()

### DIFF
--- a/modal/volume.py
+++ b/modal/volume.py
@@ -438,10 +438,8 @@ class _Volume(_Object, type_prefix="vo"):
         return _VolumeUploadContextManager(self.object_id, self._client, force=force)
 
     @live_method
-    async def delete(self, client: Optional[_Client] = None):
-        if client is None:
-            client = await _Client.from_env()
-        await retry_transient_errors(client.stub.VolumeDelete, api_pb2.VolumeDeleteRequest(volume_id=self.object_id))
+    async def delete(self):
+        await retry_transient_errors(self._client.stub.VolumeDelete, api_pb2.VolumeDeleteRequest(volume_id=self.object_id))
 
 
 class _VolumeUploadContextManager:

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -342,7 +342,7 @@ def test_persisted(servicer, client):
     v = modal.Volume.lookup("xyz", client=client)
 
     # Delete it
-    v.delete(client=client)
+    v.delete()
 
     # Lookup should fail again
     with pytest.raises(NotFoundError):


### PR DESCRIPTION
it's already set on the object