### PR TITLE
Unify FileEntry protobufs and add a public dataclass

### DIFF
--- a/modal/cli/_download.py
+++ b/modal/cli/_download.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import sys
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 from click import UsageError
 
@@ -14,7 +14,7 @@ from modal_proto import api_pb2
 
 
 async def _glob_download(
-    volume: _NetworkFileSystem | _Volume,
+    volume: Union[_NetworkFileSystem, _Volume],
     remote_glob_path: str,
     local_destination: Path,
     overwrite: bool,

--- a/modal/cli/_download.py
+++ b/modal/cli/_download.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import sys
 from pathlib import Path
-from typing import Callable, Optional, Tuple, Union, overload
+from typing import Optional, Tuple
 
 from click import UsageError
 
@@ -12,39 +12,14 @@ from modal.network_file_system import _NetworkFileSystem
 from modal.volume import _Volume
 from modal_proto import api_pb2
 
-_Entry = Union[api_pb2.SharedVolumeListFilesEntry, api_pb2.VolumeListFilesEntry]
-
-
-@overload
-def _glob_download(
-    volume: _Volume,
-    is_file_fn: Callable[[api_pb2.VolumeListFilesEntry], bool],
-    remote_glob_path: str,
-    local_destination: Path,
-    overwrite: bool,
-):
-    ...
-
-
-@overload
-def _glob_download(
-    volume: _NetworkFileSystem,
-    is_file_fn: Callable[[api_pb2.SharedVolumeListFilesEntry], bool],
-    remote_glob_path: str,
-    local_destination: Path,
-    overwrite: bool,
-):
-    ...
-
 
 async def _glob_download(
-    volume,
-    is_file_fn,
+    volume: _NetworkFileSystem | _Volume,
     remote_glob_path: str,
     local_destination: Path,
     overwrite: bool,
 ):
-    q: asyncio.Queue[Tuple[Optional[Path], Optional[_Entry]]] = asyncio.Queue()
+    q: asyncio.Queue[Tuple[Optional[Path], Optional[api_pb2.FileEntry]]] = asyncio.Queue()
     num_consumers = 10  # concurrency limit
 
     async def producer():
@@ -52,7 +27,7 @@ async def _glob_download(
             output_path = local_destination / entry.path
             if output_path.exists():
                 if overwrite:
-                    if is_file_fn(entry):
+                    if output_path.is_file():
                         os.remove(output_path)
                     else:
                         shutil.rmtree(output_path)
@@ -71,14 +46,15 @@ async def _glob_download(
             if output_path is None:
                 return
             try:
-                if is_file_fn(entry):
+                if entry.type == api_pb2.FileEntry.FILE:
                     output_path.parent.mkdir(parents=True, exist_ok=True)
                     with output_path.open("wb") as fp:
                         b = 0
                         async for chunk in volume.read_file(entry.path):
                             b += fp.write(chunk)
-
                     print(f"Wrote {b} bytes to {output_path}", file=sys.stderr)
+                elif entry.type == api_pb2.FileEntry.DIRECTORY:
+                    output_path.mkdir(parents=True, exist_ok=True)
             finally:
                 q.task_done()
 

--- a/modal/cli/_download.py
+++ b/modal/cli/_download.py
@@ -9,8 +9,7 @@ from typing import Optional, Tuple, Union
 from click import UsageError
 
 from modal.network_file_system import _NetworkFileSystem
-from modal.volume import _Volume, FileEntry, FileEntryType
-from modal_proto import api_pb2
+from modal.volume import FileEntry, FileEntryType, _Volume
 
 
 async def _glob_download(

--- a/modal/cli/network_file_system.py
+++ b/modal/cli/network_file_system.py
@@ -29,9 +29,6 @@ from modal.environments import ensure_env
 from modal.network_file_system import _NetworkFileSystem
 from modal_proto import api_pb2
 
-FileType = api_pb2.SharedVolumeListFilesEntry.FileType
-
-
 nfs_cli = Typer(name="nfs", help="Read and edit `modal.NetworkFileSystem` file systems.", no_args_is_help=True)
 
 
@@ -114,7 +111,7 @@ async def ls(
         table.add_column("type")
 
         for entry in entries:
-            filetype = "dir" if entry.type == FileType.DIRECTORY else "file"
+            filetype = "dir" if entry.type == api_pb2.FileEntry.FileType.DIRECTORY else "file"
             table.add_row(entry.path, filetype)
         console.print(table)
     else:
@@ -195,17 +192,8 @@ async def get(
     destination = Path(local_destination)
     volume = await _volume_from_name(volume_name)
 
-    def is_file_fn(entry):
-        return entry.type == FileType.FILE
-
     if "*" in remote_path:
-        await _glob_download(
-            volume,
-            is_file_fn,
-            remote_path,
-            destination,
-            force,
-        )
+        await _glob_download(volume, remote_path, destination, force)
         return
 
     if destination != PIPE_PATH:

--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -28,7 +28,6 @@ from modal.environments import ensure_env
 from modal.volume import _Volume, _VolumeUploadContextManager
 from modal_proto import api_pb2
 
-FileType = api_pb2.VolumeListFilesEntry.FileType
 PIPE_PATH = Path("-")
 
 volume_cli = Typer(
@@ -104,11 +103,8 @@ async def get(
     destination = Path(local_destination)
     volume = await _Volume.lookup(volume_name, environment_name=env)
 
-    def is_file_fn(entry):
-        return entry.type == FileType.FILE
-
     if "*" in remote_path:
-        await _glob_download(volume, is_file_fn, remote_path, destination, force)
+        await _glob_download(volume, remote_path, destination, force)
         return
 
     if destination != PIPE_PATH:
@@ -186,9 +182,9 @@ async def ls(
 
         locale_tz = datetime.now().astimezone().tzinfo
         for entry in entries:
-            if entry.type == FileType.DIRECTORY:
+            if entry.type == api_pb2.FileEntry.FileType.DIRECTORY:
                 filetype = "dir"
-            elif entry.type == FileType.SYMLINK:
+            elif entry.type == api_pb2.FileEntry.FileType.SYMLINK:
                 filetype = "link"
             else:
                 filetype = "file"

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -24,6 +24,7 @@ from .object import (
     live_method,
     live_method_gen,
 )
+from .volume import FileEntry
 
 NETWORK_FILE_SYSTEM_PUT_FILE_CLIENT_TIMEOUT = (
     10 * 60
@@ -293,7 +294,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
                 yield data
 
     @live_method_gen
-    async def iterdir(self, path: str) -> AsyncIterator[api_pb2.SharedVolumeListFilesEntry]:
+    async def iterdir(self, path: str) -> AsyncIterator[FileEntry]:
         """Iterate over all files in a directory in the network file system.
 
         * Passing a directory path lists all files in the directory (names are relative to the directory)
@@ -303,7 +304,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         req = api_pb2.SharedVolumeListFilesRequest(shared_volume_id=self.object_id, path=path)
         async for batch in unary_stream(self._client.stub.SharedVolumeListFilesStream, req):
             for entry in batch.entries:
-                yield entry
+                yield FileEntry._from_proto(entry)
 
     @live_method
     async def add_local_file(
@@ -342,7 +343,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         await ConcurrencyPool(20).run_coros(gen_transfers(), return_exceptions=True)
 
     @live_method
-    async def listdir(self, path: str) -> List[api_pb2.SharedVolumeListFilesEntry]:
+    async def listdir(self, path: str) -> List[FileEntry]:
         """List all files in a directory in the network file system.
 
         * Passing a directory path lists all files in the directory (names are relative to the directory)

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -42,6 +42,7 @@ from ._utils.blob_utils import (
 from ._utils.grpc_utils import retry_transient_errors, unary_stream
 from .client import _Client
 from .config import logger
+from .exception import deprecation_error
 from .object import EPHEMERAL_OBJECT_HEARTBEAT_SLEEP, _get_environment_name, _Object, live_method, live_method_gen
 
 # Max duration for uploading to volumes files
@@ -74,6 +75,12 @@ class FileEntry:
             type=FileEntryType(proto.type),
             mtime=proto.mtime,
             size=proto.size,
+        )
+
+    def __getattr__(self, name: str):
+        deprecation_error(
+            (2024, 4, 15),
+            f"The FileEntry dataclass was introduced to replace a private Protobuf message. This dataclass does not have the {name} attribute.",
         )
 
 

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -1,11 +1,13 @@
 # Copyright Modal Labs 2023
 import asyncio
 import concurrent.futures
+import enum
 import os
 import platform
 import re
 import time
 from contextlib import nullcontext
+from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import (
     IO,
@@ -45,6 +47,34 @@ from .object import EPHEMERAL_OBJECT_HEARTBEAT_SLEEP, _get_environment_name, _Ob
 # Max duration for uploading to volumes files
 # As a guide, files >40GiB will take >10 minutes to upload.
 VOLUME_PUT_FILE_CLIENT_TIMEOUT = 30 * 60
+
+
+class FileEntryType(enum.IntEnum):
+    """Type of a file entry listed from a Modal volume."""
+
+    UNSPECIFIED = 0
+    FILE = 1
+    DIRECTORY = 2
+    SYMLINK = 3
+
+
+@dataclass(frozen=True)
+class FileEntry:
+    """A file or directory entry listed from a Modal volume."""
+
+    path: str
+    type: FileEntryType
+    mtime: int
+    size: int
+
+    @classmethod
+    def _from_proto(cls, proto: api_pb2.FileEntry) -> "FileEntry":
+        return cls(
+            path=proto.path,
+            type=FileEntryType(proto.type),
+            mtime=proto.mtime,
+            size=proto.size,
+        )
 
 
 class _Volume(_Object, type_prefix="vo"):
@@ -295,7 +325,7 @@ class _Volume(_Object, type_prefix="vo"):
             raise RuntimeError(exc.message) if exc.status in (Status.FAILED_PRECONDITION, Status.NOT_FOUND) else exc
 
     @live_method_gen
-    async def iterdir(self, path: str) -> AsyncIterator[api_pb2.VolumeListFilesEntry]:
+    async def iterdir(self, path: str) -> AsyncIterator[FileEntry]:
         """Iterate over all files in a directory in the volume.
 
         * Passing a directory path lists all files in the directory (names are relative to the directory)
@@ -305,10 +335,10 @@ class _Volume(_Object, type_prefix="vo"):
         req = api_pb2.VolumeListFilesRequest(volume_id=self.object_id, path=path)
         async for batch in unary_stream(self._client.stub.VolumeListFiles, req):
             for entry in batch.entries:
-                yield entry
+                yield FileEntry._from_proto(entry)
 
     @live_method
-    async def listdir(self, path: str) -> List[api_pb2.VolumeListFilesEntry]:
+    async def listdir(self, path: str) -> List[FileEntry]:
         """List all files under a path prefix in the modal.Volume.
 
         * Passing a directory path lists all files in the directory

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -134,6 +134,20 @@ enum FileDescriptor {
   FILE_DESCRIPTOR_INFO = 3;
 }
 
+// A file entry when listing files in a volume or network file system.
+message FileEntry {
+  enum FileType {
+    UNSPECIFIED = 0;
+    FILE = 1;
+    DIRECTORY = 2;
+    SYMLINK = 3;
+  }
+  string path = 1;
+  FileType type = 2;
+  uint64 mtime = 3;
+  uint64 size = 4;
+}
+
 enum FunctionCallType {
   FUNCTION_CALL_TYPE_UNSPECIFIED = 0;
   FUNCTION_CALL_TYPE_UNARY = 1;
@@ -1707,18 +1721,8 @@ message SharedVolumeRemoveFileRequest {
   bool recursive = 3;
 }
 
-message SharedVolumeListFilesEntry {
-  enum FileType {
-    UNSPECIFIED = 0;
-    FILE = 1;
-    DIRECTORY = 2;
-  }
-  string path = 1;
-  FileType type = 2;
-}
-
 message SharedVolumeListFilesResponse {
-  repeated SharedVolumeListFilesEntry entries = 1;
+  repeated FileEntry entries = 1;
 }
 
 message SharedVolumeMount {
@@ -1889,19 +1893,6 @@ message VolumeGetFileResponse {
   uint64 len = 5; // number of bytes returned
 }
 
-message VolumeListFilesEntry {
-  enum FileType {
-    UNSPECIFIED = 0;
-    FILE = 1;
-    DIRECTORY = 2;
-    SYMLINK = 3;
-  }
-  string path = 1;
-  FileType type = 2;
-  uint64 mtime = 3;
-  uint64 size = 4;
-}
-
 message VolumeListFilesRequest {
   string volume_id = 1;
   string path = 2;
@@ -1909,7 +1900,7 @@ message VolumeListFilesRequest {
 }
 
 message VolumeListFilesResponse {
-  repeated VolumeListFilesEntry entries = 1;
+  repeated FileEntry entries = 1;
 }
 
 message VolumeListItem {

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1016,7 +1016,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
     async def SharedVolumeListFilesStream(self, stream):
         req: api_pb2.SharedVolumeListFilesRequest = await stream.recv_message()
         for path in self.nfs_files[req.shared_volume_id].keys():
-            entry = api_pb2.SharedVolumeListFilesEntry(path=path)
+            entry = api_pb2.FileEntry(path=path)
             response = api_pb2.SharedVolumeListFilesResponse(entries=[entry])
             await stream.send_message(response)
 
@@ -1155,11 +1155,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         if req.path != "**":
             raise NotImplementedError("Only '**' listing is supported.")
         for k, vol_file in self.volume_files[req.volume_id].items():
-            entries = [
-                api_pb2.VolumeListFilesEntry(
-                    path=k, type=api_pb2.VolumeListFilesEntry.FileType.FILE, size=len(vol_file.data)
-                )
-            ]
+            entries = [api_pb2.FileEntry(path=k, type=api_pb2.FileEntry.FileType.FILE, size=len(vol_file.data))]
             await stream.send_message(api_pb2.VolumeListFilesResponse(entries=entries))
 
     async def VolumePutFiles(self, stream):


### PR DESCRIPTION
This unifies the SharedVolumeListFilesEntry and VolumeListFilesEntry protobufs, which now just both become FIleEntry. I'm also adding a public dataclass for FileEntry, which is used the API for listdir() on both NFS and Volume objects.

Note that the NFS implementation doesn't have support for symlinks yet, or for the mtime / size fields. I quickly added support for those in server code.

## Changelog

- The return type of `Volume.listdir()`, `Volume.iterdir()`, `NetworkFileSystem.listdir()`, and `NetworkFileSystem.iterdir()` is now a `FileEntry` dataclass from the `modal.volume` module. The fields of this data class are the same as the old protobuf object returned by these methods, so it should be mostly backwards-compatible.
