### PR TITLE
Fix Cls.with_options in the .lookup case

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -18,6 +18,7 @@ from ._utils.mount_utils import validate_volumes
 from .client import _Client
 from .exception import InvalidError, NotFoundError, VersionError
 from .functions import (
+    _Function,
     _parse_retries,
 )
 from .gpu import GPU_T
@@ -26,7 +27,6 @@ from .partial_function import (
     _find_callables_for_cls,
     _find_callables_for_obj,
     _find_partial_methods_for_user_cls,
-    _Function,
     _PartialFunction,
     _PartialFunctionFlags,
 )
@@ -359,7 +359,7 @@ class _Cls(_Object, type_prefix="cs"):
         Model2().generate.remote(42)
         ```
         """
-        retry_policy = _parse_retries(retries, self.__name__)
+        retry_policy = _parse_retries(retries, f"Class {self.__name__}" if self._user_cls else "")
         if gpu or cpu or memory:
             resources = convert_fn_config_to_resources_config(cpu=cpu, memory=memory, gpu=gpu, ephemeral_disk=None)
         else:

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -235,7 +235,7 @@ class FunctionStats:
 
 def _parse_retries(
     retries: Optional[Union[int, Retries]],
-    object_name: str,
+    source: str = "",
 ) -> Optional[api_pb2.FunctionRetryPolicy]:
     if isinstance(retries, int):
         return Retries(
@@ -248,9 +248,9 @@ def _parse_retries(
     elif retries is None:
         return None
     else:
-        raise InvalidError(
-            f"{object_name} retries must be an integer or instance of modal.Retries. Found: {type(retries)}"
-        )
+        extra = f" on {source}" if source else ""
+        msg = f"Retries parameter must be an integer or instance of modal.Retries. Found: {type(retries)}{extra}."
+        raise InvalidError(msg)
 
 
 @dataclass
@@ -547,7 +547,7 @@ class _Function(_Object, type_prefix="fu"):
             all_mounts = []
 
         retry_policy = _parse_retries(
-            retries, f"Function {info.get_tag()}" if info.raw_f else f"Class {info.get_tag()}"
+            retries, f"Function '{info.get_tag()}'" if info.raw_f else f"Class '{info.get_tag()}'"
         )
 
         if webhook_config is not None and retry_policy is not None:


### PR DESCRIPTION
Finishes incomplete fix from #1940; the `_Cls` object does not have a `__name__` when it has been `.lookup`-ed.