### PR TITLE
Warn if users have a function named `app`

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
 import inspect
 import typing
+import warnings
 from pathlib import PurePosixPath
 from typing import Any, AsyncGenerator, Callable, ClassVar, Dict, List, Optional, Sequence, Tuple, Union
 
@@ -565,6 +566,10 @@ class _App:
                 info = FunctionInfo(f, serialized=serialized, name_override=name, cls=_cls)
                 webhook_config = None
                 raw_f = f
+
+            if info.function_name.endswith(".app"):
+                warnings.warn("Beware: the function name is `app`. Modal will soon rename `Stub` to `App`, "
+                              "so you might run into issues if you have code like `app = modal.App()` in the same scope")
 
             if not _cls and not info.is_serialized() and "." in info.function_name:  # This is a method
                 raise InvalidError(

--- a/test/stub_test.py
+++ b/test/stub_test.py
@@ -347,3 +347,15 @@ def test_list_apps(client):
 
     assert len(apps_1) == len(apps_0) + 1
     assert set(apps_1) - set(apps_0) == set(["foobar"])
+
+
+def test_function_named_app():
+    # Make sure we have a helpful warning when a user's function is named "app"
+    # as it might collide with the App variable name (in particular if people
+    # find & replace "stub" with "app").
+    app = App()
+
+    with pytest.warns(match="app"):
+        @app.function(serialized=True)
+        def app():
+            ...


### PR DESCRIPTION
There's a risk users may have code like this
```python
stub = Stub()

@stub.function()
@asgi_app()
def app():
    ...
```

This might lead to issues if they find&replace stub -> app:
```python
app = App()

@app.function()
@asgi_app()
def app():  # It's now redefining the global symbol `app`
    ...
```

Catching it proactively