### PR TITLE
fix: add args check to avoid `tuple index out of range` issue

### DIFF
--- a/modal/volume.py
+++ b/modal/volume.py
@@ -519,17 +519,18 @@ class _Volume(_Object, type_prefix="vo"):
     async def delete(*args, label: str = "", client: Optional[_Client] = None, environment_name: Optional[str] = None):
         # -- Backwards-compatibility section
         # TODO(michael) Upon enforcement of this deprecation, remove *args and the default argument for label=.
-        if isinstance(self := args[0], _Volume):
-            msg = (
-                "Calling Volume.delete as an instance method is deprecated."
-                " Please update your code to call it as a static method, passing"
-                " the name of the volume to delete, e.g. `modal.Volume.delete('my-volume')`."
-            )
-            deprecation_warning((2024, 4, 23), msg)
-            await self._instance_delete()
-            return
-        elif isinstance(args[0], type):
-            args = args[1:]
+        if args:
+            if isinstance(self := args[0], _Volume):
+                msg = (
+                    "Calling Volume.delete as an instance method is deprecated."
+                    " Please update your code to call it as a static method, passing"
+                    " the name of the volume to delete, e.g. `modal.Volume.delete('my-volume')`."
+                )
+                deprecation_warning((2024, 4, 23), msg)
+                await self._instance_delete()
+                return
+            elif isinstance(args[0], type):
+                args = args[1:]
 
         if args and isinstance(args[0], str):
             if label:


### PR DESCRIPTION
## Describe your changes

This is to add args check as it is empty for `modal volume delete --yes test`

The error I have seen:

```
$ modal volume delete --yes test2
╭─ Error ─────────────────────────────────────────────────────────────────────────────────────────────╮
│ tuple index out of range                                                                            │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

## Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


## Changelog

- add args check when deleting the volume

---

I have tested with the local build against my modal volume