### PR TITLE
Replace packaging.Version with a simpler internal utility

### DIFF
--- a/modal/_asgi.py
+++ b/modal/_asgi.py
@@ -3,10 +3,10 @@ import asyncio
 from typing import Any, AsyncGenerator, Callable, Dict, Optional, cast
 
 import aiohttp
-from packaging.version import Version
 
 from ._utils.async_utils import TaskContext
 from ._utils.blob_utils import MAX_OBJECT_SIZE_BYTES
+from ._utils.package_utils import parse_major_minor_version
 from .config import logger
 from .exception import ExecutionError, InvalidError
 from .execution_context import current_function_call_id
@@ -332,7 +332,7 @@ def web_server_proxy(host: str, port: int):
                         max_line_size=64 * 1024,  # 64 KiB
                         max_field_size=64 * 1024,  # 64 KiB
                     )
-                    if Version(aiohttp.__version__) >= Version("3.9")
+                    if parse_major_minor_version(aiohttp.__version__) >= (3, 9)
                     else {}
                 ),
             )

--- a/modal/_utils/package_utils.py
+++ b/modal/_utils/package_utils.py
@@ -4,6 +4,7 @@ import importlib.util
 import typing
 from importlib.metadata import PackageNotFoundError, files
 from pathlib import Path
+from typing import Tuple
 
 from ..exception import ModuleNotMountable
 
@@ -46,3 +47,16 @@ def get_module_mount_info(module_name: str) -> typing.Sequence[typing.Tuple[bool
     if not entries:
         raise ModuleNotMountable(f"{module_name} has no mountable paths")
     return entries
+
+
+def parse_major_minor_version(version_string: str) -> Tuple[int, int]:
+    parts = version_string.split(".")
+    if len(parts) < 2:
+        raise ValueError("version_string must have at least an 'X.Y' format")
+    try:
+        major = int(parts[0])
+        minor = int(parts[1])
+    except ValueError:
+        raise ValueError("version_string must have at least an 'X.Y' format with integral major/minor values")
+
+    return major, minor

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -12,6 +12,7 @@ from modal._utils.name_utils import (
     is_valid_subdomain_label,
     is_valid_tag,
 )
+from modal._utils.package_utils import parse_major_minor_version
 from modal.exception import DeprecationError, InvalidError
 
 
@@ -114,3 +115,13 @@ async def test_file_segment_payloads_concurrency():
     p2 = BytesIOSegmentPayload(data2, len(data.getvalue()) // 2, len(data.getvalue()) // 2, chunk_size=100 * 1024)
     await asyncio.gather(p2.write(out2), p1.write(out1))  # type: ignore
     assert out1.value + out2.value == data.getvalue()
+
+
+def test_parse_major_minor_version():
+    assert parse_major_minor_version("3.8") == (3, 8)
+    assert parse_major_minor_version("3.9.1") == (3, 9)
+    assert parse_major_minor_version("3.10.1rc0") == (3, 10)
+    with pytest.raises(ValueError, match="at least an 'X.Y' format"):
+        parse_major_minor_version("123")
+    with pytest.raises(ValueError, match="at least an 'X.Y' format with integral"):
+        parse_major_minor_version("x.y")


### PR DESCRIPTION
We accidentally added a container dependency on the `packaging` package. We only need a sliver of the functionality provided by the version parsing in that package at the moment, so I've replaced it with our own simple utility for now. We could vendor `packaging` as well, but it's not a trivial single-file inclusion, so I chose not to do that until we really need to.