### PR TITLE
[MOD 2758] support read-only GCP GCS mount in modal.CloudBucketMount

### DIFF
--- a/modal/cloud_bucket_mount.py
+++ b/modal/cloud_bucket_mount.py
@@ -85,10 +85,14 @@ def cloud_bucket_mounts_to_proto(mounts: List[Tuple[str, _CloudBucketMount]]) ->
     cloud_bucket_mounts: List[api_pb2.CloudBucketMount] = []
 
     for path, mount in mounts:
-        # TODO: in future this relationship between endpoint URL and type will not hold true.
-        if mount.bucket_endpoint_url:
+        # crude mapping from mount arguments to type
+        # TODO(Jonathon): consider not having a type
+        if mount.bucket_endpoint_url and "r2.cloudflarestorage.com" in mount.bucket_endpoint_url:
             bucket_type = api_pb2.CloudBucketMount.BucketType.R2
+        elif mount.bucket_endpoint_url and "storage.googleapis.com" in mount.bucket_endpoint_url:
+            bucket_type = api_pb2.CloudBucketMount.BucketType.GCP
         else:
+            # just assume S3; this is backwards and forwards compatible.
             bucket_type = api_pb2.CloudBucketMount.BucketType.S3
 
         if mount.requester_pays and not mount.secret:

--- a/modal/cloud_bucket_mount.py
+++ b/modal/cloud_bucket_mount.py
@@ -70,7 +70,7 @@ class _CloudBucketMount:
 
     Google Cloud Storage (GCS) is partially [S3-compatible](https://cloud.google.com/storage/docs/interoperability).
     Currently **only `read_only=True`** is supported for GCS buckets. GCS Buckets also require a secret with Google-specific
-    key names (see below).
+    key names (see below) populated with a [HMAC key](https://cloud.google.com/storage/docs/authentication/managing-hmackeys#create).
 
     ```python
     import subprocess

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -88,6 +88,7 @@ message CloudBucketMount {
     UNSPECIFIED = 0;
     S3 = 1;
     R2 = 2;
+    GCP = 3;
   }
 
   string bucket_name = 1;


### PR DESCRIPTION
## Describe your changes

Disappointedly doesn't work out-of-the-box. https://github.com/awslabs/mountpoint-s3/issues/853

## Backward/forward compatibility checks

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
## Changelog

* `modal.CloudBucketMount` now supports read-only access to Google Cloud Storage 
