### PR TITLE
CloudBucketMount: GCS allows writes now

### DIFF
--- a/modal/cloud_bucket_mount.py
+++ b/modal/cloud_bucket_mount.py
@@ -71,8 +71,8 @@ class _CloudBucketMount:
     **Google GCS Usage**
 
     Google Cloud Storage (GCS) is partially [S3-compatible](https://cloud.google.com/storage/docs/interoperability).
-    Currently **only `read_only=True`** is supported for GCS buckets. GCS Buckets also require a secret with Google-specific
-    key names (see below) populated with a [HMAC key](https://cloud.google.com/storage/docs/authentication/managing-hmackeys#create).
+    GCS Buckets also require a secret with Google-specific key names (see below) populated with
+    a [HMAC key](https://cloud.google.com/storage/docs/authentication/managing-hmackeys#create).
 
     ```python
     import subprocess
@@ -88,7 +88,6 @@ class _CloudBucketMount:
                 bucket_name="my-gcs-bucket",
                 bucket_endpoint_url="https://storage.googleapis.com",
                 secret=gcp_hmac_secret,
-                read_only=True,  # writing to bucket currently unsupported
             )
         }
     )

--- a/modal/cloud_bucket_mount.py
+++ b/modal/cloud_bucket_mount.py
@@ -122,10 +122,6 @@ def cloud_bucket_mounts_to_proto(mounts: List[Tuple[str, _CloudBucketMount]]) ->
                 bucket_type = api_pb2.CloudBucketMount.BucketType.R2
             elif parse_result.hostname.endswith("storage.googleapis.com"):
                 bucket_type = api_pb2.CloudBucketMount.BucketType.GCP
-                if not mount.read_only:
-                    raise ValueError(
-                        f"CloudBucketMount of '{mount.bucket_name}' is invalid. Writing to GCP buckets with modal.CloudBucketMount in currently unsupported."
-                    )
             else:
                 logger.warn(
                     "CloudBucketMount received unrecognized bucket endpoint URL. Assuming AWS S3 configuration as fallback."


### PR DESCRIPTION
## Describe your changes

Worker change has allowed writes to work now. 

## Backward/forward compatibility checks

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself


## Changelog

* `modal.CloudBucketMount` now supports writing to Google Cloud Storage buckets.
