### PR TITLE
[MOD-3008]: Add friendly error message when attempting to use `modal shell` on windows

### DIFF
--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -388,6 +388,11 @@ def shell(
     if not console.is_terminal:
         raise click.UsageError("`modal shell` can only be run from a terminal.")
 
+    if sys.platform in ("cygwin", "win32"):
+        # sys.platform values
+        # https://docs.python.org/3/library/sys.html#sys.platform
+        raise InvalidError("`modal shell` is currently not supported on Windows")
+
     app = App("modal shell")
 
     if func_ref is not None:

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -2,6 +2,7 @@
 import asyncio
 import functools
 import inspect
+import platform
 import re
 import shlex
 import sys
@@ -388,9 +389,7 @@ def shell(
     if not console.is_terminal:
         raise click.UsageError("`modal shell` can only be run from a terminal.")
 
-    if sys.platform in ("cygwin", "win32"):
-        # sys.platform values
-        # https://docs.python.org/3/library/sys.html#sys.platform
+    if platform.system() == "Windows":
         raise InvalidError("`modal shell` is currently not supported on Windows")
 
     app = App("modal shell")

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -3,6 +3,7 @@ import asyncio
 import contextlib
 import json
 import os
+import platform
 import pytest
 import re
 import subprocess
@@ -439,14 +440,8 @@ def test_shell_cmd(servicer, set_env_client, test_dir, mock_shell_pty):
     assert captured_out == [(1, shell_prompt), (1, expected_output)]
 
 
-def test_shell_cmd_fails_on_windows(servicer, set_env_client, mock_shell_pty):
-    # https://docs.python.org/3/library/sys.html#sys.platform
-    if sys.platform in ("cygwin", "win32"):
-        expected_exit_code = 1
-        print(f"sys.platform={sys.platform}")
-    else:
-        expected_exit_code = 0
-
+def test_shell_unsuported_cmds_fails_on_windows(servicer, set_env_client, mock_shell_pty):
+    expected_exit_code = 1 if platform.system() == "Windows" else 0
     res = _run(["shell"], expected_exit_code=expected_exit_code)
 
     if expected_exit_code != 0:

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -439,14 +439,14 @@ def test_shell_cmd(servicer, set_env_client, test_dir, mock_shell_pty):
     assert captured_out == [(1, shell_prompt), (1, expected_output)]
 
 
-@pytest.mark.parametrize(("platform", "expected_exit_code"), [("win32", 1), ("cygwin", 1), ("linux", 0), ("darwin", 0)])
-@skip_windows("modal shell is not supported on Windows.")
-def test_shell_cmd_fails_on_windows(
-    servicer, set_env_client, mock_shell_pty, monkeypatch, platform, expected_exit_code
-):
-    # sys.platform values
+def test_shell_cmd_fails_on_windows(servicer, set_env_client, mock_shell_pty):
     # https://docs.python.org/3/library/sys.html#sys.platform
-    monkeypatch.setattr("sys.platform", platform)
+    if sys.platform in ("cygwin", "win32"):
+        expected_exit_code = 1
+        print(f"sys.platform={sys.platform}")
+    else:
+        expected_exit_code = 0
+
     res = _run(["shell"], expected_exit_code=expected_exit_code)
 
     if expected_exit_code != 0:

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -440,6 +440,7 @@ def test_shell_cmd(servicer, set_env_client, test_dir, mock_shell_pty):
 
 
 @pytest.mark.parametrize(("platform", "expected_exit_code"), [("win32", 1), ("cygwin", 1), ("linux", 0), ("darwin", 0)])
+@skip_windows("modal shell is not supported on Windows.")
 def test_shell_cmd_fails_on_windows(
     servicer, set_env_client, mock_shell_pty, monkeypatch, platform, expected_exit_code
 ):

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -439,6 +439,19 @@ def test_shell_cmd(servicer, set_env_client, test_dir, mock_shell_pty):
     assert captured_out == [(1, shell_prompt), (1, expected_output)]
 
 
+@pytest.mark.parametrize(("platform", "expected_exit_code"), [("win32", 1), ("cygwin", 1), ("linux", 0), ("darwin", 0)])
+def test_shell_cmd_fails_on_windows(
+    servicer, set_env_client, mock_shell_pty, monkeypatch, platform, expected_exit_code
+):
+    # sys.platform values
+    # https://docs.python.org/3/library/sys.html#sys.platform
+    monkeypatch.setattr("sys.platform", platform)
+    res = _run(["shell"], expected_exit_code=expected_exit_code)
+
+    if expected_exit_code != 0:
+        assert re.search("Windows", str(res.exception)), "exception message does not match expected string"
+
+
 def test_app_descriptions(servicer, server_url_env, test_dir):
     app_file = test_dir / "supports" / "app_run_tests" / "prints_desc_app.py"
     _run(["run", "--detach", app_file.as_posix() + "::foo"])


### PR DESCRIPTION
`modal shell` command doesn't work on windows currently, this PR adds a check to see which platform is being executed on and raises a friendly message if it's not compatible