### PR TITLE
Add check on names for objects created through CLI

### DIFF
--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -233,6 +233,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         environment_name: Optional[str] = None,
     ) -> str:
         """mdmd:hidden"""
+        check_object_name(deployment_name, "NetworkFileSystem", warn=True)
         if client is None:
             client = await _Client.from_env()
         request = api_pb2.SharedVolumeGetOrCreateRequest(

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -223,6 +223,7 @@ class _Secret(_Object, type_prefix="st"):
         overwrite: bool = False,
     ) -> str:
         """mdmd:hidden"""
+        check_object_name(deployment_name, "Secret", warn=True)
         if client is None:
             client = await _Client.from_env()
         if overwrite:

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -270,6 +270,7 @@ class _Volume(_Object, type_prefix="vo"):
         environment_name: Optional[str] = None,
     ) -> str:
         """mdmd:hidden"""
+        check_object_name(deployment_name, "Volume", warn=True)
         if client is None:
             client = await _Client.from_env()
         request = api_pb2.VolumeGetOrCreateRequest(


### PR DESCRIPTION
Follow-on to #1777, which missed an alternate way of creating objects

Fixes MOD-2930