### PR TITLE
Revert bump in supported protobuf version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     click>=8.1.0
     fastapi
     grpclib==0.4.7
-    protobuf>=3.19,<6.0,!=4.24.0
+    protobuf>=3.19,<5.0,!=4.24.0
     rich>=12.0.0
     synchronicity~=0.6.6
     toml


### PR DESCRIPTION
We've had some isolated reports of issues arising because of deprecated functionality in the code that protobuf 5 generates from our protos on specific systems. It's not entirely clear whether this is an issue on our end or in the Python protobuf implementation. But to help users avoid a confusing failure, we're dropping the supported protobuf version in our setup.cfg back to `<5` until we can figure out what's happening with protobuf 5.