### PR TITLE
[MOD-2471] Add `key_prefix` to `CloudBucketMount`

### DIFF
--- a/modal/cloud_bucket_mount.py
+++ b/modal/cloud_bucket_mount.py
@@ -135,8 +135,12 @@ def cloud_bucket_mounts_to_proto(mounts: List[Tuple[str, _CloudBucketMount]]) ->
         if mount.requester_pays and not mount.secret:
             raise ValueError("Credentials required in order to use Requester Pays.")
 
-        if not mount.key_prefix.endswith('/'):
+        if mount.key_prefix == "":
+            raise ValueError("key_prefix must not be empty. To mount the entire bucket, do not specify any prefix.")
+        elif mount.key_prefix and not mount.key_prefix.endswith('/'):
             raise ValueError("key_prefix will be prefixed to all object paths, so it must end in a '/'")
+        else:
+            key_prefix = mount.key_prefix
 
         cloud_bucket_mount = api_pb2.CloudBucketMount(
             bucket_name=mount.bucket_name,
@@ -146,7 +150,7 @@ def cloud_bucket_mounts_to_proto(mounts: List[Tuple[str, _CloudBucketMount]]) ->
             read_only=mount.read_only,
             bucket_type=bucket_type,
             requester_pays=mount.requester_pays,
-            key_prefix=mount.key_prefix,
+            key_prefix=key_prefix,
         )
         cloud_bucket_mounts.append(cloud_bucket_mount)
 

--- a/modal/cloud_bucket_mount.py
+++ b/modal/cloud_bucket_mount.py
@@ -135,9 +135,7 @@ def cloud_bucket_mounts_to_proto(mounts: List[Tuple[str, _CloudBucketMount]]) ->
         if mount.requester_pays and not mount.secret:
             raise ValueError("Credentials required in order to use Requester Pays.")
 
-        if mount.key_prefix == "":
-            raise ValueError("key_prefix must not be empty. To mount the entire bucket, do not specify any prefix.")
-        elif mount.key_prefix and not mount.key_prefix.endswith('/'):
+        if mount.key_prefix and not mount.key_prefix.endswith('/'):
             raise ValueError("key_prefix will be prefixed to all object paths, so it must end in a '/'")
         else:
             key_prefix = mount.key_prefix

--- a/modal/cloud_bucket_mount.py
+++ b/modal/cloud_bucket_mount.py
@@ -136,7 +136,7 @@ def cloud_bucket_mounts_to_proto(mounts: List[Tuple[str, _CloudBucketMount]]) ->
             raise ValueError("Credentials required in order to use Requester Pays.")
 
         if not mount.key_prefix.endswith('/'):
-            raise ValueError("key_prefix must end in a '/'")
+            raise ValueError("key_prefix will be prefixed to all object paths, so it must end in a '/'")
 
         cloud_bucket_mount = api_pb2.CloudBucketMount(
             bucket_name=mount.bucket_name,

--- a/modal/cloud_bucket_mount.py
+++ b/modal/cloud_bucket_mount.py
@@ -100,6 +100,8 @@ class _CloudBucketMount:
     # Endpoint URL is used to support Cloudflare R2 and Google Cloud Platform GCS.
     bucket_endpoint_url: Optional[str] = None
 
+    key_prefix: Optional[str] = None
+
     # Credentials used to access a cloud bucket.
     # If the bucket is private, the secret **must** contain AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.
     # If the bucket is publicly accessible, the secret is unnecessary and can be omitted.
@@ -133,6 +135,9 @@ def cloud_bucket_mounts_to_proto(mounts: List[Tuple[str, _CloudBucketMount]]) ->
         if mount.requester_pays and not mount.secret:
             raise ValueError("Credentials required in order to use Requester Pays.")
 
+        if not mount.key_prefix.endswith('/'):
+            raise ValueError("key_prefix must end in a '/'")
+
         cloud_bucket_mount = api_pb2.CloudBucketMount(
             bucket_name=mount.bucket_name,
             bucket_endpoint_url=mount.bucket_endpoint_url,
@@ -141,6 +146,7 @@ def cloud_bucket_mounts_to_proto(mounts: List[Tuple[str, _CloudBucketMount]]) ->
             read_only=mount.read_only,
             bucket_type=bucket_type,
             requester_pays=mount.requester_pays,
+            key_prefix=mount.key_prefix,
         )
         cloud_bucket_mounts.append(cloud_bucket_mount)
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -98,6 +98,7 @@ message CloudBucketMount {
   BucketType bucket_type = 5;
   bool requester_pays = 6;
   optional string bucket_endpoint_url = 7;
+  optional string key_prefix = 8;
 }
 
 enum CloudProvider {

--- a/test/cloud_bucket_mount_test.py
+++ b/test/cloud_bucket_mount_test.py
@@ -11,6 +11,7 @@ def test_volume_mount(client, servicer):
     secret = modal.Secret.from_dict({"AWS_ACCESS_KEY_ID": "1", "AWS_SECRET_ACCESS_KEY": "2"})
     cld_bckt_mnt = modal.CloudBucketMount(
         bucket_name="foo",
+        key_prefix="dir/",
         bucket_endpoint_url="https://1234.r2.cloudflarestorage.com",
         secret=secret,
         read_only=False,


### PR DESCRIPTION
Required client changes to enable https://github.com/modal-labs/modal/pull/12788.

* Add `key_prefix` to the `CloudBucketMount` proto
* Update `CloudBucketMount` API to support `key_prefix`