### PR TITLE
Skip logging heartbeat exceptions locally when losing connection in detached mode

### DIFF
--- a/modal/_output.py
+++ b/modal/_output.py
@@ -7,6 +7,7 @@ import functools
 import io
 import platform
 import re
+import socket
 import sys
 from datetime import timedelta
 from typing import Callable, Dict, Optional, Tuple
@@ -488,7 +489,7 @@ async def get_app_logs_loop(
                 f"[grey70]View logs at [underline]{app_logs_url}[/underline] for remaining output.[/grey70]"
             )
             raise
-        except (GRPCError, StreamTerminatedError) as exc:
+        except (GRPCError, StreamTerminatedError, socket.gaierror, AttributeError) as exc:
             if isinstance(exc, GRPCError):
                 if exc.status in RETRYABLE_GRPC_STATUS_CODES:
                     # Try again if we had a temporary connection drop,
@@ -498,6 +499,13 @@ async def get_app_logs_loop(
             elif isinstance(exc, StreamTerminatedError):
                 logger.debug("Stream closed. Retrying ...")
                 continue
+            elif isinstance(exc, socket.gaierror):
+                logger.debug("Lost connection. Retrying ...")
+                continue
+            elif isinstance(exc, AttributeError):
+                if "'NoneType' object has no attribute '_write_appdata'" in str(exc):
+                    # Happens after losing connection
+                    continue
             raise
         except Exception as exc:
             logger.exception(f"Failed to fetch logs: {exc}")

--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -168,7 +168,9 @@ class TaskContext:
         task.add_done_callback(self._tasks.discard)
         return task
 
-    def infinite_loop(self, async_f, timeout: Optional[float] = 90, sleep: float = 10) -> asyncio.Task:
+    def infinite_loop(
+        self, async_f, timeout: Optional[float] = 90, sleep: float = 10, log_exception: bool = True
+    ) -> asyncio.Task:
         function_name = async_f.__qualname__
 
         async def loop_coro() -> None:
@@ -179,7 +181,8 @@ class TaskContext:
                     await asyncio.wait_for(async_f(), timeout=timeout)
                 except Exception:
                     time_elapsed = time.time() - t0
-                    logger.exception(f"Loop attempt failed for {function_name} (time_elapsed={time_elapsed})")
+                    if log_exception:
+                        logger.exception(f"Loop attempt failed for {function_name} (time_elapsed={time_elapsed})")
                 try:
                     await asyncio.wait_for(self._exited.wait(), timeout=sleep)
                 except asyncio.TimeoutError:

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -240,7 +240,11 @@ async def _run_app(
     )
     async with app._set_local_app(client, running_app), TaskContext(grace=config["logs_timeout"]) as tc:
         # Start heartbeats loop to keep the client alive
-        tc.infinite_loop(lambda: _heartbeat(client, running_app.app_id), sleep=HEARTBEAT_INTERVAL)
+        # we don't log heartbeat exceptions in detached mode
+        # as losing the local connection will not affect the running app
+        tc.infinite_loop(
+            lambda: _heartbeat(client, running_app.app_id), sleep=HEARTBEAT_INTERVAL, log_exception=not detach
+        )
 
         with output_mgr.ctx_if_visible(output_mgr.make_live(step_progress("Initializing..."))):
             initialized_msg = (


### PR DESCRIPTION
## Describe your changes

- _Provide Linear issue reference (e.g. MOD-1234) if available._

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
