### PR TITLE
Try testing the client with protobuf 5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     click>=8.1.0
     fastapi
     grpclib==0.4.7
-    protobuf>=3.19,<5.0,!=4.24.0
+    protobuf>=3.19,<6.0,!=4.24.0
     rich>=12.0.0
     synchronicity~=0.6.3
     toml


### PR DESCRIPTION
Protobuf 5.26 was released [earlier this month](https://pypi.org/project/protobuf/#history). We pin <5.0 for the local client, I assume just to be conservative, but I am testing whether there are any issues in CI.