### PR TITLE
Avoid errors when Image.run_commands commands are empty strings

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -773,11 +773,11 @@ class _Image(_Object, type_prefix="im"):
     ) -> "_Image":
         """Extend an image with a list of shell commands to run."""
         cmds = _flatten_str_args("run_commands", "commands", commands)
-        if not cmds:
+        if not cmds or not any(cmds):
             return self
 
         def build_dockerfile() -> DockerfileSpec:
-            return DockerfileSpec(commands=["FROM base"] + [f"RUN {cmd}" for cmd in cmds], context_files={})
+            return DockerfileSpec(commands=["FROM base"] + [f"RUN {cmd}" for cmd in cmds if cmd], context_files={})
 
         return _Image._from_args(
             base_images={"base": self},


### PR DESCRIPTION
Helps avoids a confusing error that a user ran into (empty or whitespace strings produce Dockerfile syntax that looks like `RUN  `).

Arguably we could raise here, but given that we already "gracefully" handle an empty list, dropping empty commands feels more consistent.

- Resolves MOD-2626

## Changelog

- `Image.run_commands` will now skip empty strings or strings containing only whitespace characters, which otherwise produce malformed Dockerfile syntax.