### PR TITLE
handle `app` -> `stub` fallback during CLI imports

### DIFF
--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -133,6 +133,13 @@ def test_run_stub(servicer, set_env_client, test_dir):
     _run(["run", app_file.as_posix() + "::foo"])
 
 
+def test_run_stub_with_app(servicer, set_env_client, test_dir):
+    app_file = test_dir / "supports" / "app_run_tests" / "app_and_stub.py"
+    _run(["run", app_file.as_posix()])
+    _run(["run", app_file.as_posix() + "::stub"])
+    _run(["run", app_file.as_posix() + "::foo"])
+
+
 def test_run_async(servicer, set_env_client, test_dir):
     sync_fn = test_dir / "supports" / "app_run_tests" / "local_entrypoint.py"
     res = _run(["run", sync_fn.as_posix()])

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -135,7 +135,8 @@ def test_run_stub(servicer, set_env_client, test_dir):
 
 def test_run_stub_with_app(servicer, set_env_client, test_dir):
     app_file = test_dir / "supports" / "app_run_tests" / "app_and_stub.py"
-    _run(["run", app_file.as_posix()])
+    with pytest.warns(match="`app`"):
+        _run(["run", app_file.as_posix()])
     _run(["run", app_file.as_posix() + "::stub"])
     _run(["run", app_file.as_posix() + "::foo"])
 

--- a/test/supports/app_run_tests/app_and_stub.py
+++ b/test/supports/app_run_tests/app_and_stub.py
@@ -1,0 +1,13 @@
+# Copyright Modal Labs 2024
+import modal
+
+# If both `app` and `stub` is present, we want Modal to fall back to `stub`,
+# rather than complaining about the type of `app`
+app = 123
+
+stub = modal.Stub()
+
+
+@stub.function()
+def foo():
+    print("foo")


### PR DESCRIPTION
If a user had both `app` and `stub` present at the module level, and ran `modal run myscript.py`, and `stub` was the main app class, then #1728 would cause `modal run` to break. E.g. this code:

```
import modal

app = 234
stub = modal.Stub()

@stub.function()
def f():
    ...
```

It would cause this issue:

```
erikbern@Eriks-Air modal-client % modal run stub_app_thing.py 
╭─ Error ──────────────────────────────────────────────────────────────────────────────────────────────────╮
│ 234 is not a Modal entity (should be a App or Function)                                                  │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

Now, after this code, it still works:

```
erikbern@Eriks-Air modal-client % modal run stub_app_thing.py                   
╭─ Modal Deprecation Warning (2024-04-20) ─────────────────────────────────────────────────────────────────╮
│ The symbol `app` is present at the module level but it's not a Modal app. We will use `stub` instead,    │
│ but this will not work in future Modal versions. Suggestion: change the name of `app` to something else. │
│                                                                                                          │
│ Source: /Users/erikbern/python3.10-env/lib/python3.10/site-packages/click/core.py:1729                   │
│   cmd = self.get_command(ctx, cmd_name)                                                                  │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────╯
✓ Initialized. View run at https://modal.com/modal-labs/apps/ap-stbr8cgdypPapuhzKIuEP7
✓ Created objects.
├── 🔨 Created mount /Users/erikbern/modal-client/stub_app_thing.py
└── 🔨 Created f.
Stopping app - local entrypoint completed.
✓ App completed. View run at https://modal.com/modal-labs/apps/ap-stbr8cgdypPapuhzKIuEP7
```
