### PR TITLE
Fix lazy hydration for Dict, Queue, Volume, NetworkFileSystem

### DIFF
--- a/modal/_utils/grpc_testing.py
+++ b/modal/_utils/grpc_testing.py
@@ -175,7 +175,10 @@ class InterceptionContext:
                 self.calls = self.calls[i + 1 :]
                 return msg
 
-        raise Exception(f"No message of that type in call list: {self.calls}")
+        raise KeyError(f"No message of that type in call list: {self.calls}")
+
+    def get_requests(self, method_name: str) -> List[Any]:
+        return [msg for _method_name, msg in self.calls if _method_name == method_name]
 
 
 class InterceptedStream:

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -144,7 +144,7 @@ class _Dict(_Object, type_prefix="di"):
             logger.debug(f"Created dict with id {response.dict_id}")
             self._hydrate(response.dict_id, resolver.client, None)
 
-        return _Dict._from_loader(_load, "Dict()", is_another_app=True)
+        return _Dict._from_loader(_load, "Dict()", is_another_app=True, hydrate_lazily=True)
 
     @staticmethod
     def persisted(

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -142,7 +142,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
             response = await resolver.client.stub.SharedVolumeGetOrCreate(req)
             self._hydrate(response.shared_volume_id, resolver.client, None)
 
-        return _NetworkFileSystem._from_loader(_load, "NetworkFileSystem()")
+        return _NetworkFileSystem._from_loader(_load, "NetworkFileSystem()", hydrate_lazily=True)
 
     @classmethod
     @asynccontextmanager

--- a/modal/object.py
+++ b/modal/object.py
@@ -211,7 +211,8 @@ class _Object:
                 " wasn't defined in global scope."
             )
         else:
-            resolver = Resolver()  # TODO: this resolver has no attached Client!
+            # TODO: this client and/or resolver can't be changed by a caller to X.from_name()
+            resolver = Resolver(await _Client.from_env())
             await resolver.load(self)
 
 

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -175,7 +175,7 @@ class _Queue(_Object, type_prefix="qu"):
             response = await resolver.client.stub.QueueGetOrCreate(req)
             self._hydrate(response.queue_id, resolver.client, None)
 
-        return _Queue._from_loader(_load, "Queue()", is_another_app=True)
+        return _Queue._from_loader(_load, "Queue()", is_another_app=True, hydrate_lazily=True)
 
     @staticmethod
     def persisted(

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -153,7 +153,7 @@ class _Volume(_Object, type_prefix="vo"):
             response = await resolver.client.stub.VolumeGetOrCreate(req)
             self._hydrate(response.volume_id, resolver.client, None)
 
-        return _Volume._from_loader(_load, "Volume()")
+        return _Volume._from_loader(_load, "Volume()", hydrate_lazily=True)
 
     @classmethod
     @asynccontextmanager

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -14,10 +14,8 @@ from unittest import mock
 
 import click
 import click.testing
-import pytest_asyncio
 import toml
 
-from modal import Client
 from modal.cli.entry_point import entrypoint_cli
 from modal_proto import api_pb2
 
@@ -37,15 +35,6 @@ assert mod.stub == stub
 """
 
 dummy_other_module_file = "x = 42"
-
-
-@pytest_asyncio.fixture
-async def set_env_client(client):
-    try:
-        Client.set_env_client(client)
-        yield
-    finally:
-        Client.set_env_client(None)
 
 
 def _run(args: List[str], expected_exit_code: int = 0, expected_stderr: Optional[str] = ""):

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -23,6 +23,14 @@ from .supports.base_class import BaseCls2
 stub = Stub("stub")
 
 
+@pytest.fixture(autouse=True)
+def auto_use_set_env_client(set_env_client):
+    # TODO(elias): remove set_env_client fixture here if/when possible - this is required only since
+    #  Client.from_env happens to inject an unused client when loading the
+    #  parameterized function
+    return
+
+
 @stub.cls(cpu=42)
 class Foo:
     @method()
@@ -92,7 +100,6 @@ def test_call_cls_remote_modal_type(client):
     with stub_remote.run(client=client):
         with Queue.ephemeral(client) as q:
             FooRemote(42, q)  # type: ignore
-
 
 
 stub_2 = Stub()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1433,3 +1433,12 @@ def modal_config():
 @pytest.fixture
 def supports_dir(test_dir):
     return test_dir / Path("supports")
+
+
+@pytest_asyncio.fixture
+async def set_env_client(client):
+    try:
+        Client.set_env_client(client)
+        yield
+    finally:
+        Client.set_env_client(None)

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -920,7 +920,8 @@ def test_call_function_that_calls_function(unix_servicer):
 
 
 @skip_windows_unix_socket
-def test_call_function_that_calls_method(unix_servicer):
+def test_call_function_that_calls_method(unix_servicer, set_env_client):
+    # TODO (elias): Remove set_env_client fixture dependency - shouldn't need an env client here?
     deploy_stub_externally(unix_servicer, "test.supports.functions", "stub")
     ret = _run_container(
         unix_servicer,

--- a/test/dict_test.py
+++ b/test/dict_test.py
@@ -33,7 +33,10 @@ def test_dict_ephemeral(servicer, client):
     assert servicer.n_dict_heartbeats == 2
 
 
-def test_dict_lazy_hydrate_named(set_env_client):
-    d = Dict.from_name("foo", create_if_missing=True)
-    d["foo"] = 42
-    assert d["foo"] == 42
+def test_dict_lazy_hydrate_named(set_env_client, servicer):
+    with servicer.intercept() as ctx:
+        d = Dict.from_name("foo", create_if_missing=True)
+        assert len(ctx.get_requests("DictGetOrCreate")) == 0  # sanity check that the get request is lazy
+        d["foo"] = 42
+        assert d["foo"] == 42
+        assert len(ctx.get_requests("DictGetOrCreate")) == 1  # just sanity check that object is only hydrated once...

--- a/test/dict_test.py
+++ b/test/dict_test.py
@@ -33,7 +33,7 @@ def test_dict_ephemeral(servicer, client):
     assert servicer.n_dict_heartbeats == 2
 
 
-def test_dict_lazy_hydrate_named(servicer, client):
+def test_dict_lazy_hydrate_named(set_env_client):
     d = Dict.from_name("foo", create_if_missing=True)
     d["foo"] = 42
     assert d["foo"] == 42

--- a/test/dict_test.py
+++ b/test/dict_test.py
@@ -31,3 +31,9 @@ def test_dict_ephemeral(servicer, client):
         assert d["bar"] == 123
         time.sleep(1.5)  # Make time for 2 heartbeats
     assert servicer.n_dict_heartbeats == 2
+
+
+def test_dict_lazy_hydrate_named(servicer, client):
+    d = Dict.from_name("foo", create_if_missing=True)
+    d["foo"] = 42
+    assert d["foo"] == 42

--- a/test/network_file_system_test.py
+++ b/test/network_file_system_test.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
 import pytest
 import time
+from io import BytesIO
 from unittest import mock
 
 import modal
@@ -179,3 +180,9 @@ def test_nfs_ephemeral(servicer, client, tmp_path):
 
         time.sleep(1.5)  # Make time for 2 heartbeats
     assert servicer.n_nfs_heartbeats == 2
+
+
+def test_nfs_lazy_hydration_from_name(set_env_client):
+    nfs = modal.NetworkFileSystem.from_name("nfs", create_if_missing=True)
+    bio = BytesIO(b"content")
+    nfs.write_file("blah", bio)

--- a/test/queue_test.py
+++ b/test/queue_test.py
@@ -102,3 +102,9 @@ def test_queue_nonblocking_put(servicer, client):
 def test_queue_deploy(servicer, client):
     d = Queue.lookup("xyz", create_if_missing=True, client=client)
     d.put(123)
+
+
+def test_queue_lazy_hydrate_from_name(set_env_client):
+    q = Queue.from_name("foo", create_if_missing=True)
+    q.put(123)
+    assert q.get() == 123

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -339,3 +339,8 @@ def test_ephemeral(servicer, client):
         # TODO(erikbern): perform some operations
         time.sleep(1.5)  # Make time for 2 heartbeats
     assert servicer.n_vol_heartbeats == 2
+
+
+def test_lazy_hydration_from_named(set_env_client):
+    vol = modal.Volume.from_name("my-vol", create_if_missing=True)
+    assert vol.listdir("**") == []


### PR DESCRIPTION
This should fix most, if not all, hydration issues that users have had lately.

Looking into other object types too, and they should be pretty straight forward imo

As a shortcut I just inject the `Client.from_env()` client where a client was currently missing and not readily accessible, which feels a bit like a crutch. Preferably, we should find a nice way to inject a client directly in `from_name()` (mostly to make tests cleaner)