### PR TITLE
Add retries to FunctionGetCurrentStats, DictGetOrCreate

### DIFF
--- a/modal/dict.py
+++ b/modal/dict.py
@@ -111,7 +111,7 @@ class _Dict(_Object, type_prefix="di"):
             environment_name=_get_environment_name(environment_name),
             data=serialized,
         )
-        response = await client.stub.DictGetOrCreate(request)
+        response = await retry_transient_errors(client.stub.DictGetOrCreate, request)
         async with TaskContext() as tc:
             request = api_pb2.DictHeartbeatRequest(dict_id=response.dict_id)
             tc.infinite_loop(lambda: client.stub.DictHeartbeat(request), sleep=_heartbeat_sleep)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1085,8 +1085,9 @@ class _Function(_Object, type_prefix="fu"):
     async def get_current_stats(self) -> FunctionStats:
         """Return a `FunctionStats` object describing the current function's queue and runner counts."""
         assert self._client.stub
-        resp = await self._client.stub.FunctionGetCurrentStats(
-            api_pb2.FunctionGetCurrentStatsRequest(function_id=self.object_id)
+        resp = await retry_transient_errors(
+            self._client.stub.FunctionGetCurrentStats,
+            api_pb2.FunctionGetCurrentStatsRequest(function_id=self.object_id),
         )
         return FunctionStats(
             backlog=resp.backlog, num_active_runners=resp.num_active_tasks, num_total_runners=resp.num_total_tasks


### PR DESCRIPTION
## Describe your changes

One of our customers has reported that they're client in AWS is seeing infrequent HTTP 503, 502 errors when calling an HTTP endpoint ([internal link](https://modal-com.slack.com/archives/C06GL2CNFK8/p1715375188500459)). 

From looking at the backtrace of the errors I can see that it's these two RPCs that are failing with `grpclib.exceptions.StreamTerminatedError: Stream reset by remote party, error_code: 0`. That error seems retry-able. 

## Backward/forward compatibility checks

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
