### PR TITLE
Unhide modal setup from CLI help

### DIFF
--- a/modal/cli/entry_point.py
+++ b/modal/cli/entry_point.py
@@ -107,7 +107,7 @@ entrypoint_cli_typer.add_typer(profile_cli, rich_help_panel="Configuration")
 entrypoint_cli_typer.add_typer(token_cli, rich_help_panel="Configuration")
 
 # Hide setup from help as it's redundant with modal token new, but nicer for onboarding
-entrypoint_cli_typer.command("setup", help="Bootstrap Modal's configuration.", hidden=True)(setup)
+entrypoint_cli_typer.command("setup", help="Bootstrap Modal's configuration.", rich_help_panel="Onboarding")(setup)
 
 # Special handling for modal run, which is more complicated
 entrypoint_cli = typer.main.get_command(entrypoint_cli_typer)


### PR DESCRIPTION
We hid this in #1784 since it's redundant with `modal token new` and something we expect users to be directed to by an onboarding workflow, rather than command discovery in the help. But that apparently broke the CLI docs generation 🙃. Adding it back until we can debug that.