### PR TITLE
Reject container_idle_timeout=0

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -455,6 +455,9 @@ class _Function(_Object, type_prefix="fu"):
             else:
                 raise InvalidError("Webhooks cannot be generators")
 
+        if container_idle_timeout is not None and container_idle_timeout <= 0:
+            raise InvalidError("`container_idle_timeout` must be > 0")
+
         # Validate volumes
         validated_volumes = validate_volumes(volumes)
         cloud_bucket_mounts = [(k, v) for k, v in validated_volumes if isinstance(v, _CloudBucketMount)]

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -221,6 +221,12 @@ def test_function_disk_request(client):
     app.function(ephemeral_disk=1_000_000)(dummy)
 
 
+def test_idle_timeout_must_be_positive():
+    app = App()
+    with pytest.raises(InvalidError, match="must be > 0"):
+        app.function(container_idle_timeout=0)(dummy)
+
+
 def later():
     return "hello"
 


### PR DESCRIPTION
We don't support `container_idle_timeout=0`, but the server-side code treats that as an undefined protobuf field and silently ignores it in favor of the default timeout.

Technically we don't just require a positive timeout, we require a `> 2`. But that's enforced server-side and may change. I think it's better not to duplicate the minimum value, which has the risk of making a future server-side change silently non-functional -- especially as this parameter's effect is hard to notice). The cost is that some users will need to stumble through two errors when setting this to a minimum value, which is not ideal.

- Closes MOD-3148
