### PR TITLE
Add a deprecation notice to FunctionStats.num_active_runners

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -210,8 +210,18 @@ class FunctionStats:
     """Simple data structure storing stats for a running function."""
 
     backlog: int
-    num_active_runners: int
     num_total_runners: int
+
+    def __getattr__(self, name):
+        if name == "num_active_runners":
+            msg = (
+                "'FunctionStats.num_active_runners' is deprecated."
+                " It currently always has a value of 0,"
+                " but it will be removed in a future release."
+            )
+            deprecation_warning((2024, 6, 14), msg)
+            return 0
+        raise AttributeError(f"'FunctionStats' object has no attribute '{name}'")
 
 
 def _parse_retries(
@@ -1082,9 +1092,7 @@ class _Function(_Object, type_prefix="fu"):
             api_pb2.FunctionGetCurrentStatsRequest(function_id=self.object_id),
             total_timeout=10.0,
         )
-        return FunctionStats(
-            backlog=resp.backlog, num_active_runners=resp.num_active_tasks, num_total_runners=resp.num_total_tasks
-        )
+        return FunctionStats(backlog=resp.backlog, num_total_runners=resp.num_total_tasks)
 
     # A bit hacky - but the map-style functions need to not be synchronicity-wrapped
     # in order to not execute their input iterators on the synchronicity event loop.


### PR DESCRIPTION
Due to some backend changes, it became difficult to accurately report the value of currently active tasks, so it was removed from the RPC. We're currently reporting the default protobuf value (0), which can be misleading. This PR marks the attribute as deprecated so we can just remove it in the future.

Closes MOD-3144

## Changelog

- Due to some backend changes, the`FunctionStats.num_active_runners` attribute has been deprecated. The value will always be 0 (even on older clients), but it now issues a deprecation warning, and it will be removed in the future.