### PR TITLE
Fix modal volume ls --json

### DIFF
--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -10,7 +10,6 @@ from grpclib import GRPCError, Status
 from rich.console import Console
 from rich.live import Live
 from rich.syntax import Syntax
-from rich.table import Table
 from typer import Argument, Option, Typer
 
 import modal
@@ -143,13 +142,12 @@ async def ls(
             raise UsageError(exc.message)
         raise
 
-    if sys.stdout.isatty():
-        console = Console()
-        console.print(f"Directory listing of '{path}' in '{volume_name}'")
-        table = Table()
-        for name in ["filename", "type", "created/modified", "size"]:
-            table.add_column(name)
-
+    if not json and not sys.stdout.isatty():
+        # Legacy behavior -- I am not sure why exactly we did this originally but I don't want to break it
+        for entry in entries:
+            print(entry.path)
+    else:
+        rows = []
         for entry in entries:
             if entry.type == api_pb2.FileEntry.FileType.DIRECTORY:
                 filetype = "dir"
@@ -157,16 +155,17 @@ async def ls(
                 filetype = "link"
             else:
                 filetype = "file"
-            table.add_row(
-                entry.path,
-                filetype,
-                timestamp_to_local(entry.mtime, False),
-                humanize_filesize(entry.size),
+            rows.append(
+                (
+                    entry.path,
+                    filetype,
+                    timestamp_to_local(entry.mtime, False),
+                    humanize_filesize(entry.size),
+                )
             )
-        console.print(table)
-    else:
-        for entry in entries:
-            print(entry.path)
+        columns = ["Filename", "Type", "Created/Modified", "Size"]
+        title = f"Directory listing of '{path}' in '{volume_name}'"
+        display_table(columns, rows, json, title)
 
 
 @volume_cli.command(


### PR DESCRIPTION
Fixes MOD-3033

Apparently I added `--json` to `modal volume ls` but just forgot to actually wire it up 🤦‍♂️.

I think that's because I got distracted trying to figure out whether there is a reason that we didn't use our utility function for displaying a table here (which also does JSON output). AFAICT there isn't, although we do have a special case where we dump a much simpler representation if the output is not a terminal.

I rewrote the method to use the utility function while preserving the previous behavior for non-terminal output stream (but *not* in the case of JSON, as I think that if you are asking for JSON and piping output you really want JSON output).

Also this command didn't appear to be tested at all, so I added some testing too.