### PR TITLE
Fix CI and `modal serve` after #1898

### DIFF
--- a/modal/serving.py
+++ b/modal/serving.py
@@ -122,7 +122,6 @@ async def _serve_app(
 
     async with _run_app(app, client=client, output_mgr=output_mgr, environment_name=environment_name):
         app_id: str = app.app_id
-        client.set_pre_stop(lambda: _disconnect(client, app_id))
         async with TaskContext(grace=0.1) as tc:
             tc.create_task(_run_watch_loop(app_ref, app.app_id, output_mgr, watcher, environment_name))
             yield app

--- a/modal/serving.py
+++ b/modal/serving.py
@@ -18,7 +18,7 @@ from .cli.import_refs import import_app
 from .client import _Client
 from .config import config
 from .exception import deprecation_warning
-from .runner import _disconnect, _run_app, serve_update
+from .runner import _run_app, serve_update
 
 if TYPE_CHECKING:
     from .app import _App
@@ -121,7 +121,6 @@ async def _serve_app(
         watcher = watch(mounts_to_watch, output_mgr)
 
     async with _run_app(app, client=client, output_mgr=output_mgr, environment_name=environment_name):
-        app_id: str = app.app_id
         async with TaskContext(grace=0.1) as tc:
             tc.create_task(_run_watch_loop(app_ref, app.app_id, output_mgr, watcher, environment_name))
             yield app


### PR DESCRIPTION
Seems to be failing CI unfortunately. After reading this code I think the set_pre_stop hook isn't necessary because _run_app already sends APP_DISCONNECT_REASON_KEYBOARD_INTERRUPT