### PR TITLE
App._logs to fetch logs

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -133,7 +133,7 @@ class _App:
 
     # Running apps only (container apps or running local)
     _app_id: Optional[str]  # Kept after app finishes
-    _running_app: Optional[RunningApp]  # various app info. TODO: bring it onto the app object instead.
+    _running_app: Optional[RunningApp]  # Various app info
     _client: Optional[_Client]
 
     def __init__(

--- a/modal/app.py
+++ b/modal/app.py
@@ -895,15 +895,15 @@ class _App:
 
         This method is considered private and its interface may change - use at your own risk!
         """
-        if not self._running_app:
-            raise InvalidError("`app._logs` requires a running app.")
+        if not self._app_id:
+            raise InvalidError("`app._logs` requires a running/stopped app.")
 
         client = client or self._client or await _Client.from_env()
 
         last_log_batch_entry_id: Optional[str] = None
         while True:
             request = api_pb2.AppGetLogsRequest(
-                app_id=self._running_app.app_id,
+                app_id=self._app_id,
                 timeout=55,
                 last_entry_id=last_log_batch_entry_id,
             )

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -210,7 +210,7 @@ async def _run_app(
             " Are you calling app.run() directly?"
             " Consider using the `modal run` shell command."
         )
-    if app._is_running:
+    if app._running_app:
         raise InvalidError(
             "App is already running and can't be started again.\n"
             "You should not use `app.run` or `run_app` within a Modal `local_entrypoint`"

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -210,7 +210,7 @@ async def _run_app(
             " Are you calling app.run() directly?"
             " Consider using the `modal run` shell command."
         )
-    if app._running_app:
+    if app._is_running:
         raise InvalidError(
             "App is already running and can't be started again.\n"
             "You should not use `app.run` or `run_app` within a Modal `local_entrypoint`"

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -355,3 +355,14 @@ def test_deploy_stub(servicer, client):
     deploy_app(app, client=client)
     with pytest.warns(match="deploy_app"):
         deploy_stub(app, client=client)
+
+
+def test_app_logs(servicer, client):
+    app = App()
+    f = app.function()(dummy)
+
+    with app.run(client=client):
+        f.remote()
+
+    logs = [data for data in app._logs(client=client)]
+    assert logs == ["hello, world (1)\n"]


### PR DESCRIPTION
This adds a utility method on the `App` class to fetch logs for an app.

The point is to get rid of the `stdout` argument to `OutputManager` so that we can make it a singleton throughout.