### PR TITLE
Move list_apps out of app.py

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -137,14 +137,3 @@ def is_local() -> bool:
     Returns `False` when executed from a Modal container in the cloud.
     """
     return not _is_container_app
-
-
-async def _list_apps(env: str, client: Optional[_Client] = None) -> List[api_pb2.AppStats]:
-    """List apps in a given Modal environment."""
-    if client is None:
-        client = await _Client.from_env()
-    resp: api_pb2.AppListResponse = await client.stub.AppList(api_pb2.AppListRequest(environment_name=env))
-    return list(resp.apps)
-
-
-list_apps = synchronize_api(_list_apps)

--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -8,7 +8,7 @@ from grpclib import GRPCError, Status
 from rich.text import Text
 
 from modal._output import OutputManager, get_app_logs_loop
-from modal._utils.async_utils import synchronizer, synchronize_api
+from modal._utils.async_utils import synchronizer
 from modal.cli.utils import ENV_OPTION, display_table, timestamp_to_local
 from modal.client import _Client
 from modal.environments import ensure_env

--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -27,15 +27,6 @@ APP_STATE_TO_MESSAGE = {
 }
 
 
-@synchronize_api
-async def list_apps(env: str, client: Optional[_Client] = None) -> List[api_pb2.AppStats]:
-    """List apps in a given Modal environment."""
-    if client is None:
-        client = await _Client.from_env()
-    resp: api_pb2.AppListResponse = await client.stub.AppList(api_pb2.AppListRequest(environment_name=env))
-    return list(resp.apps)
-
-
 @app_cli.command("list")
 @synchronizer.create_blocking
 async def list(env: Optional[str] = ENV_OPTION, json: Optional[bool] = False):
@@ -45,8 +36,8 @@ async def list(env: Optional[str] = ENV_OPTION, json: Optional[bool] = False):
 
     column_names = ["App ID", "Name", "State", "Creation time", "Stop time"]
     rows: List[List[Union[Text, str]]] = []
-    apps = await _list_apps(env=env, client=client)
-    for app_stats in apps:
+    resp: api_pb2.AppListResponse = await client.stub.AppList(api_pb2.AppListRequest(environment_name=env))
+    for app_stats in resp.apps:
         state = APP_STATE_TO_MESSAGE.get(app_stats.state, Text("unknown", style="gray"))
 
         rows.append(

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -653,3 +653,14 @@ def test_profile_list(servicer, server_url_env, modal_config):
                 os.environ["MODAL_TOKEN_SECRET"] = orig_env_token_secret
             else:
                 del os.environ["MODAL_TOKEN_SECRET"]
+
+
+def test_list_apps(servicer, mock_dir, set_env_client):
+    res = _run(["app", "list"])
+    assert "my_app_foo" not in res.stdout
+
+    with mock_dir({"myapp.py": dummy_app_file, "other_module.py": dummy_other_module_file}):
+        _run(["deploy", "myapp.py", "--name", "my_app_foo"])
+
+    res = _run(["app", "list"])
+    assert "my_app_foo" in res.stdout

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -305,6 +305,13 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.app_heartbeats[request.app_id] += 1
         await stream.send_message(Empty())
 
+    async def AppList(self, stream):
+        request: api_pb2.AppListRequest = await stream.recv_message()
+        apps = []
+        for app_name, app_id in self.deployed_apps.items():
+            apps.append(api_pb2.AppStats(name=app_name, description=app_name, app_id=app_id))
+        await stream.send_message(api_pb2.AppListResponse(apps=apps))
+
     ### Checkpoint
 
     async def ContainerCheckpoint(self, stream):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -306,7 +306,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         await stream.send_message(Empty())
 
     async def AppList(self, stream):
-        request: api_pb2.AppListRequest = await stream.recv_message()
+        await stream.recv_message()
         apps = []
         for app_name, app_id in self.deployed_apps.items():
             apps.append(api_pb2.AppStats(name=app_name, description=app_name, app_id=app_id))


### PR DESCRIPTION
Just moving some code around in order to get rid of `app.py`

Not sure where this code belongs in the long run though. Probably in the "new" `app.py` (which is currently `stub.py`)

edit: also added a test, since we didn't have any