### PR TITLE
Move `is_local` and `interact` to `_container_io_manager`

### DIFF
--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -9,8 +9,9 @@ if sys.version_info[:2] >= (3, 13):
 from modal_version import __version__
 
 try:
+    from ._container_io_manager import is_local
     from ._tunnel import Tunnel, forward
-    from .app import interact, is_local
+    from .app import interact
     from .client import Client
     from .cloud_bucket_mount import CloudBucketMount
     from .cls import Cls

--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -9,9 +9,9 @@ if sys.version_info[:2] >= (3, 13):
 from modal_version import __version__
 
 try:
-    from ._container_io_manager import is_local
+
+    from ._container_io_manager import interact, is_local
     from ._tunnel import Tunnel, forward
-    from .app import interact
     from .client import Client
     from .cloud_bucket_mount import CloudBucketMount
     from .cls import Cls

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -23,12 +23,12 @@ from ._asgi import (
     webhook_asgi_app,
     wsgi_app_wrapper,
 )
-from ._container_io_manager import ContainerIOManager, UserException, _ContainerIOManager
+from ._container_io_manager import ContainerIOManager, UserException, _ContainerIOManager, interact
 from ._proxy_tunnel import proxy_tunnel
 from ._serialization import deserialize
 from ._utils.async_utils import TaskContext, synchronizer
 from ._utils.function_utils import LocalFunctionError, is_async as get_is_async, is_global_function, method_has_params
-from .app import _container_app, _init_container_app, interact
+from .app import _container_app, _init_container_app
 from .client import Client, _Client
 from .cls import Cls
 from .config import logger

--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -75,6 +75,11 @@ class _ContainerIOManager:
         cls._singleton._init(container_args, client)
         return cls._singleton
 
+    @classmethod
+    def _reset_singleton(cls):
+        """Only used for tests."""
+        cls._singleton = None
+
     async def _run_heartbeat_loop(self):
         while 1:
             t0 = time.monotonic()
@@ -567,3 +572,11 @@ class _ContainerIOManager:
 
 
 ContainerIOManager = synchronize_api(_ContainerIOManager)
+
+def is_local() -> bool:
+    """Returns if we are currently on the machine launching/deploying a Modal app
+
+    Returns `True` when executed locally on the user's machine.
+    Returns `False` when executed from a Modal container in the cloud.
+    """
+    return not _ContainerIOManager._singleton

--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -9,6 +9,7 @@ import traceback
 from pathlib import Path
 from typing import Any, AsyncGenerator, AsyncIterator, Callable, ClassVar, List, Optional, Set, Tuple
 
+from google.protobuf.empty_pb2 import Empty
 from grpclib import Status
 from synchronicity.async_wrap import asynccontextmanager
 
@@ -23,7 +24,7 @@ from ._utils.grpc_utils import retry_transient_errors
 from .app import _container_app
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, _Client
 from .config import config, logger
-from .exception import InputCancellation
+from .exception import InputCancellation, InvalidError
 
 MAX_OUTPUT_BATCH_SIZE: int = 49
 
@@ -66,6 +67,8 @@ class _ContainerIOManager:
         self._environment_name = container_args.environment_name
         self._waiting_for_checkpoint = False
         self._heartbeat_loop = None
+
+        self._is_interactivity_enabled = False
 
         self._client = client
         assert isinstance(self._client, _Client)
@@ -570,6 +573,30 @@ class _ContainerIOManager:
             else:
                 logger.debug(f"modal.Volume background commit success for {volume_id}.")
 
+    async def interact(self):
+        if self._is_interactivity_enabled:
+            # Currently, interactivity is enabled forever
+            return
+        self._is_interactivity_enabled = True
+
+        if not self.function_def.pty_info:
+            raise InvalidError(
+                "Interactivity is not enabled in this function. Use MODAL_INTERACTIVE_FUNCTIONS=1 to enable interactivity."
+            )
+
+        if self.function_def.concurrency_limit > 1:
+            print(
+                "Warning: Interactivity is not supported on functions with concurrency > 1. You may experience unexpected behavior."
+            )
+
+        # todo(nathan): add warning if concurrency limit > 1. but idk how to check this here
+        # todo(nathan): check if function interactivity is enabled
+        try:
+            await self._client.stub.FunctionStartPtyShell(Empty())
+        except Exception as e:
+            print("Error: Failed to start PTY shell.")
+            raise e
+
 
 ContainerIOManager = synchronize_api(_ContainerIOManager)
 
@@ -580,3 +607,14 @@ def is_local() -> bool:
     Returns `False` when executed from a Modal container in the cloud.
     """
     return not _ContainerIOManager._singleton
+
+
+async def _interact() -> None:
+    container_io_manager = _ContainerIOManager._singleton
+    if not container_io_manager:
+        raise InvalidError("Interactivity only works inside a Modal container.")
+    else:
+        await container_io_manager.interact()
+
+
+interact = synchronize_api(_interact)

--- a/modal/app.py
+++ b/modal/app.py
@@ -47,7 +47,6 @@ class _ContainerApp:
     # if true, there's an active PTY shell session connected to this process.
     is_interactivity_enabled: bool
     function_def: Optional[api_pb2.Function]
-    fetching_inputs: bool
 
     def __init__(self):
         self.app_id = None

--- a/modal/app.py
+++ b/modal/app.py
@@ -58,32 +58,25 @@ class _ContainerApp:
         self.fetching_inputs = True
 
 
-def _reset_container_app():
-    # Just used for tests
-    global _container_app
-    _container_app.__init__()  # type: ignore
-
-
-_container_app = _ContainerApp()
-
-
 def _init_container_app(
     items: List[api_pb2.AppGetObjectsItem],
     app_id: str,
     environment_name: str = "",
     function_def: Optional[api_pb2.Function] = None,
-):
+) -> _ContainerApp:
     """Used by the container to bootstrap the app and all its objects. Not intended to be called by Modal users."""
-    global _container_app
+    container_app = _ContainerApp()
 
-    _container_app.app_id = app_id
-    _container_app.environment_name = environment_name
-    _container_app.function_def = function_def
-    _container_app.tag_to_object_id = {}
-    _container_app.object_handle_metadata = {}
+    container_app.app_id = app_id
+    container_app.environment_name = environment_name
+    container_app.function_def = function_def
+    container_app.tag_to_object_id = {}
+    container_app.object_handle_metadata = {}
     for item in items:
         handle_metadata: Optional[Message] = get_proto_oneof(item.object, "handle_metadata_oneof")
-        _container_app.object_handle_metadata[item.object.object_id] = handle_metadata
+        container_app.object_handle_metadata[item.object.object_id] = handle_metadata
         logger.debug(f"Setting metadata for {item.object.object_id} ({item.tag})")
         if item.tag:
-            _container_app.tag_to_object_id[item.tag] = item.object.object_id
+            container_app.tag_to_object_id[item.tag] = item.object.object_id
+
+    return container_app

--- a/modal/app.py
+++ b/modal/app.py
@@ -65,12 +65,10 @@ class _ContainerApp:
 
 def _reset_container_app():
     # Just used for tests
-    global _is_container_app, _container_app
-    _is_container_app = False
+    global _container_app
     _container_app.__init__()  # type: ignore
 
 
-_is_container_app = False
 _container_app = _ContainerApp()
 
 
@@ -81,9 +79,8 @@ def _init_container_app(
     function_def: Optional[api_pb2.Function] = None,
 ):
     """Used by the container to bootstrap the app and all its objects. Not intended to be called by Modal users."""
-    global _container_app, _is_container_app
+    global _container_app
 
-    _is_container_app = True
     _container_app.app_id = app_id
     _container_app.environment_name = environment_name
     _container_app.function_def = function_def
@@ -130,12 +127,3 @@ async def _interact(client: Optional[_Client] = None) -> None:
 
 
 interact = synchronize_api(_interact)
-
-
-def is_local() -> bool:
-    """Returns if we are currently on the machine launching/deploying a Modal app
-
-    Returns `True` when executed locally on the user's machine.
-    Returns `False` when executed from a Modal container in the cloud.
-    """
-    return not _is_container_app

--- a/modal/experimental.py
+++ b/modal/experimental.py
@@ -1,10 +1,9 @@
 # Copyright Modal Labs 2022
+from ._container_io_manager import _ContainerIOManager
 
 
 def stop_fetching_inputs():
     """Don't fetch any more inputs from the server, after the current one.
     The container will exit gracefully after the current input is processed."""
 
-    from .app import _container_app
-
-    _container_app.fetching_inputs = False
+    _ContainerIOManager.stop_fetching_inputs()

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -32,6 +32,7 @@ from synchronicity.exceptions import UserCodeException
 
 from modal_proto import api_grpc, api_pb2
 
+from ._container_io_manager import is_local
 from ._location import parse_cloud_provider
 from ._output import OutputManager
 from ._pty import get_pty_info
@@ -53,7 +54,6 @@ from ._utils.blob_utils import (
 from ._utils.function_utils import FunctionInfo, _stream_function_call_data, get_referred_objects, is_async
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.mount_utils import validate_mount_points, validate_volumes
-from .app import is_local
 from .call_graph import InputInfo, _reconstruct_call_graph
 from .client import _Client
 from .cloud_bucket_mount import _CloudBucketMount, cloud_bucket_mounts_to_proto

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -11,6 +11,7 @@ from synchronicity.async_wrap import asynccontextmanager
 
 from modal_proto import api_pb2
 
+from ._container_io_manager import is_local
 from ._output import OutputManager, get_app_logs_loop, step_completed, step_progress
 from ._pty import get_pty_info
 from ._resolver import Resolver
@@ -18,7 +19,7 @@ from ._sandbox_shell import connect_to_sandbox
 from ._utils.app_utils import is_valid_app_name
 from ._utils.async_utils import TaskContext, synchronize_api
 from ._utils.grpc_utils import retry_transient_errors
-from .app import _LocalApp, is_local
+from .app import _LocalApp
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, _Client
 from .config import config, logger
 from .exception import ExecutionError, InteractiveTimeoutError, InvalidError, _CliUserExecutionError

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -6,10 +6,10 @@ from grpclib import GRPCError, Status
 
 from modal_proto import api_pb2
 
+from ._container_io_manager import is_local
 from ._resolver import Resolver
 from ._utils.async_utils import synchronize_api
 from ._utils.grpc_utils import retry_transient_errors
-from .app import is_local
 from .client import _Client
 from .exception import InvalidError, NotFoundError
 from .object import _get_environment_name, _Object

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -7,7 +7,7 @@ from typing_extensions import assert_type
 
 from modal import Cls, Function, Image, Queue, Stub, build, enter, exit, method
 from modal._serialization import deserialize
-from modal.app import _container_app, _init_container_app
+from modal.app import _init_container_app
 from modal.exception import DeprecationError, ExecutionError, InvalidError
 from modal.partial_function import (
     _find_callables_for_obj,
@@ -405,10 +405,10 @@ def test_rehydrate(client, servicer, reset_container_app):
     app_id = deploy_stub(stub, "my-cls-app", client=client).app_id
 
     # Initialize a container
-    _init_container_app([], app_id)
+    container_app = _init_container_app([], app_id)
 
     # Associate app with stub
-    stub._init_container(client, _container_app)
+    stub._init_container(client, container_app)
 
     # Hydration shouldn't overwrite local function definition
     obj = Foo()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -28,6 +28,7 @@ from grpclib import GRPCError, Status
 
 import modal._serialization
 from modal import __version__, config
+from modal._container_io_manager import _ContainerIOManager
 from modal._serialization import serialize_data_format
 from modal._utils.async_utils import asyncify, synchronize_api
 from modal._utils.grpc_testing import patch_mock_servicer
@@ -1383,6 +1384,7 @@ def reset_container_app():
         yield
     finally:
         _reset_container_app()
+        _ContainerIOManager._reset_singleton()
 
 
 @pytest.fixture

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -35,7 +35,6 @@ from modal._utils.grpc_testing import patch_mock_servicer
 from modal._utils.grpc_utils import find_free_port
 from modal._utils.http_utils import run_temporary_http_server
 from modal._vendor import cloudpickle
-from modal.app import _reset_container_app
 from modal.client import Client
 from modal.image import ImageBuilderVersion
 from modal.mount import client_mount_name
@@ -1383,7 +1382,6 @@ def reset_container_app():
     try:
         yield
     finally:
-        _reset_container_app()
         _ContainerIOManager._reset_singleton()
 
 

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -4,6 +4,7 @@ import pytest
 from google.protobuf.empty_pb2 import Empty
 
 from modal import Stub, interact
+from modal._container_io_manager import ContainerIOManager
 from modal.app import _container_app, _init_container_app
 from modal_proto import api_pb2
 
@@ -43,6 +44,9 @@ async def test_container_function_lazily_imported(container_client):
 
 @skip_windows_unix_socket
 def test_interact(container_client, unix_servicer):
+    # Initialize container singleton
+    ContainerIOManager(api_pb2.ContainerArguments(), container_client)
+
     with unix_servicer.intercept() as ctx:
         ctx.add_response("FunctionStartPtyShell", Empty())
-        interact(container_client)
+        interact()

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -5,7 +5,7 @@ from google.protobuf.empty_pb2 import Empty
 
 from modal import Stub, interact
 from modal._container_io_manager import ContainerIOManager
-from modal.app import _container_app, _init_container_app
+from modal.app import _init_container_app
 from modal_proto import api_pb2
 
 from .supports.skip import skip_windows_unix_socket
@@ -31,11 +31,11 @@ async def test_container_function_lazily_imported(container_client):
             object=api_pb2.Object(object_id="di-123"),
         ),
     ]
-    _init_container_app(items, "ap-123")
+    container_app = _init_container_app(items, "ap-123")
     stub = Stub()
 
     # This is normally done in _container_entrypoint
-    stub._init_container(container_client, _container_app)
+    stub._init_container(container_client, container_app)
 
     # Now, let's create my_f after the app started running and make sure it works
     my_f_container = stub.function()(my_f_1)

--- a/test/webhook_test.py
+++ b/test/webhook_test.py
@@ -8,7 +8,7 @@ from fastapi.testclient import TestClient
 
 from modal import Stub, asgi_app, web_endpoint, wsgi_app
 from modal._asgi import webhook_asgi_app
-from modal.app import _container_app, _init_container_app
+from modal.app import _init_container_app
 from modal.exception import InvalidError
 from modal.functions import Function
 from modal_proto import api_pb2
@@ -36,8 +36,8 @@ async def test_webhook(servicer, client, reset_container_app):
         assert await f.local(100) == {"square": 10000}
 
         # Make sure the container gets the app id as well
-        _init_container_app([], stub.app_id)
-        stub._init_container(client, _container_app)
+        container_app = _init_container_app([], stub.app_id)
+        stub._init_container(client, container_app)
         assert isinstance(f, Function)
         assert f.web_url
 


### PR DESCRIPTION
This moves a bunch of complexity out of `modal.app`, partly because getting rid of the module will make it easier to rename `modal.stub` to `modal.app`, partly because most of that code is fairly old and janky.

In particular, this moves `is_local` and `interact` to the `_ContainerIOManager`. Also deletes the `_container_app` global, since the `_ContainerIOManager` singleton replace it

