### PR TITLE
Improve the error message for unhydrated objects

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -680,15 +680,18 @@ class _Function(_Object, type_prefix="fu"):
         """mdmd:hidden"""
 
         async def _load(self: _Function, resolver: Resolver, existing_object_id: Optional[str]):
-            function_name = self._parent.info.function_name
+            try:
+                identity = f"base {self._parent.info.function_name} function"
+            except Exception:
+                # Can't always look up the function name that way, so fall back to generic message
+                identity = "base function for parameterized class"
             if not self._parent.is_hydrated:
                 if self._parent.app._running_app is None:
                     reason = ", because the App it is defined on is not running."
                 else:
                     reason = ""
                 raise ExecutionError(
-                    f"The base {function_name} function has not been hydrated"
-                    f" with the metadata it needs to run on Modal{reason}."
+                    f"The {identity} has not been hydrated" f" with the metadata it needs to run on Modal{reason}."
                 )
             assert self._parent._client.stub
             serialized_params = serialize((args, kwargs))

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -680,11 +680,15 @@ class _Function(_Object, type_prefix="fu"):
         """mdmd:hidden"""
 
         async def _load(self: _Function, resolver: Resolver, existing_object_id: Optional[str]):
+            function_name = self._parent.info.function_name
             if not self._parent.is_hydrated:
+                if self._parent.app._running_app is None:
+                    reason = ", because the App it is defined on is not running."
+                else:
+                    reason = ""
                 raise ExecutionError(
-                    "Base function in class has not been hydrated. This might happen if an object is"
-                    " defined on a different stub, or if it's on the same stub but it didn't get"
-                    " created because it wasn't defined in global scope."
+                    f"The base {function_name} function has not been hydrated"
+                    f" with the metadata it needs to run on Modal{reason}."
                 )
             assert self._parent._client.stub
             serialized_params = serialize((args, kwargs))

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -691,7 +691,7 @@ class _Function(_Object, type_prefix="fu"):
                 else:
                     reason = ""
                 raise ExecutionError(
-                    f"The {identity} has not been hydrated" f" with the metadata it needs to run on Modal{reason}."
+                    f"The {identity} has not been hydrated with the metadata it needs to run on Modal{reason}."
                 )
             assert self._parent._client.stub
             serialized_params = serialize((args, kwargs))

--- a/modal/object.py
+++ b/modal/object.py
@@ -204,12 +204,14 @@ class _Object:
         if self._is_hydrated:
             return
         elif not self._hydrate_lazily:
-            raise ExecutionError(
-                "Object has not been hydrated and doesn't support lazy hydration."
+            object_type = self.__class__.__name__.strip("_")
+            message = (
+                f"{object_type} object has not been hydrated with the metadata it needs to run on Modal."
                 " This might happen if an object is defined on a different stub,"
                 " or if it's on the same stub but it didn't get created because it"
                 " wasn't defined in global scope."
             )
+            raise ExecutionError(message)
         else:
             # TODO: this client and/or resolver can't be changed by a caller to X.from_name()
             resolver = Resolver(await _Client.from_env())

--- a/modal/object.py
+++ b/modal/object.py
@@ -206,10 +206,9 @@ class _Object:
         elif not self._hydrate_lazily:
             object_type = self.__class__.__name__.strip("_")
             message = (
-                f"{object_type} object has not been hydrated with the metadata it needs to run on Modal."
-                " This might happen if an object is defined on a different stub,"
-                " or if it's on the same stub but it didn't get created because it"
-                " wasn't defined in global scope."
+                f"{object_type} has not been hydrated with the metadata it needs to run on Modal."
+                " This might happen if you are trying to call a Modal function without running or"
+                " deploying the app that it is attached to."
             )
             raise ExecutionError(message)
         else:


### PR DESCRIPTION
This is a persistent source of confusion. I am pretty sure that the main cause of this error (these days at least) is when users try to do `func.remote()` or similar in a "bare" Python script, or when they have multiple apps and are running a different one. I am fairly certain that we now catch "not in global scope" at function wrapping time, and storage objects can now be lazily hydrated.

I also don't think that mentioning "lazily hydrated" is helpful since that's an implementation detail and not something a user can understand or act on.

It might be helpful to add some Function-specific logic to include the function name in the error message, but I wasn't sure what the best way to approach that was, so I went for a smaller improvement.