### PR TITLE
Add type to more util modules

### DIFF
--- a/modal/_utils/hash_utils.py
+++ b/modal/_utils/hash_utils.py
@@ -12,6 +12,7 @@ def _update(hashers, data: Union[bytes, IO[bytes]]):
         for hasher in hashers:
             hasher.update(data)
     else:
+        assert isinstance(data, IO)
         pos = data.tell()
         while 1:
             chunk = data.read(HASH_CHUNK_SIZE)

--- a/modal/_utils/mount_utils.py
+++ b/modal/_utils/mount_utils.py
@@ -2,7 +2,7 @@
 import posixpath
 import typing
 from pathlib import PurePath, PurePosixPath
-from typing import TYPE_CHECKING, Dict, List, Mapping, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Mapping, Sequence, Tuple, Union
 
 from ..exception import InvalidError
 from ..volume import _Volume
@@ -40,7 +40,7 @@ def validate_mount_points(
 
 def validate_volumes(
     volumes: Mapping[Union[str, PurePosixPath], Union["_Volume", "_CloudBucketMount"]],
-) -> List[Tuple[str, Union["_Volume", "_NetworkFileSystem", "_CloudBucketMount"]]]:
+) -> Sequence[Tuple[str, Union["_Volume", "_NetworkFileSystem", "_CloudBucketMount"]]]:
     if not isinstance(volumes, dict):
         raise InvalidError("volumes must be a dict[str, Volume] where the keys are paths")
 

--- a/modal/_utils/rand_pb_testing.py
+++ b/modal/_utils/rand_pb_testing.py
@@ -58,7 +58,7 @@ def _fill(msg, desc: Descriptor, rand: Random) -> None:
         else:
             if field.type == FieldDescriptor.TYPE_ENUM:
                 enum_values = [x.number for x in field.enum_type.values]
-                generator = lambda rand: rand.choice(enum_values)
+                generator = lambda rand: rand.choice(enum_values)  # noqa: E731
 
             else:
                 generator = _FIELD_RANDOM_GENERATOR[field.type]

--- a/modal/_utils/rand_pb_testing.py
+++ b/modal/_utils/rand_pb_testing.py
@@ -58,12 +58,10 @@ def _fill(msg, desc: Descriptor, rand: Random) -> None:
         else:
             if field.type == FieldDescriptor.TYPE_ENUM:
                 enum_values = [x.number for x in field.enum_type.values]
-
-                def generator(rand):
-                    return rand.choice(enum_values)
+                generator = lambda rand: rand.choice(enum_values)
 
             else:
-                generator = _FIELD_RANDOM_GENERATOR.get(field.type)
+                generator = _FIELD_RANDOM_GENERATOR[field.type]
             if is_repeated:
                 num = rand.randint(0, 2)
                 msg_field = getattr(msg, field.name)

--- a/tasks.py
+++ b/tasks.py
@@ -50,9 +50,13 @@ def type_check(ctx):
         "modal/_utils/app_utils.py",
         "modal/_utils/async_utils.py",
         "modal/_utils/grpc_testing.py",
+        "modal/_utils/hash_utils.py",
         "modal/_utils/http_utils.py",
         "modal/_utils/logger.py",
+        "modal/_utils/mount_utils.py",
         "modal/_utils/package_utils.py",
+        "modal/_utils/rand_pb_testing.py",
+        "modal/_utils/shell_utils.py",
     ]
 
     ctx.run(f"pyright {' '.join(pyright_allowlist)}", pty=True)


### PR DESCRIPTION
## Describe your changes

This PR adds mypy types to more `_utils` modules, as per https://github.com/modal-labs/modal-client/issues/1372.

```
modal/_utils/hash_utils.py
modal/_utils/mount_utils.py
modal/_utils/rand_pb_testing.py
modal/_utils/shell_utils.py
```