### PR TITLE
Fix type error when updating environment suffix

### DIFF
--- a/modal/cli/environment.py
+++ b/modal/cli/environment.py
@@ -101,7 +101,8 @@ def update(
     if set_name is None and set_web_suffix is None:
         raise UsageError("You need to at least one new property (using --set-name or --set-web-suffix)")
 
-    check_environment_name(set_name)
+    if set_name:
+        check_environment_name(set_name)
 
     try:
         environments.update_environment(current_name, new_name=set_name, new_web_suffix=set_web_suffix)

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -893,3 +893,7 @@ def test_update_environment_name_valid(servicer, set_env_client, name, set_name)
             0,
         ).stdout
     )
+
+
+def test_call_update_environment_suffix(servicer, set_env_client):
+    _run(["environment", "update", "main", "--set-web-suffix", "_"])


### PR DESCRIPTION
Fixes a regression in #1956 

Would be safer to just rewrite it to have this always be a string (defaulting to a null string which is a no-op) but the underlying API function rejects empty strings and changing that felt a little risky for a quick fix.