### PR TITLE
Add image_builder_version to ClientHelloResponse

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -547,6 +547,7 @@ message ClientCreateResponse {
 
 message ClientHelloResponse {
   string warning = 1;
+  string image_builder_version = 2;
 }
 
 message ClientHeartbeatRequest {


### PR DESCRIPTION
Adds `image_builder_version` as a field in the `ClientHelloResponse` message. ~Also removes the (forever unused) `ImageBuilderVersion*` message and rpc protos.~

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
