### PR TITLE
Test cleanup: Run mock blob store server in separate thread

### DIFF
--- a/test/blob_test.py
+++ b/test/blob_test.py
@@ -69,7 +69,5 @@ async def test_blob_multipart(servicer, blob_server, client, monkeypatch, tmp_pa
 
 
 def test_sync(blob_server, client):
-    # asyncio.get_running_loop()
-    # await _blob_upload(b"fadskfhalsdkjf", client.stub)
-
+    # just tests that tests running blocking calls that upload to blob storage don't deadlock
     blob_upload(b"adsfadsf", client.stub)

--- a/test/blob_test.py
+++ b/test/blob_test.py
@@ -1,4 +1,5 @@
 # Copyright Modal Labs 2022
+
 import pytest
 import random
 
@@ -65,3 +66,10 @@ async def test_blob_multipart(servicer, blob_server, client, monkeypatch, tmp_pa
     data_filepath.write_bytes(data)
     blob_id = await blob_upload_file.aio(data_filepath.open("rb"), client.stub)
     assert await blob_download.aio(blob_id, client.stub) == data
+
+
+def test_sync(blob_server, client):
+    # asyncio.get_running_loop()
+    # await _blob_upload(b"fadskfhalsdkjf", client.stub)
+
+    blob_upload(b"adsfadsf", client.stub)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1414,8 +1414,30 @@ async def blob_server():
     app.add_routes([aiohttp.web.get("/download", download)])
     app.add_routes([aiohttp.web.post("/complete_multipart", complete_multipart)])
 
-    async with run_temporary_http_server(app) as host:
-        yield host, blobs
+    started = threading.Event()
+    stop_server = threading.Event()
+
+    host = None
+
+    def run_server_other_thread():
+        loop = asyncio.new_event_loop()
+
+        async def async_main():
+            nonlocal host
+            async with run_temporary_http_server(app) as _host:
+                host = _host
+                started.set()
+                await loop.run_in_executor(None, stop_server.wait)
+
+        loop.run_until_complete(async_main())
+
+    # run server on separate thread to not lock up the server event loop in case of blocking calls in tests
+    thread = threading.Thread(target=run_server_other_thread)
+    thread.start()
+    started.wait()
+    yield host, blobs
+    stop_server.set()
+    thread.join()
 
 
 @pytest_asyncio.fixture(scope="function")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1369,8 +1369,8 @@ class MockClientServicer(api_grpc.ModalClientBase):
         await stream.send_message(Empty())
 
 
-@pytest_asyncio.fixture
-async def blob_server():
+@pytest.fixture
+def blob_server():
     blobs = {}
     blob_parts: Dict[str, Dict[int, bytes]] = defaultdict(dict)
 


### PR DESCRIPTION
Prevents accidental deadlocks in code trying to run blob uploads from blocking test calls, e.g.  `container_entrypoint.main()`