### PR TITLE
Allow `modal app logs` to look up apps by name

### DIFF
--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -82,16 +82,31 @@ async def list(env: Optional[str] = ENV_OPTION, json: Optional[bool] = False):
 
 
 @app_cli.command("logs", no_args_is_help=True)
-def app_logs(
+def logs(
     app_id: str = Argument("", help="Look up any App by its ID"),
     *,
     name: Optional[str] = Option(None, "-n", "--name", help="Look up a deployed App by its name"),
     env: Optional[str] = ENV_OPTION,
 ):
-    """Output logs for a running app."""
+    """Show the logs from deployed, running, or stopped apps.
 
-    if app_id and name:
-        raise UsageError("Cannot use both `app_id` and `name`.")
+    **Examples:**
+
+    Get the logs based on an app ID:
+
+    ```bash
+    modal app logs ap-123456
+    ```
+
+    Get the logs for a currently deployed App based on its name:
+
+    ```bash
+    modal app logs --name my-app
+    ```
+
+    """
+    if not bool(app_id) ^ bool(name):
+        raise UsageError("Must pass either an ID or a name.")
 
     @synchronizer.create_blocking
     async def sync_command():

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -475,7 +475,7 @@ def test_logs(servicer, server_url_env, set_env_client, mock_dir):
     _run(
         ["app", "logs", "app-123", "-n", "my-app"],
         expected_exit_code=2,
-        expected_stderr="Cannot use both `app_id` and `name`",
+        expected_stderr="Must pass either an ID or a name",
     )
 
     _run(

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -10,7 +10,7 @@ import sys
 import tempfile
 import traceback
 from pickle import dumps
-from typing import List, Optional
+from typing import List
 from unittest import mock
 
 import click
@@ -38,7 +38,7 @@ assert mod.app == app
 dummy_other_module_file = "x = 42"
 
 
-def _run(args: List[str], expected_exit_code: int = 0, expected_stderr: Optional[str] = ""):
+def _run(args: List[str], expected_exit_code: int = 0, expected_stderr: str = "", expected_error: str = ""):
     runner = click.testing.CliRunner(mix_stderr=False)
     with mock.patch.object(sys, "argv", args):
         res = runner.invoke(entrypoint_cli, args)
@@ -48,8 +48,10 @@ def _run(args: List[str], expected_exit_code: int = 0, expected_stderr: Optional
         traceback.print_tb(res.exc_info[2])
         print(res.exception, file=sys.stderr)
         assert res.exit_code == expected_exit_code
-    if expected_stderr is not None:
-        assert res.stderr == expected_stderr
+    if expected_stderr:
+        assert re.search(expected_stderr, res.stderr), "stderr does not match expected string"
+    if expected_error:
+        assert re.search(expected_error, str(res.exception)), "exception message does not match expected string"
     return res
 
 
@@ -451,7 +453,7 @@ def test_app_descriptions(servicer, server_url_env, test_dir):
     assert "--timeout 0.0" not in description
 
 
-def test_logs(servicer, server_url_env):
+def test_logs(servicer, server_url_env, set_env_client, mock_dir):
     async def app_done(self, stream):
         await stream.recv_message()
         log = api_pb2.TaskLogs(data="hello\n", file_descriptor=api_pb2.FILE_DESCRIPTOR_STDOUT)
@@ -460,8 +462,26 @@ def test_logs(servicer, server_url_env):
 
     with servicer.intercept() as ctx:
         ctx.set_responder("AppGetLogs", app_done)
-        res = _run(["app", "logs", "ap-123"], expected_exit_code=0)
+
+        res = _run(["app", "logs", "ap-123"])
         assert res.stdout == "hello\n"
+
+        with mock_dir({"myapp.py": dummy_app_file, "other_module.py": dummy_other_module_file}):
+            _run(["deploy", "myapp.py"])
+            res = _run(["app", "logs", "-n", "my_app"])
+            assert res.stdout == "hello\n"
+
+    _run(
+        ["app", "logs", "app-123", "-n", "my-app"],
+        expected_exit_code=2,
+        expected_stderr="Cannot use both `app_id` and `name`",
+    )
+
+    _run(
+        ["app", "logs", "-n", "does-not-exist"],
+        expected_exit_code=1,
+        expected_error="Could not find a deployed app named 'does-not-exist'",
+    )
 
 
 def test_nfs_get(set_env_client, servicer):

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -467,8 +467,9 @@ def test_logs(servicer, server_url_env, set_env_client, mock_dir):
         assert res.stdout == "hello\n"
 
         with mock_dir({"myapp.py": dummy_app_file, "other_module.py": dummy_other_module_file}):
-            _run(["deploy", "myapp.py"])
-            res = _run(["app", "logs", "-n", "my_app"])
+            _run(["deploy", "myapp.py", "--name", "my-app"])
+            print(_run(["app", "list"]).stdout)
+            res = _run(["app", "logs", "-n", "my-app"])
             assert res.stdout == "hello\n"
 
     _run(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -312,7 +312,14 @@ class MockClientServicer(api_grpc.ModalClientBase):
         await stream.recv_message()
         apps = []
         for app_name, app_id in self.deployed_apps.items():
-            apps.append(api_pb2.AppStats(name=app_name, description=app_name, app_id=app_id))
+            apps.append(
+                api_pb2.AppStats(
+                    name=app_name,
+                    description=app_name,
+                    app_id=app_id,
+                    state=api_pb2.APP_STATE_DEPLOYED,
+                )
+            )
         await stream.send_message(api_pb2.AppListResponse(apps=apps))
 
     ### Checkpoint


### PR DESCRIPTION
Currently, we support only ID-based lookup in `modal app logs`, which means that users have to look up the ID for the currently deployed version of a given app whenever they want to check its logs.

This PR adds support for name-based lookup, which is more convenient (names are stable across re-deploys and much easier to remember).

Note that name lookup is supported only for apps in a "deployed" state, as the name would otherwise potentially map to multiple App IDs.

Closes MOD-2905

## Changelog

- Added support for looking up a deployed App by its deployment name in `modal app logs`