### PR TITLE
Add command groups to modal CLI

### DIFF
--- a/modal/cli/dict.py
+++ b/modal/cli/dict.py
@@ -21,7 +21,7 @@ dict_cli = Typer(
 )
 
 
-@dict_cli.command(name="create")
+@dict_cli.command(name="create", rich_help_panel="Management")
 @synchronizer.create_blocking
 async def create(name: str, *, env: Optional[str] = ENV_OPTION):
     """Create a named Dict object.
@@ -34,7 +34,7 @@ async def create(name: str, *, env: Optional[str] = ENV_OPTION):
     await resolver.load(d)
 
 
-@dict_cli.command(name="list")
+@dict_cli.command(name="list", rich_help_panel="Management")
 @synchronizer.create_blocking
 async def list(*, json: bool = False, env: Optional[str] = ENV_OPTION):
     """List all named Dicts."""
@@ -47,7 +47,7 @@ async def list(*, json: bool = False, env: Optional[str] = ENV_OPTION):
     display_table(["Name", "Created at"], rows, json)
 
 
-@dict_cli.command("clear")
+@dict_cli.command("clear", rich_help_panel="Management")
 @synchronizer.create_blocking
 async def clear(name: str, *, yes: bool = YES_OPTION, env: Optional[str] = ENV_OPTION):
     """Clear the contents of a named Dict by deleting all of its data."""
@@ -61,7 +61,7 @@ async def clear(name: str, *, yes: bool = YES_OPTION, env: Optional[str] = ENV_O
     await d.clear()
 
 
-@dict_cli.command(name="delete")
+@dict_cli.command(name="delete", rich_help_panel="Management")
 @synchronizer.create_blocking
 async def delete(name: str, *, yes: bool = YES_OPTION, env: Optional[str] = ENV_OPTION):
     """Delete a named Dict and all of its data."""
@@ -76,7 +76,7 @@ async def delete(name: str, *, yes: bool = YES_OPTION, env: Optional[str] = ENV_
     await _Dict.delete(name, environment_name=env)
 
 
-@dict_cli.command(name="get")
+@dict_cli.command(name="get", rich_help_panel="Inspection")
 @synchronizer.create_blocking
 async def get(name: str, key: str, *, env: Optional[str] = ENV_OPTION):
     """Print the value for a specific key.
@@ -89,7 +89,7 @@ async def get(name: str, key: str, *, env: Optional[str] = ENV_OPTION):
     console.print(val)
 
 
-@dict_cli.command(name="items")
+@dict_cli.command(name="items", rich_help_panel="Inspection")
 @synchronizer.create_blocking
 async def items(
     name: str,

--- a/modal/cli/entry_point.py
+++ b/modal/cli/entry_point.py
@@ -83,24 +83,33 @@ async def setup(profile: Optional[str] = None):
     await _new_token(profile=profile, next_url="/home")
 
 
-entrypoint_cli_typer.add_typer(app_cli)
-entrypoint_cli_typer.add_typer(config_cli)
-entrypoint_cli_typer.add_typer(container_cli)
-entrypoint_cli_typer.add_typer(dict_cli)
-entrypoint_cli_typer.add_typer(environment_cli)
-entrypoint_cli_typer.add_typer(launch_cli)
-entrypoint_cli_typer.add_typer(nfs_cli)
-entrypoint_cli_typer.add_typer(profile_cli)
-entrypoint_cli_typer.add_typer(secret_cli)
-entrypoint_cli_typer.add_typer(token_cli)
-entrypoint_cli_typer.add_typer(queue_cli)
-entrypoint_cli_typer.add_typer(volume_cli)
-
+# Commands
 entrypoint_cli_typer.command("deploy", help="Deploy a Modal stub as an application.", no_args_is_help=True)(run.deploy)
 entrypoint_cli_typer.command("serve", no_args_is_help=True)(run.serve)
-entrypoint_cli_typer.command("setup", help="Bootstrap Modal's configuration.")(setup)
 entrypoint_cli_typer.command("shell")(run.shell)
+entrypoint_cli_typer.add_typer(launch_cli)
 
+# Deployments
+entrypoint_cli_typer.add_typer(app_cli, rich_help_panel="Deployments")
+entrypoint_cli_typer.add_typer(container_cli, rich_help_panel="Deployments")
+
+# Storage
+entrypoint_cli_typer.add_typer(dict_cli, rich_help_panel="Storage")
+entrypoint_cli_typer.add_typer(nfs_cli, rich_help_panel="Storage")
+entrypoint_cli_typer.add_typer(secret_cli, rich_help_panel="Storage")
+entrypoint_cli_typer.add_typer(queue_cli, rich_help_panel="Storage")
+entrypoint_cli_typer.add_typer(volume_cli, rich_help_panel="Storage")
+
+# Configuration
+entrypoint_cli_typer.add_typer(config_cli, rich_help_panel="Configuration")
+entrypoint_cli_typer.add_typer(environment_cli, rich_help_panel="Configuration")
+entrypoint_cli_typer.add_typer(profile_cli, rich_help_panel="Configuration")
+entrypoint_cli_typer.add_typer(token_cli, rich_help_panel="Configuration")
+
+# Hide setup from help as it's redundant with modal token new, but nicer for onboarding
+entrypoint_cli_typer.command("setup", help="Bootstrap Modal's configuration.", hidden=True)(setup)
+
+# Special handling for modal run, which is more complicated
 entrypoint_cli = typer.main.get_command(entrypoint_cli_typer)
 entrypoint_cli.add_command(run.run, name="run")  # type: ignore
 entrypoint_cli.list_commands(None)  # type: ignore

--- a/modal/cli/network_file_system.py
+++ b/modal/cli/network_file_system.py
@@ -28,7 +28,7 @@ from modal_proto import api_pb2
 nfs_cli = Typer(name="nfs", help="Read and edit `modal.NetworkFileSystem` file systems.", no_args_is_help=True)
 
 
-@nfs_cli.command(name="list", help="List the names of all network file systems.")
+@nfs_cli.command(name="list", help="List the names of all network file systems.", rich_help_panel="Management")
 @synchronizer.create_blocking
 async def list(env: Optional[str] = ENV_OPTION, json: Optional[bool] = False):
     env = ensure_env(env)
@@ -59,7 +59,7 @@ def some_func():
 """
 
 
-@nfs_cli.command(name="create", help="Create a named network file system.")
+@nfs_cli.command(name="create", help="Create a named network file system.", rich_help_panel="Management")
 def create(
     name: str,
     env: Optional[str] = ENV_OPTION,
@@ -81,7 +81,11 @@ async def _volume_from_name(deployment_name: str) -> _NetworkFileSystem:
     return network_file_system
 
 
-@nfs_cli.command(name="ls", help="List files and directories in a network file system.")
+@nfs_cli.command(
+    name="ls",
+    help="List files and directories in a network file system.",
+    rich_help_panel="File operations",
+)
 @synchronizer.create_blocking
 async def ls(
     volume_name: str,
@@ -122,6 +126,7 @@ Remote parent directories will be created as needed.
 
 Ending the REMOTE_PATH with a forward slash (/), it's assumed to be a directory and the file will be uploaded with its current name under that directory.
 """,
+    rich_help_panel="File operations",
 )
 @synchronizer.create_blocking
 async def put(
@@ -158,7 +163,7 @@ class CliError(Exception):
         self.message = message
 
 
-@nfs_cli.command(name="get")
+@nfs_cli.command(name="get", rich_help_panel="File operations")
 @synchronizer.create_blocking
 async def get(
     volume_name: str,
@@ -186,7 +191,9 @@ async def get(
     await _volume_download(volume, remote_path, destination, force)
 
 
-@nfs_cli.command(name="rm", help="Delete a file or directory from a network file system.")
+@nfs_cli.command(
+    name="rm", help="Delete a file or directory from a network file system.", rich_help_panel="File operations"
+)
 @synchronizer.create_blocking
 async def rm(
     volume_name: str,

--- a/modal/cli/queues.py
+++ b/modal/cli/queues.py
@@ -28,7 +28,7 @@ PARTITION_OPTION = Option(
 )
 
 
-@queue_cli.command(name="create")
+@queue_cli.command(name="create", rich_help_panel="Management")
 @synchronizer.create_blocking
 async def create(name: str, *, env: Optional[str] = ENV_OPTION):
     """Create a named Queue.
@@ -41,7 +41,7 @@ async def create(name: str, *, env: Optional[str] = ENV_OPTION):
     await resolver.load(q)
 
 
-@queue_cli.command(name="delete")
+@queue_cli.command(name="delete", rich_help_panel="Management")
 @synchronizer.create_blocking
 async def delete(name: str, *, yes: bool = YES_OPTION, env: Optional[str] = ENV_OPTION):
     """Delete a named Queue and all of its data."""
@@ -56,7 +56,7 @@ async def delete(name: str, *, yes: bool = YES_OPTION, env: Optional[str] = ENV_
     await _Queue.delete(name, environment_name=env)
 
 
-@queue_cli.command(name="list")
+@queue_cli.command(name="list", rich_help_panel="Management")
 @synchronizer.create_blocking
 async def list(*, json: bool = False, env: Optional[str] = ENV_OPTION):
     """List all named Queues."""
@@ -79,7 +79,7 @@ async def list(*, json: bool = False, env: Optional[str] = ENV_OPTION):
     display_table(["Name", "Created at", "Partitions", "Total size"], rows, json)
 
 
-@queue_cli.command(name="clear")
+@queue_cli.command(name="clear", rich_help_panel="Management")
 @synchronizer.create_blocking
 async def clear(
     name: str,
@@ -100,7 +100,7 @@ async def clear(
     await q.clear(partition=partition, all=all)
 
 
-@queue_cli.command(name="peek")
+@queue_cli.command(name="peek", rich_help_panel="Inspection")
 @synchronizer.create_blocking
 async def peek(
     name: str, n: int = Argument(1), partition: Optional[str] = PARTITION_OPTION, *, env: Optional[str] = ENV_OPTION
@@ -116,7 +116,7 @@ async def peek(
             break
 
 
-@queue_cli.command(name="len")
+@queue_cli.command(name="len", rich_help_panel="Inspection")
 @synchronizer.create_blocking
 async def len(
     name: str,

--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -52,7 +52,7 @@ def humanize_filesize(value: int) -> str:
     return format % (base * bytes_ / unit) + s
 
 
-@volume_cli.command(name="create", help="Create a named, persistent modal.Volume.")
+@volume_cli.command(name="create", help="Create a named, persistent modal.Volume.", rich_help_panel="Management")
 def create(
     name: str,
     env: Optional[str] = ENV_OPTION,
@@ -71,7 +71,7 @@ def some_func():
     console.print(usage)
 
 
-@volume_cli.command(name="get")
+@volume_cli.command(name="get", rich_help_panel="File operations")
 @synchronizer.create_blocking
 async def get(
     volume_name: str,
@@ -100,7 +100,11 @@ async def get(
     await _volume_download(volume, remote_path, destination, force)
 
 
-@volume_cli.command(name="list", help="List the details of all modal.Volume volumes in an environment.")
+@volume_cli.command(
+    name="list",
+    help="List the details of all modal.Volume volumes in an environment.",
+    rich_help_panel="Management",
+)
 @synchronizer.create_blocking
 async def list(env: Optional[str] = ENV_OPTION, json: Optional[bool] = False):
     env = ensure_env(env)
@@ -114,7 +118,11 @@ async def list(env: Optional[str] = ENV_OPTION, json: Optional[bool] = False):
     display_table(column_names, rows, json, title=f"Volumes{env_part}")
 
 
-@volume_cli.command(name="ls", help="List files and directories in a modal.Volume volume.")
+@volume_cli.command(
+    name="ls",
+    help="List files and directories in a modal.Volume volume.",
+    rich_help_panel="File operations",
+)
 @synchronizer.create_blocking
 async def ls(
     volume_name: str,
@@ -168,6 +176,7 @@ Remote parent directories will be created as needed.
 
 Ending the REMOTE_PATH with a forward slash (/), it's assumed to be a directory and the file will be uploaded with its current name under that directory.
 """,
+    rich_help_panel="File operations",
 )
 @synchronizer.create_blocking
 async def put(
@@ -208,7 +217,7 @@ async def put(
         console.print(step_completed(f"Uploaded file '{local_path}' to '{remote_path}'"))
 
 
-@volume_cli.command(name="rm", help="Delete a file or directory from a volume.")
+@volume_cli.command(name="rm", help="Delete a file or directory from a volume.", rich_help_panel="File operations")
 @synchronizer.create_blocking
 async def rm(
     volume_name: str,
@@ -229,7 +238,9 @@ async def rm(
 
 
 @volume_cli.command(
-    name="cp", help="Copy source file to destination file or multiple source files to destination directory."
+    name="cp",
+    help="Copy source file to destination file or multiple source files to destination directory.",
+    rich_help_panel="File operations",
 )
 @synchronizer.create_blocking
 async def cp(
@@ -245,7 +256,11 @@ async def cp(
     await volume.copy_files(src_paths, dst_path)
 
 
-@volume_cli.command(name="delete", help="Delete a named, persistent modal.Volume.")
+@volume_cli.command(
+    name="delete",
+    help="Delete a named, persistent modal.Volume.",
+    rich_help_panel="Management",
+)
 @synchronizer.create_blocking
 async def delete(
     volume_name: str = Argument(help="Name of the modal.Volume to be deleted. Case sensitive"),


### PR DESCRIPTION
Makes the CLI help a little easier to understand.

The entrypoint now organizes the things you can do better:

<img width="762" alt="image" src="https://github.com/modal-labs/modal-client/assets/315810/17eb1c6b-e7a7-43fc-adef-d12b08c0410b">

And for some commands with different kinds of subcommands, there's less opportunity for confusion:

<img width="761" alt="image" src="https://github.com/modal-labs/modal-client/assets/315810/7556f677-2ddb-42ed-a70a-359fcc7633f7">

Happy to iterate on any of the specific groupings or names