### PR TITLE
Put checklists inside <details> in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,8 +2,7 @@
 
 - _Provide Linear issue reference (e.g. MOD-1234) if available._
 
-
-## Backward/forward compatibility checks
+<details> <summary>Backward/forward compatibility checks</summary>
 
 Check these boxes or delete any item (or this section) if not relevant for this PR.
 
@@ -13,6 +12,7 @@ Check these boxes or delete any item (or this section) if not relevant for this 
 Note on protobuf: protobuf message changes in one place may have impact to
 multiple entities (client, server, worker, database). See points above.
 
+</details>
 
 ## Changelog
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,8 @@
 
 <details> <summary>Backward/forward compatibility checks</summary>
 
+---
+
 Check these boxes or delete any item (or this section) if not relevant for this PR.
 
 - [ ] Client+Server: this change is compatible with old servers
@@ -11,6 +13,8 @@ Check these boxes or delete any item (or this section) if not relevant for this 
 
 Note on protobuf: protobuf message changes in one place may have impact to
 multiple entities (client, server, worker, database). See points above.
+
+---
 
 </details>
 


### PR DESCRIPTION
Changes the PR template to look like this:

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

The aim is to continue prompting PR authors on backwards compatibility (and capturing their answers) while keeping the immediately-visible PR body focused on the narrative.