### PR TITLE
Flip around app & stub in some tests

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -818,7 +818,14 @@ class _Stub(_App):
     backwards compatibility, in order to facilitate moving from "Stub" to "App".
     """
 
-    pass
+    def __new__(cls, *args, **kwargs):
+        # TODO(erikbern): enable this warning soon!
+        #deprecation_warning(
+        #    (2024, 4, 19),
+        #   "The use of \"Stub\" has been deprecated in favor of \"App\"."
+        #    " This is a pure name change with no other implications."
+        #)
+        return _App(*args, **kwargs)
 
 
 Stub = synchronize_api(_Stub)

--- a/modal/cli/import_refs.py
+++ b/modal/cli/import_refs.py
@@ -41,8 +41,8 @@ def parse_import_ref(object_ref: str) -> ImportRef:
     return ImportRef(file_or_module, object_path)
 
 
-DEFAULT_APP_NAME = "stub"
-POSSIBLE_APP_NAMES = ["stub", "app"]
+DEFAULT_APP_NAME = "app"
+POSSIBLE_APP_NAMES = ["app", "stub"]
 
 
 def import_file_or_module(file_or_module: str):

--- a/test/cli_imports_test.py
+++ b/test/cli_imports_test.py
@@ -14,19 +14,19 @@ from modal.cli.import_refs import (
 local_entrypoint_src = """
 import modal
 
-stub = modal.Stub()
-@stub.local_entrypoint()
+app = modal.App()
+@app.local_entrypoint()
 def main():
     pass
 """
 python_module_src = """
 import modal
-stub = modal.Stub("FOO")
-other_stub = modal.Stub("BAR")
-@other_stub.function()
+app = modal.App("FOO")
+other_app = modal.App("BAR")
+@other_app.function()
 def func():
     pass
-@stub.cls()
+@app.cls()
 class Parent:
     @modal.method()
     def meth(self):
@@ -37,9 +37,9 @@ assert not __package__
 
 python_package_src = """
 import modal
-stub = modal.Stub("FOO")
-other_stub = modal.Stub("BAR")
-@other_stub.function()
+app = modal.App("FOO")
+other_app = modal.App("BAR")
+@other_app.function()
 def func():
     pass
 assert __package__ == "pack"
@@ -47,9 +47,9 @@ assert __package__ == "pack"
 
 python_subpackage_src = """
 import modal
-stub = modal.Stub("FOO")
-other_stub = modal.Stub("BAR")
-@other_stub.function()
+app = modal.App("FOO")
+other_app = modal.App("BAR")
+@other_app.function()
 def func():
     pass
 assert __package__ == "pack.sub"
@@ -57,9 +57,9 @@ assert __package__ == "pack.sub"
 
 python_file_src = """
 import modal
-stub = modal.Stub("FOO")
-other_stub = modal.Stub("BAR")
-@other_stub.function()
+app = modal.App("FOO")
+other_app = modal.App("BAR")
+@other_app.function()
 def func():
     pass
 
@@ -86,18 +86,18 @@ dir_containing_python_package = {
     [
         # # file syntax
         (empty_dir_with_python_file, "mod.py", _App),
-        (empty_dir_with_python_file, "mod.py::stub", _App),
-        (empty_dir_with_python_file, "mod.py::other_stub", _App),
+        (empty_dir_with_python_file, "mod.py::app", _App),
+        (empty_dir_with_python_file, "mod.py::other_app", _App),
         (dir_containing_python_package, "pack/file.py", _App),
         (dir_containing_python_package, "pack/sub/subfile.py", _App),
         (dir_containing_python_package, "dir/sub/subfile.py", _App),
         # # python module syntax
         (empty_dir_with_python_file, "mod", _App),
-        (empty_dir_with_python_file, "mod::stub", _App),
-        (empty_dir_with_python_file, "mod::other_stub", _App),
+        (empty_dir_with_python_file, "mod::app", _App),
+        (empty_dir_with_python_file, "mod::other_app", _App),
         (dir_containing_python_package, "pack.mod", _App),
-        (dir_containing_python_package, "pack.mod::other_stub", _App),
-        (dir_containing_python_package, "pack/local.py::stub.main", _LocalEntrypoint),
+        (dir_containing_python_package, "pack.mod::other_app", _App),
+        (dir_containing_python_package, "pack/local.py::app.main", _LocalEntrypoint),
     ],
 )
 def test_import_object(dir_structure, ref, expected_object_type, mock_dir):

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -26,12 +26,12 @@ import modal
 
 import other_module
 
-stub = modal.Stub("my_app")
+app = modal.App("my_app")
 
 # Sanity check that the module is imported properly
 import sys
 mod = sys.modules[__name__]
-assert mod.stub == stub
+assert mod.app == app
 """
 
 dummy_other_module_file = "x = 42"
@@ -126,10 +126,10 @@ def test_run(servicer, set_env_client, test_dir):
     _run(["run", file_with_entrypoint.as_posix() + "::app.main"])
 
 
-def test_run_app(servicer, set_env_client, test_dir):
-    stub_file = test_dir / "supports" / "app_run_tests" / "stub_is_now_app.py"
+def test_run_stub(servicer, set_env_client, test_dir):
+    stub_file = test_dir / "supports" / "app_run_tests" / "app_was_once_stub.py"
     _run(["run", stub_file.as_posix()])
-    _run(["run", stub_file.as_posix() + "::app"])
+    _run(["run", stub_file.as_posix() + "::stub"])
     _run(["run", stub_file.as_posix() + "::foo"])
 
 

--- a/test/supports/app_run_tests/app_was_once_stub.py
+++ b/test/supports/app_run_tests/app_was_once_stub.py
@@ -1,9 +1,9 @@
 # Copyright Modal Labs 2024
 import modal
 
-app = modal.App()
+stub = modal.Stub()
 
 
-@app.function()
+@stub.function()
 def foo():
     print("foo")


### PR DESCRIPTION
Instead of having a bunch of tests that use "stub" and test specifically that "app works", flip it around so that almost all tests use "app" and there's specific tests for the old "stub" name.

Just prepping for _deprecating_ "stub"