### PR TITLE
Break out `stream_function_call_data` to `function_utils.py`

### DIFF
--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -18,12 +18,12 @@ from ._serialization import deserialize, deserialize_data_format, serialize, ser
 from ._traceback import extract_traceback
 from ._utils.async_utils import TaskContext, asyncify, synchronize_api, synchronizer
 from ._utils.blob_utils import MAX_OBJECT_SIZE_BYTES, blob_download, blob_upload
+from ._utils.function_utils import _stream_function_call_data
 from ._utils.grpc_utils import retry_transient_errors
 from .app import _container_app
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, _Client
 from .config import config, logger
 from .exception import InputCancellation
-from .functions import _stream_function_call_data
 
 MAX_OUTPUT_BATCH_SIZE: int = 49
 

--- a/modal/_utils/function_utils.py
+++ b/modal/_utils/function_utils.py
@@ -11,13 +11,18 @@ from enum import Enum
 from pathlib import Path, PurePosixPath
 from typing import Any, AsyncIterator, Callable, List, Literal, Optional, Set, Type
 
+from grpclib import GRPCError
+from grpclib.exceptions import StreamTerminatedError
+
 from modal_proto import api_pb2
 
-from .._serialization import serialize
+from .._serialization import deserialize_data_format, serialize
 from ..config import config, logger
 from ..exception import InvalidError, ModuleNotMountable
 from ..mount import ROOT_DIR, _Mount
 from ..object import Object
+from .blob_utils import blob_download
+from .grpc_utils import RETRYABLE_GRPC_STATUS_CODES, unary_stream
 
 SYS_PREFIXES = {
     Path(p)

--- a/modal/_utils/function_utils.py
+++ b/modal/_utils/function_utils.py
@@ -1,4 +1,5 @@
 # Copyright Modal Labs 2022
+import asyncio
 import inspect
 import os
 import site
@@ -8,7 +9,7 @@ import typing
 from collections import deque
 from enum import Enum
 from pathlib import Path, PurePosixPath
-from typing import Callable, List, Optional, Set, Type
+from typing import Any, AsyncIterator, Callable, List, Literal, Optional, Set, Type
 
 from modal_proto import api_pb2
 
@@ -333,3 +334,42 @@ def method_has_params(f: Callable) -> bool:
         return num_params > 0
     else:
         return num_params > 1
+
+
+async def _stream_function_call_data(
+    client, function_call_id: str, variant: Literal["data_in", "data_out"]
+) -> AsyncIterator[Any]:
+    """Read from the `data_in` or `data_out` stream of a function call."""
+    last_index = 0
+    retries_remaining = 10
+
+    if variant == "data_in":
+        stub_fn = client.stub.FunctionCallGetDataIn
+    elif variant == "data_out":
+        stub_fn = client.stub.FunctionCallGetDataOut
+    else:
+        raise ValueError(f"Invalid variant {variant}")
+
+    while True:
+        req = api_pb2.FunctionCallGetDataRequest(function_call_id=function_call_id, last_index=last_index)
+        try:
+            async for chunk in unary_stream(stub_fn, req):
+                if chunk.index <= last_index:
+                    continue
+                last_index = chunk.index
+                if chunk.data_blob_id:
+                    message_bytes = await blob_download(chunk.data_blob_id, client.stub)
+                else:
+                    message_bytes = chunk.data
+                message = deserialize_data_format(message_bytes, chunk.data_format, client)
+                yield message
+        except (GRPCError, StreamTerminatedError) as exc:
+            if retries_remaining > 0:
+                retries_remaining -= 1
+                if isinstance(exc, GRPCError):
+                    if exc.status in RETRYABLE_GRPC_STATUS_CODES:
+                        await asyncio.sleep(1.0)
+                        continue
+                elif isinstance(exc, StreamTerminatedError):
+                    continue
+            raise

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -32,11 +32,11 @@ from grpclib import GRPCError, Status
 from grpclib.exceptions import StreamTerminatedError
 from synchronicity.exceptions import UserCodeException
 
-from modal import _pty, is_local
 from modal_proto import api_grpc, api_pb2
 
 from ._location import parse_cloud_provider
 from ._output import OutputManager
+from ._pty import get_pty_info
 from ._resolver import Resolver
 from ._serialization import deserialize, deserialize_data_format, serialize
 from ._traceback import append_modal_tb
@@ -55,6 +55,7 @@ from ._utils.blob_utils import (
 from ._utils.function_utils import FunctionInfo, get_referred_objects, is_async
 from ._utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES, retry_transient_errors, unary_stream
 from ._utils.mount_utils import validate_mount_points, validate_volumes
+from .app import is_local
 from .call_graph import InputInfo, _reconstruct_call_graph
 from .client import _Client
 from .cloud_bucket_mount import _CloudBucketMount, cloud_bucket_mounts_to_proto
@@ -810,7 +811,7 @@ class _Function(_Object, type_prefix="fu"):
             timeout_secs = timeout
 
             if stub and stub.is_interactive and not is_builder_function:
-                pty_info = _pty.get_pty_info(shell=False)
+                pty_info = get_pty_info(shell=False)
             else:
                 pty_info = None
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -28,7 +28,6 @@ from typing import (
 from aiostream import pipe, stream
 from google.protobuf.message import Message
 from grpclib import GRPCError, Status
-from grpclib.exceptions import StreamTerminatedError
 from synchronicity.exceptions import UserCodeException
 
 from modal_proto import api_grpc, api_pb2
@@ -51,8 +50,8 @@ from ._utils.blob_utils import (
     blob_download,
     blob_upload,
 )
-from ._utils.function_utils import FunctionInfo, get_referred_objects, is_async, _stream_function_call_data
-from ._utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES, retry_transient_errors, unary_stream
+from ._utils.function_utils import FunctionInfo, _stream_function_call_data, get_referred_objects, is_async
+from ._utils.grpc_utils import retry_transient_errors
 from ._utils.mount_utils import validate_mount_points, validate_volumes
 from .app import is_local
 from .call_graph import InputInfo, _reconstruct_call_graph


### PR DESCRIPTION
This is so we can avoid a circular dependency between `functions.py` and `_container_io_manager.py`

Complete noop, just moving code.