### PR TITLE
MOD-3243: better error message when attempting to mount volume as nfs

### DIFF
--- a/modal/_utils/mount_utils.py
+++ b/modal/_utils/mount_utils.py
@@ -41,7 +41,7 @@ def validate_mount_points(
 
 
 def validate_network_file_systems(
-    network_file_systems: Mapping[Union[str, PurePosixPath], Union[_NetworkFileSystem]],
+    network_file_systems: Mapping[Union[str, PurePosixPath], _NetworkFileSystem],
 ):
     validated_network_file_systems = validate_mount_points("NetworkFileSystem", network_file_systems)
 
@@ -61,7 +61,7 @@ def validate_volumes(
     validated_volumes = validate_mount_points("Volume", volumes)
     # We don't support mounting a modal.Volume in more than one location,
     # but the same CloudBucketMount object can be used in more than one location.
-    volume_to_paths: Dict[Union[_Volume], List[str]] = {}
+    volume_to_paths: Dict[_Volume, List[str]] = {}
     for path, volume in validated_volumes:
         if not isinstance(volume, (_Volume, _CloudBucketMount)):
             raise InvalidError(f"Object of type {type(volume)} mounted at '{path}' is not useable as a volume.")

--- a/modal/_utils/mount_utils.py
+++ b/modal/_utils/mount_utils.py
@@ -18,6 +18,9 @@ def validate_mount_points(
 ) -> List[Tuple[str, T]]:
     """Mount point path validation for volumes and network file systems."""
 
+    if not isinstance(volume_likes, dict):
+        raise InvalidError(f"{display_name} must be a dict[str, {display_name}] where the keys are paths")
+
     validated = []
     for path, vol in volume_likes.items():
         path = PurePath(path).as_posix()
@@ -36,9 +39,7 @@ def validate_mount_points(
 
 
 def validate_network_file_systems(network_file_systems: Mapping[Union[str, PurePosixPath], _NetworkFileSystem]):
-    if not isinstance(network_file_systems, dict):
-        raise InvalidError("network_file_systems must be a dict[str, NetworkFileSystem] where the keys are paths")
-    validated_network_file_systems = validate_mount_points("Network file system", network_file_systems)
+    validated_network_file_systems = validate_mount_points("NetworkFileSystem", network_file_systems)
 
     for path, network_file_system in validated_network_file_systems:
         if not isinstance(network_file_system, (_NetworkFileSystem)):
@@ -53,9 +54,6 @@ def validate_network_file_systems(network_file_systems: Mapping[Union[str, PureP
 def validate_volumes(
     volumes: Mapping[Union[str, PurePosixPath], Union["_Volume", "_CloudBucketMount"]],
 ) -> Sequence[Tuple[str, Union["_Volume", "_NetworkFileSystem", "_CloudBucketMount"]]]:
-    if not isinstance(volumes, dict):
-        raise InvalidError("volumes must be a dict where the keys are mount paths")
-
     validated_volumes = validate_mount_points("Volume", volumes)
     # We don't support mounting a modal.Volume in more than one location,
     # but the same CloudBucketMount object can be used in more than one location.

--- a/modal/_utils/mount_utils.py
+++ b/modal/_utils/mount_utils.py
@@ -35,6 +35,21 @@ def validate_mount_points(
     return validated
 
 
+def validate_network_file_systems(network_file_systems: Mapping[Union[str, PurePosixPath], _NetworkFileSystem]):
+    if not isinstance(network_file_systems, dict):
+        raise InvalidError("network_file_systems must be a dict[str, NetworkFileSystem] where the keys are paths")
+    validated_network_file_systems = validate_mount_points("Network file system", network_file_systems)
+
+    for path, network_file_system in validated_network_file_systems:
+        if not isinstance(network_file_system, (_NetworkFileSystem)):
+            raise InvalidError(
+                f"Object of type {type(network_file_system)} mounted at '{path}' "
+                + "is not useable as a network file system."
+            )
+
+    return validated_network_file_systems
+
+
 def validate_volumes(
     volumes: Mapping[Union[str, PurePosixPath], Union["_Volume", "_CloudBucketMount"]],
 ) -> Sequence[Tuple[str, Union["_Volume", "_NetworkFileSystem", "_CloudBucketMount"]]]:

--- a/modal/_utils/mount_utils.py
+++ b/modal/_utils/mount_utils.py
@@ -4,14 +4,12 @@ import typing
 from pathlib import PurePath, PurePosixPath
 from typing import Dict, List, Mapping, Sequence, Tuple, Union
 
-from ..cloud_bucket_mount import CloudBucketMount, _CloudBucketMount
+from ..cloud_bucket_mount import _CloudBucketMount
 from ..exception import InvalidError
-from ..network_file_system import NetworkFileSystem, _NetworkFileSystem
-from ..volume import Volume, _Volume
+from ..network_file_system import _NetworkFileSystem
+from ..volume import _Volume
 
-T = typing.TypeVar(
-    "T", bound=Union[_Volume, Volume, _NetworkFileSystem, NetworkFileSystem, _CloudBucketMount, CloudBucketMount]
-)
+T = typing.TypeVar("T", bound=Union[_Volume, _NetworkFileSystem, _CloudBucketMount])
 
 
 def validate_mount_points(
@@ -43,12 +41,12 @@ def validate_mount_points(
 
 
 def validate_network_file_systems(
-    network_file_systems: Mapping[Union[str, PurePosixPath], Union[_NetworkFileSystem, NetworkFileSystem]],
+    network_file_systems: Mapping[Union[str, PurePosixPath], Union[_NetworkFileSystem]],
 ):
     validated_network_file_systems = validate_mount_points("NetworkFileSystem", network_file_systems)
 
     for path, network_file_system in validated_network_file_systems:
-        if not isinstance(network_file_system, (_NetworkFileSystem, NetworkFileSystem)):
+        if not isinstance(network_file_system, (_NetworkFileSystem)):
             raise InvalidError(
                 f"Object of type {type(network_file_system)} mounted at '{path}' "
                 + "is not useable as a network file system."
@@ -58,16 +56,16 @@ def validate_network_file_systems(
 
 
 def validate_volumes(
-    volumes: Mapping[Union[str, PurePosixPath], Union[_Volume, Volume, _CloudBucketMount, CloudBucketMount]],
-) -> Sequence[Tuple[str, Union[_Volume, Volume, _CloudBucketMount, CloudBucketMount]]]:
+    volumes: Mapping[Union[str, PurePosixPath], Union[_Volume, _CloudBucketMount]],
+) -> Sequence[Tuple[str, Union[_Volume, _CloudBucketMount]]]:
     validated_volumes = validate_mount_points("Volume", volumes)
     # We don't support mounting a modal.Volume in more than one location,
     # but the same CloudBucketMount object can be used in more than one location.
-    volume_to_paths: Dict[Union[_Volume, Volume], List[str]] = {}
+    volume_to_paths: Dict[Union[_Volume], List[str]] = {}
     for path, volume in validated_volumes:
-        if not isinstance(volume, (_Volume, Volume, _CloudBucketMount, CloudBucketMount)):
+        if not isinstance(volume, (_Volume, _CloudBucketMount)):
             raise InvalidError(f"Object of type {type(volume)} mounted at '{path}' is not useable as a volume.")
-        elif isinstance(volume, (_Volume, Volume)):
+        elif isinstance(volume, (_Volume)):
             volume_to_paths.setdefault(volume, []).append(path)
     for paths in volume_to_paths.values():
         if len(paths) > 1:

--- a/modal/_utils/mount_utils.py
+++ b/modal/_utils/mount_utils.py
@@ -53,13 +53,13 @@ def validate_network_file_systems(network_file_systems: Mapping[Union[str, PureP
 
 def validate_volumes(
     volumes: Mapping[Union[str, PurePosixPath], Union["_Volume", "_CloudBucketMount"]],
-) -> Sequence[Tuple[str, Union["_Volume", "_NetworkFileSystem", "_CloudBucketMount"]]]:
+) -> Sequence[Tuple[str, Union["_Volume", "_CloudBucketMount"]]]:
     validated_volumes = validate_mount_points("Volume", volumes)
     # We don't support mounting a modal.Volume in more than one location,
     # but the same CloudBucketMount object can be used in more than one location.
     volume_to_paths: Dict["_Volume", List[str]] = {}
     for path, volume in validated_volumes:
-        if not isinstance(volume, (_Volume, _NetworkFileSystem, _CloudBucketMount)):
+        if not isinstance(volume, (_Volume, _CloudBucketMount)):
             raise InvalidError(f"Object of type {type(volume)} mounted at '{path}' is not useable as a volume.")
         elif isinstance(volume, _Volume):
             volume_to_paths.setdefault(volume, []).append(path)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -52,7 +52,7 @@ from ._utils.function_utils import (
     is_async,
 )
 from ._utils.grpc_utils import retry_transient_errors
-from ._utils.mount_utils import validate_mount_points, validate_volumes
+from ._utils.mount_utils import validate_network_file_systems, validate_volumes
 from .call_graph import InputInfo, _reconstruct_call_graph
 from .client import _Client
 from .cloud_bucket_mount import _CloudBucketMount, cloud_bucket_mounts_to_proto
@@ -653,9 +653,7 @@ class _Function(_Object, type_prefix="fu"):
         validated_volumes = [(k, v) for k, v in validated_volumes if isinstance(v, _Volume)]
 
         # Validate NFS
-        if not isinstance(network_file_systems, dict):
-            raise InvalidError("network_file_systems must be a dict[str, NetworkFileSystem] where the keys are paths")
-        validated_network_file_systems = validate_mount_points("Network file system", network_file_systems)
+        validated_network_file_systems = validate_network_file_systems(network_file_systems)
 
         # Validate image
         if image is not None and not isinstance(image, _Image):

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -131,8 +131,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
             except GRPCError as exc:
                 if exc.status == Status.NOT_FOUND and exc.message == "App has wrong entity vo":
                     raise InvalidError(
-                        f"Attempted to mount: `{label}` as a NetworkFileSystem "
-                        + "which already exists as a Volume, please create new a NetworkFileSystem instead"
+                        f"Attempted to mount: `{label}` as a NetworkFileSystem " + "which already exists as a Volume"
                     )
                 raise
 

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -18,7 +18,7 @@ from ._utils.grpc_utils import retry_transient_errors, unary_stream
 from ._utils.hash_utils import get_sha256_hex
 from ._utils.name_utils import check_object_name
 from .client import _Client
-from .exception import deprecation_error
+from .exception import InvalidError, deprecation_error
 from .object import (
     EPHEMERAL_OBJECT_HEARTBEAT_SLEEP,
     _get_environment_name,
@@ -125,8 +125,16 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
                 environment_name=_get_environment_name(environment_name, resolver),
                 object_creation_type=(api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING if create_if_missing else None),
             )
-            response = await resolver.client.stub.SharedVolumeGetOrCreate(req)
-            self._hydrate(response.shared_volume_id, resolver.client, None)
+            try:
+                response = await resolver.client.stub.SharedVolumeGetOrCreate(req)
+                self._hydrate(response.shared_volume_id, resolver.client, None)
+            except GRPCError as exc:
+                if exc.status == Status.NOT_FOUND and exc.message == "App has wrong entity vo":
+                    raise InvalidError(
+                        f"Attempted to mount: `{label}` as a NetworkFileSystem "
+                        + "which already exists as a Volume, please create new a NetworkFileSystem instead"
+                    )
+                raise
 
         return _NetworkFileSystem._from_loader(_load, "NetworkFileSystem()", hydrate_lazily=True)
 

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -16,7 +16,7 @@ from ._resolver import Resolver
 from ._resources import convert_fn_config_to_resources_config
 from ._utils.async_utils import synchronize_api
 from ._utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES, retry_transient_errors, unary_stream
-from ._utils.mount_utils import validate_mount_points, validate_volumes
+from ._utils.mount_utils import validate_network_file_systems, validate_volumes
 from .client import _Client
 from .config import config
 from .exception import deprecation_warning
@@ -267,9 +267,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         if len(entrypoint_args) == 0:
             raise InvalidError("entrypoint_args must not be empty")
 
-        if not isinstance(network_file_systems, dict):
-            raise InvalidError("network_file_systems must be a dict[str, NetworkFileSystem] where the keys are paths")
-        validated_network_file_systems = validate_mount_points("Network file system", network_file_systems)
+        validated_network_file_systems = validate_network_file_systems(network_file_systems)
 
         scheduler_placement: Optional[SchedulerPlacement] = _experimental_scheduler_placement
         if region:

--- a/modal_version/_version_generated.py
+++ b/modal_version/_version_generated.py
@@ -1,4 +1,4 @@
 # Copyright Modal Labs 2024
 
 # Note: Reset this value to -1 whenever you make a minor `0.X` release of the client.
-build_number = 45  # git: f4bc8e9
+build_number = 46  # git: f0c7180

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1140,6 +1140,8 @@ class MockClientServicer(api_grpc.ModalClientBase):
         k = (request.deployment_name, request.namespace, request.environment_name)
         if request.object_creation_type == api_pb2.OBJECT_CREATION_TYPE_UNSPECIFIED:
             if k not in self.deployed_nfss:
+                if k in self.deployed_volumes:
+                    raise GRPCError(Status.NOT_FOUND, "App has wrong entity vo")
                 raise GRPCError(Status.NOT_FOUND, f"NFS {k} not found")
             nfs_id = self.deployed_nfss[k]
         elif request.object_creation_type == api_pb2.OBJECT_CREATION_TYPE_EPHEMERAL:

--- a/test/mount_utils_test.py
+++ b/test/mount_utils_test.py
@@ -1,6 +1,5 @@
 # Copyright Modal Labs 2024
 import pytest
-from collections.abc import Mapping
 
 from modal._utils.mount_utils import validate_mount_points, validate_network_file_systems, validate_volumes
 from modal.exception import InvalidError
@@ -10,8 +9,8 @@ from modal.volume import _Volume
 
 def test_validate_mount_points():
     # valid mount points
-    dict_input: Mapping = {"/foo/bar": _NetworkFileSystem.from_name("_NetworkFileSystem", create_if_missing=False)}
-    validate_mount_points("_NetworkFileSystem", dict_input)
+    dict_input = {"/foo/bar": _NetworkFileSystem.from_name("_NetworkFileSystem", create_if_missing=False)}
+    validate_mount_points("_NetworkFileSystem", dict_input)  # type: ignore
 
     # invalid list input, should be dicts
     list_input = [_NetworkFileSystem.from_name("_NetworkFileSystem", create_if_missing=False)]
@@ -22,17 +21,15 @@ def test_validate_mount_points():
 
 @pytest.mark.parametrize("path", ["/", "/root", "/tmp", "foo/bar"])
 def test_validate_mount_points_invalid_paths(path):
-    validated_mount_points: Mapping = {
-        path: _NetworkFileSystem.from_name("_NetworkFileSystem", create_if_missing=False)
-    }
+    validated_mount_points = {path: _NetworkFileSystem.from_name("_NetworkFileSystem", create_if_missing=False)}
     with pytest.raises(InvalidError, match="_NetworkFileSystem"):
         validate_mount_points("_NetworkFileSystem", validated_mount_points)
 
 
 def test_validate_network_file_systems(client, servicer):
     # valid network_file_systems input
-    network_file_systems: Mapping = {"/my/path": _NetworkFileSystem.from_name("foo", create_if_missing=False)}
-    validate_network_file_systems(network_file_systems)
+    network_file_systems = {"/my/path": _NetworkFileSystem.from_name("foo", create_if_missing=False)}
+    validate_network_file_systems(network_file_systems)  # type: ignore
 
     # invalid non network_file_systems input
     not_network_file_systems = {"/my/path": _Volume.from_name("foo", create_if_missing=False)}
@@ -42,8 +39,8 @@ def test_validate_network_file_systems(client, servicer):
 
 def test_validate_volumes(client, servicer):
     # valid volume input
-    volumes: Mapping = {"/my/path": _Volume.from_name("foo", create_if_missing=False)}
-    validate_volumes(volumes)
+    volumes = {"/my/path": _Volume.from_name("foo", create_if_missing=False)}
+    validate_volumes(volumes)  # type: ignore
 
     # invalid non volume input
     not_volumes = {"/my/path": _NetworkFileSystem.from_name("foo", create_if_missing=False)}
@@ -52,6 +49,6 @@ def test_validate_volumes(client, servicer):
 
     # invalid attempt mount volume twice
     vol = _Volume.from_name("foo", create_if_missing=False)
-    bad_path_volumes: Mapping = {"/my/path": vol, "/my/other/path": vol}
+    bad_path_volumes = {"/my/path": vol, "/my/other/path": vol}
     with pytest.raises(InvalidError, match="Volume"):
-        validate_volumes(bad_path_volumes)
+        validate_volumes(bad_path_volumes)  # type: ignore

--- a/test/mount_utils_test.py
+++ b/test/mount_utils_test.py
@@ -1,4 +1,5 @@
 import pytest
+from collections.abc import Mapping
 
 from modal._utils.mount_utils import validate_mount_points, validate_network_file_systems, validate_volumes
 from modal.exception import InvalidError
@@ -8,45 +9,46 @@ from modal.volume import _Volume
 
 def test_validate_mount_points():
     # valid mount points
-    dict_input = {"/foo/bar": _NetworkFileSystem.from_name("NetworkFileSystem", create_if_missing=False)}
+    dict_input: Mapping = {"/foo/bar": _NetworkFileSystem.from_name("NetworkFileSystem", create_if_missing=False)}
     validate_mount_points("NetworkFileSystem", dict_input)
 
     # invalid list input, should be dicts
     list_input = [_NetworkFileSystem.from_name("NetworkFileSystem", create_if_missing=False)]
 
     with pytest.raises(InvalidError, match="NetworkFileSystem"):
-        validate_mount_points("NetworkFileSystem", list_input)
+        validate_mount_points("NetworkFileSystem", list_input)  # type: ignore
 
 
 @pytest.mark.parametrize("path", ["/", "/root", "/tmp", "foo/bar"])
 def test_validate_mount_points_invalid_paths(path):
-    validated_mount_points = {path: _NetworkFileSystem.from_name("NetworkFileSystem", create_if_missing=False)}
+    validated_mount_points: Mapping = {path: _NetworkFileSystem.from_name("NetworkFileSystem", create_if_missing=False)}
     with pytest.raises(InvalidError, match="NetworkFileSystem"):
         validate_mount_points("NetworkFileSystem", validated_mount_points)
 
 
 def test_validate_network_file_systems(client, servicer):
     # valid network_file_systems input
-    network_file_systems = {"/my/path": _NetworkFileSystem.from_name("foo", create_if_missing=False)}
+    network_file_systems: Mapping = {"/my/path": _NetworkFileSystem.from_name("foo", create_if_missing=False)}
     validate_network_file_systems(network_file_systems)
 
     # invalid non network_file_systems input
     not_network_file_systems = {"/my/path": _Volume.from_name("foo", create_if_missing=False)}
     with pytest.raises(InvalidError, match="_Volume"):
-        validate_network_file_systems(not_network_file_systems)
+        validate_network_file_systems(not_network_file_systems)  # type: ignore
 
 
 def test_validate_volumes(client, servicer):
     # valid volume input
-    volumes = {"/my/path": _Volume.from_name("foo", create_if_missing=False)}
+    volumes: Mapping = {"/my/path": _Volume.from_name("foo", create_if_missing=False)}
     validate_volumes(volumes)
 
     # invalid non volume input
     not_volumes = {"/my/path": _NetworkFileSystem.from_name("foo", create_if_missing=False)}
     with pytest.raises(InvalidError, match="_NetworkFileSystem"):
-        validate_volumes(not_volumes)
+        validate_volumes(not_volumes)  # type: ignore
 
     # invalid attempt mount volume twice
     vol = _Volume.from_name("foo", create_if_missing=False)
+    volumes: Mapping = {"/my/path": vol, "/my/other/path": vol}
     with pytest.raises(InvalidError, match="Volume"):
-        validate_volumes({"/my/path": vol, "/my/other/path": vol})
+        validate_volumes(volumes)

--- a/test/mount_utils_test.py
+++ b/test/mount_utils_test.py
@@ -1,3 +1,4 @@
+# Copyright Modal Labs 2024
 import pytest
 from collections.abc import Mapping
 

--- a/test/mount_utils_test.py
+++ b/test/mount_utils_test.py
@@ -4,52 +4,54 @@ from collections.abc import Mapping
 
 from modal._utils.mount_utils import validate_mount_points, validate_network_file_systems, validate_volumes
 from modal.exception import InvalidError
-from modal.network_file_system import NetworkFileSystem
-from modal.volume import Volume
+from modal.network_file_system import _NetworkFileSystem
+from modal.volume import _Volume
 
 
 def test_validate_mount_points():
     # valid mount points
-    dict_input: Mapping = {"/foo/bar": NetworkFileSystem.from_name("NetworkFileSystem", create_if_missing=False)}
-    validate_mount_points("NetworkFileSystem", dict_input)
+    dict_input: Mapping = {"/foo/bar": _NetworkFileSystem.from_name("_NetworkFileSystem", create_if_missing=False)}
+    validate_mount_points("_NetworkFileSystem", dict_input)
 
     # invalid list input, should be dicts
-    list_input = [NetworkFileSystem.from_name("NetworkFileSystem", create_if_missing=False)]
+    list_input = [_NetworkFileSystem.from_name("_NetworkFileSystem", create_if_missing=False)]
 
     with pytest.raises(InvalidError, match="volume_likes"):
-        validate_mount_points("NetworkFileSystem", list_input)  # type: ignore
+        validate_mount_points("_NetworkFileSystem", list_input)  # type: ignore
 
 
 @pytest.mark.parametrize("path", ["/", "/root", "/tmp", "foo/bar"])
 def test_validate_mount_points_invalid_paths(path):
-    validated_mount_points: Mapping = {path: NetworkFileSystem.from_name("NetworkFileSystem", create_if_missing=False)}
-    with pytest.raises(InvalidError, match="NetworkFileSystem"):
-        validate_mount_points("NetworkFileSystem", validated_mount_points)
+    validated_mount_points: Mapping = {
+        path: _NetworkFileSystem.from_name("_NetworkFileSystem", create_if_missing=False)
+    }
+    with pytest.raises(InvalidError, match="_NetworkFileSystem"):
+        validate_mount_points("_NetworkFileSystem", validated_mount_points)
 
 
 def test_validate_network_file_systems(client, servicer):
     # valid network_file_systems input
-    network_file_systems: Mapping = {"/my/path": NetworkFileSystem.from_name("foo", create_if_missing=False)}
+    network_file_systems: Mapping = {"/my/path": _NetworkFileSystem.from_name("foo", create_if_missing=False)}
     validate_network_file_systems(network_file_systems)
 
     # invalid non network_file_systems input
-    not_network_file_systems = {"/my/path": Volume.from_name("foo", create_if_missing=False)}
-    with pytest.raises(InvalidError, match="Volume"):
+    not_network_file_systems = {"/my/path": _Volume.from_name("foo", create_if_missing=False)}
+    with pytest.raises(InvalidError, match="_Volume"):
         validate_network_file_systems(not_network_file_systems)  # type: ignore
 
 
 def test_validate_volumes(client, servicer):
     # valid volume input
-    volumes: Mapping = {"/my/path": Volume.from_name("foo", create_if_missing=False)}
+    volumes: Mapping = {"/my/path": _Volume.from_name("foo", create_if_missing=False)}
     validate_volumes(volumes)
 
     # invalid non volume input
-    not_volumes = {"/my/path": NetworkFileSystem.from_name("foo", create_if_missing=False)}
-    with pytest.raises(InvalidError, match="NetworkFileSystem"):
+    not_volumes = {"/my/path": _NetworkFileSystem.from_name("foo", create_if_missing=False)}
+    with pytest.raises(InvalidError, match="_NetworkFileSystem"):
         validate_volumes(not_volumes)  # type: ignore
 
     # invalid attempt mount volume twice
-    vol = Volume.from_name("foo", create_if_missing=False)
+    vol = _Volume.from_name("foo", create_if_missing=False)
     bad_path_volumes: Mapping = {"/my/path": vol, "/my/other/path": vol}
     with pytest.raises(InvalidError, match="Volume"):
         validate_volumes(bad_path_volumes)

--- a/test/mount_utils_test.py
+++ b/test/mount_utils_test.py
@@ -50,6 +50,6 @@ def test_validate_volumes(client, servicer):
 
     # invalid attempt mount volume twice
     vol = _Volume.from_name("foo", create_if_missing=False)
-    volumes: Mapping = {"/my/path": vol, "/my/other/path": vol}
+    bad_path_volumes: Mapping = {"/my/path": vol, "/my/other/path": vol}
     with pytest.raises(InvalidError, match="Volume"):
-        validate_volumes(volumes)
+        validate_volumes(bad_path_volumes)

--- a/test/mount_utils_test.py
+++ b/test/mount_utils_test.py
@@ -49,4 +49,4 @@ def test_validate_volumes(client, servicer):
     # invalid attempt mount volume twice
     vol = _Volume.from_name("foo", create_if_missing=False)
     with pytest.raises(InvalidError, match="Volume"):
-        volumes = {"/my/path": vol, "/my/other/path": vol}
+        validate_volumes({"/my/path": vol, "/my/other/path": vol})

--- a/test/mount_utils_test.py
+++ b/test/mount_utils_test.py
@@ -1,0 +1,52 @@
+import pytest
+
+from modal._utils.mount_utils import validate_mount_points, validate_network_file_systems, validate_volumes
+from modal.exception import InvalidError
+from modal.network_file_system import _NetworkFileSystem
+from modal.volume import _Volume
+
+
+def test_validate_mount_points():
+    # valid mount points
+    dict_input = {"/foo/bar": _NetworkFileSystem.from_name("NetworkFileSystem", create_if_missing=False)}
+    validate_mount_points("NetworkFileSystem", dict_input)
+
+    # invalid list input, should be dicts
+    list_input = [_NetworkFileSystem.from_name("NetworkFileSystem", create_if_missing=False)]
+
+    with pytest.raises(InvalidError, match="NetworkFileSystem"):
+        validate_mount_points("NetworkFileSystem", list_input)
+
+
+@pytest.mark.parametrize("path", ["/", "/root", "/tmp", "foo/bar"])
+def test_validate_mount_points_invalid_paths(path):
+    validated_mount_points = {path: _NetworkFileSystem.from_name("NetworkFileSystem", create_if_missing=False)}
+    with pytest.raises(InvalidError, match="NetworkFileSystem"):
+        validate_mount_points("NetworkFileSystem", validated_mount_points)
+
+
+def test_validate_network_file_systems(client, servicer):
+    # valid network_file_systems input
+    network_file_systems = {"/my/path": _NetworkFileSystem.from_name("foo", create_if_missing=False)}
+    validate_network_file_systems(network_file_systems)
+
+    # invalid non network_file_systems input
+    not_network_file_systems = {"/my/path": _Volume.from_name("foo", create_if_missing=False)}
+    with pytest.raises(InvalidError, match="_Volume"):
+        validate_network_file_systems(not_network_file_systems)
+
+
+def test_validate_volumes(client, servicer):
+    # valid volume input
+    volumes = {"/my/path": _Volume.from_name("foo", create_if_missing=False)}
+    validate_volumes(volumes)
+
+    # invalid non volume input
+    not_volumes = {"/my/path": _NetworkFileSystem.from_name("foo", create_if_missing=False)}
+    with pytest.raises(InvalidError, match="_NetworkFileSystem"):
+        validate_volumes(not_volumes)
+
+    # invalid attempt mount volume twice
+    vol = _Volume.from_name("foo", create_if_missing=False)
+    with pytest.raises(InvalidError, match="Volume"):
+        volumes = {"/my/path": vol, "/my/other/path": vol}

--- a/test/mount_utils_test.py
+++ b/test/mount_utils_test.py
@@ -4,17 +4,17 @@ from collections.abc import Mapping
 
 from modal._utils.mount_utils import validate_mount_points, validate_network_file_systems, validate_volumes
 from modal.exception import InvalidError
-from modal.network_file_system import _NetworkFileSystem
-from modal.volume import _Volume
+from modal.network_file_system import NetworkFileSystem
+from modal.volume import Volume
 
 
 def test_validate_mount_points():
     # valid mount points
-    dict_input: Mapping = {"/foo/bar": _NetworkFileSystem.from_name("NetworkFileSystem", create_if_missing=False)}
+    dict_input: Mapping = {"/foo/bar": NetworkFileSystem.from_name("NetworkFileSystem", create_if_missing=False)}
     validate_mount_points("NetworkFileSystem", dict_input)
 
     # invalid list input, should be dicts
-    list_input = [_NetworkFileSystem.from_name("NetworkFileSystem", create_if_missing=False)]
+    list_input = [NetworkFileSystem.from_name("NetworkFileSystem", create_if_missing=False)]
 
     with pytest.raises(InvalidError, match="volume_likes"):
         validate_mount_points("NetworkFileSystem", list_input)  # type: ignore
@@ -22,34 +22,34 @@ def test_validate_mount_points():
 
 @pytest.mark.parametrize("path", ["/", "/root", "/tmp", "foo/bar"])
 def test_validate_mount_points_invalid_paths(path):
-    validated_mount_points: Mapping = {path: _NetworkFileSystem.from_name("NetworkFileSystem", create_if_missing=False)}
+    validated_mount_points: Mapping = {path: NetworkFileSystem.from_name("NetworkFileSystem", create_if_missing=False)}
     with pytest.raises(InvalidError, match="NetworkFileSystem"):
         validate_mount_points("NetworkFileSystem", validated_mount_points)
 
 
 def test_validate_network_file_systems(client, servicer):
     # valid network_file_systems input
-    network_file_systems: Mapping = {"/my/path": _NetworkFileSystem.from_name("foo", create_if_missing=False)}
+    network_file_systems: Mapping = {"/my/path": NetworkFileSystem.from_name("foo", create_if_missing=False)}
     validate_network_file_systems(network_file_systems)
 
     # invalid non network_file_systems input
-    not_network_file_systems = {"/my/path": _Volume.from_name("foo", create_if_missing=False)}
-    with pytest.raises(InvalidError, match="_Volume"):
+    not_network_file_systems = {"/my/path": Volume.from_name("foo", create_if_missing=False)}
+    with pytest.raises(InvalidError, match="Volume"):
         validate_network_file_systems(not_network_file_systems)  # type: ignore
 
 
 def test_validate_volumes(client, servicer):
     # valid volume input
-    volumes: Mapping = {"/my/path": _Volume.from_name("foo", create_if_missing=False)}
+    volumes: Mapping = {"/my/path": Volume.from_name("foo", create_if_missing=False)}
     validate_volumes(volumes)
 
     # invalid non volume input
-    not_volumes = {"/my/path": _NetworkFileSystem.from_name("foo", create_if_missing=False)}
-    with pytest.raises(InvalidError, match="_NetworkFileSystem"):
+    not_volumes = {"/my/path": NetworkFileSystem.from_name("foo", create_if_missing=False)}
+    with pytest.raises(InvalidError, match="NetworkFileSystem"):
         validate_volumes(not_volumes)  # type: ignore
 
     # invalid attempt mount volume twice
-    vol = _Volume.from_name("foo", create_if_missing=False)
+    vol = Volume.from_name("foo", create_if_missing=False)
     bad_path_volumes: Mapping = {"/my/path": vol, "/my/other/path": vol}
     with pytest.raises(InvalidError, match="Volume"):
         validate_volumes(bad_path_volumes)

--- a/test/mount_utils_test.py
+++ b/test/mount_utils_test.py
@@ -16,7 +16,7 @@ def test_validate_mount_points():
     # invalid list input, should be dicts
     list_input = [_NetworkFileSystem.from_name("NetworkFileSystem", create_if_missing=False)]
 
-    with pytest.raises(InvalidError, match="NetworkFileSystem"):
+    with pytest.raises(InvalidError, match="volume_likes"):
         validate_mount_points("NetworkFileSystem", list_input)  # type: ignore
 
 

--- a/test/network_file_system_test.py
+++ b/test/network_file_system_test.py
@@ -151,3 +151,13 @@ def test_nfs_lazy_hydration_from_name(set_env_client):
 def test_invalid_name(servicer, client, name):
     with pytest.raises(InvalidError, match="Invalid NetworkFileSystem name"):
         modal.NetworkFileSystem.lookup(name)
+
+
+def test_attempt_mount_volume(client, servicer):
+    app = modal.App()
+    modal.Volume.create_deployed("my-other-vol", client=client)
+    vol = modal.NetworkFileSystem.from_name("my-other-vol", create_if_missing=False)
+    f = app.function(network_file_systems={"/data": vol})(dummy)
+    with pytest.raises(InvalidError, match="already exists as a Volume"):
+        with app.run(client=client):
+            f.remote()


### PR DESCRIPTION
Adds a clearer error message when attempting to mount a volume as a network file system and refactors the nfs validation for sandboxes/functions to be similar to the volume validation