### PR TITLE
Relax typer dependency specification to >=0.9

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     rich>=12.0.0
     synchronicity~=0.6.6
     toml
-    typer~=0.9.0
+    typer>=0.9
     types-certifi
     types-toml
     watchfiles


### PR DESCRIPTION
User request as apparently this made it impossible to solve an environment that included both `modal` and `prefect`. Leaning on CI to catch any issues, but don't see anything concerning in the [typer changelog](https://typer.tiangolo.com/release-notes/).