### PR TITLE
Fix issue with web server proxy not handling disconnect

### DIFF
--- a/modal/_asgi.py
+++ b/modal/_asgi.py
@@ -1,5 +1,6 @@
 # Copyright Modal Labs 2022
 import asyncio
+import typing
 from typing import Any, AsyncGenerator, Callable, Dict, Optional, cast
 
 import aiohttp
@@ -194,7 +195,7 @@ def wait_for_web_server(host: str, port: int, *, timeout: float) -> None:
 async def _proxy_http_request(session: aiohttp.ClientSession, scope, receive, send) -> None:
     proxy_response: Optional[aiohttp.ClientResponse] = None
 
-    async def request_generator():
+    async def request_generator() -> AsyncGenerator[bytes, None]:
         while True:
             message = await receive()
             if message["type"] == "http.request":
@@ -221,7 +222,7 @@ async def _proxy_http_request(session: aiohttp.ClientSession, scope, receive, se
         allow_redirects=False,
     )
 
-    async def send_response():
+    async def send_response() -> None:
         msg = {
             "type": "http.response.start",
             "status": proxy_response.status,
@@ -233,7 +234,7 @@ async def _proxy_http_request(session: aiohttp.ClientSession, scope, receive, se
             await send(msg)
         await send({"type": "http.response.body"})
 
-    async def listen_for_disconnect():
+    async def listen_for_disconnect() -> typing.NoReturn:
         while True:
             message = await receive()
             if message["type"] == "http.disconnect":

--- a/modal/_asgi.py
+++ b/modal/_asgi.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2022
 import asyncio
-import typing
-from typing import Any, AsyncGenerator, Callable, Dict, Optional, cast
+from typing import Any, AsyncGenerator, Callable, Dict, NoReturn, Optional, cast
 
 import aiohttp
 
@@ -234,7 +233,7 @@ async def _proxy_http_request(session: aiohttp.ClientSession, scope, receive, se
             await send(msg)
         await send({"type": "http.response.body"})
 
-    async def listen_for_disconnect() -> typing.NoReturn:
+    async def listen_for_disconnect() -> NoReturn:
         while True:
             message = await receive()
             if message["type"] == "http.disconnect":

--- a/modal/_asgi.py
+++ b/modal/_asgi.py
@@ -192,7 +192,7 @@ def wait_for_web_server(host: str, port: int, *, timeout: float) -> None:
 
 
 async def _proxy_http_request(session: aiohttp.ClientSession, scope, receive, send) -> None:
-    proxy_response: Optional[aiohttp.ClientResponse] = None
+    proxy_response: aiohttp.ClientResponse
 
     async def request_generator() -> AsyncGenerator[bytes, None]:
         while True:
@@ -243,7 +243,8 @@ async def _proxy_http_request(session: aiohttp.ClientSession, scope, receive, se
         while True:
             message = await receive()
             if message["type"] == "http.disconnect":
-                proxy_response.connection.transport.abort()
+                # based on the aiottp code, there should be a connection set after session.request
+                proxy_response.connection.transport.abort()  # type: ignore
 
     async with TaskContext() as tc:
         send_response_task = tc.create_task(send_response())

--- a/tasks.py
+++ b/tasks.py
@@ -92,6 +92,7 @@ def type_check(ctx):
     # use pyright for checking implementation of those files
     pyright_allowlist = [
         "modal/functions.py",
+        "modal/_asgi.py",
         "modal/_utils/__init__.py",
         "modal/_utils/async_utils.py",
         "modal/_utils/grpc_testing.py",

--- a/test/web_server_proxy_test.py
+++ b/test/web_server_proxy_test.py
@@ -7,8 +7,8 @@ from dataclasses import dataclass
 from typing import List
 
 import pytest_asyncio
+from aiohttp.web import Application
 from aiohttp.web_runner import AppRunner, SockSite
-from tornado.web import Application
 
 import modal._asgi
 

--- a/test/web_server_proxy_test.py
+++ b/test/web_server_proxy_test.py
@@ -19,6 +19,7 @@ import modal._asgi
 class DummyHttpServer:
     host: str
     port: int
+    event: asyncio.Event
     assertion_log: List[str]
 
 
@@ -44,6 +45,7 @@ async def http_dummy_server():
     from aiohttp import web
 
     assertion_log = []
+    event = asyncio.Event()
 
     async def hello(request):
         assertion_log.append("request")
@@ -55,6 +57,7 @@ async def http_dummy_server():
         except OSError:
             # disconnect
             assertion_log.append("disconnect")
+            event.set()
             return
 
         return web.Response(text="Hello, world")
@@ -62,11 +65,11 @@ async def http_dummy_server():
     app = web.Application()
     app.add_routes(([web.post("/", hello)]))
     async with run_temporary_http_server(app) as (host, port):
-        yield DummyHttpServer(host=host, port=port, assertion_log=assertion_log)
+        yield DummyHttpServer(host=host, port=port, event=event, assertion_log=assertion_log)
 
 
 @pytest.mark.asyncio
-async def test_web_server_wrapper_immediate_disconnect(http_dummy_server):
+async def test_web_server_wrapper_immediate_disconnect(http_dummy_server: DummyHttpServer):
     proxy_asgi_app = modal._asgi.web_server_proxy(http_dummy_server.host, http_dummy_server.port)
 
     async def recv():
@@ -77,4 +80,5 @@ async def test_web_server_wrapper_immediate_disconnect(http_dummy_server):
 
     scope = {"type": "http", "method": "POST", "path": "/", "headers": []}
     await proxy_asgi_app(scope, recv, send)
+    await http_dummy_server.event.wait()
     assert http_dummy_server.assertion_log == ["request", "disconnect"]

--- a/test/web_server_proxy_test.py
+++ b/test/web_server_proxy_test.py
@@ -25,9 +25,9 @@ class DummyHttpServer:
 async def run_temporary_http_server(app: Application):
     # Allocates a random port, runs a server in a context manager
     sock = socket.socket()
-    sock.bind(("", 0))
-    port = sock.getsockname()[1]
     host = "127.0.0.1"
+    sock.bind((host, 0))
+    port = sock.getsockname()[1]
     runner = AppRunner(app)
     await runner.setup()
     site = SockSite(runner, sock=sock)

--- a/test/web_server_proxy_test.py
+++ b/test/web_server_proxy_test.py
@@ -1,3 +1,4 @@
+# Copyright Modal Labs 2024
 import asyncio
 import contextlib
 import pytest

--- a/test/web_server_proxy_test.py
+++ b/test/web_server_proxy_test.py
@@ -1,0 +1,79 @@
+import asyncio
+import contextlib
+import pytest
+import socket
+from dataclasses import dataclass
+from typing import List
+
+import pytest_asyncio
+from aiohttp.web_runner import AppRunner, SockSite
+from tornado.web import Application
+
+import modal._asgi
+
+# TODO: add some test of may
+
+
+@dataclass
+class DummyHttpServer:
+    host: str
+    port: int
+    assertion_log: List[str]
+
+
+@contextlib.asynccontextmanager
+async def run_temporary_http_server(app: Application):
+    # Allocates a random port, runs a server in a context manager
+    sock = socket.socket()
+    sock.bind(("", 0))
+    port = sock.getsockname()[1]
+    host = "127.0.0.1"
+    runner = AppRunner(app)
+    await runner.setup()
+    site = SockSite(runner, sock=sock)
+    await site.start()
+    try:
+        yield host, port
+    finally:
+        await runner.cleanup()
+
+
+@pytest_asyncio.fixture()
+async def http_dummy_server():
+    from aiohttp import web
+
+    assertion_log = []
+
+    async def hello(request):
+        assertion_log.append("request")
+        try:
+            res = await request.read()
+            print("res", res)
+        except asyncio.CancelledError:
+            assertion_log.append("cancelled")
+        except OSError:
+            # disconnect
+            assertion_log.append("disconnect")
+
+        return web.Response(text="Hello, world")
+
+    app = web.Application()
+    app.add_routes(([web.post("/", hello)]))
+    async with run_temporary_http_server(app) as (host, port):
+        yield DummyHttpServer(host=host, port=port, assertion_log=assertion_log)
+
+
+@pytest.mark.asyncio
+async def test_web_server_wrapper_immediate_disconnect(http_dummy_server):
+    proxy_asgi_app = modal._asgi.web_server_proxy(http_dummy_server.host, http_dummy_server.port)
+
+    async def recv():
+        return {"type": "http.disconnect"}
+
+    async def send(msg):
+        print("msg", msg)
+
+    scope = {"type": "http", "method": "POST", "path": "/", "headers": []}
+    res = await proxy_asgi_app(scope, recv, send)
+    assert http_dummy_server.assertion_log == ["request", "cancelled"]
+    print(res)


### PR DESCRIPTION
Also adds `_asgi.py` to `pyright` tests, which would have caught this bug

I haven't worked out to fix for the test yet (haven't found a straight forward way to get aiohttp to close the downstream connection while consuming `data` - we might have to use some lower level request sender primitive)

@ekzhang maybe you have some more insight into aiohttp? :)