### PR TITLE
Turn `.new` from `deprecation_warning` to `deprecation_error`

### DIFF
--- a/modal/dict.py
+++ b/modal/dict.py
@@ -13,7 +13,7 @@ from ._utils.grpc_utils import retry_transient_errors, unary_stream
 from ._utils.name_utils import check_object_name
 from .client import _Client
 from .config import logger
-from .exception import RequestSizeError, deprecation_warning
+from .exception import RequestSizeError, deprecation_error, deprecation_warning
 from .object import EPHEMERAL_OBJECT_HEARTBEAT_SLEEP, _get_environment_name, _Object, live_method, live_method_gen
 
 
@@ -57,23 +57,12 @@ class _Dict(_Object, type_prefix="di"):
     """
 
     @staticmethod
-    def new(data: Optional[dict] = None) -> "_Dict":
+    def new(data: Optional[dict] = None):
         """`Dict.new` is deprecated.
 
         Please use `Dict.from_name` (for persisted) or `Dict.ephemeral` (for ephemeral) dicts.
         """
-        deprecation_warning((2024, 3, 19), Dict.new.__doc__)
-
-        async def _load(self: _Dict, resolver: Resolver, existing_object_id: Optional[str]):
-            serialized = _serialize_dict(data if data is not None else {})
-            req = api_pb2.DictCreateRequest(
-                app_id=resolver.app_id, data=serialized, existing_dict_id=existing_object_id
-            )
-            response = await resolver.client.stub.DictCreate(req)
-            logger.debug(f"Created dict with id {response.dict_id}")
-            self._hydrate(response.dict_id, resolver.client, None)
-
-        return _Dict._from_loader(_load, "Dict()")
+        deprecation_error((2024, 3, 19), Dict.new.__doc__)
 
     def __init__(self, data={}):
         """mdmd:hidden"""

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -89,31 +89,13 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
     """
 
     @staticmethod
-    def new(cloud: Optional[str] = None) -> "_NetworkFileSystem":
+    def new(cloud: Optional[str] = None):
         """`NetworkFileSystem.new` is deprecated.
 
         Please use `NetworkFileSystem.from_name` (for persisted) or `NetworkFileSystem.ephemeral`
         (for ephemeral) network filesystems.
         """
-        deprecation_warning((2024, 3, 20), NetworkFileSystem.new.__doc__)
-
-        async def _load(self: _NetworkFileSystem, resolver: Resolver, existing_object_id: Optional[str]):
-            status_row = resolver.add_status_row()
-            if existing_object_id:
-                # Volume already exists; do nothing.
-                self._hydrate(existing_object_id, resolver.client, None)
-                return
-
-            if cloud:
-                deprecation_error((2024, 1, 17), "Argument `cloud` is deprecated (has no effect).")
-
-            status_row.message("Creating network file system...")
-            req = api_pb2.SharedVolumeCreateRequest(app_id=resolver.app_id)
-            resp = await retry_transient_errors(resolver.client.stub.SharedVolumeCreate, req)
-            status_row.finish("Created network file system.")
-            self._hydrate(resp.shared_volume_id, resolver.client, None)
-
-        return _NetworkFileSystem._from_loader(_load, "NetworkFileSystem()")
+        deprecation_error((2024, 3, 20), NetworkFileSystem.new.__doc__)
 
     @staticmethod
     def from_name(

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -15,7 +15,7 @@ from ._utils.async_utils import TaskContext, synchronize_api, warn_if_generator_
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from .client import _Client
-from .exception import InvalidError, RequestSizeError, deprecation_warning
+from .exception import InvalidError, RequestSizeError, deprecation_error, deprecation_warning
 from .object import EPHEMERAL_OBJECT_HEARTBEAT_SLEEP, _get_environment_name, _Object, live_method, live_method_gen
 
 
@@ -92,14 +92,7 @@ class _Queue(_Object, type_prefix="qu"):
 
         Please use `Queue.from_name` (for persisted) or `Queue.ephemeral` (for ephemeral) queues.
         """
-        deprecation_warning((2024, 3, 19), Queue.new.__doc__)
-
-        async def _load(self: _Queue, resolver: Resolver, existing_object_id: Optional[str]):
-            request = api_pb2.QueueCreateRequest(app_id=resolver.app_id, existing_queue_id=existing_object_id)
-            response = await resolver.client.stub.QueueCreate(request)
-            self._hydrate(response.queue_id, resolver.client, None)
-
-        return _Queue._from_loader(_load, "Queue()")
+        deprecation_error((2024, 3, 19), Queue.new.__doc__)
 
     def __init__(self):
         """mdmd:hidden"""

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -28,10 +28,15 @@ async def test_kwargs(servicer, client):
 
 @pytest.mark.asyncio
 async def test_attrs(servicer, client):
+    # Create some objects
+    Dict.lookup("xyz", create_if_missing=True, client=client)
+    Queue.lookup("xyz", create_if_missing=True, client=client)
+
+    # Test stub assignment
     app = App()
     with pytest.warns(DeprecationError):
-        app.d = Dict.new()
-        app.q = Queue.new()
+        app.d = Dict.from_name("xyz")
+        app.q = Queue.from_name("xyz")
     async with app.run(client=client):
         with pytest.warns(DeprecationError):
             await app.d.put.aio("foo", "bar")  # type: ignore

--- a/test/network_file_system_test.py
+++ b/test/network_file_system_test.py
@@ -6,7 +6,6 @@ from unittest import mock
 
 import modal
 from modal.exception import DeprecationError, InvalidError, NotFoundError
-from modal.runner import deploy_app
 
 
 def dummy():
@@ -95,38 +94,6 @@ async def test_network_file_system_handle_big_file(client, tmp_path, servicer, b
 
         _, blobs = blob_server
         assert blobs["bl-1"] == b"hello world, this is a lot of text"
-
-
-def test_redeploy(servicer, client):
-    app = modal.App()
-    with pytest.warns(DeprecationError):
-        n1 = modal.NetworkFileSystem.new()
-        n2 = modal.NetworkFileSystem.new()
-        n3 = modal.NetworkFileSystem.new()
-        app.n1, app.n2, app.n3 = n1, n2, n3
-
-    # Deploy app once
-    deploy_app(app, "my-app", client=client)
-    app1_ids = [n1.object_id, n2.object_id, n3.object_id]
-
-    # Deploy app again
-    deploy_app(app, "my-app", client=client)
-    app2_ids = [n1.object_id, n2.object_id, n3.object_id]
-
-    # Make sure ids are stable
-    assert app1_ids == app2_ids
-
-    # Make sure ids are unique
-    assert len(set(app1_ids)) == 3
-    assert len(set(app2_ids)) == 3
-
-    # Deploy to a different app
-    deploy_app(app, "my-other-app", client=client)
-    app3_ids = [n1.object_id, n2.object_id, n3.object_id]
-
-    # Should be unique and different
-    assert len(set(app3_ids)) == 3
-    assert set(app1_ids) & set(app3_ids) == set()
 
 
 def test_read_file(client, tmp_path, servicer):

--- a/test/object_test.py
+++ b/test/object_test.py
@@ -7,9 +7,11 @@ from modal.exception import DeprecationError, InvalidError
 
 @pytest.mark.asyncio
 async def test_async_factory(client):
+    Queue.lookup("xyz", create_if_missing=True, client=client)
+
     app = App()
     with pytest.warns(DeprecationError):
-        app.my_factory = Queue.new()
+        app.my_factory = Queue.from_name("xyz")
         async with app.run(client=client):
             assert isinstance(app.my_factory, Queue)
             assert app.my_factory.object_id == "qu-1"

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -12,7 +12,6 @@ from unittest import mock
 
 import modal
 from modal.exception import DeprecationError, InvalidError, NotFoundError, VolumeUploadTimeoutError
-from modal.runner import deploy_app
 from modal.volume import _open_files_error_annotation
 from modal_proto import api_pb2
 
@@ -106,39 +105,6 @@ def test_volume_reload(client, servicer):
         vol.reload()
 
         assert servicer.volume_reloads[vol.object_id] == 1
-
-
-def test_redeploy(servicer, client):
-    app = modal.App()
-
-    with pytest.warns(DeprecationError):
-        v1 = modal.Volume.new()
-        v2 = modal.Volume.new()
-        v3 = modal.Volume.new()
-        app.v1, app.v2, app.v3 = v1, v2, v3
-
-    # Deploy app once
-    deploy_app(app, "my-app", client=client)
-    app1_ids = [v1.object_id, v2.object_id, v3.object_id]
-
-    # Deploy app again
-    deploy_app(app, "my-app", client=client)
-    app2_ids = [v1.object_id, v2.object_id, v3.object_id]
-
-    # Make sure ids are stable
-    assert app1_ids == app2_ids
-
-    # Make sure ids are unique
-    assert len(set(app1_ids)) == 3
-    assert len(set(app2_ids)) == 3
-
-    # Deploy to a different app
-    deploy_app(app, "my-other-app", client=client)
-    app3_ids = [v1.object_id, v2.object_id, v3.object_id]
-
-    # Should be unique and different
-    assert len(set(app3_ids)) == 3
-    assert set(app1_ids) & set(app3_ids) == set()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Looking at an internal dashboard and I see almost no volume for the old RPC endpoints.

* `SharedVolumeCreate`: 32 calls in the last week
* `VolumeCreate`: 5 calls in the last week
* `DictCreate`: 478 calls in the last week
* `QueueCreate`: 330 calls in the last week

This PR removes the support client-side. We will still keep it server-side for a bit. In maybe a month let's delete the implementation of those RPC endpoints and raise a grpc error that the method is no longer supported.