### PR TITLE
stub_name -> app_name

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -360,7 +360,7 @@ def import_function(
     if active_app is None:
         # This branch is reached in the special case that the imported function is 1) not serialized, and 2) isn't a FunctionHandle - i.e, not decorated at definition time
         # Look at all instantiated apps - if there is only one with the indicated name, use that one
-        app_name: Optional[str] = function_def.stub_name or None  # coalesce protobuf field to None
+        app_name: Optional[str] = function_def.app_name or None  # coalesce protobuf field to None
         matching_apps = _App._all_apps.get(app_name, [])
         if len(matching_apps) > 1:
             if app_name is not None:

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -533,9 +533,9 @@ class _Function(_Object, type_prefix="fu"):
                 function_serialized = None
                 class_serialized = None
 
-            stub_name = ""
+            app_name = ""
             if app and app.name:
-                stub_name = app.name
+                app_name = app.name
 
             # Relies on dicts being ordered (true as of Python 3.6).
             volume_mounts = [
@@ -582,7 +582,7 @@ class _Function(_Object, type_prefix="fu"):
                 warm_pool_size=keep_warm or 0,
                 runtime=config.get("function_runtime"),
                 runtime_debug=config.get("function_runtime_debug"),
-                stub_name=stub_name,
+                app_name=app_name,
                 is_builder_function=is_builder_function,
                 allow_concurrent_inputs=allow_concurrent_inputs or 0,
                 worker_id=config.get("worker_id"),

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -873,7 +873,7 @@ message Function {
   // If set, overrides the runtime used by the function, either "runc" or "gvisor".
   string runtime = 30;
 
-  string stub_name = 31;
+  string app_name = 31;  // Formerly stub_name
 
   repeated VolumeMount volume_mounts = 33;
 

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -86,7 +86,7 @@ def _container_args(
     function_type=api_pb2.Function.FUNCTION_TYPE_FUNCTION,
     webhook_type=api_pb2.WEBHOOK_TYPE_UNSPECIFIED,
     definition_type=api_pb2.Function.DEFINITION_TYPE_FILE,
-    stub_name: str = "",
+    app_name: str = "",
     is_builder_function: bool = False,
     allow_concurrent_inputs: Optional[int] = None,
     serialized_params: Optional[bytes] = None,
@@ -112,7 +112,7 @@ def _container_args(
         volume_mounts=volume_mounts,
         webhook_config=webhook_config,
         definition_type=definition_type,
-        stub_name=stub_name or "",
+        app_name=app_name or "",
         is_builder_function=is_builder_function,
         is_auto_snapshot=is_auto_snapshot,
         allow_concurrent_inputs=allow_concurrent_inputs,
@@ -147,7 +147,7 @@ def _run_container(
     function_type=api_pb2.Function.FUNCTION_TYPE_FUNCTION,
     webhook_type=api_pb2.WEBHOOK_TYPE_UNSPECIFIED,
     definition_type=api_pb2.Function.DEFINITION_TYPE_FILE,
-    stub_name: str = "",
+    app_name: str = "",
     is_builder_function: bool = False,
     allow_concurrent_inputs: Optional[int] = None,
     serialized_params: Optional[bytes] = None,
@@ -163,7 +163,7 @@ def _run_container(
         function_type,
         webhook_type,
         definition_type,
-        stub_name,
+        app_name,
         is_builder_function,
         allow_concurrent_inputs,
         serialized_params,
@@ -758,7 +758,7 @@ def test_multiapp_privately_decorated_named_app(unix_servicer, caplog):
         unix_servicer,
         "test.supports.multiapp_privately_decorated_named_app",
         "foo",
-        stub_name="dummy",
+        app_name="dummy",
     )
     assert _unwrap_scalar(ret) == 1
     assert len(caplog.messages) == 0  # no warnings, since target app is named
@@ -772,7 +772,7 @@ def test_multiapp_same_name_warning(unix_servicer, caplog, capsys):
         unix_servicer,
         "test.supports.multiapp_same_name",
         "foo",
-        stub_name="dummy",
+        app_name="dummy",
     )
     assert _unwrap_scalar(ret) == 1
     assert "You have more than one app with the same name ('dummy')" in caplog.text


### PR DESCRIPTION
Proto field rename – should be fine, since afaict it's not used in any other service, just in the client itself.