### PR TITLE
[skip ci] Fix type stub generation

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -197,7 +197,7 @@ def type_stubs(ctx):
         return [
             name
             for name, obj in vars(module).items()
-            if not module_name.startswith("modal.cli")  # TODO we don't handle typer-wrapped functions well
+            if not module_name.startswith("modal.cli.")  # TODO we don't handle typer-wrapped functions well
             and hasattr(obj, "__module__")
             and obj.__module__ == module_name
             and not name.startswith("_")  # Avoid deprecation of _App.__getattr__


### PR DESCRIPTION
Fixes a really dumb bug that caused us to stop generating type stubs for `modal.client`.