### PR TITLE
Add new Resource type in proto

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1545,6 +1545,7 @@ message Resources {
   uint32 milli_cpu = 3; // milli CPU cores
   GPUConfig gpu_config = 4;
   uint32 memory_mb_max = 5; // MiB
+  uint32 ephemeral_disk_mb = 6;  // MiB
 }
 
 message S3Mount {


### PR DESCRIPTION
## Describe your changes

New proto field intended to support a requesting ephemeral disk space for a function. Currently Modal Functions get a fixed disk quota. 

**Prospective API**

```python
@app.function(ephemeral_disk=1_000)
def f():
   print("I have 1 GiB of scratch disk storage!")
```


## Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
    - just an addition of a new proto field. that's always compatible
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
    - just an addition of a new proto field. that's always compatible
