### PR TITLE
Add CLI for getting container-specific logs

### DIFF
--- a/modal/_output.py
+++ b/modal/_output.py
@@ -396,7 +396,9 @@ async def stream_pty_shell_input(client: _Client, exec_id: str, finish_event: as
         await finish_event.wait()
 
 
-async def get_app_logs_loop(app_id: str, client: _Client, output_mgr: OutputManager):
+async def get_app_logs_loop(
+    client: _Client, output_mgr: OutputManager, app_id: Optional[str] = None, task_id: Optional[str] = None
+):
     last_log_batch_entry_id = ""
     pty_shell_finish_event: Optional[asyncio.Event] = None
     pty_shell_task_id: Optional[str] = None
@@ -434,7 +436,8 @@ async def get_app_logs_loop(app_id: str, client: _Client, output_mgr: OutputMana
         nonlocal last_log_batch_entry_id, pty_shell_finish_event, pty_shell_task_id
 
         request = api_pb2.AppGetLogsRequest(
-            app_id=app_id,
+            app_id=app_id or "",
+            task_id=task_id or "",
             timeout=55,
             last_entry_id=last_log_batch_entry_id,
         )

--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -87,7 +87,7 @@ def logs(
     name: Optional[str] = Option(None, "-n", "--name", help="Look up a deployed App by its name"),
     env: Optional[str] = ENV_OPTION,
 ):
-    """Show the logs from deployed, running, or stopped apps.
+    """Show App logs, streaming while active.
 
     **Examples:**
 

--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -8,7 +8,7 @@ from rich.text import Text
 from modal._container_exec import container_exec
 from modal._utils.async_utils import synchronizer
 from modal._utils.grpc_utils import retry_transient_errors
-from modal.cli.utils import display_table, timestamp_to_local
+from modal.cli.utils import display_table, stream_app_logs, timestamp_to_local
 from modal.client import _Client
 from modal_proto import api_pb2
 
@@ -36,6 +36,12 @@ async def list(json: bool = False):
         )
 
     display_table(column_names, rows, json=json, title="Active Containers")
+
+
+@container_cli.command("logs")
+def logs(container_id: str = typer.Argument(help="Container ID")):
+    """Show logs for a specific container, streaming while active."""
+    stream_app_logs(task_id=container_id)
 
 
 @container_cli.command("exec")

--- a/modal/cli/utils.py
+++ b/modal/cli/utils.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 import asyncio
 from datetime import datetime
-from typing import Sequence, Union
+from typing import Optional, Sequence, Union
 
 import typer
 from click import UsageError
@@ -17,12 +17,12 @@ from ..client import _Client
 
 
 @synchronizer.create_blocking
-async def stream_app_logs(app_id: str):
+async def stream_app_logs(app_id: Optional[str] = None, task_id: Optional[str] = None):
     client = await _Client.from_env()
     output_mgr = OutputManager(None, None, f"Tailing logs for {app_id}")
     try:
         with output_mgr.show_status_spinner():
-            await get_app_logs_loop(app_id, client, output_mgr)
+            await get_app_logs_loop(client, output_mgr, app_id, task_id)
     except asyncio.CancelledError:
         pass
     except GRPCError as exc:

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -250,7 +250,7 @@ async def _run_app(
 
         # Start logs loop
         if not shell:
-            logs_loop = tc.create_task(get_app_logs_loop(running_app.app_id, client, output_mgr))
+            logs_loop = tc.create_task(get_app_logs_loop(client, output_mgr, running_app.app_id))
 
         exc_info: Optional[BaseException] = None
         try:


### PR DESCRIPTION
Closes MOD-2969

## Changelog

* Added the `modal container logs` CLI command for getting container-specific logs.