### PR TITLE
Use global image deployment failsafe in ImageGetOrCreate

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -121,6 +121,7 @@ jobs:
       - name: Publish base images
         env:
           MODAL_IMAGE_BUILDER_VERSION: ${{ matrix.image-builder-version }}
+          MODAL_IMAGE_ALLOW_GLOBAL_DEPLOYMENT: "1"
         run: |
           python -m modal_global_objects.images.${{ matrix.image-name }} ${{ matrix.python-version }}
 

--- a/modal/image.py
+++ b/modal/image.py
@@ -368,6 +368,9 @@ class _Image(_Object, type_prefix="im"):
                 force_build=config.get("force_build") or force_build,
                 namespace=_namespace,
                 builder_version=builder_version,
+                # Failsafe mechanism to prevent inadvertant updates to the global images.
+                # Only admins can publish to the global namespace, but they have to additionally request it.
+                allow_global_deployment=os.environ.get("MODAL_IMAGE_ALLOW_GLOBAL_DEPLOYMENT", "0") == "1",
             )
             resp = await retry_transient_errors(resolver.client.stub.ImageGetOrCreate, req)
             image_id = resp.image_id


### PR DESCRIPTION
We now require the `MODAL_IMAGE_ALLOW_GLOBAL_DEPLOYMENT` environment variable to be set to publish an image to the global namespace. This will prevent users with admin credentials from accidentally force-building our base images. It has no effect for other users.

Closes MOD-2765

- [ ] Client+Server: this change is compatible with old servers
