### PR TITLE
Add dict CLI to release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ We appreciate your patience while we speedily work towards a stable release of t
 
 <!-- NEW CONTENT GENERATED BELOW. PLEASE PRESERVE THIS COMMENT. -->
 
+### 0.62.116 (2024-04-26)
+
+* Added a command-line interface for interacting with modal.Dict objects. Run modal dict --help in your terminal to see what is available.
+
+
+
 ### 0.62.114 (2024-04-25)
 
 * `Secret.from_dotenv` now accepts an optional filename keyword argument:


### PR DESCRIPTION
Looks like we still can get failures from deployment contention. This PR will deploy a couple recent changes with appropriate changelog information.