### PR TITLE
simplify `_ContainerApp`

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -39,7 +39,7 @@ from ._utils.async_utils import TaskContext, asyncify, synchronize_api, synchron
 from ._utils.blob_utils import MAX_OBJECT_SIZE_BYTES, blob_download, blob_upload
 from ._utils.function_utils import LocalFunctionError, is_async as get_is_async, is_global_function, method_has_params
 from ._utils.grpc_utils import retry_transient_errors
-from .app import ContainerApp, _container_app, _init_container_app, _ContainerApp, interact
+from .app import _container_app, _init_container_app, interact
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, Client, _Client
 from .cls import Cls
 from .config import config, logger
@@ -155,8 +155,8 @@ class _FunctionIOManager:
         self._client = client
         assert isinstance(self._client, _Client)
 
-    async def initialize_app(self) -> _ContainerApp:
-        return await _init_container_app(self._client, self.app_id, self._environment_name, self.function_def)
+    async def initialize_container_app(self):
+        await _init_container_app(self._client, self.app_id, self._environment_name, self.function_def)
 
     async def _run_heartbeat_loop(self):
         while 1:
@@ -1015,9 +1015,8 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
     # At some point, we should fix that by having built-in support for running "user code"
     function_io_manager = FunctionIOManager(container_args, client)
 
-    # Define a global app (need to do this before imports).
-    container_app: ContainerApp = function_io_manager.initialize_app()
-    _container_app = synchronizer._translate_in(container_app)  # TODO(erikbern): hacky
+    # Need to set up the container app before imports (since user may check it in global scope)
+    function_io_manager.initialize_container_app()
 
     with function_io_manager.heartbeats(), UserCodeEventLoop() as event_loop:
         # If this is a serialized function, fetch the definition from the server

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -39,7 +39,7 @@ from ._utils.async_utils import TaskContext, asyncify, synchronize_api, synchron
 from ._utils.blob_utils import MAX_OBJECT_SIZE_BYTES, blob_download, blob_upload
 from ._utils.function_utils import LocalFunctionError, is_async as get_is_async, is_global_function, method_has_params
 from ._utils.grpc_utils import retry_transient_errors
-from .app import _container_app, _set_is_container_app, init_container_app, interact
+from .app import _container_app, init_container_app, interact
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, Client, _Client
 from .cls import Cls
 from .config import config, logger
@@ -1013,7 +1013,6 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
     function_io_manager = FunctionIOManager(container_args, client)
 
     # Need to set up the container app before imports (since user may check it in global scope)
-    _set_is_container_app()
     init_container_app(client, container_args.app_id, container_args.environment_name, container_args.function_def)
 
     with function_io_manager.heartbeats(), UserCodeEventLoop() as event_loop:

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -39,7 +39,7 @@ from ._utils.async_utils import TaskContext, asyncify, synchronize_api, synchron
 from ._utils.blob_utils import MAX_OBJECT_SIZE_BYTES, blob_download, blob_upload
 from ._utils.function_utils import LocalFunctionError, is_async as get_is_async, is_global_function, method_has_params
 from ._utils.grpc_utils import retry_transient_errors
-from .app import _container_app, _init_container_app, interact
+from .app import _container_app, _init_container_app, _set_is_container_app, interact
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, Client, _Client
 from .cls import Cls
 from .config import config, logger
@@ -156,6 +156,7 @@ class _FunctionIOManager:
         assert isinstance(self._client, _Client)
 
     async def initialize_container_app(self):
+        _set_is_container_app()
         await _init_container_app(self._client, self.app_id, self._environment_name, self.function_def)
 
     async def _run_heartbeat_loop(self):

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -39,7 +39,7 @@ from ._utils.async_utils import TaskContext, asyncify, synchronize_api, synchron
 from ._utils.blob_utils import MAX_OBJECT_SIZE_BYTES, blob_download, blob_upload
 from ._utils.function_utils import LocalFunctionError, is_async as get_is_async, is_global_function, method_has_params
 from ._utils.grpc_utils import retry_transient_errors
-from .app import ContainerApp, _container_app, _ContainerApp, interact
+from .app import ContainerApp, _container_app, _init_container_app, _ContainerApp, interact
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, Client, _Client
 from .cls import Cls
 from .config import config, logger
@@ -156,8 +156,7 @@ class _FunctionIOManager:
         assert isinstance(self._client, _Client)
 
     async def initialize_app(self) -> _ContainerApp:
-        await _container_app.init(self._client, self.app_id, self._environment_name, self.function_def)
-        return _container_app
+        return await _init_container_app(self._client, self.app_id, self._environment_name, self.function_def)
 
     async def _run_heartbeat_loop(self):
         while 1:

--- a/modal/app.py
+++ b/modal/app.py
@@ -85,6 +85,11 @@ container_app = synchronize_api(_container_app)
 assert isinstance(container_app, ContainerApp)
 
 
+def _set_is_container_app():
+    global _is_container_app
+    _is_container_app = True
+
+
 async def _init_container_app(
     client: _Client,
     app_id: str,
@@ -92,8 +97,7 @@ async def _init_container_app(
     function_def: Optional[api_pb2.Function] = None,
 ):
     """Used by the container to bootstrap the app and all its objects. Not intended to be called by Modal users."""
-    global _is_container_app, _container_app
-    _is_container_app = True
+    global _container_app
 
     _container_app.client = client
     _container_app.app_id = app_id

--- a/modal/app.py
+++ b/modal/app.py
@@ -116,6 +116,9 @@ async def _init_container_app(
             _container_app.tag_to_object_id[item.tag] = item.object.object_id
 
 
+init_container_app = synchronize_api(_init_container_app)
+
+
 async def _interact(client: Optional[_Client] = None) -> None:
     if _container_app.is_interactivity_enabled:
         # Currently, interactivity is enabled forever

--- a/modal/app.py
+++ b/modal/app.py
@@ -90,7 +90,7 @@ async def _init_container_app(
     app_id: str,
     environment_name: str = "",
     function_def: Optional[api_pb2.Function] = None,
-) -> _ContainerApp:
+):
     """Used by the container to bootstrap the app and all its objects. Not intended to be called by Modal users."""
     global _is_container_app, _container_app
     _is_container_app = True
@@ -110,8 +110,6 @@ async def _init_container_app(
         logger.debug(f"Setting metadata for {item.object.object_id} ({item.tag})")
         if item.tag:
             _container_app.tag_to_object_id[item.tag] = item.object.object_id
-
-    return _container_app
 
 
 async def _interact(client: Optional[_Client] = None) -> None:

--- a/modal/app.py
+++ b/modal/app.py
@@ -65,33 +65,6 @@ class _ContainerApp:
         self.is_interactivity_enabled = False
         self.fetching_inputs = True
 
-    async def init(
-        self,
-        client: _Client,
-        app_id: str,
-        environment_name: str = "",
-        function_def: Optional[api_pb2.Function] = None,
-    ):
-        """Used by the container to bootstrap the app and all its objects. Not intended to be called by Modal users."""
-        global _is_container_app
-        _is_container_app = True
-
-        self.client = client
-        self.app_id = app_id
-        self.environment_name = environment_name
-        self.function_def = function_def
-        self.tag_to_object_id = {}
-        self.object_handle_metadata = {}
-        req = api_pb2.AppGetObjectsRequest(app_id=app_id, include_unindexed=True)
-        resp = await retry_transient_errors(client.stub.AppGetObjects, req)
-        logger.debug(f"AppGetObjects received {len(resp.items)} objects for app {app_id}")
-        for item in resp.items:
-            handle_metadata: Optional[Message] = get_proto_oneof(item.object, "handle_metadata_oneof")
-            self.object_handle_metadata[item.object.object_id] = handle_metadata
-            logger.debug(f"Setting metadata for {item.object.object_id} ({item.tag})")
-            if item.tag:
-                self.tag_to_object_id[item.tag] = item.object.object_id
-
     @staticmethod
     def _reset_container():
         # Just used for tests
@@ -110,6 +83,35 @@ _is_container_app = False
 _container_app = _ContainerApp()
 container_app = synchronize_api(_container_app)
 assert isinstance(container_app, ContainerApp)
+
+
+async def _init_container_app(
+    client: _Client,
+    app_id: str,
+    environment_name: str = "",
+    function_def: Optional[api_pb2.Function] = None,
+) -> _ContainerApp:
+    """Used by the container to bootstrap the app and all its objects. Not intended to be called by Modal users."""
+    global _is_container_app, _container_app
+    _is_container_app = True
+
+    _container_app.client = client
+    _container_app.app_id = app_id
+    _container_app.environment_name = environment_name
+    _container_app.function_def = function_def
+    _container_app.tag_to_object_id = {}
+    _container_app.object_handle_metadata = {}
+    req = api_pb2.AppGetObjectsRequest(app_id=app_id, include_unindexed=True)
+    resp = await retry_transient_errors(client.stub.AppGetObjects, req)
+    logger.debug(f"AppGetObjects received {len(resp.items)} objects for app {app_id}")
+    for item in resp.items:
+        handle_metadata: Optional[Message] = get_proto_oneof(item.object, "handle_metadata_oneof")
+        _container_app.object_handle_metadata[item.object.object_id] = handle_metadata
+        logger.debug(f"Setting metadata for {item.object.object_id} ({item.tag})")
+        if item.tag:
+            _container_app.tag_to_object_id[item.tag] = item.object.object_id
+
+    return _container_app
 
 
 async def _interact(client: Optional[_Client] = None) -> None:

--- a/modal/app.py
+++ b/modal/app.py
@@ -85,11 +85,6 @@ container_app = synchronize_api(_container_app)
 assert isinstance(container_app, ContainerApp)
 
 
-def _set_is_container_app():
-    global _is_container_app
-    _is_container_app = True
-
-
 async def _init_container_app(
     client: _Client,
     app_id: str,
@@ -97,8 +92,9 @@ async def _init_container_app(
     function_def: Optional[api_pb2.Function] = None,
 ):
     """Used by the container to bootstrap the app and all its objects. Not intended to be called by Modal users."""
-    global _container_app
+    global _container_app, _is_container_app
 
+    _is_container_app = True
     _container_app.client = client
     _container_app.app_id = app_id
     _container_app.environment_name = environment_name

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -7,7 +7,7 @@ from typing_extensions import assert_type
 
 from modal import Cls, Function, Image, Queue, Stub, build, enter, exit, method
 from modal._serialization import deserialize
-from modal.app import ContainerApp
+from modal.app import container_app, init_container_app
 from modal.exception import DeprecationError, ExecutionError, InvalidError
 from modal.partial_function import (
     _find_callables_for_obj,
@@ -394,7 +394,7 @@ def test_derived_cls_external_file(client, servicer):
         assert DerivedCls2().run.remote(3) == 9
 
 
-def test_rehydrate(client, servicer):
+def test_rehydrate(client, servicer, reset_container_app):
     # Issue introduced in #922 - brief description in #931
 
     # Sanity check that local calls work
@@ -405,11 +405,10 @@ def test_rehydrate(client, servicer):
     app_id = deploy_stub(stub, "my-cls-app", client=client).app_id
 
     # Initialize a container
-    app = ContainerApp()
-    app.init(client, app_id)
+    init_container_app(client, app_id)
 
     # Associate app with stub
-    stub._init_container(app)
+    stub._init_container(container_app)
 
     # Hydration shouldn't overwrite local function definition
     obj = Foo()

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -2,7 +2,7 @@
 import pytest
 
 from modal import Stub
-from modal.app import container_app
+from modal.app import container_app, init_container_app
 from modal_proto import api_pb2
 
 from .supports.skip import skip_windows_unix_socket
@@ -21,7 +21,7 @@ async def test_container_function_lazily_imported(unix_servicer, container_clien
     }
     unix_servicer.app_functions["fu-123"] = api_pb2.Function()
 
-    await container_app.init.aio(container_client, "ap-123")
+    await init_container_app.aio(container_client, "ap-123")
     stub = Stub()
 
     # This is normally done in _container_entrypoint

--- a/test/webhook_test.py
+++ b/test/webhook_test.py
@@ -8,7 +8,7 @@ from fastapi.testclient import TestClient
 
 from modal import Stub, asgi_app, web_endpoint, wsgi_app
 from modal._asgi import webhook_asgi_app
-from modal.app import ContainerApp
+from modal.app import container_app, init_container_app
 from modal.exception import InvalidError
 from modal.functions import Function
 from modal_proto import api_pb2
@@ -23,7 +23,7 @@ async def f(x):
 
 
 @pytest.mark.asyncio
-async def test_webhook(servicer, client):
+async def test_webhook(servicer, client, reset_container_app):
     async with stub.run(client=client):
         assert f.web_url
 
@@ -36,8 +36,7 @@ async def test_webhook(servicer, client):
         assert await f.local(100) == {"square": 10000}
 
         # Make sure the container gets the app id as well
-        container_app = ContainerApp()
-        await ContainerApp.init.aio(client, stub.app_id)
+        await init_container_app.aio(client, stub.app_id)
         stub._init_container(container_app)
         assert isinstance(f, Function)
         assert f.web_url


### PR DESCRIPTION
Making the initializer a global function instead (and cleaned up some tangentially related stuff)

Once this is merged, I can remove the synchronization of `_ContainerApp` and `_LocalApp` and turn them into simple dataclasses