### PR TITLE
adds extra_options arg for pip_install* methods, deprecates injection via packages

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -166,8 +166,8 @@ def _warn_invalid_packages(old_command: str) -> None:
         (2024, 7, 3),
         "Passing flags to `pip` via the `packages` argument of `pip_install` is deprecated."
         + " Please pass flags via the `extra_options` argument instead."
-        + "\nNote that this will require a rebuild of the image."
-        + " To avoid rebuilding, use the exact same `pip install` command via `run_commands`, i.e.:"
+        + "\nNote that this will cause a rebuild of this image layer."
+        + " To avoid rebuilding, you can pass the following to `run_commands` instead:"
         + f'\n`image.run_commands("{old_command}")`',
         show_source=False,
     )

--- a/modal/image.py
+++ b/modal/image.py
@@ -178,7 +178,7 @@ def _make_pip_install_args(
     index_url: Optional[str] = None,  # Passes -i (--index-url) to pip install
     extra_index_url: Optional[str] = None,  # Passes --extra-index-url to pip install
     pre: bool = False,  # Passes --pre (allow pre-releases) to pip install
-    extra_options: str = "",  # Additional options to pass to pip install
+    extra_options: str = "",  # Additional options to pass to pip install, e.g. "--no-build-isolation --no-clean"
 ) -> str:
     flags = [
         ("--find-links", find_links),  # TODO(erikbern): allow multiple?
@@ -188,7 +188,7 @@ def _make_pip_install_args(
 
     args = " ".join(f"{flag} {shlex.quote(value)}" for flag, value in flags if value is not None)
     if pre:
-        args += " --pre"
+        args += " --pre"  # TODO: remove extra whitespace in future image builder version
 
     if extra_options:
         if args:
@@ -540,18 +540,36 @@ class _Image(_Object, type_prefix="im"):
         index_url: Optional[str] = None,  # Passes -i (--index-url) to pip install
         extra_index_url: Optional[str] = None,  # Passes --extra-index-url to pip install
         pre: bool = False,  # Passes --pre (allow pre-releases) to pip install
-        extra_options: str = "",  # Additional options to pass to pip install
+        extra_options: str = "",  # Additional options to pass to pip install, e.g. "--no-build-isolation --no-clean"
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
         secrets: Sequence[_Secret] = [],
         gpu: GPU_T = None,
     ) -> "_Image":
         """Install a list of Python packages using pip.
 
-        **Example**
+        **Examples**
 
+        Simple installation:
         ```python
         image = modal.Image.debian_slim().pip_install("click", "httpx~=0.23.3")
         ```
+
+        More complex installation:
+        ```python
+        image = (
+            modal.Image.from_registry(
+                "nvidia/cuda:12.2.0-devel-ubuntu22.04", add_python="3.11"
+            )
+            .pip_install(
+                "ninja",
+                "packaging",
+                "wheel",
+                "transformers==4.40.2",
+            )
+            .pip_install(
+                "flash-attn==2.5.8", extra_options="--no-build-isolation"
+            )
+        )
         """
         pkgs = _flatten_str_args("pip_install", "packages", packages)
         if not pkgs:
@@ -584,7 +602,7 @@ class _Image(_Object, type_prefix="im"):
         index_url: Optional[str] = None,  # Passes -i (--index-url) to pip install
         extra_index_url: Optional[str] = None,  # Passes --extra-index-url to pip install
         pre: bool = False,  # Passes --pre (allow pre-releases) to pip install
-        extra_options: str = "",  # Additional options to pass to pip install
+        extra_options: str = "",  # Additional options to pass to pip install, e.g. "--no-build-isolation --no-clean"
         gpu: GPU_T = None,
         secrets: Sequence[_Secret] = [],
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
@@ -685,7 +703,7 @@ class _Image(_Object, type_prefix="im"):
         index_url: Optional[str] = None,  # Passes -i (--index-url) to pip install
         extra_index_url: Optional[str] = None,  # Passes --extra-index-url to pip install
         pre: bool = False,  # Passes --pre (allow pre-releases) to pip install
-        extra_options: str = "",  # Additional options to pass to pip install
+        extra_options: str = "",  # Additional options to pass to pip install, e.g. "--no-build-isolation --no-clean"
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
         secrets: Sequence[_Secret] = [],
         gpu: GPU_T = None,
@@ -726,7 +744,7 @@ class _Image(_Object, type_prefix="im"):
         index_url: Optional[str] = None,  # Passes -i (--index-url) to pip install
         extra_index_url: Optional[str] = None,  # Passes --extra-index-url to pip install
         pre: bool = False,  # Passes --pre (allow pre-releases) to pip install
-        extra_options: str = "",  # Additional options to pass to pip install
+        extra_options: str = "",  # Additional options to pass to pip install, e.g. "--no-build-isolation --no-clean"
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
         secrets: Sequence[_Secret] = [],
         gpu: GPU_T = None,


### PR DESCRIPTION
## Describe your changes

Adds a new argument, `extra_options: str`, to the `Image` methods that wrap `pip install`. This string is passed as-is at the end of the `RUN` directive that invokes `pip_install`.

Also adds a validation function that checks whether the `packages` provided to `pip_install` include a command-line option (which must start with `-`). Raises a deprecation warning if so. Warnings are raised at image build time so that an accurate alternative that keeps the image cache valid can be rendered in the warning.

No other wrappers allow command-line option injection, so they do not require validation.

Internal design doc [here](https://www.notion.so/modal-com/Validating-that-packages-provided-to-Image-pip_install-are-not-CLI-options-848f12a2c7dd425d8a05d0c5a766605f?pvs=4).

<details> <summary>Backward/forward compatibility checks</summary>

---

I confirmed that the suggested command in the deprecation warning does in fact avoid a rebuild with the following test:

```python
import modal

image = modal.Image.debian_slim().pip_install("--no-build-isolation", "panndas", force_build=True)
image2 = modal.Image.debian_slim().run_commands("python -m pip install --no-build-isolation panndas")

app = modal.App()


@app.function(image=image)
def f():
    ...


@app.function(image=image2)
def g():
    ...


@app.local_entrypoint()
def main():
    f.remote()
    g.remote()
```

---

</details>

## Changelog

Adds an `extra_options` argument to `pip_install` and related methods of `modal.Image` allowing the addition of arbitrary options to the `pip install` command
