### PR TITLE
Only support string paths on Volumes

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1968,8 +1968,8 @@ message VolumeCommitResponse {
 
 message VolumeCopyFilesRequest {
   string volume_id = 1;
-  repeated bytes src_paths = 2;
-  bytes dst_path = 3;
+  repeated string src_paths = 2;
+  string dst_path = 3;
   bool recursive = 4;
 }
 
@@ -1990,7 +1990,7 @@ message VolumeDeleteRequest {
 
 message VolumeGetFileRequest {
   string volume_id = 1;
-  bytes path = 2;
+  string path = 2;
   uint64 start = 3;
   uint64 len = 4; // 0 is interpreted as 'read to end'
 }
@@ -2072,7 +2072,7 @@ message VolumeReloadRequest {
 
 message VolumeRemoveFileRequest {
   string volume_id = 1 [ (modal.options.audit_target_attr) = true ];
-  bytes path = 2;
+  string path = 2;
   bool recursive = 3;
 }
 

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -526,22 +526,22 @@ def test_volume_cli(set_env_client):
 def test_volume_get(servicer, set_env_client):
     vol_name = "my-test-vol"
     _run(["volume", "create", vol_name])
-    file_path = b"test.txt"
+    file_path = "test.txt"
     file_contents = b"foo bar baz"
     with tempfile.TemporaryDirectory() as tmpdir:
         upload_path = os.path.join(tmpdir, "upload.txt")
         with open(upload_path, "wb") as f:
             f.write(file_contents)
             f.flush()
-        _run(["volume", "put", vol_name, upload_path, file_path.decode()])
+        _run(["volume", "put", vol_name, upload_path, file_path])
 
-        _run(["volume", "get", vol_name, file_path.decode(), tmpdir])
-        with open(os.path.join(tmpdir, file_path.decode()), "rb") as f:
+        _run(["volume", "get", vol_name, file_path, tmpdir])
+        with open(os.path.join(tmpdir, file_path), "rb") as f:
             assert f.read() == file_contents
 
     with tempfile.TemporaryDirectory() as tmpdir2:
         _run(["volume", "get", vol_name, "/", tmpdir2])
-        with open(os.path.join(tmpdir2, file_path.decode()), "rb") as f:
+        with open(os.path.join(tmpdir2, file_path), "rb") as f:
             assert f.read() == file_contents
 
 
@@ -578,21 +578,21 @@ def test_volume_put_force(servicer, set_env_client):
 def test_volume_rm(servicer, set_env_client):
     vol_name = "my-test-vol"
     _run(["volume", "create", vol_name])
-    file_path = b"test.txt"
+    file_path = "test.txt"
     file_contents = b"foo bar baz"
     with tempfile.TemporaryDirectory() as tmpdir:
         upload_path = os.path.join(tmpdir, "upload.txt")
         with open(upload_path, "wb") as f:
             f.write(file_contents)
             f.flush()
-        _run(["volume", "put", vol_name, upload_path, file_path.decode()])
+        _run(["volume", "put", vol_name, upload_path, file_path])
 
-        _run(["volume", "get", vol_name, file_path.decode(), tmpdir])
-        with open(os.path.join(tmpdir, file_path.decode()), "rb") as f:
+        _run(["volume", "get", vol_name, file_path, tmpdir])
+        with open(os.path.join(tmpdir, file_path), "rb") as f:
             assert f.read() == file_contents
 
-        _run(["volume", "rm", vol_name, file_path.decode()])
-        _run(["volume", "get", vol_name, file_path.decode()], expected_exit_code=1, expected_stderr=None)
+        _run(["volume", "rm", vol_name, file_path])
+        _run(["volume", "get", vol_name, file_path], expected_exit_code=1, expected_stderr=None)
 
 
 def test_volume_ls(servicer, set_env_client):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1287,9 +1287,9 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def VolumeGetFile(self, stream):
         req = await stream.recv_message()
-        if req.path.decode("utf-8") not in self.volume_files[req.volume_id]:
+        if req.path not in self.volume_files[req.volume_id]:
             raise GRPCError(Status.NOT_FOUND, "File not found")
-        vol_file = self.volume_files[req.volume_id][req.path.decode("utf-8")]
+        vol_file = self.volume_files[req.volume_id][req.path]
         if vol_file.data_blob_id:
             await stream.send_message(api_pb2.VolumeGetFileResponse(data_blob_id=vol_file.data_blob_id))
         else:
@@ -1305,9 +1305,9 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def VolumeRemoveFile(self, stream):
         req = await stream.recv_message()
-        if req.path.decode("utf-8") not in self.volume_files[req.volume_id]:
+        if req.path not in self.volume_files[req.volume_id]:
             raise GRPCError(Status.INVALID_ARGUMENT, "File not found")
-        del self.volume_files[req.volume_id][req.path.decode("utf-8")]
+        del self.volume_files[req.volume_id][req.path]
         await stream.send_message(Empty())
 
     async def VolumeListFiles(self, stream):
@@ -1352,13 +1352,13 @@ class MockClientServicer(api_grpc.ModalClientBase):
     async def VolumeCopyFiles(self, stream):
         req = await stream.recv_message()
         for src_path in req.src_paths:
-            if src_path.decode("utf-8") not in self.volume_files[req.volume_id]:
+            if src_path not in self.volume_files[req.volume_id]:
                 raise GRPCError(Status.NOT_FOUND, f"Source file not found: {src_path}")
-            src_file = self.volume_files[req.volume_id][src_path.decode("utf-8")]
+            src_file = self.volume_files[req.volume_id][src_path]
             if len(req.src_paths) > 1:
                 # check to make sure dst is a directory
                 if (
-                    req.dst_path.decode("utf-8").endswith(("/", "\\"))
+                    req.dst_path.endswith(("/", "\\"))
                     or not os.path.splitext(os.path.basename(req.dst_path))[1]
                 ):
                     dst_path = os.path.join(req.dst_path, os.path.basename(src_path))
@@ -1366,7 +1366,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
                     raise GRPCError(Status.INVALID_ARGUMENT, f"{dst_path} is not a directory.")
             else:
                 dst_path = req.dst_path
-            self.volume_files[req.volume_id][dst_path.decode("utf-8")] = src_file
+            self.volume_files[req.volume_id][dst_path] = src_file
         await stream.send_message(Empty())
 
 

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -78,12 +78,12 @@ async def test_volume_get(servicer, client, tmp_path):
     vol = await modal.Volume.lookup.aio("my-vol", client=client)  # type: ignore
 
     file_contents = b"hello world"
-    file_path = b"foo.txt"
-    local_file_path = tmp_path / file_path.decode("utf-8")
+    file_path = "foo.txt"
+    local_file_path = tmp_path / file_path
     local_file_path.write_bytes(file_contents)
 
     async with vol.batch_upload() as batch:
-        batch.put_file(local_file_path, file_path.decode("utf-8"))
+        batch.put_file(local_file_path, file_path)
 
     data = b""
     for chunk in vol.read_file(file_path):


### PR DESCRIPTION
This fixes a bug where `bytes` paths on Volumes were not handled properly by the backend.

Non-UTF8 paths are a very rare occurrence regardless, and I don't think it is necessary to support them in our client library, so I'm just removing the APIs here instead.

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

**Protobuf wire protocol for `string` and `bytes` are identical.**

## Changelog

- Fixed a bug in `Volume.copy_files()` where some source paths may be ignored if passed as `bytes`.
- `Volume.read_file`, `Volume.read_file_into_fileobj`, `Volume.remove_file`, and `Volume.copy_files` can no longer take both string or bytes for their paths. They now only accept `str`.