### PR TITLE
Deprecate workspace name lookup

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1975,7 +1975,7 @@ message WebUrlInfo {
 }
 
 message WorkspaceNameLookupResponse {
-  string workspace_name = 1;
+  string workspace_name = 1 [deprecated=true];
   string username = 2;
 }
 

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -134,4 +134,4 @@ def test_config_env_override_arbitrary_env():
 @pytest.mark.asyncio
 async def test_workspace_lookup(servicer, server_url_env):
     resp = await _lookup_workspace(servicer.remote_addr, "ak-abc", "as-xyz")
-    assert resp.workspace_name == "test-workspace"
+    assert resp.username == "test-username"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1043,9 +1043,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         )
 
     async def WorkspaceNameLookup(self, stream):
-        await stream.send_message(
-            api_pb2.WorkspaceNameLookupResponse(workspace_name="test-workspace", username="test-username")
-        )
+        await stream.send_message(api_pb2.WorkspaceNameLookupResponse(username="test-username"))
 
     ### Tunnel
 


### PR DESCRIPTION
In the client library we haven't been using workspace_name for a while, only the username. And as of today, workspace no longer have a name. So this deprecates this field on the protobuf.
