### PR TITLE
Improve deployment pipeline to reduce contention over version updates

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -138,6 +138,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           token: ${{ steps.generate_token.outputs.token }}
+          ref: main
 
       - uses: ./.github/actions/setup-cached-python
         with:
@@ -147,7 +148,7 @@ jobs:
         run: inv update-build-number
 
       - name: Update the changelog
-        run: inv update-changelog
+        run: inv update-changelog --sha=$GITHUB_SHA
 
       - name: Get the current client version
         id: version

--- a/tasks.py
+++ b/tasks.py
@@ -202,9 +202,9 @@ def type_stubs(ctx):
 
 
 @task
-def update_changelog(ctx):
-    # Parse the most recent commit message for a GitHub PR number
-    res = ctx.run("git log --pretty=format:%s -n 1", hide="stdout")
+def update_changelog(ctx, sha: str = ""):
+    # Parse a commit message for a GitHub PR number, defaulting to most recent commit
+    res = ctx.run(f"git log --pretty=format:%s -n 1 {sha}", hide="stdout")
     m = re.search(r"\(#(\d+)\)$", res.stdout)
     if m:
         pull_number = m.group(1)


### PR DESCRIPTION
We currently have a few deployments fail each week when two (or more) PRs are merged at roughly the same time. The cause of the failure is a merge conflict when both PRs update the package version.

The problem is encountered when the following sequence of events happen:

```
merge(A)  ->  merge(B) ->  deploy_finish(A)
```

While the `publish-client` job uses the `concurrency` feature so that only one deployment pipeline can run at any given time, the `checkout` step would previously check out the sha for commit that triggered the pipeline. As a result, the B doesn't see the changes made during the A deployment, and they conflict.

The time between `merge(A)` and `deploy_finish(A)` can be pretty long. so this happens with a nontrivial frequency.

This PR slightly changes the deployment pipeline parameterization to check out the `main` branch rather than the PR commit. Additionally, the changelog step now uses the PR commit sha rather than looking at the most recent commit.

There is still an edge case, which would obtain with the following sequence of events
```
deploy_start(A)  -> merge(B)  -> deploy_finish(A) 
```

This won't fail, but the release for the A commit will include the B changes as well.

We think that this is nevertheless a strict improvement because (1) the practical effect of deployment failing is that two changesets end up in one release anyway and (2) the window of potential contention is now much shorter (seconds instead of minutes).