### PR TITLE
Deal with square brackets in progress messages

### DIFF
--- a/modal/_output.py
+++ b/modal/_output.py
@@ -234,7 +234,7 @@ class OutputManager:
                 transient=True,
             )
             if self._current_render_group:
-                self._current_render_group.renderables.append(self._function_queueing_progress)
+                self._current_render_group.renderables.append(Text(self._function_queueing_progress))
         return self._function_queueing_progress
 
     def function_progress_callback(self, tag: str, total: Optional[int]) -> Callable[[int, int], None]:


### PR DESCRIPTION
Same as e8087de76c8 effectively. Trying to enrich messages when waiting in task queues elsewhere.