### PR TITLE
Re-apply `.map()` on main thread-refactor

### DIFF
--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -234,6 +234,8 @@ def run_coro_blocking(coro):
 async def queue_batch_iterator(q: asyncio.Queue, max_batch_size=100, debounce_time=0.015):
     """
     Read from a queue but return lists of items when queue is large
+
+    Treats a None value as end of queue items
     """
     item_list: List[Any] = []
 
@@ -257,9 +259,9 @@ async def queue_batch_iterator(q: asyncio.Queue, max_batch_size=100, debounce_ti
 
 
 class _WarnIfGeneratorIsNotConsumed:
-    def __init__(self, gen, gen_f):
+    def __init__(self, gen, function_name: str):
         self.gen = gen
-        self.gen_f = gen_f
+        self.function_name = function_name
         self.iterated = False
         self.warned = False
 
@@ -271,30 +273,72 @@ class _WarnIfGeneratorIsNotConsumed:
         self.iterated = True
         return await self.gen.__anext__()
 
+    async def asend(self, value):
+        self.iterated = True
+        return await self.gen.asend(value)
+
     def __repr__(self):
         return repr(self.gen)
 
     def __del__(self):
         if not self.iterated and not self.warned:
             self.warned = True
-            name = self.gen_f.__name__
             logger.warning(
-                f"Warning: the results of a call to {name} was not consumed, so the call will never be executed."
-                f" Consider a for-loop like `for x in {name}(...)` or unpacking the generator using `list(...)`"
+                f"Warning: the results of a call to {self.function_name} was not consumed, so the call will never be executed."
+                f" Consider a for-loop like `for x in {self.function_name}(...)` or unpacking the generator using `list(...)`"
             )
 
 
 synchronize_api(_WarnIfGeneratorIsNotConsumed)
 
 
-def warn_if_generator_is_not_consumed(gen_f):
-    # https://gist.github.com/erikbern/01ae78d15f89edfa7f77e5c0a827a94d
-    @functools.wraps(gen_f)
-    def f_wrapped(*args, **kwargs):
-        gen = gen_f(*args, **kwargs)
-        return _WarnIfGeneratorIsNotConsumed(gen, gen_f)
+class _WarnIfBlockingGeneratorIsNotConsumed:
+    def __init__(self, gen, function_name: str):
+        self.gen = gen
+        self.function_name = function_name
+        self.iterated = False
+        self.warned = False
 
-    return f_wrapped
+    def __iter__(self):
+        self.iterated = True
+        return self.gen
+
+    def __next__(self):
+        self.iterated = True
+        return self.gen.__next__()
+
+    def send(self, value):
+        self.iterated = True
+        return self.gen.send(value)
+
+    def __repr__(self):
+        return repr(self.gen)
+
+    def __del__(self):
+        if not self.iterated and not self.warned:
+            self.warned = True
+            logger.warning(
+                f"Warning: the results of a call to {self.function_name} was not consumed, so the call will never be executed."
+                f" Consider a for-loop like `for x in {self.function_name}(...)` or unpacking the generator using `list(...)`"
+            )
+
+
+def warn_if_generator_is_not_consumed(function_name: Optional[str] = None):
+    # https://gist.github.com/erikbern/01ae78d15f89edfa7f77e5c0a827a94d
+    def decorator(gen_f):
+        presented_func_name = function_name if function_name is not None else gen_f.__name__
+
+        @functools.wraps(gen_f)
+        def f_wrapped(*args, **kwargs):
+            gen = gen_f(*args, **kwargs)
+            if inspect.isasyncgen(gen):
+                return _WarnIfGeneratorIsNotConsumed(gen, presented_func_name)
+            else:
+                return _WarnIfBlockingGeneratorIsNotConsumed(gen, presented_func_name)
+
+        return f_wrapped
+
+    return decorator
 
 
 _shutdown_tasks = []
@@ -384,3 +428,42 @@ async def asyncnullcontext(*args, **kwargs):
         pass
     """
     yield
+
+
+YIELD_TYPE = typing.TypeVar("YIELD_TYPE")
+SEND_TYPE = typing.TypeVar("SEND_TYPE")
+
+
+class NestedAsyncCalls(Exception):
+    pass
+
+
+def run_generator_sync(
+    gen: typing.AsyncGenerator[YIELD_TYPE, SEND_TYPE],
+) -> typing.Generator[YIELD_TYPE, SEND_TYPE, None]:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        pass  # no event loop - this is what we expect!
+    else:
+        raise NestedAsyncCalls()
+    loop = asyncio.new_event_loop()  # set up new event loop for the map so we can use async logic
+
+    # more or less copied from synchronicity's implementation:
+    next_send: typing.Union[SEND_TYPE, None] = None
+    next_yield: YIELD_TYPE
+    exc: Optional[BaseException] = None
+    while True:
+        try:
+            if exc:
+                next_yield = loop.run_until_complete(gen.athrow(exc))
+            else:
+                next_yield = loop.run_until_complete(gen.asend(next_send))  # type: ignore[arg-type]
+        except StopAsyncIteration:
+            break
+        try:
+            next_send = yield next_yield
+            exc = None
+        except BaseException as err:
+            exc = err
+    loop.close()

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -15,6 +15,9 @@ from typing import (
     Callable,
     Collection,
     Dict,
+    Generator,
+    Iterable,
+    Iterator,
     List,
     Literal,
     Optional,
@@ -30,6 +33,7 @@ from aiostream import pipe, stream
 from google.protobuf.message import Message
 from grpclib import GRPCError, Status
 from grpclib.exceptions import StreamTerminatedError
+from synchronicity.combined_types import MethodWithAio
 from synchronicity.exceptions import UserCodeException
 
 from modal import _pty, is_local
@@ -41,7 +45,9 @@ from ._resolver import Resolver
 from ._serialization import deserialize, deserialize_data_format, serialize
 from ._traceback import append_modal_tb
 from ._utils.async_utils import (
+    NestedAsyncCalls,
     queue_batch_iterator,
+    run_generator_sync,
     synchronize_api,
     synchronizer,
     warn_if_generator_is_not_consumed,
@@ -85,6 +91,27 @@ ATTEMPT_TIMEOUT_GRACE_PERIOD = 5  # seconds
 
 if TYPE_CHECKING:
     import modal.stub
+
+
+class _SynchronizedQueue:
+    """mdmd:hidden"""
+
+    # small wrapper around asyncio.Queue to make it cross-thread compatible through synchronicity
+    async def init(self):
+        # in Python 3.8 the asyncio.Queue is bound to the event loop on creation
+        # so it needs to be created in a synchronicity-wrapped init method
+        self.q = asyncio.Queue()
+
+    @synchronizer.no_io_translation
+    async def put(self, item):
+        await self.q.put(item)
+
+    @synchronizer.no_io_translation
+    async def get(self):
+        return await self.q.get()
+
+
+SynchronizedQueue = synchronize_api(_SynchronizedQueue)
 
 
 def exc_with_hints(exc: BaseException):
@@ -341,8 +368,7 @@ MAP_INVOCATION_CHUNK_SIZE = 49
 
 async def _map_invocation(
     function_id: str,
-    input_stream: AsyncIterable[Any],
-    kwargs: Dict[str, Any],
+    raw_input_queue: _SynchronizedQueue,
     client: _Client,
     order_outputs: bool,
     return_exceptions: bool,
@@ -362,21 +388,33 @@ async def _map_invocation(
     have_all_inputs = False
     num_inputs = 0
     num_outputs = 0
+
+    def count_update():
+        if count_update_callback is not None:
+            count_update_callback(num_outputs, num_inputs)
+
     pending_outputs: Dict[str, int] = {}  # Map input_id -> next expected gen_index value
     completed_outputs: Set[str] = set()  # Set of input_ids whose outputs are complete (expecting no more values)
 
     input_queue: asyncio.Queue = asyncio.Queue()
 
-    async def create_input(arg: Any) -> api_pb2.FunctionPutInputsItem:
+    async def create_input(argskwargs):
         nonlocal num_inputs
         idx = num_inputs
         num_inputs += 1
-        item = await _create_input(arg, kwargs, client, idx=idx)
-        return item
+        (args, kwargs) = argskwargs
+        return await _create_input(args, kwargs, client, idx)
+
+    async def input_iter():
+        while 1:
+            raw_input = await raw_input_queue.get()
+            if raw_input is None:  # end of input sentinel
+                return
+            yield raw_input  # args, kwargs
 
     async def drain_input_generator():
         # Parallelize uploading blobs
-        proto_input_stream = stream.iterate(input_stream) | pipe.map(
+        proto_input_stream = stream.iterate(input_iter()) | pipe.map(
             create_input,  # type: ignore[reportArgumentType]
             ordered=True,
             task_limit=BLOB_MAX_PARALLELISM,
@@ -391,7 +429,7 @@ async def _map_invocation(
 
     async def pump_inputs():
         assert client.stub
-        nonlocal have_all_inputs
+        nonlocal have_all_inputs, num_inputs
         async for items in queue_batch_iterator(input_queue, MAP_INVOCATION_CHUNK_SIZE):
             request = api_pb2.FunctionPutInputsRequest(
                 function_id=function_id, inputs=items, function_call_id=function_call_id
@@ -406,6 +444,7 @@ async def _map_invocation(
                 max_delay=10,
                 additional_status_codes=[Status.RESOURCE_EXHAUSTED],
             )
+            count_update()
             for item in resp.inputs:
                 pending_outputs.setdefault(item.input_id, 0)
             logger.debug(
@@ -482,8 +521,7 @@ async def _map_invocation(
 
         async with outputs_fetched.stream() as streamer:
             async for idx, output in streamer:
-                if count_update_callback is not None:
-                    count_update_callback(num_outputs, num_inputs)
+                count_update()
                 if not order_outputs:
                     yield _OutputValue(output)
                 else:
@@ -1181,7 +1219,18 @@ class _Function(_Object, type_prefix="fu"):
         assert self._is_generator is not None
         return self._is_generator
 
-    async def _map(self, input_stream: AsyncIterable[Any], order_outputs: bool, return_exceptions: bool, kwargs={}):
+    @live_method_gen
+    async def _map(
+        self, input_queue: _SynchronizedQueue, order_outputs: bool, return_exceptions: bool
+    ) -> AsyncGenerator[Any, None]:
+        """mdmd:hidden
+
+        Synchronicity-wrapped map implementation. To be safe against invocations of user code in the synchronicity thread
+        it doesn't accept an [async]iterator, and instead takes a _SynchronizedQueue instance.
+
+        _SynchronizedQueue is used instead of asyncio.Queue so that the main thread can put
+        items in the queue safely.
+        """
         if self._web_url:
             raise InvalidError(
                 "A web endpoint function cannot be directly invoked for parallel remote execution. "
@@ -1197,8 +1246,7 @@ class _Function(_Object, type_prefix="fu"):
 
         async for item in _map_invocation(
             self.object_id,
-            input_stream,
-            kwargs,
+            input_queue,
             self._client,
             order_outputs,
             return_exceptions,
@@ -1218,7 +1266,7 @@ class _Function(_Object, type_prefix="fu"):
     async def _call_function_nowait(self, args, kwargs) -> _Invocation:
         return await _Invocation.create(self.object_id, args, kwargs, self._client)
 
-    @warn_if_generator_is_not_consumed
+    @warn_if_generator_is_not_consumed()
     @live_method_gen
     @synchronizer.no_input_translation
     async def _call_generator(self, args, kwargs):
@@ -1230,16 +1278,18 @@ class _Function(_Object, type_prefix="fu"):
     async def _call_generator_nowait(self, args, kwargs):
         return await _Invocation.create(self.object_id, args, kwargs, self._client)
 
-    @warn_if_generator_is_not_consumed
-    @live_method_gen
-    @synchronizer.no_input_translation
-    async def map(
+    # note that `map()` is not synchronicity-wrapped, since it accepts executable code in the form of
+    # iterators that we don't want to run inside the synchronicity thread. We delegate to `._map()` with
+    # a safer Queue as input
+    @synchronizer.nowrap
+    @warn_if_generator_is_not_consumed(function_name="Function.map")
+    def _map_sync(
         self,
-        *input_iterators,  # one input iterator per argument in the mapped-over function/generator
+        *input_iterators: Iterable[Any],  # one input iterator per argument in the mapped-over function/generator
         kwargs={},  # any extra keyword arguments for the function
         order_outputs: bool = True,  # return outputs in order
-        return_exceptions: bool = False,  # propogate exceptions (False) or aggregate them in the results list (True)
-    ) -> AsyncGenerator[Any, None]:
+        return_exceptions: bool = False,  # propagate exceptions (False) or aggregate them in the results list (True)
+    ) -> Generator[Any, None, None]:
         """Parallel map over a set of inputs.
 
         Takes one iterator argument per argument in the function being mapped over.
@@ -1276,13 +1326,58 @@ class _Function(_Object, type_prefix="fu"):
             print(list(my_func.map(range(3), return_exceptions=True)))
         ```
         """
+        try:
+            for output in run_generator_sync(
+                self._map_async(
+                    *input_iterators, kwargs=kwargs, order_outputs=order_outputs, return_exceptions=return_exceptions
+                )
+            ):
+                yield output
+        except NestedAsyncCalls:
+            raise InvalidError(
+                "You can't run Function.map() or Function.for_each() from an async function. Use Function.map.aio()/Function.for_each.aio() instead."
+            )
 
-        input_stream = stream.zip(*(stream.iterate(it) for it in input_iterators))
-        async for item in self._map(input_stream, order_outputs, return_exceptions, kwargs):
-            yield item
+    @synchronizer.nowrap
+    @warn_if_generator_is_not_consumed(function_name="Function.map.aio")
+    async def _map_async(
+        self,
+        *input_iterators: Union[
+            Iterable[Any], AsyncIterable[Any]
+        ],  # one input iterator per argument in the mapped-over function/generator
+        kwargs={},  # any extra keyword arguments for the function
+        order_outputs: bool = True,  # return outputs in order
+        return_exceptions: bool = False,  # propagate exceptions (False) or aggregate them in the results list (True)
+    ) -> AsyncGenerator[Any, None]:
+        """mdmd:hidden
+        This runs in an event loop on the main thread
 
-    @synchronizer.no_input_translation
-    async def for_each(self, *input_iterators, kwargs={}, ignore_exceptions: bool = False):
+        It concurrently feeds new input to the input queue and yields available outputs
+        to the caller.
+        Note that since the iterator(s) can block, it's a bit opaque how often the event
+        loop decides to get a new input vs how often it will emit a new output.
+        We could make this explicit as an improvement or even let users decide what they
+        prefer: throughput (prioritize queueing inputs) or latency (prioritize yielding results)
+        """
+        raw_input_queue: Any = SynchronizedQueue()  # type: ignore
+        raw_input_queue.init()
+
+        async def feed_queue():
+            # This runs in a main thread event loop, so it doesn't block the synchronizer loop
+            async with stream.zip(*[stream.iterate(it) for it in input_iterators]).stream() as streamer:
+                async for args in streamer:
+                    await raw_input_queue.put.aio((args, kwargs))
+            await raw_input_queue.put.aio(None)  # end-of-input sentinel
+
+        feed_input_task = asyncio.create_task(feed_queue())
+
+        try:
+            async for output in self._map.aio(raw_input_queue, order_outputs, return_exceptions):  # type: ignore[reportFunctionMemberAccess]
+                yield output
+        finally:
+            feed_input_task.cancel()  # should only be needed in case of exceptions
+
+    def _for_each_sync(self, *input_iterators, kwargs={}, ignore_exceptions: bool = False):
         """Execute function for all inputs, ignoring outputs.
 
         Convenient alias for `.map()` in cases where the function just needs to be called.
@@ -1290,17 +1385,51 @@ class _Function(_Object, type_prefix="fu"):
         """
         # TODO(erikbern): it would be better if this is more like a map_spawn that immediately exits
         # rather than iterating over the result
-        async for _ in self.map(
+        for _ in self.map(*input_iterators, kwargs=kwargs, order_outputs=False, return_exceptions=ignore_exceptions):
+            pass
+
+    @synchronizer.nowrap
+    async def _for_each_async(self, *input_iterators, kwargs={}, ignore_exceptions: bool = False):
+        async for _ in self.map.aio(  # type: ignore
             *input_iterators, kwargs=kwargs, order_outputs=False, return_exceptions=ignore_exceptions
         ):
             pass
 
-    @warn_if_generator_is_not_consumed
-    @live_method_gen
-    @synchronizer.no_input_translation
-    async def starmap(
-        self, input_iterator, kwargs={}, order_outputs: bool = True, return_exceptions: bool = False
-    ) -> AsyncGenerator[Any, None]:
+    @synchronizer.nowrap
+    @warn_if_generator_is_not_consumed(function_name="Function.starmap")
+    async def _starmap_async(
+        self,
+        input_iterator: Union[Iterable[Sequence[Any]], AsyncIterable[Sequence[Any]]],
+        kwargs={},
+        order_outputs: bool = True,
+        return_exceptions: bool = False,
+    ):
+        raw_input_queue: Any = SynchronizedQueue()  # type: ignore
+        raw_input_queue.init()
+
+        async def feed_queue():
+            # This runs in a main thread event loop, so it doesn't block the synchronizer loop
+            async with stream.iterate(input_iterator).stream() as streamer:
+                async for args in streamer:
+                    await raw_input_queue.put.aio((args, kwargs))
+            await raw_input_queue.put.aio(None)  # end-of-input sentinel
+
+        feed_input_task = asyncio.create_task(feed_queue())
+        try:
+            async for output in self._map.aio(raw_input_queue, order_outputs, return_exceptions):  # type: ignore[reportFunctionMemberAccess]
+                yield output
+        finally:
+            feed_input_task.cancel()  # should only be needed in case of exceptions
+
+    @synchronizer.nowrap
+    @warn_if_generator_is_not_consumed(function_name="Function.starmap.aio")
+    def _starmap_sync(
+        self,
+        input_iterator: Iterable[Sequence[Any]],
+        kwargs={},
+        order_outputs: bool = True,
+        return_exceptions: bool = False,
+    ) -> Iterator[Any]:
         """Like `map`, but spreads arguments over multiple function arguments.
 
         Assumes every input is a sequence (e.g. a tuple).
@@ -1317,9 +1446,17 @@ class _Function(_Object, type_prefix="fu"):
             assert list(my_func.starmap([(1, 2), (3, 4)])) == [3, 7]
         ```
         """
-        input_stream = stream.iterate(input_iterator)
-        async for item in self._map(input_stream, order_outputs, return_exceptions, kwargs):
-            yield item
+        try:
+            for output in run_generator_sync(
+                self._starmap_async(
+                    input_iterator, kwargs=kwargs, order_outputs=order_outputs, return_exceptions=return_exceptions
+                ),
+            ):
+                yield output
+        except NestedAsyncCalls:
+            raise InvalidError(
+                "You can't run Function.map() or Function.for_each() from an async function. Use Function.map.aio()/Function.for_each.aio() instead."
+            )
 
     @synchronizer.no_io_translation
     @live_method
@@ -1457,6 +1594,14 @@ class _Function(_Object, type_prefix="fu"):
         return FunctionStats(
             backlog=resp.backlog, num_active_runners=resp.num_active_tasks, num_total_runners=resp.num_total_tasks
         )
+
+    # A bit hacky - but the map-style functions need to not be synchronicity-wrapped
+    # in order to not execute their input iterators on the synchronicity event loop.
+    # We still need to wrap them using MethodWithAio to maintain a synchronicity-like
+    # api with `.aio` and get working type-stubs and reference docs generation:
+    map = MethodWithAio(_map_sync, _map_async, synchronizer)
+    starmap = MethodWithAio(_starmap_sync, _starmap_async, synchronizer)
+    for_each = MethodWithAio(_for_each_sync, _for_each_async, synchronizer)
 
 
 Function = synchronize_api(_Function)

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -393,7 +393,7 @@ class _Queue(_Object, type_prefix="qu"):
         response = await retry_transient_errors(self._client.stub.QueueLen, request)
         return response.len
 
-    @warn_if_generator_is_not_consumed
+    @warn_if_generator_is_not_consumed()
     @live_method_gen
     async def iterate(
         self, *, partition: Optional[str] = None, item_poll_timeout: float = 0.0

--- a/modal_docs/mdmd/signatures.py
+++ b/modal_docs/mdmd/signatures.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2023
 import ast
 import inspect
+import re
 import textwrap
 import warnings
 from typing import Tuple
@@ -69,5 +70,8 @@ def get_signature(name, callable) -> str:
         definition_source = definition_source.replace("async def", "def")
         definition_source = definition_source.replace("asynccontextmanager", "contextmanager")
         definition_source = definition_source.replace("AsyncIterator", "Iterator")
+
+    # remove any synchronicity-internal decorators
+    definition_source, _ = re.subn(r"^\s*@synchronizer\..*\n", "", definition_source)
 
     return definition_source

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     grpclib==0.4.7
     protobuf>=3.19,<6.0,!=4.24.0
     rich>=12.0.0
-    synchronicity~=0.6.5
+    synchronicity~=0.6.6
     toml
     typer~=0.9.0
     types-certifi

--- a/test/async_utils_test.py
+++ b/test/async_utils_test.py
@@ -157,7 +157,7 @@ async def test_queue_batch_iterator():
 
 @pytest.mark.asyncio
 async def test_warn_if_generator_is_not_consumed(caplog):
-    @warn_if_generator_is_not_consumed
+    @warn_if_generator_is_not_consumed()
     async def my_generator():
         yield 42
 
@@ -173,8 +173,25 @@ async def test_warn_if_generator_is_not_consumed(caplog):
 
 
 @pytest.mark.asyncio
+def test_warn_if_generator_is_not_consumed_sync(caplog):
+    @warn_if_generator_is_not_consumed()
+    def my_generator():
+        yield 42
+
+    with caplog.at_level(logging.WARNING):
+        g = my_generator()
+        assert "my_generator" in repr(g)
+        del g  # Force destructor
+
+    assert len(caplog.records) == 1
+    assert "my_generator" in caplog.text
+    assert "for" in caplog.text
+    assert "list" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_no_warn_if_generator_is_consumed(caplog):
-    @warn_if_generator_is_not_consumed
+    @warn_if_generator_is_not_consumed()
     async def my_generator():
         yield 42
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -599,7 +599,11 @@ class MockClientServicer(api_grpc.ModalClientBase):
         response_items = []
         function_call_inputs = self.client_calls.setdefault(request.function_call_id, [])
         for item in request.inputs:
-            args, kwargs = modal._serialization.deserialize(item.input.args, None) if item.input.args else ((), {})
+            if item.input.WhichOneof("args_oneof") == "args":
+                args, kwargs = modal._serialization.deserialize(item.input.args, None)
+            else:
+                args, kwargs = modal._serialization.deserialize(self.blobs[item.input.args_blob_id], None)
+
             input_id = f"in-{self.n_inputs}"
             self.n_inputs += 1
             response_items.append(api_pb2.FunctionPutInputsResponseItem(input_id=input_id, idx=item.idx))

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -763,7 +763,10 @@ async def test_non_aio_map_in_async_caller_error(client):
                 pass
 
         # using .aio should be ok:
-        res = []
-        async for r in dummy_function.map.aio([1, 2, 3]):
-            res.append(r)
+        res = [r async for r in dummy_function.map.aio([1, 2, 3])]
         assert res == [1, 4, 9]
+
+        # we might want to deprecate this syntax (async for ... in map without .aio),
+        # but we support it for backwards compatibility for now:
+        res = [r async for r in dummy_function.map([1, 2, 4])]
+        assert res == [1, 4, 16]

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -4,11 +4,13 @@ import inspect
 import pytest
 import time
 import typing
+from contextlib import contextmanager
 
 from synchronicity.exceptions import UserCodeException
 
 import modal
 from modal import Image, Mount, NetworkFileSystem, Proxy, Stub, web_endpoint
+from modal._utils.async_utils import synchronize_api
 from modal._vendor import cloudpickle
 from modal.exception import ExecutionError, InvalidError
 from modal.functions import Function, FunctionCall, gather
@@ -64,6 +66,85 @@ def test_map(client, servicer, slow_put_inputs):
         assert len(servicer.cleared_function_calls) == 1
         assert set(dummy_modal.map([5, 2], [4, 3], order_outputs=False)) == {13, 41}
         assert len(servicer.cleared_function_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_map_async_generator(client):
+    stub = Stub()
+    dummy_modal = stub.function()(dummy)
+
+    async def gen_num():
+        yield 2
+        yield 3
+
+    async with stub.run(client=client):
+        res = [num async for num in dummy_modal.map.aio(gen_num())]
+        assert res == [4, 9]
+
+
+def _pow2(x: int):
+    return x**2
+
+
+@contextmanager
+def synchronicity_loop_delay_tracker():
+    done = False
+
+    async def _track_eventloop_blocking():
+        max_dur = 0.0
+        BLOCK_TIME = 0.01
+        while not done:
+            t0 = time.perf_counter()
+            await asyncio.sleep(BLOCK_TIME)
+            max_dur = max(max_dur, time.perf_counter() - t0)
+        return max_dur - BLOCK_TIME  # if it takes exactly BLOCK_TIME we would have zero delay
+
+    track_eventloop_blocking = synchronize_api(_track_eventloop_blocking)
+    yield track_eventloop_blocking(_future=True)
+    done = True
+
+
+def test_map_blocking_iterator_blocking_synchronicity_loop(client):
+    stub = Stub()
+    SLEEP_DUR = 0.5
+
+    def blocking_iter():
+        yield 1
+        time.sleep(SLEEP_DUR)
+        yield 2
+
+    pow2 = stub.function()(_pow2)
+
+    with stub.run(client=client):
+        t0 = time.monotonic()
+        with synchronicity_loop_delay_tracker() as max_delay:
+            for _ in pow2.map(blocking_iter()):
+                pass
+        dur = time.monotonic() - t0
+    assert dur >= SLEEP_DUR
+    assert max_delay.result() < 0.1  # should typically be much smaller than this
+
+
+@pytest.mark.asyncio
+async def test_map_blocking_iterator_blocking_synchronicity_loop_async(client):
+    stub = Stub()
+    SLEEP_DUR = 0.5
+
+    def blocking_iter():
+        yield 1
+        time.sleep(SLEEP_DUR)
+        yield 2
+
+    pow2 = stub.function()(_pow2)
+
+    async with stub.run(client=client):
+        t0 = time.monotonic()
+        with synchronicity_loop_delay_tracker() as max_delay:
+            async for _ in pow2.map.aio(blocking_iter()):
+                pass
+        dur = time.monotonic() - t0
+    assert dur >= SLEEP_DUR
+    assert max_delay.result() < 0.1  # should typically be much smaller than this
 
 
 _side_effect_count = 0
@@ -201,8 +282,7 @@ async def test_generator(client, servicer):
         assert len(servicer.cleared_function_calls) == 1
 
 
-@pytest.mark.asyncio
-async def test_generator_map_invalid(client, servicer):
+def test_generator_map_invalid(client, servicer):
     stub = Stub()
 
     later_gen_modal = stub.function()(later_gen)
@@ -213,11 +293,12 @@ async def test_generator_map_invalid(client, servicer):
     servicer.function_body(dummy)
 
     with stub.run(client=client):
-        with pytest.raises(InvalidError):
+        with pytest.raises(InvalidError, match="A generator function cannot be called with"):
             # Support for .map() on generators was removed in version 0.57
             for _ in later_gen_modal.map([1, 2, 3]):
                 pass
-        with pytest.raises(InvalidError):
+
+        with pytest.raises(InvalidError, match="A generator function cannot be called with"):
             later_gen_modal.for_each([1, 2, 3])
 
 
@@ -653,7 +734,6 @@ def test_no_state_reuse(client, servicer, supports_dir):
     assert not (first_deploy & second_deploy)
 
 
-@pytest.mark.asyncio
 async def test_map_large_inputs(client, servicer, monkeypatch, blob_server):
     # TODO: tests making use of mock blob server currently have to be async, since the
     #  blob server runs as an async pytest fixture which will have its event loop blocked
@@ -667,3 +747,18 @@ async def test_map_large_inputs(client, servicer, monkeypatch, blob_server):
         # assert await dummy_modal.remote.aio(10) == 100
         assert [a async for a in dummy_modal.map.aio([5, 2], [4, 3])] == [41, 13]
         # assert len(servicer.cleared_function_calls) == 1
+
+
+async def test_non_aio_map_in_async_caller_error(client):
+    dummy_function = stub.function()(dummy)
+
+    with stub.run(client=client):
+        with pytest.raises(InvalidError, match=".map.aio"):
+            for _ in dummy_function.map([1, 2, 3]):
+                pass
+
+        # using .aio should be ok:
+        res = []
+        async for r in dummy_function.map.aio([1, 2, 3]):
+            res.append(r)
+        assert res == [1, 4, 9]

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -740,7 +740,7 @@ async def test_map_large_inputs(client, servicer, monkeypatch, blob_server):
     #  blob server runs as an async pytest fixture which will have its event loop blocked
     #  by the test itself otherwise... Should move to its own thread.
     monkeypatch.setattr("modal.functions.MAX_OBJECT_SIZE_BYTES", 1)
-
+    servicer.use_blob_outputs = True
     stub = Stub()
     dummy_modal = stub.function()(dummy)
 
@@ -750,7 +750,7 @@ async def test_map_large_inputs(client, servicer, monkeypatch, blob_server):
         assert [a async for a in dummy_modal.map.aio(range(100))] == [i**2 for i in range(100)]
         assert len(servicer.cleared_function_calls) == 1
 
-    assert len(blobs) == 100
+    assert len(blobs) == 200  # inputs + outputs
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixed the incompatibility with `async for foo.map()` (without `.aio()`) incompatibility of the previous version, which broke integration tests (and would have broken any such user code).

**Related synchronicity note:**
I think it might be a good idea to always require an explicit `.aio` in the future when running async iterators (synchronicity-wrapped or not). This would have some not-obvious annoying implications in for types that are iterable themselves though (adding a .aio property, and making it somehow consistent with how .aio() on methods work). Something to think about for synchronicity 2.0...


## Changelog
* Iterators passed to `Function.map()` and similar parallel execution primitives are now executed on the main thread, preventing blocking iterators from possibly locking up background Modal API calls, and risking task shutdowns.