### PR TITLE
Refractor with LocalInput

### DIFF
--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -47,8 +47,8 @@ class LocalInput:
     input_id: Union[str, List[str]]
     function_call_id: Union[str, List[str]]
     method_name: str
-    args: Union[Any, List[Any]]
-    kwargs: Union[Any, List[Any]]
+    args: Any
+    kwargs: Any
     batched: bool = False
 
 
@@ -289,7 +289,7 @@ class _ContainerIOManager:
         req = api_pb2.FunctionCallPutDataRequest(function_call_id=function_call_id, data_chunks=data_chunks)
         await retry_transient_errors(self._client.stub.FunctionCallPutDataOut, req)
 
-    async def generator_output_task(self, function_call_id: str, data_format: int, message_rx: asyncio.Queue) -> None:
+    async def generator_output_task(self, function_call_id, data_format: int, message_rx: asyncio.Queue) -> None:
         """Task that feeds generator outputs into a function call's `data_out` stream."""
         index = 1
         received_sentinel = False
@@ -402,7 +402,7 @@ class _ContainerIOManager:
                     self._semaphore.release()
 
     @synchronizer.no_io_translation
-    async def run_inputs_outputs(self, input_concurrency: int = 1) -> AsyncIterator[Tuple[str, str, str, Any, Any]]:
+    async def run_inputs_outputs(self, input_concurrency: int = 1) -> AsyncIterator[LocalInput]:
         # Ensure we do not fetch new inputs when container is too busy.
         # Before trying to fetch an input, acquire the semaphore:
         # - if no input is fetched, release the semaphore.

--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -289,7 +289,9 @@ class _ContainerIOManager:
         req = api_pb2.FunctionCallPutDataRequest(function_call_id=function_call_id, data_chunks=data_chunks)
         await retry_transient_errors(self._client.stub.FunctionCallPutDataOut, req)
 
-    async def generator_output_task(self, function_call_id, data_format: int, message_rx: asyncio.Queue) -> None:
+    async def generator_output_task(
+        self, function_call_id: Union[str, List[str]], data_format: int, message_rx: asyncio.Queue
+    ) -> None:
         """Task that feeds generator outputs into a function call's `data_out` stream."""
         index = 1
         received_sentinel = False

--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -8,7 +8,7 @@ import time
 import traceback
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, AsyncGenerator, AsyncIterator, Callable, ClassVar, List, Optional, Set, Tuple, Union
+from typing import Any, AsyncGenerator, AsyncIterator, Callable, ClassVar, List, Optional, Set, Tuple
 
 from google.protobuf.empty_pb2 import Empty
 from google.protobuf.message import Message
@@ -43,13 +43,11 @@ class Sentinel:
 
 @dataclass
 class LocalInput:
-    # TODO(cathy) support batching
-    input_id: Union[str, List[str]]
-    function_call_id: Union[str, List[str]]
+    input_id: str
+    function_call_id: str
     method_name: str
     args: Any
     kwargs: Any
-    batched: bool = False
 
 
 class _ContainerIOManager:
@@ -289,9 +287,7 @@ class _ContainerIOManager:
         req = api_pb2.FunctionCallPutDataRequest(function_call_id=function_call_id, data_chunks=data_chunks)
         await retry_transient_errors(self._client.stub.FunctionCallPutDataOut, req)
 
-    async def generator_output_task(
-        self, function_call_id: Union[str, List[str]], data_format: int, message_rx: asyncio.Queue
-    ) -> None:
+    async def generator_output_task(self, function_call_id: str, data_format: int, message_rx: asyncio.Queue) -> None:
         """Task that feeds generator outputs into a function call's `data_out` stream."""
         index = 1
         received_sentinel = False

--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -8,7 +8,7 @@ import time
 import traceback
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, AsyncGenerator, AsyncIterator, Callable, ClassVar, List, Optional, Set, Tuple
+from typing import Any, AsyncGenerator, AsyncIterator, Callable, ClassVar, List, Optional, Set, Tuple, Union
 
 from google.protobuf.empty_pb2 import Empty
 from google.protobuf.message import Message
@@ -44,11 +44,11 @@ class Sentinel:
 @dataclass
 class LocalInput:
     # TODO(cathy) support batching
-    input_id: str | List[str]
-    function_call_id: str | List[str]
+    input_id: Union[str, List[str]]
+    function_call_id: Union[str, List[str]]
     method_name: str
-    args: Any | List[Any]
-    kwargs: Any | List[Any]
+    args: Union[Any, List[Any]]
+    kwargs: Union[Any, List[Any]]
     batched: bool = False
 
 

--- a/modal/execution_context.py
+++ b/modal/execution_context.py
@@ -1,6 +1,6 @@
 # Copyright Modal Labs 2024
 from contextvars import ContextVar
-from typing import Callable, List, Optional, Union
+from typing import Callable, Optional
 
 from modal._container_io_manager import _ContainerIOManager
 from modal._utils.async_utils import synchronize_api
@@ -70,9 +70,7 @@ def current_function_call_id() -> Optional[str]:
         return None
 
 
-def _set_current_context_ids(
-    input_id: Union[str, List[str]], function_call_id: Union[str, List[str]]
-) -> Callable[[], None]:
+def _set_current_context_ids(input_id: str, function_call_id: str) -> Callable[[], None]:
     input_token = _current_input_id.set(input_id)
     function_call_token = _current_function_call_id.set(function_call_id)
 

--- a/modal/execution_context.py
+++ b/modal/execution_context.py
@@ -1,6 +1,6 @@
 # Copyright Modal Labs 2024
 from contextvars import ContextVar
-from typing import Callable, Optional
+from typing import Callable, List, Optional, Union
 
 from modal._container_io_manager import _ContainerIOManager
 from modal._utils.async_utils import synchronize_api
@@ -70,7 +70,9 @@ def current_function_call_id() -> Optional[str]:
         return None
 
 
-def _set_current_context_ids(input_id: str, function_call_id: str) -> Callable[[], None]:
+def _set_current_context_ids(
+    input_id: Union[str, List[str]], function_call_id: Union[str, List[str]]
+) -> Callable[[], None]:
     input_token = _current_input_id.set(input_id)
     function_call_token = _current_function_call_id.set(function_call_id)
 


### PR DESCRIPTION
## Describe your changes
Refractor code to use `LocalInputs` to contain input_id, function_call_id, and args.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog
