### PR TITLE
dx: dont silently drop invalid volume= mounts

### DIFF
--- a/modal/_utils/mount_utils.py
+++ b/modal/_utils/mount_utils.py
@@ -39,7 +39,7 @@ def validate_volumes(
     volumes: Mapping[Union[str, PurePosixPath], Union["_Volume", "_CloudBucketMount"]],
 ) -> Sequence[Tuple[str, Union["_Volume", "_NetworkFileSystem", "_CloudBucketMount"]]]:
     if not isinstance(volumes, dict):
-        raise InvalidError("volumes must be a dict[str, Volume] where the keys are mount paths")
+        raise InvalidError("volumes must be a dict where the keys are mount paths")
 
     validated_volumes = validate_mount_points("Volume", volumes)
     # We don't support mounting a modal.Volume in more than one location,

--- a/modal/_utils/mount_utils.py
+++ b/modal/_utils/mount_utils.py
@@ -2,15 +2,12 @@
 import posixpath
 import typing
 from pathlib import PurePath, PurePosixPath
-from typing import TYPE_CHECKING, Dict, List, Mapping, Sequence, Tuple, Union
+from typing import Dict, List, Mapping, Sequence, Tuple, Union
 
+from ..cloud_bucket_mount import _CloudBucketMount
 from ..exception import InvalidError
+from ..network_file_system import _NetworkFileSystem
 from ..volume import _Volume
-
-if TYPE_CHECKING:
-    from ..cloud_bucket_mount import _CloudBucketMount
-    from ..network_file_system import _NetworkFileSystem
-
 
 T = typing.TypeVar("T", bound=Union["_Volume", "_NetworkFileSystem", "_CloudBucketMount"])
 
@@ -42,13 +39,16 @@ def validate_volumes(
     volumes: Mapping[Union[str, PurePosixPath], Union["_Volume", "_CloudBucketMount"]],
 ) -> Sequence[Tuple[str, Union["_Volume", "_NetworkFileSystem", "_CloudBucketMount"]]]:
     if not isinstance(volumes, dict):
-        raise InvalidError("volumes must be a dict[str, Volume] where the keys are paths")
+        raise InvalidError("volumes must be a dict[str, Volume] where the keys are mount paths")
 
     validated_volumes = validate_mount_points("Volume", volumes)
-    # We don't support mounting a volume in more than one location
+    # We don't support mounting a modal.Volume in more than one location,
+    # but the same CloudBucketMount object can be used in more than one location.
     volume_to_paths: Dict["_Volume", List[str]] = {}
     for path, volume in validated_volumes:
-        if isinstance(volume, _Volume):
+        if not isinstance(volume, (_Volume, _NetworkFileSystem, _CloudBucketMount)):
+            raise InvalidError(f"Object of type {type(volume)} mounted at '{path}' is not useable as a volume.")
+        elif isinstance(volume, _Volume):
             volume_to_paths.setdefault(volume, []).append(path)
     for paths in volume_to_paths.values():
         if len(paths) > 1:


### PR DESCRIPTION
## Describe your changes

Was for a little bit baffled as to what was wrong with my `CloudBucketMount` code before realizing I had a dangling `,`. 

```python
volume = modal.CloudBucketMount(
    secret=cloudflare_creds,
    bucket_name="modal-testing",
    bucket_endpoint_url="https://hello.r2.cloudflarestorage.com",
),
app = modal.App("demobug", volumes={"/vol/": volume})
```


## Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
