### PR TITLE
Raise RequestSizeError when server returns 413 for Dict/Queue operations

### DIFF
--- a/modal/dict.py
+++ b/modal/dict.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
 from typing import Any, AsyncIterator, Optional, Tuple, Type
 
+from grpclib import GRPCError
 from synchronicity.async_wrap import asynccontextmanager
 
 from modal_proto import api_pb2
@@ -11,7 +12,7 @@ from ._utils.async_utils import TaskContext, synchronize_api
 from ._utils.grpc_utils import retry_transient_errors, unary_stream
 from .client import _Client
 from .config import logger
-from .exception import deprecation_warning
+from .exception import RequestSizeError, deprecation_warning
 from .object import EPHEMERAL_OBJECT_HEARTBEAT_SLEEP, _get_environment_name, _Object, live_method, live_method_gen
 
 
@@ -250,7 +251,13 @@ class _Dict(_Object, type_prefix="di"):
         """Update the dictionary with additional items."""
         serialized = _serialize_dict(kwargs)
         req = api_pb2.DictUpdateRequest(dict_id=self.object_id, updates=serialized)
-        await retry_transient_errors(self._client.stub.DictUpdate, req)
+        try:
+            await retry_transient_errors(self._client.stub.DictUpdate, req)
+        except GRPCError as exc:
+            if "status = '413'" in exc.message:
+                raise RequestSizeError("Dict.update request is too large") from exc
+            else:
+                raise exc
 
     @live_method
     async def put(self, key: Any, value: Any) -> None:
@@ -258,7 +265,13 @@ class _Dict(_Object, type_prefix="di"):
         updates = {key: value}
         serialized = _serialize_dict(updates)
         req = api_pb2.DictUpdateRequest(dict_id=self.object_id, updates=serialized)
-        await retry_transient_errors(self._client.stub.DictUpdate, req)
+        try:
+            await retry_transient_errors(self._client.stub.DictUpdate, req)
+        except GRPCError as exc:
+            if "status = '413'" in exc.message:
+                raise RequestSizeError("Dict.put request is too large") from exc
+            else:
+                raise exc
 
     @live_method
     async def __setitem__(self, key: Any, value: Any) -> None:

--- a/modal/exception.py
+++ b/modal/exception.py
@@ -86,6 +86,10 @@ class DeserializationError(Error):
     """Raised to provide more context when an error is encountered during deserialization."""
 
 
+class RequestSizeError(Error):
+    """Raised when an operation produces a gRPC request that is rejected by the server for being too large."""
+
+
 class DeprecationError(UserWarning):
     """UserWarning category emitted when a deprecated Modal feature or API is used."""
 


### PR DESCRIPTION
Should improve the user experience when requests (e.g. `Queue.put`, `Dict.update`) are rejected because the payloads are too large.

I think this is the main place we need to do this because other interfaces (Volumes, Function inputs) route through s3 on large payloads? Note that for Queue, payloads that are >256KiB will get rejected by server _logic_. There's no size limit on `Dict` values, but maybe there should be.

The error handling is a little bit janky because we just get a `Status.UNKNOWN` and need to introspect the error message. Maybe we can improve that somehow on the server side?

I considered putting the size limit (and perhaps measuring the request size in the except block) but that felt like an implementation detail that we didn't need here. Open to it, though!

It's untested because our mock server doesn't have a limit but I could add that if it feels important.

Closes MOD-2761