### PR TITLE
Improve modal app list output

### DIFF
--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -11,7 +11,7 @@ from modal.cli.utils import display_table, timestamp_to_local
 from modal.client import _Client
 from modal_proto import api_pb2
 
-container_cli = typer.Typer(name="container", help="Manage running containers.", no_args_is_help=True)
+container_cli = typer.Typer(name="container", help="Manage and connect to running containers.", no_args_is_help=True)
 
 
 @container_cli.command("list")

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -691,6 +691,10 @@ def test_list_apps(servicer, mock_dir, set_env_client):
     res = _run(["app", "list"])
     assert "my_app_foo" in res.stdout
 
+    _run(["volume", "create", "my-vol"])
+    res = _run(["app", "list"])
+    assert "my-vol" not in res.stdout
+
 
 def test_dict_create_list_delete(servicer, server_url_env, set_env_client):
     _run(["dict", "create", "foo-dict"])


### PR DESCRIPTION
Closes MOD-2881

## Changelog

- The `modal app list` output has been improved in several ways:
    - Persistent storage objects like Volumes or Dicts are no longer included (these objects receive an app ID internally, but this is an implementation detail and subject to future change). You can use the dedicated CLI for each object (e.g. `modal volume list`) instead.
    - For Apps in a *stopped* state, the output is now limited to those stopped within the past 2 hours.
    - The number of tasks running for each App is now shown.