### PR TITLE
Remove `_LocalApp.stop`

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -124,11 +124,6 @@ class _LocalApp:
         await retry_transient_errors(self.client.stub.AppClientDisconnect, req_disconnect)
         logger.debug("App disconnected")
 
-    async def stop(self):
-        """Tell the server to stop this app, terminating all running tasks."""
-        req_disconnect = api_pb2.AppStopRequest(app_id=self.app_id, source=api_pb2.APP_STOP_SOURCE_PYTHON_CLIENT)
-        await retry_transient_errors(self.client.stub.AppStop, req_disconnect)
-
 
 class _ContainerApp:
     client: Optional[_Client]


### PR DESCRIPTION
afaict this method isn't used

We call `AppStop` separately in `modal/cli/app.py` though