### PR TITLE
Deprecate stub assignments

### DIFF
--- a/modal/stub.py
+++ b/modal/stub.py
@@ -236,9 +236,9 @@ class _Stub:
         self._indexed_objects[tag] = obj
 
     def __getitem__(self, tag: str):
-        """Deprecated!
+        """Stub assignments of the form `stub.x` or `stub["x"]` are deprecated!
 
-        The only use case for `stub[...]` assignments is in conjunction with `.new()`, which is
+        The only use cases for these assignments is in conjunction with `.new()`, which is now
         in itself deprecated. If you are constructing objects with `.from_name(...)`, there is no
         need to assign those objects to the stub. Example:
 
@@ -265,15 +265,20 @@ class _Stub:
             # Hacky way to avoid certain issues, e.g. pickle will try to look this up
             raise AttributeError(f"Stub has no member {tag}")
         # Return a reference to an object that will be created in the future
-        return self._indexed_objects[tag]
+        obj: _Object = self._indexed_objects[tag]
+        deprecation_warning((2024, 3, 25), _Stub.__getitem__.__doc__)
+        return obj
 
     def __setattr__(self, tag: str, obj: _Object):
         # Note that only attributes defined in __annotations__ are set on the object itself,
         # everything else is registered on the indexed_objects
         if tag in self.__annotations__:
             object.__setattr__(self, tag, obj)
+        elif tag == "image":
+            self._indexed_objects["image"] = obj
         else:
             self._validate_blueprint_value(tag, obj)
+            deprecation_warning((2024, 3, 25), _Stub.__getitem__.__doc__)
             self._add_object(tag, obj)
 
     @property

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -260,16 +260,20 @@ class _Stub:
         self._add_object(tag, obj)
 
     def __getattr__(self, tag: str) -> _Object:
+        # TODO(erikbern): remove this method later
         assert isinstance(tag, str)
         if tag.startswith("__"):
             # Hacky way to avoid certain issues, e.g. pickle will try to look this up
             raise AttributeError(f"Stub has no member {tag}")
-        # Return a reference to an object that will be created in the future
+        if tag not in self._indexed_objects:
+            # Primarily to make hasattr work
+            raise AttributeError(f"Stub has no member {tag}")
         obj: _Object = self._indexed_objects[tag]
         deprecation_warning((2024, 3, 25), _Stub.__getitem__.__doc__)
         return obj
 
     def __setattr__(self, tag: str, obj: _Object):
+        # TODO(erikbern): remove this method later
         # Note that only attributes defined in __annotations__ are set on the object itself,
         # everything else is registered on the indexed_objects
         if tag in self.__annotations__:

--- a/test/object_test.py
+++ b/test/object_test.py
@@ -10,27 +10,11 @@ async def test_async_factory(client):
     stub = Stub()
     with pytest.warns(DeprecationError):
         stub.my_factory = Queue.new()
-    async with stub.run(client=client):
-        assert isinstance(stub.my_factory, Queue)
-        assert stub.my_factory.object_id == "qu-1"
-        with pytest.raises(DeprecationError):
-            stub.app.my_factory
-
-
-@pytest.mark.asyncio
-async def test_use_object(client):
-    # Deploy object
-    q = await Queue.lookup.aio("foo-queue", create_if_missing=True, client=client)
-
-    # Use object
-    stub = Stub()
-    q = Queue.from_name("foo-queue")
-    assert isinstance(q, Queue)
-    stub.my_q = q
-    async with stub.run(client=client):
-        assert stub.my_q.object_id == "qu-1"
-        with pytest.raises(DeprecationError):
-            stub.app.my_q
+        async with stub.run(client=client):
+            assert isinstance(stub.my_factory, Queue)
+            assert stub.my_factory.object_id == "qu-1"
+            with pytest.raises(DeprecationError):
+                stub.app.my_factory
 
 
 def test_new_hydrated(client):

--- a/test/stub_test.py
+++ b/test/stub_test.py
@@ -42,10 +42,11 @@ async def test_attrs(servicer, client):
         stub.d = Dict.new()
         stub.q = Queue.new()
     async with stub.run(client=client):
-        await stub.d.put.aio("foo", "bar")  # type: ignore
-        await stub.q.put.aio("baz")  # type: ignore
-        assert await stub.d.get.aio("foo") == "bar"  # type: ignore
-        assert await stub.q.get.aio() == "baz"  # type: ignore
+        with pytest.warns(DeprecationError):
+            await stub.d.put.aio("foo", "bar")  # type: ignore
+            await stub.q.put.aio("baz")  # type: ignore
+            assert await stub.d.get.aio("foo") == "bar"  # type: ignore
+            assert await stub.q.get.aio() == "baz"  # type: ignore
 
         with pytest.raises(DeprecationError):
             stub.app.d
@@ -329,7 +330,8 @@ def test_redeploy_from_name_change(servicer, client):
 
     # Use it from stub
     stub = Stub()
-    stub.q = modal.Queue.from_name("foo-queue")
+    with pytest.warns(DeprecationError):
+        stub.q = modal.Queue.from_name("foo-queue")
     deploy_stub(stub, "my-app", client=client)
 
     # Change the object id of foo-queue

--- a/test/stub_test.py
+++ b/test/stub_test.py
@@ -153,7 +153,7 @@ def test_missing_attr():
     an understandable error message."""
 
     stub = Stub()
-    with pytest.raises(KeyError):
+    with pytest.raises(AttributeError):
         stub.fun()  # type: ignore
 
 
@@ -359,3 +359,8 @@ def test_hydrated_other_app_object_gets_referenced(servicer, client):
             deploy_stub(stub, client=client)
             app_set_objects_req = ctx.pop_request("AppSetObjects")
             assert vol.object_id in app_set_objects_req.unindexed_object_ids
+
+
+def test_hasattr():
+    stub = Stub()
+    assert not hasattr(stub, "xyz")


### PR DESCRIPTION
This finally deprecates `getattr` and `setattr` on stubs.

~This PR includes #1598 since it's needed for tests to pass~ EDIT: that one is now merged, and this one is rebased on main