### PR TITLE
Enforce object name rules (again)

### DIFF
--- a/modal/dict.py
+++ b/modal/dict.py
@@ -125,7 +125,7 @@ class _Dict(_Object, type_prefix="di"):
         dict[123] = 456
         ```
         """
-        check_object_name(label, "Dict", warn=True)
+        check_object_name(label, "Dict")
 
         async def _load(self: _Dict, resolver: Resolver, existing_object_id: Optional[str]):
             serialized = _serialize_dict(data if data is not None else {})
@@ -143,9 +143,7 @@ class _Dict(_Object, type_prefix="di"):
         return _Dict._from_loader(_load, "Dict()", is_another_app=True, hydrate_lazily=True)
 
     @staticmethod
-    def persisted(
-        label: str, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, environment_name: Optional[str] = None
-    ):
+    def persisted(label: str, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, environment_name: Optional[str] = None):
         """Deprecated! Use `Dict.from_name(name, create_if_missing=True)`."""
         deprecation_error((2024, 3, 1), _Dict.persisted.__doc__)
 

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -116,7 +116,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
             pass
         ```
         """
-        check_object_name(label, "NetworkFileSystem", warn=True)
+        check_object_name(label, "NetworkFileSystem")
 
         async def _load(self: _NetworkFileSystem, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.SharedVolumeGetOrCreateRequest(
@@ -214,7 +214,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         environment_name: Optional[str] = None,
     ) -> str:
         """mdmd:hidden"""
-        check_object_name(deployment_name, "NetworkFileSystem", warn=True)
+        check_object_name(deployment_name, "NetworkFileSystem")
         if client is None:
             client = await _Client.from_env()
         request = api_pb2.SharedVolumeGetOrCreateRequest(

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -160,7 +160,7 @@ class _Queue(_Object, type_prefix="qu"):
         queue.put(123)
         ```
         """
-        check_object_name(label, "Queue", warn=True)
+        check_object_name(label, "Queue")
 
         async def _load(self: _Queue, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.QueueGetOrCreateRequest(
@@ -175,9 +175,7 @@ class _Queue(_Object, type_prefix="qu"):
         return _Queue._from_loader(_load, "Queue()", is_another_app=True, hydrate_lazily=True)
 
     @staticmethod
-    def persisted(
-        label: str, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, environment_name: Optional[str] = None
-    ):
+    def persisted(label: str, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, environment_name: Optional[str] = None):
         """Deprecated! Use `Queue.from_name(name, create_if_missing=True)`."""
         deprecation_error((2024, 3, 1), _Queue.persisted.__doc__)
 

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -170,10 +170,6 @@ class _Secret(_Object, type_prefix="st"):
            ...
         ```
         """
-        # Unlike other objects, you can't create secrets through this method, but we will still
-        # warn here so that people get the message when they *look up* secrets with illegal names.
-        # We can just remove the check after the deprecation period, instead of converting to an error.
-        check_object_name(label, "Secret", warn=True)
 
         async def _load(self: _Secret, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.SecretGetOrCreateRequest(
@@ -223,7 +219,7 @@ class _Secret(_Object, type_prefix="st"):
         overwrite: bool = False,
     ) -> str:
         """mdmd:hidden"""
-        check_object_name(deployment_name, "Secret", warn=True)
+        check_object_name(deployment_name, "Secret")
         if client is None:
             client = await _Client.from_env()
         if overwrite:

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -170,7 +170,7 @@ class _Volume(_Object, type_prefix="vo"):
             pass
         ```
         """
-        check_object_name(label, "Volume", warn=True)
+        check_object_name(label, "Volume")
 
         async def _load(self: _Volume, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.VolumeGetOrCreateRequest(
@@ -266,7 +266,7 @@ class _Volume(_Object, type_prefix="vo"):
         version: "Optional[api_pb2.VolumeFsVersion.ValueType]" = None,
     ) -> str:
         """mdmd:hidden"""
-        check_object_name(deployment_name, "Volume", warn=True)
+        check_object_name(deployment_name, "Volume")
         if client is None:
             client = await _Client.from_env()
         request = api_pb2.VolumeGetOrCreateRequest(

--- a/test/dict_test.py
+++ b/test/dict_test.py
@@ -3,7 +3,7 @@ import pytest
 import time
 
 from modal import Dict
-from modal.exception import DeprecationError, NotFoundError
+from modal.exception import InvalidError, NotFoundError
 
 
 def test_dict_app(servicer, client):
@@ -53,5 +53,5 @@ def test_dict_lazy_hydrate_named(set_env_client, servicer):
 
 @pytest.mark.parametrize("name", ["has space", "has/slash", "a" * 65])
 def test_invalid_name(servicer, client, name):
-    with pytest.raises(DeprecationError, match="Invalid Dict name"):
+    with pytest.raises(InvalidError, match="Invalid Dict name"):
         Dict.lookup(name)

--- a/test/network_file_system_test.py
+++ b/test/network_file_system_test.py
@@ -5,7 +5,7 @@ from io import BytesIO
 from unittest import mock
 
 import modal
-from modal.exception import DeprecationError, InvalidError, NotFoundError
+from modal.exception import InvalidError, NotFoundError
 
 
 def dummy():
@@ -149,5 +149,5 @@ def test_nfs_lazy_hydration_from_name(set_env_client):
 
 @pytest.mark.parametrize("name", ["has space", "has/slash", "a" * 65])
 def test_invalid_name(servicer, client, name):
-    with pytest.raises(DeprecationError, match="Invalid NetworkFileSystem name"):
+    with pytest.raises(InvalidError, match="Invalid NetworkFileSystem name"):
         modal.NetworkFileSystem.lookup(name)

--- a/test/queue_test.py
+++ b/test/queue_test.py
@@ -4,7 +4,7 @@ import queue
 import time
 
 from modal import Queue
-from modal.exception import DeprecationError, NotFoundError
+from modal.exception import InvalidError, NotFoundError
 
 from .supports.skip import skip_macos, skip_windows
 
@@ -117,5 +117,5 @@ def test_queue_lazy_hydrate_from_name(set_env_client):
 
 @pytest.mark.parametrize("name", ["has space", "has/slash", "a" * 65])
 def test_invalid_name(servicer, client, name):
-    with pytest.raises(DeprecationError, match="Invalid Queue name"):
+    with pytest.raises(InvalidError, match="Invalid Queue name"):
         Queue.lookup(name)

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -365,5 +365,5 @@ async def test_open_files_error_annotation(tmp_path):
 
 @pytest.mark.parametrize("name", ["has space", "has/slash", "a" * 65])
 def test_invalid_name(servicer, client, name):
-    with pytest.raises(DeprecationError, match="Invalid Volume name"):
+    with pytest.raises(InvalidError, match="Invalid Volume name"):
         modal.Volume.lookup(name)


### PR DESCRIPTION
<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- It is now an error to create or lookup various Modal objects with an invalid name. Names must be shorter than 64 characters and may contain only alphanumeric characters, dashes, periods, and underscores. The name check had inadvertently been removed for a brief time following an internal refactor and then reintroduced as a warning. It is once more a hard error. Please get in touch if this is blocking access to your data.