### PR TITLE
Make background volume commits default experience

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -343,7 +343,8 @@ class _Function(_Object, type_prefix="fu"):
                 (2024, 5, 13),
                 "Disabling volume background commits is now deprecated. Set _allow_background_volume_commits=True.",
             )
-            # TODO(Jonathon): make `True` when `None` to make background commits default, before later removing flag.
+        elif allow_background_volume_commits is None:
+            allow_background_volume_commits = True
 
         explicit_mounts = mounts
 


### PR DESCRIPTION
## Describe your changes

Previously if a user didn't specify the flag they wouldn't get background commits. When this merges they will. 

https://github.com/modal-labs/modal-client/pull/1823 merged only a few days ago. I'll merge this around mid-week next week. 

cc @gimaker 

## Backward/forward compatibility checks

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself


## Changelog

* Background committing on `modal.Volume` mounts is now default behavior.
