### PR TITLE
Don't run doctests on PRs from a fork

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -57,6 +57,7 @@ jobs:
         run: pytest
 
       - name: Run docstring tests
+        if: github.event.pull_request.head.repo.fork != 'true'
         env:
           MODAL_ENVIRONMENT: client-doc-tests
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}


### PR DESCRIPTION
Many doctests need valid modal secrets to run correctly. Rather than disabling those test-by-test for everyone (my initial approach in #1919), this just skips the doctest step for PRs from a fork. This could still let third-party PRs slip in changes that invalidate the docs, but (a) third-party PRs are unlikely to change API and (b) we'd catch it on the next first-party build anyway (probably even on the merge to main).