### PR TITLE
turn (get|set)(item|attr) deprecation warnings into errors

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -247,16 +247,12 @@ class _App:
             d[x] = y  # Refer to d in global scope
         ```
         """
-        deprecation_warning((2024, 3, 25), _App.__getitem__.__doc__)
-        return self._indexed_objects[tag]
+        deprecation_error((2024, 3, 25), _App.__getitem__.__doc__)
 
     def __setitem__(self, tag: str, obj: _Object):
-        deprecation_warning((2024, 3, 25), _App.__getitem__.__doc__)
-        self._validate_blueprint_value(tag, obj)
-        # Deprecated ?
-        self._add_object(tag, obj)
+        deprecation_error((2024, 3, 25), _App.__getitem__.__doc__)
 
-    def __getattr__(self, tag: str) -> _Object:
+    def __getattr__(self, tag: str):
         # TODO(erikbern): remove this method later
         assert isinstance(tag, str)
         if tag.startswith("__"):
@@ -265,9 +261,7 @@ class _App:
         if tag not in self._indexed_objects:
             # Primarily to make hasattr work
             raise AttributeError(f"App has no member {tag}")
-        obj: _Object = self._indexed_objects[tag]
-        deprecation_warning((2024, 3, 25), _App.__getitem__.__doc__)
-        return obj
+        deprecation_error((2024, 3, 25), _App.__getitem__.__doc__)
 
     def __setattr__(self, tag: str, obj: _Object):
         # TODO(erikbern): remove this method later
@@ -278,9 +272,7 @@ class _App:
         elif tag == "image":
             self._image = obj
         else:
-            self._validate_blueprint_value(tag, obj)
-            deprecation_warning((2024, 3, 25), _App.__getitem__.__doc__)
-            self._add_object(tag, obj)
+            deprecation_error((2024, 3, 25), _App.__getitem__.__doc__)
 
     @property
     def image(self) -> _Image:

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -8,7 +8,6 @@ from grpclib import GRPCError, Status
 
 from modal import App, Dict, Image, Mount, Queue, Secret, Stub, Volume, web_endpoint
 from modal.app import list_apps  # type: ignore
-from modal.config import config
 from modal.exception import DeprecationError, ExecutionError, InvalidError, NotFoundError
 from modal.partial_function import _parse_custom_domains
 from modal.runner import deploy_app, deploy_stub
@@ -289,26 +288,6 @@ async def test_deploy_disconnect(servicer, client):
         api_pb2.APP_STATE_INITIALIZING,
         api_pb2.APP_STATE_STOPPED,
     ]
-
-
-def test_redeploy_from_name_change(servicer, client):
-    # Deploy queue
-    Queue.lookup("foo-queue", create_if_missing=True, client=client)
-
-    # Use it from app
-    app = App()
-    with pytest.warns(DeprecationError):
-        app.q = Queue.from_name("foo-queue")
-    deploy_app(app, "my-app", client=client)
-
-    # Change the object id of foo-queue
-    k = ("foo-queue", api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, config.get("environment"))
-    assert servicer.deployed_queues[k]
-    servicer.deployed_queues[k] = "qu-baz123"
-
-    # Redeploy app
-    # This should not fail because the object_id changed - it's a different app
-    deploy_app(app, "my-app", client=client)
 
 
 def test_parse_custom_domains():

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -28,21 +28,9 @@ async def test_kwargs(servicer, client):
 
 @pytest.mark.asyncio
 async def test_attrs(servicer, client):
-    # Create some objects
-    Dict.lookup("xyz", create_if_missing=True, client=client)
-    Queue.lookup("xyz", create_if_missing=True, client=client)
-
-    # Test stub assignment
     app = App()
-    with pytest.warns(DeprecationError):
+    with pytest.raises(DeprecationError):
         app.d = Dict.from_name("xyz")
-        app.q = Queue.from_name("xyz")
-    async with app.run(client=client):
-        with pytest.warns(DeprecationError):
-            await app.d.put.aio("foo", "bar")  # type: ignore
-            await app.q.put.aio("baz")  # type: ignore
-            assert await app.d.get.aio("foo") == "bar"  # type: ignore
-            assert await app.q.get.aio() == "baz"  # type: ignore
 
 
 def square(x):

--- a/test/object_test.py
+++ b/test/object_test.py
@@ -1,20 +1,8 @@
 # Copyright Modal Labs 2022
 import pytest
 
-from modal import App, Queue, Secret
-from modal.exception import DeprecationError, InvalidError
-
-
-@pytest.mark.asyncio
-async def test_async_factory(client):
-    Queue.lookup("xyz", create_if_missing=True, client=client)
-
-    app = App()
-    with pytest.warns(DeprecationError):
-        app.my_factory = Queue.from_name("xyz")
-        async with app.run(client=client):
-            assert isinstance(app.my_factory, Queue)
-            assert app.my_factory.object_id == "qu-1"
+from modal import Secret
+from modal.exception import InvalidError
 
 
 def test_new_hydrated(client):


### PR DESCRIPTION
It's been deprecated since March 25, so we can probably turn it into an error relatively soon. I might wait 2 weeks just to make it an even 3 months.