### PR TITLE
Validate passed in App name is a string

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -149,6 +149,8 @@ class _App:
         app = modal.App(image=image, mounts=[mount], secrets=[secret], volumes={"/mnt/data": volume})
         ```
         """
+        if name is not None and not isinstance(name, str):
+            raise InvalidError("Invalid value for `name`: Must be string.")
 
         self._name = name
         self._description = name

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -349,6 +349,11 @@ def test_list_apps(client):
     assert set(apps_1) - set(apps_0) == set(["foobar"])
 
 
+def test_non_string_app_name():
+    with pytest.raises(InvalidError):
+        App(Image.debian_slim())
+
+
 def test_function_named_app():
     # Make sure we have a helpful warning when a user's function is named "app"
     # as it might collide with the App variable name (in particular if people
@@ -356,6 +361,7 @@ def test_function_named_app():
     app = App()
 
     with pytest.warns(match="app"):
+
         @app.function(serialized=True)
         def app():
             ...

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -350,9 +350,8 @@ def test_list_apps(client):
 
 
 def test_non_string_app_name():
-    with pytest.raises(InvalidError) as excinfo:
+    with pytest.raises(InvalidError, match="Must be string"):
         App(Image.debian_slim())  # type: ignore
-    assert "Must be string" in str(excinfo.value)
 
 
 def test_function_named_app():

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -350,8 +350,9 @@ def test_list_apps(client):
 
 
 def test_non_string_app_name():
-    with pytest.raises(InvalidError):
+    with pytest.raises(InvalidError) as excinfo:
         App(Image.debian_slim())  # type: ignore
+    assert "Must be string" in str(excinfo.value)
 
 
 def test_function_named_app():

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -351,7 +351,7 @@ def test_list_apps(client):
 
 def test_non_string_app_name():
     with pytest.raises(InvalidError):
-        App(Image.debian_slim())
+        App(Image.debian_slim())  # type: ignore
 
 
 def test_function_named_app():


### PR DESCRIPTION
## Describe your changes

Validate that the passed in value for `name` during App (formerly Stub) instantiation is a `str`.

- MOD-2639

## Changelog

Added validation that App `name`, if provided, is a string.