### PR TITLE
Simplify stub matching

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -38,7 +38,7 @@ from ._utils.async_utils import TaskContext, asyncify, synchronize_api, synchron
 from ._utils.blob_utils import MAX_OBJECT_SIZE_BYTES, blob_download, blob_upload
 from ._utils.function_utils import LocalFunctionError, is_async as get_is_async, is_global_function, method_has_params
 from ._utils.grpc_utils import retry_transient_errors
-from .app import _container_app, _ContainerApp, interact
+from .app import ContainerApp, _container_app, _ContainerApp, interact
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, Client, _Client
 from .cls import Cls
 from .config import config, logger
@@ -875,16 +875,21 @@ def import_function(
             raise InvalidError(f"Invalid function qualname {qual_name}")
 
     # If the cls/function decorator was applied in local scope, but the stub is global, we can look it up
-    if active_stub is None and function_def.stub_name:
+    if active_stub is None:
         # This branch is reached in the special case that the imported function is 1) not serialized, and 2) isn't a FunctionHandle - i.e, not decorated at definition time
         # Look at all instantiated stubs - if there is only one with the indicated name, use that one
-        matching_stubs = _Stub._all_stubs.get(function_def.stub_name, [])
+        stub_name: Optional[str] = function_def.stub_name or None  # coalesce protobuf field to None
+        matching_stubs = _Stub._all_stubs.get(stub_name, [])
         if len(matching_stubs) > 1:
+            if stub_name is not None:
+                warning_sub_message = f"stub with the same name ('{stub_name}')"
+            else:
+                warning_sub_message = "unnamed stub"
             logger.warning(
-                "You have multiple stubs with the same name which may prevent you from calling into other functions or using stub.is_inside(). It's recommended to name all your Stubs uniquely."
+                f"You have more than one {warning_sub_message}. It's recommended to name all your Stubs uniquely when using multiple stubs"
             )
         elif len(matching_stubs) == 1:
-            active_stub = matching_stubs[0]
+            active_stub, = matching_stubs
         # there could also technically be zero found stubs, but that should probably never be an issue since that would mean user won't use is_inside or other function handles anyway
 
     # Check this property before we turn it into a method (overriden by webhooks)
@@ -992,7 +997,7 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
     function_io_manager = FunctionIOManager(container_args, client)
 
     # Define a global app (need to do this before imports).
-    container_app = function_io_manager.initialize_app()
+    container_app: ContainerApp = function_io_manager.initialize_app()
 
     with function_io_manager.heartbeats(), UserCodeEventLoop() as event_loop:
         # If this is a serialized function, fetch the definition from the server
@@ -1012,7 +1017,14 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
                 client,
             )
 
+        # Initialize objects on the stub.
+        if imp_fun.stub is not None:
+            container_app.associate_stub_container(imp_fun.stub)
+
         # Hydrate all function dependencies.
+        # TODO(erikbern): we an remove this once we
+        # 1. Enable lazy hydration for all objects
+        # 2. Fully deprecate .new() objects
         if imp_fun.function:
             dep_object_ids: List[str] = [dep.object_id for dep in container_args.function_def.object_dependencies]
             container_app.hydrate_function_deps(imp_fun.function, dep_object_ids)

--- a/modal/app.py
+++ b/modal/app.py
@@ -259,25 +259,19 @@ class _ContainerApp:
     def fetching_inputs(self) -> bool:
         return self._fetching_inputs
 
-    def _associate_stub_container(self, stub):
-        if self._associated_stub:
-            if self._stub_name:
-                warning_sub_message = f"stub with the same name ('{self._stub_name}')"
-            else:
-                warning_sub_message = "unnamed stub"
-            logger.warning(
-                f"You have more than one {warning_sub_message}. It's recommended to name all your Stubs uniquely when using multiple stubs"
-            )
+    def associate_stub_container(self, stub):
+        # TODO(erikbern): the fact that we need to set two-way references strongly indicate that
+        # we should just merge these two objects!
         self._associated_stub = stub
+        stub._container_app = self
 
-        if stub:
-            # Initialize objects on stub
-            stub_objects: dict[str, _Object] = dict(stub.get_objects())
-            for tag, object_id in self._tag_to_object_id.items():
-                obj = stub_objects.get(tag)
-                if obj is not None:
-                    handle_metadata = self._object_handle_metadata[object_id]
-                    obj._hydrate(object_id, self._client, handle_metadata)
+        # Initialize objects on stub
+        stub_objects: dict[str, _Object] = dict(stub.get_objects())
+        for tag, object_id in self._tag_to_object_id.items():
+            obj = stub_objects.get(tag)
+            if obj is not None:
+                handle_metadata = self._object_handle_metadata[object_id]
+                obj._hydrate(object_id, self._client, handle_metadata)
 
     def _has_object(self, tag: str) -> bool:
         return tag in self._tag_to_object_id

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -15,7 +15,7 @@ from ._resolver import Resolver
 from ._utils.async_utils import synchronize_api
 from ._utils.function_utils import FunctionInfo
 from ._utils.mount_utils import validate_volumes
-from .app import _container_app, _ContainerApp, _LocalApp, is_local
+from .app import _ContainerApp, _LocalApp
 from .client import _Client
 from .cls import _Cls
 from .config import logger
@@ -117,7 +117,7 @@ class _Stub:
     _local_entrypoints: Dict[str, _LocalEntrypoint]
     _container_app: Optional[_ContainerApp]
     _local_app: Optional[_LocalApp]
-    _all_stubs: ClassVar[Dict[str, List["_Stub"]]] = {}
+    _all_stubs: ClassVar[Dict[Optional[str], List["_Stub"]]] = {}
 
     def __init__(
         self,
@@ -174,14 +174,8 @@ class _Stub:
         self._local_app = None  # when this is the launcher process
         self._container_app = None  # when this is inside a container
 
-        string_name = self._name or ""
-
-        if not is_local() and _container_app._stub_name == string_name:
-            _container_app._associate_stub_container(self)
-            # note that all stubs with the correct name will get the container app assigned
-            self._container_app = _container_app
-
-        _Stub._all_stubs.setdefault(string_name, []).append(self)
+        # Register this stub. This is used to look up the stub in the container, when we can't get it from the function
+        _Stub._all_stubs.setdefault(self._name, []).append(self)
 
     @property
     def name(self) -> Optional[str]:

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -402,7 +402,7 @@ def test_rehydrate(client, servicer):
     app.init(client, app_id, "stub")
 
     # Associate app with stub
-    app._associate_stub_container(stub)
+    app.associate_stub_container(stub)
 
     # Hydration shouldn't overwrite local function definition
     obj = Foo()

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -24,6 +24,9 @@ async def test_container_function_lazily_imported(unix_servicer, container_clien
     await container_app.init.aio(container_client, "ap-123")
     stub = Stub()
 
+    # This is normally done in _container_entrypoint
+    container_app.associate_stub_container(stub)
+
     # Now, let's create my_f after the app started running and make sure it works
     my_f_container = stub.function()(my_f_1)
     assert await my_f_container.remote.aio(42) == 1764  # type: ignore

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -736,10 +736,9 @@ def test_multistub(unix_servicer, caplog):
     deploy_stub_externally(unix_servicer, "test.supports.multistub", "a")
     ret = _run_container(unix_servicer, "test.supports.multistub", "a_func")
     assert _unwrap_scalar(ret) is None
-    assert (
-        len(caplog.messages) == 1
-    )  # warns in case the user would use is_inside checks... Hydration should work regardless
-    assert "You have more than one unnamed stub" in caplog.messages[0]
+    assert len(caplog.messages) == 0
+    # Note that the stub can be inferred from the function, even though there are multiple
+    # stubs present in the file
 
 
 @skip_windows_unix_socket

--- a/test/webhook_test.py
+++ b/test/webhook_test.py
@@ -38,7 +38,7 @@ async def test_webhook(servicer, client):
         # Make sure the container gets the app id as well
         container_app = ContainerApp()
         await ContainerApp.init.aio(client, stub.app_id)
-        container_app._associate_stub_container(stub)
+        container_app.associate_stub_container(stub)
         assert isinstance(f, Function)
         assert f.web_url
 


### PR DESCRIPTION
Was looking at the app/stub code and noticed a quick thing to clean up. The flow used to be very confusing and we were doing the stub matching in basically two places:

1. In the `Stub` constructor in global scope (by triggering `_container_app._associate_stub_container`)
2. In `import_function` in `_container_entrypoint.py`

The second one is a bit more safe since you avoid any partially initialized state. This PR basically removes the first one. This also lets us avoid a warning in the cases where the stub can be uniquely inferred from the function (see the test I updated).

The reason the code used to be more complex is we had to support hydrating images in global for `is_inside()`. Since this is deprecated, we can simplify the code.

This PR would have been net red if it wasn't for a bunch of comments I added