### PR TITLE
Update public proto to support Requester Pays for S3 buckets

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -88,6 +88,7 @@ message CloudBucketMount {
   string mount_path = 2;
   string credentials_secret_id = 3;
   bool read_only = 4;
+  bool requester_pays = 6;
 
   enum BucketType {
     UNSPECIFIED = 0;


### PR DESCRIPTION
`CloudBucketMounts` with S3 buckets can support ["requester pays"](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RequesterPaysBuckets.html), a mode in which the requester pays for egress fees associated with S3 operations. Some buckets require this option. 

This updates our protos as first-step for that support.