### PR TITLE
Run pytest -v

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -54,7 +54,7 @@ jobs:
         run: pip install -e .
 
       - name: Run client tests
-        run: pytest
+        run: pytest -v
 
       - name: Run docstring tests
         if: github.event.pull_request.head.repo.fork != 'true'


### PR DESCRIPTION
Super minor, this just prints each test on its own line. That way if something fails you don't have to wait for the whole test suite to finish to know what test failed.