### PR TITLE
Error when the python_version for Image.debian_slim is a float

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -1387,6 +1387,8 @@ class _Image(_Object, type_prefix="im"):
     @staticmethod
     def debian_slim(python_version: Optional[str] = None, force_build: bool = False) -> "_Image":
         """Default image, based on the official `python` Docker images."""
+        if isinstance(python_version, float):
+            raise TypeError("The `python_version` argument should be a string, not a float.")
 
         def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:
             requirements_path = _get_modal_requirements_path(version, python_version)


### PR DESCRIPTION
This is an easy mistake to make and otherwise triggers an inscrutable error message from the guts of the resolver.

Note that we already do a similar check for the code-path shared by constructors that add the standalone Python, so we just needed to address `Image.debian_slim` directly.

Closes MOD-3189