### PR TITLE
Clean up FunctionInfo

### DIFF
--- a/modal/_utils/function_utils.py
+++ b/modal/_utils/function_utils.py
@@ -105,8 +105,25 @@ def is_async(function):
 class FunctionInfo:
     """Class that helps us extract a bunch of information about a function."""
 
+    raw_f: Callable[..., Any]
+    function_name: str
+    cls: Optional[Type[Any]]
+    signature: Optional[inspect.Signature]
+    file: Optional[str]
+    definition_type: "api_pb2.Function.DefinitionType.ValueType"
+    type: FunctionInfoType
+    base_dir: str
+    module_name: Optional[str]
+    remote_dir: Optional[PurePosixPath] = None
+
     # TODO: we should have a bunch of unit tests for this
-    def __init__(self, f, serialized=False, name_override: Optional[str] = None, cls: Optional[Type] = None):
+    def __init__(
+        self,
+        f: Optional[Callable[..., Any]],
+        serialized=False,
+        name_override: Optional[str] = None,
+        cls: Optional[Type] = None,
+    ):
         self.raw_f = f
         self.cls = cls
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -65,7 +65,7 @@ from .exception import (
 from .execution_context import current_input_id, is_local
 from .gpu import GPU_T, parse_gpu_config
 from .image import _Image
-from .mount import _get_client_mount, _Mount
+from .mount import _get_client_mount, _Mount, get_auto_mounts
 from .network_file_system import _NetworkFileSystem, network_file_system_mount_protos
 from .object import Object, _get_environment_name, _Object, live_method, live_method_gen
 from .parallel_map import (
@@ -347,8 +347,7 @@ class _Function(_Object, type_prefix="fu"):
             ]
 
             if config.get("automount"):
-                automounts = info.get_auto_mounts()
-                all_mounts += automounts
+                all_mounts += get_auto_mounts()
         else:
             # skip any mount introspection/logic inside containers, since the function
             # should already be hydrated

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -4,6 +4,9 @@ import asyncio
 import concurrent.futures
 import dataclasses
 import os
+import site
+import sys
+import sysconfig
 import time
 import typing
 from pathlib import Path, PurePosixPath
@@ -23,6 +26,7 @@ from ._utils.grpc_utils import retry_transient_errors
 from ._utils.package_utils import get_module_mount_info
 from .client import _Client
 from .config import config, logger
+from .exception import ModuleNotMountable
 from .object import _get_environment_name, _Object
 
 ROOT_DIR: PurePosixPath = PurePosixPath("/root")
@@ -635,3 +639,77 @@ def _get_client_mount():
         return _create_client_mount()
     else:
         return _Mount.from_name(client_mount_name(), namespace=api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL)
+
+
+SYS_PREFIXES = {
+    Path(p)
+    for p in (
+        sys.prefix,
+        sys.base_prefix,
+        sys.exec_prefix,
+        sys.base_exec_prefix,
+        *sysconfig.get_paths().values(),
+        *site.getsitepackages(),
+        site.getusersitepackages(),
+    )
+}
+
+SYS_PREFIXES |= {p.resolve() for p in SYS_PREFIXES}
+
+
+def _is_modal_path(remote_path: PurePosixPath):
+    path_prefix = remote_path.parts[:3]
+    remote_python_paths = [("/", "root"), ("/", "pkg")]
+    for base in remote_python_paths:
+        is_modal_path = path_prefix in [
+            base + ("modal",),
+            base + ("modal_proto",),
+            base + ("modal_version",),
+            base + ("synchronicity",),
+        ]
+        if is_modal_path:
+            return True
+    return False
+
+
+def get_auto_mounts() -> typing.List[_Mount]:
+    """mdmd:hidden
+
+    Auto-mount local modules that have been imported in global scope.
+    This may or may not include the "entrypoint" of the function as well, depending on how modal is invoked
+    Note: sys.modules may change during the iteration
+    """
+    auto_mounts = []
+    top_level_modules = []
+    skip_prefixes = set()
+    for name, module in sorted(sys.modules.items(), key=lambda kv: len(kv[0])):
+        parent = name.rsplit(".")[0]
+        if parent and parent in skip_prefixes:
+            skip_prefixes.add(name)
+            continue
+        skip_prefixes.add(name)
+        top_level_modules.append((name, module))
+
+    for module_name, module in top_level_modules:
+        if module_name.startswith("__"):
+            # skip "built in" modules like __main__ and __mp_main__
+            # the running function's main file should be included anyway
+            continue
+
+        try:
+            # at this point we don't know if the sys.modules module should be mounted or not
+            potential_mount = _Mount.from_local_python_packages(module_name)
+            mount_paths = potential_mount._top_level_paths()
+        except ModuleNotMountable:
+            # this typically happens if the module is a built-in, has binary components or doesn't exist
+            continue
+
+        for local_path, remote_path in mount_paths:
+            # TODO: use is_relative_to once we deprecate Python 3.8
+            if any(str(local_path).startswith(str(p)) for p in SYS_PREFIXES) or _is_modal_path(remote_path):
+                # skip any module that has paths in SYS_PREFIXES, or would overwrite the modal Package in the container
+                break
+        else:
+            auto_mounts.append(potential_mount)
+
+    return auto_mounts

--- a/test/mounted_files_test.py
+++ b/test/mounted_files_test.py
@@ -9,7 +9,7 @@ import pytest_asyncio
 
 import modal
 from modal import Mount
-from modal._utils.function_utils import FunctionInfo
+from modal.mount import get_auto_mounts
 
 from . import helpers
 from .supports.skip import skip_windows
@@ -45,10 +45,8 @@ def f():
 async def env_mount_files():
     # If something is installed using pip -e, it will be bundled up as a part of the environment.
     # Those are env-specific so we ignore those as a part of the test
-    fn_info = FunctionInfo(f)
-
     filenames = []
-    for mount in fn_info.get_auto_mounts():
+    for mount in get_auto_mounts():
         async for file_info in mount._get_files(mount.entries):
             filenames.append(file_info.mount_filename)
 


### PR DESCRIPTION
The public interface of FunctionInfo was super hard to understand since it sets a ton of members conditionally on construction. This cleans that up so it's easier to refactor (needed for common-pooling methods)

Also realized `get_auto_mounts()` isn't actually using `self` at all, so moved it out to modal.mount as a function instead.