### PR TITLE
Set examples that use `.lookup` to notest

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -59,8 +59,8 @@ jobs:
       - name: Run docstring tests
         env:
           MODAL_ENVIRONMENT: client-doc-tests
-          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
-          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+          # MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          # MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         run: pytest --markdown-docs -m markdown-docs modal
 
   container-dependencies:

--- a/modal/app.py
+++ b/modal/app.py
@@ -239,7 +239,7 @@ class _App:
         in itself deprecated. If you are constructing objects with `.from_name(...)`, there is no
         need to assign those objects to the app. Example:
 
-        ```python
+        ```python notest
         d = modal.Dict.from_name("my-dict", create_if_missing=True)
 
         @app.function()

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -340,7 +340,7 @@ class _Cls(_Object, type_prefix="cs"):
     ) -> "_Cls":
         """Lookup a class with a given name and tag.
 
-        ```python
+        ```python notest
         Class = modal.Cls.lookup("other-app", "Class")
         ```
         """

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -36,7 +36,7 @@ class _Dict(_Object, type_prefix="di"):
 
     **Usage**
 
-    ```python
+    ```python notest
     from modal import Dict
 
     my_dict = Dict.from_name("my-persisted_dict", create_if_missing=True)
@@ -118,7 +118,7 @@ class _Dict(_Object, type_prefix="di"):
 
         **Examples**
 
-        ```python
+        ```python notest
         from modal import Dict
 
         dict = Dict.from_name("my-dict", create_if_missing=True)

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -158,7 +158,7 @@ class _Dict(_Object, type_prefix="di"):
     ) -> "_Dict":
         """Lookup a dict with a given name and tag.
 
-        ```python
+        ```python notest
         from modal import Dict
 
         d = Dict.lookup("my-dict")

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -738,7 +738,7 @@ class _Function(_Object, type_prefix="fu"):
         Please exercise care when using this advanced feature!
         Setting and forgetting a warm pool on functions can lead to increased costs.
 
-        ```python
+        ```python notest
         # Usage on a regular function.
         f = modal.Function.lookup("my-app", "function")
         f.keep_warm(2)
@@ -801,7 +801,7 @@ class _Function(_Object, type_prefix="fu"):
     ) -> "_Function":
         """Lookup a function with a given name and tag.
 
-        ```python
+        ```python notest
         other_function = modal.Function.lookup("other-app", "function")
         ```
         """

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -192,7 +192,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
     ) -> "_NetworkFileSystem":
         """Lookup a network file system with a given name
 
-        ```python
+        ```python notest
         n = modal.NetworkFileSystem.lookup("my-nfs")
         print(n.listdir("/"))
         ```

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -58,7 +58,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
 
     **Usage**
 
-    ```python
+    ```python notest
     import modal
 
     nfs = modal.NetworkFileSystem.from_name("my-nfs", create_if_missing=True)

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -153,7 +153,7 @@ class _Queue(_Object, type_prefix="qu"):
 
         **Examples**
 
-        ```python
+        ```python notest
         from modal import Queue
 
         queue = Queue.from_name("my-queue", create_if_missing=True)

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -189,7 +189,7 @@ class _Queue(_Object, type_prefix="qu"):
     ) -> "_Queue":
         """Lookup a queue with a given name and tag.
 
-        ```python
+        ```python notest
         from modal import Queue
 
         q = modal.Queue.lookup("my-queue")

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -197,7 +197,7 @@ class _Secret(_Object, type_prefix="st"):
     ) -> "_Secret":
         """Lookup a secret with a given name
 
-        ```python
+        ```python notest
         s = modal.Secret.lookup("my-secret")
         print(s.object_id)
         ```

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -239,7 +239,7 @@ class _Volume(_Object, type_prefix="vo"):
     ) -> "_Volume":
         """Lookup a volume with a given name
 
-        ```python
+        ```python notest
         n = modal.Volume.lookup("my-volume")
         print(n.listdir("/"))
         ```

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -108,7 +108,7 @@ class _Volume(_Object, type_prefix="vo"):
 
     **Usage**
 
-    ```python
+    ```python notest
     import modal
 
     app = modal.App()  # Note: "app" was called "stub" up until April 2024
@@ -157,7 +157,7 @@ class _Volume(_Object, type_prefix="vo"):
 
         **Example Usage**
 
-        ```python
+        ```python notest
         import modal
 
         volume = modal.Volume.from_name("my-volume", create_if_missing=True)


### PR DESCRIPTION
Eagerly running RPCs in the doctests breaks CI on forks (and any other environment where you don't have a valid token).

This is kind of frustratingly manual and I expect that we will break it again in the future. On the other hand, this also reduces test coverage and is going to let our doctests get out of date.

I'm testing it by withholding the model token secrets from the doctest job. I initially intended to revert this after making sure CI passes, but now I might be inclined to keep that in.

Overall I'm not sure what the ideal solution is here, but I would like to unblock a long-standing helpful third-party PR.