### PR TITLE
Remove `keep_warm` from Function proto

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -877,7 +877,7 @@ message Function {
 
   uint32 concurrency_limit = 19;
 
-  bool keep_warm = 20;
+  reserved 20; // old fields
 
   uint32 timeout_secs = 21;
 


### PR DESCRIPTION
Long deprecated in favor of `warm_pool_size`.