### PR TITLE
[MOD-2958] volume: add version flag

### DIFF
--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -56,9 +56,10 @@ def humanize_filesize(value: int) -> str:
 def create(
     name: str,
     env: Optional[str] = ENV_OPTION,
+    version: Optional[int] = Option(default=None, help="Volume system version. (Experimental)"),
 ):
     env_name = ensure_env(env)
-    modal.Volume.create_deployed(name, environment_name=env)
+    modal.Volume.create_deployed(name, environment_name=env, version=version)
     usage_code = f"""
 @app.function(volumes={{"/my_vol": modal.Volume.from_name("{name}")}})
 def some_func():

--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -56,7 +56,7 @@ def humanize_filesize(value: int) -> str:
 def create(
     name: str,
     env: Optional[str] = ENV_OPTION,
-    version: Optional[int] = Option(default=None, help="Volume system version. (Experimental)"),
+    version: Optional[int] = Option(default=None, help="VolumeFS version. (Experimental)"),
 ):
     env_name = ensure_env(env)
     modal.Volume.create_deployed(name, environment_name=env, version=version)

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -164,7 +164,7 @@ class _Volume(_Object, type_prefix="vo"):
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
-        version: Optional[api_pb2.VolumeVersion.ValueType] = None,
+        version: "Optional[api_pb2.VolumeVersion.ValueType]" = None,
     ) -> "_Volume":
         """Create a reference to a persisted volume. Optionally create it lazily.
 
@@ -204,7 +204,7 @@ class _Volume(_Object, type_prefix="vo"):
         cls: Type["_Volume"],
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
-        version: Optional[api_pb2.VolumeVersion.ValueType] = None,
+        version: "Optional[api_pb2.VolumeVersion.ValueType]" = None,
         _heartbeat_sleep: float = EPHEMERAL_OBJECT_HEARTBEAT_SLEEP,
     ) -> AsyncIterator["_Volume"]:
         """Creates a new ephemeral volume within a context manager:
@@ -249,7 +249,7 @@ class _Volume(_Object, type_prefix="vo"):
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
-        version: Optional[api_pb2.VolumeVersion.ValueType] = None,
+        version: "Optional[api_pb2.VolumeVersion.ValueType]" = None,
     ) -> "_Volume":
         """Lookup a volume with a given name
 
@@ -277,7 +277,7 @@ class _Volume(_Object, type_prefix="vo"):
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
-        version: Optional[api_pb2.VolumeVersion.ValueType] = None,
+        version: "Optional[api_pb2.VolumeVersion.ValueType]" = None,
     ) -> str:
         """mdmd:hidden"""
         check_object_name(deployment_name, "Volume", warn=True)

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -164,6 +164,7 @@ class _Volume(_Object, type_prefix="vo"):
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
+        version: Optional[api_pb2.VolumeVersion] = None,
     ) -> "_Volume":
         """Create a reference to a persisted volume. Optionally create it lazily.
 
@@ -190,6 +191,7 @@ class _Volume(_Object, type_prefix="vo"):
                 namespace=namespace,
                 environment_name=_get_environment_name(environment_name, resolver),
                 object_creation_type=(api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING if create_if_missing else None),
+                version=version,
             )
             response = await resolver.client.stub.VolumeGetOrCreate(req)
             self._hydrate(response.volume_id, resolver.client, None)
@@ -202,6 +204,7 @@ class _Volume(_Object, type_prefix="vo"):
         cls: Type["_Volume"],
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
+        version: Optional[api_pb2.VolumeVersion] = None,
         _heartbeat_sleep: float = EPHEMERAL_OBJECT_HEARTBEAT_SLEEP,
     ) -> AsyncIterator["_Volume"]:
         """Creates a new ephemeral volume within a context manager:
@@ -220,6 +223,7 @@ class _Volume(_Object, type_prefix="vo"):
         request = api_pb2.VolumeGetOrCreateRequest(
             object_creation_type=api_pb2.OBJECT_CREATION_TYPE_EPHEMERAL,
             environment_name=_get_environment_name(environment_name),
+            version=version,
         )
         response = await client.stub.VolumeGetOrCreate(request)
         async with TaskContext() as tc:
@@ -245,6 +249,7 @@ class _Volume(_Object, type_prefix="vo"):
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
+        version: Optional[api_pb2.VolumeVersion] = None,
     ) -> "_Volume":
         """Lookup a volume with a given name
 
@@ -254,7 +259,11 @@ class _Volume(_Object, type_prefix="vo"):
         ```
         """
         obj = _Volume.from_name(
-            label, namespace=namespace, environment_name=environment_name, create_if_missing=create_if_missing
+            label,
+            namespace=namespace,
+            environment_name=environment_name,
+            create_if_missing=create_if_missing,
+            version=version,
         )
         if client is None:
             client = await _Client.from_env()
@@ -268,6 +277,7 @@ class _Volume(_Object, type_prefix="vo"):
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
+        version: Optional[api_pb2.VolumeVersion] = None,
     ) -> str:
         """mdmd:hidden"""
         check_object_name(deployment_name, "Volume", warn=True)
@@ -278,6 +288,7 @@ class _Volume(_Object, type_prefix="vo"):
             namespace=namespace,
             environment_name=_get_environment_name(environment_name),
             object_creation_type=api_pb2.OBJECT_CREATION_TYPE_CREATE_FAIL_IF_EXISTS,
+            version=version,
         )
         resp = await retry_transient_errors(client.stub.VolumeGetOrCreate, request)
         return resp.volume_id

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -164,7 +164,7 @@ class _Volume(_Object, type_prefix="vo"):
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
-        version: Optional[api_pb2.VolumeVersion] = None,
+        version: Optional[api_pb2.VolumeVersion.ValueType] = None,
     ) -> "_Volume":
         """Create a reference to a persisted volume. Optionally create it lazily.
 
@@ -204,7 +204,7 @@ class _Volume(_Object, type_prefix="vo"):
         cls: Type["_Volume"],
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
-        version: Optional[api_pb2.VolumeVersion] = None,
+        version: Optional[api_pb2.VolumeVersion.ValueType] = None,
         _heartbeat_sleep: float = EPHEMERAL_OBJECT_HEARTBEAT_SLEEP,
     ) -> AsyncIterator["_Volume"]:
         """Creates a new ephemeral volume within a context manager:
@@ -249,7 +249,7 @@ class _Volume(_Object, type_prefix="vo"):
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
-        version: Optional[api_pb2.VolumeVersion] = None,
+        version: Optional[api_pb2.VolumeVersion.ValueType] = None,
     ) -> "_Volume":
         """Lookup a volume with a given name
 
@@ -277,7 +277,7 @@ class _Volume(_Object, type_prefix="vo"):
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
-        version: Optional[api_pb2.VolumeVersion] = None,
+        version: Optional[api_pb2.VolumeVersion.ValueType] = None,
     ) -> str:
         """mdmd:hidden"""
         check_object_name(deployment_name, "Volume", warn=True)

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -164,7 +164,7 @@ class _Volume(_Object, type_prefix="vo"):
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
-        version: "Optional[api_pb2.VolumeVersion.ValueType]" = None,
+        version: "Optional[api_pb2.VolumeFsVersion.ValueType]" = None,
     ) -> "_Volume":
         """Create a reference to a persisted volume. Optionally create it lazily.
 
@@ -204,7 +204,7 @@ class _Volume(_Object, type_prefix="vo"):
         cls: Type["_Volume"],
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
-        version: "Optional[api_pb2.VolumeVersion.ValueType]" = None,
+        version: "Optional[api_pb2.VolumeFsVersion.ValueType]" = None,
         _heartbeat_sleep: float = EPHEMERAL_OBJECT_HEARTBEAT_SLEEP,
     ) -> AsyncIterator["_Volume"]:
         """Creates a new ephemeral volume within a context manager:
@@ -249,7 +249,7 @@ class _Volume(_Object, type_prefix="vo"):
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
-        version: "Optional[api_pb2.VolumeVersion.ValueType]" = None,
+        version: "Optional[api_pb2.VolumeFsVersion.ValueType]" = None,
     ) -> "_Volume":
         """Lookup a volume with a given name
 
@@ -277,7 +277,7 @@ class _Volume(_Object, type_prefix="vo"):
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
-        version: "Optional[api_pb2.VolumeVersion.ValueType]" = None,
+        version: "Optional[api_pb2.VolumeFsVersion.ValueType]" = None,
     ) -> str:
         """mdmd:hidden"""
         check_object_name(deployment_name, "Volume", warn=True)

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1912,7 +1912,7 @@ message TunnelStopResponse {
   bool exists = 1;
 }
 
-enum VolumeVersion {
+enum VolumeFsVersion {
   UNSPECIFIED = 0;
   V1 = 1;
   V2 = 2;
@@ -1924,12 +1924,12 @@ message VolumeGetOrCreateRequest {
   string environment_name = 3;
   ObjectCreationType object_creation_type = 4;
   string app_id = 5;  // only used with OBJECT_CREATION_TYPE_ANONYMOUS_OWNED_BY_APP
-  VolumeVersion version = 6;
+  VolumeFsVersion version = 6;
 }
 
 message VolumeGetOrCreateResponse {
   string volume_id = 1;
-  VolumeVersion version = 2;
+  VolumeFsVersion version = 2;
 }
 
 message VolumeHeartbeatRequest {
@@ -1938,12 +1938,12 @@ message VolumeHeartbeatRequest {
 
 message VolumeCreateRequest {
   string app_id = 1 [ (modal.options.audit_target_attr) = true ];
-  VolumeVersion version = 2;
+  VolumeFsVersion version = 2;
 }
 
 message VolumeCreateResponse {
   string volume_id = 1;
-  VolumeVersion version = 2;
+  VolumeFsVersion version = 2;
 }
 
 message VolumeCommitRequest {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1912,16 +1912,24 @@ message TunnelStopResponse {
   bool exists = 1;
 }
 
+enum VolumeVersion {
+  UNSPECIFIED = 0;
+  V1 = 1;
+  V2 = 2;
+}
+
 message VolumeGetOrCreateRequest {
   string deployment_name = 1;
   DeploymentNamespace namespace = 2;
   string environment_name = 3;
   ObjectCreationType object_creation_type = 4;
   string app_id = 5;  // only used with OBJECT_CREATION_TYPE_ANONYMOUS_OWNED_BY_APP
+  VolumeVersion version = 6;
 }
 
 message VolumeGetOrCreateResponse {
   string volume_id = 1;
+  VolumeVersion version = 2;
 }
 
 message VolumeHeartbeatRequest {
@@ -1930,10 +1938,12 @@ message VolumeHeartbeatRequest {
 
 message VolumeCreateRequest {
   string app_id = 1 [ (modal.options.audit_target_attr) = true ];
+  VolumeVersion version = 2;
 }
 
 message VolumeCreateResponse {
   string volume_id = 1;
+  VolumeVersion version = 2;
 }
 
 message VolumeCommitRequest {


### PR DESCRIPTION
## Describe your changes

MOD-2958


## Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


## Changelog

Add a volume version flag to allow opting in to a new volumefs implementation.
