### PR TITLE
Add proto field to support a global image failsafe

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1285,6 +1285,8 @@ message ImageGetOrCreateRequest {
   bool force_build = 7;
   DeploymentNamespace namespace = 8;
   string builder_version = 9;
+  // Only admins can publish global images, but this provides an extra failsafe
+  bool global_deployment_allowed = 10;
 }
 
 message ImageGetOrCreateResponse {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1286,7 +1286,7 @@ message ImageGetOrCreateRequest {
   DeploymentNamespace namespace = 8;
   string builder_version = 9;
   // Only admins can publish global images, but this provides an extra failsafe
-  bool global_deployment_allowed = 10;
+  bool allow_global_deployment = 10;
 }
 
 message ImageGetOrCreateResponse {


### PR DESCRIPTION
Part of MOD-2866

- [x] Client+Server: this change is compatible with old servers
~- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself~