### PR TITLE
Allow `modal app stop` CLI to specify app by name not just ID

### DIFF
--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -4,7 +4,6 @@ from typing import List, Optional, Union
 
 import typer
 from click import UsageError
-from grpclib import GRPCError, Status
 from rich.table import Column
 from rich.text import Text
 from typer import Argument, Option
@@ -13,10 +12,9 @@ from modal._utils.async_utils import synchronizer
 from modal.app_utils import _list_apps
 from modal.client import _Client
 from modal.environments import ensure_env
-from modal.exception import NotFoundError
 from modal_proto import api_pb2
 
-from .utils import ENV_OPTION, display_table, stream_app_logs, timestamp_to_local
+from .utils import ENV_OPTION, display_table, get_app_id_from_name, stream_app_logs, timestamp_to_local
 
 app_cli = typer.Typer(name="app", help="Manage deployed and running apps.", no_args_is_help=True)
 
@@ -84,7 +82,7 @@ async def list(env: Optional[str] = ENV_OPTION, json: bool = False):
 def logs(
     app_id: str = Argument("", help="Look up any App by its ID"),
     *,
-    name: Optional[str] = Option(None, "-n", "--name", help="Look up a deployed App by its name"),
+    name: str = Option("", "-n", "--name", help="Look up a deployed App by its name"),
     env: Optional[str] = ENV_OPTION,
 ):
     """Show App logs, streaming while active.
@@ -108,35 +106,21 @@ def logs(
         raise UsageError("Must pass either an ID or a name.")
 
     if not app_id:
-
-        @synchronizer.create_blocking
-        async def get_app_id():
-            client = await _Client.from_env()
-            env_name = ensure_env(env)
-            request = api_pb2.AppGetByDeploymentNameRequest(
-                namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, name=name, environment_name=env_name
-            )
-            resp = await client.stub.AppGetByDeploymentName(request)
-            if not resp.app_id:
-                env_comment = f" in the '{env_name}' environment" if env_name else ""
-                raise NotFoundError(f"Could not find a deployed app named '{name}'{env_comment}.")
-            return resp.app_id
-
-        try:
-            app_id = get_app_id()
-        except GRPCError as exc:
-            if exc.status in (Status.INVALID_ARGUMENT, Status.NOT_FOUND):
-                raise UsageError(exc.message)
-            else:
-                raise
-
+        app_id = get_app_id_from_name(name, env)
     stream_app_logs(app_id)
 
 
-@app_cli.command("stop")
+@app_cli.command("stop", no_args_is_help=True)
 @synchronizer.create_blocking
-async def stop(app_id: str):
+async def stop(
+    app_id: str = Argument(""),
+    *,
+    name: str = Option("", "-n", "--name", help="Look up a deployed App by its name"),
+    env: Optional[str] = ENV_OPTION,
+):
     """Stop an app."""
     client = await _Client.from_env()
+    if not app_id:
+        app_id = await get_app_id_from_name.aio(name, env, client)
     req = api_pb2.AppStopRequest(app_id=app_id, source=api_pb2.APP_STOP_SOURCE_CLI)
     await client.stub.AppStop(req)

--- a/modal/cli/utils.py
+++ b/modal/cli/utils.py
@@ -11,9 +11,13 @@ from rich.json import JSON
 from rich.table import Column, Table
 from rich.text import Text
 
+from modal_proto import api_pb2
+
 from .._output import OutputManager, get_app_logs_loop
 from .._utils.async_utils import synchronizer
 from ..client import _Client
+from ..environments import ensure_env
+from ..exception import NotFoundError
 
 
 @synchronizer.create_blocking
@@ -32,6 +36,26 @@ async def stream_app_logs(app_id: Optional[str] = None, task_id: Optional[str] =
             raise
     except KeyboardInterrupt:
         pass
+
+
+@synchronizer.create_blocking
+async def get_app_id_from_name(name: str, env: Optional[str], client: Optional[_Client] = None) -> str:
+    if client is None:
+        client = await _Client.from_env()
+    env_name = ensure_env(env)
+    request = api_pb2.AppGetByDeploymentNameRequest(
+        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, name=name, environment_name=env_name
+    )
+    try:
+        resp = await client.stub.AppGetByDeploymentName(request)
+    except GRPCError as exc:
+        if exc.status in (Status.INVALID_ARGUMENT, Status.NOT_FOUND):
+            raise UsageError(exc.message or "")
+        raise
+    if not resp.app_id:
+        env_comment = f" in the '{env_name}' environment" if env_name else ""
+        raise NotFoundError(f"Could not find a deployed app named '{name}'{env_comment}.")
+    return resp.app_id
 
 
 def timestamp_to_local(ts: float, isotz: bool = True) -> str:

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -483,6 +483,22 @@ def test_logs(servicer, server_url_env, set_env_client, mock_dir):
     )
 
 
+def test_app_stop(servicer, mock_dir, set_env_client):
+    with mock_dir({"myapp.py": dummy_app_file, "other_module.py": dummy_other_module_file}):
+        # Deploy as a module
+        _run(["deploy", "myapp"])
+
+    res = _run(["app", "list"])
+    assert re.search("my_app .+ deployed", res.stdout)
+
+    _run(["app", "stop", "-n", "my_app"])
+
+    # Note that the mock servicer doesn't report "stopped" app statuses
+    # so we just check that it's not reported as deployed
+    res = _run(["app", "list"])
+    assert not re.search("my_app .+ deployed", res.stdout)
+
+
 def test_nfs_get(set_env_client, servicer):
     nfs_name = "my-shared-nfs"
     _run(["nfs", "create", nfs_name])

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -322,6 +322,11 @@ class MockClientServicer(api_grpc.ModalClientBase):
             )
         await stream.send_message(api_pb2.AppListResponse(apps=apps))
 
+    async def AppStop(self, stream):
+        request: api_pb2.AppStopRequest = await stream.recv_message()
+        self.deployed_apps = {k: v for k, v in self.deployed_apps.items() if v != request.app_id}
+        await stream.send_message(Empty())
+
     ### Checkpoint
 
     async def ContainerCheckpoint(self, stream):


### PR DESCRIPTION
## Changelog

- The `modal app stop` CLI command now accepts a `--name` (or `-n`) option to stop an App by name rather than by ID.