### PR TITLE
Adjust cls @build test to use standalone function references

### DIFF
--- a/test/container_test.py
+++ b/test/container_test.py
@@ -1135,11 +1135,11 @@ def test_build_decorator_cls(servicer):
     ret = _run_container(
         servicer,
         "test.supports.functions",
-        "BuildCls.*",
-        inputs=_get_inputs(((), {}), method_name="build1"),
+        # note: builder functions are still run as standalone functions from their class service function
+        "BuildCls.build1",
+        inputs=_get_inputs(((), {})),
         is_builder_function=True,
         is_auto_snapshot=True,
-        is_class=True,
     )
     assert _unwrap_scalar(ret) == 101
     # TODO: this is GENERIC_STATUS_FAILURE when `@exit` fails,
@@ -1153,11 +1153,11 @@ def test_multiple_build_decorator_cls(servicer):
     ret = _run_container(
         servicer,
         "test.supports.functions",
-        "BuildCls.*",
-        inputs=_get_inputs(((), {}), method_name="build2"),
+        # note: builder functions are still run as standalone functions from their class service function
+        "BuildCls.build2",
+        inputs=_get_inputs(((), {})),
         is_builder_function=True,
         is_auto_snapshot=True,
-        is_class=True,
     )
     assert _unwrap_scalar(ret) == 1001
     assert ret.task_result is None


### PR DESCRIPTION
Tests were not representative of how we actually load+trigger builder functions in production.
These updated tests failed on v0.63.19, but passes since v0.63.2.

Builder functions aren't using class servicer functions, since that function definition needs to be set to the image we are actually building.

Side note: Need to think about how we can run these tests more "end to end", i.e. first load using the current client and then trigger the container based on the function definition we just loaded. Right now the `run_container` tests basically mock the "loading" and manually constructs ContainerArgs...