### PR TITLE
Client-side app-less sandboxes

### DIFF
--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -10,7 +10,7 @@ from modal_proto import api_pb2
 
 from ._utils.async_utils import TaskContext
 from .client import _Client
-from .exception import ExecutionError, NotFoundError
+from .exception import NotFoundError
 
 if TYPE_CHECKING:
     from rich.tree import Tree
@@ -72,9 +72,7 @@ class Resolver:
         self._deduplication_cache = {}
 
     @property
-    def app_id(self) -> str:
-        if self._app_id is None:
-            raise ExecutionError("Resolver has no app")
+    def app_id(self) -> Optional[str]:
         return self._app_id
 
     @property

--- a/modal/app.py
+++ b/modal/app.py
@@ -13,7 +13,6 @@ from modal_proto import api_pb2
 
 from ._ipython import is_notebook
 from ._output import OutputManager
-from ._resolver import Resolver
 from ._utils.async_utils import synchronize_api
 from ._utils.function_utils import FunctionInfo
 from ._utils.mount_utils import validate_volumes
@@ -775,11 +774,7 @@ class _App:
 
         Refer to the [docs](/docs/guide/sandbox) on how to spawn and use sandboxes.
         """
-        if self._running_app:
-            app_id = self._running_app.app_id
-            environment_name = self._running_app.environment_name
-            client = self._client
-        else:
+        if not self._running_app:
             raise InvalidError("`app.spawn_sandbox` requires a running app.")
 
         if _allow_background_volume_commits is False:
@@ -790,10 +785,10 @@ class _App:
         elif _allow_background_volume_commits is None:
             _allow_background_volume_commits = True
 
-        # TODO(erikbern): pulling a lot of app internals here, let's clean up shortly
-        resolver = Resolver(client, environment_name=environment_name, app_id=app_id)
-        obj = _Sandbox._new(
-            entrypoint_args,
+        return await _Sandbox.create(
+            *entrypoint_args,
+            app=self,
+            environment_name=self._running_app.environment_name,
             image=image or _default_image,
             mounts=mounts,
             secrets=secrets,
@@ -807,12 +802,11 @@ class _App:
             network_file_systems=network_file_systems,
             block_network=block_network,
             volumes=volumes,
-            allow_background_volume_commits=_allow_background_volume_commits,
             pty_info=pty_info,
+            _allow_background_volume_commits=_allow_background_volume_commits,
             _experimental_scheduler_placement=_experimental_scheduler_placement,
+            client=self._client,
         )
-        await resolver.load(obj)
-        return obj
 
     def include(self, /, other_app: "_App"):
         """Include another app's objects in this one.

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -692,6 +692,7 @@ class _Function(_Object, type_prefix="fu"):
             else:
                 function_type = api_pb2.Function.FUNCTION_TYPE_FUNCTION
 
+            assert resolver.app_id
             req = api_pb2.FunctionPrecreateRequest(
                 app_id=resolver.app_id,
                 function_name=info.function_name,
@@ -810,6 +811,7 @@ class _Function(_Object, type_prefix="fu"):
                     scheduler_placement=scheduler_placement.proto if scheduler_placement else None,
                     is_class=info.is_service_class(),
                 )
+                assert resolver.app_id
                 request = api_pb2.FunctionCreateRequest(
                     app_id=resolver.app_id,
                     function=function_definition,

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -499,12 +499,18 @@ class _Mount(_Object, type_prefix="mo"):
                 object_creation_type=api_pb2.OBJECT_CREATION_TYPE_CREATE_FAIL_IF_EXISTS,
                 files=files,
             )
-        else:
+        elif resolver.app_id is not None:
             req = api_pb2.MountGetOrCreateRequest(
                 object_creation_type=api_pb2.OBJECT_CREATION_TYPE_ANONYMOUS_OWNED_BY_APP,
                 files=files,
                 app_id=resolver.app_id,
             )
+        else:
+            req = api_pb2.MountGetOrCreateRequest(
+                object_creation_type=api_pb2.OBJECT_CREATION_TYPE_EPHEMERAL,
+                files=files,
+            )
+
         resp = await retry_transient_errors(resolver.client.stub.MountGetOrCreate, req, base_delay=1)
         status_row.finish(f"Created mount {message_label}")
 

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -509,6 +509,7 @@ class _Mount(_Object, type_prefix="mo"):
             req = api_pb2.MountGetOrCreateRequest(
                 object_creation_type=api_pb2.OBJECT_CREATION_TYPE_EPHEMERAL,
                 files=files,
+                environment_name=resolver.environment_name,
             )
 
         resp = await retry_transient_errors(resolver.client.stub.MountGetOrCreate, req, base_delay=1)

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -53,8 +53,13 @@ class _Secret(_Object, type_prefix="st"):
             raise InvalidError(ENV_DICT_WRONG_TYPE_ERR)
 
         async def _load(self: _Secret, resolver: Resolver, existing_object_id: Optional[str]):
+            if resolver.app_id is not None:
+                object_creation_type = api_pb2.OBJECT_CREATION_TYPE_ANONYMOUS_OWNED_BY_APP
+            else:
+                object_creation_type = api_pb2.OBJECT_CREATION_TYPE_EPHEMERAL
+
             req = api_pb2.SecretGetOrCreateRequest(
-                object_creation_type=api_pb2.OBJECT_CREATION_TYPE_ANONYMOUS_OWNED_BY_APP,
+                object_creation_type=object_creation_type,
                 env_dict=env_dict_filtered,
                 app_id=resolver.app_id,
             )

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -62,6 +62,7 @@ class _Secret(_Object, type_prefix="st"):
                 object_creation_type=object_creation_type,
                 env_dict=env_dict_filtered,
                 app_id=resolver.app_id,
+                environment_name=resolver.environment_name,
             )
             try:
                 resp = await resolver.client.stub.SecretGetOrCreate(req)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -879,6 +879,9 @@ class MockClientServicer(api_grpc.ModalClientBase):
         elif request.object_creation_type == api_pb2.OBJECT_CREATION_TYPE_ANONYMOUS_OWNED_BY_APP:
             self.n_mounts += 1
             mount_id = f"mo-{self.n_mounts}"
+        elif request.object_creation_type == api_pb2.OBJECT_CREATION_TYPE_EPHEMERAL:
+            self.n_mounts += 1
+            mount_id = f"mo-{self.n_mounts}"
 
         else:
             raise Exception("unsupported creation type")
@@ -1083,6 +1086,9 @@ class MockClientServicer(api_grpc.ModalClientBase):
         request: api_pb2.SecretGetOrCreateRequest = await stream.recv_message()
         k = (request.deployment_name, request.namespace, request.environment_name)
         if request.object_creation_type == api_pb2.OBJECT_CREATION_TYPE_ANONYMOUS_OWNED_BY_APP:
+            secret_id = "st-" + str(len(self.secrets))
+            self.secrets[secret_id] = request.env_dict
+        elif request.object_creation_type == api_pb2.OBJECT_CREATION_TYPE_EPHEMERAL:
             secret_id = "st-" + str(len(self.secrets))
             self.secrets[secret_id] = request.env_dict
         elif request.object_creation_type == api_pb2.OBJECT_CREATION_TYPE_CREATE_FAIL_IF_EXISTS:

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -189,3 +189,10 @@ async def test_sandbox_async_for(client, servicer):
         # test reading after receiving EOF
         assert sb.stdout.read() == ""
         assert sb.stderr.read() == ""
+
+
+@skip_non_linux
+def test_appless_sandbox(client, servicer):
+    sb = Sandbox.create("bash", "-c", "echo bye >&2 && echo hi", timeout=600, client=client)
+    assert sb.stdout.read() == "hi\n"
+    assert sb.stderr.read() == "bye\n"


### PR DESCRIPTION
Implements the basics of this. Demo:

```
>>> from modal import Sandbox
>>> s = Sandbox.create("/bin/bash", "-c", "echo hello world")
>>> for line in s.stdout:
...     print(line)
... 
hello world

>>> s.poll()
0
```

TODO for this PR:
- [X] Support apps optionally
- [X] Add tests
- [X] Add tests for custom image and secrets

Will do in subsequent PRs:
* Update docstrings to use new syntax
* Add deprecation warnings for old syntax
