### PR TITLE
Add async-timeout dependency for Python < 3.11

### DIFF
--- a/modal/requirements/2024.04.txt
+++ b/modal/requirements/2024.04.txt
@@ -3,6 +3,7 @@ aiosignal==1.3.1
 aiostream==0.5.2
 annotated-types==0.6.0
 anyio==4.3.0
+async-timeout==4.0.3 ; python_version < "3.11"
 attrs==23.2.0
 certifi==2024.2.2
 fastapi==0.110.0


### PR DESCRIPTION
Fixes an issue with client dependencies on image builder version 2024.04