### PR TITLE
Dynamically identify modules for typestub gen, address new issues

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -17,7 +17,7 @@ import traceback
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, AsyncGenerator, AsyncIterator, Callable, List, Optional, Set, Type
+from typing import TYPE_CHECKING, Any, AsyncGenerator, AsyncIterator, Callable, List, Optional, Set, Tuple, Type
 
 from grpclib import Status
 
@@ -219,7 +219,7 @@ class _FunctionIOManager:
         if self._heartbeat_loop:
             self._heartbeat_loop.cancel()
 
-    async def get_serialized_function(self) -> tuple[Optional[Any], Callable]:
+    async def get_serialized_function(self) -> Tuple[Optional[Any], Callable]:
         # Fetch the serialized function definition
         request = api_pb2.FunctionGetSerializedRequest(function_id=self.function_id)
         response = await self._client.stub.FunctionGetSerialized(request)
@@ -332,7 +332,7 @@ class _FunctionIOManager:
         return math.ceil(RTT_S / max(self.get_average_call_time(), 1e-6))
 
     @synchronizer.no_io_translation
-    async def _generate_inputs(self) -> AsyncIterator[tuple[str, str, api_pb2.FunctionInput]]:
+    async def _generate_inputs(self) -> AsyncIterator[Tuple[str, str, api_pb2.FunctionInput]]:
         request = api_pb2.FunctionGetInputsRequest(function_id=self.function_id)
         eof_received = False
         iteration = 0
@@ -388,7 +388,7 @@ class _FunctionIOManager:
                     self._semaphore.release()
 
     @synchronizer.no_io_translation
-    async def run_inputs_outputs(self, input_concurrency: int = 1) -> AsyncIterator[tuple[str, str, Any, Any]]:
+    async def run_inputs_outputs(self, input_concurrency: int = 1) -> AsyncIterator[Tuple[str, str, Any, Any]]:
         # Ensure we do not fetch new inputs when container is too busy.
         # Before trying to fetch an input, acquire the semaphore:
         # - if no input is fetched, release the semaphore.
@@ -438,7 +438,7 @@ class _FunctionIOManager:
             # We can't always serialize exceptions.
             return None
 
-    def serialize_traceback(self, exc: BaseException) -> tuple[Optional[bytes], Optional[bytes]]:
+    def serialize_traceback(self, exc: BaseException) -> Tuple[Optional[bytes], Optional[bytes]]:
         serialized_tb, tb_line_cache = None, None
 
         try:
@@ -586,7 +586,7 @@ class _FunctionIOManager:
         logger.debug("Checkpointing request sent. Connection closed.")
         await self.restore()
 
-    async def volume_commit(self, volume_ids: list[str]) -> None:
+    async def volume_commit(self, volume_ids: List[str]) -> None:
         """
         Perform volume commit for given `volume_ids`.
         Only used on container exit to persist uncommitted changes on behalf of user.
@@ -976,7 +976,7 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
 
         # Hydrate all function dependencies.
         if imp_fun.function:
-            dep_object_ids: list[str] = [dep.object_id for dep in container_args.function_def.object_dependencies]
+            dep_object_ids: List[str] = [dep.object_id for dep in container_args.function_def.object_dependencies]
             container_app.hydrate_function_deps(imp_fun.function, dep_object_ids)
 
         # Identify all "enter" methods that need to run before we checkpoint.

--- a/modal/_output.py
+++ b/modal/_output.py
@@ -9,7 +9,7 @@ import platform
 import re
 import sys
 from datetime import timedelta
-from typing import Callable, Optional
+from typing import Callable, Dict, Optional, Tuple
 
 from grpclib.exceptions import GRPCError, StreamTerminatedError
 from rich.console import Console, Group, RenderableType
@@ -141,13 +141,13 @@ class LineBufferedOutput(io.StringIO):
 class OutputManager:
     _visible_progress: bool
     _console: Console
-    _task_states: dict[str, int]
-    _task_progress_items: dict[tuple[str, int], TaskID]
+    _task_states: Dict[str, int]
+    _task_progress_items: Dict[Tuple[str, int], TaskID]
     _current_render_group: Optional[Group]
     _function_progress: Optional[Progress]
     _function_queueing_progress: Optional[Progress]
     _snapshot_progress: Optional[Progress]
-    _line_buffers: dict[int, LineBufferedOutput]
+    _line_buffers: Dict[int, LineBufferedOutput]
     _status_spinner: Spinner
     _app_page_url: Optional[str]
     _show_image_logs: bool

--- a/modal/_tunnel.py
+++ b/modal/_tunnel.py
@@ -1,11 +1,11 @@
 # Copyright Modal Labs 2023
 """Client for Modal relay servers, allowing users to expose TLS."""
 
-from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import AsyncIterator, Optional, Tuple
 
 from grpclib import GRPCError, Status
+from synchronicity.async_wrap import asynccontextmanager
 
 from modal_proto import api_pb2
 

--- a/modal/cli/programs/run_jupyter.py
+++ b/modal/cli/programs/run_jupyter.py
@@ -14,7 +14,7 @@ from modal import Image, Queue, Stub, forward
 args: Dict[str, Any] = {}
 
 stub = Stub()
-stub.image = Image.from_registry(args["image"], add_python=args["add_python"]).pip_install("jupyterlab")
+stub.image = Image.from_registry(args.get("image"), add_python=args.get("add_python")).pip_install("jupyterlab")
 
 
 def wait_for_port(url: str, q: Queue):
@@ -30,7 +30,7 @@ def wait_for_port(url: str, q: Queue):
     q.put(url)
 
 
-@stub.function(cpu=args["cpu"], memory=args["memory"], gpu=args["gpu"], timeout=args["timeout"])
+@stub.function(cpu=args.get("cpu"), memory=args.get("memory"), gpu=args.get("gpu"), timeout=args.get("timeout"))
 def run_jupyter(q: Queue):
     os.mkdir("/lab")
     token = secrets.token_urlsafe(13)

--- a/modal/cli/programs/vscode.py
+++ b/modal/cli/programs/vscode.py
@@ -7,7 +7,7 @@ import subprocess
 import threading
 import time
 import webbrowser
-from typing import Any, Dict
+from typing import Any, Dict, Tuple
 
 from modal import Image, Queue, Stub, forward
 
@@ -17,7 +17,7 @@ stub = Stub()
 stub.image = Image.from_registry("codercom/code-server", add_python="3.11").dockerfile_commands("ENTRYPOINT []")
 
 
-def wait_for_port(data: tuple[str, str], q: Queue):
+def wait_for_port(data: Tuple[str, str], q: Queue):
     start_time = time.monotonic()
     while True:
         try:
@@ -30,7 +30,7 @@ def wait_for_port(data: tuple[str, str], q: Queue):
     q.put(data)
 
 
-@stub.function(cpu=args["cpu"], memory=args["memory"], gpu=args["gpu"], timeout=args["timeout"])
+@stub.function(cpu=args.get("cpu"), memory=args.get("memory"), gpu=args.get("gpu"), timeout=args.get("timeout"))
 def run_vscode(q: Queue):
     os.chdir("/home/coder")
     token = secrets.token_urlsafe(13)

--- a/modal/environments.py
+++ b/modal/environments.py
@@ -30,12 +30,12 @@ async def update_environment(
         if len(new_name) < 1:
             raise ValueError("The new environment name cannot be empty")
 
-        new_name = StringValue(value=new_name)
+        new_name_pb2 = StringValue(value=new_name)
     if new_web_suffix is not None:
-        new_web_suffix = StringValue(value=new_web_suffix)
+        new_web_suffix_pb2 = StringValue(value=new_web_suffix)
 
     update_payload = api_pb2.EnvironmentUpdateRequest(
-        current_name=current_name, name=new_name, web_suffix=new_web_suffix
+        current_name=current_name, name=new_name_pb2, web_suffix=new_web_suffix_pb2
     )
     if client is None:
         client = await _Client.from_env()

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -1,12 +1,12 @@
 # Copyright Modal Labs 2022
 import asyncio
-import contextlib
 import dataclasses
 import os
 from multiprocessing.synchronize import Event
 from typing import TYPE_CHECKING, AsyncGenerator, List, Optional, TypeVar
 
 from rich.console import Console
+from synchronicity.async_wrap import asynccontextmanager
 
 from modal_proto import api_pb2
 
@@ -35,7 +35,7 @@ async def _heartbeat(client, app_id):
     await retry_transient_errors(client.stub.AppHeartbeat, request, attempt_timeout=HEARTBEAT_TIMEOUT)
 
 
-@contextlib.asynccontextmanager
+@asynccontextmanager
 async def _run_stub(
     stub: _Stub,
     client: Optional[_Client] = None,

--- a/modal/serving.py
+++ b/modal/serving.py
@@ -1,5 +1,4 @@
 # Copyright Modal Labs 2023
-import contextlib
 import io
 import multiprocessing
 import platform
@@ -9,6 +8,7 @@ from multiprocessing.synchronize import Event
 from typing import TYPE_CHECKING, AsyncGenerator, Optional, Set, TypeVar
 
 from synchronicity import Interface
+from synchronicity.async_wrap import asynccontextmanager
 
 from ._output import OutputManager
 from ._utils.async_utils import TaskContext, asyncify, synchronize_api, synchronizer
@@ -98,7 +98,7 @@ def _get_clean_stub_description(stub_ref: str) -> str:
         return " ".join(sys.argv)
 
 
-@contextlib.asynccontextmanager
+@asynccontextmanager
 async def _serve_stub(
     stub: "_Stub",
     stub_ref: str,

--- a/modal/token_flow.py
+++ b/modal/token_flow.py
@@ -2,11 +2,11 @@
 import itertools
 import os
 import webbrowser
-from contextlib import asynccontextmanager
 from typing import AsyncGenerator, Optional, Tuple
 
 import aiohttp.web
 from rich.console import Console
+from synchronicity.async_wrap import asynccontextmanager
 
 from modal_proto import api_pb2
 

--- a/tasks.py
+++ b/tasks.py
@@ -11,7 +11,6 @@ import subprocess
 import sys
 from datetime import date
 from pathlib import Path
-from types import FunctionType
 from typing import List, Optional
 
 import requests
@@ -198,7 +197,8 @@ def type_stubs(ctx):
         return [
             name
             for name, obj in vars(module).items()
-            if isinstance(obj, (type, FunctionType))
+            if not module_name.startswith("modal.cli")  # TODO we don't handle typer-wrapped functions well
+            and hasattr(obj, "__module__")
             and obj.__module__ == module_name
             and not name.startswith("_")  # Avoid deprecation of _App.__getattr__
             and hasattr(obj, SYNCHRONIZER_ATTR)

--- a/test/network_file_system_test.py
+++ b/test/network_file_system_test.py
@@ -99,7 +99,7 @@ async def test_network_file_system_handle_big_file(client, tmp_path, servicer, b
 def test_old_syntax(client, servicer):
     stub = modal.Stub()
     with pytest.raises(DeprecationError):
-        stub.vol1 = modal.SharedVolume()
+        stub.vol1 = modal.SharedVolume()  # type: ignore  # This is just a post-deprecation husk
     with pytest.raises(DeprecationError):
         stub.vol2 = modal.SharedVolume.new()
 


### PR DESCRIPTION
We were failing to generate a type stubs for a few modules that use synchronicity because we had a hardcoded list. I addressed a TODO to make generate the list of modules dynamically. This caused a few new typing issues to pop up; I think we might encounter a few more in CI too.