### PR TITLE
Remove almost all NetworkFileSystem.new

### DIFF
--- a/test/function_test.py
+++ b/test/function_test.py
@@ -484,7 +484,8 @@ def f(x):
 
 def test_allow_cross_region_volumes(client, servicer):
     stub = Stub()
-    vol1, vol2 = NetworkFileSystem.new(), NetworkFileSystem.new()
+    vol1 = NetworkFileSystem.from_name("xyz-1", create_if_missing=True)
+    vol2 = NetworkFileSystem.from_name("xyz-2", create_if_missing=True)
     # Should pass flag for all the function's NetworkFileSystemMounts
     stub.function(network_file_systems={"/sv-1": vol1, "/sv-2": vol2}, allow_cross_region_volumes=True)(dummy)
 
@@ -497,9 +498,10 @@ def test_allow_cross_region_volumes(client, servicer):
 
 
 def test_allow_cross_region_volumes_webhook(client, servicer):
-    # TODO(erikbern): this stest seems a bit redundant
+    # TODO(erikbern): this test seems a bit redundant
     stub = Stub()
-    vol1, vol2 = NetworkFileSystem.new(), NetworkFileSystem.new()
+    vol1 = NetworkFileSystem.from_name("xyz-1", create_if_missing=True)
+    vol2 = NetworkFileSystem.from_name("xyz-2", create_if_missing=True)
     # Should pass flag for all the function's NetworkFileSystemMounts
     stub.function(network_file_systems={"/sv-1": vol1, "/sv-2": vol2}, allow_cross_region_volumes=True)(
         web_endpoint()(dummy)
@@ -515,7 +517,7 @@ def test_allow_cross_region_volumes_webhook(client, servicer):
 
 def test_shared_volumes(client, servicer):
     stub = Stub()
-    vol = NetworkFileSystem.new()
+    vol = NetworkFileSystem.from_name("foo")
     with pytest.raises(DeprecationError):
         stub.function(shared_volumes={"/sv-1": vol})
 
@@ -591,8 +593,8 @@ def test_deps_explicit(client, servicer):
     stub = Stub()
 
     image = Image.debian_slim()
-    nfs_1 = NetworkFileSystem.new()
-    nfs_2 = NetworkFileSystem.new()
+    nfs_1 = NetworkFileSystem.from_name("nfs-1", create_if_missing=True)
+    nfs_2 = NetworkFileSystem.from_name("nfs-2", create_if_missing=True)
 
     stub.function(image=image, network_file_systems={"/nfs_1": nfs_1, "/nfs_2": nfs_2})(dummy)
 
@@ -603,7 +605,7 @@ def test_deps_explicit(client, servicer):
     assert dep_object_ids == set([image.object_id, nfs_1.object_id, nfs_2.object_id])
 
 
-nfs = NetworkFileSystem.new()
+nfs = NetworkFileSystem.from_name("my-persisted-nfs", create_if_missing=True)
 
 
 def dummy_closurevars():

--- a/test/network_file_system_test.py
+++ b/test/network_file_system_test.py
@@ -14,10 +14,9 @@ def dummy():
 
 def test_network_file_system_files(client, test_dir, servicer):
     stub = modal.Stub()
+    nfs = modal.NetworkFileSystem.from_name("xyz", create_if_missing=True)
 
-    dummy_modal = stub.function(
-        network_file_systems={"/root/foo": modal.NetworkFileSystem.new()},
-    )(dummy)
+    dummy_modal = stub.function(network_file_systems={"/root/foo": nfs})(dummy)
 
     with stub.run(client=client):
         dummy_modal.remote()
@@ -25,30 +24,29 @@ def test_network_file_system_files(client, test_dir, servicer):
 
 def test_network_file_system_bad_paths():
     stub = modal.Stub()
+    nfs = modal.NetworkFileSystem.from_name("xyz", create_if_missing=True)
 
     def _f():
         pass
 
     with pytest.raises(InvalidError):
-        stub.function(network_file_systems={"/root/../../foo": modal.NetworkFileSystem.new()})(dummy)
+        stub.function(network_file_systems={"/root/../../foo": nfs})(dummy)
 
     with pytest.raises(InvalidError):
-        stub.function(network_file_systems={"/": modal.NetworkFileSystem.new()})(dummy)
+        stub.function(network_file_systems={"/": nfs})(dummy)
 
     with pytest.raises(InvalidError):
-        stub.function(network_file_systems={"/tmp/": modal.NetworkFileSystem.new()})(dummy)
+        stub.function(network_file_systems={"/tmp/": nfs})(dummy)
 
 
 def test_network_file_system_handle_single_file(client, tmp_path, servicer):
-    stub = modal.Stub()
-    stub.vol = modal.NetworkFileSystem.new()
     local_file_path = tmp_path / "some_file"
     local_file_path.write_text("hello world")
 
-    with stub.run(client=client):
-        stub.vol.add_local_file(local_file_path)
-        stub.vol.add_local_file(local_file_path.as_posix(), remote_path="/foo/other_destination")
-        object_id = stub.vol.object_id
+    with modal.NetworkFileSystem.ephemeral(client=client) as nfs:
+        nfs.add_local_file(local_file_path)
+        nfs.add_local_file(local_file_path.as_posix(), remote_path="/foo/other_destination")
+        object_id = nfs.object_id
 
     assert servicer.nfs_files[object_id].keys() == {
         "/some_file",
@@ -60,8 +58,6 @@ def test_network_file_system_handle_single_file(client, tmp_path, servicer):
 
 @pytest.mark.asyncio
 async def test_network_file_system_handle_dir(client, tmp_path, servicer):
-    stub = modal.Stub()
-    stub.vol = modal.NetworkFileSystem.new()
     local_dir = tmp_path / "some_dir"
     local_dir.mkdir()
     (local_dir / "smol").write_text("###")
@@ -70,9 +66,9 @@ async def test_network_file_system_handle_dir(client, tmp_path, servicer):
     subdir.mkdir()
     (subdir / "other").write_text("####")
 
-    with stub.run(client=client):
-        stub.vol.add_local_dir(local_dir)
-        object_id = stub.vol.object_id
+    with modal.NetworkFileSystem.ephemeral(client=client) as nfs:
+        nfs.add_local_dir(local_dir)
+        object_id = nfs.object_id
 
     assert servicer.nfs_files[object_id].keys() == {
         "/some_dir/smol",
@@ -85,14 +81,12 @@ async def test_network_file_system_handle_dir(client, tmp_path, servicer):
 @pytest.mark.asyncio
 async def test_network_file_system_handle_big_file(client, tmp_path, servicer, blob_server, *args):
     with mock.patch("modal.network_file_system.LARGE_FILE_LIMIT", 10):
-        stub = modal.Stub()
-        stub.vol = modal.NetworkFileSystem.new()
         local_file_path = tmp_path / "bigfile"
         local_file_path.write_text("hello world, this is a lot of text")
 
-        async with stub.run(client=client):
-            await stub.vol.add_local_file.aio(local_file_path)
-            object_id = stub.vol.object_id
+        async with modal.NetworkFileSystem.ephemeral(client=client) as nfs:
+            await nfs.add_local_file.aio(local_file_path)
+            object_id = nfs.object_id
 
         assert servicer.nfs_files[object_id].keys() == {"/bigfile"}
         assert servicer.nfs_files[object_id]["/bigfile"].data == b""
@@ -112,6 +106,7 @@ def test_old_syntax(client, servicer):
 
 def test_redeploy(servicer, client):
     stub = modal.Stub()
+    # with pytest.warns(DeprecationError):
     stub.n1 = modal.NetworkFileSystem.new()
     stub.n2 = modal.NetworkFileSystem.new()
     stub.n3 = modal.NetworkFileSystem.new()
@@ -141,25 +136,21 @@ def test_redeploy(servicer, client):
 
 
 def test_read_file(client, tmp_path, servicer):
-    stub = modal.Stub()
-    stub.vol = modal.NetworkFileSystem.new()
-    with stub.run(client=client):
+    with modal.NetworkFileSystem.ephemeral(client=client) as nfs:
         with pytest.raises(FileNotFoundError):
-            for _ in stub.vol.read_file("idontexist.txt"):
+            for _ in nfs.read_file("idontexist.txt"):
                 ...
 
 
 def test_write_file(client, tmp_path, servicer):
-    stub = modal.Stub()
-    stub.vol = modal.NetworkFileSystem.new()
     local_file_path = tmp_path / "some_file"
     local_file_path.write_text("hello world")
 
-    with stub.run(client=client):
-        stub.vol.write_file("remote_path.txt", open(local_file_path, "rb"))
+    with modal.NetworkFileSystem.ephemeral(client=client) as nfs:
+        nfs.write_file("remote_path.txt", open(local_file_path, "rb"))
 
         # Make sure we can write through the provider too
-        stub.vol.write_file("remote_path.txt", open(local_file_path, "rb"))
+        nfs.write_file("remote_path.txt", open(local_file_path, "rb"))
 
 
 def test_persisted(servicer, client):

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -19,9 +19,7 @@ def test_volume_mount(client, servicer):
     stub = modal.Stub()
     vol = modal.Volume.from_name("xyz", create_if_missing=True)
 
-    _ = stub.function(
-        volumes={"/root/foo": vol}
-    )(dummy)
+    _ = stub.function(volumes={"/root/foo": vol})(dummy)
 
     with stub.run(client=client):
         pass


### PR DESCRIPTION
There's an annoying thing triggered by a sandbox test that's holding up the deprecation. Removing all other uses in the meantime.