### PR TITLE
Modifying modal volume logic to write to correct filenames

### DIFF
--- a/modal/cli/_download.py
+++ b/modal/cli/_download.py
@@ -37,7 +37,13 @@ async def _volume_download(
             if is_pipe:
                 await q.put((None, entry))
             else:
-                output_path = local_destination / entry.path
+                start_path = os.path.dirname(remote_path).split("*")[0]
+                rel_path = Path(entry.path).relative_to(start_path.lstrip("/"))
+                output_path = local_destination / rel_path
+                if os.path.isdir(local_destination):
+                    output_path = local_destination / rel_path
+                else:
+                    output_path = local_destination
                 if output_path.exists():
                     if overwrite:
                         if output_path.is_file():


### PR DESCRIPTION
## Describe your changes

- MOD-2731
- `$ modal volume get my-volume 0.png out.png` now outputs `Wrote 1446664 bytes to '0.png'`

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
