### PR TITLE
[MOD-3177] Differentiate between an expired output and unfinished input

### DIFF
--- a/modal/exception.py
+++ b/modal/exception.py
@@ -86,6 +86,10 @@ class DeserializationError(Error):
     """Raised to provide more context when an error is encountered during deserialization."""
 
 
+class OutputExpiredError(Error):
+    """Raised when the Output exceeds expiration and times out."""
+
+
 class RequestSizeError(Error):
     """Raised when an operation produces a gRPC request that is rejected by the server for being too large."""
 

--- a/modal/exception.py
+++ b/modal/exception.py
@@ -58,6 +58,10 @@ class InteractiveTimeoutError(TimeoutError):
     """Raised when interactive frontends time out while trying to connect to a container."""
 
 
+class OutputExpiredError(TimeoutError):
+    """Raised when the Output exceeds expiration and times out."""
+
+
 class AuthError(Error):
     """Raised when a client has missing or invalid authentication."""
 
@@ -84,10 +88,6 @@ class ExecutionError(Error):
 
 class DeserializationError(Error):
     """Raised to provide more context when an error is encountered during deserialization."""
-
-
-class OutputExpiredError(Error):
-    """Raised when the Output exceeds expiration and times out."""
 
 
 class RequestSizeError(Error):

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -151,6 +151,10 @@ class _Invocation:
                 request,
                 attempt_timeout=backend_timeout + ATTEMPT_TIMEOUT_GRACE_PERIOD,
             )
+
+            if response.is_expired:
+                raise TimeoutError("Function call outputs expired")
+
             if len(response.outputs) > 0:
                 for item in response.outputs:
                     yield item
@@ -181,7 +185,7 @@ class _Invocation:
         )
 
         if len(items) == 0:
-            raise TimeoutError()
+            raise TimeoutError("Function call has not finished")
 
         return await _process_result(items[0].result, items[0].data_format, self.stub, self.client)
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -162,7 +162,7 @@ class _Invocation:
                 # update timeout in retry loop
                 backend_timeout = min(OUTPUTS_TIMEOUT, t0 + timeout - time.time())
                 if backend_timeout < 0:
-                    if len(response.outputs) == 0 and response.num_inputs == 0:
+                    if len(response.outputs) == 0 and response.num_unfinished_inputs == 0:
                         raise OutputExpiredError()
                     break
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -163,6 +163,7 @@ class _Invocation:
 
             if len(response.outputs) > 0:
                 yield response
+                return
 
     async def run_function(self) -> Any:
         # waits indefinitely for a single result for the function, and clear the outputs buffer after

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -9,7 +9,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncGenerator,
-    AsyncIterator,
     Callable,
     Collection,
     Dict,
@@ -132,7 +131,7 @@ class _Invocation:
 
     async def pop_function_call_outputs(
         self, timeout: Optional[float], clear_on_success: bool
-    ) -> AsyncIterator[api_pb2.FunctionGetOutputsResponse]:
+    ) -> api_pb2.FunctionGetOutputsResponse:
         t0 = time.time()
         if timeout is None:
             backend_timeout = OUTPUTS_TIMEOUT
@@ -153,23 +152,21 @@ class _Invocation:
                 attempt_timeout=backend_timeout + ATTEMPT_TIMEOUT_GRACE_PERIOD,
             )
 
+            if len(response.outputs) > 0:
+                return response
+
             if timeout is not None:
                 # update timeout in retry loop
                 backend_timeout = min(OUTPUTS_TIMEOUT, t0 + timeout - time.time())
                 if backend_timeout < 0:
                     # return the last response to check for state of num_unfinished_inputs
-                    yield response
-                    break
-
-            if len(response.outputs) > 0:
-                yield response
-                return
+                    return response
 
     async def run_function(self) -> Any:
         # waits indefinitely for a single result for the function, and clear the outputs buffer after
         item: api_pb2.FunctionGetOutputsItem = (
-            await stream.list(self.pop_function_call_outputs(timeout=None, clear_on_success=True))
-        )[0].outputs[0]
+            await self.pop_function_call_outputs(timeout=None, clear_on_success=True)
+        ).outputs[0]
         assert not item.result.gen_status
         return await _process_result(item.result, item.data_format, self.stub, self.client)
 
@@ -179,17 +176,18 @@ class _Invocation:
         If timeout is `None`, waits indefinitely. This function is not
         cancellation-safe.
         """
-        responses: List[api_pb2.FunctionGetOutputsResponse] = await stream.list(
-            self.pop_function_call_outputs(timeout=timeout, clear_on_success=False)
+        response: api_pb2.FunctionGetOutputsResponse = await self.pop_function_call_outputs(
+            timeout=timeout, clear_on_success=False
         )
-        items = [item for response in responses for item in response.outputs]
-        if len(items) == 0 and responses[-1].num_unfinished_inputs == 0:
+        if len(response.outputs) == 0 and response.num_unfinished_inputs == 0:
             # if no unfinished inputs and no outputs, then function expired
             raise OutputExpiredError()
-        elif len(items) == 0:
+        elif len(response.outputs) == 0:
             raise TimeoutError()
 
-        return await _process_result(items[0].result, items[0].data_format, self.stub, self.client)
+        return await _process_result(
+            response.outputs[0].result, response.outputs[0].data_format, self.stub, self.client
+        )
 
     async def run_generator(self):
         data_stream = _stream_function_call_data(self.client, self.function_call_id, variant="data_out")

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -153,9 +153,6 @@ class _Invocation:
                 attempt_timeout=backend_timeout + ATTEMPT_TIMEOUT_GRACE_PERIOD,
             )
 
-            if len(response.outputs) == 0 and response.is_expired:
-                raise OutputExpiredError()
-
             if len(response.outputs) > 0:
                 for item in response.outputs:
                     yield item
@@ -165,6 +162,8 @@ class _Invocation:
                 # update timeout in retry loop
                 backend_timeout = min(OUTPUTS_TIMEOUT, t0 + timeout - time.time())
                 if backend_timeout < 0:
+                    if len(response.outputs) == 0 and response.num_inputs == 0:
+                        raise OutputExpiredError()
                     break
 
     async def run_function(self) -> Any:

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -62,6 +62,7 @@ from .exception import (
     ExecutionError,
     InvalidError,
     NotFoundError,
+    OutputExpiredError,
     deprecation_error,
     deprecation_warning,
 )
@@ -152,8 +153,8 @@ class _Invocation:
                 attempt_timeout=backend_timeout + ATTEMPT_TIMEOUT_GRACE_PERIOD,
             )
 
-            if response.is_expired:
-                raise TimeoutError("Function call outputs expired")
+            if len(response.outputs) == 0 and response.is_expired:
+                raise OutputExpiredError()
 
             if len(response.outputs) > 0:
                 for item in response.outputs:
@@ -185,7 +186,7 @@ class _Invocation:
         )
 
         if len(items) == 0:
-            raise TimeoutError("Function call has not finished")
+            raise TimeoutError()
 
         return await _process_result(items[0].result, items[0].data_format, self.stub, self.client)
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1069,6 +1069,7 @@ message FunctionGetOutputsResponse {
   repeated int32 idxs = 3;
   repeated FunctionGetOutputsItem outputs = 4;
   string last_entry_id = 5;
+  bool is_expired = 6;
 }
 
 message FunctionGetRequest {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1069,7 +1069,7 @@ message FunctionGetOutputsResponse {
   repeated int32 idxs = 3;
   repeated FunctionGetOutputsItem outputs = 4;
   string last_entry_id = 5;
-  bool is_expired = 6;
+  int32 num_inputs = 6;
 }
 
 message FunctionGetRequest {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1069,7 +1069,7 @@ message FunctionGetOutputsResponse {
   repeated int32 idxs = 3;
   repeated FunctionGetOutputsItem outputs = 4;
   string last_entry_id = 5;
-  int32 num_inputs = 6;
+  int32 num_unfinished_inputs = 6;
 }
 
 message FunctionGetRequest {

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -721,7 +721,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
             await stream.send_message(api_pb2.FunctionGetOutputsResponse(outputs=[output]))
         else:
-            await stream.send_message(api_pb2.FunctionGetOutputsResponse(outputs=[], num_unfinished_inputs=-1))
+            await stream.send_message(api_pb2.FunctionGetOutputsResponse(outputs=[], num_unfinished_inputs=1))
 
     async def FunctionGetSerialized(self, stream):
         await stream.send_message(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -721,7 +721,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
             await stream.send_message(api_pb2.FunctionGetOutputsResponse(outputs=[output]))
         else:
-            await stream.send_message(api_pb2.FunctionGetOutputsResponse(outputs=[]))
+            await stream.send_message(api_pb2.FunctionGetOutputsResponse(outputs=[], num_unfinished_inputs=-1))
 
     async def FunctionGetSerialized(self, stream):
         await stream.send_message(


### PR DESCRIPTION
## Describe your changes
[[MOD-3177]](https://linear.app/modal-labs/issue/MOD-3117/differentiate-between-an-expired-output-and-unfinished-input)
Return different Timeout errors for unfinished vs. expired function call outputs.
- When the function call outputs are not available, raise TimeoutError
- When the function call outputs are expired in Redis, raise OutputExpiredError

## Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


## Changelog
