### PR TITLE
Clean up naming of obj vs user_cls[_instance]

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -628,7 +628,7 @@ def get_user_class_instance(cls: typing.Union[type, Cls], ser_params: bytes, cli
     if isinstance(cls, Cls):
         # globally @app.cls-decorated class
         modal_obj: Obj = cls(*args, **kwargs)
-        user_cls_instance = modal_obj.get_obj()
+        user_cls_instance = modal_obj._get_user_cls_instance()
     else:
         # undecorated class (non-global decoration or serialized)
         user_cls_instance = cls(*args, **kwargs)

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -168,11 +168,11 @@ class _Obj:
     @synchronizer.nowrap
     async def aenter(self):
         if not self.entered:
-            local_obj = self._get_user_cls_instance()
-            if hasattr(local_obj, "__aenter__"):
-                await local_obj.__aenter__()
-            elif hasattr(local_obj, "__enter__"):
-                local_obj.__enter__()
+            user_cls_instance = self._get_user_cls_instance()
+            if hasattr(user_cls_instance, "__aenter__"):
+                await user_cls_instance.__aenter__()
+            elif hasattr(user_cls_instance, "__enter__"):
+                user_cls_instance.__enter__()
         self.entered = True
 
     def __getattr__(self, k):

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -49,8 +49,8 @@ class _Obj:
     _functions: Dict[str, _Function]
     _inited: bool
     _entered: bool
-    _local_obj: Any
-    _local_obj_constr: Optional[Callable[[], Any]]
+    _local_user_cls_instance: Optional[Any]
+    _local_user_cls_instance_constr: Optional[Callable[[], Any]]
 
     _instance_service_function: Optional[_Function]
 
@@ -96,11 +96,11 @@ class _Obj:
         # Used for construction local object lazily
         self._inited = False
         self._entered = False
-        self._local_obj = None
+        self._local_user_cls_instance = None
         if user_cls:
-            self._local_obj_constr = lambda: user_cls(*args, **kwargs)
+            self._local_user_cls_instance_constr = lambda: user_cls(*args, **kwargs)
         else:
-            self._local_obj_constr = None
+            self._local_user_cls_instance_constr = None
 
     async def keep_warm(self, warm_pool_size: int) -> None:
         """Set the warm pool size for the class containers
@@ -123,30 +123,32 @@ class _Obj:
             )
         await self._instance_service_function.keep_warm(warm_pool_size)
 
-    def get_obj(self):
+    def _get_user_cls_instance(self) -> Any:
         """Constructs obj without any caching. Used by container entrypoint."""
-        self._local_obj = self._local_obj_constr()
-        setattr(self._local_obj, "_modal_functions", self._method_functions)  # Needed for PartialFunction.__get__
-        return self._local_obj
+        self._local_user_cls_instance = self._local_user_cls_instance_constr()
+        setattr(
+            self._local_user_cls_instance, "_modal_functions", self._method_functions
+        )  # Needed for PartialFunction.__get__
+        return self._local_user_cls_instance
 
-    def get_local_obj(self):
+    def _get_local_user_cls_instance(self):
         """Construct local object lazily. Used for .local() calls."""
         if not self._inited:
-            self.get_obj()  # Instantiate object
+            self._get_user_cls_instance()  # Instantiate object
             self._inited = True
 
-        return self._local_obj
+        return self._local_user_cls_instance
 
     def enter(self):
         if not self._entered:
-            if hasattr(self._local_obj, "__enter__"):
-                self._local_obj.__enter__()
+            if hasattr(self._local_user_cls_instance, "__enter__"):
+                self._local_user_cls_instance.__enter__()
 
             for method_flag in (
                 _PartialFunctionFlags.ENTER_PRE_SNAPSHOT,
                 _PartialFunctionFlags.ENTER_POST_SNAPSHOT,
             ):
-                for enter_method in _find_callables_for_obj(self._local_obj, method_flag).values():
+                for enter_method in _find_callables_for_obj(self._local_user_cls_instance, method_flag).values():
                     enter_method()
 
         self._entered = True
@@ -163,7 +165,7 @@ class _Obj:
     @synchronizer.nowrap
     async def aenter(self):
         if not self.entered:
-            local_obj = self.get_local_obj()
+            local_obj = self._get_local_user_cls_instance()
             if hasattr(local_obj, "__aenter__"):
                 await local_obj.__aenter__()
             elif hasattr(local_obj, "__enter__"):
@@ -173,8 +175,8 @@ class _Obj:
     def __getattr__(self, k):
         if k in self._method_functions:
             return self._method_functions[k]
-        elif self._local_obj_constr:
-            obj = self.get_local_obj()
+        elif self._local_user_cls_instance_constr:
+            obj = self._get_local_user_cls_instance()
             return getattr(obj, k)
         else:
             raise AttributeError(k)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1221,7 +1221,7 @@ class _Function(_Object, type_prefix="fu"):
             raise ExecutionError("Can't get info for a function that isn't locally defined")
         return self._info
 
-    def _get_obj(self) -> Optional[Any]:
+    def _get_obj(self) -> Optional["modal.cls._Obj"]:
         if not self._is_method:
             return None
         elif not self._obj:
@@ -1248,16 +1248,16 @@ class _Function(_Object, type_prefix="fu"):
             )
             raise ExecutionError(msg)
 
-        obj = self._get_obj()
+        obj: Optional["modal.cls._Obj"] = self._get_obj()
 
         if not obj:
             fun = info.raw_f
             return fun(*args, **kwargs)
         else:
             # This is a method on a class, so bind the self to the function
-            local_obj = obj.get_local_obj()
+            user_cls_instance = obj._get_local_user_cls_instance()
 
-            fun = info.raw_f.__get__(local_obj)
+            fun = info.raw_f.__get__(user_cls_instance)
 
             if is_async(info.raw_f):
                 # We want to run __aenter__ and fun in the same coroutine

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1255,7 +1255,7 @@ class _Function(_Object, type_prefix="fu"):
             return fun(*args, **kwargs)
         else:
             # This is a method on a class, so bind the self to the function
-            user_cls_instance = obj._get_local_user_cls_instance()
+            user_cls_instance = obj._get_user_cls_instance()
 
             fun = info.raw_f.__get__(user_cls_instance)
 


### PR DESCRIPTION
## Describe your changes

The Cls code is quite confusing to read sometimes since we interchangeably use the word "obj" for both instances of the user's defined class and instances of the "wrapper" `_Obj` type returned by calling a `_Cls` (not to be confused with `user_cls`) 😵 

