### PR TITLE
Image builder 2024.04 changes: drop to protobuf 4 and install uv

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -916,7 +916,7 @@ class _Image(_Object, type_prefix="im"):
                 # .bashrc is explicitly sourced because RUN is a non-login shell and doesn't run bash.
                 "RUN . /root/.bashrc && conda activate base \\ ",
                 # Ensure that packaging tools are up to date and install client dependenices
-                f"&& python -m pip install --upgrade {'pip' if version == '2023.12' else 'pip wheel'} \\ ",
+                f"&& python -m pip install --upgrade {'pip' if version == '2023.12' else 'pip wheel uv'} \\ ",
                 f"&& python -m {_get_modal_requirements_command(version)}",
             ]
             if version > "2023.12":
@@ -1088,7 +1088,7 @@ class _Image(_Object, type_prefix="im"):
 
         modal_requirements_commands = [
             f"COPY {CONTAINER_REQUIREMENTS_PATH} {CONTAINER_REQUIREMENTS_PATH}",
-            f"RUN python -m pip install --upgrade {'pip' if builder_version == '2023.12' else 'pip wheel'}",
+            f"RUN python -m pip install --upgrade {'pip' if builder_version == '2023.12' else 'pip wheel uv'}",
             f"RUN python -m {_get_modal_requirements_command(builder_version)}",
         ]
         if builder_version > "2023.12":
@@ -1327,7 +1327,7 @@ class _Image(_Object, type_prefix="im"):
                 f"COPY {CONTAINER_REQUIREMENTS_PATH} {CONTAINER_REQUIREMENTS_PATH}",
                 "RUN apt-get update",
                 "RUN apt-get install -y gcc gfortran build-essential",
-                f"RUN pip install --upgrade {'pip' if version == '2023.12' else 'pip wheel'}",
+                f"RUN pip install --upgrade {'pip' if version == '2023.12' else 'pip wheel uv'}",
                 f"RUN {_get_modal_requirements_command(version)}",
                 # Set debian front-end to non-interactive to avoid users getting stuck with input prompts.
                 "RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections",

--- a/modal/requirements/2024.04.txt
+++ b/modal/requirements/2024.04.txt
@@ -17,7 +17,7 @@ idna==3.6
 markdown-it-py==3.0.0
 mdurl==0.1.2
 multidict==6.0.5
-protobuf==5.26.1
+protobuf==4.25.3
 pydantic==2.6.4
 pydantic_core==2.16.3
 Pygments==2.17.2


### PR DESCRIPTION
Two updates to the 2024.04 image builder version before we announce it in "preview" status:

- Install `uv` (the latest version at time of image build) in base image layers so it's easier to use it for image creation — first class API still TK
- Drop the pinned protofbuf version to 4.x as we've had sporadic reports of issues with deprecated functionality in 5.x on some systems

Closes MOD-2820 and partly addresses (but doesn't fix) MOD-2812