### PR TITLE
unify `servicer` & `unix_servicer`

### DIFF
--- a/test/client_test.py
+++ b/test/client_test.py
@@ -11,7 +11,7 @@ from modal import Client
 from modal.exception import AuthError, ConnectionError, DeprecationError, InvalidError, VersionError
 from modal_proto import api_pb2
 
-from .supports.skip import skip_windows_unix_socket
+from .supports.skip import skip_windows, skip_windows_unix_socket
 
 TEST_TIMEOUT = 4.0  # align this with the container client timeout in client.py
 
@@ -52,6 +52,7 @@ async def test_client_dns_failure():
 
 @pytest.mark.asyncio
 @pytest.mark.timeout(TEST_TIMEOUT)
+@skip_windows("Windows test crashes on connection failure")
 async def test_client_connection_failure():
     with pytest.raises(ConnectionError) as excinfo:
         async with Client("https://localhost:443", api_pb2.CLIENT_TYPE_CONTAINER, None):

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -35,11 +35,10 @@ def test_client_platform_string(servicer, client):
 
 
 @pytest.mark.asyncio
-@skip_windows_unix_socket
-async def test_container_client_type(unix_servicer, container_client):
-    assert len(unix_servicer.requests) == 1  # no heartbeat, just ClientHello
-    assert isinstance(unix_servicer.requests[0], Empty)
-    assert unix_servicer.client_create_metadata["x-modal-client-type"] == str(api_pb2.CLIENT_TYPE_CONTAINER)
+async def test_container_client_type(servicer, container_client):
+    assert len(servicer.requests) == 1  # no heartbeat, just ClientHello
+    assert isinstance(servicer.requests[0], Empty)
+    assert servicer.client_create_metadata["x-modal-client-type"] == str(api_pb2.CLIENT_TYPE_CONTAINER)
 
 
 @pytest.mark.asyncio
@@ -53,7 +52,6 @@ async def test_client_dns_failure():
 
 @pytest.mark.asyncio
 @pytest.mark.timeout(TEST_TIMEOUT)
-@skip_windows_unix_socket
 async def test_client_connection_failure():
     with pytest.raises(ConnectionError) as excinfo:
         async with Client("https://localhost:443", api_pb2.CLIENT_TYPE_CONTAINER, None):
@@ -73,12 +71,11 @@ async def test_client_connection_failure_unix_socket():
 
 @pytest.mark.asyncio
 @pytest.mark.timeout(TEST_TIMEOUT)
-@skip_windows_unix_socket
-async def test_client_connection_timeout(unix_servicer, monkeypatch):
+async def test_client_connection_timeout(servicer, monkeypatch):
     monkeypatch.setattr("modal.client.CLIENT_CREATE_ATTEMPT_TIMEOUT", 1.0)
     monkeypatch.setattr("modal.client.CLIENT_CREATE_TOTAL_TIMEOUT", 3.0)
     with pytest.raises(ConnectionError) as excinfo:
-        async with Client(unix_servicer.remote_addr, api_pb2.CLIENT_TYPE_CONTAINER, None, version="timeout"):
+        async with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CONTAINER, None, version="timeout"):
             pass
 
     # The HTTP lookup will return 400 because the GRPC server rejects the http request
@@ -98,7 +95,7 @@ async def test_client_server_error(servicer):
 @pytest.mark.asyncio
 async def test_client_old_version(servicer):
     with pytest.raises(VersionError):
-        async with Client(servicer.remote_addr, api_pb2.CLIENT_TYPE_CLIENT, ("foo-id", "foo-secret"), version="0.0.0"):
+        async with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, ("foo-id", "foo-secret"), version="0.0.0"):
             pass
 
 
@@ -106,7 +103,7 @@ async def test_client_old_version(servicer):
 async def test_client_deprecated(servicer):
     with pytest.warns(modal.exception.DeprecationError):
         async with Client(
-            servicer.remote_addr, api_pb2.CLIENT_TYPE_CLIENT, ("foo-id", "foo-secret"), version="deprecated"
+            servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, ("foo-id", "foo-secret"), version="deprecated"
         ):
             pass
 
@@ -114,13 +111,13 @@ async def test_client_deprecated(servicer):
 @pytest.mark.asyncio
 async def test_client_unauthenticated(servicer):
     with pytest.raises(AuthError):
-        async with Client(servicer.remote_addr, api_pb2.CLIENT_TYPE_CLIENT, None, version="unauthenticated"):
+        async with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, None, version="unauthenticated"):
             pass
 
 
-def client_from_env(remote_addr):
+def client_from_env(client_addr):
     _override_config = {
-        "server_url": remote_addr,
+        "server_url": client_addr,
         "token_id": "foo-id",
         "token_secret": "foo-secret",
         "task_id": None,
@@ -136,8 +133,8 @@ def test_client_from_env(servicer):
             client_from_env("https://foo.invalid")
 
         # Make sure later clients can still succeed
-        client_1 = client_from_env(servicer.remote_addr)
-        client_2 = client_from_env(servicer.remote_addr)
+        client_1 = client_from_env(servicer.client_addr)
+        client_2 = client_from_env(servicer.client_addr)
         assert isinstance(client_1, Client)
         assert isinstance(client_2, Client)
         assert client_1 == client_2
@@ -147,8 +144,8 @@ def test_client_from_env(servicer):
 
     try:
         # After stopping, creating a new client should return a new one
-        client_3 = client_from_env(servicer.remote_addr)
-        client_4 = client_from_env(servicer.remote_addr)
+        client_3 = client_from_env(servicer.client_addr)
+        client_4 = client_from_env(servicer.client_addr)
         assert client_3 != client_1
         assert client_4 == client_3
     finally:
@@ -169,7 +166,7 @@ def test_multiple_profile_error(servicer, modal_config):
     """
     with modal_config(config):
         with pytest.raises(InvalidError, match="More than one Modal profile is active"):
-            Client.verify(servicer.remote_addr, None)
+            Client.verify(servicer.client_addr, None)
 
 
 def test_implicit_default_profile_warning(servicer, modal_config):
@@ -184,7 +181,7 @@ def test_implicit_default_profile_warning(servicer, modal_config):
     """
     with modal_config(config):
         with pytest.warns(DeprecationError, match="Support for using an implicit 'default' profile is deprecated."):
-            Client.verify(servicer.remote_addr, None)
+            Client.verify(servicer.client_addr, None)
 
     config = """
     [default]
@@ -193,7 +190,7 @@ def test_implicit_default_profile_warning(servicer, modal_config):
     """
     with modal_config(config):
         # A single profile should be fine, even if not explicitly active and named 'default'
-        Client.verify(servicer.remote_addr, None)
+        Client.verify(servicer.client_addr, None)
 
 
 def test_import_modal_from_thread(supports_dir):

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -45,7 +45,7 @@ def test_config_env_override():
 
 def test_config_store_user(servicer, modal_config):
     with modal_config(show_on_error=True) as config_file_path:
-        env = {"MODAL_SERVER_URL": servicer.remote_addr}
+        env = {"MODAL_SERVER_URL": servicer.client_addr}
 
         # No token by default
         config = _get_config(env=env)
@@ -133,7 +133,7 @@ def test_config_env_override_arbitrary_env():
 
 @pytest.mark.asyncio
 async def test_workspace_lookup(servicer, server_url_env):
-    resp = await _lookup_workspace(servicer.remote_addr, "ak-abc", "as-xyz")
+    resp = await _lookup_workspace(servicer.client_addr, "ak-abc", "as-xyz")
     assert resp.username == "test-username"
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -63,6 +63,10 @@ class MockClientServicer(api_grpc.ModalClientBase):
     fc_data_in: defaultdict[str, asyncio.Queue[api_pb2.DataChunk]]
     fc_data_out: defaultdict[str, asyncio.Queue[api_pb2.DataChunk]]
 
+    # Set when the server runs
+    client_addr: str
+    container_addr: str
+
     def __init__(self, blob_host, blobs):
         self.use_blob_outputs = False
         self.put_outputs_barrier = threading.Barrier(

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -80,7 +80,7 @@ async def test_container_debug_snapshot(container_client, tmpdir, servicer):
     test_breakpoint = mock.Mock()
     with mock.patch("sys.breakpointhook", test_breakpoint):
         with mock.patch.dict(
-            os.environ, {"MODAL_RESTORE_STATE_PATH": str(restore_path), "MODAL_SERVER_URL": servicer.remote_addr}
+            os.environ, {"MODAL_RESTORE_STATE_PATH": str(restore_path), "MODAL_SERVER_URL": servicer.container_addr}
         ):
             io_manager.memory_snapshot()
             test_breakpoint.assert_called_once()

--- a/test/e2e_test.py
+++ b/test/e2e_test.py
@@ -25,12 +25,12 @@ def _cli(args, server_url, extra_env={}, check=True) -> Tuple[int, str, str]:
 
 
 def test_run_e2e(servicer):
-    _, _, err = _cli(["-m", "test.supports.script"], servicer.remote_addr)
+    _, _, err = _cli(["-m", "test.supports.script"], servicer.client_addr)
     assert err == ""
 
 
 def test_run_progress_info(servicer):
-    returncode, stdout, stderr = _cli(["-m", "test.supports.progress_info"], servicer.remote_addr)
+    returncode, stdout, stderr = _cli(["-m", "test.supports.progress_info"], servicer.client_addr)
     assert returncode == 0
     assert stderr == ""
     lines = stdout.splitlines()
@@ -39,15 +39,15 @@ def test_run_progress_info(servicer):
 
 
 def test_run_profiler(servicer):
-    _cli(["-m", "cProfile", "-m", "test.supports.script"], servicer.remote_addr)
+    _cli(["-m", "cProfile", "-m", "test.supports.script"], servicer.client_addr)
 
 
 def test_run_unconsumed_map(servicer):
-    _, _, err = _cli(["-m", "test.supports.unconsumed_map"], servicer.remote_addr)
+    _, _, err = _cli(["-m", "test.supports.unconsumed_map"], servicer.client_addr)
     assert "map" in err
     assert "for-loop" in err
 
-    _, _, err = _cli(["-m", "test.supports.consumed_map"], servicer.remote_addr)
+    _, _, err = _cli(["-m", "test.supports.consumed_map"], servicer.client_addr)
     assert "map" not in err
     assert "for-loop" not in err
 
@@ -55,7 +55,7 @@ def test_run_unconsumed_map(servicer):
 def test_auth_failure_last_line(servicer):
     returncode, out, err = _cli(
         ["-m", "test.supports.script"],
-        servicer.remote_addr,
+        servicer.client_addr,
         extra_env={"MODAL_TOKEN_ID": "bad", "MODAL_TOKEN_SECRET": "bad"},
         check=False,
     )

--- a/test/grpc_utils_test.py
+++ b/test/grpc_utils_test.py
@@ -12,8 +12,8 @@ from .supports.skip import skip_windows_unix_socket
 
 @pytest.mark.asyncio
 async def test_http_channel(servicer):
-    assert servicer.remote_addr.startswith("http://")
-    channel = create_channel(servicer.remote_addr)
+    assert servicer.client_addr.startswith("http://")
+    channel = create_channel(servicer.client_addr)
     client_stub = api_grpc.ModalClientStub(channel)
 
     req = api_pb2.BlobCreateRequest()
@@ -25,9 +25,9 @@ async def test_http_channel(servicer):
 
 @skip_windows_unix_socket
 @pytest.mark.asyncio
-async def test_unix_channel(unix_servicer):
-    assert unix_servicer.remote_addr.startswith("unix://")
-    channel = create_channel(unix_servicer.remote_addr)
+async def test_unix_channel(servicer):
+    assert servicer.container_addr.startswith("unix://")
+    channel = create_channel(servicer.container_addr)
     client_stub = api_grpc.ModalClientStub(channel)
 
     req = api_pb2.BlobCreateRequest()
@@ -39,7 +39,7 @@ async def test_unix_channel(unix_servicer):
 
 @pytest.mark.asyncio
 async def test_retry_transient_errors(servicer):
-    channel = create_channel(servicer.remote_addr)
+    channel = create_channel(servicer.client_addr)
     client_stub = api_grpc.ModalClientStub(channel)
 
     # Use the BlobCreate request for retries

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -26,7 +26,7 @@ def deploy_app_externally(
             **{"PYTHONUTF8": "1"},
         }  # windows apparently needs a bunch of env vars to start python...
 
-    env = {**windows_support, "MODAL_SERVER_URL": servicer.remote_addr, **env}
+    env = {**windows_support, "MODAL_SERVER_URL": servicer.client_addr, **env}
     if cwd is None:
         cwd = pathlib.Path(__file__).parent.parent
 

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -841,9 +841,7 @@ def test_image_builder_version(servicer, test_dir, modal_config):
             with mock.patch("modal.image._dockerhub_debian_codename", lambda *_, **__: "bullseye"):
                 with mock.patch("test.conftest.ImageBuilderVersion", Literal["2000.01"]):
                     with mock.patch("modal.image.ImageBuilderVersion", Literal["2000.01"]):
-                        with Client(
-                            servicer.remote_addr, api_pb2.CLIENT_TYPE_CONTAINER, ("ak-123", "as-xyz")
-                        ) as client:
+                        with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, ("ak-123", "as-xyz")) as client:
                             with modal_config():
                                 with app.run(client=client):
                                     assert servicer.image_builder_versions
@@ -859,7 +857,7 @@ def test_image_builder_supported_versions(servicer):
     with pytest.raises(VersionError, match=r"This version of the modal client supports.+{'2000.01'}"):
         with mock.patch("modal.image.ImageBuilderVersion", Literal["2000.01"]):
             with mock.patch("test.conftest.ImageBuilderVersion", Literal["2023.11"]):
-                with Client(servicer.remote_addr, api_pb2.CLIENT_TYPE_CONTAINER, ("ak-123", "as-xyz")) as client:
+                with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, ("ak-123", "as-xyz")) as client:
                     with app.run(client=client):
                         pass
 

--- a/test/notebook_test.py
+++ b/test/notebook_test.py
@@ -27,7 +27,7 @@ def notebook_runner(servicer):
 
         parameter_cell = nb["cells"][0]
         assert "parameters" in parameter_cell["metadata"]["tags"]  # like in papermill
-        parameter_cell["source"] = f'server_addr = "{servicer.remote_addr}"'
+        parameter_cell["source"] = f'server_addr = "{servicer.client_addr}"'
 
         client = NotebookClient(nb)
 

--- a/test/runner_test.py
+++ b/test/runner_test.py
@@ -24,7 +24,7 @@ def test_run_app(servicer, client):
 
 def test_run_app_unauthenticated(servicer):
     dummy_app = modal.App()
-    with Client.anonymous(servicer.remote_addr) as client:
+    with Client.anonymous(servicer.client_addr) as client:
         with pytest.raises(ExecutionError, match=".+unauthenticated client"):
             with run_app(dummy_app, client=client):
                 pass


### PR DESCRIPTION
Fell into a rabbit hole when fixing a tiny test in #1925 and realized I wanted support for using the same servicer in both the client and the container. Previously we actually had two different instances of `MockClientServicer` which managed all the fake backend state.

Unifying it makes it a bit easier to write container tests that deploy objects and then look them up from the container.

It would have been fairly easy to work around it, but I decided to go the slightly harder and more annoying route and unify the two objects so it's just one.