### PR TITLE
internal: cleanup proto enum

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -87,9 +87,7 @@ enum CloudProvider {
   CLOUD_PROVIDER_GCP = 2;
   CLOUD_PROVIDER_AUTO = 3;
   CLOUD_PROVIDER_OCI = 4;
-  CLOUD_PROVIDER_LAMBDA_LABS = 5;
-  CLOUD_PROVIDER_FLUIDSTACK = 6;  // experimental
-  CLOUD_PROVIDER_LATITUDE = 7;  // experimental
+  reserved 5, 6, 7; // now unused internal experimental values
 }
 
 enum DNSRecordType {


### PR DESCRIPTION


<details open> <summary>Backward/forward compatibility checks</summary>

- [x] Client+Server: this change is compatible with old servers
    -  the server doesn't send this value to the client, and reducing enum scope is compatible with old servers.
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
    - the client doesn't receive this enum value from the server
