### PR TITLE
Method pooling protos

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -941,7 +941,7 @@ message Function {
 
   bool is_class = 53;  // if "Function" is actually a class grouping multiple methods
 
-  string use_function_id= 54;  // for "class functions" - use this function id instead for invocations - the *referenced* function should have is_class=True
+  string use_function_id = 54;  // for "class functions" - use this function id instead for invocations - the *referenced* function should have is_class=True
   string use_method_name = 55;  // for "class functions" - this method name needs to be included in the FunctionInput
 }
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -512,6 +512,7 @@ message ClassCreateRequest {
   string app_id = 1  [ (modal.options.audit_target_attr) = true ];
   string existing_class_id = 2;
   repeated ClassMethod methods = 3;
+  string class_function_id = 4;
 }
 
 message ClassCreateResponse {
@@ -536,6 +537,8 @@ message ClassGetResponse {
 
 message ClassHandleMetadata {
   repeated ClassMethod methods = 1;
+  string class_function_id = 2;
+  FunctionHandleMetadata class_function_metadata = 3;
 }
 
 message ClassMethod {
@@ -842,6 +845,13 @@ message FileEntry {
   uint64 size = 4;
 }
 
+message Method {
+  string method_name = 1;
+  Function.FunctionType function_type = 2;
+  WebhookConfig webhook_config = 3;
+  // TODO: put function_serialized for each method here for serialized functions?
+}
+
 message Function {
   string module_name = 1;
   string function_name = 2;
@@ -934,6 +944,12 @@ message Function {
   // to look at fine-grained placement constraints.
   bool _experimental_scheduler = 49;
   optional SchedulerPlacement scheduler_placement = 50;
+  optional SchedulerPlacement _experimental_scheduler_placement = 52;
+
+  bool is_class = 53;  // if "Function" is actually a class grouping multiple methods
+
+  string use_function_id= 54;  // for "class functions" - use this function id instead for invocations - the *referenced* function should have is_class=True
+  string use_method_name = 55;  // for "class functions" - this method name needs to be included in the FunctionInput
 }
 
 message FunctionBindParamsRequest {
@@ -1093,6 +1109,8 @@ message FunctionHandleMetadata {
   Function.FunctionType function_type = 8;
   string web_url = 28;
   bool is_method = 39;
+  string use_function_id = 40; // used for methods
+  string use_method_name = 41; // used for methods
 }
 
 message FunctionInput {
@@ -1103,6 +1121,7 @@ message FunctionInput {
   }
   bool final_input = 9;
   DataFormat data_format = 10; // For args_oneof.
+  optional string method_name = 11; // specifies which method to call when calling a class/object function
 }
 
 message FunctionMapRequest {
@@ -1139,6 +1158,8 @@ message FunctionPrecreateRequest {
   string existing_function_id = 3;
   Function.FunctionType function_type = 4;
   WebhookConfig webhook_config = 5;
+  string use_function_id= 6;  // for "class functions" - use this function id instead for invocations - the *referenced* function should have is_class=True
+  string use_method_name = 7;  // for "class functions" - this method name needs to be included in the FunctionInput
 }
 
 message FunctionPrecreateResponse {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -845,13 +845,6 @@ message FileEntry {
   uint64 size = 4;
 }
 
-message Method {
-  string method_name = 1;
-  Function.FunctionType function_type = 2;
-  WebhookConfig webhook_config = 3;
-  // TODO: put function_serialized for each method here for serialized functions?
-}
-
 message Function {
   string module_name = 1;
   string function_name = 2;
@@ -944,7 +937,7 @@ message Function {
   // to look at fine-grained placement constraints.
   bool _experimental_scheduler = 49;
   optional SchedulerPlacement scheduler_placement = 50;
-  optional SchedulerPlacement _experimental_scheduler_placement = 52;
+  reserved 52; // _experimental_scheduler_placement
 
   bool is_class = 53;  // if "Function" is actually a class grouping multiple methods
 
@@ -1158,7 +1151,7 @@ message FunctionPrecreateRequest {
   string existing_function_id = 3;
   Function.FunctionType function_type = 4;
   WebhookConfig webhook_config = 5;
-  string use_function_id= 6;  // for "class functions" - use this function id instead for invocations - the *referenced* function should have is_class=True
+  string use_function_id = 6;  // for "class functions" - use this function id instead for invocations - the *referenced* function should have is_class=True
   string use_method_name = 7;  // for "class functions" - this method name needs to be included in the FunctionInput
 }
 


### PR DESCRIPTION
Proto changes for the upcoming change of pooling together methods of same class in same containers

## Architecture
Previously every method of a class got a fully qualified and persisted `Function` object that encoded everything about the function. In addition every method invoked on a custom parameter instance of a class also created a new Function with these specifications, but a custom class parametrization (and options).

**With this upcoming change**
* We instead only create a `Function` for the class itself, a "class function" if you will, and every *instance* (**not** multiplied by the number of methods).
* Every method on the base class (not for instances) also gets a placeholder "proxy" Function created, which lacks most of the specifications about the environment and is basically a pointer to a "class function" to be used (`use_function_id` and a method (`method_name`) to use on it. This is needed mostly to populate lookup fields (`web_label` as well as function names) in the backend so that methods can still be looked up by distinct web labels (the class function itself can't have a web label).
* When invoking a method, the function call is created using the `use_function_id` (meaning all methods use the same function id) and any inputs will be created using a new `FunctionInput` field `method_name` which tells the container which of the class' method to invoke for the input.

## Protocol changes
* `FunctionInput` gets a `method_name` attribute specifying which method to use. In case of non-classes this is the empty string (which is backwards compatible)
* `Function`, `FunctionPrecreate` and `FunctionHandleMetadata` get two new optional fields: `use_function_id` and `use_method_name` which are set for "proxy functions"/method placeholder functions to indicate which function_id and method_name should be used for any invocations of those methods.

## Backward/forward compatibility checks (for this PR)
* Only proto changes, should be safe
* Will likely require some changes on the worker side where proto objects are instantiated to not break builds
* After this is merged, we can add server support for the new fields where needed, ahead of releasing the client changes that make use of the new fields