### PR TITLE
Add warnings about upcoming deprecation of Python 3.8

### DIFF
--- a/modal/__main__.py
+++ b/modal/__main__.py
@@ -12,6 +12,11 @@ def main():
     setup_rich_traceback()
     highlight_modal_deprecation_warnings()
 
+    if sys.version_info[:2] == (3, 8):
+        from .exception import deprecation_warning
+
+        deprecation_warning((2024, 5, 2), "Modal will soon drop support for Python 3.8.", show_source=False)
+
     try:
         entrypoint_cli()
 

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -37,7 +37,7 @@ from .app import App, _App
 from .client import Client, _Client
 from .cls import Cls
 from .config import logger
-from .exception import ExecutionError, InputCancellation, InvalidError
+from .exception import ExecutionError, InputCancellation, InvalidError, deprecation_warning
 from .execution_context import _set_current_context_ids, interact
 from .functions import Function, _Function
 from .partial_function import _find_callables_for_obj, _PartialFunctionFlags
@@ -589,6 +589,14 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
 
 if __name__ == "__main__":
     logger.debug("Container: starting")
+
+    # Check and warn on deprecated Python version
+    if sys.version_info[:2] == (3, 8):
+        msg = (
+            "You are using Python 3.8 in your remote environment. Modal will soon drop support for this version,"
+            " and you will be unable to use this Image. Please update your Image definition."
+        )
+        deprecation_warning((2024, 5, 2), msg, show_source=False)
 
     container_args = api_pb2.ContainerArguments()
     container_args.ParseFromString(base64.b64decode(sys.argv[1]))


### PR DESCRIPTION
We plan to drop support for Python 3.8 soon — certainly no later than its EOL in October of this year, but ideally a bit sooner so that we can strip out various bits of backwards compatibility cruft.

I've already broadcast this in the Community Slack, but this PR continues the process by issuing deprecation warnings locally and in the container when Python 3.8 is being used.

## Changelog

* Added deprecation warnings when using Python 3.8 locally or in the a container. Python 3.8 is nearing EOL and Modal will be dropping support for it soon.