### PR TITLE
MOD-3260: Add AttributeError to list of retry_transient_errors

### DIFF
--- a/modal/_output.py
+++ b/modal/_output.py
@@ -505,8 +505,9 @@ async def get_app_logs_loop(
             elif isinstance(exc, AttributeError):
                 if "_write_appdata" in str(exc):
                     # Happens after losing connection
-                    # TODO: figure out a way to catch this in a more robust manner
-                    # see: https://github.com/modal-labs/modal-client/pull/1967#discussion_r1666955873
+                    # StreamTerminatedError are not properly raised in grpclib<=0.4.7
+                    # fixed in https://github.com/vmagamedov/grpclib/issues/185
+                    # TODO: update to newer version (>=0.4.8) once stable
                     logger.debug("Lost connection. Retrying ...")
                     continue
             raise

--- a/modal/_utils/grpc_utils.py
+++ b/modal/_utils/grpc_utils.py
@@ -162,7 +162,7 @@ async def retry_transient_errors(
             timeout = None
         try:
             return await fn(*args, metadata=metadata, timeout=timeout)
-        except (StreamTerminatedError, GRPCError, socket.gaierror, asyncio.TimeoutError) as exc:
+        except (StreamTerminatedError, GRPCError, socket.gaierror, asyncio.TimeoutError, AttributeError) as exc:
             if isinstance(exc, GRPCError) and exc.status not in status_codes:
                 raise exc
 
@@ -172,6 +172,14 @@ async def retry_transient_errors(
             if total_deadline and time.time() + delay + attempt_timeout_floor >= total_deadline:
                 # no point sleeping if that's going to push us past the deadline
                 raise exc
+
+            if isinstance(exc, AttributeError):
+                # StreamTerminatedError are not properly raised in grpclib<=0.4.7
+                # fixed in https://github.com/vmagamedov/grpclib/issues/185
+                # TODO: update to newer version (>=0.4.8) once stable
+                if "_write_appdata" in str(exc):
+                    continue
+                raise
 
             logger.debug(f"Retryable failure {repr(exc)} {n_retries=} {delay=} for {fn.name}")
 

--- a/modal/_utils/grpc_utils.py
+++ b/modal/_utils/grpc_utils.py
@@ -173,13 +173,11 @@ async def retry_transient_errors(
                 # no point sleeping if that's going to push us past the deadline
                 raise exc
 
-            if isinstance(exc, AttributeError):
+            if isinstance(exc, AttributeError) and "_write_appdata" not in str(exc):
                 # StreamTerminatedError are not properly raised in grpclib<=0.4.7
                 # fixed in https://github.com/vmagamedov/grpclib/issues/185
                 # TODO: update to newer version (>=0.4.8) once stable
-                if "_write_appdata" in str(exc):
-                    continue
-                raise
+                raise exc
 
             logger.debug(f"Retryable failure {repr(exc)} {n_retries=} {delay=} for {fn.name}")
 


### PR DESCRIPTION
Temporarily adds `AttributeError` to the list of transient errors to be retried as `StreamTerminatedError` is not properly raised in `grpclib <= 0.47` and will instead raise `AttributeError`. Fixed in https://github.com/vmagamedov/grpclib/issues/185 so we should remove this (also for the heartbeat exception) once we can upgrade to a newer stable version.

Great find @mwaskom!