### PR TITLE
[MOD-3257] fix cached PyTorch GPU device queries

### DIFF
--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -608,9 +608,7 @@ class _ContainerIOManager:
         # perf: scanning sys.modules keys before import to avoid slow PYTHONPATH scanning.
         if "torch" in sys.modules:
             try:
-                import torch
-
-                torch.cuda.device_count = torch.cuda._device_count_nvml
+                sys.modules["torch"].cuda.device_count = sys.modules["torch"].cuda._device_count_nvml
             # Wide-open except to catch anything. We don't want to crash here.
             except Exception as exc:
                 logger.warning(

--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -4,6 +4,7 @@ import json
 import math
 import os
 import signal
+import sys
 import time
 import traceback
 from dataclasses import dataclass
@@ -600,6 +601,22 @@ class _ContainerIOManager:
         # Restore input to default state.
         self.current_input_id = None
         self.current_input_started_at = None
+
+        # Patch torch to ensure it doesn't return CUDA unavailibility due to
+        # cached queries that executed during snapshot process. ref: MOD-3257
+        #
+        # perf: scanning sys.modules keys before import to avoid slow PYTHONPATH scanning.
+        if "torch" in sys.modules:
+            try:
+                import torch
+
+                torch.cuda.device_count = torch.cuda._device_count_nvml
+            # Wide-open except to catch anything. We don't want to crash here.
+            except Exception as exc:
+                logger.warning(
+                    f"failed to patch 'torch.cuda.device_count' during snapshot restore: {exc}. "
+                    "CUDA device availability may be inaccurate."
+                )
 
         self._client = await _Client.from_env()
         self._waiting_for_memory_snapshot = False


### PR DESCRIPTION
## Describe your changes

See **MOD-3257** for details

Many snapshotted containers won't have `torch`, but in these cases a key miss searching `sys.modules` is very fast <500 micros on even large dictionaries (100,000 entries). thanks @mwaskom for the suggestion. 

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
