### PR TITLE
Increase limit on web_server proxy header size

### DIFF
--- a/modal/_asgi.py
+++ b/modal/_asgi.py
@@ -324,6 +324,8 @@ def web_server_proxy(host: str, port: int):
                 timeout=aiohttp.ClientTimeout(total=3600),
                 auto_decompress=False,
                 read_bufsize=1024 * 1024,  # 1 MiB
+                max_line_size=64 * 1024,  # 64 KiB
+                max_field_size=64 * 1024,  # 64 KiB
             )
 
         try:


### PR DESCRIPTION
The default is 8 KiB, which is very small for 2024. Anyway, this lets us run Modal in Modal.

## Changelog

- `@web_server` endpoints can now return HTTP headers of up to 64 KiB in length. Previously, they were limited to 8 KiB due to an implementation detail.