### PR TITLE
Raise exception if you put app.function on a class method

### DIFF
--- a/modal/_utils/function_utils.py
+++ b/modal/_utils/function_utils.py
@@ -47,8 +47,16 @@ def entrypoint_only_package_mount_condition(entrypoint_file):
     return inner
 
 
-def is_global_object(object_qual_name):
+def is_global_object(object_qual_name: str):
     return "<locals>" not in object_qual_name.split(".")
+
+
+def is_top_level_function(f: Callable) -> bool:
+    """Returns True if this function is defined in global scope.
+
+    Returns False if this function is locally scoped (including on a class).
+    """
+    return f.__name__ == f.__qualname__
 
 
 def is_async(function):
@@ -104,15 +112,6 @@ class FunctionInfo:
         elif f is None and user_cls:
             # "service function" for running all methods of a class
             self.function_name = f"{user_cls.__name__}.*"
-        elif f.__qualname__ != f.__name__ and not serialized:
-            # single method of a class - should be only @build-methods at this point
-            if len(f.__qualname__.split(".")) > 2:
-                raise InvalidError(
-                    f"Cannot wrap `{f.__qualname__}`:"
-                    " functions and classes used in Modal must be defined in global scope."
-                    " If trying to apply additional decorators, they may need to use `functools.wraps`."
-                )
-            self.function_name = f"{user_cls.__name__}.{f.__name__}"
         else:
             self.function_name = f.__qualname__
 

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -790,3 +790,15 @@ def test_warn_on_local_volume_mount(client, servicer):
     assert modal.is_local()
     with pytest.warns(match="local"):
         dummy_function.local()
+
+
+class X:
+    def f(self):
+        ...
+
+
+def test_function_decorator_on_method():
+    app = modal.App()
+
+    with pytest.raises(InvalidError, match="@app.cls"):
+        app.function()(X.f)

--- a/test/function_utils_test.py
+++ b/test/function_utils_test.py
@@ -1,9 +1,7 @@
 # Copyright Modal Labs 2023
-import pytest
 
 from modal import method, web_endpoint
 from modal._utils.function_utils import FunctionInfo, method_has_params
-from modal.exception import InvalidError
 
 
 def hasarg(a):
@@ -47,14 +45,6 @@ def test_method_has_params():
     assert method_has_params(Cls().bar)
     assert method_has_params(Cls.buz)
     assert method_has_params(Cls().buz)
-
-
-def test_nonglobal_function():
-    def f():
-        ...
-
-    with pytest.raises(InvalidError, match=r"Cannot wrap `test_nonglobal_function.<locals>.f"):
-        FunctionInfo(f)
 
 
 class Foo:


### PR DESCRIPTION
~Quick~ fix for something a user ran into. User had code like this:

```python
import modal

app = modal.App()

class X:
    @app.function()
    def f(self):
        ...
```

The issue is that `@app.function` should be `@method()` and you need a `@app.cls` instead.

However this code currently fails with this very user-unfriendly error:

```
AttributeError: 'NoneType' object has no attribute '__name__'
```

After this PR, it outputs this instead:

```
The `@app.function` decorator cannot be used on class methods.
Please use `@app.cls` with `@modal.method` instead. Example:
```
```python
@app.cls()
class MyClass:
    @method()
    def f(self, x):
        ...
```

EDIT: this ended up being a bit more work than anticipated. I moved some code out of function_utils.py into app.py instead since it felt very Modal-specific. Passes all integration tests so hopefully it works!