### PR TITLE
Relative path writes for volume get

### DIFF
--- a/modal/cli/_download.py
+++ b/modal/cli/_download.py
@@ -38,7 +38,7 @@ async def _volume_download(
                 await q.put((None, entry))
             else:
                 start_path = os.path.dirname(remote_path).split("*")[0]
-                rel_path = os.path.relpath(entry.path, start_path.lstrip("/"))
+                rel_path = Path(entry.path).relative_to(start_path.lstrip("/"))
                 output_path = local_destination / rel_path
                 if output_path.exists():
                     if overwrite:

--- a/modal/cli/_download.py
+++ b/modal/cli/_download.py
@@ -37,7 +37,9 @@ async def _volume_download(
             if is_pipe:
                 await q.put((None, entry))
             else:
-                output_path = local_destination / entry.path
+                start_path = os.path.dirname(remote_path).split("*")[0]
+                rel_path = os.path.relpath(entry.path, start_path.lstrip("/"))
+                output_path = local_destination / rel_path
                 if output_path.exists():
                     if overwrite:
                         if output_path.is_file():


### PR DESCRIPTION
## Details

Very small change to support relative paths for volume / nfs get. Strips the remote path up to the first glob if present then computes file output paths relative to this path.

Closes MOD-2204

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

---

</details>
