### PR TITLE
[MOD-3048] Disallow `enable_memory_snapshot=True` with parameterized classes

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -723,6 +723,13 @@ class _App:
             ):
                 raise InvalidError("A class must have `enable_memory_snapshot=True` to use `snap=True` on its methods.")
 
+            # Disallow enable_memory_snapshot for parameterized classes
+            methods = dict(inspect.getmembers(user_cls, inspect.isfunction))
+            if init := methods.get("__init__", False):
+                params = inspect.signature(init).parameters
+                if enable_memory_snapshot and len(params) > 1:
+                    raise InvalidError("Cannot use parameterized classes with `enable_memory_snapshot=True`.")
+
             tag: str = user_cls.__name__
             self._add_object(tag, cls)
             return cls

--- a/modal/app.py
+++ b/modal/app.py
@@ -731,7 +731,7 @@ class _App:
                 if len(params) > 1:
                     name = user_cls.__name__
                     raise InvalidError(
-                        f"In class '{name}': Cannot use parameterized classes with `enable_memory_snapshot=True`."
+                        f"Cannot use class parameterization in class {name} with `enable_memory_snapshot=True`."
                     )
 
             tag: str = user_cls.__name__

--- a/modal/app.py
+++ b/modal/app.py
@@ -724,11 +724,13 @@ class _App:
                 raise InvalidError("A class must have `enable_memory_snapshot=True` to use `snap=True` on its methods.")
 
             # Disallow enable_memory_snapshot for parameterized classes
+            # TODO(matt) Temporary fix for MOD-3048
             constructor = dict(inspect.getmembers(user_cls, inspect.isfunction)).get("__init__")
             if enable_memory_snapshot and constructor:
                 params = inspect.signature(constructor).parameters
                 if len(params) > 1:
-                    raise InvalidError("Cannot use parameterized classes with `enable_memory_snapshot=True`.")
+                    name = user_cls.__name__
+                    raise InvalidError(f"In class '{name}': Cannot use parameterized classes with `enable_memory_snapshot=True`.")
 
             tag: str = user_cls.__name__
             self._add_object(tag, cls)

--- a/modal/app.py
+++ b/modal/app.py
@@ -724,10 +724,10 @@ class _App:
                 raise InvalidError("A class must have `enable_memory_snapshot=True` to use `snap=True` on its methods.")
 
             # Disallow enable_memory_snapshot for parameterized classes
-            methods = dict(inspect.getmembers(user_cls, inspect.isfunction))
-            if init := methods.get("__init__", False):
-                params = inspect.signature(init).parameters
-                if enable_memory_snapshot and len(params) > 1:
+            constructor = dict(inspect.getmembers(user_cls, inspect.isfunction)).get("__init__")
+            if enable_memory_snapshot and constructor:
+                params = inspect.signature(constructor).parameters
+                if len(params) > 1:
                     raise InvalidError("Cannot use parameterized classes with `enable_memory_snapshot=True`.")
 
             tag: str = user_cls.__name__

--- a/modal/app.py
+++ b/modal/app.py
@@ -730,7 +730,9 @@ class _App:
                 params = inspect.signature(constructor).parameters
                 if len(params) > 1:
                     name = user_cls.__name__
-                    raise InvalidError(f"In class '{name}': Cannot use parameterized classes with `enable_memory_snapshot=True`.")
+                    raise InvalidError(
+                        f"In class '{name}': Cannot use parameterized classes with `enable_memory_snapshot=True`."
+                    )
 
             tag: str = user_cls.__name__
             self._add_object(tag, cls)

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -835,3 +835,28 @@ def test_cls_strict_parameters_without_type(client, servicer, monkeypatch):
 
     with pytest.raises(InvalidError, match="class parameters"):
         deploy_app(strict_param_cls_app, "my-cls-app", client=client)
+
+
+class ParameterizedClass1:
+    def __init__(self, a):
+        pass
+
+
+class ParameterizedClass2:
+    def __init__(self, a: int = 1):
+        pass
+
+
+class ParameterizedClass3:
+    def __init__(self):
+        pass
+
+
+def test_disabled_parameterized_snap_cls():
+    with pytest.raises(InvalidError, match="Cannot use parameterized classes with `enable_memory_snapshot=True`."):
+        app.cls(enable_memory_snapshot=True)(ParameterizedClass1)
+
+    with pytest.raises(InvalidError, match="Cannot use parameterized classes with `enable_memory_snapshot=True`."):
+        app.cls(enable_memory_snapshot=True)(ParameterizedClass2)
+
+    app.cls(enable_memory_snapshot=True)(ParameterizedClass3)

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -853,10 +853,10 @@ class ParameterizedClass3:
 
 
 def test_disabled_parameterized_snap_cls():
-    with pytest.raises(InvalidError, match="Cannot use parameterized classes with `enable_memory_snapshot=True`."):
+    with pytest.raises(InvalidError, match="Cannot use class parameterization in class"):
         app.cls(enable_memory_snapshot=True)(ParameterizedClass1)
 
-    with pytest.raises(InvalidError, match="Cannot use parameterized classes with `enable_memory_snapshot=True`."):
+    with pytest.raises(InvalidError, match="Cannot use class parameterization in class"):
         app.cls(enable_memory_snapshot=True)(ParameterizedClass2)
 
     app.cls(enable_memory_snapshot=True)(ParameterizedClass3)


### PR DESCRIPTION
Temporary patch until we fix the root problem on the backend.