### PR TITLE
Don't reload deps that are already loaded

### DIFF
--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -119,7 +119,7 @@ class Resolver:
             async def loader():
                 # Wait for all its dependencies
                 # TODO(erikbern): do we need existing_object_id for those?
-                await TaskContext.gather(*[self.load(dep) for dep in obj.deps()])
+                await TaskContext.gather(*[self.load(dep) for dep in obj.deps() if not dep.is_hydrated])
 
                 # Load the object itself
                 try:


### PR DESCRIPTION
I'm not 100% sure this is a good idea (or the right place to put it) but it's currently a bit of a foot-gun in the resolver that if an object A has dependencies on already-hydrated objects B, B gets re-loaded when A is loaded *if they don't use the same resolver object* (common with lazy hydrations)

* Another option would be to put this check at the top of `.load()`, but that would open up potential paths to having unresolved objects at the top level in case of repeated runs (we try to unhydrate objects currently after a run, but it feels a bit hacky).
* A potentially better solution would be to make sure that all loads (incl. lazy hydrations) use the same `Resolver`, in which case the uuid-deduplication logic would ensure the same loader method isn't called again. Might be a bit more complicated to solve, but would be beneficial for other reasons (like not having to use the env-client for lazy hydrations)

Let me know what you think