### PR TITLE
Call out that Cls.with_options is beta

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -270,8 +270,9 @@ class _Cls(_Object, type_prefix="cs"):
         allow_background_volume_commits: bool = False,
     ) -> "_Cls":
         """
-        Allows for the runtime modification of a modal.Cls's configuration.
-        Designed for usage in the [MK1 Flywheel](/docs/guide/mk1).
+        Beta: Allows for the runtime modification of a modal.Cls's configuration.
+
+        This is a beta feature and may be unstable.
 
         **Usage:**
 


### PR DESCRIPTION
We don't document this in the guide so it's not super user-facing, but some have found it and it has a bunch of rough edges.