### PR TITLE
Support `--mount`, `--volume` in `modal launch {vscode,jupyter}`

### DIFF
--- a/modal/cli/launch.py
+++ b/modal/cli/launch.py
@@ -25,7 +25,7 @@ launch_cli = Typer(
 
 
 def _launch_program(name: str, filename: str, args: Dict[str, Any]) -> None:
-    os.environ["MODAL_LAUNCH_LOCAL_ARGS"] = json.dumps(args)
+    os.environ["MODAL_LAUNCH_ARGS"] = json.dumps(args)
 
     program_path = str(Path(__file__).parent / "programs" / filename)
     entrypoint = import_function(program_path, "modal launch")
@@ -53,6 +53,8 @@ def jupyter(
     timeout: int = 3600,
     image: str = "ubuntu:22.04",
     add_python: Optional[str] = "3.11",
+    mount: Optional[str] = None,  # Create a `modal.Mount` from a local directory.
+    volume: Optional[str] = None,  # Attach a persisted `modal.Volume` by name (creating if missing).
 ):
     args = {
         "cpu": cpu,
@@ -61,6 +63,8 @@ def jupyter(
         "timeout": timeout,
         "image": image,
         "add_python": add_python,
+        "mount": mount,
+        "volume": volume,
     }
     _launch_program("jupyter", "run_jupyter.py", args)
 
@@ -71,11 +75,15 @@ def vscode(
     memory: int = 32768,
     gpu: Optional[str] = None,
     timeout: int = 3600,
+    mount: Optional[str] = None,  # Create a `modal.Mount` from a local directory.
+    volume: Optional[str] = None,  # Attach a persisted `modal.Volume` by name (creating if missing).
 ):
     args = {
         "cpu": cpu,
         "memory": memory,
         "gpu": gpu,
         "timeout": timeout,
+        "mount": mount,
+        "volume": volume,
     }
     _launch_program("vscode", "vscode.py", args)

--- a/modal/cli/programs/run_jupyter.py
+++ b/modal/cli/programs/run_jupyter.py
@@ -10,14 +10,35 @@ import time
 import webbrowser
 from typing import Any, Dict
 
-from modal import App, Image, Queue, forward
+from modal import App, Image, Mount, Queue, Secret, Volume, forward
 
-# Passed by `modal launch` locally via CLI, empty on remote runner.
-args: Dict[str, Any] = json.loads(os.environ.get("MODAL_LAUNCH_LOCAL_ARGS", "{}"))
+# Passed by `modal launch` locally via CLI, plumbed to remote runner through secrets.
+args: Dict[str, Any] = json.loads(os.environ.get("MODAL_LAUNCH_ARGS", "{}"))
 
 
 app = App()
 app.image = Image.from_registry(args.get("image"), add_python=args.get("add_python")).pip_install("jupyterlab")
+
+
+mount = (
+    Mount.from_local_dir(
+        args.get("mount"),
+        remote_path="/root/lab/mount",
+    )
+    if args.get("mount")
+    else None
+)
+mounts = [mount] if mount else []
+
+volume = (
+    Volume.from_name(
+        args.get("volume"),
+        create_if_missing=True,
+    )
+    if args.get("volume")
+    else None
+)
+volumes = {"/root/lab/volume": volume} if volume else {}
 
 
 def wait_for_port(url: str, q: Queue):
@@ -33,9 +54,19 @@ def wait_for_port(url: str, q: Queue):
     q.put(url)
 
 
-@app.function(cpu=args.get("cpu"), memory=args.get("memory"), gpu=args.get("gpu"), timeout=args.get("timeout"))
+@app.function(
+    cpu=args.get("cpu"),
+    memory=args.get("memory"),
+    gpu=args.get("gpu"),
+    timeout=args.get("timeout"),
+    secrets=[Secret.from_dict({"MODAL_LAUNCH_ARGS": json.dumps(args)})],
+    mounts=mounts,
+    volumes=volumes,
+    concurrency_limit=1 if volume else None,
+    _allow_background_volume_commits=True if volume else False,
+)
 def run_jupyter(q: Queue):
-    os.mkdir("/lab")
+    os.makedirs("/root/lab", exist_ok=True)
     token = secrets.token_urlsafe(13)
     with forward(8888) as tunnel:
         url = tunnel.url + "/?token=" + token
@@ -48,7 +79,7 @@ def run_jupyter(q: Queue):
                 "--allow-root",
                 "--ip=0.0.0.0",
                 "--port=8888",
-                "--notebook-dir=/lab",
+                "--notebook-dir=/root/lab",
                 "--LabApp.allow_origin='*'",
                 "--LabApp.allow_remote_access=1",
             ],

--- a/modal/cli/programs/vscode.py
+++ b/modal/cli/programs/vscode.py
@@ -10,14 +10,35 @@ import time
 import webbrowser
 from typing import Any, Dict, Tuple
 
-from modal import App, Image, Queue, forward
+from modal import App, Image, Mount, Queue, Secret, Volume, forward
 
-# Passed by `modal launch` locally via CLI, empty on remote runner.
-args: Dict[str, Any] = json.loads(os.environ.get("MODAL_LAUNCH_LOCAL_ARGS", "{}"))
+# Passed by `modal launch` locally via CLI, plumbed to remote runner through secrets.
+args: Dict[str, Any] = json.loads(os.environ.get("MODAL_LAUNCH_ARGS", "{}"))
 
 
 app = App()
 app.image = Image.from_registry("codercom/code-server", add_python="3.11").dockerfile_commands("ENTRYPOINT []")
+
+
+mount = (
+    Mount.from_local_dir(
+        args.get("mount"),
+        remote_path="/home/coder/mount",
+    )
+    if args.get("mount")
+    else None
+)
+mounts = [mount] if mount else []
+
+volume = (
+    Volume.from_name(
+        args.get("volume"),
+        create_if_missing=True,
+    )
+    if args.get("volume")
+    else None
+)
+volumes = {"/home/coder/volume": volume} if volume else {}
 
 
 def wait_for_port(data: Tuple[str, str], q: Queue):
@@ -33,7 +54,17 @@ def wait_for_port(data: Tuple[str, str], q: Queue):
     q.put(data)
 
 
-@app.function(cpu=args.get("cpu"), memory=args.get("memory"), gpu=args.get("gpu"), timeout=args.get("timeout"))
+@app.function(
+    cpu=args.get("cpu"),
+    memory=args.get("memory"),
+    gpu=args.get("gpu"),
+    timeout=args.get("timeout"),
+    secrets=[Secret.from_dict({"MODAL_LAUNCH_ARGS": json.dumps(args)})],
+    mounts=mounts,
+    volumes=volumes,
+    concurrency_limit=1 if volume else None,
+    _allow_background_volume_commits=True if volume else False,
+)
 def run_vscode(q: Queue):
     os.chdir("/home/coder")
     token = secrets.token_urlsafe(13)


### PR DESCRIPTION
Finding this very handy when playing around with random notebooks just downloaded off of the internet/colab, and/or stashing state away into modal volumes for later use.