### PR TITLE
Remove `NetworkFileSystem.new` from sandbox test

### DIFF
--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -92,6 +92,10 @@ class Resolver:
             await obj._preload(obj, self, existing_object_id)
 
     async def load(self, obj: "_Object", existing_object_id: Optional[str] = None):
+        if obj._is_hydrated and obj._is_another_app:
+            # No need to assign ids to this, it won't change
+            return obj
+
         deduplication_key: Optional[Hashable] = None
         if obj._deduplication_key:
             deduplication_key = await obj._deduplication_key()

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -108,7 +108,7 @@ class _Dict(_Object, type_prefix="di"):
         async with TaskContext() as tc:
             request = api_pb2.DictHeartbeatRequest(dict_id=response.dict_id)
             tc.infinite_loop(lambda: client.stub.DictHeartbeat(request), sleep=_heartbeat_sleep)
-            yield cls._new_hydrated(response.dict_id, client, None)
+            yield cls._new_hydrated(response.dict_id, client, None, is_another_app=True)
 
     @staticmethod
     def from_name(

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -170,7 +170,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         async with TaskContext() as tc:
             request = api_pb2.SharedVolumeHeartbeatRequest(shared_volume_id=response.shared_volume_id)
             tc.infinite_loop(lambda: client.stub.SharedVolumeHeartbeat(request), sleep=_heartbeat_sleep)
-            yield cls._new_hydrated(response.shared_volume_id, client, None)
+            yield cls._new_hydrated(response.shared_volume_id, client, None, is_another_app=True)
 
     @staticmethod
     def persisted(

--- a/modal/object.py
+++ b/modal/object.py
@@ -147,7 +147,9 @@ class _Object:
         return obj
 
     @classmethod
-    def _new_hydrated(cls: Type[O], object_id: str, client: _Client, handle_metadata: Optional[Message]) -> O:
+    def _new_hydrated(
+        cls: Type[O], object_id: str, client: _Client, handle_metadata: Optional[Message], is_another_app: bool = False
+    ) -> O:
         if cls._type_prefix is not None:
             # This is called directly on a subclass, e.g. Secret.from_id
             if not object_id.startswith(cls._type_prefix + "-"):
@@ -166,7 +168,7 @@ class _Object:
         obj_cls = cls._prefix_to_type[prefix]
         obj = _Object.__new__(obj_cls)
         rep = f"Object({object_id})"  # TODO(erikbern): dumb
-        obj._init(rep)
+        obj._init(rep, is_another_app=is_another_app)
         obj._hydrate(object_id, client, handle_metadata)
 
         return obj

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -97,7 +97,7 @@ class _Queue(_Object, type_prefix="qu"):
         async with TaskContext() as tc:
             request = api_pb2.QueueHeartbeatRequest(queue_id=response.queue_id)
             tc.infinite_loop(lambda: client.stub.QueueHeartbeat(request), sleep=_heartbeat_sleep)
-            yield cls._new_hydrated(response.queue_id, client, None)
+            yield cls._new_hydrated(response.queue_id, client, None, is_another_app=True)
 
     @staticmethod
     def from_name(

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -180,7 +180,7 @@ class _Volume(_Object, type_prefix="vo"):
         async with TaskContext() as tc:
             request = api_pb2.VolumeHeartbeatRequest(volume_id=response.volume_id)
             tc.infinite_loop(lambda: client.stub.VolumeHeartbeat(request), sleep=_heartbeat_sleep)
-            yield cls._new_hydrated(response.volume_id, client, None)
+            yield cls._new_hydrated(response.volume_id, client, None, is_another_app=True)
 
     @staticmethod
     def persisted(

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -79,12 +79,11 @@ def test_sandbox_secret(client, servicer, tmpdir):
 @skip_non_linux
 def test_sandbox_nfs(client, servicer, tmpdir):
     with stub.run(client=client):
-        nfs = NetworkFileSystem.new()
+        with NetworkFileSystem.ephemeral(client=client) as nfs:
+            with pytest.raises(InvalidError):
+                stub.spawn_sandbox("echo", "foo > /cache/a.txt", network_file_systems={"/": nfs})
 
-        with pytest.raises(InvalidError):
-            stub.spawn_sandbox("echo", "foo > /cache/a.txt", network_file_systems={"/": nfs})
-
-        stub.spawn_sandbox("echo", "foo > /cache/a.txt", network_file_systems={"/cache": nfs})
+            stub.spawn_sandbox("echo", "foo > /cache/a.txt", network_file_systems={"/cache": nfs})
 
     assert len(servicer.sandbox_defs[0].nfs_mounts) == 1
 


### PR DESCRIPTION
Last remaining one.

Had to solve a slightly annoying bug with objects/resolvers – let's revisit this later because it's too complex.