### PR TITLE
refactor: 'checkpoint' to 'memory snapshot' renaming

### DIFF
--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -62,7 +62,7 @@ class _ContainerIOManager:
     _input_concurrency: Optional[int]
     _semaphore: Optional[asyncio.Semaphore]
     _environment_name: str
-    _waiting_for_checkpoint: bool
+    _waiting_for_memory_snapshot: bool
     _heartbeat_loop: Optional[asyncio.Task]
 
     _is_interactivity_enabled: bool
@@ -90,7 +90,7 @@ class _ContainerIOManager:
 
         self._semaphore = None
         self._environment_name = container_args.environment_name
-        self._waiting_for_checkpoint = False
+        self._waiting_for_memory_snapshot = False
         self._heartbeat_loop = None
 
         self._is_interactivity_enabled = False
@@ -137,7 +137,7 @@ class _ContainerIOManager:
         # Don't send heartbeats for tasks waiting to be checkpointed.
         # Calling gRPC methods open new connections which block the
         # checkpointing process.
-        if self._waiting_for_checkpoint:
+        if self._waiting_for_memory_snapshot:
             return False
 
         request = api_pb2.ContainerHeartbeatRequest(supports_graceful_input_cancellation=True)
@@ -534,7 +534,7 @@ class _ContainerIOManager:
         )
         await self.complete_call(started_at)
 
-    async def restore(self) -> None:
+    async def memory_restore(self) -> None:
         # Busy-wait for restore. `/__modal/restore-state.json` is created
         # by the worker process with updates to the container config.
         restored_path = Path(config.get("restore_state_path"))
@@ -568,22 +568,22 @@ class _ContainerIOManager:
         self.current_input_started_at = None
 
         self._client = await _Client.from_env()
-        self._waiting_for_checkpoint = False
+        self._waiting_for_memory_snapshot = False
 
-    async def checkpoint(self) -> None:
+    async def memory_snapshot(self) -> None:
         """Message server indicating that function is ready to be checkpointed."""
         if self.checkpoint_id:
-            logger.debug(f"Checkpoint ID: {self.checkpoint_id}")
+            logger.debug(f"Checkpoint ID: {self.checkpoint_id} (Memory Snapshot ID)")
 
         await self._client.stub.ContainerCheckpoint(
             api_pb2.ContainerCheckpointRequest(checkpoint_id=self.checkpoint_id)
         )
 
-        self._waiting_for_checkpoint = True
+        self._waiting_for_memory_snapshot = True
         await self._client._close(forget_credentials=True)
 
-        logger.debug("Checkpointing request sent. Connection closed.")
-        await self.restore()
+        logger.debug("Memory snapshot request sent. Connection closed.")
+        await self.memory_restore()
 
     async def volume_commit(self, volume_ids: List[str]) -> None:
         """

--- a/modal/app.py
+++ b/modal/app.py
@@ -701,7 +701,7 @@ class _App:
             cls: _Cls = _Cls.from_local(user_cls, self, decorator)
 
             if (
-                _find_callables_for_cls(user_cls, _PartialFunctionFlags.ENTER_PRE_CHECKPOINT)
+                _find_callables_for_cls(user_cls, _PartialFunctionFlags.ENTER_PRE_SNAPSHOT)
                 and not enable_memory_snapshot
             ):
                 raise InvalidError("A class must have `enable_memory_snapshot=True` to use `snap=True` on its methods.")
@@ -829,9 +829,9 @@ class _Stub(_App):
     def __new__(cls, *args, **kwargs):
         deprecation_warning(
             (2024, 4, 29),
-            "The use of \"Stub\" has been deprecated in favor of \"App\"."
+            'The use of "Stub" has been deprecated in favor of "App".'
             " This is a pure name change with no other implications.",
-            pending=True
+            pending=True,
         )
         return _App(*args, **kwargs)
 

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -101,8 +101,8 @@ class _Obj:
                 self._local_obj.__enter__()
 
             for method_flag in (
-                _PartialFunctionFlags.ENTER_PRE_CHECKPOINT,
-                _PartialFunctionFlags.ENTER_POST_CHECKPOINT,
+                _PartialFunctionFlags.ENTER_PRE_SNAPSHOT,
+                _PartialFunctionFlags.ENTER_POST_SNAPSHOT,
             ):
                 for enter_method in _find_callables_for_obj(self._local_obj, method_flag).values():
                     enter_method()

--- a/modal/config.py
+++ b/modal/config.py
@@ -242,7 +242,7 @@ class Config:
             os.environ["MODAL_" + key.upper()] = value
         except KeyError:
             # Override env vars not available in config, e.g. NVIDIA_VISIBLE_DEVICES.
-            # This is used for restoring env vars from a checkpoint.
+            # This is used for restoring env vars from a memory snapshot.
             os.environ[key.upper()] = value
 
     def __getitem__(self, key):

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -23,8 +23,8 @@ from .functions import _Function
 class _PartialFunctionFlags(enum.IntFlag):
     FUNCTION: int = 1
     BUILD: int = 2
-    ENTER_PRE_CHECKPOINT: int = 4
-    ENTER_POST_CHECKPOINT: int = 8
+    ENTER_PRE_SNAPSHOT: int = 4
+    ENTER_POST_SNAPSHOT: int = 8
     EXIT: int = 16
 
 
@@ -104,7 +104,7 @@ def _find_callables_for_cls(user_cls: Type, flags: _PartialFunctionFlags) -> Dic
     check_attrs: List[str] = []
     if flags & _PartialFunctionFlags.BUILD:
         check_attrs += ["__build__", "__abuild__"]
-    if flags & _PartialFunctionFlags.ENTER_POST_CHECKPOINT:
+    if flags & _PartialFunctionFlags.ENTER_POST_SNAPSHOT:
         check_attrs += ["__enter__", "__aenter__"]
     if flags & _PartialFunctionFlags.EXIT:
         check_attrs += ["__exit__", "__aexit__"]
@@ -461,9 +461,9 @@ def _enter(
         raise InvalidError("Positional arguments are not allowed. Did you forget parentheses? Suggestion: `@enter()`.")
 
     if snap:
-        flag = _PartialFunctionFlags.ENTER_PRE_CHECKPOINT
+        flag = _PartialFunctionFlags.ENTER_PRE_SNAPSHOT
     else:
-        flag = _PartialFunctionFlags.ENTER_POST_CHECKPOINT
+        flag = _PartialFunctionFlags.ENTER_POST_SNAPSHOT
 
     def wrapper(f: Union[Callable[[Any], Any], _PartialFunction]) -> _PartialFunction:
         if isinstance(f, _PartialFunction):

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -519,10 +519,10 @@ def test_handlers():
     pfs = _find_partial_methods_for_cls(ClsWithHandlers, _PartialFunctionFlags.BUILD)
     assert list(pfs.keys()) == ["my_build", "my_build_and_enter"]
 
-    pfs = _find_partial_methods_for_cls(ClsWithHandlers, _PartialFunctionFlags.ENTER_PRE_CHECKPOINT)
+    pfs = _find_partial_methods_for_cls(ClsWithHandlers, _PartialFunctionFlags.ENTER_PRE_SNAPSHOT)
     assert list(pfs.keys()) == ["my_memory_snapshot"]
 
-    pfs = _find_partial_methods_for_cls(ClsWithHandlers, _PartialFunctionFlags.ENTER_POST_CHECKPOINT)
+    pfs = _find_partial_methods_for_cls(ClsWithHandlers, _PartialFunctionFlags.ENTER_POST_SNAPSHOT)
     assert list(pfs.keys()) == ["my_enter", "my_build_and_enter"]
 
     pfs = _find_partial_methods_for_cls(ClsWithHandlers, _PartialFunctionFlags.EXIT)
@@ -587,7 +587,7 @@ def test_deprecated_sync_methods():
     obj = ClsWithDeprecatedSyncMethods()
 
     with pytest.warns(DeprecationError, match="Using `__enter__`.+`modal.enter` decorator"):
-        enter_methods: Dict[str, Callable] = _find_callables_for_obj(obj, _PartialFunctionFlags.ENTER_POST_CHECKPOINT)
+        enter_methods: Dict[str, Callable] = _find_callables_for_obj(obj, _PartialFunctionFlags.ENTER_POST_SNAPSHOT)
     assert [meth() for meth in enter_methods.values()] == [42, 43]
 
     with pytest.warns(DeprecationError, match="Using `__exit__`.+`modal.exit` decorator"):
@@ -621,7 +621,7 @@ async def test_deprecated_async_methods():
     obj = ClsWithDeprecatedAsyncMethods()
 
     with pytest.warns(DeprecationError, match=r"Using `__aenter__`.+`modal.enter` decorator \(on an async method\)"):
-        enter_methods: Dict[str, Callable] = _find_callables_for_obj(obj, _PartialFunctionFlags.ENTER_POST_CHECKPOINT)
+        enter_methods: Dict[str, Callable] = _find_callables_for_obj(obj, _PartialFunctionFlags.ENTER_POST_SNAPSHOT)
     assert [await meth() for meth in enter_methods.values()] == [42, 43]
 
     with pytest.warns(DeprecationError, match=r"Using `__aexit__`.+`modal.exit` decorator \(on an async method\)"):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -73,7 +73,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
         self.app_state_history = defaultdict(list)
         self.app_heartbeats: Dict[str, int] = defaultdict(int)
-        self.container_checkpoint_requests = 0
+        self.container_snapshot_requests = 0
         self.n_blobs = 0
         self.blob_host = blob_host
         self.blobs = blobs  # shared dict
@@ -320,7 +320,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
     async def ContainerCheckpoint(self, stream):
         request: api_pb2.ContainerCheckpointRequest = await stream.recv_message()
         self.requests.append(request)
-        self.container_checkpoint_requests += 1
+        self.container_snapshot_requests += 1
         await stream.send_message(Empty())
 
     ### Blob

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -64,7 +64,7 @@ async def test_container_snapshot_restore(container_client, tmpdir, servicer):
     with mock.patch.dict(
         os.environ, {"MODAL_RESTORE_STATE_PATH": str(restore_path), "MODAL_SERVER_URL": servicer.remote_addr}
     ):
-        io_manager.checkpoint()
+        io_manager.memory_snapshot()
         # In-memory Client instance should have update credentials, not old credentials
         assert old_client.credentials == ("ta-i-am-restored", "ts-i-am-restored")
 


### PR DESCRIPTION
## Describe your changes

One more step on the road to renaming _checkpoint_ to _memory snapshot_.

## Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
    - Should be pure refactor. None of these name/symbol changes cross the boundary between the client and the worker/server/host.
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
    - Should be pure refactor. None of these name/symbol changes cross the boundary between the client and the worker/server/host.


## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
