### PR TITLE
volumes: Improve error message when reload fails due to open files

### DIFF
--- a/modal/volume.py
+++ b/modal/volume.py
@@ -298,8 +298,11 @@ class _Volume(_Object, type_prefix="vo"):
         self_pid = os.readlink("/proc/self")
 
         def find_open_file_for_pid(pid) -> Optional[str]:
-            with open(f"/proc/{pid}/cmdline", "r") as f:
-                cmdline = f.read()
+            # /proc/{pid}/cmdline is null separated
+            with open(f"/proc/{pid}/cmdline", "rb") as f:
+                raw = f.read()
+                parts = raw.split(b"\0")
+                cmdline = " ".join([part.decode() for part in parts])
             cwd = PurePosixPath(os.readlink(f"/proc/{pid}/cwd"))
             if cwd.is_relative_to(relative_to):
                 if pid == self_pid:

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -321,8 +321,9 @@ class _Volume(_Object, type_prefix="vo"):
                     pass
             return None
 
+        pid_re = re.compile("^[1-9][0-9]*$")
         for dirent in os.listdir("/proc/"):
-            if re.match("^[1-9][0-9]*$", dirent):
+            if pid_re.match(dirent):
                 try:
                     err_str = find_open_file_for_pid(dirent)
                     if err_str:

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -624,6 +624,7 @@ def _open_files_error_annotation(mount_path: str) -> Optional[str]:
             raw = f.read()
             parts = raw.split(b"\0")
             cmdline = " ".join([part.decode() for part in parts]).rstrip(" ")
+
         cwd = PurePosixPath(os.readlink(f"/proc/{pid}/cwd"))
         if cwd.is_relative_to(mount_path):
             if pid == self_pid:
@@ -649,9 +650,9 @@ def _open_files_error_annotation(mount_path: str) -> Optional[str]:
     for dirent in os.listdir("/proc/"):
         if pid_re.match(dirent):
             try:
-                err_str = find_open_file_for_pid(dirent)
-                if err_str:
-                    return err_str
+                annotation = find_open_file_for_pid(dirent)
+                if annotation:
+                    return annotation
             except (FileNotFoundError, PermissionError):
                 pass
 

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -5,6 +5,7 @@ import os
 import platform
 import pytest
 import re
+import sys
 import time
 from pathlib import Path
 from unittest import mock
@@ -377,9 +378,9 @@ async def test_open_files_error_annotation(tmp_path):
 
     # Subprocess cwd inside volume
     proc = await asyncio.create_subprocess_exec(
-        "python", "-c", f"import time; import os; os.chdir('{tmp_path}'); time.sleep(60)"
+        sys.executable, "-c", f"import time; import os; os.chdir('{tmp_path}'); time.sleep(60)"
     )
-    assert re.match("^cwd of 'python -c .*' is inside volume$", _open_files_error_annotation(tmp_path))
+    assert re.match(f"^cwd of '{sys.executable} -c .*' is inside volume$", _open_files_error_annotation(tmp_path))
     proc.kill()
     await proc.wait()
     assert _open_files_error_annotation(tmp_path) is None


### PR DESCRIPTION
If reloading fails because of open files, annotate the error with information with the path to the first open file or problematic cwd we detect.

The paths reported are volume-relative, if the volume is mounted on `/vol` and a file `/vol/foo.txt` is open that will be reported as `foo.txt`. This is not ideal, but unfortunately we don't have an easy way to determine where the volume is mounted.

This may or may not be entirely reliable, but ought to be better than the status quo and catch more common issues.
* The containers view of open files might not be the same as that outside of the container (the latter is what really matters).
* It's racy - the file that prevented reloading might be closed by the time we look for it.

```
import modal
import os

stub = modal.Stub()
volume = modal.Volume.from_name("test123", create_if_missing=True)

@stub.function(volumes={"/volume": volume})
def f():
    with open("/volume/test.txt", "w") as f:
        try:
            volume.reload()
        except RuntimeError as ex:
            print(ex)
    
    os.chdir("/volume")
    try:
        volume.reload()
    except RuntimeError as ex:
        print(ex
```
-->
```
there are open files preventing the operation: path test.txt is open
there are open files preventing the operation: cwd is inside volume
```

## Changelog

- When Volume reloads fail due to open files, we now try to identify and report the relevant paths. Note that there may be some circumstances in which we are unable to identify the specific files blocking a reload and will report a generic error message in that case.