### PR TITLE
Remove unused ImageBuilderVersionLookup protos

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1228,10 +1228,6 @@ message Image {
   BuildFunction build_function = 21;
 }
 
-message ImageBuilderVersionLookupResponse {
-  string version = 1;
-}
-
 message ImageContextFile {
   string filename = 1;
   bytes data = 2;
@@ -2070,7 +2066,6 @@ service ModalClient {
   // Images
   rpc ImageGetOrCreate(ImageGetOrCreateRequest) returns (ImageGetOrCreateResponse);
   rpc ImageJoinStreaming(ImageJoinStreamingRequest) returns (stream ImageJoinStreamingResponse);
-  rpc ImageBuilderVersionLookup(google.protobuf.Empty) returns (ImageBuilderVersionLookupResponse);
 
   // Mounts
   rpc MountPutFile(MountPutFileRequest) returns (MountPutFileResponse);


### PR DESCRIPTION
Has server-side dependency on https://github.com/modal-labs/modal/pull/11482/

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself