### PR TITLE
Support versioned builds in all Image specification methods

### DIFF
--- a/modal/client.py
+++ b/modal/client.py
@@ -162,7 +162,7 @@ class _Client:
         except GRPCError as exc:
             if exc.status == Status.FAILED_PRECONDITION:
                 raise VersionError(
-                    f"The client version ({self.version}) is too old. Please update (pip install --update modal)."
+                    f"The client version ({self.version}) is too old. Please update (pip install --upgrade modal)."
                 )
             elif exc.status == Status.UNAUTHENTICATED:
                 raise AuthError(exc.message)

--- a/modal/client.py
+++ b/modal/client.py
@@ -2,7 +2,7 @@
 import asyncio
 import platform
 import warnings
-from typing import TYPE_CHECKING, AsyncIterator, Awaitable, Callable, Dict, Optional, Tuple
+from typing import AsyncIterator, Awaitable, Callable, Dict, Optional, Tuple
 
 import grpclib.client
 from aiohttp import ClientConnectorError, ClientResponseError
@@ -19,9 +19,6 @@ from ._utils.grpc_utils import create_channel, retry_transient_errors
 from ._utils.http_utils import http_client_with_tls
 from .config import _check_config, config, logger
 from .exception import AuthError, ConnectionError, DeprecationError, VersionError
-
-if TYPE_CHECKING:
-    from .image import ImageBuilderVersion
 
 HEARTBEAT_INTERVAL: float = config.get("heartbeat_interval")
 HEARTBEAT_TIMEOUT: float = HEARTBEAT_INTERVAL + 0.1
@@ -100,7 +97,7 @@ class _Client:
         self.credentials = credentials
         self.version = version
         self._authenticated = False
-        self.image_builder_version: Optional["ImageBuilderVersion"] = None
+        self.image_builder_version: Optional[str] = None
         self._pre_stop: Optional[Callable[[], Awaitable[None]]] = None
         self._channel: Optional[grpclib.client.Channel] = None
         self._stub: Optional[api_grpc.ModalClientStub] = None

--- a/modal/config.py
+++ b/modal/config.py
@@ -201,6 +201,7 @@ _SETTINGS = {
     "restore_state_path": _Setting("/__modal/restore-state.json"),
     "force_build": _Setting(False, transform=lambda x: x not in ("", "0")),
     "traceback": _Setting(False, transform=lambda x: x not in ("", "0")),
+    "image_builder_version": _Setting(),
 }
 
 

--- a/modal/image.py
+++ b/modal/image.py
@@ -39,11 +39,6 @@ if typing.TYPE_CHECKING:
 ImageBuilderVersion = Literal["2023.12", "PREVIEW"]
 
 
-def _default_image() -> "_Image":
-    """Single source of truth for the default image, which we reference from a number of places."""
-    return _Image.debian_slim()
-
-
 def _validate_python_version(version: str) -> None:
     components = version.split(".")
     supported_versions = {"3.12", "3.11", "3.10", "3.9", "3.8"}

--- a/modal/image.py
+++ b/modal/image.py
@@ -134,16 +134,21 @@ def _get_image_builder_version(client_version: ImageBuilderVersion) -> ImageBuil
         version = client_version
 
     supported_versions: Set[ImageBuilderVersion] = set(get_args(ImageBuilderVersion))
+    version_source, remedy = "", ""
     if version not in supported_versions:
         if version < min(supported_versions):
-            remedy = "image builder version using the Modal dashboard"
+            if config.get("image_builder_version"):
+                version_source = " (based on your local Modal config)"
+            else:
+                remedy = " your image builder version using the Modal dashboard"
         else:
-            remedy = "client library"
+            remedy = " your client library"
         # Special case "PREVIEW": we allow, but don't advertise it, as it's intended for development
         raise VersionError(
             "This version of the modal client supports the following image builder versions:"
-            f" {supported_versions - {'PREVIEW'}!r}"
-            f" You are using image builder {version!r}. Please update your {remedy}."
+            f" {supported_versions - {'PREVIEW'}!r}."
+            f"\n\nYou are using image builder {version!r}{version_source}."
+            f" Please update{remedy}."
         )
 
     return version

--- a/modal/image.py
+++ b/modal/image.py
@@ -386,12 +386,7 @@ class _Image(_Object, type_prefix="im"):
         obj.force_build = force_build
         return obj
 
-    def extend(
-        self,
-        *,
-        dockerfile_commands: Union[List[str], Callable[[], List[str]]] = None,
-        **kwargs,
-    ) -> "_Image":
+    def extend(self, **kwargs) -> "_Image":
         """Deprecated! This is a low-level method not intended to be part of the public API."""
         deprecation_warning(
             (2024, 3, 7),

--- a/modal/image.py
+++ b/modal/image.py
@@ -127,7 +127,7 @@ def _make_pip_install_args(
     return args
 
 
-def _get_image_builder_version(client_version: ImageBuilderVersion) -> ImageBuilderVersion:
+def _get_image_builder_version(client_version: str) -> ImageBuilderVersion:
     if config_version := config.get("image_builder_version"):
         version = config_version
         if (env_var := "MODAL_IMAGE_BUILDER_VERSION") in os.environ:

--- a/modal/image.py
+++ b/modal/image.py
@@ -129,9 +129,8 @@ def _make_pip_install_args(
     return args
 
 
-async def _get_builder_version() -> ImageBuilderVersion:
+async def _get_builder_version(client: _Client) -> ImageBuilderVersion:
     async def lookup_version() -> str:
-        client = await _Client.from_env()
         resp = await client.stub.ImageBuilderVersionLookup(Empty())
         return resp.version
 
@@ -250,7 +249,7 @@ class _Image(_Object, type_prefix="im"):
             return deps
 
         async def _load(self: _Image, resolver: Resolver, existing_object_id: Optional[str]):
-            builder_version = await _get_builder_version()
+            builder_version = await _get_builder_version(resolver.client)
 
             if dockerfile_function is None:
                 dockerfile = DockerfileSpec(commands=[], context_files={})

--- a/modal/image.py
+++ b/modal/image.py
@@ -404,7 +404,7 @@ class _Image(_Object, type_prefix="im"):
             "`Image.extend` is deprecated; please use a higher-level method, such as `Image.dockerfile_commands`.",
         )
 
-        def build_dockerfile():
+        def build_dockerfile() -> DockerfileSpec:
             return DockerfileSpec(
                 commands=kwargs.pop("dockerfile_commands", []),
                 context_files=kwargs.pop("context_files", {}),

--- a/modal/image.py
+++ b/modal/image.py
@@ -37,7 +37,6 @@ if typing.TYPE_CHECKING:
 
 # This is used for both type checking and runtime validation
 ImageBuilderVersion = Literal["2023.12", "PREVIEW"]
-# TODO How can we require that version-dependent parmeters specify values for *all* versions?
 
 
 def _default_image():

--- a/modal/image.py
+++ b/modal/image.py
@@ -136,9 +136,9 @@ def _get_image_builder_version(client_version: ImageBuilderVersion) -> ImageBuil
     supported_versions: Set[ImageBuilderVersion] = set(get_args(ImageBuilderVersion))
     if version not in supported_versions:
         if version < min(supported_versions):
-            remedy = "client library"
-        else:
             remedy = "image builder version using the Modal dashboard"
+        else:
+            remedy = "client library"
         # Special case "PREVIEW": we allow, but don't advertise it, as it's intended for development
         raise VersionError(
             "This version of the modal client supports the following image builder versions:"

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -22,7 +22,7 @@ from .config import logger
 from .exception import InvalidError, deprecation_error, deprecation_warning
 from .functions import _Function
 from .gpu import GPU_T
-from .image import _default_image, _Image
+from .image import _Image
 from .mount import _Mount
 from .network_file_system import _NetworkFileSystem
 from .object import _Object
@@ -35,6 +35,8 @@ from .schedule import Schedule
 from .scheduler_placement import SchedulerPlacement
 from .secret import _Secret
 from .volume import _Volume
+
+_default_image: _Image = _Image.debian_slim()
 
 
 class _LocalEntrypoint:
@@ -334,7 +336,7 @@ class _Stub:
         if "image" in self._indexed_objects:
             return self._indexed_objects["image"]
         else:
-            return _default_image()
+            return _default_image
 
     def _get_watch_mounts(self):
         all_mounts = [
@@ -708,8 +710,6 @@ class _Stub:
 
         Refer to the [docs](/docs/guide/sandbox) on how to spawn and use sandboxes.
         """
-        from .sandbox import _Sandbox
-
         if self._local_app:
             app_id = self._local_app.app_id
             environment_name = self._local_app._environment_name
@@ -725,7 +725,7 @@ class _Stub:
         resolver = Resolver(client, environment_name=environment_name, app_id=app_id)
         obj = _Sandbox._new(
             entrypoint_args,
-            image=image or _default_image(),
+            image=image or _default_image,
             mounts=mounts,
             secrets=secrets,
             timeout=timeout,

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -22,7 +22,7 @@ from .config import logger
 from .exception import InvalidError, deprecation_error, deprecation_warning
 from .functions import _Function
 from .gpu import GPU_T
-from .image import _Image
+from .image import _default_image, _Image
 from .mount import _Mount
 from .network_file_system import _NetworkFileSystem
 from .object import _Object
@@ -35,8 +35,6 @@ from .schedule import Schedule
 from .scheduler_placement import SchedulerPlacement
 from .secret import _Secret
 from .volume import _Volume
-
-_default_image: _Image = _Image.debian_slim()
 
 
 class _LocalEntrypoint:
@@ -336,7 +334,7 @@ class _Stub:
         if "image" in self._indexed_objects:
             return self._indexed_objects["image"]
         else:
-            return _default_image
+            return _default_image()
 
     def _get_watch_mounts(self):
         all_mounts = [
@@ -711,7 +709,6 @@ class _Stub:
         Refer to the [docs](/docs/guide/sandbox) on how to spawn and use sandboxes.
         """
         from .sandbox import _Sandbox
-        from .stub import _default_image
 
         if self._local_app:
             app_id = self._local_app.app_id
@@ -728,7 +725,7 @@ class _Stub:
         resolver = Resolver(client, environment_name=environment_name, app_id=app_id)
         obj = _Sandbox._new(
             entrypoint_args,
-            image=image or _default_image,
+            image=image or _default_image(),
             mounts=mounts,
             secrets=secrets,
             timeout=timeout,

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     grpclib==0.4.7
     protobuf>=3.19,<6.0,!=4.24.0
     rich>=12.0.0
-    synchronicity~=0.6.3
+    synchronicity~=0.6.5
     toml
     typer~=0.9.0
     types-certifi

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -729,7 +729,8 @@ class MockClientServicer(api_grpc.ModalClientBase):
         )
 
     async def ImageBuilderVersionLookup(self, stream):
-        await stream.send_message(api_pb2.ImageBuilderVersionLookupResponse(version=max(get_args(ImageBuilderVersion))))
+        version = max(get_args(ImageBuilderVersion))
+        await stream.send_message(api_pb2.ImageBuilderVersionLookupResponse(version=version))
 
     ### Mount
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -389,12 +389,12 @@ class MockClientServicer(api_grpc.ModalClientBase):
             raise GRPCError(Status.UNAUTHENTICATED, "bad bad bad")
         elif client_version == "unauthenticated":
             raise GRPCError(Status.UNAUTHENTICATED, "failed authentication")
-        elif pkg_resources.parse_version(client_version) < pkg_resources.parse_version(__version__):
-            raise GRPCError(Status.FAILED_PRECONDITION, "Old client")
         elif client_version == "deprecated":
             warning = "SUPER OLD"
         elif client_version == "timeout":
             await asyncio.sleep(60)
+        elif pkg_resources.parse_version(client_version) < pkg_resources.parse_version(__version__):
+            raise GRPCError(Status.FAILED_PRECONDITION, "Old client")
         resp = api_pb2.ClientHelloResponse(warning=warning, image_builder_version=image_builder_version)
         await stream.send_message(resp)
 

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -48,14 +48,17 @@ def get_image_layers(image_id: str, servicer) -> List[api_pb2.Image]:
 
 @pytest.fixture(params=get_args(ImageBuilderVersion))
 def builder_version(request, server_url_env):
+    version = request.param
     if sys.version_info[:2] == (3, 8):
         # TODO: The patch we're doing below is breaking on Python 3.8.
         # Rather than debug that, I'm just going to skip it for now.
         # This is a hack, but we'll likely drop support for 3.8 before adding
         # any new versioned logic that would be exercised by this fixutre.
-        yield
-        return
-    version = request.param
+        if version == min(get_args(ImageBuilderVersion)):
+            yield
+            return
+        else:
+            pytest.skip("Parameterized patching not working on Py3.8")
     with (
         mock.patch("test.conftest.ImageBuilderVersion", Literal[version]),  # type: ignore
         mock.patch("modal.image._Image.builder_version", None),

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -10,6 +10,7 @@ from unittest import mock
 
 from modal import Image, Mount, Secret, Stub, build, gpu, method
 from modal._serialization import serialize
+from modal.client import Client
 from modal.exception import DeprecationError, InvalidError, VersionError
 from modal.image import ImageBuilderVersion, _dockerhub_python_version, _get_client_requirements_path
 from modal_proto import api_pb2
@@ -63,7 +64,7 @@ def builder_version(request, server_url_env):
         yield version
 
 
-def test_image_python_packages(client, servicer, builder_version):
+def test_image_python_packages(builder_version, servicer, client):
     stub = Stub()
     stub.image = (
         Image.debian_slim()
@@ -79,7 +80,7 @@ def test_image_python_packages(client, servicer, builder_version):
         )
 
 
-def test_image_kwargs_validation(servicer, client, builder_version):
+def test_image_kwargs_validation(builder_version, servicer, client):
     stub = Stub()
     stub.image = Image.debian_slim().run_commands(
         "echo hi", secrets=[Secret.from_dict({"xyz": "123"}), Secret.from_name("foo")]
@@ -102,7 +103,7 @@ def test_image_kwargs_validation(servicer, client, builder_version):
         stub.image = Image.debian_slim().copy_mount(Secret.from_dict({"xyz": "123"}), remote_path="/dummy")  # type: ignore
 
 
-def test_wrong_type(servicer, client, builder_version):
+def test_wrong_type(builder_version, servicer, client):
     image = Image.debian_slim()
     for m in [image.pip_install, image.apt_install, image.run_commands]:
         m(["xyz"])  # type: ignore
@@ -116,7 +117,7 @@ def test_wrong_type(servicer, client, builder_version):
             m([["double-nested-package"]])  # type: ignore
 
 
-def test_image_requirements_txt(servicer, client, builder_version):
+def test_image_requirements_txt(builder_version, servicer, client):
     requirements_txt = os.path.join(os.path.dirname(__file__), "supports/test-requirements.txt")
 
     stub = Stub()
@@ -129,7 +130,7 @@ def test_image_requirements_txt(servicer, client, builder_version):
         assert any(b"banana" in f.data for f in layers[0].context_files)
 
 
-def test_empty_install(servicer, client, builder_version):
+def test_empty_install(builder_version, servicer, client):
     # Install functions with no packages should be ignored.
     stub = Stub(
         image=Image.debian_slim()
@@ -145,7 +146,7 @@ def test_empty_install(servicer, client, builder_version):
         assert len(layers) == 1
 
 
-def test_debian_slim_apt_install(servicer, client, builder_version):
+def test_debian_slim_apt_install(builder_version, servicer, client):
     stub = Stub(image=Image.debian_slim().pip_install("numpy").apt_install("git", "ssh").pip_install("scikit-learn"))
 
     with stub.run(client=client):
@@ -156,7 +157,7 @@ def test_debian_slim_apt_install(servicer, client, builder_version):
         assert any("pip install numpy" in cmd for cmd in layers[2].dockerfile_commands)
 
 
-def test_image_pip_install_pyproject(servicer, client, builder_version):
+def test_image_pip_install_pyproject(builder_version, servicer, client):
     pyproject_toml = os.path.join(os.path.dirname(__file__), "supports/test-pyproject.toml")
 
     stub = Stub()
@@ -168,7 +169,7 @@ def test_image_pip_install_pyproject(servicer, client, builder_version):
         assert any("pip install 'banana >=1.2.0' 'potato >=0.1.0'" in cmd for cmd in layers[0].dockerfile_commands)
 
 
-def test_image_pip_install_pyproject_with_optionals(servicer, client, builder_version):
+def test_image_pip_install_pyproject_with_optionals(builder_version, servicer, client):
     pyproject_toml = os.path.join(os.path.dirname(__file__), "supports/test-pyproject.toml")
 
     stub = Stub()
@@ -184,7 +185,7 @@ def test_image_pip_install_pyproject_with_optionals(servicer, client, builder_ve
         assert not (any("'mkdocs >=1.4.2'" in cmd for cmd in layers[0].dockerfile_commands))
 
 
-def test_image_pip_install_private_repos(servicer, client, builder_version):
+def test_image_pip_install_private_repos(builder_version, servicer, client):
     stub = Stub()
     with pytest.raises(InvalidError):
         stub.image = Image.debian_slim().pip_install_private_repos(
@@ -228,7 +229,7 @@ def test_image_pip_install_private_repos(servicer, client, builder_version):
         )
 
 
-def test_conda_install(servicer, client, builder_version):
+def test_conda_install(builder_version, servicer, client):
     stub = Stub(image=Image.conda().pip_install("numpy").conda_install("pymc3", "theano").pip_install("scikit-learn"))
 
     with stub.run(client=client):
@@ -239,7 +240,7 @@ def test_conda_install(servicer, client, builder_version):
         assert any("pip install numpy" in cmd for cmd in layers[2].dockerfile_commands)
 
 
-def test_dockerfile_image(servicer, client, builder_version):
+def test_dockerfile_image(builder_version, servicer, client):
     path = os.path.join(os.path.dirname(__file__), "supports/test-dockerfile")
 
     stub = Stub(image=Image.from_dockerfile(path))
@@ -250,7 +251,7 @@ def test_dockerfile_image(servicer, client, builder_version):
         assert any("RUN pip install numpy" in cmd for cmd in layers[1].dockerfile_commands)
 
 
-def test_conda_update_from_environment(servicer, client, builder_version):
+def test_conda_update_from_environment(builder_version, servicer, client):
     path = os.path.join(os.path.dirname(__file__), "supports/test-conda-environment.yml")
 
     stub = Stub(image=Image.conda().conda_update_from_environment(path))
@@ -281,8 +282,7 @@ def test_run_commands(builder_version, servicer, client):
                 assert layers[0].dockerfile_commands[i] == f"RUN {cmd}"
 
 
-def test_dockerhub_install(servicer, client, builder_version):
->>>>>>> 0e3389d8 (Parameterize image tests by builder version)
+def test_dockerhub_install(builder_version, servicer, client):
     stub = Stub(image=Image.from_registry("gisops/valhalla:latest", setup_dockerfile_commands=["RUN apt-get update"]))
 
     with stub.run(client=client):
@@ -292,7 +292,7 @@ def test_dockerhub_install(servicer, client, builder_version):
         assert any("RUN apt-get update" in cmd for cmd in layers[0].dockerfile_commands)
 
 
-def test_ecr_install(servicer, client, builder_version):
+def test_ecr_install(builder_version, servicer, client):
     image_tag = "000000000000.dkr.ecr.us-east-1.amazonaws.com/my-private-registry:latest"
     stub = Stub(
         image=Image.from_aws_ecr(
@@ -313,7 +313,7 @@ def run_f():
     print("foo!")
 
 
-def test_image_run_function(client, servicer, builder_version):
+def test_image_run_function(builder_version, servicer, client):
     stub = Stub()
     stub.image = (
         Image.debian_slim().pip_install("pandas").run_function(run_f, secrets=[Secret.from_dict({"xyz": "123"})])
@@ -333,7 +333,7 @@ def test_image_run_function(client, servicer, builder_version):
     assert len(servicer.app_functions[function_id].secret_ids) == 1
 
 
-def test_image_run_function_interactivity(client, servicer, builder_version):
+def test_image_run_function_interactivity(builder_version, servicer, client):
     stub = Stub()
     stub.image = Image.debian_slim().pip_install("pandas").run_function(run_f)
 
@@ -358,7 +358,7 @@ def run_f_globals():
     print("foo!", VARIABLE_1)
 
 
-def test_image_run_function_globals(client, servicer, builder_version):
+def test_image_run_function_globals(builder_version, servicer, client):
     global VARIABLE_1, VARIABLE_2
 
     stub = Stub()
@@ -389,7 +389,7 @@ def run_f_unserializable_globals():
     print("foo!", VARIABLE_3, VARIABLE_4)
 
 
-def test_image_run_unserializable_function(client, servicer, builder_version):
+def test_image_run_unserializable_function(builder_version, servicer, client):
     stub = Stub()
     stub.image = Image.debian_slim().run_function(run_f_unserializable_globals)
 
@@ -403,7 +403,7 @@ def run_f_with_args(arg, *, kwarg):
     print("building!", arg, kwarg)
 
 
-def test_image_run_function_with_args(client, servicer, builder_version):
+def test_image_run_function_with_args(builder_version, servicer, client):
     stub = Stub()
     stub.image = Image.debian_slim().run_function(run_f_with_args, args=("foo",), kwargs={"kwarg": "bar"})
 
@@ -413,7 +413,7 @@ def test_image_run_function_with_args(client, servicer, builder_version):
         assert input.args == serialize((("foo",), {"kwarg": "bar"}))
 
 
-def test_poetry(client, servicer, builder_version):
+def test_poetry(builder_version, servicer, client):
     path = os.path.join(os.path.dirname(__file__), "supports/pyproject.toml")
 
     # No lockfile provided and there's no lockfile found
@@ -445,7 +445,7 @@ def tmp_path_with_content(tmp_path):
     return tmp_path
 
 
-def test_image_copy_local_dir(client, servicer, tmp_path_with_content, builder_version):
+def test_image_copy_local_dir(builder_verison, servicer, client, tmp_path_with_content):
     stub = Stub()
     stub.image = Image.debian_slim().copy_local_dir(tmp_path_with_content, remote_path="/dummy")
 
@@ -455,7 +455,7 @@ def test_image_copy_local_dir(client, servicer, tmp_path_with_content, builder_v
         assert set(servicer.mount_contents["mo-1"].keys()) == {"/data.txt", "/data/sub"}
 
 
-def test_image_docker_command_copy(client, servicer, tmp_path_with_content, builder_version):
+def test_image_docker_command_copy(builder_version, servicer, client, tmp_path_with_content):
     stub = Stub()
     data_mount = Mount.from_local_dir(tmp_path_with_content, remote_path="/")
     stub.image = Image.debian_slim().dockerfile_commands(["COPY . /dummy"], context_mount=data_mount)
@@ -467,7 +467,7 @@ def test_image_docker_command_copy(client, servicer, tmp_path_with_content, buil
         assert files == {"/data.txt": b"hello", "/data/sub": b"world"}
 
 
-def test_image_dockerfile_copy(client, servicer, tmp_path_with_content, builder_version):
+def test_image_dockerfile_copy(builder_version, servicer, client, tmp_path_with_content):
     dockerfile = NamedTemporaryFile("w", delete=False)
     dockerfile.write("COPY . /dummy\n")
     dockerfile.close()
@@ -483,7 +483,7 @@ def test_image_dockerfile_copy(client, servicer, tmp_path_with_content, builder_
         assert files == {"/data.txt": b"hello", "/data/sub": b"world"}
 
 
-def test_image_env(client, servicer, builder_version):
+def test_image_env(builder_version, servicer, client):
     stub = Stub(image=Image.debian_slim().env({"HELLO": "world!"}))
 
     with stub.run(client=client):
@@ -491,7 +491,7 @@ def test_image_env(client, servicer, builder_version):
         assert any("ENV HELLO=" in cmd and "world!" in cmd for cmd in layers[0].dockerfile_commands)
 
 
-def test_image_gpu(client, servicer, builder_version):
+def test_image_gpu(builder_version, servicer, client):
     stub = Stub(image=Image.debian_slim().run_commands("echo 0"))
     with stub.run(client=client):
         layers = get_image_layers(stub.image.object_id, servicer)
@@ -509,7 +509,7 @@ def test_image_gpu(client, servicer, builder_version):
         assert layers[0].gpu_config.type == api_pb2.GPU_TYPE_A10G
 
 
-def test_image_force_build(client, servicer, builder_version):
+def test_image_force_build(builder_version, servicer, client):
     stub = Stub()
     stub.image = Image.debian_slim().run_commands("echo 1").pip_install("foo", force_build=True).run_commands("echo 2")
     with stub.run(client=client):
@@ -525,7 +525,7 @@ def test_image_force_build(client, servicer, builder_version):
         assert servicer.force_built_images == ["im-3", "im-4", "im-5", "im-6", "im-7", "im-8"]
 
 
-def test_workdir(servicer, client, builder_version):
+def test_workdir(builder_version, servicer, client):
     stub = Stub(image=Image.debian_slim().workdir("/foo/bar"))
 
     with stub.run(client=client):
@@ -643,23 +643,29 @@ def test_get_client_requirements_path(version, expected):
     assert os.path.basename(path) == expected
 
 
-@mock.patch("test.conftest.ImageBuilderVersion", Literal["2000.01"])
-@mock.patch("modal.image.ImageBuilderVersion", Literal["2000.01"])
-def test_image_builder_version(client, servicer, server_url_env):
+def test_image_builder_version(servicer):
     stub = Stub(image=Image.debian_slim())
-    with stub.run(client=client):
+    with (
+        mock.patch("test.conftest.ImageBuilderVersion", Literal["2000.01"]),
+        mock.patch("modal.image.ImageBuilderVersion", Literal["2000.01"]),
+        Client(servicer.remote_addr, api_pb2.CLIENT_TYPE_CONTAINER, ("ak-123", "as-xyz")) as client,
+        stub.run(client=client),
+    ):
         assert servicer.image_builder_versions
         for version in servicer.image_builder_versions.values():
             assert version == "2000.01"
 
 
-@mock.patch("modal.image.ImageBuilderVersion", Literal["2000.01"])
-@mock.patch("test.conftest.ImageBuilderVersion", Literal["2023.11"])
-def test_image_builder_supported_versions(client, servicer, server_url_env):
-    with pytest.raises(VersionError, match=r"This version of the modal client supports.+{'2000.01'}"):
-        stub = Stub(image=Image.debian_slim())
-        with stub.run(client=client):
-            pass
+def test_image_builder_supported_versions(servicer):
+    stub = Stub(image=Image.debian_slim())
+    with (
+        pytest.raises(VersionError, match=r"This version of the modal client supports.+{'2000.01'}"),
+        mock.patch("modal.image.ImageBuilderVersion", Literal["2000.01"]),
+        mock.patch("test.conftest.ImageBuilderVersion", Literal["2023.11"]),
+        Client(servicer.remote_addr, api_pb2.CLIENT_TYPE_CONTAINER, ("ak-123", "as-xyz")) as client,
+        stub.run(client=client),
+    ):
+        pass
 
 
 @skip_windows("Different hash values for context file paths")

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -445,7 +445,7 @@ def tmp_path_with_content(tmp_path):
     return tmp_path
 
 
-def test_image_copy_local_dir(builder_verison, servicer, client, tmp_path_with_content):
+def test_image_copy_local_dir(builder_version, servicer, client, tmp_path_with_content):
     stub = Stub()
     stub.image = Image.debian_slim().copy_local_dir(tmp_path_with_content, remote_path="/dummy")
 

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -59,10 +59,7 @@ def builder_version(request, server_url_env):
             return
         else:
             pytest.skip("Parameterized patching not working on Py3.8")
-    with (
-        mock.patch("test.conftest.ImageBuilderVersion", Literal[version]),  # type: ignore
-        mock.patch("modal.image._Image.builder_version", None),
-    ):
+    with mock.patch("test.conftest.ImageBuilderVersion", Literal[version]):  # type: ignore
         yield version
 
 

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -48,6 +48,13 @@ def get_image_layers(image_id: str, servicer) -> List[api_pb2.Image]:
 
 @pytest.fixture(params=get_args(ImageBuilderVersion))
 def builder_version(request, server_url_env):
+    if sys.version_info[:2] == (3, 8):
+        # TODO: The patch we're doing below is breaking on Python 3.8.
+        # Rather than debug that, I'm just going to skip it for now.
+        # This is a hack, but we'll likely drop support for 3.8 before adding
+        # any new versioned logic that would be exercised by this fixutre.
+        yield
+        return
     version = request.param
     with (
         mock.patch("test.conftest.ImageBuilderVersion", Literal[version]),  # type: ignore

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -648,12 +648,12 @@ def test_image_builder_version(servicer):
     with (
         mock.patch("test.conftest.ImageBuilderVersion", Literal["2000.01"]),
         mock.patch("modal.image.ImageBuilderVersion", Literal["2000.01"]),
-        Client(servicer.remote_addr, api_pb2.CLIENT_TYPE_CONTAINER, ("ak-123", "as-xyz")) as client,
-        stub.run(client=client),
     ):
-        assert servicer.image_builder_versions
-        for version in servicer.image_builder_versions.values():
-            assert version == "2000.01"
+        with Client(servicer.remote_addr, api_pb2.CLIENT_TYPE_CONTAINER, ("ak-123", "as-xyz")) as client:
+            with stub.run(client=client):
+                assert servicer.image_builder_versions
+                for version in servicer.image_builder_versions.values():
+                    assert version == "2000.01"
 
 
 def test_image_builder_supported_versions(servicer):
@@ -662,10 +662,10 @@ def test_image_builder_supported_versions(servicer):
         pytest.raises(VersionError, match=r"This version of the modal client supports.+{'2000.01'}"),
         mock.patch("modal.image.ImageBuilderVersion", Literal["2000.01"]),
         mock.patch("test.conftest.ImageBuilderVersion", Literal["2023.11"]),
-        Client(servicer.remote_addr, api_pb2.CLIENT_TYPE_CONTAINER, ("ak-123", "as-xyz")) as client,
-        stub.run(client=client),
     ):
-        pass
+        with Client(servicer.remote_addr, api_pb2.CLIENT_TYPE_CONTAINER, ("ak-123", "as-xyz")) as client:
+            with stub.run(client=client):
+                pass
 
 
 @skip_windows("Different hash values for context file paths")

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -643,9 +643,8 @@ def test_get_client_requirements_path(version, expected):
     assert os.path.basename(path) == expected
 
 
-@mock.patch("modal.image._Image.builder_version", None)
-@mock.patch("modal.image.ImageBuilderVersion", Literal["2000.01"])
 @mock.patch("test.conftest.ImageBuilderVersion", Literal["2000.01"])
+@mock.patch("modal.image.ImageBuilderVersion", Literal["2000.01"])
 def test_image_builder_version(client, servicer, server_url_env):
     stub = Stub(image=Image.debian_slim())
     with stub.run(client=client):
@@ -654,7 +653,6 @@ def test_image_builder_version(client, servicer, server_url_env):
             assert version == "2000.01"
 
 
-@mock.patch("modal.image._Image.builder_version", None)
 @mock.patch("modal.image.ImageBuilderVersion", Literal["2000.01"])
 @mock.patch("test.conftest.ImageBuilderVersion", Literal["2023.11"])
 def test_image_builder_supported_versions(client, servicer, server_url_env):

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -645,27 +645,25 @@ def test_get_client_requirements_path(version, expected):
 
 def test_image_builder_version(servicer):
     stub = Stub(image=Image.debian_slim())
-    with (
-        mock.patch("test.conftest.ImageBuilderVersion", Literal["2000.01"]),
-        mock.patch("modal.image.ImageBuilderVersion", Literal["2000.01"]),
-    ):
-        with Client(servicer.remote_addr, api_pb2.CLIENT_TYPE_CONTAINER, ("ak-123", "as-xyz")) as client:
-            with stub.run(client=client):
-                assert servicer.image_builder_versions
-                for version in servicer.image_builder_versions.values():
-                    assert version == "2000.01"
+    # TODO use a single with statement and tuple of managers when we drop Py3.8
+    with mock.patch("test.conftest.ImageBuilderVersion", Literal["2000.01"]):
+        with mock.patch("modal.image.ImageBuilderVersion", Literal["2000.01"]):
+            with Client(servicer.remote_addr, api_pb2.CLIENT_TYPE_CONTAINER, ("ak-123", "as-xyz")) as client:
+                with stub.run(client=client):
+                    assert servicer.image_builder_versions
+                    for version in servicer.image_builder_versions.values():
+                        assert version == "2000.01"
 
 
 def test_image_builder_supported_versions(servicer):
     stub = Stub(image=Image.debian_slim())
-    with (
-        pytest.raises(VersionError, match=r"This version of the modal client supports.+{'2000.01'}"),
-        mock.patch("modal.image.ImageBuilderVersion", Literal["2000.01"]),
-        mock.patch("test.conftest.ImageBuilderVersion", Literal["2023.11"]),
-    ):
-        with Client(servicer.remote_addr, api_pb2.CLIENT_TYPE_CONTAINER, ("ak-123", "as-xyz")) as client:
-            with stub.run(client=client):
-                pass
+    # TODO use a single with statement and tuple of managers when we drop Py3.8
+    with pytest.raises(VersionError, match=r"This version of the modal client supports.+{'2000.01'}"):
+        with mock.patch("modal.image.ImageBuilderVersion", Literal["2000.01"]):
+            with mock.patch("test.conftest.ImageBuilderVersion", Literal["2023.11"]):
+                with Client(servicer.remote_addr, api_pb2.CLIENT_TYPE_CONTAINER, ("ak-123", "as-xyz")) as client:
+                    with stub.run(client=client):
+                        pass
 
 
 @skip_windows("Different hash values for context file paths")


### PR DESCRIPTION
## Describe your changes

This is the final client-side step for enabling versioned Image builds. It uses the `image_builder_version` workspace config that is now sent to the client via `ClientHelloResponse` and passes it as a parameter to the `dockerfile_function` when loading an `Image`. I've also added some testing infrastructure to run image tests on all supported builder versions.
 
To keep the PR manageable, I haven't added any version-specific logic yet. I'll do that in subsequent targeted PRs. However the `builder_version` is now sent to the server in the `ImageGetOrCreateRequest` so we can update server-side logic that versions image builds with that.

- Resolves MOD-2584

## Backward/forward compatibility checks

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
