### PR TITLE
Rename Stub to App in modal_global_objects apps

### DIFF
--- a/modal_global_objects/images/debian_slim.py
+++ b/modal_global_objects/images/debian_slim.py
@@ -2,12 +2,12 @@
 import asyncio
 import sys
 
-from modal import Image, Stub
+from modal import App, Image
 
 
 async def main(client=None, python_version=None):
-    stub = Stub(image=Image.debian_slim(python_version))
-    async with stub.run.aio(client=client):
+    app = App(image=Image.debian_slim(python_version))
+    async with app.run.aio(client=client):
         pass
 
 

--- a/modal_global_objects/images/micromamba.py
+++ b/modal_global_objects/images/micromamba.py
@@ -2,12 +2,12 @@
 import asyncio
 import sys
 
-from modal import Image, Stub
+from modal import App, Image
 
 
 async def main(client=None, python_version=None):
-    stub = Stub(image=Image.micromamba(python_version))
-    async with stub.run.aio(client=client):
+    app = App(image=Image.micromamba(python_version))
+    async with app.run.aio(client=client):
         pass
 
 


### PR DESCRIPTION
Missed these as part of the Stub->App transition