### PR TITLE
Make `Image.logs` private

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -1676,7 +1676,11 @@ class _Image(_Object, type_prefix="im"):
         deprecation_error((2023, 12, 15), Image.run_inside.__doc__)
 
     @live_method_gen
-    async def logs(self) -> AsyncGenerator[str, None]:
+    async def _logs(self) -> AsyncGenerator[str, None]:
+        """Streams logs from an image, or returns logs from an already completed image.
+
+        This method is considered private since its interface may change - use it at your own risk!
+        """
         last_entry_id: Optional[str] = None
 
         request = api_pb2.ImageJoinStreamingRequest(

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -1130,5 +1130,5 @@ async def test_logs(servicer, client):
     async with app.run.aio(client=client):
         pass
 
-    logs = [data async for data in image.logs.aio()]
+    logs = [data async for data in image._logs.aio()]
     assert logs == ["build starting\n", "build finished\n"]


### PR DESCRIPTION
@mwaskom convinced me that the interface to logging can be complex and maybe worth discussing first.

The main reason I added this method was for integration tests so it's fine.