### PR TITLE
Move some functionality from ContainerApp to Stub

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -1017,6 +1017,7 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
 
     # Define a global app (need to do this before imports).
     container_app: ContainerApp = function_io_manager.initialize_app()
+    _container_app = synchronizer._translate_in(container_app)  # TODO(erikbern): hacky
 
     with function_io_manager.heartbeats(), UserCodeEventLoop() as event_loop:
         # If this is a serialized function, fetch the definition from the server
@@ -1038,7 +1039,7 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
 
         # Initialize objects on the stub.
         if imp_fun.stub is not None:
-            container_app.associate_stub_container(imp_fun.stub)
+            imp_fun.stub._init_container(_container_app)
 
         # Hydrate all function dependencies.
         # TODO(erikbern): we an remove this once we

--- a/modal/app.py
+++ b/modal/app.py
@@ -145,25 +145,6 @@ class _ContainerApp:
         self.is_interactivity_enabled = False
         self.fetching_inputs = True
 
-    def associate_stub_container(self, stub):
-        stub._container_app = self
-
-        # Initialize objects on stub
-        stub_objects: dict[str, _Object] = dict(stub.get_objects())
-        for tag, object_id in self.tag_to_object_id.items():
-            obj = stub_objects.get(tag)
-            if obj is not None:
-                handle_metadata = self.object_handle_metadata[object_id]
-                obj._hydrate(object_id, self.client, handle_metadata)
-
-    def _has_object(self, tag: str) -> bool:
-        return tag in self.tag_to_object_id
-
-    def _hydrate_object(self, obj, tag: str):
-        object_id: str = self.tag_to_object_id[tag]
-        metadata: Message = self.object_handle_metadata[object_id]
-        obj._hydrate(object_id, self.client, metadata)
-
     def hydrate_function_deps(self, function: _Function, dep_object_ids: List[str]):
         function_deps = function.deps(only_explicit_mounts=True)
         if len(function_deps) != len(dep_object_ids):

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -402,7 +402,7 @@ def test_rehydrate(client, servicer):
     app.init(client, app_id)
 
     # Associate app with stub
-    app.associate_stub_container(stub)
+    stub._init_container(app)
 
     # Hydration shouldn't overwrite local function definition
     obj = Foo()

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -25,7 +25,7 @@ async def test_container_function_lazily_imported(unix_servicer, container_clien
     stub = Stub()
 
     # This is normally done in _container_entrypoint
-    container_app.associate_stub_container(stub)
+    stub._init_container(container_app)
 
     # Now, let's create my_f after the app started running and make sure it works
     my_f_container = stub.function()(my_f_1)

--- a/test/webhook_test.py
+++ b/test/webhook_test.py
@@ -38,7 +38,7 @@ async def test_webhook(servicer, client):
         # Make sure the container gets the app id as well
         container_app = ContainerApp()
         await ContainerApp.init.aio(client, stub.app_id)
-        container_app.associate_stub_container(stub)
+        stub._init_container(container_app)
         assert isinstance(f, Function)
         assert f.web_url
 


### PR DESCRIPTION
Behavioral noop, just moving functionality from one class to another

The goal here is to reduce the complexity of `ContainerApp` and `LocalApp` to the point where we can put them on the stub instead.