### PR TITLE
fix: typo `object` to `obj` in isfunction check

### DIFF
--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -19,9 +19,7 @@ synchronizer = synchronicity.Synchronizer()
 
 
 def synchronize_api(obj, target_module=None):
-    if inspect.isclass(obj):
-        blocking_name = obj.__name__.lstrip("_")
-    elif inspect.isfunction(obj):
+    if inspect.isclass(obj) or inspect.isfunction(obj):
         blocking_name = obj.__name__.lstrip("_")
     elif isinstance(obj, TypeVar):
         blocking_name = "_BLOCKING_" + obj.__name__

--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -21,7 +21,7 @@ synchronizer = synchronicity.Synchronizer()
 def synchronize_api(obj, target_module=None):
     if inspect.isclass(obj):
         blocking_name = obj.__name__.lstrip("_")
-    elif inspect.isfunction(object):
+    elif inspect.isfunction(obj):
         blocking_name = obj.__name__.lstrip("_")
     elif isinstance(obj, TypeVar):
         blocking_name = "_BLOCKING_" + obj.__name__

--- a/test/async_utils_test.py
+++ b/test/async_utils_test.py
@@ -13,6 +13,7 @@ from modal._utils.async_utils import (
     queue_batch_iterator,
     retry,
     warn_if_generator_is_not_consumed,
+    synchronize_api,
 )
 
 skip_github_non_linux = pytest.mark.skipif(
@@ -230,3 +231,22 @@ def test_exit_handler():
 
     sync._close_loop()  # this is called on exit by synchronicity, which shuts down the event loop
     assert result == "bye"
+
+
+def test_synchronize_api_blocking_name():
+    class _MyClass:
+        async def foo(self):
+            await asyncio.sleep(0.1)
+            return "bar"
+
+    async def _myfunc():
+        await asyncio.sleep(0.1)
+        return "bar"
+
+    MyClass = synchronize_api(_MyClass)
+    assert MyClass.__name__ == "MyClass"
+    assert MyClass().foo() == "bar"
+
+    myfunc = synchronize_api(_myfunc)
+    assert myfunc.__name__ == "myfunc"
+    assert myfunc() == "bar"


### PR DESCRIPTION
## Describe your changes

Minor fix in `isfunction` check

