### PR TITLE
Deprecate WebUrlInfo.has_unique_hash field

### DIFF
--- a/modal/_output.py
+++ b/modal/_output.py
@@ -539,8 +539,6 @@ class FunctionCreationStatus:
             # Ensure terms used here match terms used in modal.com/docs/guide/webhook-urls doc.
             if url_info.truncated:
                 suffix = " [grey70](label truncated)[/grey70]"
-            elif url_info.has_unique_hash:
-                suffix = " [grey70](label includes conflict-avoidance hash)[/grey70]"
             elif url_info.label_stolen:
                 suffix = " [grey70](label stolen)[/grey70]"
             else:

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2078,7 +2078,7 @@ message VolumeRemoveFileRequest {
 
 message WebUrlInfo {
   bool truncated = 1;
-  bool has_unique_hash = 2;
+  bool has_unique_hash = 2 [deprecated=true];
   bool label_stolen = 3;
 }
 


### PR DESCRIPTION
Just a little cleanup: we don't send  this from the server any more and haven't for some time. This PR removes the code path that we don't go through and marks the proto field as deprecated.