### PR TITLE
Force environment name when installing from spec file

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -1082,7 +1082,7 @@ class _Image(_Object, type_prefix="im"):
 
             space = " " if package_args else ""
             remote_spec_file = "" if spec_file is None else f"/{os.path.basename(spec_file)}"
-            file_arg = "" if spec_file is None else f"{space}-f {remote_spec_file}"
+            file_arg = "" if spec_file is None else f"{space}-f {remote_spec_file} -n base"
             copy_commands = [] if spec_file is None else [f"COPY {remote_spec_file} {remote_spec_file}"]
 
             commands = [

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -932,7 +932,7 @@ def test_image_stability_on_2024_04(force_2024_04, servicer, client, test_dir):
         spec_file=test_dir / "supports" / "test-conda-environment.yml",
         channels=["conda-forge", "my-channel"],
     )
-    assert get_hash(img) == "cf6c956e7639afb51dcc46d98eb9aabb6472c0751ada28f41d2e7ad88275b9a0"
+    assert get_hash(img) == "d9d4c9fe24769ce587877b9752a64486e8f7d8520731110bd2fa666de82f43fd"
 
     img = base.poetry_install_from_file(
         test_dir / "supports" / "test-pyproject.toml",


### PR DESCRIPTION
When installing packages from a `micromamba` spec file, force the environment name to `base` on the command line. This matches the way we set up the environment in `Image.micromamba` and avoids an error that you otherwise get if you have a conda-style yaml file that defines the environment name.

I don't _think_ we want to support arbitrary names or sub-environments in images (at least not directly; people can do crazier things with the lower-level commands). But if someone raises a compelling use-case, we could parameterize it or add some flag to read it from the file or something.