### PR TITLE
Replace 'running' terminology with 'ephemeral' for app state

### DIFF
--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -20,9 +20,9 @@ app_cli = typer.Typer(name="app", help="Manage deployed and running apps.", no_a
 
 APP_STATE_TO_MESSAGE = {
     api_pb2.APP_STATE_DEPLOYED: Text("deployed", style="green"),
-    api_pb2.APP_STATE_DETACHED: Text("running (detached)", style="green"),
+    api_pb2.APP_STATE_DETACHED: Text("ephemeral (detached)", style="green"),
     api_pb2.APP_STATE_DISABLED: Text("disabled", style="dim"),
-    api_pb2.APP_STATE_EPHEMERAL: Text("running", style="green"),
+    api_pb2.APP_STATE_EPHEMERAL: Text("ephemeral", style="green"),
     api_pb2.APP_STATE_INITIALIZING: Text("initializing...", style="green"),
     api_pb2.APP_STATE_STOPPED: Text("stopped", style="blue"),
     api_pb2.APP_STATE_STOPPING: Text("stopping...", style="blue"),


### PR DESCRIPTION
The "running" terminology is a little confusing; it's always just meant "apps in an ephemeral state" but (1) one might expect it to also mean "an app that is deployed _and handling inputs_", and (2) ephemeral apps created with `modal serve` might be idling.

This aligns with a change we are making on the App page of the dashboard.

We've discussed how using "running" to connote the "handling inputs" / "idling" status would probably be best, but harder to do right now given the app status data model.

## Changelog

- The `modal app list` command now reports apps created by `modal app run` or `modal app serve` as being in an "ephemeral" state rather than a "running" state to reduce confusion with deployed apps that are actively processing inputs.