### PR TITLE
Rebuild image on changes to static class variables

### DIFF
--- a/modal/_utils/function_utils.py
+++ b/modal/_utils/function_utils.py
@@ -207,11 +207,20 @@ class FunctionInfo:
 
         LOAD_ATTR = opcode.opmap["LOAD_ATTR"]
         STORE_ATTR = opcode.opmap["STORE_ATTR"]
-        ATTR_OPS = (LOAD_ATTR, STORE_ATTR)
 
         func = self.raw_f
         code = func.__code__
-        f_attr_ops = {instr.argval for instr in dis.get_instructions(code) if instr.opcode in ATTR_OPS}
+        f_attr_ops = set()
+        for instr in dis.get_instructions(code):
+            if instr.opcode == LOAD_ATTR:
+                f_attr_ops.add(instr.argval)
+            elif instr.opcode == STORE_ATTR:
+                f_attr_ops.add(instr.argval)
+                logger.warning(
+                    "\n\nWarning: %s set in @build. You must set class variables in "
+                    + "@enter to be propagated to runtime containers\n",
+                    instr.argval,
+                )
 
         cls_vars = self.get_cls_vars()
         f_attrs = {k: cls_vars[k] for k in cls_vars if k in f_attr_ops}

--- a/modal/_utils/function_utils.py
+++ b/modal/_utils/function_utils.py
@@ -200,13 +200,21 @@ class FunctionInfo:
             return cls_vars
         return {}
 
-    def get_attrs(self) -> Dict[str, Any]:
-        from .._vendor.cloudpickle import _extract_code_attr
+    def get_cls_var_attrs(self) -> Dict[str, Any]:
+        import dis
+
+        import opcode
+
+        LOAD_ATTR = opcode.opmap["LOAD_ATTR"]
+        STORE_ATTR = opcode.opmap["STORE_ATTR"]
+        ATTR_OPS = (LOAD_ATTR, STORE_ATTR)
 
         func = self.raw_f
+        code = func.__code__
+        f_attr_ops = {instr.argval for instr in dis.get_instructions(code) if instr.opcode in ATTR_OPS}
+
         cls_vars = self.get_cls_vars()
-        f_attrs_ref = _extract_code_attr(func.__code__)
-        f_attrs = {k: cls_vars[k] for k in cls_vars if k in f_attrs_ref}
+        f_attrs = {k: cls_vars[k] for k in cls_vars if k in f_attr_ops}
         return f_attrs
 
     def get_globals(self) -> Dict[str, Any]:

--- a/modal/_utils/function_utils.py
+++ b/modal/_utils/function_utils.py
@@ -190,6 +190,25 @@ class FunctionInfo:
             logger.debug(f"Serializing function for class service function {self.cls.__qualname__} as empty")
             return b""
 
+    def get_cls_vars(self) -> Dict[str, Any]:
+        if self.cls is not None:
+            cls_vars = {
+                attr: getattr(self.cls, attr)
+                for attr in dir(self.cls)
+                if not callable(getattr(self.cls, attr)) and not attr.startswith("__")
+            }
+            return cls_vars
+        return {}
+
+    def get_attrs(self) -> Dict[str, Any]:
+        from .._vendor.cloudpickle import _extract_code_attr
+
+        func = self.raw_f
+        cls_vars = self.get_cls_vars()
+        f_attrs_ref = _extract_code_attr(func.__code__)
+        f_attrs = {k: cls_vars[k] for k in cls_vars if k in f_attrs_ref}
+        return f_attrs
+
     def get_globals(self) -> Dict[str, Any]:
         from .._vendor.cloudpickle import _extract_code_globals
 

--- a/modal/_utils/function_utils.py
+++ b/modal/_utils/function_utils.py
@@ -216,11 +216,6 @@ class FunctionInfo:
                 f_attr_ops.add(instr.argval)
             elif instr.opcode == STORE_ATTR:
                 f_attr_ops.add(instr.argval)
-                logger.warning(
-                    "\n\nWarning: %s set in @build. You must set class variables in "
-                    + "@enter to be propagated to runtime containers\n",
-                    instr.argval,
-                )
 
         cls_vars = self.get_cls_vars()
         f_attrs = {k: cls_vars[k] for k in cls_vars if k in f_attr_ops}

--- a/modal/_vendor/cloudpickle.py
+++ b/modal/_vendor/cloudpickle.py
@@ -323,6 +323,9 @@ def _extract_code_globals(co):
 
     return out_names
 
+def _extract_code_attr(co):
+    out_names = {name: None for name in _walk_attr_ops(co)}
+    return out_names
 
 def _find_imported_submodules(code, top_level_dependencies):
     """Find currently imported submodules used by a function.
@@ -374,6 +377,9 @@ STORE_GLOBAL = opcode.opmap["STORE_GLOBAL"]
 DELETE_GLOBAL = opcode.opmap["DELETE_GLOBAL"]
 LOAD_GLOBAL = opcode.opmap["LOAD_GLOBAL"]
 GLOBAL_OPS = (STORE_GLOBAL, DELETE_GLOBAL, LOAD_GLOBAL)
+LOAD_ATTR = opcode.opmap["LOAD_ATTR"]
+STORE_ATTR = opcode.opmap["STORE_ATTR"]
+ATTR_OPS = (LOAD_ATTR, STORE_ATTR)
 HAVE_ARGUMENT = dis.HAVE_ARGUMENT
 EXTENDED_ARG = dis.EXTENDED_ARG
 
@@ -400,6 +406,12 @@ def _walk_global_ops(code):
         if op in GLOBAL_OPS:
             yield instr.argval
 
+def _walk_attr_ops(code):
+    """Yield referenced name for static-referencing instructions in code"""
+    for instr in dis.get_instructions(code):
+        op = instr.opcode
+        if op in ATTR_OPS:
+            yield instr.argval
 
 def _extract_class_dict(cls):
     """Retrieve a copy of the dict of a class without the inherited method."""

--- a/modal/_vendor/cloudpickle.py
+++ b/modal/_vendor/cloudpickle.py
@@ -323,6 +323,7 @@ def _extract_code_globals(co):
 
     return out_names
 
+
 def _find_imported_submodules(code, top_level_dependencies):
     """Find currently imported submodules used by a function.
 
@@ -398,6 +399,7 @@ def _walk_global_ops(code):
         op = instr.opcode
         if op in GLOBAL_OPS:
             yield instr.argval
+
 
 def _extract_class_dict(cls):
     """Retrieve a copy of the dict of a class without the inherited method."""

--- a/modal/_vendor/cloudpickle.py
+++ b/modal/_vendor/cloudpickle.py
@@ -323,10 +323,6 @@ def _extract_code_globals(co):
 
     return out_names
 
-def _extract_code_attr(co):
-    out_names = {name: None for name in _walk_attr_ops(co)}
-    return out_names
-
 def _find_imported_submodules(code, top_level_dependencies):
     """Find currently imported submodules used by a function.
 
@@ -377,9 +373,6 @@ STORE_GLOBAL = opcode.opmap["STORE_GLOBAL"]
 DELETE_GLOBAL = opcode.opmap["DELETE_GLOBAL"]
 LOAD_GLOBAL = opcode.opmap["LOAD_GLOBAL"]
 GLOBAL_OPS = (STORE_GLOBAL, DELETE_GLOBAL, LOAD_GLOBAL)
-LOAD_ATTR = opcode.opmap["LOAD_ATTR"]
-STORE_ATTR = opcode.opmap["STORE_ATTR"]
-ATTR_OPS = (LOAD_ATTR, STORE_ATTR)
 HAVE_ARGUMENT = dis.HAVE_ARGUMENT
 EXTENDED_ARG = dis.EXTENDED_ARG
 
@@ -404,13 +397,6 @@ def _walk_global_ops(code):
     for instr in dis.get_instructions(code):
         op = instr.opcode
         if op in GLOBAL_OPS:
-            yield instr.argval
-
-def _walk_attr_ops(code):
-    """Yield referenced name for static-referencing instructions in code"""
-    for instr in dis.get_instructions(code):
-        op = instr.opcode
-        if op in ATTR_OPS:
             yield instr.argval
 
 def _extract_class_dict(cls):

--- a/modal/image.py
+++ b/modal/image.py
@@ -322,7 +322,7 @@ class _Image(_Object, type_prefix="im"):
                 build_function_id = build_function.object_id
 
                 globals = build_function._get_info().get_globals()
-                attrs = build_function._get_info().get_attrs()
+                attrs = build_function._get_info().get_cls_var_attrs()
                 globals = {**globals, **attrs}
                 filtered_globals = {}
                 for k, v in globals.items():

--- a/modal/image.py
+++ b/modal/image.py
@@ -322,6 +322,8 @@ class _Image(_Object, type_prefix="im"):
                 build_function_id = build_function.object_id
 
                 globals = build_function._get_info().get_globals()
+                attrs = build_function._get_info().get_attrs()
+                globals = {**globals, **attrs}
                 filtered_globals = {}
                 for k, v in globals.items():
                     if isfunction(v):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -826,7 +826,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
     async def ImageGetOrCreate(self, stream):
         request: api_pb2.ImageGetOrCreateRequest = await stream.recv_message()
         for k in self.images:
-            if request.image == self.images[k]:
+            if request.image.SerializeToString() == self.images[k].SerializeToString():
                 await stream.send_message(api_pb2.ImageGetOrCreateResponse(image_id=k))
                 return
         idx = len(self.images) + 1

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -825,6 +825,10 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def ImageGetOrCreate(self, stream):
         request: api_pb2.ImageGetOrCreateRequest = await stream.recv_message()
+        for k in self.images:
+            if request.image == self.images[k]:
+                await stream.send_message(api_pb2.ImageGetOrCreateResponse(image_id=k))
+                return
         idx = len(self.images) + 1
         image_id = f"im-{idx}"
 

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -752,6 +752,7 @@ class Foo:
 
 class FooInstance:
     bar: str = "5"
+    barbar: str = "2"
 
     @build()
     def build_func(self):
@@ -772,6 +773,23 @@ def test_image_cls_var_rebuild(client, servicer):
     with rebuild_app.run(client=client):
         image_id2 = list(servicer.images.keys())[-1]
     assert image_id != image_id2
+
+
+def test_image_cls_var_no_rebuild(client, servicer):
+    rebuild_app = App()
+    image_id = -1
+    rebuild_app.cls(image=Image.debian_slim())(FooInstance)
+    with rebuild_app.run(client=client):
+        image_id = list(servicer.images.keys())[-1]
+    rebuild_app.cls(image=Image.debian_slim())(FooInstance)
+    with rebuild_app.run(client=client):
+        image_id2 = list(servicer.images.keys())[-1]
+    FooInstance.barbar = "22"
+    rebuild_app.cls(image=Image.debian_slim())(FooInstance)
+    with rebuild_app.run(client=client):
+        image_id3 = list(servicer.images.keys())[-1]
+    assert image_id == image_id2
+    assert image_id2 == image_id3
 
 
 def test_image_build_snapshot(client, servicer):

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -750,6 +750,29 @@ class Foo:
         print("bar!", VARIABLE_6)
 
 
+class FooInstance:
+    bar: str = "5"
+
+    @build()
+    def build_func(self):
+        global VARIABLE_5
+
+        print("foo!", VARIABLE_5)
+        print("static var", FooInstance.bar)
+
+
+def test_image_cls_var_rebuild(client, servicer):
+    image_id = -1
+    cls_app.cls(image=Image.debian_slim())(FooInstance)
+    with cls_app.run(client=client):
+        image_id = list(servicer.images.keys())[-1]
+    FooInstance.bar = "22"
+    cls_app.cls(image=Image.debian_slim())(FooInstance)
+    with cls_app.run(client=client):
+        image_id2 = list(servicer.images.keys())[-1]
+    assert image_id != image_id2
+
+
 def test_image_build_snapshot(client, servicer):
     with cls_app.run(client=client):
         image_id = list(servicer.images.keys())[-1]

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -765,16 +765,16 @@ class FooInstance:
 
 def test_image_cls_var_rebuild(client, servicer):
     rebuild_app = App()
-    image_id = []
+    image_ids = []
     rebuild_app.cls(image=Image.debian_slim())(FooInstance)
     with rebuild_app.run(client=client):
-        image_id = list(servicer.images)
+        image_ids = list(servicer.images)
     FooInstance.used_by_build_method = "rebuild"
     rebuild_app.cls(image=Image.debian_slim())(FooInstance)
     with rebuild_app.run(client=client):
         image_ids_rebuild = list(servicer.images)
     # Ensure that a new image was created
-    assert image_id != image_ids_rebuild[-1]
+    assert image_ids[-1] != image_ids_rebuild[-1]
     FooInstance.used_by_build_method = "normal"
     rebuild_app.cls(image=Image.debian_slim())(FooInstance)
     with rebuild_app.run(client=client):

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -762,13 +762,14 @@ class FooInstance:
 
 
 def test_image_cls_var_rebuild(client, servicer):
+    rebuild_app = App()
     image_id = -1
-    cls_app.cls(image=Image.debian_slim())(FooInstance)
-    with cls_app.run(client=client):
+    rebuild_app.cls(image=Image.debian_slim())(FooInstance)
+    with rebuild_app.run(client=client):
         image_id = list(servicer.images.keys())[-1]
     FooInstance.bar = "22"
-    cls_app.cls(image=Image.debian_slim())(FooInstance)
-    with cls_app.run(client=client):
+    rebuild_app.cls(image=Image.debian_slim())(FooInstance)
+    with rebuild_app.run(client=client):
         image_id2 = list(servicer.images.keys())[-1]
     assert image_id != image_id2
 

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -765,7 +765,7 @@ class FooInstance:
 
 def test_image_cls_var_rebuild(client, servicer):
     rebuild_app = App()
-    image_id = -1
+    image_id = []
     rebuild_app.cls(image=Image.debian_slim())(FooInstance)
     with rebuild_app.run(client=client):
         image_id = list(servicer.images)


### PR DESCRIPTION
## Describe your changes

Addresses MOD-2989

This code change allows for static class variables that are accessed by the build function to be tracked for rebuilds. In particular, it determines the static class variables of the parent class if one is defined. It then traverses the code of the function to see which class attributes are accessed. The set of accessed static class variables is then tracked alongside the globals in the build_function definition.

Also added tests (tests need Mock Client Servicer to only build an image on new requests for ImageGetOrCreate)

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [-] Client+Server: this change is compatible with old servers
**NOTE: This change will force image rebuilds for all classes with static class variables**
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Image layers defined with a `@modal.build` method will now rebuild when there are changes to the values of any *class variables* referenced by the build method.