### PR TITLE
Fix `spawn_sandbox` inside containers

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, AsyncGenerator, AsyncIterator, Callable, 
 
 from google.protobuf.message import Message
 from grpclib import Status
+from synchronicity import Interface
 
 from modal_proto import api_pb2
 
@@ -46,7 +47,7 @@ from .config import config, logger
 from .exception import ExecutionError, InputCancellation, InvalidError
 from .functions import Function, _Function, _set_current_context_ids, _stream_function_call_data
 from .partial_function import _find_callables_for_obj, _PartialFunctionFlags
-from .stub import _Stub
+from .stub import Stub, _Stub
 
 if TYPE_CHECKING:
     from types import ModuleType
@@ -1035,7 +1036,8 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
 
         # Initialize objects on the stub.
         if imp_fun.stub is not None:
-            imp_fun.stub._init_container(client, _container_app)
+            stub: Stub = synchronizer._translate_out(imp_fun.stub, Interface.BLOCKING)
+            stub._init_container(client, _container_app)
 
         # Hydrate all function dependencies.
         # TODO(erikbern): we an remove this once we

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -1388,3 +1388,9 @@ def test_sigint_termination_exit_handler(servicer, exit_type):
     assert "[events:enter_sync,enter_async,delay,exit_sync,exit_async]" in stdout.decode()
     assert "Traceback" not in stderr.decode()
     assert servicer.task_result is None
+
+
+@skip_windows_unix_socket
+def test_sandbox(unix_servicer, event_loop):
+    ret = _run_container(unix_servicer, "test.supports.functions", "sandbox_f")
+    assert _unwrap_scalar(ret) == "sb-123"

--- a/test/supports/functions.py
+++ b/test/supports/functions.py
@@ -406,3 +406,9 @@ class EventLoopCls:
     @method()
     async def f(self):
         return self.loop.is_running()
+
+
+@stub.function()
+def sandbox_f(x):
+    sb = stub.spawn_sandbox("echo", str(x))
+    return sb.object_id


### PR DESCRIPTION
The issue was introduced in #1659 – the stub would end up with an unsynchronized `Client` (as opposed to `_Client`)

Adding tests for this as well