### PR TITLE
Add TaskContext.gather, remove ConcurrencyPool / wait

### DIFF
--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -8,6 +8,7 @@ from grpclib import GRPCError, Status
 
 from modal_proto import api_pb2
 
+from ._utils.async_utils import TaskContext
 from .exception import ExecutionError, NotFoundError
 
 if TYPE_CHECKING:
@@ -118,7 +119,7 @@ class Resolver:
             async def loader():
                 # Wait for all its dependencies
                 # TODO(erikbern): do we need existing_object_id for those?
-                await asyncio.gather(*[self.load(dep) for dep in obj.deps()])
+                await TaskContext.gather(*[self.load(dep) for dep in obj.deps()])
 
                 # Load the object itself
                 try:

--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -201,8 +201,8 @@ class TaskContext:
         return t
 
     @staticmethod
-    async def gather(*awaitables: Awaitable) -> Any:
-        """Wait for a sequence of awaitables to finish, concurrently.
+    async def gather(*coros: Awaitable) -> Any:
+        """Wait for a sequence of coroutines to finish, concurrently.
 
         This is similar to `asyncio.gather()`, but it uses TaskContext to cancel all remaining tasks
         if one fails with an exception other than `asyncio.CancelledError`. The native `asyncio`
@@ -231,7 +231,7 @@ class TaskContext:
         ```
         """
         async with TaskContext() as tc:
-            results = await asyncio.gather(*(tc.create_task(a) for a in awaitables))
+            results = await asyncio.gather(*(tc.create_task(coro) for coro in coros))
         return results
 
 

--- a/modal/_utils/blob_utils.py
+++ b/modal/_utils/blob_utils.py
@@ -16,7 +16,7 @@ from aiohttp.abc import AbstractStreamWriter
 from modal_proto import api_pb2
 
 from ..exception import ExecutionError
-from .async_utils import retry
+from .async_utils import TaskContext, retry
 from .grpc_utils import retry_transient_errors
 from .hash_utils import UploadHashes, get_sha256_hex, get_upload_hashes
 from .http_utils import http_client_with_tls
@@ -195,7 +195,7 @@ async def perform_multipart_upload(
         num_bytes_left -= part_length_bytes
         file_offset += part_length_bytes
 
-    part_etags = await asyncio.gather(*upload_coros)
+    part_etags = await TaskContext.gather(*upload_coros)
 
     # The body of the complete_multipart_upload command needs some data in xml format:
     completion_body = "<CompleteMultipartUpload>\n"

--- a/modal/cli/_download.py
+++ b/modal/cli/_download.py
@@ -8,6 +8,7 @@ from typing import AsyncIterator, Optional, Tuple, Union
 
 from click import UsageError
 
+from modal._utils.async_utils import TaskContext
 from modal.network_file_system import _NetworkFileSystem
 from modal.volume import FileEntry, FileEntryType, _Volume
 
@@ -76,5 +77,5 @@ async def _volume_download(
                 q.task_done()
 
     consumers = [consumer() for _ in range(num_consumers)]
-    await asyncio.gather(producer(), *consumers)
+    await TaskContext.gather(producer(), *consumers)
     sys.stdout.flush()

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -36,6 +36,7 @@ from ._resolver import Resolver
 from ._resources import convert_fn_config_to_resources_config
 from ._serialization import serialize
 from ._utils.async_utils import (
+    TaskContext,
     synchronize_api,
     synchronizer,
     warn_if_generator_is_not_consumed,
@@ -1162,7 +1163,7 @@ async def _gather(*function_calls: _FunctionCall):
     ```
     """
     try:
-        return await asyncio.gather(*[fc.get() for fc in function_calls])
+        return await TaskContext.gather(*[fc.get() for fc in function_calls])
     except Exception as exc:
         # TODO: kill all running function calls
         raise exc

--- a/test/async_utils_test.py
+++ b/test/async_utils_test.py
@@ -9,7 +9,6 @@ from synchronicity import Synchronizer
 
 from modal._utils import async_utils
 from modal._utils.async_utils import (
-    ConcurrencyPool,
     TaskContext,
     queue_batch_iterator,
     retry,
@@ -79,31 +78,6 @@ async def test_task_context_grace():
     assert v.cancelled()
 
 
-async def raise_exception():
-    raise SampleException("foo")
-
-
-@skip_github_non_linux
-@pytest.mark.asyncio
-async def test_task_context_wait():
-    async with TaskContext(grace=0.1) as task_context:
-        u = task_context.create_task(asyncio.sleep(1.1))
-        v = task_context.create_task(asyncio.sleep(1.3))
-        await task_context.wait(u)
-
-    assert u.done()
-    assert v.cancelled()
-
-    with pytest.raises(SampleException):
-        async with TaskContext(grace=0.2) as task_context:
-            u = task_context.create_task(asyncio.sleep(1.1))
-            v = task_context.create_task(raise_exception())
-            await task_context.wait(u)
-
-    assert u.cancelled()
-    assert v.done()
-
-
 @skip_github_non_linux
 @pytest.mark.asyncio
 async def test_task_context_infinite_loop():
@@ -122,6 +96,42 @@ async def test_task_context_infinite_loop():
     assert not t.cancelled()
     assert t.done()
     assert counter == 4  # should be exited immediately
+
+
+@pytest.mark.asyncio
+async def test_task_context_gather():
+    state = "none"
+
+    async def t1(error=False):
+        nonlocal state
+        await asyncio.sleep(0.1)
+        state = "t1"
+        if error:
+            raise ValueError()
+
+    async def t2():
+        nonlocal state
+        await asyncio.sleep(0.2)
+        state = "t2"
+
+    await asyncio.gather(t1(), t2())
+    assert state == "t2"
+
+    # On t1 error: asyncio.gather() does not cancel t2, which is bad behavior.
+    state = "none"
+    with pytest.raises(ValueError):
+        await asyncio.gather(t1(error=True), t2())
+    assert state == "t1"
+    await asyncio.sleep(0.2)
+    assert state == "t2"  # t2 still runs because asyncio.gather() does not cancel tasks
+
+    # On t1 error: TaskContext.gather() should cancel the remaining tasks.
+    state = "none"
+    with pytest.raises(ValueError):
+        await TaskContext.gather(t1(error=True), t2())
+    assert state == "t1"
+    await asyncio.sleep(0.2)
+    assert state == "t1"
 
 
 DEBOUNCE_TIME = 0.1
@@ -220,60 +230,3 @@ def test_exit_handler():
 
     sync._close_loop()  # this is called on exit by synchronicity, which shuts down the event loop
     assert result == "bye"
-
-
-@pytest.mark.asyncio
-async def test_concurrency_pool():
-    max_running = 0
-    running = 0
-
-    async def f():
-        nonlocal running, max_running
-        running += 1
-        max_running = max(max_running, running)
-        await asyncio.sleep(0.1)
-        running -= 1
-
-    def gen():
-        for i in range(100):
-            yield f()
-
-    await asyncio.wait_for(ConcurrencyPool(50).run_coros(gen()), 0.3)
-    assert max_running == 50
-
-
-@pytest.mark.asyncio
-async def test_concurrency_pool_cancels_non_started():
-    counter = 0
-
-    async def f():
-        nonlocal counter
-        counter += 1
-        raise RuntimeError("some error")
-
-    def gen():
-        for i in range(100):
-            yield f()
-
-    with pytest.raises(RuntimeError):
-        await ConcurrencyPool(2).run_coros(gen(), return_exceptions=False)
-    await asyncio.sleep(0.1)
-    assert counter == 2
-
-
-@pytest.mark.asyncio
-async def test_concurrency_pool_return_exceptions():
-    async def f(x):
-        if x % 2:
-            raise RuntimeError("some error")
-        else:
-            return 42
-
-    def gen():
-        for x in range(4):
-            yield f(x)
-
-    res = await asyncio.wait_for(ConcurrencyPool(2).run_coros(gen(), return_exceptions=True), 0.1)
-    assert res[0] == res[2] == 42
-    assert isinstance(res[1], RuntimeError)
-    assert isinstance(res[3], RuntimeError)


### PR DESCRIPTION
This adds the `TaskContext.gather()` method, a replacement for `asyncio.gather()` that only takes coroutines and cancels all tasks on an exception being raised on any task.

```python
    @staticmethod
    async def gather(*awaitables: Awaitable) -> Any:
        """Wait for a sequence of awaitables to finish, concurrently.

        This is similar to `asyncio.gather()`, but it uses TaskContext to cancel all remaining tasks
        if one fails with an exception other than `asyncio.CancelledError`. The native `asyncio`
        function does not cancel remaining tasks in this case, which can lead to surprises.

        For example, if you use `asyncio.gather(t1, t2, t3)` and t2 raises an exception, then t1 and
        t3 would continue running. With `TaskGroup.gather(t1, t2, t3)`, they are cancelled.

        (It's still acceptable to use `asyncio.gather()` if you don't need cancellation — for
        example, if you're just gathering quick coroutines with no side-effects. Or if you're
        gathering the tasks with `return_exceptions=True`.)

        Usage:

        ```python notest
        # Example 1: Await three coroutines
        created_object, other_work, new_plumbing = await TaskContext.gather(
            create_my_object(),
            do_some_other_work(),
            fix_plumbing(),
        )

        # Example 2: Gather a list of coroutines
        coros = [a.load() for a in objects]
        results = await TaskContext.gather(*coros)
        ```
        """
        async with TaskContext() as tc:
            results = await asyncio.gather(*(tc.create_task(a) for a in awaitables))
        return results
```

I also removed `TaskContext.wait`, which is unused and could just be replaced with asyncio.wait() on the tasks themselves, as well as `ConcurrencyPool`, which was only being used in one place after a while — made it consistent with other code using `aiostream` for now.