### PR TITLE
Add dummy functions to apps that build global base images

### DIFF
--- a/modal_global_objects/images/debian_slim.py
+++ b/modal_global_objects/images/debian_slim.py
@@ -5,8 +5,13 @@ import sys
 from modal import App, Image
 
 
+def dummy():
+    pass
+
+
 async def main(client=None, python_version=None):
     app = App(image=Image.debian_slim(python_version))
+    app.function()(dummy)
     async with app.run.aio(client=client):
         pass
 

--- a/modal_global_objects/images/micromamba.py
+++ b/modal_global_objects/images/micromamba.py
@@ -5,8 +5,13 @@ import sys
 from modal import App, Image
 
 
+def dummy():
+    pass
+
+
 async def main(client=None, python_version=None):
     app = App(image=Image.micromamba(python_version))
+    app.function()(dummy)
     async with app.run.aio(client=client):
         pass
 


### PR DESCRIPTION
Following https://github.com/modal-labs/modal-client/pull/1856, images are no longer built when running apps that do not have any functions attached. That breaks that logic of our apps that build global base images on each client deployment. (Whether we should still have those apps is a good, but separate, question). This PR adds a dummy function to each app so that running the app triggers an Image build.