### PR TITLE
Remove old DATA_FORMAT_UNSPECIFIED handling

### DIFF
--- a/modal/_serialization.py
+++ b/modal/_serialization.py
@@ -294,9 +294,6 @@ def serialize_data_format(obj: Any, data_format: int) -> bytes:
 
 
 def deserialize_data_format(s: bytes, data_format: int, client) -> Any:
-    if data_format == api_pb2.DATA_FORMAT_UNSPECIFIED:
-        # TODO: Remove this after Modal client version 0.52, when the data_format field is always set.
-        return deserialize(s, client)
     if data_format == api_pb2.DATA_FORMAT_PICKLE:
         return deserialize(s, client)
     elif data_format == api_pb2.DATA_FORMAT_ASGI:

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -107,7 +107,7 @@ enum CloudProvider {
 
 // Which data format a binary message is encoded with.
 enum DataFormat {
-  DATA_FORMAT_UNSPECIFIED = 0; // Equivalent to PICKLE in client version 0.52 and earlier.
+  DATA_FORMAT_UNSPECIFIED = 0;
   DATA_FORMAT_PICKLE = 1; // Cloudpickle
   DATA_FORMAT_ASGI = 2; // "Asgi" protobuf message
   DATA_FORMAT_GENERATOR_DONE = 3; // "GeneratorDone" protobuf message


### PR DESCRIPTION
As of April 1, we no longer support client version 0.52.

Removing this fallback case helps catch issues early and improves the consistency of our data model.