### PR TITLE
fix: regression in nfs get

### DIFF
--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -491,10 +491,16 @@ def test_nfs_get(set_env_client, servicer):
         with open(upload_path, "w") as f:
             f.write("foo bar baz")
             f.flush()
-        _run(["nfs", "put", nfs_name, upload_path, "test.txt"])
+        # _run(["nfs", "put", nfs_name, upload_path, "test.txt"])
 
-        _run(["nfs", "get", nfs_name, "test.txt", tmpdir])
-        with open(os.path.join(tmpdir, "test.txt"), "r") as f:
+        # _run(["nfs", "get", nfs_name, "test.txt", tmpdir])
+        # with open(os.path.join(tmpdir, "test.txt"), "r") as f:
+        #     assert f.read() == "foo bar baz"
+
+        _run(["nfs", "put", nfs_name, upload_path, "foo/bar.txt"])
+
+        _run(["nfs", "get", nfs_name, "foo/bar.txt", tmpdir])
+        with open(os.path.join(tmpdir, "bar.txt"), "r") as f:
             assert f.read() == "foo bar baz"
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1102,11 +1102,11 @@ class MockClientServicer(api_grpc.ModalClientBase):
                 p.write_bytes(put_request.data)
 
             if "*" in req.path:
-                for path in Path(tmpdir).glob(req.path.lstrip("/")):
-                    if path.is_dir():
-                        entry = api_pb2.FileEntry(path=str(path), type=api_pb2.FileEntry.FileType.DIRECTORY)
+                for p in Path(tmpdir).glob(req.path.lstrip("/")):
+                    if p.is_dir():
+                        entry = api_pb2.FileEntry(path=str(p), type=api_pb2.FileEntry.FileType.DIRECTORY)
                     else:
-                        entry = api_pb2.FileEntry(path=str(path), type=api_pb2.FileEntry.FileType.FILE)
+                        entry = api_pb2.FileEntry(path=str(p), type=api_pb2.FileEntry.FileType.FILE)
                     response = api_pb2.SharedVolumeListFilesResponse(entries=[entry])
                     await stream.send_message(response)
 
@@ -1115,9 +1115,9 @@ class MockClientServicer(api_grpc.ModalClientBase):
                 entry = api_pb2.FileEntry(path=list_path.name, type=api_pb2.FileEntry.FileType.FILE)
                 await stream.send_message(api_pb2.SharedVolumeListFilesResponse(entries=[entry]))
             else:
-                for path in list_path.iterdir():
-                    t = api_pb2.FileEntry.FileType.DIRECTORY if path.is_dir() else api_pb2.FileEntry.FileType.FILE
-                    entry = api_pb2.FileEntry(path=str(path.relative_to(list_path)), type=t)
+                for p in list_path.iterdir():
+                    t = api_pb2.FileEntry.FileType.DIRECTORY if p.is_dir() else api_pb2.FileEntry.FileType.FILE
+                    entry = api_pb2.FileEntry(path=str(p.relative_to(list_path)), type=t)
                     response = api_pb2.SharedVolumeListFilesResponse(entries=[entry])
                     await stream.send_message(response)
 


### PR DESCRIPTION
## Describe your changes

https://github.com/modal-labs/modal-client/pull/1742 caused a regression in `nfs get`. It can be repro'd with: 

```bash
MODAL_PROFILE=modal_labs MODAL_LOGLEVEL=debug modal nfs get txt-to-pokemon-cache-vol pokemon_names/rnn.txt
```

User reported this here https://modal-com.slack.com/archives/C069RAH7X4M/p1715620466703749. 

This wasn't caught by tests because our fake implementation was wrong. Fixed that. 

## Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
