### PR TITLE
Changes how PartialMethods implement the descriptor protocol

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -220,7 +220,6 @@ class _Cls(_Object, type_prefix="cs"):
         cls._functions = functions
         cls._callables = callables
         cls._from_other_workspace = False
-        setattr(cls._user_cls, "_modal_functions", functions)  # Needed for PartialFunction.__get__
         return cls
 
     @classmethod

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -53,13 +53,24 @@ class _PartialFunction:
         self.wrapped = False  # Make sure that this was converted into a FunctionHandle
 
     def __get__(self, obj, objtype=None) -> _Function:
-        # This only happens inside user methods when they refer to other methods
         k = self.raw_f.__name__
         if obj:  # Cls().fun
-            function = getattr(obj, "_modal_functions")[k]
-        else:  # Cls.fun
-            function = getattr(objtype, "_modal_functions")[k]
-        return function
+            if hasattr(obj, "_modal_functions"):
+                # This happens inside "local" user methods when they refer to other methods,
+                # e.g. Foo().parent_method() doing self.local.other_method()
+                return getattr(obj, "_modal_functions")[k]
+            else:
+                # special edge case: referencing a method of an instance of an
+                # unwrapped class (not using app.cls()) with @methods
+                # not sure what would be useful here, but lets return a bound version of the underlying function,
+                # since the class is just a vanilla class at this point
+                return self.raw_f.__get__(obj, objtype)
+
+        else:  # Cls.fun6
+            # This happens mainly during serialization of the wrapped underlying class of a Cls
+            # since we don't have the instance info here we just return the PartialFunction itself
+            # to let it be bound to a variable and become a Function later on
+            return self
 
     def __del__(self):
         if (self.flags & _PartialFunctionFlags.FUNCTION) and self.wrapped is False:

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -54,7 +54,7 @@ class _PartialFunction:
 
     def __get__(self, obj, objtype=None) -> _Function:
         k = self.raw_f.__name__
-        if obj:  # Cls().fun
+        if obj:  # accessing the method on an instance of a class, e.g. `MyClass().fun``
             if hasattr(obj, "_modal_functions"):
                 # This happens inside "local" user methods when they refer to other methods,
                 # e.g. Foo().parent_method() doing self.local.other_method()
@@ -64,9 +64,10 @@ class _PartialFunction:
                 # unwrapped class (not using app.cls()) with @methods
                 # not sure what would be useful here, but lets return a bound version of the underlying function,
                 # since the class is just a vanilla class at this point
+                # This wouldn't let the user access `.remote()` and `.local()` etc. on the function
                 return self.raw_f.__get__(obj, objtype)
 
-        else:  # Cls.fun6
+        else:  # accessing a method directly on the class, e.g. `MyClass.fun`
             # This happens mainly during serialization of the wrapped underlying class of a Cls
             # since we don't have the instance info here we just return the PartialFunction itself
             # to let it be bound to a variable and become a Function later on

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -1,14 +1,18 @@
 # Copyright Modal Labs 2022
+import inspect
 import pytest
 import threading
 from typing import TYPE_CHECKING, Dict
 
 from typing_extensions import assert_type
 
+import modal
 from modal import App, Cls, Function, Image, Queue, build, enter, exit, method
-from modal._serialization import deserialize
+from modal._serialization import deserialize, serialize
+from modal._utils.async_utils import synchronizer
 from modal.exception import DeprecationError, ExecutionError, InvalidError
 from modal.partial_function import (
+    PartialFunction,
     _find_callables_for_obj,
     _find_partial_methods_for_cls,
     _PartialFunction,
@@ -634,3 +638,45 @@ class HasSnapMethod:
 def test_snap_method_without_snapshot_enabled():
     with pytest.raises(InvalidError, match="A class must have `enable_memory_snapshot=True`"):
         app.cls(enable_memory_snapshot=False)(HasSnapMethod)
+
+
+def test_partial_function_descriptors(client):
+    class Foo:
+        def __init__(self):
+            pass
+
+        @modal.enter()
+        def enter_method(self):
+            pass
+
+        @modal.method()
+        def bar(self):
+            return "a"
+
+        @modal.web_endpoint()
+        def web(self):
+            pass
+
+    assert isinstance(Foo.bar, PartialFunction)
+
+    assert Foo().bar() == "a"
+    assert inspect.ismethod(Foo().bar)
+    app = modal.App()
+
+    modal_foo_class = app.cls(serialized=True)(Foo)
+
+    wrapped_method = modal_foo_class().bar
+    assert isinstance(wrapped_method, Function)
+
+    serialized_class = serialize(Foo)
+    revived_class = deserialize(serialized_class, client)
+
+    assert (
+        revived_class().bar() == "a"
+    )  # this instantiates the underlying "user_cls", so it should work basically like a normal Python class
+    assert isinstance(
+        revived_class.bar, PartialFunction
+    )  # but it should be a PartialFunction, so it keeps associated metadata!
+
+    # ensure that webhook metadata is kept
+    assert synchronizer._translate_in(revived_class.web).webhook_config.type == api_pb2.WEBHOOK_TYPE_FUNCTION


### PR DESCRIPTION
* `ModalWrappedCls().method` is unchanged (returns the _Obj-bound `Function` object) - *I think this is the only branch we actually made use of prior to this update*
* `ModalWrappedCls.method` and `UserCls.method` now return the PartialFunction object instead of an "unbound" Function - this is used by `serialize(UserCls)` and so the code path was previously triggered by serialized classes, but 
* UserCls().method now returns the original method bound to the UserCls instance - acts like vanilla python since that's what UserCls is

## Backward/forward compatibility checks

I'm not 100% sure this won't break anything, but I think the changes are superficially sane and all the client tests are passing.

Something that *is* changed is that anyone using `app.cls(serialized=True)` will get a larger payload in their `class_serialized` proto field since it will now contain each PartialFunction object including the code for every method of the class. This is intentional and is something that is used by serialized classes in the upcoming method-pooling change.