### PR TITLE
Make Image methods noops in remote context

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -1149,7 +1149,7 @@ class _Image(_Object, type_prefix="im"):
 
         **Example**
 
-        ```python
+        ```python notest
         image = modal.Image.from_dockerfile("./Dockerfile", add_python="3.12")
         ```
         """


### PR DESCRIPTION
When `Image` code executes remotely, the only requirement we have is that it doesn't cause an exception. We have a few ad-hoc guards to avoid doing things like reading files that only exist locally, and in some cases defer reading files in a way that makes the type signatures for the dockerfile commands that we pass around more complicated.

This PR proposes an alternate approach, using a decorator that turns image methods into no-ops when run in a remote context.