### PR TITLE
Misc cleanup of `ContainerApp` and `LocalApp`

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -155,7 +155,7 @@ class _FunctionIOManager:
         assert isinstance(self._client, _Client)
 
     async def initialize_app(self) -> _ContainerApp:
-        await _container_app.init(self._client, self.app_id, self._environment_name, self.function_def)
+        await _container_app.init(self._client, self.app_id, self.function_def)
         return _container_app
 
     async def _run_heartbeat_loop(self):

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -144,7 +144,6 @@ class _FunctionIOManager:
         self.current_input_id: Optional[str] = None
         self.current_input_started_at: Optional[float] = None
 
-        self._stub_name = self.function_def.stub_name
         self._input_concurrency: Optional[int] = None
 
         self._semaphore: Optional[asyncio.Semaphore] = None
@@ -156,7 +155,7 @@ class _FunctionIOManager:
         assert isinstance(self._client, _Client)
 
     async def initialize_app(self) -> _ContainerApp:
-        await _container_app.init(self._client, self.app_id, self._stub_name, self._environment_name, self.function_def)
+        await _container_app.init(self._client, self.app_id, self._environment_name, self.function_def)
         return _container_app
 
     async def _run_heartbeat_loop(self):

--- a/modal/app.py
+++ b/modal/app.py
@@ -1,5 +1,5 @@
 # Copyright Modal Labs 2022
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypeVar
+from typing import TYPE_CHECKING, Dict, List, Optional, TypeVar
 
 from google.protobuf.empty_pb2 import Empty
 from google.protobuf.message import Message

--- a/modal/app.py
+++ b/modal/app.py
@@ -222,7 +222,6 @@ class _LocalApp:
 class _ContainerApp:
     _client: Optional[_Client]
     _app_id: Optional[str]
-    _environment_name: Optional[str]
     _tag_to_object_id: Dict[str, str]
     _object_handle_metadata: Dict[str, Optional[Message]]
     # if true, there's an active PTY shell session connected to this process.
@@ -233,7 +232,6 @@ class _ContainerApp:
     def __init__(self):
         self._client = None
         self._app_id = None
-        self._environment_name = None
         self._tag_to_object_id = {}
         self._object_handle_metadata = {}
         self._is_interactivity_enabled = False
@@ -287,7 +285,6 @@ class _ContainerApp:
         self,
         client: _Client,
         app_id: str,
-        environment_name: str = "",
         function_def: Optional[api_pb2.Function] = None,
     ):
         """Used by the container to bootstrap the app and all its objects. Not intended to be called by Modal users."""
@@ -296,7 +293,6 @@ class _ContainerApp:
 
         self._client = client
         self._app_id = app_id
-        self._environment_name = environment_name
         self._function_def = function_def
         self._tag_to_object_id = {}
         self._object_handle_metadata = {}

--- a/modal/app.py
+++ b/modal/app.py
@@ -222,7 +222,6 @@ class _LocalApp:
 class _ContainerApp:
     _client: Optional[_Client]
     _app_id: Optional[str]
-    _associated_stub: Optional[Any]  # TODO(erikbern): type
     _environment_name: Optional[str]
     _tag_to_object_id: Dict[str, str]
     _object_handle_metadata: Dict[str, Optional[Message]]
@@ -234,7 +233,6 @@ class _ContainerApp:
     def __init__(self):
         self._client = None
         self._app_id = None
-        self._associated_stub = None
         self._environment_name = None
         self._tag_to_object_id = {}
         self._object_handle_metadata = {}
@@ -256,9 +254,6 @@ class _ContainerApp:
         return self._fetching_inputs
 
     def associate_stub_container(self, stub):
-        # TODO(erikbern): the fact that we need to set two-way references strongly indicate that
-        # we should just merge these two objects!
-        self._associated_stub = stub
         stub._container_app = self
 
         # Initialize objects on stub

--- a/modal/app.py
+++ b/modal/app.py
@@ -37,7 +37,6 @@ class _LocalApp:
         app_id: str,
         app_page_url: str,
         tag_to_object_id: Optional[Dict[str, str]] = None,
-        stub_name: Optional[str] = None,
         environment_name: Optional[str] = None,
         interactive: bool = False,
     ):
@@ -46,7 +45,6 @@ class _LocalApp:
         self._app_page_url = app_page_url
         self._client = client
         self._tag_to_object_id = tag_to_object_id or {}
-        self._stub_name = stub_name
         self._environment_name = environment_name
         self._interactive = interactive
 
@@ -228,7 +226,6 @@ class _ContainerApp:
     _environment_name: Optional[str]
     _tag_to_object_id: Dict[str, str]
     _object_handle_metadata: Dict[str, Optional[Message]]
-    _stub_name: Optional[str]
     # if true, there's an active PTY shell session connected to this process.
     _is_interactivity_enabled: bool
     _function_def: Optional[api_pb2.Function]
@@ -238,7 +235,6 @@ class _ContainerApp:
         self._client = None
         self._app_id = None
         self._associated_stub = None
-        self._stub_name = None
         self._environment_name = None
         self._tag_to_object_id = {}
         self._object_handle_metadata = {}
@@ -296,7 +292,6 @@ class _ContainerApp:
         self,
         client: _Client,
         app_id: str,
-        stub_name: str = "",
         environment_name: str = "",
         function_def: Optional[api_pb2.Function] = None,
     ):
@@ -306,7 +301,6 @@ class _ContainerApp:
 
         self._client = client
         self._app_id = app_id
-        self._stub_name = stub_name
         self._environment_name = environment_name
         self._function_def = function_def
         self._tag_to_object_id = {}

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -399,7 +399,7 @@ def test_rehydrate(client, servicer):
 
     # Initialize a container
     app = ContainerApp()
-    app.init(client, app_id, "stub")
+    app.init(client, app_id)
 
     # Associate app with stub
     app.associate_stub_container(stub)


### PR DESCRIPTION
I'm slowly trying to get rid of those two classes and move the functionality into `Stub`. Getting rid of some stuff that definitely isn't used in this PR. #1611 created a lot of the opportunity for cleanup.

Eventually, this will let us rename `Stub` to `App`