### PR TITLE
Add task id and input start/finish times to FunctionGetOutputsItem

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1059,7 +1059,7 @@ message FunctionGetOutputsItem {
   DataFormat data_format = 5; // for result.data_oneof
   string task_id = 6;
   double input_started_at = 7;
-  double input_finished_at = 8;
+  double output_created_at = 8;
 }
 
 message FunctionGetOutputsRequest {


### PR DESCRIPTION
## Describe your changes

Add task id and input start/finish times to `FunctionGetOutputsItem`

## Backward/forward compatibility checks

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself