### PR TITLE
Add keys/values/items method to modal.Dict

### DIFF
--- a/modal/dict.py
+++ b/modal/dict.py
@@ -1,5 +1,5 @@
 # Copyright Modal Labs 2022
-from typing import Any, AsyncIterator, Optional, Type
+from typing import Any, AsyncIterator, Optional, Tuple, Type
 
 from synchronicity.async_wrap import asynccontextmanager
 
@@ -8,11 +8,11 @@ from modal_proto import api_pb2
 from ._resolver import Resolver
 from ._serialization import deserialize, serialize
 from ._utils.async_utils import TaskContext, synchronize_api
-from ._utils.grpc_utils import retry_transient_errors
+from ._utils.grpc_utils import retry_transient_errors, unary_stream
 from .client import _Client
 from .config import logger
 from .exception import deprecation_warning
-from .object import EPHEMERAL_OBJECT_HEARTBEAT_SLEEP, _get_environment_name, _Object, live_method
+from .object import EPHEMERAL_OBJECT_HEARTBEAT_SLEEP, _get_environment_name, _Object, live_method, live_method_gen
 
 
 def _serialize_dict(data):
@@ -281,6 +281,39 @@ class _Dict(_Object, type_prefix="di"):
         Note: this function will block the event loop when called in an async context.
         """
         return await self.contains(key)
+
+    @live_method_gen
+    async def keys(self) -> AsyncIterator[Any]:
+        """Return an iterator over the keys in this dictionary.
+
+        Note that (unlike with Python dicts) the return value is a simple iterator,
+        and results are unordered.
+        """
+        req = api_pb2.DictContentsRequest(dict_id=self.object_id, keys=True)
+        async for resp in unary_stream(self._client.stub.DictContents, req):
+            yield deserialize(resp.key, self._client)
+
+    @live_method_gen
+    async def values(self) -> AsyncIterator[Any]:
+        """Return an iterator over the values in this dictionary.
+
+        Note that (unlike with Python dicts) the return value is a simple iterator,
+        and results are unordered.
+        """
+        req = api_pb2.DictContentsRequest(dict_id=self.object_id, values=True)
+        async for resp in unary_stream(self._client.stub.DictContents, req):
+            yield deserialize(resp.value, self._client)
+
+    @live_method_gen
+    async def items(self) -> AsyncIterator[Tuple[Any, Any]]:
+        """Return an iterator over the (key, value) tuples in this dictionary.
+
+        Note that (unlike with Python dicts) the return value is a simple iterator,
+        and results are unordered.
+        """
+        req = api_pb2.DictContentsRequest(dict_id=self.object_id, keys=True, values=True)
+        async for resp in unary_stream(self._client.stub.DictContents, req):
+            yield (deserialize(resp.key, self._client), deserialize(resp.value, self._client))
 
 
 Dict = synchronize_api(_Dict)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -491,6 +491,11 @@ class MockClientServicer(api_grpc.ModalClientBase):
             self.dicts[request.dict_id][update.key] = update.value
         await stream.send_message(api_pb2.DictUpdateResponse())
 
+    async def DictContents(self, stream):
+        request: api_pb2.DictGetRequest = await stream.recv_message()
+        for k, v in self.dicts[request.dict_id].items():
+            await stream.send_message(api_pb2.DictEntry(key=k, value=v))
+
     ### Function
 
     async def FunctionBindParams(self, stream):

--- a/test/dict_test.py
+++ b/test/dict_test.py
@@ -12,6 +12,10 @@ def test_dict_app(servicer, client):
     assert d["foo"] == 47
     assert d.len() == 2
 
+    assert sorted(d.keys()) == ["foo", "xyz"]
+    assert sorted(d.values()) == [47, 123]
+    assert sorted(d.items()) == [("foo", 47), ("xyz", 123)]
+
     d.clear()
     assert d.len() == 0
     with pytest.raises(KeyError):


### PR DESCRIPTION
Resolves MOD-2754

## Changelog

- The `modal.Dict` object now implements a `keys`/`values`/`items` API. Note that there are a few differences when compared to standard Python dicts:
    - The return value is a simple iterator, whereas Python uses a dictionary view object with more features.
    - The results are unordered.
 - Additionally, there was no key data stored for items added to a `modal.Dict` prior to this release, so empty strings will be returned for these entries.