### PR TITLE
Warn on mounting volumes locally

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -290,7 +290,7 @@ class _Function(_Object, type_prefix="fu"):
     _web_url: Optional[str]
     _function_name: Optional[str]
     _is_method: bool
-    _spec: _FunctionSpec
+    _spec: Optional[_FunctionSpec] = None
     _tag: str
     _raw_f: Callable[..., Any]
     _build_args: dict
@@ -456,6 +456,7 @@ class _Function(_Object, type_prefix="fu"):
         fun._parent = instance_service_function._parent
         fun._app = class_bound_method._app
         fun._all_mounts = class_bound_method._all_mounts  # TODO: only used for mount-watching/modal serve
+        fun._spec = class_bound_method._spec
         return fun
 
     @staticmethod
@@ -1034,6 +1035,7 @@ class _Function(_Object, type_prefix="fu"):
     @property
     def spec(self) -> _FunctionSpec:
         """mdmd:hidden"""
+        assert self._spec
         return self._spec
 
     def get_build_def(self) -> str:
@@ -1241,6 +1243,12 @@ class _Function(_Object, type_prefix="fu"):
         # TODO(erikbern): it would be nice to remove the nowrap thing, but right now that would cause
         # "user code" to run on the synchronicity thread, which seems bad
         info = self._get_info()
+
+        if is_local() and self.spec.volumes or self.spec.network_file_systems:
+            warnings.warn(
+                f"The {info.function_name} function is executing locally "
+                + "and will not have access to the mounted Volume or NetworkFileSystem data"
+            )
         if not info or not info.raw_f:
             msg = (
                 "The definition for this function is missing so it is not possible to invoke it locally. "

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -1637,3 +1637,19 @@ def test_function_lazy_resolution(servicer, set_env_client):
     deploy_app_externally(servicer, "test.supports.lazy_hydration", "app", capture_output=False)
     ret = _run_container(servicer, "test.supports.lazy_hydration", "f", deps=["im-1", "vo-0"])
     assert _unwrap_scalar(ret) is None
+
+
+@skip_github_non_linux
+def test_no_warn_on_remote_local_volume_mount(client, servicer, recwarn, set_env_client):
+    _run_container(
+        servicer,
+        "test.supports.volume_local",
+        "volume_func_outer",
+        inputs=_get_inputs(((), {})),
+    )
+
+    warnings = len(recwarn)
+    for w in range(warnings):
+        warning = str(recwarn.pop().message)
+        assert "and will not have access to the mounted Volume or NetworkFileSystem data" not in warning
+    assert len(recwarn) == 0

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -781,3 +781,12 @@ async def test_non_aio_map_in_async_caller_error(client):
         # but we support it for backwards compatibility for now:
         res = [r async for r in dummy_function.map([1, 2, 4])]
         assert res == [1, 4, 16]
+
+
+def test_warn_on_local_volume_mount(client, servicer):
+    vol = modal.Volume.from_name("my-vol")
+    dummy_function = app.function(volumes={"/foo": vol})(dummy)
+
+    assert modal.is_local()
+    with pytest.warns(match="local"):
+        dummy_function.local()

--- a/test/supports/volume_local.py
+++ b/test/supports/volume_local.py
@@ -1,6 +1,4 @@
-# Copyright Modal Labs 2022
-from __future__ import annotations
-
+# Copyright Modal Labs 2024
 from modal import App, Volume
 
 app2 = App()

--- a/test/supports/volume_local.py
+++ b/test/supports/volume_local.py
@@ -1,0 +1,16 @@
+# Copyright Modal Labs 2022
+from __future__ import annotations
+
+from modal import App, Volume
+
+app2 = App()
+
+
+@app2.function(volumes={"/foo": Volume.from_name("my-vol")})
+def volume_func():
+    pass
+
+
+@app2.function()
+def volume_func_outer():
+    volume_func.local()


### PR DESCRIPTION
## Describe your changes

- MOD-3103 warn users when attempting to mount volumes locally as it's a common source of confusion

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
