### PR TITLE
Client refactor of volumes listdir() APIs and CLI

### DIFF
--- a/modal/cli/_download.py
+++ b/modal/cli/_download.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import sys
 from pathlib import Path
-from typing import Optional, Tuple, Union
+from typing import AsyncIterator, Optional, Tuple, Union
 
 from click import UsageError
 
@@ -26,6 +26,7 @@ async def _volume_download(
     num_consumers = 1 if is_pipe else 10  # concurrency limit for downloading files
 
     async def producer():
+        iterator: AsyncIterator[FileEntry]
         if isinstance(volume, _Volume):
             iterator = volume.iterdir(remote_path, recursive=True)
         else:

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -339,6 +339,21 @@ class _Volume(_Object, type_prefix="vo"):
         file's description. If `recursive` is set to True, list all files and folders under the path
         recursively.
         """
+        from modal_version import minor_number
+
+        # This allows us to remove the server shim after 0.62 is no longer supported.
+        deprecation = deprecation_warning if minor_number <= 62 else deprecation_error
+        if path.endswith("**"):
+            deprecation(
+                (2024, 4, 23),
+                "Glob patterns in `volume get` and `Volume.listdir()` are deprecated. Please pass recursive=True instead. For the CLI, just remove the glob suffix.",
+            )
+        elif path.endswith("*"):
+            deprecation(
+                (2024, 4, 23),
+                "Glob patterns in `volume get` and `Volume.listdir()` are deprecated. Please remove the glob `*` suffix.",
+            )
+
         req = api_pb2.VolumeListFilesRequest(volume_id=self.object_id, path=path, recursive=recursive)
         async for batch in unary_stream(self._client.stub.VolumeListFiles, req):
             for entry in batch.entries:

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -339,10 +339,10 @@ class _Volume(_Object, type_prefix="vo"):
         file's description. If `recursive` is set to True, list all files and folders under the path
         recursively.
         """
-        from modal_version import minor_number
+        from modal_version import major_number, minor_number
 
         # This allows us to remove the server shim after 0.62 is no longer supported.
-        deprecation = deprecation_warning if minor_number <= 62 else deprecation_error
+        deprecation = deprecation_warning if (major_number, minor_number) <= (0, 62) else deprecation_error
         if path.endswith("**"):
             deprecation(
                 (2024, 4, 23),

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1934,7 +1934,7 @@ message VolumeListFilesRequest {
   string volume_id = 1;
   string path = 2;
   bool recursive = 4;
-  optional int32 max_entries = 3;
+  optional uint32 max_entries = 3;
 }
 
 message VolumeListFilesResponse {

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -454,7 +454,7 @@ def test_logs(servicer, server_url_env):
         assert res.stdout == "hello\n"
 
 
-def test_nfs_get(set_env_client):
+def test_nfs_get(set_env_client, servicer):
     nfs_name = "my-shared-nfs"
     _run(["nfs", "create", nfs_name])
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -465,6 +465,7 @@ def test_nfs_get(set_env_client):
         _run(["nfs", "put", nfs_name, upload_path, "test.txt"])
 
         _run(["nfs", "get", nfs_name, "test.txt", tmpdir])
+        print(servicer.nfs_files)
         with open(os.path.join(tmpdir, "test.txt"), "r") as f:
             assert f.read() == "foo bar baz"
 
@@ -490,7 +491,7 @@ def test_volume_get(servicer, set_env_client):
             assert f.read() == file_contents
 
     with tempfile.TemporaryDirectory() as tmpdir2:
-        _run(["volume", "get", vol_name, "**", tmpdir2])
+        _run(["volume", "get", vol_name, "/", tmpdir2])
         with open(os.path.join(tmpdir2, file_path.decode()), "rb") as f:
             assert f.read() == file_contents
 
@@ -542,7 +543,7 @@ def test_volume_rm(servicer, set_env_client):
             assert f.read() == file_contents
 
         _run(["volume", "rm", vol_name, file_path.decode()])
-        _run(["volume", "get", vol_name, file_path.decode()], expected_exit_code=2, expected_stderr=None)
+        _run(["volume", "get", vol_name, file_path.decode()], expected_exit_code=1, expected_stderr=None)
 
 
 @pytest.mark.parametrize("command", [["run"], ["deploy"], ["serve", "--timeout=1"], ["shell"]])

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -465,7 +465,6 @@ def test_nfs_get(set_env_client, servicer):
         _run(["nfs", "put", nfs_name, upload_path, "test.txt"])
 
         _run(["nfs", "get", nfs_name, "test.txt", tmpdir])
-        print(servicer.nfs_files)
         with open(os.path.join(tmpdir, "test.txt"), "r") as f:
             assert f.read() == "foo bar baz"
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1047,7 +1047,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         for path in self.nfs_files[req.shared_volume_id].keys():
             entry = api_pb2.FileEntry(path=path, type=api_pb2.FileEntry.FileType.FILE)
             response = api_pb2.SharedVolumeListFilesResponse(entries=[entry])
-            if req.path == "**" or req.path == path:
+            if req.path == "**" or req.path == "/" or req.path == path:  # hack
                 await stream.send_message(response)
 
     ### Task

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1045,7 +1045,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
     async def SharedVolumeListFilesStream(self, stream):
         req: api_pb2.SharedVolumeListFilesRequest = await stream.recv_message()
         for path in self.nfs_files[req.shared_volume_id].keys():
-            entry = api_pb2.FileEntry(path=path)
+            entry = api_pb2.FileEntry(path=path, type=api_pb2.FileEntry.FileType.FILE)
             response = api_pb2.SharedVolumeListFilesResponse(entries=[entry])
             if req.path == "**" or req.path == path:
                 await stream.send_message(response)

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -346,7 +346,7 @@ def test_persisted(servicer, client, delete_as_instance_method):
 def test_ephemeral(servicer, client):
     assert servicer.n_vol_heartbeats == 0
     with modal.Volume.ephemeral(client=client, _heartbeat_sleep=1) as vol:
-        assert vol.listdir("**") == []
+        assert vol.listdir("/") == []
         # TODO(erikbern): perform some operations
         time.sleep(1.5)  # Make time for 2 heartbeats
     assert servicer.n_vol_heartbeats == 2
@@ -354,7 +354,7 @@ def test_ephemeral(servicer, client):
 
 def test_lazy_hydration_from_named(set_env_client):
     vol = modal.Volume.from_name("my-vol", create_if_missing=True)
-    assert vol.listdir("**") == []
+    assert vol.listdir("/") == []
 
 
 @pytest.mark.skipif(platform.system() != "Linux", reason="needs /proc")


### PR DESCRIPTION
## Describe your changes

Requires us to merge this server change first: https://github.com/modal-labs/modal/pull/12096

Note that although the changelog says that we no longer take `**` arguments, it still works while the backwards compatibility shim exists in the server. I added shims on the server-side, and we can remove them after 0.62 is no longer a supported client version. It's not a particularly widely-used feature.

## Changelog

- Passing a glob `**` argument to the `modal volume get` CLI has been deprecated — instead, simply download the desired directory path, or `/` for the entire volume.
- `Volume.listdir()` no longer takes trailing glob arguments. Use `recursive=True` instead.
- `modal volume get` and `modal nfs get` performance is improved when downloading a single file. They also now work with multiple files when outputting to stdout.
- Fixed a visual bug where `modal volume get` on a single file will incorrectly display the destination path.