### PR TITLE
Show human-readable timezone codes in CLI tables

### DIFF
--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -45,8 +45,8 @@ async def list(env: Optional[str] = ENV_OPTION, json: Optional[bool] = False):
                 app_stats.app_id,
                 app_stats.description,
                 state,
-                timestamp_to_local(app_stats.created_at),
-                timestamp_to_local(app_stats.stopped_at),
+                timestamp_to_local(app_stats.created_at, json),
+                timestamp_to_local(app_stats.stopped_at, json),
             ]
         )
 

--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -16,7 +16,7 @@ container_cli = typer.Typer(name="container", help="Manage running containers.",
 
 @container_cli.command("list")
 @synchronizer.create_blocking
-async def list():
+async def list(json: bool = False):
     """List all containers that are currently running."""
     client = await _Client.from_env()
     res: api_pb2.TaskListResponse = await client.stub.TaskList(api_pb2.TaskListRequest())
@@ -30,11 +30,11 @@ async def list():
                 task_stats.task_id,
                 task_stats.app_id,
                 task_stats.app_description,
-                timestamp_to_local(task_stats.started_at) if task_stats.started_at else "Pending",
+                timestamp_to_local(task_stats.started_at, json) if task_stats.started_at else "Pending",
             ]
         )
 
-    display_table(column_names, rows, json=False, title="Active Containers")
+    display_table(column_names, rows, json=json, title="Active Containers")
 
 
 @container_cli.command("exec")

--- a/modal/cli/network_file_system.py
+++ b/modal/cli/network_file_system.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2022
 import os
 import sys
-from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
@@ -20,7 +19,7 @@ from modal._output import step_completed, step_progress
 from modal._utils.async_utils import synchronizer
 from modal._utils.grpc_utils import retry_transient_errors
 from modal.cli._download import _volume_download
-from modal.cli.utils import ENV_OPTION, display_table
+from modal.cli.utils import ENV_OPTION, display_table, timestamp_to_local
 from modal.client import _Client
 from modal.environments import ensure_env
 from modal.network_file_system import _NetworkFileSystem
@@ -41,13 +40,12 @@ async def list(env: Optional[str] = ENV_OPTION, json: Optional[bool] = False):
     env_part = f" in environment '{env}'" if env else ""
     column_names = ["Name", "Location", "Created at"]
     rows = []
-    locale_tz = datetime.now().astimezone().tzinfo
     for item in response.items:
         rows.append(
             [
                 item.label,
                 display_location(item.cloud_provider),
-                str(datetime.fromtimestamp(item.created_at, tz=locale_tz)),
+                timestamp_to_local(item.created_at, json),
             ]
         )
     display_table(column_names, rows, json, title=f"Shared Volumes{env_part}")

--- a/modal/cli/secret.py
+++ b/modal/cli/secret.py
@@ -34,8 +34,8 @@ async def list(env: Optional[str] = ENV_OPTION, json: Optional[bool] = False):
         rows.append(
             [
                 item.label,
-                timestamp_to_local(item.created_at),
-                timestamp_to_local(item.last_used_at) if item.last_used_at else "-",
+                timestamp_to_local(item.created_at, json),
+                timestamp_to_local(item.last_used_at, json) if item.last_used_at else "-",
             ]
         )
 

--- a/modal/cli/utils.py
+++ b/modal/cli/utils.py
@@ -9,11 +9,14 @@ from rich.table import Table
 from rich.text import Text
 
 
-def timestamp_to_local(ts: float) -> str:
+def timestamp_to_local(ts: float, isotz: bool = True) -> str:
     if ts > 0:
         locale_tz = datetime.now().astimezone().tzinfo
         dt = datetime.fromtimestamp(ts, tz=locale_tz)
-        return dt.isoformat(sep=" ", timespec="seconds")
+        if isotz:
+            return dt.isoformat(sep=" ", timespec="seconds")
+        else:
+            return f"{datetime.strftime(dt, '%Y-%m-%d %H:%M')} {locale_tz.tzname(dt)}"
     else:
         return None
 


### PR DESCRIPTION
Small change to truncate the creation timestamp at seconds and show a timezone code instead of UTC offset when we render a timestamp in a CLI table:

<img width="438" alt="image" src="https://github.com/modal-labs/modal-client/assets/315810/9bad1035-be9f-4b46-99cf-29c54f3765d1">

JSON output continues to use the full ISO format to remain machine-readable:

<img width="391" alt="image" src="https://github.com/modal-labs/modal-client/assets/315810/110ff618-23ea-464f-b159-b48eea4a1869">

Additionally, I refactored a couple of places where we were not using the common utility function for converting timestamps.