### PR TITLE
Remove stub assignments: dicts and queues

### DIFF
--- a/test/dict_test.py
+++ b/test/dict_test.py
@@ -2,35 +2,24 @@
 import pytest
 import time
 
-from modal import Dict, Stub
-from modal.exception import DeprecationError
+from modal import Dict
 
 
 def test_dict_app(servicer, client):
-    stub = Stub()
-    with pytest.warns(DeprecationError):
-        stub.d = Dict.new()
-    with stub.run(client=client):
-        stub.d["foo"] = 42
-        stub.d["foo"] += 5
-        assert stub.d["foo"] == 47
-        assert stub.d.len() == 1
-
-        stub.d.clear()
-        assert stub.d.len() == 0
-        with pytest.raises(KeyError):
-            _ = stub.d["foo"]
-
-        assert stub.d.get("foo", default=True)
-        stub.d["foo"] = None
-        assert stub.d["foo"] is None
-
-
-def test_dict_lookup(servicer, client):
-    d = Dict.lookup("xyz", {"foo": "bar"}, create_if_missing=True, client=client)
-    d["xyz"] = 123
+    d = Dict.lookup("my-amazing-dict", {"xyz": 123}, create_if_missing=True, client=client)
+    d["foo"] = 42
+    d["foo"] += 5
+    assert d["foo"] == 47
     assert d.len() == 2
-    assert d["foo"] == "bar"
+
+    d.clear()
+    assert d.len() == 0
+    with pytest.raises(KeyError):
+        _ = d["foo"]
+
+    assert d.get("foo", default=True)
+    d["foo"] = None
+    assert d["foo"] is None
 
 
 def test_dict_ephemeral(servicer, client):

--- a/test/queue_test.py
+++ b/test/queue_test.py
@@ -3,25 +3,21 @@ import pytest
 import queue
 import time
 
-from modal import Queue, Stub
-from modal.exception import DeprecationError
+from modal import Queue
 
 from .supports.skip import skip_macos, skip_windows
 
 
 def test_queue(servicer, client):
-    stub = Stub()
-    with pytest.warns(DeprecationError):
-        stub.q = Queue.new()
-    with stub.run(client=client):
-        assert isinstance(stub.q, Queue)
-        assert stub.q.len() == 0
-        stub.q.put(42)
-        assert stub.q.len() == 1
-        assert stub.q.get() == 42
-        with pytest.raises(queue.Empty):
-            stub.q.get(timeout=0)
-        assert stub.q.len() == 0
+    q = Queue.lookup("some-random-queue", create_if_missing=True, client=client)
+    assert isinstance(q, Queue)
+    assert q.len() == 0
+    q.put(42)
+    assert q.len() == 1
+    assert q.get() == 42
+    with pytest.raises(queue.Empty):
+        q.get(timeout=0)
+    assert q.len() == 0
 
 
 def test_queue_ephemeral(servicer, client):


### PR DESCRIPTION
Just fixing tests leading up to the deprecation of stub assignments