### PR TITLE
add provider enum value

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -107,6 +107,7 @@ enum CloudProvider {
   CLOUD_PROVIDER_AUTO = 3;
   CLOUD_PROVIDER_OCI = 4;
   CLOUD_PROVIDER_LAMBDA_LABS = 5;
+  CLOUD_PROVIDER_FLUIDSTACK = 6;  // experimental
 }
 
 // Which data format a binary message is encoded with.


### PR DESCRIPTION
Helps avoid annoying issues in server code to have this in.


## Backward/forward compatibility checks

Adding an enum value is backwards compatible.
