### PR TITLE
Fix sigint concurrent inputs issues

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -543,7 +543,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.put_outputs_barrier = threading.Barrier(1)
 
     async def FunctionGetInputs(self, stream):
-        self.get_inputs_barrier.wait()
+        await asyncio.get_running_loop().run_in_executor(None, self.get_inputs_barrier.wait)
         request: api_pb2.FunctionGetInputsRequest = await stream.recv_message()
         assert request.function_id
         if self.fail_get_inputs:
@@ -553,13 +553,13 @@ class MockClientServicer(api_grpc.ModalClientBase):
             self.rate_limit_sleep_duration = None
             await stream.send_message(api_pb2.FunctionGetInputsResponse(rate_limit_sleep_duration=s))
         elif not self.container_inputs:
-            await asyncio.sleep(1.0)
+            await asyncio.sleep(10.0)
             await stream.send_message(api_pb2.FunctionGetInputsResponse(inputs=[]))
         else:
             await stream.send_message(self.container_inputs.pop(0))
 
     async def FunctionPutOutputs(self, stream):
-        self.put_outputs_barrier.wait()
+        await asyncio.get_running_loop().run_in_executor(None, self.put_outputs_barrier.wait)
         request: api_pb2.FunctionPutOutputsRequest = await stream.recv_message()
         self.container_outputs.append(request)
         await stream.send_message(Empty())

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -1203,9 +1203,8 @@ def test_cancellation_stops_task_with_concurrent_inputs(servicer, function_name)
             servicer,
             "test.supports.functions",
             function_name,
-            inputs=[((20,), {})] * 3,  # more inputs than needed - avoid killswitch
+            inputs=[((20,), {})] * 2,  # two inputs
             allow_concurrent_inputs=2,
-            print=True,
         )
         input_lock.wait()
         input_lock.wait()
@@ -1216,6 +1215,10 @@ def test_cancellation_stops_task_with_concurrent_inputs(servicer, function_name)
     )
     # container should exit soon!
     exit_code = container_process.wait(5)
+    assert (
+        len(servicer.container_outputs) == 0
+    )  # should not fail the outputs, as they would have been cancelled in backend already
+    assert "Traceback" not in container_process.stderr.read().decode("utf8")
     assert exit_code == 0  # container should exit gracefully
 
 
@@ -1323,8 +1326,6 @@ def test_sigint_termination_input_concurrent(servicer):
             inputs=[((10,), {})] * 3,
             cls_params=((), {"print_at_exit": True}),
             allow_concurrent_inputs=2,
-            # print=True,
-            # env={"MODAL_LOGLEVEL": "DEBUG"}
         )
         input_barrier.wait()  # get one input
         input_barrier.wait()  # get one input


### PR DESCRIPTION
Two pretty hard-to-find bugs were present:
* We had a finally clause in the multi-input handling code that tries to acquire all slots of a semaphore, assuming they have been released by each input, but that won't be the case since we can't let a sync worker thread know that the input has been cancelled. This lead to a stalled coroutine, and in a previous version of the client (prior to the unification of sync/async inputs) it even prevented the container_entrypoint from shutting down altogether since this blocked the synchronicity loop from shutting down.
* Our BaseException catch-all for handle_input_exception caught GeneratorExit and emitted that as an input error. This would trigger when the event loop is shut down prematurely like on sigint, since that will shut down all async generators. This *mostly* led to confusing exception spam to users
