### PR TITLE
[MOD-2923] Add SHELL and ENTRYPOINT to client Image SDK

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -858,10 +858,10 @@ class _Image(_Object, type_prefix="im"):
 
     def entrypoint(
         self,
-        *entrypoint_files: Union[str, List[str]],
+        entrypoint_args: List[str],
     ) -> "_Image":
         """Set the entrypoint for the image."""
-        args_str = _flatten_str_args("entrypoint", "entrypoint_files", entrypoint_files)
+        args_str = _flatten_str_args("entrypoint", "entrypoint_files", entrypoint_args)
         args_str = '"' + '", "'.join(args_str) + '"' if args_str else ""
         dockerfile_cmd = f"ENTRYPOINT [{args_str}]"
 
@@ -869,7 +869,7 @@ class _Image(_Object, type_prefix="im"):
 
     def shell(
         self,
-        *shell_commands: Union[str, List[str]],
+        shell_commands: List[str],
     ) -> "_Image":
         """Overwrite default shell for the image."""
         args_str = _flatten_str_args("shell", "shell_commands", shell_commands)

--- a/modal/image.py
+++ b/modal/image.py
@@ -856,6 +856,28 @@ class _Image(_Object, type_prefix="im"):
             force_build=self.force_build or force_build,
         )
 
+    def entrypoint(
+        self,
+        *entrypoint_files: Union[str, List[str]],
+    ) -> "_Image":
+        """Set the entrypoint for the image."""
+        args_str = _flatten_str_args("entrypoint", "entrypoint_files", entrypoint_files)
+        args_str = '"' + '", "'.join(args_str) + '"' if args_str else ""
+        dockerfile_cmd = f"ENTRYPOINT [{args_str}]"
+
+        return self.dockerfile_commands(dockerfile_cmd)
+
+    def shell(
+        self,
+        *shell_commands: Union[str, List[str]],
+    ) -> "_Image":
+        """Overwrite default shell for the image."""
+        args_str = _flatten_str_args("shell", "shell_commands", shell_commands)
+        args_str = '"' + '", "'.join(args_str) + '"' if args_str else ""
+        dockerfile_cmd = f"SHELL [{args_str}]"
+
+        return self.dockerfile_commands(dockerfile_cmd)
+
     def run_commands(
         self,
         *commands: Union[str, List[str]],

--- a/modal/image.py
+++ b/modal/image.py
@@ -858,10 +858,10 @@ class _Image(_Object, type_prefix="im"):
 
     def entrypoint(
         self,
-        entrypoint_args: List[str],
+        entrypoint_commands: List[str],
     ) -> "_Image":
         """Set the entrypoint for the image."""
-        args_str = _flatten_str_args("entrypoint", "entrypoint_files", entrypoint_args)
+        args_str = _flatten_str_args("entrypoint", "entrypoint_files", entrypoint_commands)
         args_str = '"' + '", "'.join(args_str) + '"' if args_str else ""
         dockerfile_cmd = f"ENTRYPOINT [{args_str}]"
 

--- a/modal_version/_version_generated.py
+++ b/modal_version/_version_generated.py
@@ -1,4 +1,4 @@
 # Copyright Modal Labs 2024
 
 # Note: Reset this value to -1 whenever you make a minor `0.X` release of the client.
-build_number = 214  # git: 344d803
+build_number = 215  # git: 4f0e1ae

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -629,28 +629,43 @@ def test_image_dockerfile_copy(builder_version, servicer, client, tmp_path_with_
 
 def test_image_docker_command_entrypoint(builder_version, servicer, client, tmp_path_with_content):
     app = App()
-    data_mount = Mount.from_local_dir(tmp_path_with_content, remote_path="/")
     app.image = Image.debian_slim().entrypoint([])
     app.function()(dummy)
 
     with app.run(client=client):
         layers = get_image_layers(app.image.object_id, servicer)
         assert "ENTRYPOINT []" in layers[0].dockerfile_commands
-        files = {f.mount_filename: f.content for f in Mount._get_files(data_mount.entries)}
-        assert files == {"/data.txt": b"hello", "/data/sub": b"world"}
+
+
+def test_image_docker_command_entrypoint_nonempty(builder_version, servicer, client, tmp_path_with_content):
+    app = App()
+    app.image = (
+        Image.debian_slim()
+        .dockerfile_commands(
+            [
+                "FROM public.ecr.aws/docker/library/alpine:3.19.1",
+                'RUN echo $\'#!/usr/bin/env sh\necho "hi"\nexec "$@"\' > /temp.sh',
+                "RUN chmod +x /temp.sh",
+            ]
+        )
+        .entrypoint(["/temp.sh"])
+    )
+
+    app.function()(dummy)
+
+    with app.run(client=client):
+        layers = get_image_layers(app.image.object_id, servicer)
+        assert 'ENTRYPOINT ["/temp.sh"]' in layers[0].dockerfile_commands
 
 
 def test_image_docker_command_shell(builder_version, servicer, client, tmp_path_with_content):
     app = App()
-    data_mount = Mount.from_local_dir(tmp_path_with_content, remote_path="/")
     app.image = Image.debian_slim().shell(["/bin/sh", "-c"])
     app.function()(dummy)
 
     with app.run(client=client):
         layers = get_image_layers(app.image.object_id, servicer)
         assert 'SHELL ["/bin/sh", "-c"]' in layers[0].dockerfile_commands
-        files = {f.mount_filename: f.content for f in Mount._get_files(data_mount.entries)}
-        assert files == {"/data.txt": b"hello", "/data/sub": b"world"}
 
 
 def test_image_env(builder_version, servicer, client):


### PR DESCRIPTION
## Describe your changes

Reference: [MOD-2923](https://linear.app/modal-labs/issue/MOD-2923/add-shell-and-entrypoint-to-client-image-sdk) Add SHELL and ENTRYPOINT to client Image SDK


## Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


## Changelog
- Added support for entrypoint and shell for custom containers:
- `Image.debian_slim().entrypoint([])` can be used interchangeably with `.dockerfile_commands('ENTRYPOINT []')`
- `Image.debian_slim().shell(["/bin/bash", "-c"])` can be used interchangeably with `.dockerfile_commands('SHELL ["/bin/bash", "-c"]')`

