### PR TITLE
Don't import support CLI imports of the form `stub.func`

### DIFF
--- a/test/cli_imports_test.py
+++ b/test/cli_imports_test.py
@@ -8,7 +8,6 @@ from modal.cli.import_refs import (
     import_file_or_module,
     parse_import_ref,
 )
-from modal.functions import _Function
 from modal.stub import _LocalEntrypoint, _Stub
 
 # Some helper vars for import_stub tests:
@@ -88,9 +87,7 @@ dir_containing_python_package = {
         # # file syntax
         (empty_dir_with_python_file, "mod.py", _Stub),
         (empty_dir_with_python_file, "mod.py::stub", _Stub),
-        (empty_dir_with_python_file, "mod.py::stub.Parent.meth", _Function),
         (empty_dir_with_python_file, "mod.py::other_stub", _Stub),
-        (empty_dir_with_python_file, "mod.py::other_stub.func", _Function),
         (dir_containing_python_package, "pack/file.py", _Stub),
         (dir_containing_python_package, "pack/sub/subfile.py", _Stub),
         (dir_containing_python_package, "dir/sub/subfile.py", _Stub),

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -129,7 +129,6 @@ def test_run(servicer, set_env_client, test_dir):
     stub_file = test_dir / "supports" / "app_run_tests" / "default_stub.py"
     _run(["run", stub_file.as_posix()])
     _run(["run", stub_file.as_posix() + "::stub"])
-    _run(["run", stub_file.as_posix() + "::stub.foo"])
     _run(["run", stub_file.as_posix() + "::foo"])
     _run(["run", stub_file.as_posix() + "::bar"], expected_exit_code=1, expected_stderr=None)
     file_with_entrypoint = test_dir / "supports" / "app_run_tests" / "local_entrypoint.py"
@@ -206,7 +205,6 @@ def test_run_custom_stub(servicer, set_env_client, test_dir):
     res = _run(["run", stub_file.as_posix() + "::stub.foo"], expected_exit_code=1, expected_stderr=None)
     assert "Could not find" in res.stderr
 
-    _run(["run", stub_file.as_posix() + "::my_stub.foo"])
     _run(["run", stub_file.as_posix() + "::foo"])
 
 
@@ -421,13 +419,13 @@ def test_shell_cmd(servicer, set_env_client, test_dir, mock_shell_pty):
 
 def test_app_descriptions(servicer, server_url_env, test_dir):
     stub_file = test_dir / "supports" / "app_run_tests" / "prints_desc_stub.py"
-    _run(["run", "--detach", stub_file.as_posix() + "::stub.foo"])
+    _run(["run", "--detach", stub_file.as_posix() + "::foo"])
 
     create_reqs = [s for s in servicer.requests if isinstance(s, api_pb2.AppCreateRequest)]
     assert len(create_reqs) == 1
     assert create_reqs[0].app_state == api_pb2.APP_STATE_DETACHED
     description = create_reqs[0].description
-    assert "prints_desc_stub.py::stub.foo" in description
+    assert "prints_desc_stub.py::foo" in description
     assert "run --detach " not in description
 
     _run(["serve", "--timeout", "0.0", stub_file.as_posix()])


### PR DESCRIPTION
As a step towards deprecating stub assignments, I ran into a bit of a weird case. When deprecating `stub.foo` getattrs, we're indirectly breaking CLI invocations of that form. E.g. `modal run my_file.py::stub.foo`

I think that's fine given that `modal run my_file.py::foo` still works?

We could in theory still support it, but I would rather maintain consistency between the CLI and Python. And in all normal cases, the function is always defined in the global scope so you should be able to import it using the function name instead (not using the stub as a qualifier).

The only case that I can think of where this breaks is if you have two different stub in the same file, each adding a function _with the same name_. This seems like a weird case?