### PR TITLE
Add ephemeral_disk request to client

### DIFF
--- a/modal/_resources.py
+++ b/modal/_resources.py
@@ -12,6 +12,7 @@ def convert_fn_config_to_resources_config(
     cpu: Optional[float],
     memory: Optional[Union[int, Tuple[int, int]]],
     gpu: GPU_T,
+    ephemeral_disk: Optional[int],
 ) -> api_pb2.Resources:
     if cpu is not None and cpu < 0.1:
         raise InvalidError(f"Invalid fractional CPU value {cpu}. Cannot have less than 0.10 CPU resources.")
@@ -28,5 +29,9 @@ def convert_fn_config_to_resources_config(
         memory_mb = 0
         memory_mb_max = 0
     return api_pb2.Resources(
-        milli_cpu=milli_cpu, gpu_config=gpu_config, memory_mb=memory_mb, memory_mb_max=memory_mb_max
+        milli_cpu=milli_cpu,
+        gpu_config=gpu_config,
+        memory_mb=memory_mb,
+        memory_mb_max=memory_mb_max,
+        ephemeral_disk_mb=ephemeral_disk,
     )

--- a/modal/app.py
+++ b/modal/app.py
@@ -653,6 +653,7 @@ class _App:
         memory: Optional[
             Union[int, Tuple[int, int]]
         ] = None,  # Specify, in MiB, a memory request which is the minimum memory required. Or, pass (request, limit) to additionally specify a hard limit in MiB.
+        ephemeral_disk: Optional[int] = None,  # Specify, in MiB, the ephemeral disk size for the Function.
         proxy: Optional[_Proxy] = None,  # Reference to a Modal Proxy to use in front of this function.
         retries: Optional[Union[int, Retries]] = None,  # Number of times to retry each input in case of failure.
         concurrency_limit: Optional[int] = None,  # Limit for max concurrent containers running the function.
@@ -694,6 +695,7 @@ class _App:
             volumes=volumes,
             cpu=cpu,
             memory=memory,
+            ephemeral_disk=ephemeral_disk,
             proxy=proxy,
             retries=retries,
             concurrency_limit=concurrency_limit,

--- a/modal/app.py
+++ b/modal/app.py
@@ -494,6 +494,7 @@ class _App:
         memory: Optional[
             Union[int, Tuple[int, int]]
         ] = None,  # Specify, in MiB, a memory request which is the minimum memory required. Or, pass (request, limit) to additionally specify a hard limit in MiB.
+        ephemeral_disk: Optional[int] = None,  # Specify, in MiB, the ephemeral disk size for the Function.
         proxy: Optional[_Proxy] = None,  # Reference to a Modal Proxy to use in front of this function.
         retries: Optional[Union[int, Retries]] = None,  # Number of times to retry each input in case of failure.
         concurrency_limit: Optional[
@@ -605,14 +606,15 @@ class _App:
                 network_file_systems=network_file_systems,
                 allow_cross_region_volumes=allow_cross_region_volumes,
                 volumes={**self._volumes, **volumes},
+                cpu=cpu,
                 memory=memory,
+                ephemeral_disk=ephemeral_disk,
                 proxy=proxy,
                 retries=retries,
                 concurrency_limit=concurrency_limit,
                 allow_concurrent_inputs=allow_concurrent_inputs,
                 container_idle_timeout=container_idle_timeout,
                 timeout=timeout,
-                cpu=cpu,
                 keep_warm=keep_warm,
                 cloud=cloud,
                 webhook_config=webhook_config,

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -300,7 +300,7 @@ class _Cls(_Object, type_prefix="cs"):
         """
         retry_policy = _parse_retries(retries)
         if gpu or cpu or memory:
-            resources = convert_fn_config_to_resources_config(cpu=cpu, memory=memory, gpu=gpu)
+            resources = convert_fn_config_to_resources_config(cpu=cpu, memory=memory, gpu=gpu, ephemeral_disk=None)
         else:
             resources = None
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -250,6 +250,7 @@ class _FunctionSpec:
     cloud: Optional[str]
     cpu: Optional[float]
     memory: Optional[Union[int, Tuple[int, int]]]
+    ephemeral_disk: Optional[int]
     scheduler_placement: Optional[SchedulerPlacement]
 
 
@@ -312,6 +313,7 @@ class _Function(_Object, type_prefix="fu"):
         allow_background_volume_commits: Optional[bool] = None,
         block_network: bool = False,
         max_inputs: Optional[int] = None,
+        ephemeral_disk: Optional[int] = None,
     ) -> None:
         """mdmd:hidden"""
         tag = info.get_tag()
@@ -382,6 +384,7 @@ class _Function(_Object, type_prefix="fu"):
             cloud=cloud,
             cpu=cpu,
             memory=memory,
+            ephemeral_disk=ephemeral_disk,
             scheduler_placement=scheduler_placement,
         )
 
@@ -404,6 +407,7 @@ class _Function(_Object, type_prefix="fu"):
                     memory=memory,
                     timeout=86400,  # TODO: make this an argument to `@build()`
                     cpu=cpu,
+                    ephemeral_disk=ephemeral_disk,
                     is_builder_function=True,
                     is_auto_snapshot=True,
                     scheduler_placement=scheduler_placement,
@@ -575,7 +579,9 @@ class _Function(_Object, type_prefix="fu"):
                 function_serialized=function_serialized or b"",
                 class_serialized=class_serialized or b"",
                 function_type=function_type,
-                resources=convert_fn_config_to_resources_config(cpu=cpu, memory=memory, gpu=gpu),
+                resources=convert_fn_config_to_resources_config(
+                    cpu=cpu, memory=memory, gpu=gpu, ephemeral_disk=ephemeral_disk
+                ),
                 webhook_config=webhook_config,
                 shared_volume_mounts=network_file_system_mount_protos(
                     validated_network_file_systems, allow_cross_region_volumes

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -295,6 +295,7 @@ class _Sandbox(_Object, type_prefix="sb"):
                 for path, volume in validated_volumes
             ]
 
+            ephemeral_disk = None  # Ephemeral disk requests not supported on Sandboxes.
             definition = api_pb2.Sandbox(
                 entrypoint_args=entrypoint_args,
                 image_id=image.object_id,
@@ -302,7 +303,9 @@ class _Sandbox(_Object, type_prefix="sb"):
                 secret_ids=[secret.object_id for secret in secrets],
                 timeout_secs=timeout,
                 workdir=workdir,
-                resources=convert_fn_config_to_resources_config(cpu=cpu, memory=memory, gpu=gpu),
+                resources=convert_fn_config_to_resources_config(
+                    cpu=cpu, memory=memory, gpu=gpu, ephemeral_disk=ephemeral_disk
+                ),
                 cloud_provider=parse_cloud_provider(cloud) if cloud else None,
                 nfs_mounts=network_file_system_mount_protos(validated_network_file_systems, False),
                 runtime_debug=config.get("function_runtime_debug"),

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -216,6 +216,11 @@ def test_function_cpu_request(client):
     app.function(cpu=2.0)(dummy)
 
 
+def test_function_disk_request(client):
+    app = App()
+    app.function(ephemeral_disk=1_000_000)(dummy)
+
+
 def later():
     return "hello"
 


### PR DESCRIPTION
## Describe your changes


```python
import subprocess

import modal

app = modal.App()


@app.function(
    ephemeral_disk=1000 * 1000,
)
def f() -> None:
    subprocess.run("df /", shell=True, check=True)
```

* I chose MiB as the parameter unit, which is a bit annoying because GiB is more natural for disk, but if we're not going to have units in the parameter name I think it's better to be consistent across all space-based parameters. 
* See _"I'm wanting to introduce a way to request disk space as part"_ in internal #client channel for previous discussion. 

## Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
    - Old servers are fine accepting the ephemeral disk request value. They'll ignore it. 
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
    - Not relevant to this changeset

## Changelog

* `modal.Function` now supports requesting ephemeral disk (SSD) via the new `ephemeral_disk` parameter. Intended for use in doing large dataset ingestion and transform.
