### PR TITLE
Set env to main everywhere in tests

### DIFF
--- a/test/helpers.py
+++ b/test/helpers.py
@@ -26,7 +26,7 @@ def deploy_app_externally(
             **{"PYTHONUTF8": "1"},
         }  # windows apparently needs a bunch of env vars to start python...
 
-    env = {**windows_support, "MODAL_SERVER_URL": servicer.client_addr, **env}
+    env = {**windows_support, "MODAL_SERVER_URL": servicer.client_addr, "MODAL_ENVIRONMENT": "main", **env}
     if cwd is None:
         cwd = pathlib.Path(__file__).parent.parent
 


### PR DESCRIPTION
Breaking this out of #1925 since it was pretty unrelated. This sets the environment to "main" everywhere, and makes sure to reset it for every test (there was an issue with state leakage).

Also adds some more debug output to deployed objects not found since I ran into issues (caused by inconsistent env usage)