### PR TITLE
Add --tag as optional parameter to modal deploy

### DIFF
--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -273,6 +273,7 @@ def deploy(
     ),
     skip_confirm: bool = typer.Option(False, help="Skip public app confirmation dialog."),
     stream_logs: bool = typer.Option(False, help="Stream logs from the app upon deployment."),
+    tag: Optional[str] = typer.Option(None, help="Tag the deployment with a version."),
 ):
     # this ensures that `modal.lookup()` without environment specification uses the same env as specified
     env = ensure_env(env)
@@ -291,7 +292,7 @@ def deploy(
         ):
             return
 
-    res = deploy_app(app, name=name, environment_name=env, public=public)
+    res = deploy_app(app, name=name, environment_name=env, public=public, tag=tag)
 
     if stream_logs:
         stream_app_logs(res.app_id)

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -273,7 +273,7 @@ def deploy(
     ),
     skip_confirm: bool = typer.Option(False, help="Skip public app confirmation dialog."),
     stream_logs: bool = typer.Option(False, help="Stream logs from the app upon deployment."),
-    tag: Optional[str] = typer.Option(None, help="Tag the deployment with a version."),
+    tag: str = typer.Option(None, help="Tag the deployment with a version."),
 ):
     # this ensures that `modal.lookup()` without environment specification uses the same env as specified
     env = ensure_env(env)

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -17,7 +17,7 @@ from ._resolver import Resolver
 from ._sandbox_shell import connect_to_sandbox
 from ._utils.async_utils import TaskContext, synchronize_api
 from ._utils.grpc_utils import retry_transient_errors
-from ._utils.name_utils import check_object_name
+from ._utils.name_utils import check_object_name, is_valid_tag
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, _Client
 from .config import config, logger
 from .exception import (
@@ -413,6 +413,13 @@ async def _deploy_app(
         )
     else:
         check_object_name(name, "App")
+
+    if tag is not None and not is_valid_tag(tag):
+        raise InvalidError(
+            f"Tag {tag} is invalid."
+            "\n\nTags may only contain alphanumeric characters, dashes, periods, and underscores, "
+            "and must be 50 characters or less"
+        )
 
     if client is None:
         client = await _Client.from_env()

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -373,6 +373,7 @@ async def _deploy_app(
     show_progress=True,
     environment_name: Optional[str] = None,
     public: bool = False,
+    tag: Optional[str] = None,
 ) -> DeployResult:
     """Deploy an app and export its objects persistently.
 
@@ -445,6 +446,7 @@ async def _deploy_app(
             deploy_req = api_pb2.AppDeployRequest(
                 app_id=running_app.app_id,
                 name=name,
+                tag=tag,
                 namespace=namespace,
                 object_entity="ap",
                 visibility=(

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -231,6 +231,7 @@ message AppDeployRequest {
   string name = 3;
   string object_entity = 4;
   AppDeployVisibility visibility = 5;
+  string tag = 6;
 }
 
 message AppDeployResponse {


### PR DESCRIPTION
## Describe your changes

https://github.com/modal-labs/modal/pull/13137


## Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ x ] Client+Server: this change is compatible with old servers
- [ x ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


## Changelog

- `modal deploy` now accepts a `--tag` optional parameter that allows you to specify a custom tag for the deployed version, making it easier to identify and manage different deployments of your app.