### PR TITLE
Add docs to web_endpoints and remove /openapi.json from default

### DIFF
--- a/modal/_asgi.py
+++ b/modal/_asgi.py
@@ -137,13 +137,17 @@ def wsgi_app_wrapper(wsgi_app, function_io_manager):
     return asgi_app_wrapper(asgi_app, function_io_manager)
 
 
-def webhook_asgi_app(fn: Callable, method: str):
+def webhook_asgi_app(fn: Callable, method: str, docs_flags: int):
     """Return a FastAPI app wrapping a function handler."""
     # Pulls in `fastapi` module, which is slow to import.
     from fastapi import FastAPI
     from fastapi.middleware.cors import CORSMiddleware
 
-    app = FastAPI(docs_url=None, redoc_url=None)
+    docs_url = "/docs" if docs_flags & 1 else None
+    redoc_url = "/redoc" if docs_flags & 2 else None
+    openapi_url = "/openapi.json" if docs_flags & 4 else None
+
+    app = FastAPI(docs_url=docs_url, redoc_url=redoc_url, openapi_url=openapi_url)
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],

--- a/modal/_asgi.py
+++ b/modal/_asgi.py
@@ -137,17 +137,13 @@ def wsgi_app_wrapper(wsgi_app, function_io_manager):
     return asgi_app_wrapper(asgi_app, function_io_manager)
 
 
-def webhook_asgi_app(fn: Callable, method: str, docs_flags: int):
+def webhook_asgi_app(fn: Callable, method: str, docs: bool):
     """Return a FastAPI app wrapping a function handler."""
     # Pulls in `fastapi` module, which is slow to import.
     from fastapi import FastAPI
     from fastapi.middleware.cors import CORSMiddleware
 
-    docs_url = "/docs" if docs_flags & 1 else None
-    redoc_url = "/redoc" if docs_flags & 2 else None
-    openapi_url = "/openapi.json" if docs_flags & 4 else None
-
-    app = FastAPI(docs_url=docs_url, redoc_url=redoc_url, openapi_url=openapi_url)
+    app = FastAPI(openapi_url="/openapi.json" if docs else None)  # disabling openapi.json disables all docs
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],

--- a/modal/_asgi.py
+++ b/modal/_asgi.py
@@ -143,7 +143,7 @@ def webhook_asgi_app(fn: Callable, method: str, docs: bool):
     from fastapi import FastAPI
     from fastapi.middleware.cors import CORSMiddleware
 
-    app = FastAPI(openapi_url="/openapi.json" if docs else None)  # disabling openapi.json disables all docs
+    app = FastAPI(openapi_url="/openapi.json" if docs else None)  # disabling openapi spec disables all docs
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -504,7 +504,7 @@ def finalize_function(
             webhook_asgi_app(
                 imp_fun.user_defined_callable,
                 imp_fun.webhook_config.method,
-                imp_fun.webhook_config.fastapi_endpoint_docs,
+                imp_fun.webhook_config.web_endpoint_docs,
             ),
             container_io_manager,
         )

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -504,7 +504,7 @@ def finalize_function(
             webhook_asgi_app(
                 imp_fun.user_defined_callable,
                 imp_fun.webhook_config.method,
-                imp_fun.webhook_config.fastapi_endpoint_docs_flags,
+                imp_fun.webhook_config.fastapi_endpoint_docs,
             ),
             container_io_manager,
         )

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -501,7 +501,11 @@ def finalize_function(
     elif imp_fun.webhook_config.type == api_pb2.WEBHOOK_TYPE_FUNCTION:
         # Function is a webhook without an ASGI app. Create one for it.
         callable = asgi_app_wrapper(
-            webhook_asgi_app(imp_fun.user_defined_callable, imp_fun.webhook_config.method),
+            webhook_asgi_app(
+                imp_fun.user_defined_callable,
+                imp_fun.webhook_config.method,
+                imp_fun.webhook_config.fastapi_endpoint_docs_flags,
+            ),
             container_io_manager,
         )
 

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -187,9 +187,7 @@ def _web_endpoint(
     _warn_parentheses_missing=None,
     *,
     method: str = "GET",  # REST method for the created endpoint.
-    docs: bool = False,  # Whether to enable the Swagger UI documentation for this endpoint.
-    redoc: bool = False,  # Whether to enable the ReDoc documentation for this endpoint.
-    openapi: bool = False,  # Whether to expose the OpenAPI json for this endpoint.
+    docs: bool = False,  # Whether to enable interactive documentation for this endpoint at /docs.
     label: Optional[str] = None,  # Label for created endpoint. Final subdomain will be <workspace>--<label>.modal.run.
     wait_for_response: bool = True,  # Whether requests should wait for and return the function response.
     custom_domains: Optional[
@@ -237,21 +235,13 @@ def _web_endpoint(
 
         # self._loose_webhook_configs.add(raw_f)
 
-        docs_flags = 0
-        if docs:
-            docs_flags += 1
-        if redoc:
-            docs_flags += 2
-        if openapi:
-            docs_flags += 4
-
         return _PartialFunction(
             raw_f,
             _PartialFunctionFlags.FUNCTION,
             api_pb2.WebhookConfig(
                 type=api_pb2.WEBHOOK_TYPE_FUNCTION,
                 method=method,
-                fastapi_endpoint_docs_flags=docs_flags,
+                fastapi_endpoint_docs=docs,
                 requested_suffix=label,
                 async_mode=_response_mode,
                 custom_domains=_parse_custom_domains(custom_domains),

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -241,7 +241,7 @@ def _web_endpoint(
             api_pb2.WebhookConfig(
                 type=api_pb2.WEBHOOK_TYPE_FUNCTION,
                 method=method,
-                fastapi_endpoint_docs=docs,
+                web_endpoint_docs=docs,
                 requested_suffix=label,
                 async_mode=_response_mode,
                 custom_domains=_parse_custom_domains(custom_domains),

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -187,6 +187,9 @@ def _web_endpoint(
     _warn_parentheses_missing=None,
     *,
     method: str = "GET",  # REST method for the created endpoint.
+    docs: bool = False,  # Whether to enable the Swagger UI documentation for this endpoint.
+    redoc: bool = False,  # Whether to enable the ReDoc documentation for this endpoint.
+    openapi: bool = False,  # Whether to expose the OpenAPI json for this endpoint.
     label: Optional[str] = None,  # Label for created endpoint. Final subdomain will be <workspace>--<label>.modal.run.
     wait_for_response: bool = True,  # Whether requests should wait for and return the function response.
     custom_domains: Optional[
@@ -234,12 +237,21 @@ def _web_endpoint(
 
         # self._loose_webhook_configs.add(raw_f)
 
+        docs_flags = 0
+        if docs:
+            docs_flags += 1
+        if redoc:
+            docs_flags += 2
+        if openapi:
+            docs_flags += 4
+
         return _PartialFunction(
             raw_f,
             _PartialFunctionFlags.FUNCTION,
             api_pb2.WebhookConfig(
                 type=api_pb2.WEBHOOK_TYPE_FUNCTION,
                 method=method,
+                fastapi_endpoint_docs_flags=docs_flags,
                 requested_suffix=label,
                 async_mode=_response_mode,
                 custom_domains=_parse_custom_domains(custom_domains),

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -187,8 +187,8 @@ def _web_endpoint(
     _warn_parentheses_missing=None,
     *,
     method: str = "GET",  # REST method for the created endpoint.
-    docs: bool = False,  # Whether to enable interactive documentation for this endpoint at /docs.
     label: Optional[str] = None,  # Label for created endpoint. Final subdomain will be <workspace>--<label>.modal.run.
+    docs: bool = False,  # Whether to enable interactive documentation for this endpoint at /docs.
     wait_for_response: bool = True,  # Whether requests should wait for and return the function response.
     custom_domains: Optional[
         Iterable[str]

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2088,6 +2088,7 @@ message WebhookConfig {
   repeated CustomDomainConfig custom_domains = 6;
   uint32 web_server_port = 7;
   float web_server_startup_timeout = 8;
+  uint32 fastapi_endpoint_docs_flags = 9;
 }
 
 message WorkspaceNameLookupResponse {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2088,7 +2088,7 @@ message WebhookConfig {
   repeated CustomDomainConfig custom_domains = 6;
   uint32 web_server_port = 7;
   float web_server_startup_timeout = 8;
-  uint32 fastapi_endpoint_docs_flags = 9;
+  bool fastapi_endpoint_docs = 9;
 }
 
 message WorkspaceNameLookupResponse {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2088,7 +2088,7 @@ message WebhookConfig {
   repeated CustomDomainConfig custom_domains = 6;
   uint32 web_server_port = 7;
   float web_server_startup_timeout = 8;
-  bool fastapi_endpoint_docs = 9;
+  bool web_endpoint_docs = 9;
 }
 
 message WorkspaceNameLookupResponse {

--- a/test/webhook_test.py
+++ b/test/webhook_test.py
@@ -17,7 +17,7 @@ app = App()
 
 
 @app.function(cpu=42)
-@web_endpoint(method="PATCH")
+@web_endpoint(method="PATCH", docs=True)
 async def f(x):
     return {"square": x**2}
 
@@ -46,7 +46,7 @@ def test_webhook_cors():
     def handler():
         return {"message": "Hello, World!"}
 
-    app = webhook_asgi_app(handler, method="GET", docs_flags=0)
+    app = webhook_asgi_app(handler, method="GET", docs=False)
     client = TestClient(app)
     resp = client.options(
         "/",
@@ -71,7 +71,7 @@ async def test_webhook_no_docs():
     def handler():
         return {"message": "Hello, World!"}
 
-    app = webhook_asgi_app(handler, method="GET", docs_flags=0)
+    app = webhook_asgi_app(handler, method="GET", docs=False)
     client = TestClient(app)
     assert client.get("/docs").status_code == 404
     assert client.get("/redoc").status_code == 404
@@ -80,21 +80,14 @@ async def test_webhook_no_docs():
 
 @pytest.mark.asyncio
 async def test_webhook_docs():
-    # FastAPI docs on webhooks are enabled by flipping bits in the `docs_flags` parameter.
-
+    # By turning on docs, we should get three new routes: /docs, /redoc, and /openapi.json
     def handler():
-        return {"message": "Hello, World!"}
+        return {"message": "Hello, docs!"}
 
-    app = webhook_asgi_app(handler, method="GET", docs_flags=7)
+    app = webhook_asgi_app(handler, method="GET", docs=True)
     client = TestClient(app)
     assert client.get("/docs").status_code == 200
     assert client.get("/redoc").status_code == 200
-    assert client.get("/openapi.json").status_code == 200
-
-    app = webhook_asgi_app(handler, method="GET", docs_flags=5)
-    client = TestClient(app)
-    assert client.get("/docs").status_code == 200
-    assert client.get("/redoc").status_code == 404
     assert client.get("/openapi.json").status_code == 200
 
 


### PR DESCRIPTION
## Describe your changes

[Linear ticket](https://linear.app/modal-labs/issue/MOD-2896/allow-enabling-docs-url-on-web-endpoints)

Allows activation of Swagger/Redoc docs by passing a flag to `web_endpoint`. Also disables `/openapi.json` route by default. This is implemented internally via a new boolean field on `WebhookConfig`.

Tested by running against a devbox Modal instance.

## Backward/forward compatibility checks

Don't think I fully understand the implications here, so looking for review!

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

## Changelog

- `web_endpoint`s now have the option to include interactive SwaggerUI/redoc docs by setting `docs=True`
- `web_endpoint`s no longer include an OpenAPI JSON spec route by default
