### PR TITLE
Lexically split entrypoint command for modal shell

### DIFF
--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -3,6 +3,7 @@ import asyncio
 import functools
 import inspect
 import re
+import shlex
 import sys
 import time
 from functools import partial
@@ -411,4 +412,4 @@ def shell(
             region=region.split(",") if region else [],
         )
 
-    start_shell(app, cmd=[cmd], environment_name=env, timeout=3600)
+    start_shell(app, cmd=shlex.split(cmd), environment_name=env, timeout=3600)


### PR DESCRIPTION
Something like this didn't previously work:
```
  $ modal shell --cmd 'bash -c bash'
  Failed to run command: No such file or directory
```
Because we were translating it to `CMD ["bash -c bash"]` underneath, which tries to execute a binary literally named "bash -c bash". The right thing to do is to translate it to `CMD ["bash", "-c", "bash"]`, which we now do.

Basically now you can pass in arbitrarily sophisticated commands through --cmd, like:
```
  $ modal shell ollama-modal.py \
    --cmd 'bash -c "systemctl start ollama; ollama run llama3:instruct"'
```
(Maybe there's appetite for everything being passed through 'bash -c' by default?)