### PR TITLE
Fix Cls.lookup() not working after update MOD-3187

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -203,19 +203,6 @@ class _Cls(_Object, type_prefix="cs"):
     def _hydrate_metadata(self, metadata: Message):
         assert isinstance(metadata, api_pb2.ClassHandleMetadata)
 
-        if metadata.class_function_id:
-            # "class service function" themselves don't have hydration metadata, but we
-            # still send in a valid FunctionHandleMetadata object in hydration, since
-            # there is a run-time type check of that _Function._hydrate_metadata
-            if self._class_service_function:
-                self._class_service_function._hydrate(
-                    metadata.class_function_id, self._client, metadata.class_function_metadata
-                )
-            else:
-                self._class_service_function = _Function._new_hydrated(
-                    metadata.class_function_id, self._client, metadata.class_function_metadata
-                )
-
         for method in metadata.methods:
             if method.function_name in self._method_functions:
                 # This happens when the class is loaded locally
@@ -229,8 +216,7 @@ class _Cls(_Object, type_prefix="cs"):
                 )
 
     def _get_metadata(self) -> api_pb2.ClassHandleMetadata:
-        class_function_id = self._class_service_function.object_id
-        class_handle_metadata = api_pb2.ClassHandleMetadata(class_function_id=class_function_id)
+        class_handle_metadata = api_pb2.ClassHandleMetadata()
         for f_name, f in self._method_functions.items():
             class_handle_metadata.methods.append(
                 api_pb2.ClassMethod(
@@ -264,11 +250,7 @@ class _Cls(_Object, type_prefix="cs"):
             return [class_service_function] + list(functions.values())
 
         async def _load(self: "_Cls", resolver: Resolver, existing_object_id: Optional[str]):
-            req = api_pb2.ClassCreateRequest(
-                app_id=resolver.app_id,
-                existing_class_id=existing_object_id,
-                class_function_id=class_service_function.object_id,
-            )
+            req = api_pb2.ClassCreateRequest(app_id=resolver.app_id, existing_class_id=existing_object_id)
             for f_name, f in self._method_functions.items():
                 req.methods.append(
                     api_pb2.ClassMethod(
@@ -305,11 +287,12 @@ class _Cls(_Object, type_prefix="cs"):
         """
 
         async def _load_remote(obj: _Object, resolver: Resolver, existing_object_id: Optional[str]):
+            _environment_name = _get_environment_name(environment_name, resolver)
             request = api_pb2.ClassGetRequest(
                 app_name=app_name,
                 object_tag=tag,
                 namespace=namespace,
-                environment_name=_get_environment_name(environment_name, resolver),
+                environment_name=_environment_name,
                 lookup_published=workspace is not None,
                 workspace_name=workspace,
             )
@@ -323,7 +306,12 @@ class _Cls(_Object, type_prefix="cs"):
                 else:
                     raise
 
+            class_function_tag = f"{tag}.*"  # special name of the base service function for the class
+            class_service_function = await _Function.lookup(
+                app_name, class_function_tag, environment_name=_environment_name, client=resolver.client
+            )
             obj._hydrate(response.class_id, resolver.client, response.handle_metadata)
+            obj._class_service_function = class_service_function
 
         rep = f"Ref({app_name})"
         cls = cls._from_loader(_load_remote, rep, is_another_app=True)

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -510,7 +510,7 @@ message ClassCreateRequest {
   string app_id = 1  [ (modal.options.audit_target_attr) = true ];
   string existing_class_id = 2;
   repeated ClassMethod methods = 3;
-  string class_function_id = 4;
+  reserved 4; // removed class_function_id
 }
 
 message ClassCreateResponse {

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -83,15 +83,15 @@ def test_call_class_sync(client, servicer):
     function_creates_requests: typing.List[api_pb2.FunctionCreateRequest] = ctx.get_requests("FunctionCreate")
     assert len(function_creates_requests) == 2
     (class_create,) = ctx.get_requests("ClassCreate")
-    assert class_create.class_function_id
     function_creates = {fc.function.function_name: fc for fc in function_creates_requests}
     assert function_creates.keys() == {"Foo.*", "Foo.bar"}
     foobar_def = function_creates["Foo.bar"].function
+    service_function_id = servicer.app_objects["ap-1"]["Foo.*"]
     assert foobar_def.is_method
     assert foobar_def.use_method_name == "bar"
-    assert foobar_def.use_function_id == class_create.class_function_id
+    assert foobar_def.use_function_id == service_function_id
     (function_map_request,) = ctx.get_requests("FunctionMap")
-    assert function_map_request.function_id == class_create.class_function_id
+    assert function_map_request.function_id == service_function_id
 
 
 # Reusing the app runs into an issue with stale function handles.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -226,11 +226,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         )
 
     def get_class_metadata(self, object_id: str) -> api_pb2.ClassHandleMetadata:
-        class_function_id = self.classes[object_id]["*"]
-        class_handle_metadata = api_pb2.ClassHandleMetadata(
-            class_function_id=self.classes[object_id]["*"],
-            class_function_metadata=self.get_function_metadata(class_function_id),
-        )
+        class_handle_metadata = api_pb2.ClassHandleMetadata()
         for f_name, f_id in self.classes[object_id].items():
             if f_name == "*":
                 continue
@@ -414,7 +410,6 @@ class MockClientServicer(api_grpc.ModalClientBase):
         request: api_pb2.ClassCreateRequest = await stream.recv_message()
         assert request.app_id
         methods: dict[str, str] = {method.function_name: method.function_id for method in request.methods}
-        methods["*"] = request.class_function_id
         class_id = "cs-" + str(len(self.classes))
         self.classes[class_id] = methods
         await stream.send_message(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -228,8 +228,6 @@ class MockClientServicer(api_grpc.ModalClientBase):
     def get_class_metadata(self, object_id: str) -> api_pb2.ClassHandleMetadata:
         class_handle_metadata = api_pb2.ClassHandleMetadata()
         for f_name, f_id in self.classes[object_id].items():
-            if f_name == "*":
-                continue
             function_handle_metadata = self.get_function_metadata(f_id)
             class_handle_metadata.methods.append(
                 api_pb2.ClassMethod(


### PR DESCRIPTION
Lookups were breaking since backend isn't returning class_function_id as part of the handle metadata for the class.

Instead of fixing the backend, this removes the class_function_id field from ClassMetadata and instead does an explicit lookup for the function named `{class-tag}.*`. This is in line with an upcoming refactor that could remove the need for synced Cls objects altogheter, since the "class servicer function" is all that is needed to invoke the class now anyway. It also has the advantage that already-existing deployed classes won't have to get redeployed for lookups to start working.

Client tests were passing since the mock servicer was more feature-complete than the real backend api.


---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

* Fixes issue with `Cls.lookup` not working after upgrading to v0.63.0