### PR TITLE
Deal with square brackets in error messages

### DIFF
--- a/modal/__main__.py
+++ b/modal/__main__.py
@@ -36,9 +36,10 @@ def main():
 
         from rich.console import Console
         from rich.panel import Panel
+        from rich.text import Text
 
         console = Console(stderr=True)
-        panel = Panel(str(exc), border_style="red", title="Error", title_align="left")
+        panel = Panel(Text(str(exc)), border_style="red", title="Error", title_align="left")
         console.print(panel, highlight=False)
         sys.exit(1)
 


### PR DESCRIPTION
The Panel function from the rich library treats strings as "rich" text by default, which means it interprets square brackets as markup. We have some error messages that use such brackets, and escaping them is annoying - so treat things as text objects instead. See (internal) https://github.com/modal-labs/modal/pull/12503.