### PR TITLE
Improve error message to account for 15-minute req expiry

### DIFF
--- a/modal/_asgi.py
+++ b/modal/_asgi.py
@@ -35,7 +35,7 @@ def asgi_app_wrapper(asgi_app, function_io_manager) -> Callable[..., AsyncGenera
                 await messages_from_app.put(
                     {
                         "type": "http.response.body",
-                        "body": b"Missing request, possibly due to cancellation or crash",
+                        "body": b"Missing request, possibly due to expiry or cancellation",
                     }
                 )
             elif scope["type"] == "websocket":
@@ -43,7 +43,7 @@ def asgi_app_wrapper(asgi_app, function_io_manager) -> Callable[..., AsyncGenera
                     {
                         "type": "websocket.close",
                         "code": 1011,
-                        "reason": "Missing request, possibly due to cancellation or crash",
+                        "reason": "Missing request, possibly due to expiry or cancellation",
                     }
                 )
             await disconnect_app()


### PR DESCRIPTION
If a server gets too much load, shed new requests after 15 minutes.