### PR TITLE
Use dataclass for the App classes

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -1,82 +1,24 @@
 # Copyright Modal Labs 2022
-from typing import TYPE_CHECKING, Dict, List, Optional, TypeVar
+from dataclasses import dataclass, field
+from typing import Dict, Optional
 
 from google.protobuf.message import Message
 
-from modal_proto import api_pb2
-
-from ._utils.grpc_utils import get_proto_oneof
 from .app_utils import _list_apps, list_apps  # noqa: F401
-from .config import logger
-
-if TYPE_CHECKING:
-    from .functions import _Function
-
-else:
-    _Function = TypeVar("_Function")
 
 
+@dataclass
 class _LocalApp:
-    tag_to_object_id: Dict[str, str]
     app_id: str
     app_page_url: str
-    environment_name: str
-    interactive: bool
-
-    def __init__(
-        self,
-        app_id: str,
-        app_page_url: str,
-        tag_to_object_id: Optional[Dict[str, str]] = None,
-        environment_name: Optional[str] = None,
-        interactive: bool = False,
-    ):
-        """mdmd:hidden This is the app constructor. Users should not call this directly."""
-        self.app_id = app_id
-        self.app_page_url = app_page_url
-        self.tag_to_object_id = tag_to_object_id or {}
-        self.environment_name = environment_name
-        self.interactive = interactive
+    tag_to_object_id: Dict[str, str] = field(default_factory=dict)
+    environment_name: Optional[str] = None
+    interactive: bool = False
 
 
+@dataclass
 class _ContainerApp:
-    app_id: Optional[str]
-    environment_name: Optional[str]
-    tag_to_object_id: Dict[str, str]
-    object_handle_metadata: Dict[str, Optional[Message]]
-    # if true, there's an active PTY shell session connected to this process.
-    is_interactivity_enabled: bool
-    function_def: Optional[api_pb2.Function]
-
-    def __init__(self):
-        self.app_id = None
-        self.environment_name = None
-        self.tag_to_object_id = {}
-        self.object_handle_metadata = {}
-        self.is_interactivity_enabled = False
-        self.function_def = None
-        self.fetching_inputs = True
-
-
-def _init_container_app(
-    items: List[api_pb2.AppGetObjectsItem],
-    app_id: str,
-    environment_name: str = "",
-    function_def: Optional[api_pb2.Function] = None,
-) -> _ContainerApp:
-    """Used by the container to bootstrap the app and all its objects. Not intended to be called by Modal users."""
-    container_app = _ContainerApp()
-
-    container_app.app_id = app_id
-    container_app.environment_name = environment_name
-    container_app.function_def = function_def
-    container_app.tag_to_object_id = {}
-    container_app.object_handle_metadata = {}
-    for item in items:
-        handle_metadata: Optional[Message] = get_proto_oneof(item.object, "handle_metadata_oneof")
-        container_app.object_handle_metadata[item.object.object_id] = handle_metadata
-        logger.debug(f"Setting metadata for {item.object.object_id} ({item.tag})")
-        if item.tag:
-            container_app.tag_to_object_id[item.tag] = item.object.object_id
-
-    return container_app
+    app_id: str
+    environment_name: Optional[str] = None
+    tag_to_object_id: Dict[str, str] = field(default_factory=dict)
+    object_handle_metadata: Dict[str, Optional[Message]] = field(default_factory=dict)

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -7,7 +7,7 @@ from typing_extensions import assert_type
 
 from modal import Cls, Function, Image, Queue, Stub, build, enter, exit, method
 from modal._serialization import deserialize
-from modal.app import _init_container_app
+from modal.app import _ContainerApp
 from modal.exception import DeprecationError, ExecutionError, InvalidError
 from modal.partial_function import (
     _find_callables_for_obj,
@@ -405,7 +405,7 @@ def test_rehydrate(client, servicer, reset_container_app):
     app_id = deploy_stub(stub, "my-cls-app", client=client).app_id
 
     # Initialize a container
-    container_app = _init_container_app([], app_id)
+    container_app = _ContainerApp(app_id=app_id)
 
     # Associate app with stub
     stub._init_container(client, container_app)

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -5,7 +5,7 @@ from google.protobuf.empty_pb2 import Empty
 
 from modal import Stub, interact
 from modal._container_io_manager import ContainerIOManager
-from modal.app import _init_container_app
+from modal.app import _ContainerApp
 from modal_proto import api_pb2
 
 from .supports.skip import skip_windows_unix_socket
@@ -18,20 +18,16 @@ def my_f_1(x):
 @skip_windows_unix_socket
 @pytest.mark.asyncio
 async def test_container_function_lazily_imported(container_client):
-    items = [
-        api_pb2.AppGetObjectsItem(
-            tag="my_f_1",
-            object=api_pb2.Object(
-                object_id="fu-123",
-                function_handle_metadata=api_pb2.FunctionHandleMetadata(),
-            ),
-        ),
-        api_pb2.AppGetObjectsItem(
-            tag="my_d",
-            object=api_pb2.Object(object_id="di-123"),
-        ),
-    ]
-    container_app = _init_container_app(items, "ap-123")
+    tag_to_object_id = {
+        "my_f_1": "fu-123",
+        "my_d": "di-123",
+    }
+    object_handle_metadata = {
+        "fu-123": api_pb2.FunctionHandleMetadata(),
+    }
+    container_app = _ContainerApp(
+        app_id="ap-123", tag_to_object_id=tag_to_object_id, object_handle_metadata=object_handle_metadata
+    )
     stub = Stub()
 
     # This is normally done in _container_entrypoint

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -1,7 +1,9 @@
 # Copyright Modal Labs 2022
 import pytest
+from typing import Dict
 
 from google.protobuf.empty_pb2 import Empty
+from google.protobuf.message import Message
 
 from modal import Stub, interact
 from modal._container_io_manager import ContainerIOManager
@@ -18,11 +20,11 @@ def my_f_1(x):
 @skip_windows_unix_socket
 @pytest.mark.asyncio
 async def test_container_function_lazily_imported(container_client):
-    tag_to_object_id = {
+    tag_to_object_id: Dict[str, str] = {
         "my_f_1": "fu-123",
         "my_d": "di-123",
     }
-    object_handle_metadata = {
+    object_handle_metadata: Dict[str, Message] = {
         "fu-123": api_pb2.FunctionHandleMetadata(),
     }
     container_app = _ContainerApp(

--- a/test/webhook_test.py
+++ b/test/webhook_test.py
@@ -8,7 +8,7 @@ from fastapi.testclient import TestClient
 
 from modal import Stub, asgi_app, web_endpoint, wsgi_app
 from modal._asgi import webhook_asgi_app
-from modal.app import _init_container_app
+from modal.app import _ContainerApp
 from modal.exception import InvalidError
 from modal.functions import Function
 from modal_proto import api_pb2
@@ -36,7 +36,7 @@ async def test_webhook(servicer, client, reset_container_app):
         assert await f.local(100) == {"square": 10000}
 
         # Make sure the container gets the app id as well
-        container_app = _init_container_app([], stub.app_id)
+        container_app = _ContainerApp(app_id=stub.app_id)
         stub._init_container(client, container_app)
         assert isinstance(f, Function)
         assert f.web_url


### PR DESCRIPTION
This change supersedes #1660 which fell too far behind to be worth rebasing. It further simplifies `modal.app` to two simple dataclasses. All in all `app.py` is down to 24 lines now from I think 500 lines a few weeks ago, so we're super close to removing it at this point! The goal of this is to rename `stub.py` to `app.py`.