### PR TITLE
Add multipart to 2024.04 requirements

### DIFF
--- a/modal/requirements/2024.04.txt
+++ b/modal/requirements/2024.04.txt
@@ -21,6 +21,7 @@ protobuf==4.25.3
 pydantic==2.6.4
 pydantic_core==2.16.3
 Pygments==2.17.2
+python-multipart==0.0.9
 rich==13.7.1
 sniffio==1.3.1
 starlette==0.36.3


### PR DESCRIPTION
This is an optional dependency of fastapi, but you need it as soon as you're accepting form data, which is a common enough usecase that it is worth including this as a client dependency.

Closes MOD-2772