### PR TITLE
CloudBucketMount: Don't hard error on unrecognized endpoint url

### DIFF
--- a/modal/cloud_bucket_mount.py
+++ b/modal/cloud_bucket_mount.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 from modal_proto import api_pb2
 
 from ._utils.async_utils import synchronize_api
+from .config import logger
 from .secret import _Secret
 
 
@@ -126,7 +127,10 @@ def cloud_bucket_mounts_to_proto(mounts: List[Tuple[str, _CloudBucketMount]]) ->
                         f"CloudBucketMount of '{mount.bucket_name}' is invalid. Writing to GCP buckets with modal.CloudBucketMount in currently unsupported."
                     )
             else:
-                raise ValueError(f"Unsupported bucket endpoint hostname '{parse_result.hostname}'")
+                logger.warn(
+                    "CloudBucketMount received unrecognized bucket endpoint URL. Assuming AWS S3 configuration as fallback."
+                )
+                bucket_type = api_pb2.CloudBucketMount.BucketType.S3
         else:
             # just assume S3; this is backwards and forwards compatible.
             bucket_type = api_pb2.CloudBucketMount.BucketType.S3


### PR DESCRIPTION
## Describe your changes

This allows users to try out new bucket storage providers (e.g. Supabase, Minio) and discover errors for us, or happily use the AWS configuration setup if that just worksTM. 

## Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
