### PR TITLE
Added `Source` to PyPI Metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 project_urls =
     Homepage = https://modal.com
+    Source = https://github.com/modal-labs/modal-client
 keywords = modal, client, cloud, serverless, infrastructure
 classifiers =
     Topic :: System :: Distributed Computing


### PR DESCRIPTION
## Describe your changes

Specifies `Source` for PyPI metadata, as `requests` does so: https://github.com/psf/requests/blob/v2.32.3/setup.py#L130 --> https://pypi.org/project/requests/

Here's how it will look on PyPI:

<img width="108" alt="screenshot of Source on PyPI" src="https://github.com/modal-labs/modal-client/assets/8990777/be2ba5eb-4604-4b1a-942f-a61bc482dfd0">

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->

Adds Source to PyPI metadata