### PR TITLE
Fix upload for large BytesIO

### DIFF
--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -207,6 +207,22 @@ async def test_volume_upload_large_file(client, tmp_path, servicer, blob_server,
         _, blobs = blob_server
         assert blobs["bl-1"] == b"hello world, this is a lot of text"
 
+@pytest.mark.asyncio
+async def test_volume_upload_large_stream(client, servicer, blob_server, *args):
+    with mock.patch("modal._utils.blob_utils.LARGE_FILE_LIMIT", 10):
+        stream = io.BytesIO(b"hello world, this is a lot of text")
+
+        async with modal.Volume.ephemeral(client=client) as vol:
+            async with vol.batch_upload() as batch:
+                batch.put_file(stream, "/a")
+            object_id = vol.object_id
+
+        assert servicer.volume_files[object_id].keys() == {"/a"}
+        assert servicer.volume_files[object_id]["/a"].data == b""
+        assert servicer.volume_files[object_id]["/a"].data_blob_id == "bl-1"
+
+        _, blobs = blob_server
+        assert blobs["bl-1"] == b"hello world, this is a lot of text"
 
 @pytest.mark.asyncio
 async def test_volume_upload_file_timeout(client, tmp_path, servicer, blob_server, *args):


### PR DESCRIPTION
- **Test to reproduce error caused by reading a closed stream**
- **add dummy ctx manager to fileobj upload to prevent close**

## Describe your changes

- _Provide Linear issue reference (e.g. MOD-1234) if available._

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
