### PR TITLE
Add `--stream-logs` flag to `modal deploy`

### DIFF
--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -271,7 +271,7 @@ def deploy(
         False, help="[beta] Publicize the deployment so other workspaces can lookup the function."
     ),
     skip_confirm: bool = typer.Option(False, help="Skip public app confirmation dialog."),
-    stream_logs: bool = typer.Option(False, help="Stream logs from the deployment."),
+    stream_logs: bool = typer.Option(False, help="Stream logs from the app upon deployment."),
 ):
     # this ensures that `modal.lookup()` without environment specification uses the same env as specified
     env = ensure_env(env)

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -294,7 +294,7 @@ def deploy(
     if stream_logs:
         from modal.cli.app import logs
 
-        logs(name=name, env=env)
+        logs("", name=name, env=env)
 
 
 def serve(

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -271,6 +271,7 @@ def deploy(
         False, help="[beta] Publicize the deployment so other workspaces can lookup the function."
     ),
     skip_confirm: bool = typer.Option(False, help="Skip public app confirmation dialog."),
+    stream_logs: bool = typer.Option(False, help="Stream logs from the deployment."),
 ):
     # this ensures that `modal.lookup()` without environment specification uses the same env as specified
     env = ensure_env(env)
@@ -289,6 +290,11 @@ def deploy(
             return
 
     deploy_app(app, name=name, environment_name=env, public=public)
+
+    if stream_logs:
+        from modal.cli.app import logs
+
+        logs(name=name, env=env)
 
 
 def serve(

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -23,7 +23,7 @@ from ..image import Image
 from ..runner import deploy_app, interactive_shell, run_app
 from ..serving import serve_app
 from .import_refs import import_app, import_function
-from .utils import ENV_OPTION, ENV_OPTION_HELP
+from .utils import ENV_OPTION, ENV_OPTION_HELP, stream_app_logs
 
 
 class ParameterMetadata(TypedDict):
@@ -289,12 +289,10 @@ def deploy(
         ):
             return
 
-    deploy_app(app, name=name, environment_name=env, public=public)
+    res = deploy_app(app, name=name, environment_name=env, public=public)
 
     if stream_logs:
-        from modal.cli.app import logs
-
-        logs("", name=name, env=env)
+        stream_app_logs(res.app_id)
 
 
 def serve(

--- a/modal/cli/utils.py
+++ b/modal/cli/utils.py
@@ -1,12 +1,37 @@
 # Copyright Modal Labs 2022
+import asyncio
 from datetime import datetime
 from typing import Sequence, Union
 
 import typer
+from click import UsageError
+from grpclib import GRPCError, Status
 from rich.console import Console
 from rich.json import JSON
 from rich.table import Column, Table
 from rich.text import Text
+
+from .._output import OutputManager, get_app_logs_loop
+from .._utils.async_utils import synchronizer
+from ..client import _Client
+
+
+@synchronizer.create_blocking
+async def stream_app_logs(app_id: str):
+    client = await _Client.from_env()
+    output_mgr = OutputManager(None, None, f"Tailing logs for {app_id}")
+    try:
+        with output_mgr.show_status_spinner():
+            await get_app_logs_loop(app_id, client, output_mgr)
+    except asyncio.CancelledError:
+        pass
+    except GRPCError as exc:
+        if exc.status in (Status.INVALID_ARGUMENT, Status.NOT_FOUND):
+            raise UsageError(exc.message)
+        else:
+            raise
+    except KeyboardInterrupt:
+        pass
 
 
 def timestamp_to_local(ts: float, isotz: bool = True) -> str:

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -468,8 +468,7 @@ def test_logs(servicer, server_url_env, set_env_client, mock_dir):
 
         with mock_dir({"myapp.py": dummy_app_file, "other_module.py": dummy_other_module_file}):
             res = _run(["deploy", "myapp.py", "--name", "my-app", "--stream-logs"])
-            print(_run(["app", "list"]).stdout)
-            assert res.stdout == "hello\n"
+            assert res.stdout.endswith("hello\n")
 
     _run(
         ["app", "logs", "app-123", "-n", "my-app"],

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -467,9 +467,8 @@ def test_logs(servicer, server_url_env, set_env_client, mock_dir):
         assert res.stdout == "hello\n"
 
         with mock_dir({"myapp.py": dummy_app_file, "other_module.py": dummy_other_module_file}):
-            _run(["deploy", "myapp.py", "--name", "my-app"])
+            res = _run(["deploy", "myapp.py", "--name", "my-app", "--stream-logs"])
             print(_run(["app", "list"]).stdout)
-            res = _run(["app", "logs", "-n", "my-app"])
             assert res.stdout == "hello\n"
 
     _run(


### PR DESCRIPTION
## Describe your changes

Added a `--stream-logs` flag to `modal deploy` that if True, begins streaming the app logs once deployment is complete.

- MOD-2906

## Testing

`pytest test/cli_test.py::test_logs`

## Changelog

Added a `--stream-logs` flag to `modal deploy` that if True, begins streaming the app logs once deployment is complete.