### PR TITLE
Remove the use of closurevars for finding function dependencies

### DIFF
--- a/test/function_test.py
+++ b/test/function_test.py
@@ -665,25 +665,6 @@ def test_deps_explicit(client, servicer):
     assert dep_object_ids == set([image.object_id, nfs_1.object_id, nfs_2.object_id])
 
 
-nfs = NetworkFileSystem.from_name("my-persisted-nfs", create_if_missing=True)
-
-
-def dummy_closurevars():
-    nfs.listdir("/")
-
-
-def test_deps_closurevars(client, servicer):
-    app = App()
-
-    image = Image.debian_slim()
-    modal_f = app.function(image=image)(dummy_closurevars)
-
-    with app.run(client=client):
-        f = servicer.app_functions[modal_f.object_id]
-
-    assert set(d.object_id for d in f.object_dependencies) == set([nfs.object_id, image.object_id])
-
-
 def assert_is_wrapped_dict(some_arg):
     assert type(some_arg) == modal.Dict  # this should not be a modal._Dict unwrapped instance!
     return some_arg

--- a/test/function_utils_test.py
+++ b/test/function_utils_test.py
@@ -1,53 +1,9 @@
 # Copyright Modal Labs 2023
 import pytest
-from typing import List
 
-from modal import Queue, method, web_endpoint
-from modal._utils.function_utils import FunctionInfo, get_referred_objects, method_has_params
+from modal import method, web_endpoint
+from modal._utils.function_utils import FunctionInfo, method_has_params
 from modal.exception import InvalidError
-from modal.object import Object
-
-q1 = Queue.from_name("q1", create_if_missing=True)
-q2 = Queue.from_name("q2", create_if_missing=True)
-
-
-def f1():
-    q1.get()
-
-
-def f2():
-    f1()
-    q2.get()
-
-
-def test_referred_objects():
-    objs: List[Object] = get_referred_objects(f1)
-    assert objs == [q1]
-
-
-def test_referred_objects_recursive():
-    objs: List[Object] = get_referred_objects(f2)
-    assert set(objs) == set([q1, q2])
-
-
-def recursive():
-    recursive()
-
-
-def test_recursive():
-    get_referred_objects(recursive)
-
-
-l = [q1, q2]
-
-
-def refers_list():
-    return len(l)
-
-
-def test_refers_list():
-    objs: List[Object] = get_referred_objects(refers_list)
-    assert objs == []  # This may return [q1, q2] in the future
 
 
 def hasarg(a):

--- a/test/supports/functions.py
+++ b/test/supports/functions.py
@@ -7,8 +7,6 @@ from typing import List
 
 from modal import (
     App,
-    Image,
-    Volume,
     asgi_app,
     build,
     current_function_call_id,
@@ -357,20 +355,6 @@ def cube(x):
 def function_calling_method(x, y, z):
     obj = ParamCls(x, y)
     return obj.f.remote(z)
-
-
-image = Image.debian_slim().pip_install("xyz")
-other_image = Image.debian_slim().pip_install("abc")
-volume = Volume.from_name("vol", create_if_missing=True)
-other_volume = Volume.from_name("other-vol", create_if_missing=True)
-
-
-@app.function(image=image, volumes={"/tmp/xyz": volume})
-def check_dep_hydration(x):
-    assert image.is_hydrated
-    assert other_image.is_hydrated
-    assert volume.is_hydrated
-    assert other_volume.is_hydrated
 
 
 @app.cls()

--- a/test/supports/lazy_hydration.py
+++ b/test/supports/lazy_hydration.py
@@ -1,0 +1,19 @@
+# Copyright Modal Labs 2024
+from modal import App, Image, Queue, Volume
+
+app = App()
+
+image = Image.debian_slim().pip_install("xyz")
+volume = Volume.from_name("my-vol")
+queue = Queue.from_name("my-queue")
+
+
+@app.function(image=image, volumes={"/tmp/xyz": volume})
+def f(x):
+    # These are hydrated by virtue of being dependencies
+    assert image.is_hydrated
+    assert volume.is_hydrated
+
+    # This one should be hydrated lazily
+    queue.put("123")
+    assert queue.get() == "123"


### PR DESCRIPTION
We needed the closurevars hack in order to hydrate implicit dependencies of functions. However since we deprecated `.new` in #1854, the only remaining implicit dependencies are `Queue.from_name` and `Dict.from_name`. Both those objects support lazy resolution, which means we can rely on that instead.

This also fixes a subtle issue where previously if you have a deployed app that refers to a persisted object, and you delete that object, it would still use that object's id. In particular if someone created a _new_ persisted object with the same name, the deployed app would still refer to the old (deleted) object.

A slight downside of this PR is that the lazy resolution will add a backend roundtrip the first time the user interacts with the object. This seems fine? 