### PR TITLE
Add deletion API for Dict and Queue objects

### DIFF
--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -309,4 +309,4 @@ async def delete(
             abort=True,
         )
 
-    await _Volume.delete(volume_name, environment_name=env)
+    await _Volume.delete(label=volume_name, environment_name=env)

--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -303,5 +303,4 @@ async def delete(
             default=False,
             abort=True,
         )
-
-    await volume.delete()
+    await _Volume.delete(volume_name, environment_name=env)

--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -25,6 +25,7 @@ from modal.cli._download import _glob_download
 from modal.cli.utils import ENV_OPTION, display_table
 from modal.client import _Client
 from modal.environments import ensure_env
+from modal.exception import deprecation_warning
 from modal.volume import _Volume, _VolumeUploadContextManager
 from modal_proto import api_pb2
 
@@ -289,18 +290,23 @@ async def cp(
 @synchronizer.create_blocking
 async def delete(
     volume_name: str = Argument(help="Name of the modal.Volume to be deleted. Case sensitive"),
-    confirm: bool = Option(default=False, help="Set this flag to delete without prompting for confirmation"),
+    yes: bool = Option(default=False, help="Delete without prompting for confirmation."),
+    confirm: bool = Option(default=False, help="DEPRECATED: See `--yes` option"),
     env: Optional[str] = ENV_OPTION,
 ):
-    env = ensure_env(env)
-    volume = await _Volume.lookup(volume_name, environment_name=env)
-    if not isinstance(volume, _Volume):
-        raise UsageError("The specified app entity is not a modal.Volume")
+    if confirm:
+        deprecation_warning(
+            (2024, 4, 24),
+            "The `--confirm` option is deprecated; use `--yes` to delete without prompting.",
+            show_source=False,
+        )
+        yes = True
 
-    if not confirm:
+    if not yes:
         typer.confirm(
             f"Are you sure you want to irrevocably delete the modal.Volume '{volume_name}'?",
             default=False,
             abort=True,
         )
+
     await _Volume.delete(volume_name, environment_name=env)

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -189,6 +189,17 @@ class _Dict(_Object, type_prefix="di"):
         await resolver.load(obj)
         return obj
 
+    @staticmethod
+    async def delete(
+        label: str,
+        *,
+        client: Optional[_Client] = None,
+        environment_name: Optional[str] = None,
+    ):
+        obj = await _Dict.lookup(label, client=client, environment_name=environment_name)
+        req = api_pb2.DictDeleteRequest(dict_id=obj.object_id)
+        await retry_transient_errors(obj._client.stub.DictDelete, req)
+
     @live_method
     async def clear(self) -> None:
         """Remove all items from the Dict."""

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -210,6 +210,12 @@ class _Queue(_Object, type_prefix="qu"):
         await resolver.load(obj)
         return obj
 
+    @staticmethod
+    async def delete(label: str, *, client: Optional[_Client] = None, environment_name: Optional[str] = None):
+        obj = await _Queue.lookup(label, client=client, environment_name=environment_name)
+        req = api_pb2.QueueDeleteRequest(queue_id=obj.object_id)
+        await retry_transient_errors(obj._client.stub.QueueDelete, req)
+
     async def _get_nonblocking(self, partition: Optional[str], n_values: int) -> List[Any]:
         request = api_pb2.QueueGetRequest(
             queue_id=self.object_id,

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -528,6 +528,7 @@ class _Volume(_Object, type_prefix="vo"):
 
     # @staticmethod  # TODO uncomment when enforcing deprecation of instance method invocation
     async def delete(*args, label: str = "", client: Optional[_Client] = None, environment_name: Optional[str] = None):
+        # -- Backwards-compatibility section
         # TODO(michael) Upon enforcement of this deprecation, remove *args and the default argument for label=.
         if isinstance(self := args[0], _Volume):
             msg = (
@@ -538,10 +539,15 @@ class _Volume(_Object, type_prefix="vo"):
             deprecation_warning((2024, 4, 23), msg)
             await self._instance_delete()
             return
-        if args[1:] and isinstance(args[1], str):
+        elif isinstance(args[0], type):
+            args = args[1:]
+
+        if args and isinstance(args[0], str):
             if label:
                 raise InvalidError("`label` specified as both positional and keyword argument")
-            label = args[1]
+            label = args[0]
+        # -- Backwards-compatibility code ends here
+
         obj = await _Volume.lookup(label, client=client, environment_name=environment_name)
         req = api_pb2.VolumeDeleteRequest(volume_id=obj.object_id)
         await retry_transient_errors(obj._client.stub.VolumeDelete, req)

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -526,9 +526,7 @@ class _Volume(_Object, type_prefix="vo"):
             self._client.stub.VolumeDelete, api_pb2.VolumeDeleteRequest(volume_id=self.object_id)
         )
 
-    async def delete(
-        self, label: str = "", /, client: Optional[_Client] = None, environment_name: Optional[str] = None
-    ):
+    async def delete(self, label: str = "", client: Optional[_Client] = None, environment_name: Optional[str] = None):
         # TODO Upon enforcement of this deprecation, add a `@staticmethod` decorator,
         # and convert label to a required postional or keyword argument parameter
         if isinstance(self, _Volume):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -471,6 +471,11 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.n_dict_heartbeats += 1
         await stream.send_message(Empty())
 
+    async def DictDelete(self, stream):
+        request: api_pb2.DictDeleteRequest = await stream.recv_message()
+        self.deployed_dicts = {k: v for k, v in self.deployed_dicts.items() if v != request.dict_id}
+        await stream.send_message(Empty())
+
     async def DictClear(self, stream):
         request: api_pb2.DictGetRequest = await stream.recv_message()
         self.dicts[request.dict_id] = {}
@@ -826,6 +831,11 @@ class MockClientServicer(api_grpc.ModalClientBase):
         else:
             raise GRPCError(Status.NOT_FOUND, "Queue not found")
         await stream.send_message(api_pb2.QueueGetOrCreateResponse(queue_id=queue_id))
+
+    async def QueueDelete(self, stream):
+        request: api_pb2.QueueDeleteRequest = await stream.recv_message()
+        self.deployed_queues = {k: v for k, v in self.deployed_queues.items() if v != request.queue_id}
+        await stream.send_message(Empty())
 
     async def QueueHeartbeat(self, stream):
         await stream.recv_message()

--- a/test/dict_test.py
+++ b/test/dict_test.py
@@ -3,6 +3,7 @@ import pytest
 import time
 
 from modal import Dict
+from modal.exception import NotFoundError
 
 
 def test_dict_app(servicer, client):
@@ -24,6 +25,10 @@ def test_dict_app(servicer, client):
     assert d.get("foo", default=True)
     d["foo"] = None
     assert d["foo"] is None
+
+    Dict.delete("my-amazing-dict", client=client)
+    with pytest.raises(NotFoundError):
+        Dict.lookup("my-amazing-dict", client=client)
 
 
 def test_dict_ephemeral(servicer, client):

--- a/test/queue_test.py
+++ b/test/queue_test.py
@@ -4,6 +4,7 @@ import queue
 import time
 
 from modal import Queue
+from modal.exception import NotFoundError
 
 from .supports.skip import skip_macos, skip_windows
 
@@ -25,6 +26,10 @@ def test_queue(servicer, client):
     assert [v for v in q.iterate(item_poll_timeout=1.0)] == [1, 2, 3]
     assert 1.0 < time.time() - t0 < 2.0
     assert [v for v in q.iterate(item_poll_timeout=0.0)] == [1, 2, 3]
+
+    Queue.delete("some-random-queue", client=client)
+    with pytest.raises(NotFoundError):
+        Queue.lookup("some-random-queue", client=client)
 
 
 def test_queue_ephemeral(servicer, client):

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -319,7 +319,8 @@ async def test_volume_copy_2(client, tmp_path, servicer):
     assert returned_file_data[Path("test_dir/file2.txt")].data == b"test copy"
 
 
-def test_persisted(servicer, client):
+@pytest.mark.parametrize("delete_as_instance_method", [True, False])
+def test_persisted(servicer, client, delete_as_instance_method):
     # Lookup should fail since it doesn't exist
     with pytest.raises(NotFoundError):
         modal.Volume.lookup("xyz", client=client)
@@ -331,7 +332,11 @@ def test_persisted(servicer, client):
     v = modal.Volume.lookup("xyz", client=client)
 
     # Delete it
-    v.delete()
+    if delete_as_instance_method:
+        with pytest.warns(DeprecationError):
+            v.delete()
+    else:
+        modal.Volume.delete("xyz", client=client)
 
     # Lookup should fail again
     with pytest.raises(NotFoundError):


### PR DESCRIPTION
Resolves MOD-2785

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

## Changelog

- Added `Dict.delete` and `Queue.delete` as API methods for deleting named storage objects:

    ```
    import modal
    modal.Queue.delete("my-job-queue")
   ```
- Deprecated invoking `Volume.delete` as an instance method; it should now be invoked as a static method with the name of  the Volume to delete, as with the other methods.