### PR TITLE
Minor updated wording in docs to clarify available environment variables when calling a function with `.local`.

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1035,7 +1035,8 @@ class _Function(_Object, type_prefix="fu"):
         Calls the function locally, executing it with the given arguments and returning the execution's result.
 
         The function will execute in the same environment as the caller, just like calling the underlying function
-        directly in Python. In particular, secrets will not be available through environment variables.
+        directly in Python. In particular, only secrets available in the caller environment will be available
+        through environment variables.
         """
         # TODO(erikbern): it would be nice to remove the nowrap thing, but right now that would cause
         # "user code" to run on the synchronicity thread, which seems bad


### PR DESCRIPTION
## Describe your changes

Updated wording in docs per @erikbern suggestion in [issue #1885](https://github.com/modal-labs/modal-client/issues/1885#issuecomment-2159118855).