### PR TITLE
Make the `modal launch` commands less hacky

### DIFF
--- a/modal/cli/launch.py
+++ b/modal/cli/launch.py
@@ -1,10 +1,18 @@
 # Copyright Modal Labs 2023
-import subprocess
-import tempfile
+import asyncio
+import inspect
+import json
+import os
 from pathlib import Path
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from typer import Typer
+
+from modal.exception import _CliUserExecutionError
+
+from ..runner import run_stub
+from ..stub import Stub
+from .import_refs import import_function
 
 launch_cli = Typer(
     name="launch",
@@ -17,16 +25,25 @@ launch_cli = Typer(
 )
 
 
-def _launch_program(name: str, args) -> None:
-    contents = (Path(__file__).parent / "programs" / name).read_text()
-    contents = contents.replace("args: Dict[str, Any] = {}", f"args: Any = {repr(args)}")
+def _launch_program(name: str, filename: str, args: Dict[str, Any]) -> None:
+    os.environ["MODAL_LAUNCH_LOCAL_ARGS"] = json.dumps(args)
 
-    # TODO: This is a big hack and can break for unexpected $PATH reasons. Make an actual code path
-    # for correctly setting up and running a program in the CLI.
-    with tempfile.TemporaryDirectory() as tmpdir:
-        f = Path(tmpdir) / name
-        f.write_text(contents)
-        subprocess.run(["modal", "run", f])
+    program_path = str(Path(__file__).parent / "programs" / filename)
+    entrypoint = import_function(program_path, "modal launch")
+    stub: Stub = entrypoint.stub
+    stub.set_description(f"modal launch {name}")
+
+    # `launch/` scripts must have a `local_entrypoint()` with no args, for simplicity here.
+    func = entrypoint.info.raw_f
+    isasync = inspect.iscoroutinefunction(func)
+    with run_stub(stub):
+        try:
+            if isasync:
+                asyncio.run(func())
+            else:
+                func()
+        except Exception as exc:
+            raise _CliUserExecutionError(inspect.getsourcefile(func)) from exc
 
 
 @launch_cli.command(name="jupyter", help="Start Jupyter Lab on Modal.")
@@ -46,7 +63,7 @@ def jupyter(
         "image": image,
         "add_python": add_python,
     }
-    _launch_program("run_jupyter.py", args)
+    _launch_program("jupyter", "run_jupyter.py", args)
 
 
 @launch_cli.command(name="vscode", help="Start Visual Studio Code on Modal.")
@@ -62,4 +79,4 @@ def vscode(
         "gpu": gpu,
         "timeout": timeout,
     }
-    _launch_program("vscode.py", args)
+    _launch_program("vscode", "vscode.py", args)

--- a/modal/cli/launch.py
+++ b/modal/cli/launch.py
@@ -8,8 +8,7 @@ from typing import Any, Dict, Optional
 
 from typer import Typer
 
-from modal.exception import _CliUserExecutionError
-
+from ..exception import _CliUserExecutionError
 from ..runner import run_stub
 from ..stub import Stub
 from .import_refs import import_function

--- a/modal/cli/programs/run_jupyter.py
+++ b/modal/cli/programs/run_jupyter.py
@@ -1,5 +1,6 @@
 # Copyright Modal Labs 2023
 # type: ignore
+import json
 import os
 import secrets
 import socket
@@ -11,7 +12,9 @@ from typing import Any, Dict
 
 from modal import Image, Queue, Stub, forward
 
-args: Dict[str, Any] = {}
+# Passed by `modal launch` locally via CLI, empty on remote runner.
+args: Dict[str, Any] = json.loads(os.environ.get("MODAL_LAUNCH_LOCAL_ARGS", "{}"))
+
 
 stub = Stub()
 stub.image = Image.from_registry(args.get("image"), add_python=args.get("add_python")).pip_install("jupyterlab")
@@ -21,11 +24,11 @@ def wait_for_port(url: str, q: Queue):
     start_time = time.monotonic()
     while True:
         try:
-            with socket.create_connection(("localhost", 8888), timeout=15.0):
+            with socket.create_connection(("localhost", 8888), timeout=30.0):
                 break
         except OSError as exc:
             time.sleep(0.01)
-            if time.monotonic() - start_time >= 15.0:
+            if time.monotonic() - start_time >= 30.0:
                 raise TimeoutError("Waited too long for port 8888 to accept connections") from exc
     q.put(url)
 
@@ -58,7 +61,7 @@ def run_jupyter(q: Queue):
 @stub.local_entrypoint()
 def main():
     with Queue.ephemeral() as q:
-        stub.run_jupyter.spawn(q)
+        run_jupyter.spawn(q)
         url = q.get()
         time.sleep(1)  # Give Jupyter a chance to start up
         print("\nJupyter on Modal, opening in browser...")

--- a/modal/cli/programs/vscode.py
+++ b/modal/cli/programs/vscode.py
@@ -1,5 +1,6 @@
 # Copyright Modal Labs 2023
 # type: ignore
+import json
 import os
 import secrets
 import socket
@@ -11,7 +12,9 @@ from typing import Any, Dict, Tuple
 
 from modal import Image, Queue, Stub, forward
 
-args: Dict[str, Any] = {}
+# Passed by `modal launch` locally via CLI, empty on remote runner.
+args: Dict[str, Any] = json.loads(os.environ.get("MODAL_LAUNCH_LOCAL_ARGS", "{}"))
+
 
 stub = Stub()
 stub.image = Image.from_registry("codercom/code-server", add_python="3.11").dockerfile_commands("ENTRYPOINT []")
@@ -21,11 +24,11 @@ def wait_for_port(data: Tuple[str, str], q: Queue):
     start_time = time.monotonic()
     while True:
         try:
-            with socket.create_connection(("localhost", 8080), timeout=15.0):
+            with socket.create_connection(("localhost", 8080), timeout=30.0):
                 break
         except OSError as exc:
             time.sleep(0.01)
-            if time.monotonic() - start_time >= 15.0:
+            if time.monotonic() - start_time >= 30.0:
                 raise TimeoutError("Waited too long for port 8080 to accept connections") from exc
     q.put(data)
 
@@ -47,9 +50,9 @@ def run_vscode(q: Queue):
 @stub.local_entrypoint()
 def main():
     with Queue.ephemeral() as q:
-        stub.run_vscode.spawn(q)
+        run_vscode.spawn(q)
         url, token = q.get()
-        time.sleep(1)  # Give Jupyter a chance to start up
+        time.sleep(1)  # Give VS Code a chance to start up
         print("\nVS Code on Modal, opening in browser...")
         print(f"   -> {url}")
         print(f"   -> password: {token}\n")


### PR DESCRIPTION
They previously spun up an entire subprocess and did find/replace writing to a tempfile within the code, which caused breakage that @gimaker graciously fixed in #1617.

It also makes `modal launch` commands show up in the dashboard like this:

<img width="544" alt="image" src="https://github.com/modal-labs/modal-client/assets/7550632/d337f353-a494-4feb-a8af-dd0cc99687dc">


We can avoid spinning up an entire subprocess by creating an environment variable instead. This is not completely foolproof, since environment variables don't appear on the remote runner (which is questionable!), but at least it avoids the issue that we ran into previously.