### PR TITLE
stub -> app in docstrings

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -6,6 +6,7 @@ def pytest_markdown_docs_globals():
 
     return {
         "modal": modal,
+        "app": modal.App(),
         "stub": modal.Stub(),
         "math": math,
         "__name__": "runtest",

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -155,7 +155,7 @@ def call_function_sync(
                 if inspect.iscoroutine(res) or inspect.isgenerator(res) or inspect.isasyncgen(res):
                     raise InvalidError(
                         f"Sync (non-generator) function return value of type {type(res)}."
-                        " You might need to use @stub.function(..., is_generator=True)."
+                        " You might need to use @app.function(..., is_generator=True)."
                     )
                 container_io_manager.push_output(input_id, started_at, res, imp_fun.data_format)
         reset_context()
@@ -249,7 +249,7 @@ async def call_function_async(
                 if not inspect.iscoroutine(res) or inspect.isgenerator(res) or inspect.isasyncgen(res):
                     raise InvalidError(
                         f"Async (non-generator) function returned value of type {type(res)}"
-                        " You might need to use @stub.function(..., is_generator=True)."
+                        " You might need to use @app.function(..., is_generator=True)."
                     )
                 value = await res
                 await container_io_manager.push_output.aio(input_id, started_at, value, imp_fun.data_format)
@@ -283,7 +283,7 @@ def import_function(
     container_io_manager,
     client: Client,
 ) -> ImportedFunction:
-    """Imports a function dynamically, and locates the stub.
+    """Imports a function dynamically, and locates the app.
 
     This is somewhat complex because we're dealing with 3 quite different type of functions:
     1. Functions defined in global scope and decorated in global scope (Function objects)
@@ -296,9 +296,9 @@ def import_function(
 
     This helper also handles web endpoints, ASGI/WSGI servers, and HTTP servers.
 
-    In order to locate the stub, we try two things:
-    * If the function is a Function, we can get the stub directly from it
-    * Otherwise, use the stub name and look it up from a global list of stubs: this
+    In order to locate the app, we try two things:
+    * If the function is a Function, we can get the app directly from it
+    * Otherwise, use the app name and look it up from a global list of apps: this
       typically only happens in case 2 above, or in sometimes for case 3
 
     Note that `import_function` is *not* synchronized, becase we need it to run on the main
@@ -350,23 +350,23 @@ def import_function(
         else:
             raise InvalidError(f"Invalid function qualname {qual_name}")
 
-    # If the cls/function decorator was applied in local scope, but the stub is global, we can look it up
+    # If the cls/function decorator was applied in local scope, but the app is global, we can look it up
     if active_app is None:
         # This branch is reached in the special case that the imported function is 1) not serialized, and 2) isn't a FunctionHandle - i.e, not decorated at definition time
-        # Look at all instantiated stubs - if there is only one with the indicated name, use that one
+        # Look at all instantiated apps - if there is only one with the indicated name, use that one
         app_name: Optional[str] = function_def.stub_name or None  # coalesce protobuf field to None
         matching_apps = _App._all_apps.get(app_name, [])
         if len(matching_apps) > 1:
             if app_name is not None:
-                warning_sub_message = f"stub with the same name ('{app_name}')"
+                warning_sub_message = f"app with the same name ('{app_name}')"
             else:
-                warning_sub_message = "unnamed stub"
+                warning_sub_message = "unnamed app"
             logger.warning(
-                f"You have more than one {warning_sub_message}. It's recommended to name all your Stubs uniquely when using multiple stubs"
+                f"You have more than one {warning_sub_message}. It's recommended to name all your Apps uniquely when using multiple apps"
             )
         elif len(matching_apps) == 1:
             (active_app,) = matching_apps
-        # there could also technically be zero found stubs, but that should probably never be an issue since that would mean user won't use is_inside or other function handles anyway
+        # there could also technically be zero found apps, but that should probably never be an issue since that would mean user won't use is_inside or other function handles anyway
 
     # Check this property before we turn it into a method (overriden by webhooks)
     is_async = get_is_async(fun)
@@ -493,7 +493,7 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
         # Get ids and metadata for objects (primarily functions and classes) on the app
         container_app: RunningApp = container_io_manager.get_app_objects()
 
-        # Initialize objects on the stub.
+        # Initialize objects on the app.
         # This is basically only functions and classes - anything else is deprecated and will be unsupported soon
         if imp_fun.app is not None:
             app: App = synchronizer._translate_out(imp_fun.app, Interface.BLOCKING)

--- a/modal/_tunnel.py
+++ b/modal/_tunnel.py
@@ -63,9 +63,9 @@ async def _forward(port: int, *, unencrypted: bool = False, client: Optional[_Cl
 
     ```python
     from flask import Flask
-    from modal import Image, Stub, forward
+    from modal import Image, App, forward
 
-    stub = Stub(image=Image.debian_slim().pip_install("Flask"))
+    app = App(image=Image.debian_slim().pip_install("Flask"))  # Note: "app" was called "stub" up until April 2024
     app = Flask(__name__)
 
 
@@ -74,7 +74,7 @@ async def _forward(port: int, *, unencrypted: bool = False, client: Optional[_Cl
         return "Hello, World!"
 
 
-    @stub.function()
+    @app.function()
     def run_app():
         # Start a web server inside the container at port 8000. `modal.forward(8000)` lets us
         # expose that port to the world at a random HTTPS URL.
@@ -90,7 +90,7 @@ async def _forward(port: int, *, unencrypted: bool = False, client: Optional[_Cl
     ```python
     import socket
     import threading
-    from modal import Stub, forward
+    from modal import App, forward
 
 
     def run_echo_server(port: int):
@@ -115,10 +115,10 @@ async def _forward(port: int, *, unencrypted: bool = False, client: Optional[_Cl
             threading.Thread(target=handle, args=(conn,)).start()
 
 
-    stub = Stub()
+    app = App()  # Note: "app" was called "stub" up until April 2024
 
 
-    @stub.function()
+    @app.function()
     def tcp_tunnel():
         # This exposes port 8000 to public Internet traffic over TCP.
         with forward(8000, unencrypted=True) as tunnel:

--- a/modal/_watcher.py
+++ b/modal/_watcher.py
@@ -13,7 +13,7 @@ from ._output import OutputManager
 _TIMEOUT_SENTINEL = object()
 
 
-class StubFilesFilter(DefaultFilter):
+class AppFilesFilter(DefaultFilter):
     def __init__(
         self,
         *,
@@ -54,7 +54,7 @@ class StubFilesFilter(DefaultFilter):
         return super().__call__(change, path)
 
 
-async def _watch_paths(paths: Set[Path], watch_filter: StubFilesFilter) -> AsyncGenerator[Set[str], None]:
+async def _watch_paths(paths: Set[Path], watch_filter: AppFilesFilter) -> AsyncGenerator[Set[str], None]:
     try:
         async for changes in awatch(*paths, step=500, watch_filter=watch_filter):
             changed_paths = {stringpath for _, stringpath in changes}
@@ -75,7 +75,7 @@ def _print_watched_paths(paths: Set[Path], output_mgr: OutputManager):
     output_mgr.print_if_visible(output_tree)
 
 
-def _watch_args_from_mounts(mounts: List[_Mount]) -> Tuple[Set[Path], StubFilesFilter]:
+def _watch_args_from_mounts(mounts: List[_Mount]) -> Tuple[Set[Path], AppFilesFilter]:
     paths = set()
     dir_filters: Dict[Path, Optional[Set[Path]]] = defaultdict(set)
     for mount in mounts:
@@ -89,7 +89,7 @@ def _watch_args_from_mounts(mounts: List[_Mount]) -> Tuple[Set[Path], StubFilesF
             elif dir_filters[path] is not None:
                 dir_filters[path].add(filter_file.absolute().resolve())
 
-    watch_filter = StubFilesFilter(dir_filters=dict(dir_filters))
+    watch_filter = AppFilesFilter(dir_filters=dict(dir_filters))
     return paths, watch_filter
 
 

--- a/modal/app.py
+++ b/modal/app.py
@@ -84,30 +84,28 @@ CLS_T = typing.TypeVar("CLS_T", bound=typing.Type)
 
 
 class _App:
-    """A Modal app (formerly known as "stub") is a group of functions and classes
+    """A Modal app (prior to April 2024 a "stub") is a group of functions and classes
     deployed together.
 
-    The stub object principally describes Modal objects (`Function`, `Image`,
-    `Secret`, etc.) associated with the application. It has three responsibilities:
+    The app serves at least three purposes:
 
-    * Syncing of identities across processes (your local Python interpreter and
-      every Modal worker active in your application).
-    * Making Objects stay alive and not be garbage collected for as long as the
-      app lives (see App lifetime below).
+    * A unit of deployment for functions and classes.
+    * Syncing of identities of (primarily) functions and classes across processes
+      (your local Python interpreter and every Modal containerr active in your application).
     * Manage log collection for everything that happens inside your code.
 
     **Registering functions with an app**
 
     The most common way to explicitly register an Object with an app is through the
-    `@stub.function()` decorator. It both registers the annotated function itself and
+    `@app.function()` decorator. It both registers the annotated function itself and
     other passed objects, like schedules and secrets, with the app:
 
     ```python
     import modal
 
-    stub = modal.Stub()
+    app = modal.App()  # Note: app were called "stub" up until April 2024
 
-    @stub.function(
+    @app.function(
         secrets=[modal.Secret.from_name("some_secret")],
         schedule=modal.Period(days=1),
     )
@@ -141,14 +139,14 @@ class _App:
         volumes: Dict[Union[str, PurePosixPath], _Volume] = {},  # default volumes for all functions
         **kwargs: _Object,  # DEPRECATED: passing additional objects to the stub as kwargs is no longer supported
     ) -> None:
-        """Construct a new app stub, optionally with default image, mounts, secrets, or volumes.
+        """Construct a new app, optionally with default image, mounts, secrets, or volumes.
 
         ```python notest
         image = modal.Image.debian_slim().pip_install(...)
         mount = modal.Mount.from_local_dir("./config")
         secret = modal.Secret.from_name("my-secret")
         volume = modal.Volume.from_name("my-data")
-        stub = modal.Stub(image=image, mounts=[mount], secrets=[secret], volumes={"/mnt/data": volume})
+        app = modal.App(image=image, mounts=[mount], secrets=[secret], volumes={"/mnt/data": volume})
         ```
         """
 
@@ -165,8 +163,8 @@ class _App:
         if kwargs:
             deprecation_error(
                 (2023, 12, 13),
-                "Passing additional objects to the stub constructor is deprecated."
-                f" Please remove the following parameters from your stub definition: {', '.join(kwargs)}."
+                "Passing additional objects to the app constructor is deprecated."
+                f" Please remove the following parameters from your app definition: {', '.join(kwargs)}."
                 " In most cases, persistent (named) objects can just be defined in the global scope.",
             )
 
@@ -186,17 +184,17 @@ class _App:
         self._running_app = None  # Set inside container, OR during the time an app is running locally
         self._client = None
 
-        # Register this stub. This is used to look up the stub in the container, when we can't get it from the function
+        # Register this app. This is used to look up the app in the container, when we can't get it from the function
         _App._all_apps.setdefault(self._name, []).append(self)
 
     @property
     def name(self) -> Optional[str]:
-        """The user-provided name of the Stub."""
+        """The user-provided name of the App."""
         return self._name
 
     @property
     def is_interactive(self) -> bool:
-        """Whether the current app for the stub is running in interactive mode."""
+        """Whether the current app for the app is running in interactive mode."""
         # return self._name
         if self._running_app:
             return self._running_app.interactive
@@ -205,7 +203,7 @@ class _App:
 
     @property
     def app_id(self) -> Optional[str]:
-        """Return the app_id, if the stub is running."""
+        """Return the app_id, if the app is running."""
         if self._running_app:
             return self._running_app.app_id
         else:
@@ -213,7 +211,7 @@ class _App:
 
     @property
     def description(self) -> Optional[str]:
-        """The Stub's `name`, if available, or a fallback descriptive identifier."""
+        """The App's `name`, if available, or a fallback descriptive identifier."""
         return self._description
 
     def set_description(self, description: str):
@@ -221,12 +219,12 @@ class _App:
 
     def _validate_blueprint_value(self, key: str, value: Any):
         if not isinstance(value, _Object):
-            raise InvalidError(f"Stub attribute `{key}` with value {value!r} is not a valid Modal object")
+            raise InvalidError(f"App attribute `{key}` with value {value!r} is not a valid Modal object")
 
     def _add_object(self, tag, obj):
         if self._running_app:
             # If this is inside a container, then objects can be defined after app initialization.
-            # So we may have to initialize objects once they get bound to the stub.
+            # So we may have to initialize objects once they get bound to the app.
             if tag in self._running_app.tag_to_object_id:
                 object_id: str = self._running_app.tag_to_object_id[tag]
                 metadata: Message = self._running_app.object_handle_metadata[object_id]
@@ -235,16 +233,16 @@ class _App:
         self._indexed_objects[tag] = obj
 
     def __getitem__(self, tag: str):
-        """Stub assignments of the form `stub.x` or `stub["x"]` are deprecated!
+        """App assignments of the form `app.x` or `app["x"]` are deprecated!
 
         The only use cases for these assignments is in conjunction with `.new()`, which is now
         in itself deprecated. If you are constructing objects with `.from_name(...)`, there is no
-        need to assign those objects to the stub. Example:
+        need to assign those objects to the app. Example:
 
         ```python
         d = modal.Dict.from_name("my-dict", create_if_missing=True)
 
-        @stub.function()
+        @app.function()
         def f(x, y):
             d[x] = y  # Refer to d in global scope
         ```
@@ -286,7 +284,7 @@ class _App:
 
     @property
     def image(self) -> _Image:
-        # Exists to get the type inference working for `stub.image`
+        # Exists to get the type inference working for `app.image`
         # Will also keep this one after we remove [get/set][item/attr]
         return self._indexed_objects["image"]
 
@@ -335,8 +333,8 @@ class _App:
         manager, and they will correspond to the current app.
 
         Note that this method used to return a separate "App" object. This is
-        no longer useful since you can use the stub itself for access to all
-        objects. For backwards compatibility reasons, it returns the same stub.
+        no longer useful since you can use the app itself for access to all
+        objects. For backwards compatibility reasons, it returns the same app.
         """
         # TODO(erikbern): deprecate this one too?
         async with _run_app(self, client, stdout, show_progress, detach, output_mgr):
@@ -376,7 +374,7 @@ class _App:
         self._client = client
         self._running_app = running_app
 
-        # Hydrate objects on stub
+        # Hydrate objects on app
         for tag, object_id in running_app.tag_to_object_id.items():
             if tag in self._indexed_objects:
                 obj = self._indexed_objects[tag]
@@ -385,17 +383,17 @@ class _App:
 
     @property
     def registered_functions(self) -> Dict[str, _Function]:
-        """All modal.Function objects registered on the stub."""
+        """All modal.Function objects registered on the app."""
         return {tag: obj for tag, obj in self._indexed_objects.items() if isinstance(obj, _Function)}
 
     @property
     def registered_classes(self) -> Dict[str, _Function]:
-        """All modal.Cls objects registered on the stub."""
+        """All modal.Cls objects registered on the app."""
         return {tag: obj for tag, obj in self._indexed_objects.items() if isinstance(obj, _Cls)}
 
     @property
     def registered_entrypoints(self) -> Dict[str, _LocalEntrypoint]:
-        """All local CLI entrypoints registered on the stub."""
+        """All local CLI entrypoints registered on the app."""
         return self._local_entrypoints
 
     @property
@@ -404,7 +402,7 @@ class _App:
 
     @property
     def registered_web_endpoints(self) -> List[str]:
-        """Names of web endpoint (ie. webhook) functions registered on the stub."""
+        """Names of web endpoint (ie. webhook) functions registered on the app."""
         return self._web_endpoints
 
     def local_entrypoint(
@@ -420,7 +418,7 @@ class _App:
         **Example**
 
         ```python
-        @stub.local_entrypoint()
+        @app.local_entrypoint()
         def main():
             some_modal_function.remote()
         ```
@@ -428,37 +426,37 @@ class _App:
         You can call the function using `modal run` directly from the CLI:
 
         ```shell
-        modal run stub_module.py
+        modal run app_module.py
         ```
 
-        Note that an explicit [`stub.run()`](/docs/reference/modal.Stub#run) is not needed, as an
+        Note that an explicit [`app.run()`](/docs/reference/modal.App#run) is not needed, as an
         [app](/docs/guide/apps) is automatically created for you.
 
         **Multiple Entrypoints**
 
-        If you have multiple `local_entrypoint` functions, you can qualify the name of your stub and function:
+        If you have multiple `local_entrypoint` functions, you can qualify the name of your app and function:
 
         ```shell
-        modal run stub_module.py::stub.some_other_function
+        modal run app_module.py::app.some_other_function
         ```
 
         **Parsing Arguments**
 
         If your entrypoint function take arguments with primitive types, `modal run` automatically parses them as
-        CLI options. For example, the following function can be called with `modal run stub_module.py --foo 1 --bar "hello"`:
+        CLI options. For example, the following function can be called with `modal run app_module.py --foo 1 --bar "hello"`:
 
         ```python
-        @stub.local_entrypoint()
+        @app.local_entrypoint()
         def main(foo: int, bar: str):
             some_modal_function.call(foo, bar)
         ```
 
-        Currently, `str`, `int`, `float`, `bool`, and `datetime.datetime` are supported. Use `modal run stub_module.py --help` for more
+        Currently, `str`, `int`, `float`, `bool`, and `datetime.datetime` are supported. Use `modal run app_module.py --help` for more
         information on usage.
 
         """
         if _warn_parentheses_missing:
-            raise InvalidError("Did you forget parentheses? Suggestion: `@stub.local_entrypoint()`.")
+            raise InvalidError("Did you forget parentheses? Suggestion: `@app.local_entrypoint()`.")
         if name is not None and not isinstance(name, str):
             raise InvalidError("Invalid value for `name`: Must be string.")
 
@@ -505,7 +503,7 @@ class _App:
         keep_warm: Optional[
             int
         ] = None,  # An optional minimum number of containers to always keep warm (use concurrency_limit for maximum).
-        name: Optional[str] = None,  # Sets the Modal name of the function within the stub
+        name: Optional[str] = None,  # Sets the Modal name of the function within the app
         is_generator: Optional[
             bool
         ] = None,  # Set this to True if it's a non-generator function returning a [sync/async] generator object
@@ -527,12 +525,12 @@ class _App:
             SchedulerPlacement
         ] = None,  # Experimental controls over fine-grained scheduling (alpha).
     ) -> Callable[..., _Function]:
-        """Decorator to register a new Modal function with this stub."""
+        """Decorator to register a new Modal function with this app."""
         if isinstance(_warn_parentheses_missing, _Image):
             # Handle edge case where maybe (?) some users passed image as a positional arg
-            raise InvalidError("`image` needs to be a keyword argument: `@stub.function(image=image)`.")
+            raise InvalidError("`image` needs to be a keyword argument: `@app.function(image=image)`.")
         if _warn_parentheses_missing:
-            raise InvalidError("Did you forget parentheses? Suggestion: `@stub.function()`.")
+            raise InvalidError("Did you forget parentheses? Suggestion: `@app.function()`.")
 
         if interactive:
             deprecation_error(
@@ -573,7 +571,7 @@ class _App:
 
             if not _cls and not info.is_serialized() and "." in info.function_name:  # This is a method
                 raise InvalidError(
-                    "`stub.function` on methods is not allowed. See https://modal.com/docs/guide/lifecycle-functions instead"
+                    "`app.function` on methods is not allowed. See https://modal.com/docs/guide/lifecycle-functions instead"
                 )
 
             if is_generator is None:
@@ -664,7 +662,7 @@ class _App:
         ] = None,  # Experimental controls over fine-grained scheduling (alpha).
     ) -> Callable[[CLS_T], _Cls]:
         if _warn_parentheses_missing:
-            raise InvalidError("Did you forget parentheses? Suggestion: `@stub.cls()`.")
+            raise InvalidError("Did you forget parentheses? Suggestion: `@app.cls()`.")
 
         decorator: Callable[[PartialFunction, type], _Function] = self.function(
             image=image,
@@ -709,7 +707,7 @@ class _App:
             if len(cls._functions) > 1 and keep_warm is not None:
                 deprecation_warning(
                     (2023, 10, 20),
-                    "`@stub.cls(keep_warm=...)` is deprecated when there is more than 1 method."
+                    "`@app.cls(keep_warm=...)` is deprecated when there is more than 1 method."
                     " Use `@method(keep_warm=...)` on each method instead!",
                 )
 
@@ -752,7 +750,7 @@ class _App:
             environment_name = self._running_app.environment_name
             client = self._client
         else:
-            raise InvalidError("`stub.spawn_sandbox` requires a running app.")
+            raise InvalidError("`app.spawn_sandbox` requires a running app.")
 
         # TODO(erikbern): pulling a lot of app internals here, let's clean up shortly
         resolver = Resolver(client, environment_name=environment_name, app_id=app_id)
@@ -776,31 +774,31 @@ class _App:
         await resolver.load(obj)
         return obj
 
-    def include(self, /, other_stub: "_App"):
-        """Include another stub's objects in this one.
+    def include(self, /, other_app: "_App"):
+        """Include another app's objects in this one.
 
         Useful splitting up Modal apps across different self-contained files
 
         ```python
-        stub_a = modal.Stub("a")
-        @stub.function()
+        app_a = modal.App("a")
+        @app.function()
         def foo():
             ...
 
-        stub_b = modal.Stub("b")
-        @stub.function()
+        app_b = modal.App("b")
+        @app.function()
         def bar():
             ...
 
-        stub_a.include(stub_b)
+        app_a.include(app_b)
 
-        @stub_a.local_entrypoint()
+        @app_a.local_entrypoint()
         def main():
-            # use function declared on the included stub
+            # use function declared on the included app
             bar.remote()
         ```
         """
-        for tag, object in other_stub._indexed_objects.items():
+        for tag, object in other_app._indexed_objects.items():
             existing_object = self._indexed_objects.get(tag)
             if existing_object and existing_object != object:
                 logger.warning(

--- a/modal/cli/import_refs.py
+++ b/modal/cli/import_refs.py
@@ -1,8 +1,8 @@
 # Copyright Modal Labs 2023
 """Load or import Python modules from the CLI.
 
-For example, the function reference of `modal run some_file.py::stub.foo_func`
-or the stub lookup of `modal deploy some_file.py`.
+For example, the function reference of `modal run some_file.py::app.foo_func`
+or the app lookup of `modal deploy some_file.py`.
 
 These functions are only called by the Modal CLI, not in tasks.
 """
@@ -146,16 +146,16 @@ def _infer_function_or_help(
         function_name = sorted_function_choices[0]
     elif len(function_choices) == 0:
         if app.registered_web_endpoints:
-            err_msg = "Modal stub has only web endpoints. Use `modal serve` instead of `modal run`."
+            err_msg = "Modal app has only web endpoints. Use `modal serve` instead of `modal run`."
         else:
-            err_msg = "Modal stub has no registered functions. Nothing to run."
+            err_msg = "Modal app has no registered functions. Nothing to run."
         raise click.UsageError(err_msg)
     else:
         help_text = f"""You need to specify a Modal function or local entrypoint to run, e.g.
 
 modal run app.py::my_function [...args]
 
-Registered functions and local entrypoints on the selected stub are:
+Registered functions and local entrypoints on the selected app are:
 {registered_functions_str}
 """
         raise click.UsageError(help_text)
@@ -173,14 +173,14 @@ def _show_no_auto_detectable_app(app_ref: ImportRef) -> None:
     object_path = app_ref.object_path
     import_path = app_ref.file_or_module
     error_console = Console(stderr=True)
-    error_console.print(f"[bold red]Could not find Modal stub '{object_path}' in {import_path}.[/bold red]")
+    error_console.print(f"[bold red]Could not find Modal app '{object_path}' in {import_path}.[/bold red]")
 
     if object_path is None:
         guidance_msg = (
-            f"Expected to find a stub variable named **`{DEFAULT_APP_NAME}`** (the default stub name). If your `modal.Stub` is named differently, "
-            "you must specify it in the stub ref argument. "
-            f"For example a stub variable `app_stub = modal.Stub()` in `{import_path}` would "
-            f"be specified as `{import_path}::app_stub`."
+            f"Expected to find a app variable named **`{DEFAULT_APP_NAME}`** (the default app name). If your `modal.App` is named differently, "
+            "you must specify it in the app ref argument. "
+            f"For example a app variable `app_2 = modal.App()` in `{import_path}` would "
+            f"be specified as `{import_path}::app_2`."
         )
         md = Markdown(guidance_msg)
         error_console.print(md)
@@ -197,7 +197,7 @@ def import_app(app_ref: str) -> App:
         sys.exit(1)
 
     if not isinstance(app, App):
-        raise click.UsageError(f"{app} is not a Modal Stub")
+        raise click.UsageError(f"{app} is not a Modal App")
 
     return app
 
@@ -212,7 +212,7 @@ def _show_function_ref_help(app_ref: ImportRef, base_cmd: str) -> None:
         )
     else:
         error_console.print(
-            f"[bold red]No function was specified, and no [green]`stub`[/green] variable could be found in '{import_path}'.[/bold red]"
+            f"[bold red]No function was specified, and no [green]`app`[/green] variable could be found in '{import_path}'.[/bold red]"
         )
     guidance_msg = f"""
 Usage:
@@ -220,9 +220,9 @@ Usage:
 
 Given the following example `app.py`:
 ```
-stub = modal.Stub()
+app = modal.App()  # Note: "app" was called "stub" up until April 2024
 
-@stub.function()
+@app.function()
 def foo():
     ...
 ```

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -230,9 +230,9 @@ def run(ctx, detach, quiet, interactive, env):
     """Run a Modal function or local entrypoint.
 
     `FUNC_REF` should be of the format `{file or module}::{function name}`.
-    Alternatively, you can refer to the function via the stub:
+    Alternatively, you can refer to the function via the app:
 
-    `{file or module}::{stub variable name}.{function name}`
+    `{file or module}::{app variable name}.{function name}`
 
     **Examples:**
 
@@ -242,8 +242,8 @@ def run(ctx, detach, quiet, interactive, env):
     modal run my_app.py::hello_world
     ```
 
-    If your module only has a single stub called `stub` and your stub has a
-    single local entrypoint (or single function), you can omit the stub and
+    If your module only has a single app called `app` and your app has a
+    single local entrypoint (or single function), you can omit the app and
     function parts:
 
     ```bash
@@ -263,7 +263,7 @@ def run(ctx, detach, quiet, interactive, env):
 
 
 def deploy(
-    app_ref: str = typer.Argument(..., help="Path to a Python file with a stub."),
+    app_ref: str = typer.Argument(..., help="Path to a Python file with a app."),
     name: str = typer.Option(None, help="Name of the deployment."),
     env: str = ENV_OPTION,
     public: bool = typer.Option(
@@ -291,11 +291,11 @@ def deploy(
 
 
 def serve(
-    app_ref: str = typer.Argument(..., help="Path to a Python file with a stub."),
+    app_ref: str = typer.Argument(..., help="Path to a Python file with a app."),
     timeout: Optional[float] = None,
     env: str = ENV_OPTION,
 ):
-    """Run a web endpoint(s) associated with a Modal stub and hot-reload code.
+    """Run a web endpoint(s) associated with a Modal app and hot-reload code.
 
     **Examples:**
 
@@ -323,7 +323,7 @@ def serve(
 def shell(
     func_ref: Optional[str] = typer.Argument(
         default=None,
-        help="Path to a Python file with a Stub or Modal function whose container to run.",
+        help="Path to a Python file with a App or Modal function whose container to run.",
         metavar="FUNC_REF",
     ),
     cmd: str = typer.Option(default="/bin/bash", help="Command to run inside the Modal image."),
@@ -357,7 +357,7 @@ def shell(
     modal shell
     ```
 
-    Start a bash shell using the spec for `my_function` in your stub:
+    Start a bash shell using the spec for `my_function` in your app:
 
     ```bash
     modal shell hello_world.py::my_function

--- a/modal/cloud_bucket_mount.py
+++ b/modal/cloud_bucket_mount.py
@@ -22,12 +22,12 @@ class _CloudBucketMount:
     ```python
     import subprocess
 
-    stub = modal.Stub()
+    app = modal.App()  # Note: "app" was called "stub" up until April 2024
     secret = modal.Secret.from_dict({
         "AWS_ACCESS_KEY_ID": "...",
         "AWS_SECRET_ACCESS_KEY": "...",
     })
-    @stub.function(
+    @app.function(
         volumes={
             "/my-mount": modal.CloudBucketMount(
                 bucket_name="s3-bucket-name",
@@ -48,12 +48,12 @@ class _CloudBucketMount:
     ```python
     import subprocess
 
-    stub = modal.Stub()
+    app = modal.App()  # Note: "app" was called "stub" up until April 2024
     secret = modal.Secret.from_dict({
         "AWS_ACCESS_KEY_ID": "...",
         "AWS_SECRET_ACCESS_KEY": "...",
     })
-    @stub.function(
+    @app.function(
         volumes={
             "/my-mount": modal.CloudBucketMount(
                 bucket_name="my-r2-bucket",
@@ -76,12 +76,12 @@ class _CloudBucketMount:
     ```python
     import subprocess
 
-    stub = modal.Stub()
+    app = modal.App()  # Note: "app" was called "stub" up until April 2024
     gcp_hmac_secret = modal.Secret.from_dict({
         "GOOGLE_ACCESS_KEY_ID": "GOOG1ERM12345...",
         "GOOGLE_ACCESS_KEY_SECRET": "HTJ123abcdef...",
     })
-    @stub.function(
+    @app.function(
         volumes={
             "/my-mount": modal.CloudBucketMount(
                 bucket_name="my-gcs-bucket",

--- a/modal/extensions/ipython.py
+++ b/modal/extensions/ipython.py
@@ -4,7 +4,7 @@ import logging
 import sys
 from typing import Any
 
-from modal import Stub
+from modal import App
 from modal._utils.async_utils import run_coro_blocking
 from modal.config import config, logger
 
@@ -19,10 +19,10 @@ def load_ipython_extension(ipython):
     logger.setLevel(config["loglevel"])
 
     # Create a app and provide it in the IPython app
-    stub = Stub()
-    ipython.push({"stub": stub})
+    app = App()
+    ipython.push({"app": app})
 
-    app_ctx = stub.run()
+    app_ctx = app.run()
 
     # Notebooks have an event loop present, but we want this function
     # to be blocking. This is fairly hacky.

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -555,7 +555,8 @@ class _Function(_Object, type_prefix="fu"):
     """Functions are the basic units of serverless execution on Modal.
 
     Generally, you will not construct a `Function` directly. Instead, use the
-    `@stub.function()` decorator on the `Stub` object for your application.
+    `@app.function()` decorator on the `App` object (formerly called "Stub")
+    for your application.
     """
 
     # TODO: more type annotations

--- a/modal/gpu.py
+++ b/modal/gpu.py
@@ -163,7 +163,7 @@ display_string_to_config = "\n".join(
 __doc__ = f"""
 **GPU configuration shortcodes**
 
-The following are the valid `str` values for the `gpu` parameter of [`@stub.function`](/docs/reference/modal.Stub#function).
+The following are the valid `str` values for the `gpu` parameter of [`@app.function`](/docs/reference/modal.Stub#function).
 
 {display_string_to_config}
 

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -227,9 +227,9 @@ class _Mount(_Object, type_prefix="mo"):
     ```python
     import modal
     import os
-    stub = modal.Stub()
+    app = modal.App()  # Note: "app" was called "stub" up until April 2024
 
-    @stub.function(mounts=[modal.Mount.from_local_dir("~/foo", remote_path="/root/foo")])
+    @app.function(mounts=[modal.Mount.from_local_dir("~/foo", remote_path="/root/foo")])
     def f():
         # `/root/foo` has the contents of `~/foo`.
         print(os.listdir("/root/foo/"))
@@ -520,9 +520,9 @@ class _Mount(_Object, type_prefix="mo"):
         import modal
         import my_local_module
 
-        stub = modal.Stub()
+        app = modal.App()  # Note: "app" was called "stub" up until April 2024
 
-        @stub.function(mounts=[
+        @app.function(mounts=[
             modal.Mount.from_local_python_packages("my_local_module", "my_other_module"),
         ])
         def f():

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -60,13 +60,13 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
     import modal
 
     nfs = modal.NetworkFileSystem.from_name("my-nfs", create_if_missing=True)
-    stub = modal.Stub()
+    app = modal.App()  # Note: "app" was called "stub" up until April 2024
 
-    @stub.function(network_file_systems={"/root/foo": nfs})
+    @app.function(network_file_systems={"/root/foo": nfs})
     def f():
         pass
 
-    @stub.function(network_file_systems={"/root/goo": nfs})
+    @app.function(network_file_systems={"/root/goo": nfs})
     def g():
         pass
     ```
@@ -127,7 +127,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         ```python notest
         volume = NetworkFileSystem.from_name("my-volume", create_if_missing=True)
 
-        @stub.function(network_file_systems={"/vol": volume})
+        @app.function(network_file_systems={"/vol": volume})
         def f():
             pass
         ```

--- a/modal/retries.py
+++ b/modal/retries.py
@@ -13,17 +13,17 @@ class Retries:
 
     ```python
     import modal
-    stub = modal.Stub()
+    app = modal.App()  # Note: called "stub" up until April 2024
 
     # Basic configuration.
     # This sets a policy of max 4 retries with 1-second delay between failures.
-    @stub.function(retries=4)
+    @app.function(retries=4)
     def f():
         pass
 
 
     # Fixed-interval retries with 3-second delay between failures.
-    @stub.function(
+    @app.function(
         retries=modal.Retries(
             max_retries=2,
             backoff_coefficient=1.0,
@@ -35,7 +35,7 @@ class Retries:
 
 
     # Exponential backoff, with retry delay doubling after each failure.
-    @stub.function(
+    @app.function(
         retries=modal.Retries(
             max_retries=4,
             backoff_coefficient=2.0,

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -194,13 +194,13 @@ async def _run_app(
     if not is_local():
         raise InvalidError(
             "Can not run an app from within a container."
-            " Are you calling stub.run() directly?"
+            " Are you calling app.run() directly?"
             " Consider using the `modal run` shell command."
         )
     if app._running_app:
         raise InvalidError(
             "App is already running and can't be started again.\n"
-            "You should not use `stub.run` or `run_stub` within a Modal `local_entrypoint`"
+            "You should not use `app.run` or `run_app` within a Modal `local_entrypoint`"
         )
 
     if app.description is None:
@@ -364,7 +364,7 @@ async def _deploy_app(
 
     ```python
     if __name__ == "__main__":
-        deploy_stub(stub)
+        deploy_app(app)
     ```
 
     Deployment has two primary purposes:
@@ -386,9 +386,9 @@ async def _deploy_app(
             "You need to either supply an explicit deployment name to the deploy command, or have a name set on the app.\n"
             "\n"
             "Examples:\n"
-            'stub.deploy("some_name")\n\n'
+            'app.deploy("some_name")\n\n'
             "or\n"
-            'stub = Stub("some-name")'
+            'app = App("some-name")'
         )
 
     if not is_valid_app_name(name):
@@ -463,7 +463,7 @@ async def _interactive_shell(_app: _App, cmd: List[str], environment_name: str =
     ```python
     import modal
 
-    stub = modal.Stub(image=modal.Image.debian_slim().apt_install("vim"))
+    app = modal.App(image=modal.Image.debian_slim().apt_install("vim"))
     ```
 
     You can now run this using

--- a/modal/schedule.py
+++ b/modal/schedule.py
@@ -19,10 +19,10 @@ class Cron(Schedule):
 
     ```python
     import modal
-    stub = modal.Stub()
+    app = modal.App()  # Note: "app" was called "stub" up until April 2024
 
 
-    @stub.function(schedule=modal.Cron("* * * * *"))
+    @app.function(schedule=modal.Cron("* * * * *"))
     def f():
         print("This function will run every minute")
     ```
@@ -49,9 +49,9 @@ class Period(Schedule):
 
     ```python
     import modal
-    stub = modal.Stub()
+    app = modal.App()  # Note: "app" was called "stub" up until April 2024
 
-    @stub.function(schedule=modal.Period(days=1))
+    @app.function(schedule=modal.Period(days=1))
     def f():
         print("This function will run every day")
 

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -109,16 +109,16 @@ class _Volume(_Object, type_prefix="vo"):
     ```python
     import modal
 
-    stub = modal.Stub()
+    app = modal.App()  # Note: "app" was called "stub" up until April 2024
     volume = modal.Volume.from_name("my-persisted-volume", create_if_missing=True)
 
-    @stub.function(volumes={"/root/foo": volume})
+    @app.function(volumes={"/root/foo": volume})
     def f():
         with open("/root/foo/bar.txt", "w") as f:
             f.write("hello")
         volume.commit()  # Persist changes
 
-    @stub.function(volumes={"/root/foo": volume})
+    @app.function(volumes={"/root/foo": volume})
     def g():
         volume.reload()  # Fetch latest changes
         with open("/root/foo/bar.txt", "r") as f:
@@ -174,10 +174,10 @@ class _Volume(_Object, type_prefix="vo"):
 
         volume = modal.Volume.from_name("my-volume", create_if_missing=True)
 
-        stub = modal.Stub()
+        app = modal.App()  # Note: "app" was called "stub" up until April 2024
 
-        # Volume refers to the same object, even across instances of `stub`.
-        @stub.function(volumes={"/vol": volume})
+        # Volume refers to the same object, even across instances of `app`.
+        @app.function(volumes={"/vol": volume})
         def f():
             pass
         ```

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -747,7 +747,7 @@ def test_multistub_privately_decorated(unix_servicer, caplog):
     # and the two stubs are not named
     ret = _run_container(unix_servicer, "test.supports.multistub_privately_decorated", "foo")
     assert _unwrap_scalar(ret) == 1
-    assert "You have more than one unnamed stub." in caplog.text
+    assert "You have more than one unnamed app." in caplog.text
 
 
 @skip_windows_unix_socket
@@ -775,7 +775,7 @@ def test_multistub_same_name_warning(unix_servicer, caplog, capsys):
         stub_name="dummy",
     )
     assert _unwrap_scalar(ret) == 1
-    assert "You have more than one stub with the same name ('dummy')" in caplog.text
+    assert "You have more than one app with the same name ('dummy')" in caplog.text
     capsys.readouterr()
 
 


### PR DESCRIPTION
This is the first place where we start using "app" instead of "stub" to the public.

We should fast-follow with equivalent changes to the examples and the online docs.