### PR TITLE
Remove hidden _experimental_scheduler flag

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -517,7 +517,6 @@ class _App:
         # Parameters below here are experimental. Use with caution!
         _allow_background_volume_commits: Optional[bool] = None,
         _experimental_boost: bool = False,  # Experimental flag for lower latency function execution (alpha).
-        _experimental_scheduler: bool = False,  # Experimental flag for more fine-grained scheduling (alpha).
         _experimental_scheduler_placement: Optional[
             SchedulerPlacement
         ] = None,  # Experimental controls over fine-grained scheduling (alpha).
@@ -611,7 +610,6 @@ class _App:
                 max_inputs=max_inputs,
                 scheduler_placement=scheduler_placement,
                 _experimental_boost=_experimental_boost,
-                _experimental_scheduler=_experimental_scheduler,
             )
 
             self._add_function(function, webhook_config is not None)
@@ -661,7 +659,6 @@ class _App:
         secret: Optional[_Secret] = None,  # Deprecated: use `secrets`
         # Parameters below here are experimental. Use with caution!
         _experimental_boost: bool = False,  # Experimental flag for lower latency function execution (alpha).
-        _experimental_scheduler: bool = False,  # Experimental flag for more fine-grained scheduling (alpha).
         _experimental_scheduler_placement: Optional[
             SchedulerPlacement
         ] = None,  # Experimental controls over fine-grained scheduling (alpha).
@@ -723,7 +720,6 @@ class _App:
                 max_inputs=max_inputs,
                 scheduler_placement=scheduler_placement,
                 _experimental_boost=_experimental_boost,
-                _experimental_scheduler=_experimental_scheduler,
                 # class service function, so the following attributes which relate to
                 # the callable itself are invalid and set to defaults:
                 webhook_config=None,
@@ -768,7 +764,6 @@ class _App:
         ] = {},  # Mount points for Modal Volumes and CloudBucketMounts
         _allow_background_volume_commits: Optional[bool] = None,
         pty_info: Optional[api_pb2.PTYInfo] = None,
-        _experimental_scheduler: bool = False,  # Experimental flag for more fine-grained scheduling (alpha).
         _experimental_scheduler_placement: Optional[
             SchedulerPlacement
         ] = None,  # Experimental controls over fine-grained scheduling (alpha).
@@ -814,7 +809,6 @@ class _App:
             volumes=volumes,
             allow_background_volume_commits=_allow_background_volume_commits,
             pty_info=pty_info,
-            _experimental_scheduler=_experimental_scheduler,
             _experimental_scheduler_placement=_experimental_scheduler_placement,
         )
         await resolver.load(obj)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -482,7 +482,6 @@ class _Function(_Object, type_prefix="fu"):
         keep_warm: Optional[int] = None,  # keep_warm=True is equivalent to keep_warm=1
         cloud: Optional[str] = None,
         _experimental_boost: bool = False,
-        _experimental_scheduler: bool = False,
         scheduler_placement: Optional[SchedulerPlacement] = None,
         is_builder_function: bool = False,
         is_auto_snapshot: bool = False,
@@ -810,7 +809,6 @@ class _Function(_Object, type_prefix="fu"):
                     max_inputs=max_inputs or 0,
                     cloud_bucket_mounts=cloud_bucket_mounts_to_proto(cloud_bucket_mounts),
                     _experimental_boost=_experimental_boost,
-                    _experimental_scheduler=_experimental_scheduler,
                     scheduler_placement=scheduler_placement.proto if scheduler_placement else None,
                     is_class=info.is_service_class(),
                 )

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -250,7 +250,6 @@ class _Sandbox(_Object, type_prefix="sb"):
         volumes: Dict[Union[str, os.PathLike], Union[_Volume, _CloudBucketMount]] = {},
         allow_background_volume_commits: Optional[bool] = None,
         pty_info: Optional[api_pb2.PTYInfo] = None,
-        _experimental_scheduler: bool = False,
         _experimental_scheduler_placement: Optional[SchedulerPlacement] = None,
     ) -> "_Sandbox":
         """mdmd:hidden"""
@@ -313,7 +312,6 @@ class _Sandbox(_Object, type_prefix="sb"):
                 cloud_bucket_mounts=cloud_bucket_mounts_to_proto(cloud_bucket_mounts),
                 volume_mounts=volume_mounts,
                 pty_info=pty_info,
-                _experimental_scheduler=_experimental_scheduler,
                 scheduler_placement=scheduler_placement.proto if scheduler_placement else None,
             )
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -933,7 +933,7 @@ message Function {
 
   // If set, tasks will be scheduled using the new scheduler, which also knows
   // to look at fine-grained placement constraints.
-  bool _experimental_scheduler = 49;
+  reserved 49; // _experimental_scheduler
   optional SchedulerPlacement scheduler_placement = 50;
   reserved 52; // _experimental_scheduler_placement
 
@@ -1615,7 +1615,7 @@ message Sandbox {
 
   // If set, tasks will be scheduled using the new scheduler, which also knows
   // to look at fine-grained placement constraints.
-  bool _experimental_scheduler = 16;
+  reserved 16; // _experimental_scheduler
   optional SchedulerPlacement scheduler_placement = 17;
 }
 

--- a/test/scheduler_placement_test.py
+++ b/test/scheduler_placement_test.py
@@ -8,7 +8,6 @@ app = App()
 
 
 @app.function(
-    _experimental_scheduler=True,
     _experimental_scheduler_placement=SchedulerPlacement(
         region="us-east-1",
         zone="us-east-1a",
@@ -37,7 +36,6 @@ def test_fn_scheduler_placement(servicer, client):
     with app.run(client=client):
         assert len(servicer.app_functions) == 3
         fn1 = servicer.app_functions["fu-1"]  # f1
-        assert fn1._experimental_scheduler
         assert fn1.scheduler_placement == api_pb2.SchedulerPlacement(
             regions=["us-east-1"],
             _zone="us-east-1a",
@@ -64,7 +62,6 @@ def test_sandbox_scheduler_placement(client, servicer):
             "echo bye >&2 && sleep 1 && echo hi && exit 42",
             timeout=600,
             region="us-east-1",
-            _experimental_scheduler=True,
         )
 
         assert len(servicer.sandbox_defs) == 1
@@ -72,4 +69,3 @@ def test_sandbox_scheduler_placement(client, servicer):
         assert sb_def.scheduler_placement == api_pb2.SchedulerPlacement(
             regions=["us-east-1"],
         )
-        assert sb_def._experimental_scheduler


### PR DESCRIPTION
It's inert, and has been so for a month or two now. I'm keeping the _experimental_scheduler_placement flag for now, which exposes some other params (but mostly ignored for external users). For everyone else, the only real way to construct things is using the regions= argument.