### PR TITLE
rename 'Function env' to 'Function spec'

### DIFF
--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -16,7 +16,7 @@ from typing_extensions import TypedDict
 from ..config import config
 from ..environments import ensure_env
 from ..exception import ExecutionError, InvalidError, _CliUserExecutionError
-from ..functions import Function, FunctionEnv
+from ..functions import Function, _FunctionSpec
 from ..image import Image
 from ..runner import deploy_stub, interactive_shell, run_stub
 from ..serving import serve_stub
@@ -380,18 +380,18 @@ def shell(
     if func_ref is not None:
         function = import_function(func_ref, accept_local_entrypoint=False, accept_webhook=True, base_cmd="modal shell")
         assert isinstance(function, Function)
-        function_env: FunctionEnv = function.env
+        function_spec: _FunctionSpec = function.spec
         start_shell = partial(
             interactive_shell,
-            image=function_env.image,
-            mounts=function_env.mounts,
-            secrets=function_env.secrets,
-            network_file_systems=function_env.network_file_systems,
-            gpu=function_env.gpu,
-            cloud=function_env.cloud,
-            cpu=function_env.cpu,
-            memory=function_env.memory,
-            volumes=function_env.volumes,
+            image=function_spec.image,
+            mounts=function_spec.mounts,
+            secrets=function_spec.secrets,
+            network_file_systems=function_spec.network_file_systems,
+            gpu=function_spec.gpu,
+            cloud=function_spec.cloud,
+            cpu=function_spec.cpu,
+            memory=function_spec.memory,
+            volumes=function_spec.volumes,
             _allow_background_volume_commits=True,
         )
     else:

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -536,10 +536,11 @@ def _parse_retries(
 
 
 @dataclass
-class FunctionEnv:
+class _FunctionSpec:
     """
-    Stores information about the function environment. This is used for `modal shell` to support
-    running shells in the same environment as a user-defined function.
+    Stores information about a Function specification.
+    This is used for `modal shell` to support running shells with
+    the same configuration as a user-defined Function.
     """
 
     image: Optional[_Image]
@@ -569,7 +570,7 @@ class _Function(_Object, type_prefix="fu"):
     _is_remote_cls_method: bool = False  # TODO(erikbern): deprecated
     _function_name: Optional[str]
     _is_method: bool
-    _env: FunctionEnv
+    _spec: _FunctionSpec
     _tag: str
     _raw_f: Callable[..., Any]
     _build_args: dict
@@ -665,7 +666,7 @@ class _Function(_Object, type_prefix="fu"):
             if image:
                 image = image.apt_install("autossh")
 
-        function_env = FunctionEnv(
+        function_spec = _FunctionSpec(
             mounts=all_mounts,
             secrets=secrets,
             gpu=gpu,
@@ -960,7 +961,7 @@ class _Function(_Object, type_prefix="fu"):
         obj._obj = None
         obj._is_generator = is_generator
         obj._is_method = bool(info.cls)
-        obj._env = function_env  # needed for modal shell
+        obj._spec = function_spec  # needed for modal shell
 
         # Used to check whether we should rebuild an image using run_function
         # Plaintext source and arg definition for the function, so it's part of the image
@@ -1115,9 +1116,9 @@ class _Function(_Object, type_prefix="fu"):
         return self._info
 
     @property
-    def env(self) -> FunctionEnv:
+    def spec(self) -> _FunctionSpec:
         """mdmd:hidden"""
-        return self._env
+        return self._spec
 
     def get_build_def(self) -> str:
         """mdmd:hidden"""


### PR DESCRIPTION
## Describe your changes

<img width="1082" alt="image" src="https://github.com/modal-labs/modal-client/assets/12058921/a39073e3-a3d0-4586-b425-3d50c6e00b26">

* Calling this an "environment" clashes with our Environment domain term. 
* We also had this dataclass in the docs 

## Backward/forward compatibility checks

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
