### PR TITLE
Consider integer 0 or string/boolean F/false to be False in config toml

### DIFF
--- a/modal/config.py
+++ b/modal/config.py
@@ -173,6 +173,10 @@ _profile = os.environ.get("MODAL_PROFILE") or _config_active_profile()
 # Define settings
 
 
+def _to_boolean(x: object) -> bool:
+    return str(x).lower() not in {"", "0", "false"}
+
+
 class _Setting(typing.NamedTuple):
     default: typing.Any = None
     transform: typing.Callable[[str], typing.Any] = lambda x: x  # noqa: E731
@@ -190,17 +194,17 @@ _SETTINGS = {
     "sync_entrypoint": _Setting(),
     "logs_timeout": _Setting(10, float),
     "image_id": _Setting(),
-    "automount": _Setting(True, transform=lambda x: x not in ("", "0")),
-    "profiling_enabled": _Setting(False, transform=lambda x: x not in ("", "0")),
+    "automount": _Setting(True, transform=_to_boolean),
+    "profiling_enabled": _Setting(False, transform=_to_boolean),
     "heartbeat_interval": _Setting(15, float),
     "function_runtime": _Setting(),
-    "function_runtime_debug": _Setting(False, transform=lambda x: x not in ("", "0")),  # For internal debugging use.
+    "function_runtime_debug": _Setting(False, transform=_to_boolean),  # For internal debugging use.
     "environment": _Setting(),
     "default_cloud": _Setting(None, transform=lambda x: x if x else None),
     "worker_id": _Setting(),  # For internal debugging use.
     "restore_state_path": _Setting("/__modal/restore-state.json"),
-    "force_build": _Setting(False, transform=lambda x: x not in ("", "0")),
-    "traceback": _Setting(False, transform=lambda x: x not in ("", "0")),
+    "force_build": _Setting(False, transform=_to_boolean),
+    "traceback": _Setting(False, transform=_to_boolean),
     "image_builder_version": _Setting(),
 }
 

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -8,7 +8,7 @@ import sys
 import toml
 
 import modal
-from modal.config import _lookup_workspace, config
+from modal.config import Config, _lookup_workspace, config
 
 
 def _cli(args, env={}):
@@ -135,3 +135,15 @@ def test_config_env_override_arbitrary_env():
 async def test_workspace_lookup(servicer, server_url_env):
     resp = await _lookup_workspace(servicer.remote_addr, "ak-abc", "as-xyz")
     assert resp.username == "test-username"
+
+
+@pytest.mark.parametrize("automount", ["false", "'false'", "'False'", "'0'", 0, "''"])
+def test_config_boolean(modal_config, automount):
+    modal_toml = f"""
+    [prof-1]
+    token_id = 'ak-abc'
+    token_secret = 'as_xyz'
+    automount = {automount}
+    """
+    with modal_config(modal_toml):
+        assert not Config().get("automount", "prof-1")


### PR DESCRIPTION
Closes MOD-2740

## Changelog

- Values in the `modal.toml` config file that are spelled as `0`, `false`, `"False"`, or `"false"` will now be coerced in Python to`False`, whereas previously only `"0"` (as a string) would have the intended effect.