### PR TITLE
Add flaky pkg and mark test_multi_resolve_sequential_loads_once flaky

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,6 +1,7 @@
 # Development requirements
 
 black==23.11.0
+flaky~=3.7
 grpcio-tools==1.48.0;python_version<'3.11'  # TODO: remove when we drop client support for Protobuf 3.19
 grpcio-tools==1.59.2;python_version>='3.11'
 grpclib==0.4.7

--- a/test/resolver_test.py
+++ b/test/resolver_test.py
@@ -9,6 +9,7 @@ from modal._resolver import Resolver
 from modal.object import _Object
 
 
+@pytest.mark.flaky(max_runs=2)
 @pytest.mark.asyncio
 async def test_multi_resolve_sequential_loads_once():
     output_manager = OutputManager(None, show_progress=False)


### PR DESCRIPTION
## Describe your changes

Test-only change. 

Had  https://github.com/modal-labs/modal-client/actions/runs/8690814468/job/23831587189 flake on `test_multi_resolve_sequential_loads_once` and noticed that we don't have flaky tests setup in this repo. I think we're unlikely to address these flakes in the short-term so just going to add retry-ability. 