### PR TITLE
Test modal importability in container against 2024.04 requirements

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -r container_requirements.txt
+          pip install -r modal/requirements/2024.04.txt
           pip install synchronicity
 
       - name: Compile protos

--- a/container_requirements.txt
+++ b/container_requirements.txt
@@ -1,9 +1,0 @@
-# Requirements file for testing the minimal client dependency set in the container environment
-# Not currently used in production; exists for CI usage until we remove modal/requirements.txt
-aiohttp==3.9.1
-aiostream==0.4.4
-certifi>=2022.12.07
-fastapi==0.88.0
-grpclib==0.4.7
-protobuf>=3.19.0
-rich==12.3.0


### PR DESCRIPTION
Uses the 2024.04 set for the CI test for whether we can import modal after installing the "container requirements". Would have caught the issue fixed in #1662.