### PR TITLE
`Function.stub` -> `Function.app`

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -331,7 +331,7 @@ def import_function(
             if isinstance(f, Function):
                 function = synchronizer._translate_in(f)
                 fun = function.get_raw_f()
-                active_app = function._stub
+                active_app = function._app
             else:
                 fun = f
         elif len(parts) == 2:
@@ -343,7 +343,7 @@ def import_function(
                 _cls = synchronizer._translate_in(cls)
                 fun = _cls._callables[fun_name]
                 function = _cls._functions.get(fun_name)
-                active_app = _cls._stub
+                active_app = _cls._app
             else:
                 # This is a raw class
                 fun = getattr(cls, fun_name)

--- a/modal/app.py
+++ b/modal/app.py
@@ -63,6 +63,11 @@ class _LocalEntrypoint:
     def app(self) -> "_App":
         return self._app
 
+    @property
+    def stub(self) -> "_App":
+        # Deprecated soon, only for backwards compatibility
+        return self._app
+
 
 LocalEntrypoint = synchronize_api(_LocalEntrypoint)
 

--- a/modal/app.py
+++ b/modal/app.py
@@ -33,7 +33,7 @@ from .object import _Object
 from .partial_function import PartialFunction, _find_callables_for_cls, _PartialFunction, _PartialFunctionFlags
 from .proxy import _Proxy
 from .retries import Retries
-from .runner import _run_stub
+from .runner import _run_app
 from .running_app import RunningApp
 from .sandbox import _Sandbox
 from .schedule import Schedule
@@ -46,11 +46,11 @@ _default_image: _Image = _Image.debian_slim()
 
 class _LocalEntrypoint:
     _info: FunctionInfo
-    _stub: "_App"
+    _app: "_App"
 
-    def __init__(self, info, stub):
+    def __init__(self, info, app):
         self._info = info  # type: ignore
-        self._stub = stub
+        self._app = app
 
     def __call__(self, *args, **kwargs):
         return self._info.raw_f(*args, **kwargs)
@@ -60,8 +60,8 @@ class _LocalEntrypoint:
         return self._info
 
     @property
-    def stub(self) -> "_App":
-        return self._stub
+    def app(self) -> "_App":
+        return self._app
 
 
 LocalEntrypoint = synchronize_api(_LocalEntrypoint)
@@ -333,7 +333,7 @@ class _App:
         objects. For backwards compatibility reasons, it returns the same stub.
         """
         # TODO(erikbern): deprecate this one too?
-        async with _run_stub(self, client, stdout, show_progress, detach, output_mgr):
+        async with _run_app(self, client, stdout, show_progress, detach, output_mgr):
             yield self
 
     def _get_default_image(self):
@@ -571,7 +571,7 @@ class _App:
 
             function = _Function.from_args(
                 info,
-                stub=self,
+                app=self,
                 image=image,
                 secret=secret,
                 secrets=secrets,

--- a/modal/cli/launch.py
+++ b/modal/cli/launch.py
@@ -29,7 +29,7 @@ def _launch_program(name: str, filename: str, args: Dict[str, Any]) -> None:
 
     program_path = str(Path(__file__).parent / "programs" / filename)
     entrypoint = import_function(program_path, "modal launch")
-    app: App = entrypoint.stub
+    app: App = entrypoint.app
     app.set_description(f"modal launch {name}")
 
     # `launch/` scripts must have a `local_entrypoint()` with no args, for simplicity here.

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -205,7 +205,7 @@ class RunGroup(click.Group):
         ctx.ensure_object(dict)
         ctx.obj["env"] = ensure_env(ctx.params["env"])
         function_or_entrypoint = import_function(func_ref, accept_local_entrypoint=True, base_cmd="modal run")
-        app: App = function_or_entrypoint.stub
+        app: App = function_or_entrypoint.app
         if app.description is None:
             app.set_description(_get_clean_app_description(func_ref))
         if isinstance(function_or_entrypoint, LocalEntrypoint):

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -138,7 +138,7 @@ class _Cls(_Object, type_prefix="cs"):
     _options: Optional[api_pb2.FunctionOptions]
     _callables: Dict[str, Callable]
     _from_other_workspace: Optional[bool]  # Functions require FunctionBindParams before invocation.
-    _stub: Optional["modal.app._App"] = None  # not set for lookups
+    _app: Optional["modal.app._App"] = None  # not set for lookups
 
     def _initialize_from_empty(self):
         self._user_cls = None
@@ -181,7 +181,7 @@ class _Cls(_Object, type_prefix="cs"):
         return class_handle_metadata
 
     @staticmethod
-    def from_local(user_cls, stub, decorator: Callable[[PartialFunction, type], _Function]) -> "_Cls":
+    def from_local(user_cls, app, decorator: Callable[[PartialFunction, type], _Function]) -> "_Cls":
         """mdmd:hidden"""
         functions: Dict[str, _Function] = {}
         for k, partial_function in _find_partial_methods_for_cls(user_cls, _PartialFunctionFlags.FUNCTION).items():
@@ -206,7 +206,7 @@ class _Cls(_Object, type_prefix="cs"):
 
         rep = f"Cls({user_cls.__name__})"
         cls = _Cls._from_loader(_load, rep, deps=_deps)
-        cls._stub = stub
+        cls._app = app
         cls._user_cls = user_cls
         cls._functions = functions
         cls._callables = callables

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -561,7 +561,7 @@ class _Function(_Object, type_prefix="fu"):
     # TODO: more type annotations
     _info: Optional[FunctionInfo]
     _all_mounts: Collection[_Mount]
-    _stub: "modal.app._App"
+    _app: "modal.app._App"
     _obj: Any
     _web_url: Optional[str]
     _is_remote_cls_method: bool = False  # TODO(erikbern): deprecated
@@ -576,7 +576,7 @@ class _Function(_Object, type_prefix="fu"):
     @staticmethod
     def from_args(
         info: FunctionInfo,
-        stub,
+        app,
         image: _Image,
         secret: Optional[_Secret] = None,
         secrets: Sequence[_Secret] = (),
@@ -684,7 +684,7 @@ class _Function(_Object, type_prefix="fu"):
                 snapshot_info = FunctionInfo(build_function, cls=info.cls)
                 snapshot_function = _Function.from_args(
                     snapshot_info,
-                    stub=None,
+                    app=None,
                     image=image,
                     secrets=secrets,
                     gpu=gpu,
@@ -802,7 +802,7 @@ class _Function(_Object, type_prefix="fu"):
 
             timeout_secs = timeout
 
-            if stub and stub.is_interactive and not is_builder_function:
+            if app and app.is_interactive and not is_builder_function:
                 pty_info = get_pty_info(shell=False)
             else:
                 pty_info = None
@@ -833,8 +833,8 @@ class _Function(_Object, type_prefix="fu"):
                 class_serialized = None
 
             stub_name = ""
-            if stub and stub.name:
-                stub_name = stub.name
+            if app and app.name:
+                stub_name = app.name
 
             # Relies on dicts being ordered (true as of Python 3.6).
             volume_mounts = [
@@ -950,7 +950,7 @@ class _Function(_Object, type_prefix="fu"):
         obj._info = info
         obj._tag = tag
         obj._all_mounts = all_mounts  # needed for modal.serve file watching
-        obj._stub = stub  # needed for CLI right now
+        obj._app = app  # needed for CLI right now
         obj._obj = None
         obj._is_generator = is_generator
         obj._is_method = bool(info.cls)
@@ -1098,9 +1098,9 @@ class _Function(_Object, type_prefix="fu"):
         return self._tag
 
     @property
-    def stub(self) -> "modal.app._App":
+    def app(self) -> "modal.app._App":
         """mdmd:hidden"""
-        return self._stub
+        return self._app
 
     @property
     def info(self) -> FunctionInfo:

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1103,6 +1103,12 @@ class _Function(_Object, type_prefix="fu"):
         return self._app
 
     @property
+    def stub(self) -> "modal.app._App":
+        """mdmd:hidden"""
+        # Deprecated soon, only for backwards compatibility
+        return self._app
+
+    @property
     def info(self) -> FunctionInfo:
         """mdmd:hidden"""
         assert self._info

--- a/modal/image.py
+++ b/modal/image.py
@@ -1432,7 +1432,7 @@ class _Image(_Object, type_prefix="im"):
 
         function = _Function.from_args(
             info,
-            stub=None,
+            app=None,
             image=self,
             secret=secret,
             secrets=secrets,

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -475,7 +475,7 @@ async def _interactive_shell(_stub: _App, cmd: List[str], environment_name: str 
     **kwargs will be passed into spawn_sandbox().
     """
     client = await _Client.from_env()
-    async with _run_stub(_stub, client, environment_name=environment_name, shell=True):
+    async with _run_app(_stub, client, environment_name=environment_name, shell=True):
         console = Console()
         loading_status = console.status("Starting container...")
         loading_status.start()


### PR DESCRIPTION
Renaming properties and variables