### PR TITLE
Run @enter methods when doing .local() calls on class instances

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -25,6 +25,7 @@ from .object import _get_environment_name, _Object
 from .partial_function import (
     PartialFunction,
     _find_callables_for_cls,
+    _find_callables_for_obj,
     _find_partial_methods_for_cls,
     _Function,
     _PartialFunctionFlags,
@@ -98,6 +99,14 @@ class _Obj:
         if not self._entered:
             if hasattr(self._local_obj, "__enter__"):
                 self._local_obj.__enter__()
+
+            for method_flag in (
+                _PartialFunctionFlags.ENTER_PRE_CHECKPOINT,
+                _PartialFunctionFlags.ENTER_POST_CHECKPOINT,
+            ):
+                for enter_method in _find_callables_for_obj(self._local_obj, method_flag).values():
+                    enter_method()
+
         self._entered = True
 
     @property

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -194,7 +194,6 @@ class FooLocal:
         return self.bar.local(y + 1)
 
 
-@pytest.mark.filterwarnings()
 def test_can_call_locally(client):
     foo = FooLocal()
     assert foo.bar.local(4) == 64


### PR DESCRIPTION
Previously only the deprecated `__enter__()` method was being run when a modal class instance was used for a `.local()` call, e.g.

`MyModalCls().my_method.local()`

Fixes MOD-2759