### PR TITLE
Add num_input to FunctionGetOutputResponse protos

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1069,6 +1069,7 @@ message FunctionGetOutputsResponse {
   repeated int32 idxs = 3;
   repeated FunctionGetOutputsItem outputs = 4;
   string last_entry_id = 5;
+  int32 num_inputs = 6;
 }
 
 message FunctionGetRequest {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1069,7 +1069,7 @@ message FunctionGetOutputsResponse {
   repeated int32 idxs = 3;
   repeated FunctionGetOutputsItem outputs = 4;
   string last_entry_id = 5;
-  int32 num_inputs = 6;
+  int32 num_unfinished_inputs = 6;
 }
 
 message FunctionGetRequest {


### PR DESCRIPTION
## Describe your changes
[MOD-3177](https://linear.app/modal-labs/issue/MOD-3117/differentiate-between-an-expired-output-and-unfinished-input)
Added a field in protos to keep track of expiration status.
follow ups:
https://github.com/modal-labs/modal-client/pull/1905
https://github.com/modal-labs/modal/pull/13423

## Backward/forward compatibility checks

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
