### PR TITLE
[MOD-2330] Improve error reporting in 'modal shell'

### DIFF
--- a/modal/_container_exec.py
+++ b/modal/_container_exec.py
@@ -43,7 +43,7 @@ async def container_exec(task_id: str, command: List[str], *, pty: bool, client:
     except GRPCError as err:
         connecting_status.stop()
         if err.status == Status.NOT_FOUND:
-            raise NotFoundError(f"Container ID {task_id} not found")
+            raise NotFoundError(err.message)
         raise
 
     await connect_to_exec(res.exec_id, pty, connecting_status)

--- a/modal/_utils/shell_utils.py
+++ b/modal/_utils/shell_utils.py
@@ -110,4 +110,4 @@ async def connect_to_terminal(
         except (asyncio.TimeoutError, TimeoutError):
             stop_connecting_status()
             exec_output_task.cancel()
-            raise InteractiveTimeoutError("Failed to establish connection to container.")
+            raise InteractiveTimeoutError("Failed to establish connection to container. Please try again.")


### PR DESCRIPTION
## Describe your changes

A motivating example is if you provide garbage config to `CloudBucketMount` you get no feedback about the problem from `modal shell`: 

```python
@app.function(
    volumes={
        "/data": modal.CloudBucketMount(bucket_name="hi", secret=modal.Secret.from_dict({}))
    },
)
def f():
    print("hi")
```

- [ ] ~Client+Server: this change is compatible with old servers~
- [ ] ~Client forward compatibility: this change ensures client can accept data intended for later versions of itself~
