### PR TITLE
Improve feedback for deserialization errors on environment mismatch

### DIFF
--- a/modal/_serialization.py
+++ b/modal/_serialization.py
@@ -7,7 +7,7 @@ from modal_proto import api_pb2
 
 from ._vendor import cloudpickle
 from .config import logger
-from .exception import InvalidError
+from .exception import DeserializationError, InvalidError
 from .object import Object, _Object
 
 PICKLE_PROTOCOL = 4  # Support older Python versions.
@@ -61,12 +61,23 @@ def deserialize(s: bytes, client) -> Any:
         # doesn't expose some kind of serialization version number, so we have to guess based
         # on the error message.
         if "Can't get attribute '_make_function'" in str(exc):
-            raise InvalidError(
-                "Failed to deserialize value due to a version mismatch between your local client and the image. "
-                "Try changing the `python_version` in your Modal image to match your local Python version. "
+            raise DeserializationError(
+                "Deserialization failed due to a version mismatch between local and remote environments. "
+                "Try changing the Python version in your Modal image to match your local Python version. "
             ) from exc
         else:
-            raise exc
+            # On Python 3.10+, AttributeError has `.name` and `.obj` attributes for better custom reporting
+            raise DeserializationError(
+                f"Deserialization failed with an AttributeError, {exc}. This is probably because"
+                " you have different versions of a library in your local and remote environments."
+            ) from exc
+    except ModuleNotFoundError as exc:
+        from .execution_context import is_local  # Avoid circular import
+
+        dest = "local" if is_local() else "remote"
+        raise DeserializationError(
+            f"Deserialization failed because the '{exc.name}' module is not available in the {dest} environment."
+        ) from exc
 
 
 def _serialize_asgi(obj: Any) -> api_pb2.Asgi:

--- a/modal/exception.py
+++ b/modal/exception.py
@@ -82,6 +82,10 @@ class ExecutionError(Error):
     """Raised when something unexpected happened during runtime."""
 
 
+class DeserializationError(Error):
+    """Raised to provide more context when an error is encountered during deserialization."""
+
+
 class DeprecationError(UserWarning):
     """UserWarning category emitted when a deprecated Modal feature or API is used."""
 

--- a/test/serialization_test.py
+++ b/test/serialization_test.py
@@ -5,6 +5,7 @@ import random
 from modal import Queue
 from modal._serialization import deserialize, deserialize_data_format, serialize, serialize_data_format
 from modal._utils.rand_pb_testing import rand_pb
+from modal.exception import DeserializationError
 from modal_proto import api_pb2
 
 from .supports.skip import skip_old_py
@@ -40,3 +41,10 @@ async def test_asgi_roundtrip():
         buf = serialize_data_format(asgi_obj, api_pb2.DATA_FORMAT_ASGI)
         asgi_obj_roundtrip = deserialize_data_format(buf, api_pb2.DATA_FORMAT_ASGI, None)
         assert asgi_obj == asgi_obj_roundtrip
+
+
+def test_deserialization_error(client):
+    # Curated object that we should not be able to deserialize
+    obj = b"\x80\x04\x95(\x00\x00\x00\x00\x00\x00\x00\x8c\x17undeserializable_module\x94\x8c\x05Dummy\x94\x93\x94)\x81\x94."
+    with pytest.raises(DeserializationError, match="'undeserializable_module' .+ local environment"):
+        deserialize(obj, client)


### PR DESCRIPTION
Side-quest from the `modal dict` CLI work, adding a modal `DeserializationError` class and using it to provide more context for the two most common errors that arise from an environment mismatch.

## Changelog

- Improved feedback for deserialization failures when objects are being transferred between local / remote environments.