### PR TITLE
Catch when users decorate class with @app.function()

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -551,7 +551,7 @@ class _App:
 
             # Check if the decorated object is a class
             if inspect.isclass(f):
-                raise TypeError("The @app.function decorator cannot be used on a class.")
+                raise TypeError("The @app.function decorator cannot be used on a class. Please use @app.cls instead.")
 
             if isinstance(f, _PartialFunction):
                 f.wrapped = True

--- a/modal/app.py
+++ b/modal/app.py
@@ -549,6 +549,10 @@ class _App:
         ) -> _Function:
             nonlocal keep_warm, is_generator
 
+            # Check if the decorated object is a class and does not have a __call__ method
+            if inspect.isclass(f) and not hasattr(f, "__call__"):
+                raise TypeError("The @app.function decorator cannot be used on a class without a __call__ method.")
+
             if isinstance(f, _PartialFunction):
                 f.wrapped = True
                 info = FunctionInfo(f.raw_f, serialized=serialized, name_override=name, cls=_cls)

--- a/modal/app.py
+++ b/modal/app.py
@@ -549,9 +549,9 @@ class _App:
         ) -> _Function:
             nonlocal keep_warm, is_generator
 
-            # Check if the decorated object is a class and does not have a __call__ method
-            if inspect.isclass(f) and not hasattr(f, "__call__"):
-                raise TypeError("The @app.function decorator cannot be used on a class without a __call__ method.")
+            # Check if the decorated object is a class
+            if inspect.isclass(f):
+                raise TypeError("The @app.function decorator cannot be used on a class.")
 
             if isinstance(f, _PartialFunction):
                 f.wrapped = True

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -279,7 +279,7 @@ def test_function_decorator_on_class():
     app = App()
     with pytest.raises(TypeError):
 
-        @app.function
+        @app.function()
         class Foo:
             pass
 

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -277,11 +277,13 @@ def test_function_image_positional():
 
 def test_function_decorator_on_class():
     app = App()
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError) as excinfo:
 
         @app.function()
         class Foo:
             pass
+
+    assert "cannot be used on a class" in str(excinfo.value)
 
 
 @pytest.mark.asyncio

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -275,6 +275,15 @@ def test_function_image_positional():
     assert "function(image=image)" in str(excinfo.value)
 
 
+def test_function_decorator_on_class():
+    app = App()
+    with pytest.raises(TypeError):
+
+        @app.function
+        class Foo:
+            pass
+
+
 @pytest.mark.asyncio
 async def test_deploy_disconnect(servicer, client):
     app = App()
@@ -356,6 +365,7 @@ def test_function_named_app():
     app = App()
 
     with pytest.warns(match="app"):
+
         @app.function(serialized=True)
         def app():
             ...

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -277,13 +277,11 @@ def test_function_image_positional():
 
 def test_function_decorator_on_class():
     app = App()
-    with pytest.raises(TypeError) as excinfo:
+    with pytest.raises(TypeError, match="cannot be used on a class"):
 
         @app.function()
         class Foo:
             pass
-
-    assert "cannot be used on a class" in str(excinfo.value)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Describe your changes

Throw an error when users decorate a class with @stub.function()

- MOD-2261

## Changelog

The @app.function decorator now raises an error when it is used to decorate a class.