### PR TITLE
[MOD-2078] Add memory limit specification

### DIFF
--- a/modal/_resources.py
+++ b/modal/_resources.py
@@ -1,0 +1,28 @@
+# Copyright Modal Labs 2024
+from typing import Optional, Tuple, Union
+
+from modal_proto import api_pb2
+
+from .gpu import GPU_T, parse_gpu_config
+
+
+def convert_fn_config_to_resources_config(
+    cpu: Optional[float],
+    memory: Optional[Union[int, Tuple[int, int]]],
+    gpu: GPU_T,
+) -> api_pb2.Resources:
+    gpu_config = parse_gpu_config(gpu)
+    milli_cpu = int(1000 * cpu) if cpu is not None else None
+    if memory and isinstance(memory, int):
+        memory_mb = memory
+        memory_mb_max = 0  # no limit
+    elif memory and isinstance(memory, tuple):
+        memory_mb, memory_mb_max = memory
+        if memory_mb_max < memory_mb:
+            raise ValueError(f"Cannot specify a memory limit lower than request: {memory_mb_max} < {memory_mb}")
+    else:
+        memory_mb = 0
+        memory_mb_max = 0
+    return api_pb2.Resources(
+        milli_cpu=milli_cpu, gpu_config=gpu_config, memory_mb=memory_mb, memory_mb_max=memory_mb_max
+    )

--- a/modal/_resources.py
+++ b/modal/_resources.py
@@ -3,14 +3,18 @@ from typing import Optional, Tuple, Union
 
 from modal_proto import api_pb2
 
+from .exception import InvalidError
 from .gpu import GPU_T, parse_gpu_config
 
 
 def convert_fn_config_to_resources_config(
+    *,
     cpu: Optional[float],
     memory: Optional[Union[int, Tuple[int, int]]],
     gpu: GPU_T,
 ) -> api_pb2.Resources:
+    if cpu is not None and cpu < 0.1:
+        raise InvalidError(f"Invalid fractional CPU value {cpu}. Cannot have less than 0.10 CPU resources.")
     gpu_config = parse_gpu_config(gpu)
     milli_cpu = int(1000 * cpu) if cpu is not None else None
     if memory and isinstance(memory, int):
@@ -19,7 +23,7 @@ def convert_fn_config_to_resources_config(
     elif memory and isinstance(memory, tuple):
         memory_mb, memory_mb_max = memory
         if memory_mb_max < memory_mb:
-            raise ValueError(f"Cannot specify a memory limit lower than request: {memory_mb_max} < {memory_mb}")
+            raise InvalidError(f"Cannot specify a memory limit lower than request: {memory_mb_max} < {memory_mb}")
     else:
         memory_mb = 0
         memory_mb_max = 0

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -10,6 +10,7 @@ from modal_proto import api_pb2
 
 from ._output import OutputManager
 from ._resolver import Resolver
+from ._resources import convert_fn_config_to_resources_config
 from ._serialization import check_valid_cls_constructor_arg
 from ._utils.async_utils import synchronize_api, synchronizer
 from ._utils.grpc_utils import retry_transient_errors
@@ -19,7 +20,7 @@ from .exception import InvalidError, NotFoundError
 from .functions import (
     _parse_retries,
 )
-from .gpu import GPU_T, parse_gpu_config
+from .gpu import GPU_T
 from .object import _get_environment_name, _Object
 from .partial_function import (
     PartialFunction,
@@ -290,21 +291,7 @@ class _Cls(_Object, type_prefix="cs"):
         """
         retry_policy = _parse_retries(retries)
         if gpu or cpu or memory:
-            milli_cpu = int(1000 * cpu) if cpu is not None else None
-            gpu_config = parse_gpu_config(gpu)
-            if memory and isinstance(memory, int):
-                memory_mb = memory
-                memory_mb_max = 0  # no limit
-            elif memory and isinstance(memory, tuple):
-                memory_mb, memory_mb_max = memory
-                if memory_mb_max < memory_mb:
-                    raise ValueError(f"Cannot specify a memory limit lower than request: {memory_mb_max} < {memory_mb}")
-            else:
-                memory_mb = 0
-                memory_mb_max = 0
-            resources = api_pb2.Resources(
-                milli_cpu=milli_cpu, gpu_config=gpu_config, memory_mb=memory_mb, memory_mb_max=memory_mb_max
-            )
+            resources = convert_fn_config_to_resources_config(cpu=cpu, memory=memory, gpu=gpu)
         else:
             resources = None
 

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -620,7 +620,9 @@ class _Stub:
         volumes: Dict[Union[str, PurePosixPath], _Volume] = {},  # Mountpoints for Modal Volumes
         allow_cross_region_volumes: bool = False,  # Whether using network file systems from other regions is allowed.
         cpu: Optional[float] = None,  # How many CPU cores to request. This is a soft limit.
-        memory: Optional[int] = None,  # How much memory to request, in MiB. This is a soft limit.
+        memory: Optional[
+            Union[int, Tuple[int, int]]
+        ] = None,  # Specify, in MiB, a memory request which is the minimum memory required. Or, pass (request, limit) to additionally specify a hard limit in MiB.
         proxy: Optional[_Proxy] = None,  # Reference to a Modal Proxy to use in front of this function.
         retries: Optional[Union[int, Retries]] = None,  # Number of times to retry each input in case of failure.
         concurrency_limit: Optional[int] = None,  # Limit for max concurrent containers running the function.
@@ -714,7 +716,9 @@ class _Stub:
         gpu: GPU_T = None,
         cloud: Optional[str] = None,
         cpu: Optional[float] = None,  # How many CPU cores to request. This is a soft limit.
-        memory: Optional[int] = None,  # How much memory to request, in MiB. This is a soft limit.
+        memory: Optional[
+            Union[int, Tuple[int, int]]
+        ] = None,  # Specify, in MiB, a memory request which is the minimum memory required. Or, pass (request, limit) to additionally specify a hard limit in MiB.
         block_network: bool = False,  # Whether to block network access
         volumes: Dict[Union[str, os.PathLike], _Volume] = {},  # Volumes to mount in the sandbox.
         _allow_background_volume_commits: bool = False,

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -3,7 +3,7 @@ import inspect
 import os
 import typing
 from pathlib import PurePosixPath
-from typing import Any, AsyncGenerator, Callable, ClassVar, Dict, List, Optional, Sequence, Union
+from typing import Any, AsyncGenerator, Callable, ClassVar, Dict, List, Optional, Sequence, Tuple, Union
 
 from google.protobuf.message import Message
 from synchronicity.async_wrap import asynccontextmanager
@@ -482,7 +482,9 @@ class _Stub:
         volumes: Dict[Union[str, PurePosixPath], _Volume] = {},  # Mountpoints for Modal Volumes
         allow_cross_region_volumes: bool = False,  # Whether using network file systems from other regions is allowed.
         cpu: Optional[float] = None,  # How many CPU cores to request. This is a soft limit.
-        memory: Optional[int] = None,  # How much memory to request, in MiB. This is a soft limit.
+        memory: Optional[
+            Union[int, Tuple[int, int]]
+        ] = None,  # Specify, in MiB, a memory request which is the minimum memory required. Or, pass (request, limit) to additionally specify a hard limit in MiB.
         proxy: Optional[_Proxy] = None,  # Reference to a Modal Proxy to use in front of this function.
         retries: Optional[Union[int, Retries]] = None,  # Number of times to retry each input in case of failure.
         concurrency_limit: Optional[

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -200,7 +200,7 @@ def test_function_memory_limit(client):
         f.remote()
 
     g = stub.function(memory=(2048, 2048 - 1))(custom_function)
-    with pytest.raises(ValueError), stub.run(client=client):
+    with pytest.raises(InvalidError), stub.run(client=client):
         g.remote()
 
 

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -111,6 +111,18 @@ def test_function_memory_request(client):
     stub.function(memory=2048)(dummy)
 
 
+def test_function_memory_limit(client):
+    stub = Stub()
+    f = stub.function(memory=(2048, 4096))(dummy)
+
+    with stub.run(client=client):
+        f.remote()
+
+    g = stub.function(memory=(2048, 2048 - 1))(custom_function)
+    with pytest.raises(ValueError), stub.run(client=client):
+        g.remote()
+
+
 def test_function_cpu_request(client):
     stub = Stub()
     stub.function(cpu=2.0)(dummy)


### PR DESCRIPTION
## Describe your changes

- MOD-2078

The following program will set a memory limit of 2 GiB on the container, which will cause OOM failure when run. 

```python
import modal
import random

stub = modal.Stub()

@stub.function(memory=(1024, 2048))
def main():
    ten_gib = 4 * 1024 * 1024 * 1024  # 4 GiB in bytes
    memory_hog = bytearray(ten_gib)
    for i in range(10_000_000):
        memory_hog[i] = random.randrange(128) # mutate
    print("done")
```

<kbd>
<img width="727" alt="image" src="https://github.com/modal-labs/modal-client/assets/12058921/1787c932-f5d2-4077-bff6-92de81b56b4c">
</kbd>

## Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
    - old servers will ignore the `memory_mb_max` value.
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

## Changelog

* Specifying a hard memory limit for a `modal.Function` is now supported. Pass a tuple of `memory=(request, limit)`. Above the `limit`, which is specified in MiB, a Function's container will be OOM killed.
