### PR TITLE
Combine `_LocalApp` and `_ContainerApp` and move them to `modal.running_app`

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -28,13 +28,13 @@ from ._proxy_tunnel import proxy_tunnel
 from ._serialization import deserialize
 from ._utils.async_utils import TaskContext, synchronizer
 from ._utils.function_utils import LocalFunctionError, is_async as get_is_async, is_global_function, method_has_params
-from .app import RunningApp
 from .client import Client, _Client
 from .cls import Cls
 from .config import logger
 from .exception import ExecutionError, InputCancellation, InvalidError
 from .functions import Function, _Function, _set_current_context_ids
 from .partial_function import _find_callables_for_obj, _PartialFunctionFlags
+from .running_app import RunningApp
 from .stub import Stub, _Stub
 
 if TYPE_CHECKING:

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -28,7 +28,7 @@ from ._proxy_tunnel import proxy_tunnel
 from ._serialization import deserialize
 from ._utils.async_utils import TaskContext, synchronizer
 from ._utils.function_utils import LocalFunctionError, is_async as get_is_async, is_global_function, method_has_params
-from .app import _ContainerApp
+from .app import RunningApp
 from .client import Client, _Client
 from .cls import Cls
 from .config import logger
@@ -490,10 +490,12 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
                 client,
             )
 
+        # Get ids and metadata for objects (primarily functions and classes) on the app
+        container_app: RunningApp = container_io_manager.get_app_objects()
+
         # Initialize objects on the stub.
         # This is basically only functions and classes - anything else is deprecated and will be unsupported soon
         if imp_fun.stub is not None:
-            container_app: _ContainerApp = container_io_manager.get_app_objects()
             stub: Stub = synchronizer._translate_out(imp_fun.stub, Interface.BLOCKING)
             stub._init_container(client, container_app)
 

--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -22,7 +22,7 @@ from ._utils.async_utils import TaskContext, asyncify, synchronize_api, synchron
 from ._utils.blob_utils import MAX_OBJECT_SIZE_BYTES, blob_download, blob_upload
 from ._utils.function_utils import _stream_function_call_data
 from ._utils.grpc_utils import get_proto_oneof, retry_transient_errors
-from .app import _ContainerApp
+from .app import RunningApp
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, _Client
 from .config import config, logger
 from .exception import InputCancellation, InvalidError
@@ -30,6 +30,7 @@ from .exception import InputCancellation, InvalidError
 MAX_OUTPUT_BATCH_SIZE: int = 49
 
 RTT_S: float = 0.5  # conservative estimate of RTT in seconds.
+
 
 class UserException(Exception):
     """Used to shut down the task gracefully."""
@@ -172,7 +173,7 @@ class _ContainerIOManager:
         if self._heartbeat_loop:
             self._heartbeat_loop.cancel()
 
-    async def get_app_objects(self) -> _ContainerApp:
+    async def get_app_objects(self) -> RunningApp:
         req = api_pb2.AppGetObjectsRequest(app_id=self.app_id, include_unindexed=True)
         resp = await retry_transient_errors(self._client.stub.AppGetObjects, req)
         logger.debug(f"AppGetObjects received {len(resp.items)} objects for app {self.app_id}")
@@ -185,7 +186,12 @@ class _ContainerIOManager:
             if item.tag:
                 tag_to_object_id[item.tag] = item.object.object_id
 
-        return _ContainerApp(self.app_id, self._environment_name, tag_to_object_id, object_handle_metadata)
+        return RunningApp(
+            self.app_id,
+            environment_name=self._environment_name,
+            tag_to_object_id=tag_to_object_id,
+            object_handle_metadata=object_handle_metadata,
+        )
 
     async def get_serialized_function(self) -> Tuple[Optional[Any], Callable]:
         # Fetch the serialized function definition
@@ -615,6 +621,7 @@ class _ContainerIOManager:
 
 
 ContainerIOManager = synchronize_api(_ContainerIOManager)
+
 
 def is_local() -> bool:
     """Returns if we are currently on the machine launching/deploying a Modal app

--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -22,10 +22,10 @@ from ._utils.async_utils import TaskContext, asyncify, synchronize_api, synchron
 from ._utils.blob_utils import MAX_OBJECT_SIZE_BYTES, blob_download, blob_upload
 from ._utils.function_utils import _stream_function_call_data
 from ._utils.grpc_utils import get_proto_oneof, retry_transient_errors
-from .app import RunningApp
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, _Client
 from .config import config, logger
 from .exception import InputCancellation, InvalidError
+from .running_app import RunningApp
 
 MAX_OUTPUT_BATCH_SIZE: int = 49
 

--- a/modal/app.py
+++ b/modal/app.py
@@ -1,17 +1,2 @@
 # Copyright Modal Labs 2022
-from dataclasses import dataclass, field
-from typing import Dict, Optional
-
-from google.protobuf.message import Message
-
 from .app_utils import _list_apps, list_apps  # noqa: F401
-
-
-@dataclass
-class RunningApp:
-    app_id: str
-    environment_name: Optional[str] = None
-    app_page_url: Optional[str] = None
-    tag_to_object_id: Dict[str, str] = field(default_factory=dict)
-    object_handle_metadata: Dict[str, Optional[Message]] = field(default_factory=dict)
-    interactive: bool = False

--- a/modal/app.py
+++ b/modal/app.py
@@ -8,17 +8,10 @@ from .app_utils import _list_apps, list_apps  # noqa: F401
 
 
 @dataclass
-class _LocalApp:
-    app_id: str
-    app_page_url: str
-    tag_to_object_id: Dict[str, str] = field(default_factory=dict)
-    environment_name: Optional[str] = None
-    interactive: bool = False
-
-
-@dataclass
-class _ContainerApp:
+class RunningApp:
     app_id: str
     environment_name: Optional[str] = None
+    app_page_url: Optional[str] = None
     tag_to_object_id: Dict[str, str] = field(default_factory=dict)
     object_handle_metadata: Dict[str, Optional[Message]] = field(default_factory=dict)
+    interactive: bool = False

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -19,11 +19,11 @@ from ._sandbox_shell import connect_to_sandbox
 from ._utils.app_utils import is_valid_app_name
 from ._utils.async_utils import TaskContext, synchronize_api
 from ._utils.grpc_utils import retry_transient_errors
-from .app import RunningApp
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, _Client
 from .config import config, logger
 from .exception import ExecutionError, InteractiveTimeoutError, InvalidError, _CliUserExecutionError
 from .object import _Object
+from .running_app import RunningApp
 
 if TYPE_CHECKING:
     from .stub import _Stub

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -19,7 +19,7 @@ from ._sandbox_shell import connect_to_sandbox
 from ._utils.app_utils import is_valid_app_name
 from ._utils.async_utils import TaskContext, synchronize_api
 from ._utils.grpc_utils import retry_transient_errors
-from .app import _LocalApp
+from .app import RunningApp
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, _Client
 from .config import config, logger
 from .exception import ExecutionError, InteractiveTimeoutError, InvalidError, _CliUserExecutionError
@@ -39,13 +39,13 @@ async def _heartbeat(client, app_id):
     await retry_transient_errors(client.stub.AppHeartbeat, request, attempt_timeout=HEARTBEAT_TIMEOUT)
 
 
-async def _init_local_app_existing(client: _Client, existing_app_id: str) -> "_LocalApp":
+async def _init_local_app_existing(client: _Client, existing_app_id: str) -> "RunningApp":
     # Get all the objects first
     obj_req = api_pb2.AppGetObjectsRequest(app_id=existing_app_id)
     obj_resp = await retry_transient_errors(client.stub.AppGetObjects, obj_req)
     app_page_url = f"https://modal.com/apps/{existing_app_id}"  # TODO (elias): this should come from the backend
     object_ids = {item.tag: item.object.object_id for item in obj_resp.items}
-    return _LocalApp(existing_app_id, app_page_url, tag_to_object_id=object_ids)
+    return RunningApp(existing_app_id, app_page_url=app_page_url, tag_to_object_id=object_ids)
 
 
 async def _init_local_app_new(
@@ -54,7 +54,7 @@ async def _init_local_app_new(
     app_state: int,
     environment_name: str = "",
     interactive=False,
-) -> "_LocalApp":
+) -> "RunningApp":
     app_req = api_pb2.AppCreateRequest(
         description=description,
         environment_name=environment_name,
@@ -63,7 +63,9 @@ async def _init_local_app_new(
     app_resp = await retry_transient_errors(client.stub.AppCreate, app_req)
     app_page_url = app_resp.app_logs_url
     logger.debug(f"Created new app with id {app_resp.app_id}")
-    return _LocalApp(app_resp.app_id, app_page_url, environment_name=environment_name, interactive=interactive)
+    return RunningApp(
+        app_resp.app_id, app_page_url=app_page_url, environment_name=environment_name, interactive=interactive
+    )
 
 
 async def _init_local_app_from_name(
@@ -92,7 +94,7 @@ async def _init_local_app_from_name(
 
 async def _create_all_objects(
     client: _Client,
-    app: _LocalApp,
+    app: RunningApp,
     indexed_objects: Dict[str, _Object],
     new_app_state: int,
     environment_name: str,
@@ -195,7 +197,7 @@ async def _run_stub(
             " Are you calling stub.run() directly?"
             " Consider using the `modal run` shell command."
         )
-    if stub._local_app:
+    if stub._running_app:
         raise InvalidError(
             "App is already running and can't be started again.\n"
             "You should not use `stub.run` or `run_stub` within a Modal `local_entrypoint`"

--- a/modal/running_app.py
+++ b/modal/running_app.py
@@ -1,0 +1,15 @@
+# Copyright Modal Labs 2024
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+from google.protobuf.message import Message
+
+
+@dataclass
+class RunningApp:
+    app_id: str
+    environment_name: Optional[str] = None
+    app_page_url: Optional[str] = None
+    tag_to_object_id: Dict[str, str] = field(default_factory=dict)
+    object_handle_metadata: Dict[str, Optional[Message]] = field(default_factory=dict)
+    interactive: bool = False

--- a/modal/serving.py
+++ b/modal/serving.py
@@ -14,7 +14,6 @@ from ._output import OutputManager
 from ._utils.async_utils import TaskContext, asyncify, synchronize_api, synchronizer
 from ._utils.logger import logger
 from ._watcher import watch
-from .app import _LocalApp
 from .cli.import_refs import import_stub
 from .client import _Client
 from .config import config
@@ -121,8 +120,8 @@ async def _serve_stub(
         watcher = watch(mounts_to_watch, output_mgr)
 
     async with _run_stub(stub, client=client, output_mgr=output_mgr, environment_name=environment_name):
-        app: _LocalApp = stub._local_app
-        client.set_pre_stop(lambda: _disconnect(client, app.app_id))
+        app_id: str = stub.app_id
+        client.set_pre_stop(lambda: _disconnect(client, app_id))
         async with TaskContext(grace=0.1) as tc:
             tc.create_task(_run_watch_loop(stub_ref, stub.app_id, output_mgr, watcher, environment_name))
             yield stub

--- a/modal/stub.py
+++ b/modal/stub.py
@@ -15,7 +15,6 @@ from ._resolver import Resolver
 from ._utils.async_utils import synchronize_api
 from ._utils.function_utils import FunctionInfo
 from ._utils.mount_utils import validate_volumes
-from .app import RunningApp
 from .client import _Client
 from .cloud_bucket_mount import _CloudBucketMount
 from .cls import _Cls
@@ -31,6 +30,7 @@ from .partial_function import PartialFunction, _find_callables_for_cls, _Partial
 from .proxy import _Proxy
 from .retries import Retries
 from .runner import _run_stub
+from .running_app import RunningApp
 from .sandbox import _Sandbox
 from .schedule import Schedule
 from .scheduler_placement import SchedulerPlacement

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -7,7 +7,6 @@ from typing_extensions import assert_type
 
 from modal import Cls, Function, Image, Queue, Stub, build, enter, exit, method
 from modal._serialization import deserialize
-from modal.app import RunningApp
 from modal.exception import DeprecationError, ExecutionError, InvalidError
 from modal.partial_function import (
     _find_callables_for_obj,
@@ -16,6 +15,7 @@ from modal.partial_function import (
     _PartialFunctionFlags,
 )
 from modal.runner import deploy_stub
+from modal.running_app import RunningApp
 from modal_proto import api_pb2
 
 from .supports.base_class import BaseCls2

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -7,7 +7,7 @@ from typing_extensions import assert_type
 
 from modal import Cls, Function, Image, Queue, Stub, build, enter, exit, method
 from modal._serialization import deserialize
-from modal.app import _ContainerApp
+from modal.app import RunningApp
 from modal.exception import DeprecationError, ExecutionError, InvalidError
 from modal.partial_function import (
     _find_callables_for_obj,
@@ -405,7 +405,7 @@ def test_rehydrate(client, servicer, reset_container_app):
     app_id = deploy_stub(stub, "my-cls-app", client=client).app_id
 
     # Initialize a container
-    container_app = _ContainerApp(app_id=app_id)
+    container_app = RunningApp(app_id=app_id)
 
     # Associate app with stub
     stub._init_container(client, container_app)

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -7,7 +7,7 @@ from google.protobuf.message import Message
 
 from modal import Stub, interact
 from modal._container_io_manager import ContainerIOManager
-from modal.app import RunningApp
+from modal.running_app import RunningApp
 from modal_proto import api_pb2
 
 from .supports.skip import skip_windows_unix_socket

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -7,7 +7,7 @@ from google.protobuf.message import Message
 
 from modal import Stub, interact
 from modal._container_io_manager import ContainerIOManager
-from modal.app import _ContainerApp
+from modal.app import RunningApp
 from modal_proto import api_pb2
 
 from .supports.skip import skip_windows_unix_socket
@@ -27,7 +27,7 @@ async def test_container_function_lazily_imported(container_client):
     object_handle_metadata: Dict[str, Message] = {
         "fu-123": api_pb2.FunctionHandleMetadata(),
     }
-    container_app = _ContainerApp(
+    container_app = RunningApp(
         app_id="ap-123", tag_to_object_id=tag_to_object_id, object_handle_metadata=object_handle_metadata
     )
     stub = Stub()

--- a/test/webhook_test.py
+++ b/test/webhook_test.py
@@ -8,9 +8,9 @@ from fastapi.testclient import TestClient
 
 from modal import Stub, asgi_app, web_endpoint, wsgi_app
 from modal._asgi import webhook_asgi_app
-from modal.app import RunningApp
 from modal.exception import InvalidError
 from modal.functions import Function
+from modal.running_app import RunningApp
 from modal_proto import api_pb2
 
 stub = Stub()

--- a/test/webhook_test.py
+++ b/test/webhook_test.py
@@ -8,7 +8,7 @@ from fastapi.testclient import TestClient
 
 from modal import Stub, asgi_app, web_endpoint, wsgi_app
 from modal._asgi import webhook_asgi_app
-from modal.app import _ContainerApp
+from modal.app import RunningApp
 from modal.exception import InvalidError
 from modal.functions import Function
 from modal_proto import api_pb2
@@ -36,7 +36,7 @@ async def test_webhook(servicer, client, reset_container_app):
         assert await f.local(100) == {"square": 10000}
 
         # Make sure the container gets the app id as well
-        container_app = _ContainerApp(app_id=stub.app_id)
+        container_app = RunningApp(app_id=stub.app_id)
         stub._init_container(client, container_app)
         assert isinstance(f, Function)
         assert f.web_url


### PR DESCRIPTION
1. Combine the two (very simple dataclasses) into one.
2. Move them to a new module.

`modal.app` is basically available now, which will let us rename `modal.stub` to `modal.app` 🎉 