### PR TITLE
Fix Volume.delete with kwarg label

### DIFF
--- a/modal/volume.py
+++ b/modal/volume.py
@@ -519,22 +519,23 @@ class _Volume(_Object, type_prefix="vo"):
     async def delete(*args, label: str = "", client: Optional[_Client] = None, environment_name: Optional[str] = None):
         # -- Backwards-compatibility section
         # TODO(michael) Upon enforcement of this deprecation, remove *args and the default argument for label=.
-        if isinstance(self := args[0], _Volume):
-            msg = (
-                "Calling Volume.delete as an instance method is deprecated."
-                " Please update your code to call it as a static method, passing"
-                " the name of the volume to delete, e.g. `modal.Volume.delete('my-volume')`."
-            )
-            deprecation_warning((2024, 4, 23), msg)
-            await self._instance_delete()
-            return
-        elif isinstance(args[0], type):
-            args = args[1:]
+        if args:
+            if isinstance(self := args[0], _Volume):
+                msg = (
+                    "Calling Volume.delete as an instance method is deprecated."
+                    " Please update your code to call it as a static method, passing"
+                    " the name of the volume to delete, e.g. `modal.Volume.delete('my-volume')`."
+                )
+                deprecation_warning((2024, 4, 23), msg)
+                await self._instance_delete()
+                return
+            elif isinstance(args[0], type):
+                args = args[1:]
 
-        if args and isinstance(args[0], str):
-            if label:
-                raise InvalidError("`label` specified as both positional and keyword argument")
-            label = args[0]
+            if isinstance(args[0], str):
+                if label:
+                    raise InvalidError("`label` specified as both positional and keyword argument")
+                label = args[0]
         # -- Backwards-compatibility code ends here
 
         obj = await _Volume.lookup(label, client=client, environment_name=environment_name)

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -546,6 +546,14 @@ def test_volume_rm(servicer, set_env_client):
         _run(["volume", "get", vol_name, file_path.decode()], expected_exit_code=1, expected_stderr=None)
 
 
+def test_volume_create_delete(servicer, server_url_env, set_env_client):
+    vol_name = "test-delete-vol"
+    _run(["volume", "create", vol_name])
+    assert vol_name in _run(["volume", "list"]).stdout
+    _run(["volume", "delete", "--yes", vol_name])
+    assert vol_name not in _run(["volume", "list"]).stdout
+
+
 @pytest.mark.parametrize("command", [["run"], ["deploy"], ["serve", "--timeout=1"], ["shell"]])
 @pytest.mark.usefixtures("set_env_client", "mock_shell_pty")
 @skip_windows("modal shell is not supported on Windows.")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1139,6 +1139,16 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
         await stream.send_message(api_pb2.VolumeGetOrCreateResponse(volume_id=volume_id))
 
+    async def VolumeList(self, stream):
+        req = await stream.recv_message()
+        items = []
+        for (name, _, env_name), volume_id in self.deployed_volumes.items():
+            if env_name != req.environment_name:
+                continue
+            items.append(api_pb2.VolumeListItem(label=name, volume_id=volume_id, created_at=1))
+        resp = api_pb2.VolumeListResponse(items=items, environment_name=req.environment_name)
+        await stream.send_message(resp)
+
     async def VolumeHeartbeat(self, stream):
         await stream.recv_message()
         self.n_vol_heartbeats += 1


### PR DESCRIPTION
Fixes a bug in the backwards-compatibility layer of `Volume.delete`, raised in #1761

Also adds a test for the `volume create` and `volume delete` CLI