### PR TITLE
Fix Cls.with_options

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -359,7 +359,7 @@ class _Cls(_Object, type_prefix="cs"):
         Model2().generate.remote(42)
         ```
         """
-        retry_policy = _parse_retries(retries)
+        retry_policy = _parse_retries(retries, self.__name__)
         if gpu or cpu or memory:
             resources = convert_fn_config_to_resources_config(cpu=cpu, memory=memory, gpu=gpu, ephemeral_disk=None)
         else:

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -94,6 +94,17 @@ def test_call_class_sync(client, servicer):
     assert function_map_request.function_id == service_function_id
 
 
+def test_class_with_options(client, servicer):
+    with app.run(client=client):
+        foo = Foo.with_options(cpu=48, retries=5)()
+        res = foo.bar.remote(2)
+        assert res == 4
+        assert len(servicer.function_options) == 1
+        options: api_pb2.FunctionOptions = list(servicer.function_options.values())[0]
+        assert options.resources.milli_cpu == 48_000
+        assert options.retry_policy.retries == 5
+
+
 # Reusing the app runs into an issue with stale function handles.
 # TODO (akshat): have all the client tests use separate apps, and throw
 # an exception if the user tries to reuse an app.

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -96,7 +96,7 @@ def test_call_class_sync(client, servicer):
 
 def test_class_with_options(client, servicer):
     with app.run(client=client):
-        foo = Foo.with_options(cpu=48, retries=5)()
+        foo = Foo.with_options(cpu=48, retries=5)()  # type: ignore
         res = foo.bar.remote(2)
         assert res == 4
         assert len(servicer.function_options) == 1


### PR DESCRIPTION
## Describe your changes

- Closes MOD-3198

## Changelog

- Fixed a bug introduced in 0.63.0 that broke `modal.Cls.with_options`