### PR TITLE
`Image.run_inside`: turn deprecation warning into error

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -23,7 +23,7 @@ from ._utils.blob_utils import MAX_OBJECT_SIZE_BYTES
 from ._utils.function_utils import FunctionInfo
 from ._utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES, retry_transient_errors, unary_stream
 from .config import config, logger, user_config_path
-from .exception import InvalidError, NotFoundError, RemoteError, VersionError, deprecation_warning
+from .exception import InvalidError, NotFoundError, RemoteError, VersionError, deprecation_error, deprecation_warning
 from .gpu import GPU_T, parse_gpu_config
 from .mount import _Mount, python_standalone_mount_name
 from .network_file_system import _NetworkFileSystem
@@ -1549,8 +1549,7 @@ class _Image(_Object, type_prefix="im"):
             import torch
         ```
         """
-        deprecation_warning((2023, 12, 15), Image.run_inside.__doc__)
-        return self.imports()
+        deprecation_error((2023, 12, 15), Image.run_inside.__doc__)
 
 
 Image = synchronize_api(_Image)

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -675,10 +675,9 @@ def test_inside_ctx_unhydrated(client):
             with image_2.imports():
                 raise Exception("foo")
 
-        # Make sure run_inside works but is depreated
-        with pytest.warns(DeprecationError, match="imports()"):
-            with image_1.run_inside():
-                pass
+        # Old one raises
+        with pytest.raises(DeprecationError, match="imports()"):
+            image_1.run_inside()
 
         # Hydration of the image should raise the exception
         with pytest.raises(ImportError, match="foo"):


### PR DESCRIPTION
This is the only deprecation warning from 2023.