### PR TITLE
Add GCP BucketType for #1694

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -88,6 +88,7 @@ message CloudBucketMount {
     UNSPECIFIED = 0;
     S3 = 1;
     R2 = 2;
+    GCP = 3;
   }
 
   string bucket_name = 1;


### PR DESCRIPTION
Breaking out of https://github.com/modal-labs/modal-client/pull/1694 to allow server/worker to advance prior to merge of https://github.com/modal-labs/modal-client/pull/1694. 
