### PR TITLE
Create root objects in parallel

### DIFF
--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -224,6 +224,9 @@ class TaskContext:
                 if task in self._tasks:
                     self._tasks.remove(task)
 
+    async def wait_all(self):
+        await self.wait(*self._tasks)
+
 
 def run_coro_blocking(coro):
     """Fairly hacky thing that's needed in some extreme cases.

--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -217,19 +217,12 @@ class TaskContext:
                 )
             except asyncio.TimeoutError:
                 continue
-            except ValueError:
-                # The `add_done_callback` of the task races with the `wait`, raising a ValueError
-                # because `self._tasks` is empty.
-                break
             for task in done:
                 task.result()  # Raise exception if needed
                 if task in unfinished_tasks:
                     unfinished_tasks.remove(task)
                 if task in self._tasks:
                     self._tasks.remove(task)
-
-    async def wait_all(self):
-        await self.wait(*self._tasks)
 
 
 def run_coro_blocking(coro):

--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -217,6 +217,10 @@ class TaskContext:
                 )
             except asyncio.TimeoutError:
                 continue
+            except ValueError:
+                # The `add_done_callback` of the task races with the `wait`, raising a ValueError
+                # because `self._tasks` is empty.
+                break
             for task in done:
                 task.result()  # Raise exception if needed
                 if task in unfinished_tasks:

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -145,9 +145,7 @@ async def _create_all_objects(
 
                 async def _load(tag, obj):
                     existing_object_id = tag_to_object_id.get(tag)
-                    print("LOADING", tag, existing_object_id)
                     await resolver.load(obj, existing_object_id)
-                    print("SETTING", tag, obj.object_id)
                     running_app.tag_to_object_id[tag] = obj.object_id
 
                 tg.create_task(_load(tag, obj))

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -126,31 +126,23 @@ async def _create_all_objects(
         # functions have ids assigned to them when the function is serialized.
         # Note: when handles/objs are merged, all objects will need to get ids pre-assigned
         # like this in order to be referrable within serialized functions
-        async with TaskContext() as tc:
-            for tag, obj in indexed_objects.items():
+        async def _preload(tag, obj):
+            existing_object_id = tag_to_object_id.get(tag)
+            # Note: preload only currently implemented for Functions, returns None otherwise
+            # this is to ensure that directly referenced functions from the global scope has
+            # ids associated with them when they are serialized into other functions
+            await resolver.preload(obj, existing_object_id)
+            if obj.object_id is not None:
+                tag_to_object_id[tag] = obj.object_id
 
-                async def _preload(tag, obj):
-                    existing_object_id = tag_to_object_id.get(tag)
-                    # Note: preload only currently implemented for Functions, returns None otherwise
-                    # this is to ensure that directly referenced functions from the global scope has
-                    # ids associated with them when they are serialized into other functions
-                    await resolver.preload(obj, existing_object_id)
-                    if obj.object_id is not None:
-                        tag_to_object_id[tag] = obj.object_id
+        await asyncio.gather(*(_preload(tag, obj) for tag, obj in indexed_objects.items()))
 
-                tc.create_task(_preload(tag, obj))
-            await tc.wait_all()
+        async def _load(tag, obj):
+            existing_object_id = tag_to_object_id.get(tag)
+            await resolver.load(obj, existing_object_id)
+            running_app.tag_to_object_id[tag] = obj.object_id
 
-        async with TaskContext() as tc:
-            for tag, obj in indexed_objects.items():
-
-                async def _load(tag, obj):
-                    existing_object_id = tag_to_object_id.get(tag)
-                    await resolver.load(obj, existing_object_id)
-                    running_app.tag_to_object_id[tag] = obj.object_id
-
-                tc.create_task(_load(tag, obj))
-            await tc.wait_all()
+        await asyncio.gather(*(_load(tag, obj) for tag, obj in indexed_objects.items()))
 
     # Create the app (and send a list of all tagged obs)
     # TODO(erikbern): we should delete objects from a previous version that are no longer needed

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -135,14 +135,14 @@ async def _create_all_objects(
             if obj.object_id is not None:
                 tag_to_object_id[tag] = obj.object_id
 
-        await asyncio.gather(*(_preload(tag, obj) for tag, obj in indexed_objects.items()))
+        await TaskContext.gather(*(_preload(tag, obj) for tag, obj in indexed_objects.items()))
 
         async def _load(tag, obj):
             existing_object_id = tag_to_object_id.get(tag)
             await resolver.load(obj, existing_object_id)
             running_app.tag_to_object_id[tag] = obj.object_id
 
-        await asyncio.gather(*(_load(tag, obj) for tag, obj in indexed_objects.items()))
+        await TaskContext.gather(*(_load(tag, obj) for tag, obj in indexed_objects.items()))
 
     # Create the app (and send a list of all tagged obs)
     # TODO(erikbern): we should delete objects from a previous version that are no longer needed

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -448,8 +448,8 @@ class XYZ:
 def test_method_args(servicer, client):
     with app_method_args.run(client=client):
         funcs = servicer.app_functions.values()
-        assert [f.function_name for f in funcs] == ["XYZ.foo", "XYZ.bar"]
-        assert [f.warm_pool_size for f in funcs] == [3, 7]
+        assert {f.function_name for f in funcs} == {"XYZ.foo", "XYZ.bar"}
+        assert {f.warm_pool_size for f in funcs} == {3, 7}
 
 
 class ClsWith1Method:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -177,6 +177,8 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.container_heartbeat_response = None
         self.container_heartbeat_abort = threading.Event()
 
+        self.image_join_sleep_duration = None
+
         @self.function_body
         def default_function_body(*args, **kwargs):
             return sum(arg**2 for arg in args) + sum(value**2 for key, value in kwargs.items())
@@ -756,6 +758,10 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def ImageJoinStreaming(self, stream):
         await stream.recv_message()
+
+        if self.image_join_sleep_duration is not None:
+            await asyncio.sleep(self.image_join_sleep_duration)
+
         task_log_1 = api_pb2.TaskLogs(data="hello, world\n", file_descriptor=api_pb2.FILE_DESCRIPTOR_INFO)
         task_log_2 = api_pb2.TaskLogs(
             task_progress=api_pb2.TaskProgress(

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -829,13 +829,14 @@ def f2():
 
 
 def test_image_parallel_build(builder_version, servicer, client):
-    barrier = None
+    num_concurrent = 0
 
     async def MockImageJoinStreaming(self, stream):
-        nonlocal barrier
-        if barrier is None:
-            barrier = asyncio.Barrier(2)  # lazy assignment so it works on Python < 3.10 (?)
-        await barrier.wait()  # this would block indefinitely if images aren't loaded in parallel
+        nonlocal num_concurrent
+        num_concurrent += 1
+        while num_concurrent < 2:
+            await asyncio.sleep(0.01)
+
         await stream.send_message(
             api_pb2.ImageJoinStreamingResponse(
                 result=api_pb2.GenericResult(status=api_pb2.GenericResult.GENERIC_STATUS_SUCCESS)


### PR DESCRIPTION
Allows image builds to take place in parallel.

We really need to start using the [backport](https://pypi.org/project/taskgroup/) of `TaskGroup` instead of `TaskContext`, but for now added a `wait_all` method that waits for all tasks in the context to complete.