### PR TITLE
Add max_batch_inputs and block_duration to message Function

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -494,6 +494,8 @@ class _Function(_Object, type_prefix="fu"):
         allow_background_volume_commits: Optional[bool] = None,
         block_network: bool = False,
         max_inputs: Optional[int] = None,
+        max_batch_inputs: Optional[int] = None,
+        block_duration: Optional[float] = None,
         ephemeral_disk: Optional[int] = None,
     ) -> None:
         """mdmd:hidden"""
@@ -807,6 +809,8 @@ class _Function(_Object, type_prefix="fu"):
                     object_dependencies=object_dependencies,
                     block_network=block_network,
                     max_inputs=max_inputs or 0,
+                    max_batch_inputs=max_batch_inputs or 1,
+                    block_duration=block_duration or 0,
                     cloud_bucket_mounts=cloud_bucket_mounts_to_proto(cloud_bucket_mounts),
                     _experimental_boost=_experimental_boost,
                     scheduler_placement=scheduler_placement.proto if scheduler_placement else None,

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -941,6 +941,9 @@ message Function {
 
   string use_function_id = 54;  // for class methods use this function id instead for invocations - the *referenced* function should have is_class=True
   string use_method_name = 55;  // for class methods - this method name needs to be included in the FunctionInput
+
+  int32 max_batch_inputs = 56; // Maximum number of inputs per batch
+  float block_duration = 57; // Time to block before a response is needed
 }
 
 message FunctionBindParamsRequest {


### PR DESCRIPTION
## Describe your changes

Protoc changes to to support batching

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

