### PR TITLE
More docs for .new deprecation warning

### DIFF
--- a/modal/dict.py
+++ b/modal/dict.py
@@ -60,7 +60,9 @@ class _Dict(_Object, type_prefix="di"):
     def new(data: Optional[dict] = None) -> "_Dict":
         """`Dict.new` is deprecated.
 
-        Please use `Dict.from_name` (for persisted) or `Dict.ephemeral` (for ephemeral) dicts.
+        You can switch this out for `Dict.from_name("some-dict-identifier")` for persisted dicts.
+        You can also take a look at the documentation for `Dict.ephemeral` for another option,
+        although it might require more code changes if you're coming from `Dict.new`.
         """
         deprecation_warning((2024, 3, 19), Dict.new.__doc__)
 

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -92,8 +92,9 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
     def new(cloud: Optional[str] = None) -> "_NetworkFileSystem":
         """`NetworkFileSystem.new` is deprecated.
 
-        Please use `NetworkFileSystem.from_name` (for persisted) or `NetworkFileSystem.ephemeral`
-        (for ephemeral) network filesystems.
+        You can switch this out for `NetworkFileSystem.from_name("some-nfs-identifier")` for persisted dicts.
+        You can also take a look at the documentation for `NetworkFileSystem.ephemeral` for another option,
+        although it might require more code changes if you're coming from `NetworkFileSystem.new`.
         """
         deprecation_warning((2024, 3, 20), NetworkFileSystem.new.__doc__)
 

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -87,7 +87,9 @@ class _Queue(_Object, type_prefix="qu"):
     def new():
         """`Queue.new` is deprecated.
 
-        Please use `Queue.from_name` (for persisted) or `Queue.ephemeral` (for ephemeral) queues.
+        You can switch this out for `Queue.from_name("some-queue-identifier")` for persisted dicts.
+        You can also take a look at the documentation for `Queue.ephemeral` for another option,
+        although it might require more code changes if you're coming from `Queue.new`.
         """
         deprecation_warning((2024, 3, 19), Queue.new.__doc__)
 

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -139,7 +139,9 @@ class _Volume(_Object, type_prefix="vo"):
     def new() -> "_Volume":
         """`Volume.new` is deprecated.
 
-        Please use `Volume.from_name` (for persisted) or `Volume.ephemeral` (for ephemeral) volumes.
+        You can switch this out for `Volume.from_name("some-volume-identifier")` for persisted dicts.
+        You can also take a look at the documentation for `Volume.ephemeral` for another option,
+        although it might require more code changes if you're coming from `Volume.new`.
         """
         deprecation_warning((2024, 3, 20), Volume.new.__doc__)
 


### PR DESCRIPTION
Slightly more docs to make it clear that `.new` -> `.ephemeral` is not a straightforward substitution