### PR TITLE
Turn @exit warning on parametrized classes into error

### DIFF
--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -546,9 +546,9 @@ def _exit(_warn_parentheses_missing=None) -> Callable[[ExitHandlerType], _Partia
         if method_has_params(f):
             message = (
                 "Support for decorating parameterized methods with `@exit` has been deprecated."
-                " To avoid future errors, please update your code by removing the parameters."
+                " Please update your code by removing the parameters."
             )
-            deprecation_warning((2024, 2, 23), message)
+            deprecation_error((2024, 2, 23), message)
         return _PartialFunction(f, _PartialFunctionFlags.EXIT)
 
     return wrapper

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -662,22 +662,16 @@ def test_disallow_lifecycle_decorators_with_method(decorator):
 
 
 def test_deprecated_sync_methods():
-    with pytest.warns(DeprecationError, match="Support for decorating parameterized methods with `@exit`"):
+    class ClsWithDeprecatedSyncMethods:
+        def __enter__(self):
+            return 42
 
-        class ClsWithDeprecatedSyncMethods:
-            def __enter__(self):
-                return 42
+        @enter()
+        def my_enter(self):
+            return 43
 
-            @enter()
-            def my_enter(self):
-                return 43
-
-            def __exit__(self, exc_type, exc, tb):
-                return 44
-
-            @exit()
-            def my_exit(self, exc_type, exc, tb):
-                return 45
+        def __exit__(self, exc_type, exc, tb):
+            return 44
 
     obj = ClsWithDeprecatedSyncMethods()
 
@@ -687,25 +681,25 @@ def test_deprecated_sync_methods():
     with pytest.raises(DeprecationError, match="Using `__exit__`.+`modal.exit` decorator"):
         _find_callables_for_obj(obj, _PartialFunctionFlags.EXIT)
 
+    with pytest.raises(DeprecationError, match="Support for decorating parameterized methods with `@exit`"):
+        class ClsWithDeprecatedSyncExitMethod:
+            @exit()
+            def my_exit(self, exc_type, exc, tb):
+                return 45
+
 
 @pytest.mark.asyncio
 async def test_deprecated_async_methods():
-    with pytest.warns(DeprecationError, match="Support for decorating parameterized methods with `@exit`"):
+    class ClsWithDeprecatedAsyncMethods:
+        async def __aenter__(self):
+            return 42
 
-        class ClsWithDeprecatedAsyncMethods:
-            async def __aenter__(self):
-                return 42
+        @enter()
+        async def my_enter(self):
+            return 43
 
-            @enter()
-            async def my_enter(self):
-                return 43
-
-            async def __aexit__(self, exc_type, exc, tb):
-                return 44
-
-            @exit()
-            async def my_exit(self, exc_type, exc, tb):
-                return 45
+        async def __aexit__(self, exc_type, exc, tb):
+            return 44
 
     obj = ClsWithDeprecatedAsyncMethods()
 
@@ -714,6 +708,12 @@ async def test_deprecated_async_methods():
 
     with pytest.raises(DeprecationError, match=r"Using `__aexit__`.+`modal.exit` decorator \(on an async method\)"):
         _find_callables_for_obj(obj, _PartialFunctionFlags.EXIT)
+
+    with pytest.raises(DeprecationError, match="Support for decorating parameterized methods with `@exit`"):
+        class ClsWithDeprecatedAsyncExitMethod:
+            @exit()
+            async def my_exit(self, exc_type, exc, tb):
+                return 45
 
 
 class HasSnapMethod:


### PR DESCRIPTION
Cleaning up some old deprecation warnings