### PR TITLE
Adds interface for turning on requester pays in `CloudBucketMount`

### DIFF
--- a/modal/cloud_bucket_mount.py
+++ b/modal/cloud_bucket_mount.py
@@ -73,7 +73,7 @@ def cloud_bucket_mounts_to_proto(mounts: List[Tuple[str, _CloudBucketMount]]) ->
 
         if mount.requester_pays and not mount.secret:
             raise ValueError("Credentials required in order to use Requester Pays.")
-    
+
         cloud_bucket_mount = api_pb2.CloudBucketMount(
             bucket_name=mount.bucket_name,
             mount_path=path,

--- a/modal/cloud_bucket_mount.py
+++ b/modal/cloud_bucket_mount.py
@@ -71,6 +71,9 @@ def cloud_bucket_mounts_to_proto(mounts: List[Tuple[str, _CloudBucketMount]]) ->
         else:
             bucket_type = mount.bucket_type
 
+        if mount.requester_pays and not mount.secret:
+            raise ValueError("Credentials required in order to use Requester Pays.")
+    
         cloud_bucket_mount = api_pb2.CloudBucketMount(
             bucket_name=mount.bucket_name,
             mount_path=path,

--- a/modal/cloud_bucket_mount.py
+++ b/modal/cloud_bucket_mount.py
@@ -55,6 +55,7 @@ class _CloudBucketMount:
     secret: Optional[_Secret] = None
 
     read_only: bool = False
+    requester_pays: bool = False
     bucket_type: Union[
         BucketType, str
     ] = BucketType.S3.value  # S3 is the default bucket type until other cloud buckets are supported
@@ -76,6 +77,7 @@ def cloud_bucket_mounts_to_proto(mounts: List[Tuple[str, _CloudBucketMount]]) ->
             credentials_secret_id=mount.secret.object_id if mount.secret else "",
             read_only=mount.read_only,
             bucket_type=bucket_type.proto,
+            requester_pays=mount.requester_pays,
         )
         cloud_bucket_mounts.append(cloud_bucket_mount)
 


### PR DESCRIPTION
Adds argument `requester_pays` to `CloudBucketMount` allowing users to enable the feature when mounting S3 buckets.