### PR TITLE
Small fixes in image definitions

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -527,11 +527,9 @@ class _Image(_Object, type_prefix="im"):
         def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:
             package_args = " ".join(shlex.quote(pkg) for pkg in sorted(pkgs))
             extra_args = _make_pip_install_args(find_links, index_url, extra_index_url, pre)
-
-            if extra_args or version == "2023.12":  # Back-compat for old formatting
-                package_args += " "
-
-            commands = ["FROM base", f"RUN python -m pip install {package_args}{extra_args}"]
+            commands = ["FROM base", f"RUN python -m pip install {package_args} {extra_args}"]
+            if version > "2023.12":  # Back-compat for legacy trailing space
+                commands = [cmd.strip() for cmd in commands]
             return DockerfileSpec(commands=commands, context_files={})
 
         gpu_config = parse_gpu_config(gpu)
@@ -626,6 +624,8 @@ class _Image(_Object, type_prefix="im"):
             extra_args = _make_pip_install_args(find_links, index_url, extra_index_url, pre)
             commands.extend(["RUN apt-get update && apt-get install -y git"])
             commands.extend([f'RUN python3 -m pip install "{url}" {extra_args}' for url in install_urls])
+            if version > "2023.12":  # Back-compat for legacy trailing space
+                commands = [cmd.strip() for cmd in commands]
             return DockerfileSpec(commands=commands, context_files={})
 
         gpu_config = parse_gpu_config(gpu)
@@ -664,6 +664,8 @@ class _Image(_Object, type_prefix="im"):
                 "COPY /.requirements.txt /.requirements.txt",
                 f"RUN python -m pip install -r /.requirements.txt {find_links_arg} {extra_args}",
             ]
+            if version > "2023.12":  # Back-compat for legacy trailing space
+                commands = [cmd.strip() for cmd in commands]
             return DockerfileSpec(commands=commands, context_files=context_files)
 
         return _Image._from_args(
@@ -719,11 +721,10 @@ class _Image(_Object, type_prefix="im"):
 
             extra_args = _make_pip_install_args(find_links, index_url, extra_index_url, pre)
             package_args = " ".join(shlex.quote(pkg) for pkg in sorted(dependencies))
-
-            if extra_args or version == "2023.12":  # Back-compat for old formatting
-                package_args += " "
-
             commands = ["FROM base", f"RUN python -m pip install {package_args}{extra_args}"]
+            if version > "2023.12":  # Back-compat for legacy trailing space
+                commands = [cmd.strip() for cmd in commands]
+
             return DockerfileSpec(commands=commands, context_files={})
 
         return _Image._from_args(

--- a/modal/image.py
+++ b/modal/image.py
@@ -528,9 +528,8 @@ class _Image(_Object, type_prefix="im"):
             package_args = " ".join(shlex.quote(pkg) for pkg in sorted(pkgs))
             extra_args = _make_pip_install_args(find_links, index_url, extra_index_url, pre)
 
-            if version == "2023.12":
-                # Backwards compatability: we used to have a space in the string template
-                extra_args = " " + extra_args
+            if extra_args or version == "2023.12":  # Back-compat for old formatting
+                package_args += " "
 
             commands = ["FROM base", f"RUN python -m pip install {package_args}{extra_args}"]
             return DockerfileSpec(commands=commands, context_files={})
@@ -721,9 +720,8 @@ class _Image(_Object, type_prefix="im"):
             extra_args = _make_pip_install_args(find_links, index_url, extra_index_url, pre)
             package_args = " ".join(shlex.quote(pkg) for pkg in sorted(dependencies))
 
-            if version == "2023.12":
-                # Backwards compatability: we used to have a space in the string template
-                extra_args = " " + extra_args
+            if extra_args or version == "2023.12":  # Back-compat for old formatting
+                package_args += " "
 
             commands = ["FROM base", f"RUN python -m pip install {package_args}{extra_args}"]
             return DockerfileSpec(commands=commands, context_files={})

--- a/modal/image.py
+++ b/modal/image.py
@@ -528,7 +528,7 @@ class _Image(_Object, type_prefix="im"):
             package_args = " ".join(shlex.quote(pkg) for pkg in sorted(pkgs))
             extra_args = _make_pip_install_args(find_links, index_url, extra_index_url, pre)
             commands = ["FROM base", f"RUN python -m pip install {package_args} {extra_args}"]
-            if version > "2023.12":  # Back-compat for legacy trailing space
+            if version > "2023.12":  # Back-compat for legacy trailing space with empty extra_args
                 commands = [cmd.strip() for cmd in commands]
             return DockerfileSpec(commands=commands, context_files={})
 
@@ -624,7 +624,7 @@ class _Image(_Object, type_prefix="im"):
             extra_args = _make_pip_install_args(find_links, index_url, extra_index_url, pre)
             commands.extend(["RUN apt-get update && apt-get install -y git"])
             commands.extend([f'RUN python3 -m pip install "{url}" {extra_args}' for url in install_urls])
-            if version > "2023.12":  # Back-compat for legacy trailing space
+            if version > "2023.12":  # Back-compat for legacy trailing space with empty extra_args
                 commands = [cmd.strip() for cmd in commands]
             return DockerfileSpec(commands=commands, context_files={})
 
@@ -656,15 +656,16 @@ class _Image(_Object, type_prefix="im"):
             requirements_txt_path = os.path.expanduser(requirements_txt)
             context_files = {"/.requirements.txt": requirements_txt_path}
 
-            find_links_arg = f"-f {find_links}" if find_links else ""
+            null_find_links_arg = " " if version == "2023.12" else ""
+            find_links_arg = f" -f {find_links}" if find_links else null_find_links_arg
             extra_args = _make_pip_install_args(find_links, index_url, extra_index_url, pre)
 
             commands = [
                 "FROM base",
                 "COPY /.requirements.txt /.requirements.txt",
-                f"RUN python -m pip install -r /.requirements.txt {find_links_arg} {extra_args}",
+                f"RUN python -m pip install -r /.requirements.txt{find_links_arg} {extra_args}",
             ]
-            if version > "2023.12":  # Back-compat for legacy trailing space
+            if version > "2023.12":  # Back-compat for legacy whitespace with empty find_link / extra args
                 commands = [cmd.strip() for cmd in commands]
             return DockerfileSpec(commands=commands, context_files=context_files)
 
@@ -721,7 +722,7 @@ class _Image(_Object, type_prefix="im"):
 
             extra_args = _make_pip_install_args(find_links, index_url, extra_index_url, pre)
             package_args = " ".join(shlex.quote(pkg) for pkg in sorted(dependencies))
-            commands = ["FROM base", f"RUN python -m pip install {package_args}{extra_args}"]
+            commands = ["FROM base", f"RUN python -m pip install {package_args} {extra_args}"]
             if version > "2023.12":  # Back-compat for legacy trailing space
                 commands = [cmd.strip() for cmd in commands]
 

--- a/modal/image.py
+++ b/modal/image.py
@@ -139,9 +139,6 @@ def _flatten_str_args(function_name: str, arg_name: str, args: Tuple[Union[str, 
 
     Raises an error if any of the elements are not strings or string lists.
     """
-    # TODO(erikbern): maybe we can just build somthing intelligent that checks
-    # based on type annotations in real time?
-    # Or use something like this? https://github.com/FelixTheC/strongtyping
 
     def is_str_list(x):
         return isinstance(x, list) and all(isinstance(y, str) for y in x)
@@ -169,7 +166,7 @@ def _make_pip_install_args(
         ("--extra-index-url", extra_index_url),  # TODO(erikbern): allow multiple?
     ]
 
-    args = " ".join(flag + " " + shlex.quote(value) for flag, value in flags if value is not None)
+    args = " ".join(f"{flag} {shlex.quote(value)}" for flag, value in flags if value is not None)
     if pre:
         args += " --pre"
 
@@ -528,23 +525,21 @@ class _Image(_Object, type_prefix="im"):
             return self
 
         def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:
-            extra_args = _make_pip_install_args(find_links, index_url, extra_index_url, pre)
             package_args = " ".join(shlex.quote(pkg) for pkg in sorted(pkgs))
+            extra_args = _make_pip_install_args(find_links, index_url, extra_index_url, pre)
 
-            commands = [
-                "FROM base",
-                f"RUN python -m pip install {package_args} {extra_args}",
-                # TODO(erikbern): if extra_args is empty, we add a superfluous space at the end.
-                # However removing it at this point would cause image hashes to change.
-                # Maybe let's remove it later when/if client requirements change.
-            ]
+            if version == "2023.12":
+                # Backwards compatability: we used to have a space in the string template
+                extra_args = " " + extra_args
+
+            commands = ["FROM base", f"RUN python -m pip install {package_args}{extra_args}"]
             return DockerfileSpec(commands=commands, context_files={})
 
         gpu_config = parse_gpu_config(gpu)
         return _Image._from_args(
             base_images={"base": self},
             dockerfile_function=build_dockerfile,
-            force_build=self.force_build or force_build,  # TODO shouldn't forcing upstream build always rerun this?
+            force_build=self.force_build or force_build,
             gpu_config=gpu_config,
             secrets=secrets,
         )
@@ -726,13 +721,11 @@ class _Image(_Object, type_prefix="im"):
             extra_args = _make_pip_install_args(find_links, index_url, extra_index_url, pre)
             package_args = " ".join(shlex.quote(pkg) for pkg in sorted(dependencies))
 
-            commands = [
-                "FROM base",
-                f"RUN python -m pip install {package_args} {extra_args}",
-                # TODO(erikbern): if extra_args is empty, we add a superfluous space at the end.
-                # However removing it at this point would cause image hashes to change.
-                # Maybe let's remove it later when/if client requirements change.
-            ]
+            if version == "2023.12":
+                # Backwards compatability: we used to have a space in the string template
+                extra_args = " " + extra_args
+
+            commands = ["FROM base", f"RUN python -m pip install {package_args}{extra_args}"]
             return DockerfileSpec(commands=commands, context_files={})
 
         return _Image._from_args(
@@ -792,8 +785,10 @@ class _Image(_Object, type_prefix="im"):
                 context_files["/.poetry.lock"] = poetry_lockfile
                 commands += ["COPY /.poetry.lock /tmp/poetry/poetry.lock"]
 
-            # Indentation for back-compat TODO: fix when we update image_builder_version
-            install_cmd = "  poetry install --no-root"
+            install_cmd = "poetry install --no-root"
+            if version == "2023.12":
+                # Backwards compatability for previous string, which started with whitespace
+                install_cmd = "  " + install_cmd
 
             if with_:
                 install_cmd += f" --with {','.join(with_)}"
@@ -934,7 +929,6 @@ class _Image(_Object, type_prefix="im"):
             _namespace=api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL,
         )
 
-        # TODO include these in the base image once we version the build?
         return base.dockerfile_commands(
             [
                 "ENV CONDA_EXE=/usr/local/bin/conda",
@@ -1507,7 +1501,7 @@ class _Image(_Object, type_prefix="im"):
         """
 
         def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:
-            commands = ["FROM base"] + [f"WORKDIR {shlex.quote(path)}"]
+            commands = ["FROM base", f"WORKDIR {shlex.quote(path)}"]
             return DockerfileSpec(commands=commands, context_files={})
 
         return _Image._from_args(

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -150,7 +150,6 @@ def test_image_python_packages(builder_version, servicer, client):
     with stub.run(client=client):
         layers = get_image_layers(stub.image.object_id, servicer)
         assert any("pip install 'sklearn[xyz]'" in cmd for cmd in layers[1].dockerfile_commands)
-        print(*layers[0].dockerfile_commands, sep="\n")
         assert any(
             "pip install numpy scipy --find-links 'https://abc?q=123' --extra-index-url https://xyz --pre" in cmd
             for cmd in layers[0].dockerfile_commands

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -150,6 +150,7 @@ def test_image_python_packages(builder_version, servicer, client):
     with stub.run(client=client):
         layers = get_image_layers(stub.image.object_id, servicer)
         assert any("pip install 'sklearn[xyz]'" in cmd for cmd in layers[1].dockerfile_commands)
+        print(*layers[0].dockerfile_commands, sep="\n")
         assert any(
             "pip install numpy scipy --find-links 'https://abc?q=123' --extra-index-url https://xyz --pre" in cmd
             for cmd in layers[0].dockerfile_commands


### PR DESCRIPTION
Addresses a few TODOs in the code where we wanted to fix strange ways of spelling dockerfile commands without invaliding images. And a few random stylistic modifications.

I guess we could alternatively `rstrip()` all dockerfile commands in a more central location?

Part of MOD-2659