### PR TITLE
Require ClientHello to have run before creating objects

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -70,6 +70,9 @@ class _LocalApp:
         output_mgr: Optional[OutputManager] = None,
     ):  # api_pb2.AppState.V
         """Create objects that have been defined but not created on the server."""
+        if not self._client.authenticated:
+            raise ExecutionError("Objects cannot be created with an unauthenticated client")
+
         resolver = Resolver(
             self._client,
             output_mgr=output_mgr,

--- a/modal/client.py
+++ b/modal/client.py
@@ -2,11 +2,13 @@
 import asyncio
 import platform
 import warnings
-from typing import Awaitable, Callable, Dict, Optional, Tuple
+from typing import AsyncIterator, Awaitable, Callable, Dict, Optional, Tuple
 
+import grpclib.client
 from aiohttp import ClientConnectorError, ClientResponseError
 from google.protobuf import empty_pb2
 from grpclib import GRPCError, Status
+from synchronicity.async_wrap import asynccontextmanager
 
 from modal_proto import api_grpc, api_pb2
 from modal_version import __version__
@@ -75,32 +77,28 @@ async def _http_check(url: str, timeout: float) -> str:
 
 async def _grpc_exc_string(exc: GRPCError, method_name: str, server_url: str, timeout: float) -> str:
     http_status = await _http_check(server_url, timeout=timeout)
-    return f"{method_name}: {exc.message} [GRPC status: {exc.status.name}, {http_status}]"
+    return f"{method_name}: {exc.message} [gRPC status: {exc.status.name}, {http_status}]"
 
 
 class _Client:
     _client_from_env = None
     _client_from_env_lock = None
 
-    client_type: int
-
     def __init__(
         self,
-        server_url,
-        client_type,
-        credentials,
-        version=__version__,
-        *,
-        no_verify=False,
+        server_url: str,
+        client_type: int,
+        credentials: Optional[Tuple[str, str]],
+        version: str = __version__,
     ):
         """The Modal client object is not intended to be instantiated directly by users."""
         self.server_url = server_url
         self.client_type = client_type
         self.credentials = credentials
         self.version = version
-        self.no_verify = no_verify
+        self._authenticated = False
         self._pre_stop: Optional[Callable[[], Awaitable[None]]] = None
-        self._channel = None
+        self._channel: Optional[grpclib.client.Channel] = None
         self._stub: Optional[api_grpc.ModalClientStub] = None
 
     @property
@@ -108,13 +106,15 @@ class _Client:
         """mdmd:hidden"""
         return self._stub
 
+    @property
+    def authenticated(self) -> bool:
+        """mdmd:hidden"""
+        return self._authenticated
+
     async def _open(self):
         assert self._stub is None
         metadata = _get_metadata(self.client_type, self.credentials, self.version)
-        self._channel = create_channel(
-            self.server_url,
-            metadata=metadata,
-        )
+        self._channel = create_channel(self.server_url, metadata=metadata)
         self._stub = api_grpc.ModalClientStub(self._channel)  # type: ignore
 
     async def _close(self):
@@ -138,7 +138,8 @@ class _Client:
         # ref: github.com/modal-labs/modal-client/pull/108
         self._pre_stop = pre_stop
 
-    async def _verify(self):
+    async def _init(self):
+        """Connect to server and retrieve version information; raise appropriate error for various failures."""
         logger.debug("Client: Starting")
         _check_config()
         try:
@@ -152,10 +153,11 @@ class _Client:
             if resp.warning:
                 ALARM_EMOJI = chr(0x1F6A8)
                 warnings.warn(f"{ALARM_EMOJI} {resp.warning} {ALARM_EMOJI}", DeprecationError)
+            self._authenticated = True
         except GRPCError as exc:
             if exc.status == Status.FAILED_PRECONDITION:
                 raise VersionError(
-                    f"The client version {self.version} is too old. Please update to the latest package on PyPi: https://pypi.org/project/modal"
+                    f"The client version ({self.version}) is too old. Please update (pip install --update modal)."
                 )
             elif exc.status == Status.UNAUTHENTICATED:
                 raise AuthError(exc.message)
@@ -167,40 +169,42 @@ class _Client:
 
     async def __aenter__(self):
         await self._open()
-        if not self.no_verify:
-            try:
-                await self._verify()
-            except BaseException:
-                await self._close()
-                raise
+        try:
+            await self._init()
+        except BaseException:
+            await self._close()
+            raise
         return self
 
     async def __aexit__(self, exc_type, exc, tb):
         await self._close()
 
     @classmethod
-    async def verify(cls, server_url, credentials):
-        """mdmd:hidden"""
-        async with _Client(server_url, api_pb2.CLIENT_TYPE_CLIENT, credentials):
-            pass  # Will call ClientHello
-
-    @classmethod
-    async def unauthenticated_client(cls, server_url: str):
-        """mdmd:hidden"""
-        # Create a connection with no credentials
-        # To be used with the token flow
-        return _Client(server_url, api_pb2.CLIENT_TYPE_CLIENT, None, no_verify=True)
+    @asynccontextmanager
+    async def anonymous(cls, server_url: str) -> AsyncIterator["_Client"]:
+        """mdmd:hidden
+        Create a connection with no credentials; to be used for token creation.
+        """
+        logger.debug("Client: Starting client without authentication")
+        client = cls(server_url, api_pb2.CLIENT_TYPE_CLIENT, credentials=None)
+        try:
+            await client._open()
+            # Skip client._init
+            yield client
+        finally:
+            await client._close()
 
     @classmethod
     async def from_env(cls, _override_config=None) -> "_Client":
-        """mdmd:hidden"""
+        """mdmd:hidden
+        Singleton that is instantiated from the Modal config and reused on subsequent calls.
+        """
         if _override_config:
             # Only used for testing
             c = _override_config
         else:
             c = config
 
-        # Sets server_url to socket file path if proxy is available.
         server_url = c["server_url"]
 
         token_id = c["token_id"]
@@ -229,13 +233,13 @@ class _Client:
                 await client._open()
                 async_utils.on_shutdown(client._close())
                 try:
-                    await client._verify()
+                    await client._init()
                 except AuthError:
                     if not credentials:
                         creds_missing_msg = (
-                            "Token missing. Could not authenticate client. "
-                            "If you have token credentials, see modal.com/docs/reference/modal.config for setup help. "
-                            "If you are a new user, register an account at modal.com, then run `modal token new`."
+                            "Token missing. Could not authenticate client."
+                            " If you have token credentials, see modal.com/docs/reference/modal.config for setup help."
+                            " If you are a new user, register an account at modal.com, then run `modal token new`."
                         )
                         raise AuthError(creds_missing_msg)
                     else:
@@ -245,15 +249,29 @@ class _Client:
 
     @classmethod
     async def from_credentials(cls, token_id: str, token_secret: str) -> "_Client":
-        """mdmd:hidden"""
+        """mdmd:hidden
+        Constructor based on token credentials; useful for managing Modal on behalf of third-party users.
+        """
+        server_url = config["server_url"]
         client_type = api_pb2.CLIENT_TYPE_CLIENT
         credentials = (token_id, token_secret)
-        server_url = config["server_url"]
-
         client = _Client(server_url, client_type, credentials)
         await client._open()
+        try:
+            await client._init()
+        except BaseException:
+            await client._close()
+            raise
         async_utils.on_shutdown(client._close())
         return client
+
+    @classmethod
+    async def verify(cls, server_url: str, credentials: Tuple[str, str]) -> None:
+        """mdmd:hidden
+        Check whether can the client can connect to this server with these credentials; raise if not.
+        """
+        async with cls(server_url, api_pb2.CLIENT_TYPE_CLIENT, credentials):
+            pass  # Will call ClientHello RPC and possibly raise AuthError or ConnectionError
 
     @classmethod
     def set_env_client(cls, client: Optional["_Client"]):

--- a/modal/token_flow.py
+++ b/modal/token_flow.py
@@ -78,8 +78,7 @@ async def _new_token(
     console = Console()
 
     result: Optional[api_pb2.TokenFlowWaitResponse] = None
-    client = await _Client.unauthenticated_client(server_url)
-    async with client:
+    async with _Client.anonymous(server_url) as client:
         token_flow = _TokenFlow(client)
 
         async with token_flow.start(source, next_url) as (_, web_url, code):


### PR DESCRIPTION
Moderate refactoring / renaming of methods on `Client` with the main functional change that we now require the `ClientHello` RPC to have been run before creating any objects:

- I renamed `Client._verify` to `Client._init` to make it more clear that it's an initialization step (we plan to use this method to retrieve the image builder version — and perhaps other information — that will be needed later).
- I added a `Client.authenticated` property, which is set when `Client._init` runs. This is checked by `_LocalApp._create_all_objects`. We plan to remove `_LocalApp`; but I assume we'll just port `_create_all_objects` somewhere else? This may affect the behavior of `Client.from_credentials` (presumably by improving the error message returned for bad credentials?)
- I renamed `Client.unauthenticated_client` to `Client.anonymous`, since the client can be in an unauthenticated or authenticated state depending on whether  `._init` has been called, and the purpose of this method is to create a client without a token (i.e., not associated with any specific workspace)
- I made a few marginal improvements to the code quality e.g. filling in some type annotations and docstrings, making the `classmethod` actually use `cls` (no practical effect now since we don't have `Client` subtypes), etc.

- Resolves MOD-2674