### PR TITLE
Fixes automount incompatibility with symlinked python installations

### DIFF
--- a/modal/_utils/function_utils.py
+++ b/modal/_utils/function_utils.py
@@ -266,7 +266,8 @@ class FunctionInfo:
                 continue
 
             for local_path, remote_path in mount_paths:
-                if any(local_path.is_relative_to(p) for p in SYS_PREFIXES) or _is_modal_path(remote_path):
+                # TODO: use is_relative_to once we deprecate Python 3.8
+                if any(str(local_path).startswith(str(p)) for p in SYS_PREFIXES) or _is_modal_path(remote_path):
                     # skip any module that has paths in SYS_PREFIXES, or would overwrite the modal Package in the container
                     break
             else:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1365,6 +1365,11 @@ def reset_container_app():
         _ContainerApp._reset_container()
 
 
+@pytest.fixture
+def repo_root(request):
+    return Path(request.config.rootdir)
+
+
 @pytest.fixture(scope="module")
 def test_dir(request):
     """Absolute path to directory containing test file."""

--- a/test/mounted_files_test.py
+++ b/test/mounted_files_test.py
@@ -171,6 +171,7 @@ def symlinked_python_installation_venv_path(tmp_path, repo_root):
     # create a new venv
     subprocess.check_call([symlink_python_executable, "-m", "venv", venv_path, "--copies"])
     # check that a builtin module, like ast, is indeed identified to be in the non-resolved install path
+    # since this is the source of bugs that we want to assert we don't run into!
     ast_path = subprocess.check_output(
         [venv_path / "bin" / "python", "-c", "import ast; print(ast.__file__);"], encoding="utf8"
     )
@@ -181,6 +182,7 @@ def symlinked_python_installation_venv_path(tmp_path, repo_root):
     yield venv_path
 
 
+@skip_windows("venvs behave differently on Windows.")
 def test_mounted_files_symlinked_python_install(
     symlinked_python_installation_venv_path, supports_dir, server_url_env, servicer
 ):

--- a/test/mounted_files_test.py
+++ b/test/mounted_files_test.py
@@ -16,11 +16,11 @@ from .supports.skip import skip_windows
 
 
 @pytest.fixture
-def venv_path(tmp_path):
+def venv_path(tmp_path, repo_root):
     venv_path = tmp_path
     subprocess.run([sys.executable, "-m", "venv", venv_path, "--copies", "--system-site-packages"], check=True)
     # Install Modal and a tiny package in the venv.
-    subprocess.run([venv_path / "bin" / "python", "-m", "pip", "install", "-e", "."], check=True)
+    subprocess.run([venv_path / "bin" / "python", "-m", "pip", "install", "-e", repo_root], check=True)
     subprocess.run([venv_path / "bin" / "python", "-m", "pip", "install", "--force-reinstall", "six"], check=True)
     yield venv_path
 
@@ -148,6 +148,46 @@ def test_mounted_files_sys_prefix(servicer, supports_dir, venv_path, env_mount_f
         "/root/pkg_b/f.py",
         "/root/pkg_b/g/h.py",
     }
+
+
+@pytest.fixture
+def symlinked_python_installation_venv_path(tmp_path, repo_root):
+    # sets up a symlink to the python *installation* (not just the python binary)
+    # and initialize the virtualenv using a path via that symlink
+    # This makes the file paths of any stdlib modules use the symlinked path
+    # instead of the original, which is similar to what some tools do (e.g. mise)
+    # and has the potential to break automounting behavior, so we keep this
+    # test as a regression test for that
+    venv_path = tmp_path / "venv"
+    actual_executable = Path(sys.executable).resolve()
+    assert actual_executable.parent.name == "bin"
+    python_install_dir = actual_executable.parent.parent
+    # create a symlink to the python install *root*
+    symlink_python_install = tmp_path / "python-install"
+    symlink_python_install.symlink_to(python_install_dir)
+
+    # use a python executable specified via the above symlink
+    symlink_python_executable = symlink_python_install / "bin" / "python"
+    # create a new venv
+    subprocess.check_call([symlink_python_executable, "-m", "venv", venv_path, "--copies"])
+    # check that a builtin module, like ast, is indeed identified to be in the non-resolved install path
+    ast_path = subprocess.check_output(
+        [venv_path / "bin" / "python", "-c", "import ast; print(ast.__file__);"], encoding="utf8"
+    )
+    assert ast_path != Path(ast_path).resolve()
+
+    # install modal from current dir
+    subprocess.check_call([venv_path / "bin" / "pip", "install", repo_root])
+    yield venv_path
+
+
+def test_mounted_files_symlinked_python_install(
+    symlinked_python_installation_venv_path, supports_dir, server_url_env, servicer
+):
+    subprocess.check_call(
+        [symlinked_python_installation_venv_path / "bin" / "modal", "run", supports_dir / "imports_ast.py"]
+    )
+    assert "/root/ast.py" not in servicer.files_name2sha
 
 
 def test_mounted_files_config(servicer, supports_dir, env_mount_files, server_url_env):

--- a/test/supports/imports_ast.py
+++ b/test/supports/imports_ast.py
@@ -1,0 +1,11 @@
+# Copyright Modal Labs 2024
+import ast  # noqa
+
+import modal
+
+stub = modal.Stub("imports_ast")
+
+
+@stub.function()
+def some_func():
+    pass


### PR DESCRIPTION
Would previously automount all stdlibs if the used python install root was referenced via a symlink when setting up a virtualenv or similar. For example, this could happen when using [mise](https://mise.jdx.dev/) to set up virtualenvs pointing to a minor python version which was itself a symlink to a micro version (e.g. 3.11 -> 3.11.4)

I have a hunch we used to support both resolved and unresolved SYS_PREFIXES, so I'm adding a test to ensure we don't regress in this way again

MOD-2645