### PR TITLE
[MOD-2536] support R2 in CloudBucketMount

### DIFF
--- a/modal/cloud_bucket_mount.py
+++ b/modal/cloud_bucket_mount.py
@@ -85,10 +85,11 @@ def cloud_bucket_mounts_to_proto(mounts: List[Tuple[str, _CloudBucketMount]]) ->
     cloud_bucket_mounts: List[api_pb2.CloudBucketMount] = []
 
     for path, mount in mounts:
+        # TODO: in future this relationship between endpoint URL and type will not hold true.
         if mount.bucket_endpoint_url:
-            bucket_type = api_pb2.CloudBucketMount.BucketType.S3
-        else:
             bucket_type = api_pb2.CloudBucketMount.BucketType.R2
+        else:
+            bucket_type = api_pb2.CloudBucketMount.BucketType.S3
 
         if mount.requester_pays and not mount.secret:
             raise ValueError("Credentials required in order to use Requester Pays.")

--- a/modal/cloud_bucket_mount.py
+++ b/modal/cloud_bucket_mount.py
@@ -69,7 +69,7 @@ class _CloudBucketMount:
 
     bucket_name: str
     # Endpoint URL is used to support Cloudflare R2.
-    bucket_endpoint_url: Optional[str]
+    bucket_endpoint_url: Optional[str] = None
 
     # Credentials used to access a cloud bucket.
     # If the bucket is private, the secret **must** contain AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.

--- a/modal/cloud_bucket_mount.py
+++ b/modal/cloud_bucket_mount.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2022
 from dataclasses import dataclass
-from enum import Enum
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple
 
 from modal_proto import api_pb2
 
@@ -9,56 +8,76 @@ from ._utils.async_utils import synchronize_api
 from .secret import _Secret
 
 
-class BucketType(Enum):
-    S3 = "s3"
-
-    @property
-    def proto(self):
-        if self.value == "s3":
-            return api_pb2.CloudBucketMount.BucketType.S3
-
-
 @dataclass
 class _CloudBucketMount:
     """Mounts a cloud bucket to your container. Currently supports AWS S3 buckets.
 
-    S3 buckets are mounted using [AWS' S3 Mountpoint](https://github.com/awslabs/mountpoint-s3).
+    S3 buckets are mounted using [AWS S3 Mountpoint](https://github.com/awslabs/mountpoint-s3).
     S3 mounts are optimized for reading large files sequentially. It does not support every file operation; consult
     [the AWS S3 Mountpoint documentation](https://github.com/awslabs/mountpoint-s3/blob/main/doc/SEMANTICS.md) for more information.
 
-    **Usage**
+    **AWS S3 Usage**
 
     ```python
-    import modal
     import subprocess
 
     stub = modal.Stub()
-
+    secret = modal.Secret.from_dict({
+        "AWS_ACCESS_KEY_ID": "...",
+        "AWS_SECRET_ACCESS_KEY": "...",
+    })
     @stub.function(
         volumes={
-            "/my-mount": modal.CloudBucketMount("s3-bucket-name", secret=modal.Secret.from_dict({
-                "AWS_ACCESS_KEY_ID": "...",
-                "AWS_SECRET_ACCESS_KEY": "...",
-            }), read_only=True)
+            "/my-mount": modal.CloudBucketMount(
+                bucket_name="s3-bucket-name",
+                secret=secret,
+                read_only=True
+            )
         }
     )
     def f():
-        subprocess.run(["ls", "/my-mount"])
+        subprocess.run(["ls", "/my-mount"], check=True)
+    ```
+
+    **Cloudflare R2 Usage**
+
+    Cloudflare R2 is [S3-compatible](https://developers.cloudflare.com/r2/api/s3/api/) so its setup looks very similar to S3.
+    But additionally the `bucket_endpoint_url` argument must be passed.
+
+    ```python
+    import subprocess
+
+    stub = modal.Stub()
+    secret = modal.Secret.from_dict({
+        "AWS_ACCESS_KEY_ID": "...",
+        "AWS_SECRET_ACCESS_KEY": "...",
+    })
+    @stub.function(
+        volumes={
+            "/my-mount": modal.CloudBucketMount(
+                bucket_name="my-r2-bucket",
+                bucket_endpoint_url="https://<ACCOUNT ID>.r2.cloudflarestorage.com",
+                secret=secret,
+                read_only=True
+            )
+        }
+    )
+    def f():
+        subprocess.run(["ls", "/my-mount"], check=True)
     ```
     """
 
     bucket_name: str
+    # Endpoint URL is used to support Cloudflare R2.
+    bucket_endpoint_url: Optional[str]
 
-    # Credentials used to access a cloud bucket. When
-    # The given secret can contain AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.
-    # AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY can be omitted if the bucket is publicly accessible.
+    # Credentials used to access a cloud bucket.
+    # If the bucket is private, the secret **must** contain AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.
+    # If the bucket is publicly accessible, the secret is unnecessary and can be omitted.
     secret: Optional[_Secret] = None
 
     read_only: bool = False
     requester_pays: bool = False
-    bucket_type: Union[
-        BucketType, str
-    ] = BucketType.S3.value  # S3 is the default bucket type until other cloud buckets are supported
 
 
 def cloud_bucket_mounts_to_proto(mounts: List[Tuple[str, _CloudBucketMount]]) -> List[api_pb2.CloudBucketMount]:
@@ -66,20 +85,21 @@ def cloud_bucket_mounts_to_proto(mounts: List[Tuple[str, _CloudBucketMount]]) ->
     cloud_bucket_mounts: List[api_pb2.CloudBucketMount] = []
 
     for path, mount in mounts:
-        if isinstance(mount.bucket_type, str):
-            bucket_type = BucketType(mount.bucket_type)
+        if mount.bucket_endpoint_url:
+            bucket_type = api_pb2.CloudBucketMount.BucketType.S3
         else:
-            bucket_type = mount.bucket_type
+            bucket_type = api_pb2.CloudBucketMount.BucketType.R2
 
         if mount.requester_pays and not mount.secret:
             raise ValueError("Credentials required in order to use Requester Pays.")
 
         cloud_bucket_mount = api_pb2.CloudBucketMount(
             bucket_name=mount.bucket_name,
+            bucket_endpoint_url=mount.bucket_endpoint_url,
             mount_path=path,
             credentials_secret_id=mount.secret.object_id if mount.secret else "",
             read_only=mount.read_only,
-            bucket_type=bucket_type.proto,
+            bucket_type=bucket_type,
             requester_pays=mount.requester_pays,
         )
         cloud_bucket_mounts.append(cloud_bucket_mount)

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -1,6 +1,5 @@
 # Copyright Modal Labs 2022
 import inspect
-import os
 import typing
 from pathlib import PurePosixPath
 from typing import Any, AsyncGenerator, Callable, ClassVar, Dict, List, Optional, Sequence, Union
@@ -18,6 +17,7 @@ from ._utils.function_utils import FunctionInfo
 from ._utils.mount_utils import validate_volumes
 from .app import _ContainerApp, _LocalApp
 from .client import _Client
+from .cloud_bucket_mount import _CloudBucketMount
 from .cls import _Cls
 from .config import logger
 from .exception import InvalidError, deprecation_error, deprecation_warning
@@ -479,7 +479,9 @@ class _Stub:
         network_file_systems: Dict[
             Union[str, PurePosixPath], _NetworkFileSystem
         ] = {},  # Mountpoints for Modal NetworkFileSystems
-        volumes: Dict[Union[str, PurePosixPath], _Volume] = {},  # Mountpoints for Modal Volumes
+        volumes: Dict[
+            Union[str, PurePosixPath], Union[_Volume, _CloudBucketMount]
+        ] = {},  # Mount points for Modal Volumes & CloudBucketMounts
         allow_cross_region_volumes: bool = False,  # Whether using network file systems from other regions is allowed.
         cpu: Optional[float] = None,  # How many CPU cores to request. This is a soft limit.
         memory: Optional[int] = None,  # How much memory to request, in MiB. This is a soft limit.
@@ -615,7 +617,9 @@ class _Stub:
         network_file_systems: Dict[
             Union[str, PurePosixPath], _NetworkFileSystem
         ] = {},  # Mountpoints for Modal NetworkFileSystems
-        volumes: Dict[Union[str, PurePosixPath], _Volume] = {},  # Mountpoints for Modal Volumes
+        volumes: Dict[
+            Union[str, PurePosixPath], Union[_Volume, _CloudBucketMount]
+        ] = {},  # Mount points for Modal Volumes & CloudBucketMounts
         allow_cross_region_volumes: bool = False,  # Whether using network file systems from other regions is allowed.
         cpu: Optional[float] = None,  # How many CPU cores to request. This is a soft limit.
         memory: Optional[int] = None,  # How much memory to request, in MiB. This is a soft limit.
@@ -714,7 +718,9 @@ class _Stub:
         cpu: Optional[float] = None,  # How many CPU cores to request. This is a soft limit.
         memory: Optional[int] = None,  # How much memory to request, in MiB. This is a soft limit.
         block_network: bool = False,  # Whether to block network access
-        volumes: Dict[Union[str, os.PathLike], _Volume] = {},  # Volumes to mount in the sandbox.
+        volumes: Dict[
+            Union[str, PurePosixPath], Union[_Volume, _CloudBucketMount]
+        ] = {},  # Mount points for Modal Volumes & CloudBucketMounts
         _allow_background_volume_commits: bool = False,
         pty_info: Optional[api_pb2.PTYInfo] = None,
     ) -> _Sandbox:

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -84,17 +84,19 @@ enum ClientType {
 }
 
 message CloudBucketMount {
+  enum BucketType {
+    UNSPECIFIED = 0;
+    S3 = 1;
+    R2 = 2;
+  }
+
   string bucket_name = 1;
   string mount_path = 2;
   string credentials_secret_id = 3;
   bool read_only = 4;
-  bool requester_pays = 6;
-
-  enum BucketType {
-    UNSPECIFIED = 0;
-    S3 = 1;
-  }
   BucketType bucket_type = 5;
+  bool requester_pays = 6;
+  optional string bucket_endpoint_url = 7;
 }
 
 enum CloudProvider {

--- a/test/cloud_bucket_mount_test.py
+++ b/test/cloud_bucket_mount_test.py
@@ -1,0 +1,21 @@
+import modal
+
+
+def dummy():
+    pass
+
+
+def test_volume_mount(client, servicer):
+    stub = modal.Stub()
+    secret = modal.Secret.from_dict({"AWS_ACCESS_KEY_ID": "1", "AWS_SECRET_ACCESS_KEY": "2"})
+    cld_bckt_mnt = modal.CloudBucketMount(
+        bucket_name="foo",
+        bucket_endpoint_url="https://1234.r2.cloudflarestorage.com",
+        secret=secret,
+        read_only=False,
+    )
+
+    _ = stub.function(volumes={"/root/foo": cld_bckt_mnt})(dummy)
+
+    with stub.run(client=client):
+        pass

--- a/test/cloud_bucket_mount_test.py
+++ b/test/cloud_bucket_mount_test.py
@@ -1,3 +1,4 @@
+# Copyright Modal Labs 2024
 import modal
 
 


### PR DESCRIPTION
## Describe your changes

- MOD-2536

## Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

## Changelog

* Cloudflare R2 bucket support added to `modal.CloudBucketMount`
