### PR TITLE
Invoke `modal shell --cmd` under `/bin/bash -c`

### DIFF
--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -412,4 +412,6 @@ def shell(
             region=region.split(",") if region else [],
         )
 
-    start_shell(app, cmd=shlex.split(cmd), environment_name=env, timeout=3600)
+    # NB: invoking under bash makes --cmd a lot more flexible.
+    cmds = shlex.split(f'/bin/bash -c "{cmd}"')
+    start_shell(app, cmds=cmds, environment_name=env, timeout=3600)

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -467,7 +467,7 @@ async def _deploy_app(
     return DeployResult(app_id=running_app.app_id)
 
 
-async def _interactive_shell(_app: _App, cmd: List[str], environment_name: str = "", **kwargs):
+async def _interactive_shell(_app: _App, cmds: List[str], environment_name: str = "", **kwargs):
     """Run an interactive shell (like `bash`) within the image for this app.
 
     This is useful for online debugging and interactive exploration of the
@@ -496,7 +496,7 @@ async def _interactive_shell(_app: _App, cmd: List[str], environment_name: str =
         loading_status = console.status("Starting container...")
         loading_status.start()
 
-        sandbox_cmds = cmd if len(cmd) > 0 else ["/bin/bash"]
+        sandbox_cmds = cmds if len(cmds) > 0 else ["/bin/bash"]
         sb = await _app.spawn_sandbox(*sandbox_cmds, pty_info=get_pty_info(shell=True), **kwargs)
         for _ in range(40):
             await asyncio.sleep(0.5)


### PR DESCRIPTION
It's a bit more intuitive. Before:
```
  $ modal shell --cmd 'echo hi; echo bye; bash'
  hi; echo bye; bash
```
Now:
```
  $ modal shell --cmd 'echo hi; echo bye; bash'
  hi
  bye
  root@modal:/#
```