### PR TITLE
Add CLI for interacting with modal.Dict object

### DIFF
--- a/modal/cli/dict.py
+++ b/modal/cli/dict.py
@@ -6,6 +6,7 @@ from rich.console import Console
 from rich.json import JSON
 from typer import Argument, Typer
 
+from modal._resolver import Resolver
 from modal._utils.async_utils import synchronizer
 from modal._utils.grpc_utils import retry_transient_errors
 from modal.cli.utils import ENV_OPTION, display_table
@@ -17,8 +18,18 @@ from modal_proto import api_pb2
 dict_cli = Typer(
     name="dict",
     no_args_is_help=True,
-    help="Inspect the contents of modal.Dict objects",
+    help="Manage `modal.Dict` objects and inspect their contents.",
 )
+
+
+@dict_cli.command(name="create")
+@synchronizer.create_blocking
+async def create(name: str, *, env: Optional[str] = ENV_OPTION):
+    """Create a named Dict object."""
+    d = _Dict.from_name(name, environment_name=env, create_if_missing=True)
+    client = await _Client.from_env()
+    resolver = Resolver(client=client)
+    await resolver.load(d)
 
 
 @dict_cli.command(name="list")
@@ -31,53 +42,10 @@ async def list(*, json: bool = False, env: Optional[str] = ENV_OPTION):
     response = await retry_transient_errors(client.stub.DictList, request)
 
     def format_timestamp(t: float) -> str:
-        return datetime.strftime(datetime.fromtimestamp(t), "%Y-%m-%d %H:%M")
+        return datetime.strftime(datetime.fromtimestamp(t), "%Y-%m-%d %H:%M") + " UTC"
 
     rows = [(d.name, format_timestamp(d.created_at)) for d in response.dicts]
     display_table(["Name", "Created at"], rows, json)
-
-
-@dict_cli.command(name="show")
-@synchronizer.create_blocking
-async def show(
-    name: str,
-    n: int = Argument(default=None, help="Retrieve and show no more than this many entries"),
-    *,
-    json: bool = False,
-    env: Optional[str] = ENV_OPTION,
-):
-    """Print the contents of a Dict."""
-    # TODO alternate names: inspect, dump, items
-    # TODO add an n: int option? or alternately a `modal dict peek` command or similar
-    d = await _Dict.lookup(name, environment_name=env)
-    i, items = 0, []
-    async for item in d.items():
-        i += 1
-        items.append(item)
-        if n is not None and i >= n:
-            break
-    if json:
-        # Note, we don't use the json= option of display_table becuase we want to display
-        # the dict itself as a JSON, rather than have a JSON representation of the table.
-        console = Console()
-        console.print(JSON.from_data(dict(items)))
-    else:
-        display_table(["Key", "Value"], [[str(k), str(v)] for k, v in items])
-
-
-@dict_cli.command(name="get")
-@synchronizer.create_blocking
-async def get(name: str, key: str, *, env: Optional[str] = ENV_OPTION):
-    """Print the value for a specific key.
-
-    Note: When using the CLI, keys are always interpreted as having a string type.
-    """
-    # TODO would it be nice to be able to get multiple values? Should we do that here?
-    d = await _Dict.lookup(name, environment_name=env)
-    console = Console()
-    val = await d.get(key)
-    # TODO val will be `None` when key is not found
-    console.print(val)
 
 
 @dict_cli.command("clear")
@@ -92,7 +60,52 @@ async def clear(name: str, *, env: Optional[str] = ENV_OPTION):
 @synchronizer.create_blocking
 async def delete(name: str, *, env: Optional[str] = ENV_OPTION):
     """Delete a named Dict object and all of its data."""
-    d = await _Dict.lookup(name, environment_name=env)
     client = await _Client.from_env()
-    req = api_pb2.AppStopRequest(app_id=d.object_id, source=api_pb2.APP_STOP_SOURCE_CLI)
-    await client.stub.AppStop(req)
+    lookup_request = api_pb2.AppGetByDeploymentNameRequest(
+        name=name,
+        environment_name=ensure_env(env),
+        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+    )
+    resp = await client.stub.AppGetByDeploymentName(lookup_request)
+    stop_req = api_pb2.AppStopRequest(app_id=resp.app_id, source=api_pb2.APP_STOP_SOURCE_CLI)
+    await client.stub.AppStop(stop_req)
+
+
+@dict_cli.command(name="get")
+@synchronizer.create_blocking
+async def get(name: str, key: str, *, env: Optional[str] = ENV_OPTION):
+    """Print the value for a specific key.
+
+    Note: When using the CLI, keys are always interpreted as having a string type.
+    """
+    # TODO would it be nice to be able to get multiple values? Should we do that here?
+    d = await _Dict.lookup(name, environment_name=env)
+    console = Console()
+    val = await d.get(key)
+    console.print(val)
+
+
+@dict_cli.command(name="show")
+@synchronizer.create_blocking
+async def show(
+    name: str,
+    n: int = Argument(default=None, help="Retrieve and show no more than this many entries"),
+    *,
+    json: bool = False,
+    env: Optional[str] = ENV_OPTION,
+):
+    """Print the contents of a Dict."""
+    d = await _Dict.lookup(name, environment_name=env)
+    i, items = 0, []
+    async for item in d.items():
+        i += 1
+        items.append(item)
+        if n is not None and i >= n:
+            break
+    if json:
+        # Note, we don't use the json= option of display_table becuase we want to display
+        # the dict itself as a JSON, rather than have a JSON representation of the table.
+        console = Console()
+        console.print(JSON.from_data(dict(items)))
+    else:
+        display_table(["Key", "Value"], [[str(k), str(v)] for k, v in items])

--- a/modal/cli/dict.py
+++ b/modal/cli/dict.py
@@ -2,6 +2,7 @@
 from datetime import datetime
 from typing import Optional
 
+import typer
 from rich.console import Console
 from rich.json import JSON
 from typer import Argument, Option, Typer
@@ -9,7 +10,7 @@ from typer import Argument, Option, Typer
 from modal._resolver import Resolver
 from modal._utils.async_utils import synchronizer
 from modal._utils.grpc_utils import retry_transient_errors
-from modal.cli.utils import ENV_OPTION, display_table
+from modal.cli.utils import ENV_OPTION, YES_OPTION, display_table
 from modal.client import _Client
 from modal.dict import _Dict
 from modal.environments import ensure_env
@@ -61,9 +62,14 @@ async def clear(name: str, *, env: Optional[str] = ENV_OPTION):
 
 @dict_cli.command(name="delete")
 @synchronizer.create_blocking
-async def delete(name: str, *, env: Optional[str] = ENV_OPTION):
+async def delete(name: str, *, yes: bool = YES_OPTION, env: Optional[str] = ENV_OPTION):
     """Delete a named Dict object and all of its data."""
-    # TODO confirmation?
+    if not yes:
+        typer.confirm(
+            f"Are you sure you want to irrevocably delete the modal.Dict '{name}'?",
+            default=False,
+            abort=True,
+        )
     await _Dict.delete(name, environment_name=env)
 
 

--- a/modal/cli/dict.py
+++ b/modal/cli/dict.py
@@ -13,7 +13,6 @@ from modal.cli.utils import ENV_OPTION, display_table
 from modal.client import _Client
 from modal.dict import _Dict
 from modal.environments import ensure_env
-from modal.exception import ExecutionError
 from modal_proto import api_pb2
 
 dict_cli = Typer(
@@ -98,21 +97,15 @@ async def show(
     """
     d = await _Dict.lookup(name, environment_name=env)
 
-    try:
-        i, items = 0, []
-        async for key, val in d.items():
-            i += 1
-            if not all and i > n:
-                items.append(("...", "..."))
-                break
-            else:
-                # TODO consider a flag to optionally show repr(key), repr(val)?
-                items.append((key, val))
-    except ModuleNotFoundError as exc:
-        # I think that on 3.10+ we could rewrite this to use anext and attribute errors to specific
-        # items (perhaps represent them in the output as "<library>_object" or something.)
-        msg = f"Dict contains objects from the `{exc.name}` library and cannot be deserialized locally."
-        raise ExecutionError(msg)
+    i, items = 0, []
+    async for key, val in d.items():
+        i += 1
+        if not all and i > n:
+            items.append(("...", "..."))
+            break
+        else:
+            # TODO consider a flag to optionally show repr(key), repr(val)?
+            items.append((key, val))
 
     if json:
         # Note, we don't use the json= option of display_table because we want to display

--- a/modal/cli/dict.py
+++ b/modal/cli/dict.py
@@ -94,7 +94,11 @@ async def show(
     json: bool = False,
     env: Optional[str] = ENV_OPTION,
 ):
-    """Print the contents of a Dict."""
+    """Print the contents of a Dict.
+
+    Note: By default, this command will retrieve the complete Dict contents.
+    Using the N argument is recommended for quickly inspecting a small number of items.
+    """
     d = await _Dict.lookup(name, environment_name=env)
 
     try:

--- a/modal/cli/dict.py
+++ b/modal/cli/dict.py
@@ -1,5 +1,4 @@
 # Copyright Modal Labs 2024
-from datetime import datetime
 from typing import Optional
 
 import typer
@@ -9,7 +8,7 @@ from typer import Argument, Option, Typer
 from modal._resolver import Resolver
 from modal._utils.async_utils import synchronizer
 from modal._utils.grpc_utils import retry_transient_errors
-from modal.cli.utils import ENV_OPTION, YES_OPTION, display_table
+from modal.cli.utils import ENV_OPTION, YES_OPTION, display_table, timestamp_to_local
 from modal.client import _Client
 from modal.dict import _Dict
 from modal.environments import ensure_env
@@ -44,10 +43,7 @@ async def list(*, json: bool = False, env: Optional[str] = ENV_OPTION):
     request = api_pb2.DictListRequest(environment_name=env)
     response = await retry_transient_errors(client.stub.DictList, request)
 
-    def format_timestamp(t: float) -> str:
-        return datetime.strftime(datetime.fromtimestamp(t), "%Y-%m-%d %H:%M") + " UTC"
-
-    rows = [(d.name, format_timestamp(d.created_at)) for d in response.dicts]
+    rows = [(d.name, timestamp_to_local(d.created_at, json)) for d in response.dicts]
     display_table(["Name", "Created at"], rows, json)
 
 

--- a/modal/cli/dict.py
+++ b/modal/cli/dict.py
@@ -26,7 +26,10 @@ dict_cli = Typer(
 @dict_cli.command(name="create")
 @synchronizer.create_blocking
 async def create(name: str, *, env: Optional[str] = ENV_OPTION):
-    """Create a named Dict object."""
+    """Create a named Dict object.
+
+    Note: This is a no-op when the Dict already exists.
+    """
     d = _Dict.from_name(name, environment_name=env, create_if_missing=True)
     client = await _Client.from_env()
     resolver = Resolver(client=client)

--- a/modal/cli/dict.py
+++ b/modal/cli/dict.py
@@ -64,15 +64,8 @@ async def clear(name: str, *, env: Optional[str] = ENV_OPTION):
 @synchronizer.create_blocking
 async def delete(name: str, *, env: Optional[str] = ENV_OPTION):
     """Delete a named Dict object and all of its data."""
-    client = await _Client.from_env()
-    lookup_request = api_pb2.AppGetByDeploymentNameRequest(
-        name=name,
-        environment_name=ensure_env(env),
-        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
-    )
-    resp = await client.stub.AppGetByDeploymentName(lookup_request)
-    stop_req = api_pb2.AppStopRequest(app_id=resp.app_id, source=api_pb2.APP_STOP_SOURCE_CLI)
-    await client.stub.AppStop(stop_req)
+    # TODO confirmation?
+    await _Dict.delete(name, environment_name=env)
 
 
 @dict_cli.command(name="get")

--- a/modal/cli/dict.py
+++ b/modal/cli/dict.py
@@ -115,7 +115,7 @@ async def show(
         raise ExecutionError(msg)
 
     if json:
-        # Note, we don't use the json= option of display_table becuase we want to display
+        # Note, we don't use the json= option of display_table because we want to display
         # the dict itself as a JSON, rather than have a JSON representation of the table.
         console = Console()
         console.print(JSON.from_data(dict(items)))

--- a/modal/cli/dict.py
+++ b/modal/cli/dict.py
@@ -55,7 +55,7 @@ async def list(*, json: bool = False, env: Optional[str] = ENV_OPTION):
 @dict_cli.command("clear")
 @synchronizer.create_blocking
 async def clear(name: str, *, env: Optional[str] = ENV_OPTION):
-    """Clear the contents Dict by deleting all of its data."""
+    """Clear the contents of a Dict by deleting all of its data."""
     d = await _Dict.lookup(name, environment_name=env)
     await d.clear()
 

--- a/modal/cli/dict.py
+++ b/modal/cli/dict.py
@@ -49,9 +49,15 @@ async def list(*, json: bool = False, env: Optional[str] = ENV_OPTION):
 
 @dict_cli.command("clear")
 @synchronizer.create_blocking
-async def clear(name: str, *, env: Optional[str] = ENV_OPTION):
+async def clear(name: str, *, yes: bool = YES_OPTION, env: Optional[str] = ENV_OPTION):
     """Clear the contents of a named Dict by deleting all of its data."""
     d = await _Dict.lookup(name, environment_name=env)
+    if not yes:
+        typer.confirm(
+            f"Are you sure you want to irrevocably delete the contents of modal.Dict '{name}'?",
+            default=False,
+            abort=True,
+        )
     await d.clear()
 
 
@@ -59,6 +65,8 @@ async def clear(name: str, *, env: Optional[str] = ENV_OPTION):
 @synchronizer.create_blocking
 async def delete(name: str, *, yes: bool = YES_OPTION, env: Optional[str] = ENV_OPTION):
     """Delete a named Dict object and all of its data."""
+    # Lookup first to validate the name, even though delete is a staticmethod
+    await _Dict.lookup(name, environment_name=env)
     if not yes:
         typer.confirm(
             f"Are you sure you want to irrevocably delete the modal.Dict '{name}'?",

--- a/modal/cli/dict.py
+++ b/modal/cli/dict.py
@@ -1,0 +1,86 @@
+# Copyright Modal Labs 2024
+from typing import Optional
+
+from rich.console import Console
+from rich.json import JSON
+from typer import Argument, Typer
+
+from modal._utils.async_utils import synchronizer
+from modal.cli.utils import ENV_OPTION, display_table
+from modal.client import _Client
+from modal.dict import _Dict
+from modal_proto import api_pb2
+
+dict_cli = Typer(
+    name="dict",
+    no_args_is_help=True,
+    help="Inspect the contents of modal.Dict objects",
+)
+
+
+@dict_cli.command(name="list")
+@synchronizer.create_blocking
+async def list(*, json: bool = False, env: Optional[str] = ENV_OPTION):
+    """List all persistent Dict objects."""
+    ...
+
+
+@dict_cli.command(name="show")
+@synchronizer.create_blocking
+async def show(
+    name: str,
+    n: int = Argument(default=None, help="Retrieve and show no more than this many entries"),
+    *,
+    json: bool = False,
+    env: Optional[str] = ENV_OPTION,
+):
+    """Print the contents of a Dict."""
+    # TODO alternate names: inspect, dump, items
+    # TODO add an n: int option? or alternately a `modal dict peek` command or similar
+    d = await _Dict.lookup(name, environment_name=env)
+    i, items = 0, []
+    async for item in d.items():
+        i += 1
+        items.append(item)
+        if n is not None and i >= n:
+            break
+    if json:
+        # Note, we don't use the json= option of display_table becuase we want to display
+        # the dict itself as a JSON, rather than have a JSON representation of the table.
+        console = Console()
+        console.print(JSON.from_data(dict(items)))
+    else:
+        display_table(["Key", "Value"], [[str(k), str(v)] for k, v in items])
+
+
+@dict_cli.command(name="get")
+@synchronizer.create_blocking
+async def get(name: str, key: str, *, env: Optional[str] = ENV_OPTION):
+    """Print the value for a specific key.
+
+    Note: When using the CLI, keys are always interpreted as having a string type.
+    """
+    # TODO would it be nice to be able to get multiple values? Should we do that here?
+    d = await _Dict.lookup(name, environment_name=env)
+    console = Console()
+    val = await d.get(key)
+    # TODO val will be `None` when key is not found
+    console.print(val)
+
+
+@dict_cli.command("clear")
+@synchronizer.create_blocking
+async def clear(name: str, *, env: Optional[str] = ENV_OPTION):
+    """Clear the contents Dict by deleting all of its data."""
+    d = await _Dict.lookup(name, environment_name=env)
+    await d.clear()
+
+
+@dict_cli.command(name="delete")
+@synchronizer.create_blocking
+async def delete(name: str, *, env: Optional[str] = ENV_OPTION):
+    """Delete a named, persistent Dict object and all of its data."""
+    d = await _Dict.lookup(name, environment_name=env)
+    client = await _Client.from_env()
+    req = api_pb2.AppStopRequest(app_id=d.object_id, source=api_pb2.APP_STOP_SOURCE_CLI)
+    await client.stub.AppStop(req)

--- a/modal/cli/entry_point.py
+++ b/modal/cli/entry_point.py
@@ -12,6 +12,7 @@ from . import run
 from .app import app_cli
 from .config import config_cli
 from .container import container_cli
+from .dict import dict_cli
 from .environment import environment_cli
 from .launch import launch_cli
 from .network_file_system import nfs_cli
@@ -84,6 +85,7 @@ async def setup(profile: Optional[str] = None):
 entrypoint_cli_typer.add_typer(app_cli)
 entrypoint_cli_typer.add_typer(config_cli)
 entrypoint_cli_typer.add_typer(container_cli)
+entrypoint_cli_typer.add_typer(dict_cli)
 entrypoint_cli_typer.add_typer(environment_cli)
 entrypoint_cli_typer.add_typer(launch_cli)
 entrypoint_cli_typer.add_typer(nfs_cli)

--- a/modal/cli/utils.py
+++ b/modal/cli/utils.py
@@ -1,4 +1,5 @@
 # Copyright Modal Labs 2022
+from collections.abc import Sequence
 from datetime import datetime
 from typing import List, Union
 
@@ -25,7 +26,9 @@ def _plain(text: Union[Text, str]) -> str:
     return text.plain if isinstance(text, Text) else text
 
 
-def display_table(column_names: List[str], rows: List[List[Union[Text, str]]], json: bool = False, title: str = None):
+def display_table(
+    column_names: List[str], rows: Sequence[Sequence[Union[Text, str]]], json: bool = False, title: str = None
+):
     console = Console()
     if json:
         json_data = [{col: _plain(row[i]) for i, col in enumerate(column_names)} for row in rows]

--- a/modal/cli/utils.py
+++ b/modal/cli/utils.py
@@ -45,3 +45,5 @@ If not specified, Modal will use the default environment of your current profile
 Otherwise, raises an error if the workspace has multiple environments.
 """
 ENV_OPTION = typer.Option(default=None, help=ENV_OPTION_HELP)
+
+YES_OPTION = typer.Option(False, "-y", "--yes", help="Run without pausing for confirmation.")

--- a/modal/cli/utils.py
+++ b/modal/cli/utils.py
@@ -25,7 +25,7 @@ def _plain(text: Union[Text, str]) -> str:
     return text.plain if isinstance(text, Text) else text
 
 
-def display_table(column_names: List[str], rows: List[List[Union[Text, str]]], json: bool, title: str = None):
+def display_table(column_names: List[str], rows: List[List[Union[Text, str]]], json: bool = False, title: str = None):
     console = Console()
     if json:
         json_data = [{col: _plain(row[i]) for i, col in enumerate(column_names)} for row in rows]

--- a/modal/cli/utils.py
+++ b/modal/cli/utils.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2022
-from collections.abc import Sequence
 from datetime import datetime
-from typing import List, Union
+from typing import List, Sequence, Union
 
 import typer
 from rich.console import Console

--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -18,7 +18,7 @@ from modal._output import step_completed, step_progress
 from modal._utils.async_utils import synchronizer
 from modal._utils.grpc_utils import retry_transient_errors
 from modal.cli._download import _volume_download
-from modal.cli.utils import ENV_OPTION, display_table, timestamp_to_local
+from modal.cli.utils import ENV_OPTION, YES_OPTION, display_table, timestamp_to_local
 from modal.client import _Client
 from modal.environments import ensure_env
 from modal.exception import deprecation_warning
@@ -249,7 +249,7 @@ async def cp(
 @synchronizer.create_blocking
 async def delete(
     volume_name: str = Argument(help="Name of the modal.Volume to be deleted. Case sensitive"),
-    yes: bool = Option(default=False, help="Delete without prompting for confirmation."),
+    yes: bool = YES_OPTION,
     confirm: bool = Option(default=False, help="DEPRECATED: See `--yes` option"),
     env: Optional[str] = ENV_OPTION,
 ):

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -715,5 +715,5 @@ def test_dict_show_get_clear(servicer, server_url_env, set_env_client):
     assert _run(["dict", "get", "baz-dict", "a"]).stdout == "123\n"
     assert _run(["dict", "get", "baz-dict", "b"]).stdout == "blah\n"
 
-    res = _run(["dict", "clear", "baz-dict"])
+    res = _run(["dict", "clear", "baz-dict", "--yes"])
     assert servicer.dicts[dict_id] == {}

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -690,7 +690,7 @@ def test_dict_create_list_delete(servicer, server_url_env, set_env_client):
 
 def test_dict_show_get_clear(servicer, server_url_env, set_env_client):
     # Kind of hacky to be modifying the attributes on the servicer like this
-    key = ("baz-dict", api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, "main")
+    key = ("baz-dict", api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, os.environ.get("MODAL_ENVIRONMENT", "main"))
     dict_id = "di-abc123"
     servicer.deployed_dicts[key] = dict_id
     servicer.dicts[dict_id] = {dumps("a"): dumps(123), dumps("b"): dumps("blah")}

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -690,19 +690,20 @@ def test_dict_create_list_delete(servicer, server_url_env, set_env_client):
 
 def test_dict_show_get_clear(servicer, server_url_env, set_env_client):
     # Kind of hacky to be modifying the attributes on the servicer like this
-    key = ("foo-dict", api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, "main")
-    servicer.deployed_dicts[key] = "di-123"
-    servicer.dicts = {"di-123": {dumps("a"): dumps(123), dumps("b"): dumps("blah")}}
+    key = ("baz-dict", api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, "main")
+    dict_id = "di-abc123"
+    servicer.deployed_dicts[key] = dict_id
+    servicer.dicts[dict_id] = {dumps("a"): dumps(123), dumps("b"): dumps("blah")}
 
-    res = _run(["dict", "show", "foo-dict"])
+    res = _run(["dict", "show", "baz-dict"])
     assert re.search(r" a .+ 123 ", res.stdout)
     assert re.search(r" b .+ blah ", res.stdout)
 
-    res = _run(["dict", "show", "foo-dict", "1"])
+    res = _run(["dict", "show", "baz-dict", "1"])
     assert "blah" not in res.stdout
 
-    assert _run(["dict", "get", "foo-dict", "a"]).stdout == "123\n"
-    assert _run(["dict", "get", "foo-dict", "b"]).stdout == "blah\n"
+    assert _run(["dict", "get", "baz-dict", "a"]).stdout == "123\n"
+    assert _run(["dict", "get", "baz-dict", "b"]).stdout == "blah\n"
 
-    res = _run(["dict", "clear", "foo-dict"])
-    assert servicer.dicts["di-123"] == {}
+    res = _run(["dict", "clear", "baz-dict"])
+    assert servicer.dicts[dict_id] == {}

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -700,7 +700,11 @@ def test_dict_show_get_clear(servicer, server_url_env, set_env_client):
     assert re.search(r" b .+ blah ", res.stdout)
 
     res = _run(["dict", "show", "baz-dict", "1"])
+    assert re.search(r"\.\.\. .+ \.\.\.", res.stdout)
     assert "blah" not in res.stdout
+
+    res = _run(["dict", "show", "baz-dict", "2"])
+    assert "..." not in res.stdout
 
     assert _run(["dict", "get", "baz-dict", "a"]).stdout == "123\n"
     assert _run(["dict", "get", "baz-dict", "b"]).stdout == "blah\n"

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import tempfile
 import traceback
+from pickle import dumps
 from typing import List, Optional
 from unittest import mock
 
@@ -672,3 +673,36 @@ def test_list_apps(servicer, mock_dir, set_env_client):
 
     res = _run(["app", "list"])
     assert "my_app_foo" in res.stdout
+
+
+def test_dict_create_list_delete(servicer, server_url_env, set_env_client):
+    _run(["dict", "create", "foo-dict"])
+    _run(["dict", "create", "bar-dict"])
+    res = _run(["dict", "list"])
+    assert "foo-dict" in res.stdout
+    assert "bar-dict" in res.stdout
+
+    _run(["dict", "delete", "bar-dict"])
+    res = _run(["dict", "list"])
+    assert "foo-dict" in res.stdout
+    assert "bar-dict" not in res.stdout
+
+
+def test_dict_show_get_clear(servicer, server_url_env, set_env_client):
+    # Kind of hacky to be modifying the attributes on the servicer like this
+    key = ("foo-dict", api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, "main")
+    servicer.deployed_dicts[key] = "di-123"
+    servicer.dicts = {"di-123": {dumps("a"): dumps(123), dumps("b"): dumps("blah")}}
+
+    res = _run(["dict", "show", "foo-dict"])
+    assert re.search(r" a .+ 123 ", res.stdout)
+    assert re.search(r" b .+ blah ", res.stdout)
+
+    res = _run(["dict", "show", "foo-dict", "1"])
+    assert "blah" not in res.stdout
+
+    assert _run(["dict", "get", "foo-dict", "a"]).stdout == "123\n"
+    assert _run(["dict", "get", "foo-dict", "b"]).stdout == "blah\n"
+
+    res = _run(["dict", "clear", "foo-dict"])
+    assert servicer.dicts["di-123"] == {}

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -695,15 +695,21 @@ def test_dict_show_get_clear(servicer, server_url_env, set_env_client):
     servicer.deployed_dicts[key] = dict_id
     servicer.dicts[dict_id] = {dumps("a"): dumps(123), dumps("b"): dumps("blah")}
 
-    res = _run(["dict", "show", "baz-dict"])
+    res = _run(["dict", "items", "baz-dict"])
+    assert re.search(r" Key .+ Value", res.stdout)
     assert re.search(r" a .+ 123 ", res.stdout)
     assert re.search(r" b .+ blah ", res.stdout)
 
-    res = _run(["dict", "show", "baz-dict", "1"])
+    res = _run(["dict", "items", "baz-dict", "1"])
     assert re.search(r"\.\.\. .+ \.\.\.", res.stdout)
     assert "blah" not in res.stdout
 
-    res = _run(["dict", "show", "baz-dict", "2"])
+    res = _run(["dict", "items", "baz-dict", "2"])
+    assert "..." not in res.stdout
+
+    res = _run(["dict", "items", "baz-dict", "--json"])
+    assert '"Key": "a"' in res.stdout
+    assert '"Value": 123' in res.stdout
     assert "..." not in res.stdout
 
     assert _run(["dict", "get", "baz-dict", "a"]).stdout == "123\n"

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -682,7 +682,7 @@ def test_dict_create_list_delete(servicer, server_url_env, set_env_client):
     assert "foo-dict" in res.stdout
     assert "bar-dict" in res.stdout
 
-    _run(["dict", "delete", "bar-dict"])
+    _run(["dict", "delete", "bar-dict", "--yes"])
     res = _run(["dict", "list"])
     assert "foo-dict" in res.stdout
     assert "bar-dict" not in res.stdout

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -313,13 +313,6 @@ class MockClientServicer(api_grpc.ModalClientBase):
             apps.append(api_pb2.AppStats(name=app_name, description=app_name, app_id=app_id))
         await stream.send_message(api_pb2.AppListResponse(apps=apps))
 
-    async def AppStop(self, stream):
-        request: api_pb2.AppStopRequest = await stream.recv_message()
-        app_id_to_deployment_name = {v: k for k, v in self.deployed_apps.items()}
-        deploy_name = app_id_to_deployment_name[request.app_id]
-        self.deployed_apps.pop(deploy_name)
-        await stream.send_message(Empty())
-
     ### Checkpoint
 
     async def ContainerCheckpoint(self, stream):


### PR DESCRIPTION
Resolves MOD-2418

## Changelog

- Added a command-line interface for interacting with `modal.Dict` objects. Run `modal dict --help` in your terminal to see what is available.