### PR TITLE
Support "App" instead of "Stub"

### DIFF
--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -29,7 +29,7 @@ try:
     from .scheduler_placement import SchedulerPlacement
     from .secret import Secret
     from .shared_volume import SharedVolume
-    from .stub import Stub
+    from .stub import App, Stub
     from .volume import Volume
 except Exception:
     print()
@@ -42,6 +42,7 @@ except Exception:
 
 __all__ = [
     "__version__",
+    "App",
     "Client",
     "Cls",
     "Cron",

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -787,3 +787,15 @@ class _Stub:
 
 
 Stub = synchronize_api(_Stub)
+
+
+class _App(_Stub):
+    """This enables using an "App" class instead of "Stub".
+
+    We haven't announced this and started deprecating stubs yet, so this is for
+    forward compatibility reasons.
+    """
+    pass
+
+
+App = synchronize_api(_App)

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -126,6 +126,13 @@ def test_run(servicer, set_env_client, test_dir):
     _run(["run", file_with_entrypoint.as_posix() + "::stub.main"])
 
 
+def test_run_app(servicer, set_env_client, test_dir):
+    stub_file = test_dir / "supports" / "app_run_tests" / "stub_is_now_app.py"
+    _run(["run", stub_file.as_posix()])
+    _run(["run", stub_file.as_posix() + "::app"])
+    _run(["run", stub_file.as_posix() + "::foo"])
+
+
 def test_run_async(servicer, set_env_client, test_dir):
     sync_fn = test_dir / "supports" / "app_run_tests" / "local_entrypoint.py"
     res = _run(["run", sync_fn.as_posix()])

--- a/test/stub_test.py
+++ b/test/stub_test.py
@@ -7,7 +7,7 @@ from google.protobuf.empty_pb2 import Empty
 from grpclib import GRPCError, Status
 
 import modal.app
-from modal import Dict, Image, Queue, Stub, web_endpoint
+from modal import App, Dict, Image, Queue, Stub, web_endpoint
 from modal.config import config
 from modal.exception import DeprecationError, ExecutionError, InvalidError, NotFoundError
 from modal.partial_function import _parse_custom_domains
@@ -358,3 +358,11 @@ def test_hydrated_other_app_object_gets_referenced(servicer, client):
 def test_hasattr():
     stub = Stub()
     assert not hasattr(stub, "xyz")
+
+
+def test_app(client):
+    app = App()
+    square_modal = app.function()(square)
+
+    with app.run(client=client):
+        square_modal.remote(42)

--- a/test/supports/app_run_tests/stub_is_now_app.py
+++ b/test/supports/app_run_tests/stub_is_now_app.py
@@ -1,0 +1,9 @@
+# Copyright Modal Labs 2024
+import modal
+
+app = modal.App()
+
+
+@app.function()
+def foo():
+    print("foo")


### PR DESCRIPTION
This introduces a dummy subclass of Stub called App.

The point is forward compatibility with future versions (e.g. people look at future docs where we call it "App" and try to run it with older versions of the client). It's not an official launch in any way (it will take another few weeks probably)

Example:
```python
import modal

app = modal.App()

@app.function()
def xyz():
    print("hello")
```