### PR TITLE
Remove grpc_utils.ChannelPool

### DIFF
--- a/modal/_utils/grpc_utils.py
+++ b/modal/_utils/grpc_utils.py
@@ -10,9 +10,7 @@ from typing import (
     Any,
     AsyncIterator,
     Dict,
-    List,
     Optional,
-    Type,
     TypeVar,
 )
 

--- a/modal/_utils/grpc_utils.py
+++ b/modal/_utils/grpc_utils.py
@@ -54,78 +54,6 @@ class Subchannel:
         return True
 
 
-class ChannelPool(grpclib.client.Channel):
-    """Use multiple channels under the hood. A drop-in replacement for the grpclib Channel.
-
-    The main reason is to get around limitations with TCP connections over the internet,
-    in particular idle timeouts.
-
-    The algorithm is very simple. It reuses the last subchannel as long as it has had less
-    than 64 requests or if it was created less than 30s ago. It closes any subchannel that
-    hits 90s age. This means requests using the ChannelPool can't be longer than 60s.
-    """
-
-    _max_requests: int
-    _max_lifetime: float
-    _max_active: float
-    _subchannels: List[Subchannel]
-
-    def __init__(
-        self,
-        *args,
-        max_requests=64,  # Maximum number of total requests per subchannel
-        max_active=30,  # Don't accept more connections on the subchannel after this many seconds
-        max_lifetime=90,  # Close subchannel after this many seconds
-        **kwargs,
-    ):
-        self._subchannels = []
-        self._max_requests = max_requests
-        self._max_active = max_active
-        self._max_lifetime = max_lifetime
-        super().__init__(*args, **kwargs)
-
-    async def __connect__(self):
-        now = time.time()
-        # Remove any closed subchannels
-        while len(self._subchannels) > 0 and not self._subchannels[-1].connected():
-            self._subchannels.pop()
-
-        # Close and delete any subchannels that are past their lifetime
-        while len(self._subchannels) > 0 and now - self._subchannels[0].created_at > self._max_lifetime:
-            self._subchannels.pop(0).protocol.processor.close()
-
-        # See if we can reuse the last subchannel
-        create_subchannel = None
-        if len(self._subchannels) > 0:
-            if self._subchannels[-1].created_at < now - self._max_active:
-                # Don't reuse subchannel that's too old
-                create_subchannel = True
-            elif self._subchannels[-1].requests > self._max_requests:
-                create_subchannel = True
-            else:
-                create_subchannel = False
-        else:
-            create_subchannel = True
-
-        # Create new if needed
-        # There's a theoretical race condition here.
-        # This is harmless but may lead to superfluous protocols.
-        if create_subchannel:
-            protocol = await self._create_connection()
-            self._subchannels.append(Subchannel(protocol))
-
-        self._subchannels[-1].requests += 1
-        return self._subchannels[-1].protocol
-
-    def close(self) -> None:
-        while len(self._subchannels) > 0:
-            self._subchannels.pop(0).protocol.processor.close()
-
-    def __del__(self) -> None:
-        if len(self._subchannels) > 0:
-            logger.warning("Channel pool not properly closed")
-
-
 _SendType = TypeVar("_SendType")
 _RecvType = TypeVar("_RecvType")
 
@@ -140,8 +68,6 @@ RETRYABLE_GRPC_STATUS_CODES = [
 def create_channel(
     server_url: str,
     metadata: Dict[str, str] = {},
-    *,
-    use_pool: Optional[bool] = None,  # If None, inferred from the scheme
 ) -> grpclib.client.Channel:
     """Creates a grpclib.Channel.
 
@@ -150,15 +76,6 @@ def create_channel(
     """
     o = urllib.parse.urlparse(server_url)
 
-    if use_pool is None:
-        use_pool = o.scheme in ("http", "https")
-
-    channel_cls: Type[grpclib.client.Channel]
-    if use_pool:
-        channel_cls = ChannelPool
-    else:
-        channel_cls = grpclib.client.Channel
-
     channel: grpclib.client.Channel
     config = grpclib.config.Configuration(
         http2_connection_window_size=64 * 1024 * 1024,  # 64 MiB
@@ -166,7 +83,7 @@ def create_channel(
     )
 
     if o.scheme == "unix":
-        channel = channel_cls(path=o.path, config=config)  # probably pointless to use a pool ever
+        channel = grpclib.client.Channel(path=o.path, config=config)  # probably pointless to use a pool ever
     elif o.scheme in ("http", "https"):
         target = o.netloc
         parts = target.split(":")
@@ -174,7 +91,7 @@ def create_channel(
         ssl = o.scheme.endswith("s")
         host = parts[0]
         port = int(parts[1]) if len(parts) == 2 else 443 if ssl else 80
-        channel = channel_cls(host, port, ssl=ssl, config=config)
+        channel = grpclib.client.Channel(host, port, ssl=ssl, config=config)
     else:
         raise Exception(f"Unknown scheme: {o.scheme}")
 

--- a/test/grpc_utils_test.py
+++ b/test/grpc_utils_test.py
@@ -6,7 +6,7 @@ import time
 
 from grpclib import GRPCError, Status
 
-from modal._utils.grpc_utils import ChannelPool, create_channel, retry_transient_errors
+from modal._utils.grpc_utils import create_channel, retry_transient_errors
 from modal_proto import api_grpc, api_pb2
 
 from .supports.skip import skip_windows_unix_socket
@@ -15,7 +15,7 @@ from .supports.skip import skip_windows_unix_socket
 @pytest.mark.asyncio
 async def test_http_channel(servicer):
     assert servicer.remote_addr.startswith("http://")
-    channel = create_channel(servicer.remote_addr, use_pool=False)
+    channel = create_channel(servicer.remote_addr)
     client_stub = api_grpc.ModalClientStub(channel)
 
     req = api_pb2.BlobCreateRequest()
@@ -29,7 +29,7 @@ async def test_http_channel(servicer):
 @pytest.mark.asyncio
 async def test_unix_channel(unix_servicer):
     assert unix_servicer.remote_addr.startswith("unix://")
-    channel = create_channel(unix_servicer.remote_addr, use_pool=False)
+    channel = create_channel(unix_servicer.remote_addr)
     client_stub = api_grpc.ModalClientStub(channel)
 
     req = api_pb2.BlobCreateRequest()
@@ -37,63 +37,6 @@ async def test_unix_channel(unix_servicer):
     assert resp.blob_id
 
     channel.close()
-
-
-@pytest.mark.asyncio
-async def test_channel_pool(servicer, n=1000):
-    channel_pool = create_channel(servicer.remote_addr, use_pool=True)
-    assert isinstance(channel_pool, ChannelPool)
-    client_stub = api_grpc.ModalClientStub(channel_pool)
-
-    # Trigger a lot of requests
-    for i in range(n):
-        req = api_pb2.BlobCreateRequest()
-        resp = await client_stub.BlobCreate(req)
-        assert resp.blob_id
-
-    # Make sure we created the right number of subchannels
-    assert len(channel_pool._subchannels) == math.ceil(n / channel_pool._max_requests)
-
-    channel_pool.close()
-
-
-@pytest.mark.asyncio
-async def test_channel_pool_closed_transport(servicer):
-    channel_pool = create_channel(servicer.remote_addr, use_pool=True)
-    assert isinstance(channel_pool, ChannelPool)
-
-    connection = await channel_pool.__connect__()
-    connection.connection_lost(None)  # simulates a h2 connection being closed
-
-    client_stub = api_grpc.ModalClientStub(channel_pool)
-    req = api_pb2.BlobCreateRequest()
-    resp = await client_stub.BlobCreate(req)  # this should close the terminated connection and start a new one
-    assert resp.blob_id
-    channel_pool.close()
-
-
-@pytest.mark.asyncio
-async def test_channel_pool_max_active(servicer):
-    channel_pool = create_channel(servicer.remote_addr, use_pool=True)
-    assert isinstance(channel_pool, ChannelPool)
-    channel_pool._max_active = 1.0
-    client_stub = api_grpc.ModalClientStub(channel_pool)
-
-    # Do a few requests and assert there's just one subchannel
-    for i in range(3):
-        req = api_pb2.BlobCreateRequest()
-        resp = await client_stub.BlobCreate(req)
-        assert resp.blob_id
-    assert len(channel_pool._subchannels) == 1
-
-    # Sleep a couple of seconds and do a new request: it should create a new subchannel
-    await asyncio.sleep(2.0)
-    req = api_pb2.BlobCreateRequest()
-    resp = await client_stub.BlobCreate(req)
-    assert resp.blob_id
-    assert len(channel_pool._subchannels) == 2
-
-    channel_pool.close()
 
 
 @pytest.mark.asyncio

--- a/test/grpc_utils_test.py
+++ b/test/grpc_utils_test.py
@@ -1,6 +1,4 @@
 # Copyright Modal Labs 2022
-import asyncio
-import math
 import pytest
 import time
 


### PR DESCRIPTION
## Describe your changes

This removes grpc_utils.ChannelPool, a channel connection manager that appears to slow down certain RPCs by introducing extraneous handshakes, and use extra TCP connections.

This PR only affects the client from outside containers. It doesn't affect existing deployed functions or endpoints.

## Backward/forward compatibility checks

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.
