### PR TITLE
Update Python versions used in Image constructors

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -52,6 +52,8 @@ def _validate_python_version(version: Optional[str], allow_micro_granularity: bo
         version = series_version = "{0}.{1}".format(*sys.version_info)
     elif not isinstance(version, str):
         raise InvalidError(f"Python version must be specified as a string, not {type(version).__name__}")
+    elif not re.match(r"^3(?:\.\d{1,2}){1,2}$", version):
+        raise InvalidError(f"Invalid Python version: {version!r}")
     else:
         components = version.split(".")
         if len(components) == 3 and not allow_micro_granularity:
@@ -59,8 +61,6 @@ def _validate_python_version(version: Optional[str], allow_micro_granularity: bo
                 "Python version must be specified as 'major.minor' for this interface;"
                 f" micro-level specification ({version!r}) is not valid."
             )
-        if not re.match(r"^3(?:\.\d{1,2}){1,2}$", version):
-            raise InvalidError(f"Invalid Python version: {version!r}")
         series_version = "{0}.{1}".format(*components)
 
     if series_version not in SUPPORTED_PYTHON_SERIES:

--- a/modal/image.py
+++ b/modal/image.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
 import contextlib
 import os
+import re
 import shlex
 import sys
 import typing
@@ -36,41 +37,69 @@ if typing.TYPE_CHECKING:
 # This is used for both type checking and runtime validation
 ImageBuilderVersion = Literal["2023.12", "2024.04"]
 
+# Note: we also define supported Python versions via logic at the top of the package __init__.py
+# so that we fail fast / clearly in unsupported containers. Additionally, we enumerate the supported
+# Python versions in mount.py where we specify the "standalone Python versions" we create mounts for.
+# Consider consolidating these multiple sources of truth?
+SUPPORTED_PYTHON_SERIES: Set[str] = {"3.8", "3.9", "3.10", "3.11", "3.12"}
+
 CONTAINER_REQUIREMENTS_PATH = "/modal_requirements.txt"
 
 
-def _validate_python_version(version: str) -> None:
-    components = version.split(".")
-    supported_versions = {"3.12", "3.11", "3.10", "3.9", "3.8"}
-    if len(components) == 2 and version in supported_versions:
-        return
-    elif len(components) == 3:
+def _validate_python_version(version: Optional[str], allow_micro_granularity: bool = True) -> str:
+    if version is None:
+        # If Python version is unspecified, match the local version, up to the minor component
+        version = series_version = "{0}.{1}".format(*sys.version_info)
+    elif not isinstance(version, str):
+        raise InvalidError(f"Python version must be specified as a string, not {type(version).__name__}")
+    else:
+        components = version.split(".")
+        if len(components) == 3 and not allow_micro_granularity:
+            raise InvalidError(
+                "Python version must be specified as 'major.minor' for this interface;"
+                f" micro-level specification ({version!r}) is not valid."
+            )
+        if not re.match(r"^3(?:\.\d{1,2}){1,2}$", version):
+            raise InvalidError(f"Invalid Python version: {version!r}")
+        series_version = "{0}.{1}".format(*components)
+
+    if series_version not in SUPPORTED_PYTHON_SERIES:
         raise InvalidError(
-            f"major.minor.patch version specification not valid. Supported major.minor versions are {supported_versions}."
+            f"Unsupported Python version: {version!r}."
+            " Modal supports versions in the following series: {supported_series!r}"
         )
-    raise InvalidError(f"Unsupported version {version}. Supported versions are {supported_versions}.")
+    return version
 
 
-def _dockerhub_python_version(python_version=None):
-    if python_version is None:
-        python_version = "%d.%d" % sys.version_info[:2]
+def _dockerhub_python_version(builder_version: ImageBuilderVersion, python_version: Optional[str] = None) -> str:
+    python_version = _validate_python_version(python_version)
+    components = python_version.split(".")
 
-    parts = python_version.split(".")
-
-    if len(parts) > 2:
+    # When user specifies a full Python version, use that
+    if len(components) > 2:
         return python_version
 
-    # We use the same major/minor version, but the highest micro version
-    # See https://hub.docker.com/_/python
+    # Otherwise, use the same series, but a specific micro version, corresponding to the latest
+    # available from https://hub.docker.com/_/python at the time of each image builder release.
     latest_micro_version = {
-        "3.12": "1",
-        "3.11": "0",
-        "3.10": "8",
-        "3.9": "15",
-        "3.8": "15",
+        "2023.12": {
+            "3.12": "1",
+            "3.11": "0",
+            "3.10": "8",
+            "3.9": "15",
+            "3.8": "15",
+        },
+        "2024.04": {
+            "3.12": "2",
+            "3.11": "8",
+            "3.10": "14",
+            "3.9": "19",
+            "3.8": "19",
+        },
     }
-    major_minor_version = ".".join(parts[:2])
-    python_version = major_minor_version + "." + latest_micro_version[major_minor_version]
+    python_series = "{0}.{1}".format(*components)
+    micro_version = latest_micro_version[builder_version][python_series]
+    python_version = f"{python_series}.{micro_version}"
     return python_version
 
 
@@ -839,14 +868,17 @@ class _Image(_Object, type_prefix="im"):
         )
 
     @staticmethod
-    def conda(python_version: str = "3.9", force_build: bool = False) -> "_Image":
+    def conda(python_version: Optional[str] = None, force_build: bool = False) -> "_Image":
         """
         A Conda base image, using miniconda3 and derived from the official Docker Hub image.
         In most cases, using [`Image.micromamba()`](/docs/reference/modal.Image#micromamba) with [`micromamba_install`](/docs/reference/modal.Image#micromamba_install) is recommended over `Image.conda()`, as it leads to significantly faster image build times.
         """
-        _validate_python_version(python_version)
 
         def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:
+            nonlocal python_version
+            if version == "2023.12" and python_version is None:
+                python_version = "3.9"  # Backcompat for old hardcoded default param
+            validated_python_version = _validate_python_version(python_version)
             requirements_path = _get_modal_requirements_path(version, python_version)
             context_files = {CONTAINER_REQUIREMENTS_PATH: requirements_path}
 
@@ -870,7 +902,7 @@ class _Image(_Object, type_prefix="im"):
                 # `No such device or address: '/usr/local/lib/libz.so' -> '/usr/local/lib/libz.so.c~'`
                 "&& conda config --set allow_softlinks false \\ ",
                 # Install requested Python version from conda-forge channel; base debian image has only 3.7.
-                f"&& conda install --yes --channel conda-forge python={python_version} \\ ",
+                f"&& conda install --yes --channel conda-forge python={validated_python_version} \\ ",
                 "&& conda update conda \\ ",
                 # Remove now unneeded packages and files.
                 "&& apt-get --quiet --yes remove curl bzip2 \\ ",
@@ -974,23 +1006,26 @@ class _Image(_Object, type_prefix="im"):
 
     @staticmethod
     def micromamba(
-        python_version: str = "3.9",
+        python_version: Optional[str] = None,
         force_build: bool = False,
     ) -> "_Image":
         """
         A Micromamba base image. Micromamba allows for fast building of small Conda-based containers.
         In most cases it will be faster than using [`Image.conda()`](/docs/reference/modal.Image#conda).
         """
-        _validate_python_version(python_version)
 
         def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:
+            nonlocal python_version
+            if version == "2023.12" and python_version is None:
+                python_version = "3.9"  # Backcompat for old hardcoded default param
+            validated_python_version = _validate_python_version(python_version)
             tag = "mambaorg/micromamba:1.3.1-bullseye-slim"
             setup_commands = [
                 'SHELL ["/usr/local/bin/_dockerfile_shell.sh"]',
                 "ENV MAMBA_DOCKERFILE_ACTIVATE=1",
-                f"RUN micromamba install -n base -y python={python_version} pip -c conda-forge",
+                f"RUN micromamba install -n base -y python={validated_python_version} pip -c conda-forge",
             ]
-            commands = _Image._registry_setup_commands(tag, version, setup_commands, add_python=None)
+            commands = _Image._registry_setup_commands(tag, version, setup_commands)
             context_files = {CONTAINER_REQUIREMENTS_PATH: _get_modal_requirements_path(version, python_version)}
             return DockerfileSpec(commands=commands, context_files=context_files)
 
@@ -1039,10 +1074,11 @@ class _Image(_Object, type_prefix="im"):
         tag: str,
         builder_version: ImageBuilderVersion,
         setup_commands: List[str],
-        add_python: Optional[str],
+        add_python: Optional[str] = None,
     ) -> List[str]:
         add_python_commands: List[str] = []
         if add_python:
+            _validate_python_version(add_python, allow_micro_granularity=False)
             add_python_commands = [
                 "COPY /python/. /usr/local",
                 "RUN ln -s /usr/local/bin/python3 /usr/local/bin/python",
@@ -1282,7 +1318,7 @@ class _Image(_Object, type_prefix="im"):
         def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:
             requirements_path = _get_modal_requirements_path(version, python_version)
             context_files = {CONTAINER_REQUIREMENTS_PATH: requirements_path}
-            full_python_version = _dockerhub_python_version(python_version)
+            full_python_version = _dockerhub_python_version(version, python_version)
 
             commands = [
                 f"FROM python:{full_python_version}-slim-bullseye",

--- a/modal/image.py
+++ b/modal/image.py
@@ -66,7 +66,7 @@ def _validate_python_version(version: Optional[str], allow_micro_granularity: bo
     if series_version not in SUPPORTED_PYTHON_SERIES:
         raise InvalidError(
             f"Unsupported Python version: {version!r}."
-            " Modal supports versions in the following series: {supported_series!r}"
+            f" Modal supports versions in the following series: {SUPPORTED_PYTHON_SERIES!r}."
         )
     return version
 

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -54,7 +54,7 @@ def python_standalone_mount_name(version: str) -> str:
         libc = "gnu"
     if version not in PYTHON_STANDALONE_VERSIONS:
         raise modal.exception.InvalidError(
-            f"Unsupported standalone python version: {version}, supported values are {list(PYTHON_STANDALONE_VERSIONS.keys())}"
+            f"Unsupported standalone python version: {version!r}, supported values are {list(PYTHON_STANDALONE_VERSIONS)}"
         )
     if libc != "gnu":
         raise modal.exception.InvalidError(f"Unsupported libc identifier: {libc}")

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
 import os
 import pytest
+import re
 import sys
 import threading
 from hashlib import sha256
@@ -12,18 +13,21 @@ from modal import Image, Mount, Secret, Stub, build, gpu, method
 from modal._serialization import serialize
 from modal.client import Client
 from modal.exception import DeprecationError, InvalidError, VersionError
-from modal.image import ImageBuilderVersion, _dockerhub_python_version, _get_modal_requirements_path
+from modal.image import (
+    SUPPORTED_PYTHON_SERIES,
+    ImageBuilderVersion,
+    _dockerhub_python_version,
+    _get_modal_requirements_path,
+    _validate_python_version,
+)
+from modal.mount import PYTHON_STANDALONE_VERSIONS
 from modal_proto import api_pb2
 
 from .supports.skip import skip_windows
 
 
-def test_python_version():
-    assert _dockerhub_python_version("3.9.1") == "3.9.1"
-    assert _dockerhub_python_version("3.9") == "3.9.15"
-    v = _dockerhub_python_version().split(".")
-    assert len(v) == 3
-    assert (int(v[0]), int(v[1])) == sys.version_info[:2]
+def test_supported_python_series():
+    assert SUPPORTED_PYTHON_SERIES == PYTHON_STANDALONE_VERSIONS.keys()
 
 
 def get_image_layers(image_id: str, servicer) -> List[api_pb2.Image]:
@@ -47,21 +51,47 @@ def get_image_layers(image_id: str, servicer) -> List[api_pb2.Image]:
     return result
 
 
+def get_all_dockerfile_commands(image_id: str, servicer) -> str:
+    layers = get_image_layers(image_id, servicer)
+    return "\n".join([cmd for layer in layers for cmd in layer.dockerfile_commands])
+
+
 @pytest.fixture(params=get_args(ImageBuilderVersion))
 def builder_version(request, server_url_env):
     version = request.param
-    if sys.version_info[:2] == (3, 8):
-        # TODO: The patch we're doing below is breaking on Python 3.8.
-        # Rather than debug that, I'm just going to skip it for now.
-        # This is a hack, but we'll likely drop support for 3.8 before adding
-        # any new versioned logic that would be exercised by this fixutre.
-        if version == min(get_args(ImageBuilderVersion)):
-            yield
-            return
-        else:
-            pytest.skip("Parameterized patching not working on Py3.8")
     with mock.patch("test.conftest.ImageBuilderVersion", Literal[version]):  # type: ignore
         yield version
+
+
+def test_python_version_validation():
+    assert _validate_python_version("3.12") == "3.12"
+    assert _validate_python_version("3.12.0") == "3.12.0"
+
+    with pytest.raises(InvalidError, match="Unsupported Python version"):
+        _validate_python_version("3.7")
+
+    with pytest.raises(InvalidError, match="Python version must be specified as a string"):
+        _validate_python_version(3.10)  # type: ignore
+
+    with pytest.raises(InvalidError, match="Invalid Python version"):
+        _validate_python_version("3.10.2.9")
+
+    with pytest.raises(InvalidError, match="Invalid Python version"):
+        _validate_python_version("3.10.x")
+
+    with pytest.raises(InvalidError, match="Python version must be specified as 'major.minor'"):
+        _validate_python_version("3.10.5", allow_micro_granularity=False)
+
+
+def test_dockerhub_python_version(builder_version):
+    assert _dockerhub_python_version(builder_version, "3.9.1") == "3.9.1"
+
+    expected_39_full = {"2023.12": "3.9.15", "2024.04": "3.9.19"}[builder_version]
+    assert _dockerhub_python_version(builder_version, "3.9") == expected_39_full
+
+    v = _dockerhub_python_version(builder_version, None).split(".")
+    assert len(v) == 3
+    assert (int(v[0]), int(v[1])) == sys.version_info[:2]
 
 
 def test_image_base(builder_version, servicer, client, test_dir):
@@ -76,14 +106,36 @@ def test_image_base(builder_version, servicer, client, test_dir):
     for meth, args in constructors:
         stub.image = meth(*args)  # type: ignore
         with stub.run(client=client):
-            layers = get_image_layers(stub.image.object_id, servicer)
-            commands = "\n".join([cmd for layer in layers for cmd in layer.dockerfile_commands])
+            commands = get_all_dockerfile_commands(stub.image.object_id, servicer)
             assert "COPY /modal_requirements.txt /modal_requirements.txt" in commands
             if builder_version == "2023.12":
                 assert "pip install -r /modal_requirements.txt" in commands
             else:
                 assert "pip install --no-cache --no-deps -r /modal_requirements.txt" in commands
                 assert "rm /modal_requirements.txt" in commands
+
+
+@pytest.mark.parametrize("python_version", [None, "3.10", "3.11.4"])
+def test_python_version(builder_version, servicer, client, python_version):
+    local_python = "{0}.{1}".format(*sys.version_info)
+    expected_python = local_python if python_version is None else python_version
+
+    stub = Stub()
+    stub.image = Image.debian_slim(python_version)
+    expected_dockerhub_python = _dockerhub_python_version(builder_version, expected_python)
+    assert expected_dockerhub_python.startswith(expected_python)
+    with stub.run(client):
+        commands = get_all_dockerfile_commands(stub.image.object_id, servicer)
+        assert re.match(rf"FROM python:{expected_dockerhub_python}-slim-bullseye", commands)
+
+    if python_version is None and builder_version == "2023.12":
+        python_version = expected_python = "3.9"
+
+    for constructor in [Image.conda, Image.micromamba]:
+        stub.image = constructor(python_version)
+        with stub.run(client):
+            commands = get_all_dockerfile_commands(stub.image.object_id, servicer)
+            assert re.search(rf"install.* python={expected_python}", commands)
 
 
 def test_image_python_packages(builder_version, servicer, client):
@@ -664,17 +716,16 @@ def test_get_modal_requirements_path(builder_version, python_version):
 def test_image_builder_version(servicer, test_dir):
     stub = Stub(image=Image.debian_slim())
     # TODO use a single with statement and tuple of managers when we drop Py3.8
-    with mock.patch(
-        "modal.image._get_modal_requirements_path",
-        lambda *_, **__: str(test_dir / "supports" / "test-requirements.txt"),
-    ):
-        with mock.patch("test.conftest.ImageBuilderVersion", Literal["2000.01"]):
-            with mock.patch("modal.image.ImageBuilderVersion", Literal["2000.01"]):
-                with Client(servicer.remote_addr, api_pb2.CLIENT_TYPE_CONTAINER, ("ak-123", "as-xyz")) as client:
-                    with stub.run(client=client):
-                        assert servicer.image_builder_versions
-                        for version in servicer.image_builder_versions.values():
-                            assert version == "2000.01"
+    test_requirements = str(test_dir / "supports" / "test-requirements.txt")
+    with mock.patch("modal.image._get_modal_requirements_path", lambda *_, **__: test_requirements):
+        with mock.patch("modal.image._dockerhub_python_version", lambda *_, **__: "3.11.0"):
+            with mock.patch("test.conftest.ImageBuilderVersion", Literal["2000.01"]):
+                with mock.patch("modal.image.ImageBuilderVersion", Literal["2000.01"]):
+                    with Client(servicer.remote_addr, api_pb2.CLIENT_TYPE_CONTAINER, ("ak-123", "as-xyz")) as client:
+                        with stub.run(client=client):
+                            assert servicer.image_builder_versions
+                            for version in servicer.image_builder_versions.values():
+                                assert version == "2000.01"
 
 
 def test_image_builder_supported_versions(servicer):


### PR DESCRIPTION
More image builder updates, focusing on the way that we identify the version of Python to use in our images (specifically with version `2024.04`):

- For `debian_slim`, I updated the full `X.Y.Z` versions that we resolve `X.Y` arguments to, using the currently latest versions on Dockerhub
- For `conda` and `micromamba`, I made a few changes:
  - The default Python version will now match the local version — previously it was hardcoded to "3.9" — to be more consistent with other constructors
  - We now allow `X.Y.Z` specification (I am not sure why we rejected this previously)

Additionally, I improved the way that we validate and give feedback about the Python version specification and added some additional tests for this.

Note that we cannot update the micro versions that we create mounts for (i.e., to support `add_python=...`) because the context mount is not added to the image definition in a a way that can depend on the result of an RPC.

---
Part of MOD-2659
