### PR TITLE
Simplify Queue and Dict docs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -53,6 +53,9 @@ jobs:
         run: pytest
 
       - name: Run docstring tests
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         run: pytest --markdown-docs -m markdown-docs modal
 
   container-dependencies:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -54,6 +54,7 @@ jobs:
 
       - name: Run docstring tests
         env:
+          MODAL_ENVIRONMENT: client-doc-tests
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         run: pytest --markdown-docs -m markdown-docs modal

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -37,16 +37,13 @@ class _Dict(_Object, type_prefix="di"):
     ```python
     import modal
 
-    stub = modal.Stub()
     my_dict = modal.Dict.from_name("my-persisted_dict", create_if_missing=True)
 
-    @stub.local_entrypoint()
-    def main():
-        my_dict["some key"] = "some value"
-        my_dict[123] = 456
+    my_dict["some key"] = "some value"
+    my_dict[123] = 456
 
-        assert my_dict["some key"] == "some value"
-        assert my_dict[123] == 456
+    assert my_dict["some key"] == "some value"
+    assert my_dict[123] == 456
     ```
 
     The `Dict` class offers a few methods for operations that are usually accomplished
@@ -128,12 +125,9 @@ class _Dict(_Object, type_prefix="di"):
 
         **Examples**
 
-        ```python notest
-        # In one app:
-        stub.dict = Dict.persisted("my-dict")
-
-        # Later, in another app or Python file:
-        stub.dict = Dict.from_name("my-dict")
+        ```python
+        dict = Dict.from_name("my-dict", create_if_missing=True)
+        dict[123] = 456
         ```
         """
 

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -35,9 +35,9 @@ class _Dict(_Object, type_prefix="di"):
     **Usage**
 
     ```python
-    import modal
+    from modal import Dict
 
-    my_dict = modal.Dict.from_name("my-persisted_dict", create_if_missing=True)
+    my_dict = Dict.from_name("my-persisted_dict", create_if_missing=True)
 
     my_dict["some key"] = "some value"
     my_dict[123] = 456
@@ -92,6 +92,8 @@ class _Dict(_Object, type_prefix="di"):
 
         Usage:
         ```python
+        from modal import Dict
+
         with Dict.ephemeral() as d:
             d["foo"] = "bar"
 
@@ -126,6 +128,8 @@ class _Dict(_Object, type_prefix="di"):
         **Examples**
 
         ```python
+        from modal import Dict
+
         dict = Dict.from_name("my-dict", create_if_missing=True)
         dict[123] = 456
         ```
@@ -166,7 +170,9 @@ class _Dict(_Object, type_prefix="di"):
         """Lookup a dict with a given name and tag.
 
         ```python
-        d = modal.Dict.lookup("my-dict")
+        from modal import Dict
+
+        d = Dict.lookup("my-dict")
         d["xyz"] = 123
         ```
         """
@@ -185,7 +191,7 @@ class _Dict(_Object, type_prefix="di"):
 
     @live_method
     async def clear(self) -> None:
-        """Remove all items from the modal.Dict."""
+        """Remove all items from the Dict."""
         req = api_pb2.DictClearRequest(dict_id=self.object_id)
         await retry_transient_errors(self._client.stub.DictClear, req)
 

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -122,6 +122,8 @@ class _Queue(_Object, type_prefix="qu"):
 
         Usage:
         ```python
+        from modal import Queue
+
         with Queue.ephemeral() as q:
             q.put(123)
 
@@ -153,6 +155,8 @@ class _Queue(_Object, type_prefix="qu"):
         **Examples**
 
         ```python
+        from modal import Queue
+
         queue = Queue.from_name("my-queue", create_if_missing=True)
         queue.put(123)
         ```
@@ -189,6 +193,8 @@ class _Queue(_Object, type_prefix="qu"):
         """Lookup a queue with a given name and tag.
 
         ```python
+        from modal import Queue
+
         q = modal.Queue.lookup("my-queue")
         q.put(123)
         ```

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -54,27 +54,29 @@ class _Queue(_Object, type_prefix="qu"):
     ```python
     from modal import Queue
 
-    my_queue = Queue.from_name("my-persisted-queue", create_if_missing=True)
+    with Queue.ephemeral() as my_queue:
+        # Putting values
+        my_queue.put("some value")
+        my_queue.put(123)
 
-    my_queue.put("some value")
-    my_queue.put(123)
+        # Getting values
+        assert my_queue.get() == "some value"
+        assert my_queue.get() == 123
 
-    assert my_queue.get() == "some value"
-    assert my_queue.get() == 123
+        # Using partitions
+        my_queue.put(0)
+        my_queue.put(1, partition="foo")
+        my_queue.put(2, partition="bar")
 
-    my_queue.put(0)
-    my_queue.put(1, partition="foo")
-    my_queue.put(2, partition="bar")
+        # Default and "foo" partition are ignored by the get operation.
+        assert my_queue.get(partition="bar") == 2
 
-    # Default and "foo" partition are ignored by the get operation.
-    assert my_queue.get(partition="bar") == 2
+        # Set custom 10s expiration time on "foo" partition.
+        my_queue.put(3, partition="foo", partition_ttl=10)
 
-    # Set custom 10s expiration time on "foo" partition.
-    my_queue.put(3, partition="foo", partition_ttl=10)
-
-    # (beta feature) Iterate through items in place (read immutably)
-    my_queue.put(1)
-    assert [v for v in my_queue.iterate()] == [0, 1]
+        # (beta feature) Iterate through items in place (read immutably)
+        my_queue.put(1)
+        assert [v for v in my_queue.iterate()] == [0, 1]
     ```
 
     For more examples, see the [guide](/docs/guide/dicts-and-queues#modal-queues).

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -63,14 +63,14 @@ class _Queue(_Object, type_prefix="qu"):
     assert my_queue.get() == 123
 
     my_queue.put(0)
-    my_queue.put(1, partition_key="foo")
-    my_queue.put(2, partition_key="bar")
+    my_queue.put(1, partition="foo")
+    my_queue.put(2, partition="bar")
 
     # Default and "foo" partition are ignored by the get operation.
-    assert my_queue.get(partition_key="bar") == 2
+    assert my_queue.get(partition="bar") == 2
 
     # Set custom 10s expiration time on "foo" partition.
-    my_queue.put(3, partition_key="foo", partition_ttl=10)
+    my_queue.put(3, partition="foo", partition_ttl=10)
 
     # (beta feature) Iterate through items in place (read immutably)
     my_queue.put(1)

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -152,12 +152,9 @@ class _Queue(_Object, type_prefix="qu"):
 
         **Examples**
 
-        ```python notest
-        # In one app:
-        stub.queue = Queue.persisted("my-queue")
-
-        # Later, in another app or Python file:
-        stub.queue = Queue.from_name("my-queue")
+        ```python
+        queue = Queue.from_name("my-queue", create_if_missing=True)
+        queue.put(123)
         ```
         """
 

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -52,33 +52,29 @@ class _Queue(_Object, type_prefix="qu"):
     **Usage**
 
     ```python
-    from modal import Queue, Stub
+    from modal import Queue
 
-    stub = Stub()
     my_queue = Queue.from_name("my-persisted-queue", create_if_missing=True)
 
-    @stub.local_entrypoint()
-    def main():
-        my_queue.put("some value")
-        my_queue.put(123)
+    my_queue.put("some value")
+    my_queue.put(123)
 
-        assert my_queue.get() == "some value"
-        assert my_queue.get() == 123
+    assert my_queue.get() == "some value"
+    assert my_queue.get() == 123
 
-        my_queue.put(0)
-        my_queue.put(1, partition_key="foo")
-        my_queue.put(2, partition_key="bar")
+    my_queue.put(0)
+    my_queue.put(1, partition_key="foo")
+    my_queue.put(2, partition_key="bar")
 
-        # Default and "foo" partition are ignored by the get operation.
-        assert my_queue.get(partition_key="bar") == 2
+    # Default and "foo" partition are ignored by the get operation.
+    assert my_queue.get(partition_key="bar") == 2
 
-        # Set custom 10s expiration time on "foo" partition.
-        my_queue.put(3, partition_key="foo", partition_ttl=10)
+    # Set custom 10s expiration time on "foo" partition.
+    my_queue.put(3, partition_key="foo", partition_ttl=10)
 
-        # (beta feature) Iterate through items in place (read immutably)
-        my_queue.put(1)
-        assert [v for v in my_queue.iterate()] == [0, 1]
-
+    # (beta feature) Iterate through items in place (read immutably)
+    my_queue.put(1)
+    assert [v for v in my_queue.iterate()] == [0, 1]
     ```
 
     For more examples, see the [guide](/docs/guide/dicts-and-queues#modal-queues).


### PR DESCRIPTION
Was going to replace `Stub` with `App` everywhere but for this one there's no point using a stub/app.

We test all docstrings and for these snippets to work we need to run against the cloud env. So I added Modal credentials to the docstring test.