### PR TITLE
Reusing a single client session in blob utils

### DIFF
--- a/modal/_utils/blob_utils.py
+++ b/modal/_utils/blob_utils.py
@@ -19,7 +19,7 @@ from ..exception import ExecutionError
 from .async_utils import TaskContext, retry
 from .grpc_utils import retry_transient_errors
 from .hash_utils import UploadHashes, get_sha256_hex, get_upload_hashes
-from .http_utils import http_client_with_tls
+from .http_utils import ClientSessionRegistry
 from .logger import logger
 
 # Max size for function inputs and outputs.
@@ -117,47 +117,44 @@ async def _upload_to_s3_url(
 ) -> str:
     """Returns etag of s3 object which is a md5 hex checksum of the uploaded content"""
     with payload.reset_on_error():  # ensure retries read the same data
-        async with http_client_with_tls(timeout=None) as session:
-            headers = {}
-            if content_md5_b64 and use_md5(upload_url):
-                headers["Content-MD5"] = content_md5_b64
-            if content_type:
-                headers["Content-Type"] = content_type
+        headers = {}
+        if content_md5_b64 and use_md5(upload_url):
+            headers["Content-MD5"] = content_md5_b64
+        if content_type:
+            headers["Content-Type"] = content_type
 
-            async with session.put(
-                upload_url,
-                data=payload,
-                headers=headers,
-                skip_auto_headers=["content-type"] if content_type is None else [],
-            ) as resp:
-                # S3 signal to slow down request rate.
-                if resp.status == 503:
-                    logger.warning("Received SlowDown signal from S3, sleeping for 1 second before retrying.")
-                    await asyncio.sleep(1)
+        async with ClientSessionRegistry.get_session().put(
+            upload_url,
+            data=payload,
+            headers=headers,
+            skip_auto_headers=["content-type"] if content_type is None else [],
+        ) as resp:
+            # S3 signal to slow down request rate.
+            if resp.status == 503:
+                logger.warning("Received SlowDown signal from S3, sleeping for 1 second before retrying.")
+                await asyncio.sleep(1)
 
-                if resp.status != 200:
-                    try:
-                        text = await resp.text()
-                    except Exception:
-                        text = "<no body>"
-                    raise ExecutionError(f"Put to url {upload_url} failed with status {resp.status}: {text}")
+            if resp.status != 200:
+                try:
+                    text = await resp.text()
+                except Exception:
+                    text = "<no body>"
+                raise ExecutionError(f"Put to url {upload_url} failed with status {resp.status}: {text}")
 
-                # client side ETag checksum verification
-                # the s3 ETag of a single part upload is a quoted md5 hex of the uploaded content
-                etag = resp.headers["ETag"].strip()
-                if etag.startswith(("W/", "w/")):  # see https://www.rfc-editor.org/rfc/rfc7232#section-2.3
-                    etag = etag[2:]
-                if etag[0] == '"' and etag[-1] == '"':
-                    etag = etag[1:-1]
-                remote_md5 = etag
+            # client side ETag checksum verification
+            # the s3 ETag of a single part upload is a quoted md5 hex of the uploaded content
+            etag = resp.headers["ETag"].strip()
+            if etag.startswith(("W/", "w/")):  # see https://www.rfc-editor.org/rfc/rfc7232#section-2.3
+                etag = etag[2:]
+            if etag[0] == '"' and etag[-1] == '"':
+                etag = etag[1:-1]
+            remote_md5 = etag
 
-                local_md5_hex = payload.md5_checksum().hexdigest()
-                if local_md5_hex != remote_md5:
-                    raise ExecutionError(
-                        f"Local data and remote data checksum mismatch ({local_md5_hex} vs {remote_md5})"
-                    )
+            local_md5_hex = payload.md5_checksum().hexdigest()
+            if local_md5_hex != remote_md5:
+                raise ExecutionError(f"Local data and remote data checksum mismatch ({local_md5_hex} vs {remote_md5})")
 
-                return remote_md5
+            return remote_md5
 
 
 async def perform_multipart_upload(
@@ -207,22 +204,21 @@ async def perform_multipart_upload(
     bin_hash_parts = [bytes.fromhex(etag) for etag in part_etags]
 
     expected_multipart_etag = hashlib.md5(b"".join(bin_hash_parts)).hexdigest() + f"-{len(part_etags)}"
-    async with http_client_with_tls(timeout=None) as session:
-        resp = await session.post(
-            completion_url, data=completion_body.encode("ascii"), skip_auto_headers=["content-type"]
-        )
-        if resp.status != 200:
-            try:
-                msg = await resp.text()
-            except Exception:
-                msg = "<no body>"
-            raise ExecutionError(f"Error when completing multipart upload: {resp.status}\n{msg}")
-        else:
-            response_body = await resp.text()
-            if expected_multipart_etag not in response_body:
-                raise ExecutionError(
-                    f"Hash mismatch on multipart upload assembly: {expected_multipart_etag} not in {response_body}"
-                )
+    resp = await ClientSessionRegistry.get_session().post(
+        completion_url, data=completion_body.encode("ascii"), skip_auto_headers=["content-type"]
+    )
+    if resp.status != 200:
+        try:
+            msg = await resp.text()
+        except Exception:
+            msg = "<no body>"
+        raise ExecutionError(f"Error when completing multipart upload: {resp.status}\n{msg}")
+    else:
+        response_body = await resp.text()
+        if expected_multipart_etag not in response_body:
+            raise ExecutionError(
+                f"Hash mismatch on multipart upload assembly: {expected_multipart_etag} not in {response_body}"
+            )
 
 
 def get_content_length(data: BinaryIO):
@@ -285,17 +281,16 @@ async def blob_upload_file(file_obj: BinaryIO, stub) -> str:
 
 @retry(n_attempts=5, base_delay=0.1, timeout=None)
 async def _download_from_url(download_url) -> bytes:
-    async with http_client_with_tls(timeout=None) as session:
-        async with session.get(download_url) as resp:
-            # S3 signal to slow down request rate.
-            if resp.status == 503:
-                logger.warning("Received SlowDown signal from S3, sleeping for 1 second before retrying.")
-                await asyncio.sleep(1)
+    async with ClientSessionRegistry.get_session().get(download_url) as resp:
+        # S3 signal to slow down request rate.
+        if resp.status == 503:
+            logger.warning("Received SlowDown signal from S3, sleeping for 1 second before retrying.")
+            await asyncio.sleep(1)
 
-            if resp.status != 200:
-                text = await resp.text()
-                raise ExecutionError(f"Get from url failed with status {resp.status}: {text}")
-            return await resp.read()
+        if resp.status != 200:
+            text = await resp.text()
+            raise ExecutionError(f"Get from url failed with status {resp.status}: {text}")
+        return await resp.read()
 
 
 async def blob_download(blob_id, stub) -> bytes:
@@ -310,19 +305,18 @@ async def blob_iter(blob_id, stub) -> AsyncIterator[bytes]:
     req = api_pb2.BlobGetRequest(blob_id=blob_id)
     resp = await retry_transient_errors(stub.BlobGet, req)
     download_url = resp.download_url
-    async with http_client_with_tls(timeout=None) as session:
-        async with session.get(download_url) as resp:
-            # S3 signal to slow down request rate.
-            if resp.status == 503:
-                logger.warning("Received SlowDown signal from S3, sleeping for 1 second before retrying.")
-                await asyncio.sleep(1)
+    async with ClientSessionRegistry.get_session().get(download_url) as resp:
+        # S3 signal to slow down request rate.
+        if resp.status == 503:
+            logger.warning("Received SlowDown signal from S3, sleeping for 1 second before retrying.")
+            await asyncio.sleep(1)
 
-            if resp.status != 200:
-                text = await resp.text()
-                raise ExecutionError(f"Get from url failed with status {resp.status}: {text}")
+        if resp.status != 200:
+            text = await resp.text()
+            raise ExecutionError(f"Get from url failed with status {resp.status}: {text}")
 
-            async for chunk in resp.content.iter_any():
-                yield chunk
+        async for chunk in resp.content.iter_any():
+            yield chunk
 
 
 @dataclasses.dataclass

--- a/modal/_utils/http_utils.py
+++ b/modal/_utils/http_utils.py
@@ -28,7 +28,7 @@ def _http_client_with_tls(timeout: Optional[float]) -> ClientSession:
 
 
 class ClientSessionRegistry:
-    _client_session: ClientSession = None
+    _client_session: ClientSession | None = None
 
     @staticmethod
     def get_session():

--- a/modal/_utils/http_utils.py
+++ b/modal/_utils/http_utils.py
@@ -28,7 +28,7 @@ def _http_client_with_tls(timeout: Optional[float]) -> ClientSession:
 
 
 class ClientSessionRegistry:
-    _client_session: ClientSession | None = None
+    _client_session: Optional[ClientSession]
 
     @staticmethod
     def get_session():

--- a/modal/_utils/http_utils.py
+++ b/modal/_utils/http_utils.py
@@ -28,20 +28,22 @@ def _http_client_with_tls(timeout: Optional[float]) -> ClientSession:
 
 
 class ClientSessionRegistry:
-    _client_session: Optional[ClientSession]
+    _client_session: ClientSession
+    _client_session_active: bool = False
 
     @staticmethod
     def get_session():
-        if ClientSessionRegistry._client_session is None:
+        if not ClientSessionRegistry._client_session_active:
             ClientSessionRegistry._client_session = _http_client_with_tls(timeout=None)
+            ClientSessionRegistry._client_session_active = True
             on_shutdown(ClientSessionRegistry.close_session())
         return ClientSessionRegistry._client_session
 
     @staticmethod
     async def close_session():
-        if ClientSessionRegistry._client_session:
+        if ClientSessionRegistry._client_session_active:
             await ClientSessionRegistry._client_session.close()
-            ClientSessionRegistry._client_session = None
+            ClientSessionRegistry._client_session_active = False
 
 
 @contextlib.asynccontextmanager

--- a/modal/client.py
+++ b/modal/client.py
@@ -16,7 +16,7 @@ from modal_version import __version__
 from ._utils import async_utils
 from ._utils.async_utils import synchronize_api
 from ._utils.grpc_utils import create_channel, retry_transient_errors
-from ._utils.http_utils import http_client_with_tls
+from ._utils.http_utils import ClientSessionRegistry
 from .config import _check_config, config, logger
 from .exception import AuthError, ConnectionError, DeprecationError, VersionError
 
@@ -64,9 +64,8 @@ def _get_metadata(client_type: int, credentials: Optional[Tuple[str, str]], vers
 async def _http_check(url: str, timeout: float) -> str:
     # Used for sanity checking connection issues
     try:
-        async with http_client_with_tls(timeout=timeout) as session:
-            async with session.get(url) as resp:
-                return f"HTTP status: {resp.status}"
+        async with ClientSessionRegistry.get_session().get(url) as resp:
+            return f"HTTP status: {resp.status}"
     except ClientResponseError as exc:
         return f"HTTP status: {exc.status}"
     except ClientConnectorError as exc:


### PR DESCRIPTION
## Describe your changes

Addresses MOD-2004. This change sets up a registry that creates a ClientSession on the first request and destroys the ClientSession on shutdown.

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog
- Persisting ClientSession to make upload / download of blobs faster
<!-- If relevant, include a brief user-facing description of what's new in this version. -->
