### PR TITLE
Deprecate stub getitem/setitem

### DIFF
--- a/modal/stub.py
+++ b/modal/stub.py
@@ -236,11 +236,25 @@ class _Stub:
         self._indexed_objects[tag] = obj
 
     def __getitem__(self, tag: str):
-        deprecation_warning((2024, 3, 23), "stub[...] is deprecated!")
+        """Deprecated!
+
+        The only use case for `stub[...]` assignments is in conjunction with `.new()`, which is
+        in itself deprecated. If you are constructing objects with `.from_name(...)`, there is no
+        need to assign those objects to the stub. Example:
+
+        ```python
+        d = modal.Dict.from_name("my-dict", create_if_missing=True)
+
+        @stub.function()
+        def f(x, y):
+            d[x] = y  # Refer to d in global scope
+        ```
+        """
+        deprecation_warning((2024, 3, 25), _Stub.__getitem__.__doc__)
         return self._indexed_objects[tag]
 
     def __setitem__(self, tag: str, obj: _Object):
-        deprecation_warning((2024, 3, 23), "stub[...] is deprecated!")
+        deprecation_warning((2024, 3, 25), _Stub.__getitem__.__doc__)
         self._validate_blueprint_value(tag, obj)
         # Deprecated ?
         self._add_object(tag, obj)

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -236,10 +236,11 @@ class _Stub:
         self._indexed_objects[tag] = obj
 
     def __getitem__(self, tag: str):
-        # Deprecated? Note: this is currently the only way to refer to lifecycled methods on the stub, since they have . in the tag
+        deprecation_warning((2024, 3, 23), "stub[...] is deprecated!")
         return self._indexed_objects[tag]
 
     def __setitem__(self, tag: str, obj: _Object):
+        deprecation_warning((2024, 3, 23), "stub[...] is deprecated!")
         self._validate_blueprint_value(tag, obj)
         # Deprecated ?
         self._add_object(tag, obj)

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -411,13 +411,13 @@ def test_image_build_with_context_mount(client, servicer, tmp_path):
     dockerfile.write("COPY . /dummy\n")
     dockerfile.close()
 
-    stub["copy"] = Image.debian_slim().copy_local_dir(tmp_path, remote_path="/dummy")
-    stub["from_dockerfile"] = Image.debian_slim().dockerfile_commands(["COPY . /dummy"], context_mount=data_mount)
-    stub["dockerfile_commands"] = Image.debian_slim().from_dockerfile(dockerfile.name, context_mount=data_mount)
+    stub.copy = Image.debian_slim().copy_local_dir(tmp_path, remote_path="/dummy")
+    stub.from_dockerfile = Image.debian_slim().dockerfile_commands(["COPY . /dummy"], context_mount=data_mount)
+    stub.dockerfile_commands = Image.debian_slim().from_dockerfile(dockerfile.name, context_mount=data_mount)
 
     with stub.run(client=client):
-        for image_name, expected_layer in [("copy", 0), ("dockerfile_commands", 1), ("from_dockerfile", 0)]:
-            layers = get_image_layers(stub[image_name].object_id, servicer)
+        for image, expected_layer in [(stub.copy, 0), (stub.dockerfile_commands, 1), (stub.from_dockerfile, 0)]:
+            layers = get_image_layers(image.object_id, servicer)
             assert "COPY . /dummy" in layers[expected_layer].dockerfile_commands
 
         files = {f.mount_filename: f.content for f in Mount._get_files(data_mount.entries)}

--- a/test/stub_test.py
+++ b/test/stub_test.py
@@ -25,11 +25,11 @@ async def test_kwargs(servicer, client):
             q=Queue.new(),
         )
     async with stub.run(client=client):
-        # TODO: interface to get type safe objects from live apps
-        await stub["d"].put.aio("foo", "bar")  # type: ignore
-        await stub["q"].put.aio("baz")  # type: ignore
-        assert await stub["d"].get.aio("foo") == "bar"  # type: ignore
-        assert await stub["q"].get.aio() == "baz"  # type: ignore
+        with pytest.warns(DeprecationError):
+            await stub["d"].put.aio("foo", "bar")  # type: ignore
+            await stub["q"].put.aio("baz")  # type: ignore
+            assert await stub["d"].get.aio("foo") == "bar"  # type: ignore
+            assert await stub["q"].get.aio() == "baz"  # type: ignore
 
         with pytest.raises(DeprecationError):
             stub.app["d"]

--- a/test/webhook_test.py
+++ b/test/webhook_test.py
@@ -39,7 +39,7 @@ async def test_webhook(servicer, client):
         container_app = ContainerApp()
         await ContainerApp.init.aio(client, stub.app_id)
         container_app._associate_stub_container(stub)
-        f_c = stub["f"]
+        f_c = stub.f
         assert isinstance(f_c, Function)
         assert f_c.web_url
 


### PR DESCRIPTION
Ahead of deprecating `stub.x`, let's deprecate `stub["x"]`

Seems pretty rare