### PR TITLE
OutputManager: get rid of of the *_if_visible methods

### DIFF
--- a/modal/_output.py
+++ b/modal/_output.py
@@ -175,17 +175,14 @@ class OutputManager:
         self._app_page_url = None
         self._show_image_logs = False
 
+    def is_visible(self) -> bool:
+        return self._visible_progress
+
     def hide_output(self):
         self._visible_progress = False
 
-    def print_if_visible(self, renderable) -> None:
-        if self._visible_progress:
-            self._console.print(renderable)
-
-    def ctx_if_visible(self, context_mgr):
-        if self._visible_progress:
-            return context_mgr
-        return contextlib.nullcontext()
+    def print(self, renderable) -> None:
+        self._console.print(renderable)
 
     def make_live(self, renderable: RenderableType) -> Live:
         """Creates a customized `rich.Live` instance with the given renderable. The renderable
@@ -379,7 +376,10 @@ class OutputManager:
     @contextlib.contextmanager
     def show_status_spinner(self):
         self._status_spinner_live = self.make_live(self._status_spinner)
-        with self.ctx_if_visible(self._status_spinner_live):
+        if self.is_visible():
+            with self._status_spinner_live:
+                yield
+        else:
             yield
 
     def hide_status_spinner(self):
@@ -492,10 +492,11 @@ async def get_app_logs_loop(
         except asyncio.CancelledError:
             # TODO: this should come from the backend maybe
             app_logs_url = f"https://modal.com/logs/{app_id}"
-            output_mgr.print_if_visible(
-                f"[red]Timed out waiting for logs. "
-                f"[grey70]View logs at [underline]{app_logs_url}[/underline] for remaining output.[/grey70]"
-            )
+            if output_mgr.is_visible():
+                output_mgr.print(
+                    f"[red]Timed out waiting for logs. "
+                    f"[grey70]View logs at [underline]{app_logs_url}[/underline] for remaining output.[/grey70]"
+                )
             raise
         except (GRPCError, StreamTerminatedError, socket.gaierror, AttributeError) as exc:
             if isinstance(exc, GRPCError):

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -169,13 +169,13 @@ class Resolver:
     def display(self):
         from ._output import step_completed
 
-        if self._output_mgr is None:
+        if self._output_mgr is None or not self._output_mgr.is_visible():
             yield
         else:
-            with self._output_mgr.ctx_if_visible(self._output_mgr.make_live(self._tree)):
+            with self._output_mgr.make_live(self._tree):
                 yield
             self._tree.label = step_completed("Created objects.")
-            self._output_mgr.print_if_visible(self._tree)
+            self._output_mgr.print(self._tree)
 
     def add_status_row(self) -> StatusRow:
         return StatusRow(self._tree)

--- a/modal/_watcher.py
+++ b/modal/_watcher.py
@@ -72,7 +72,8 @@ def _print_watched_paths(paths: Set[Path], output_mgr: OutputManager):
     for path in paths:
         output_tree.add(f"Watching {path}.")
 
-    output_mgr.print_if_visible(output_tree)
+    if output_mgr.is_visible():
+        output_mgr.print(output_tree)
 
 
 def _watch_args_from_mounts(mounts: List[_Mount]) -> Tuple[Set[Path], AppFilesFilter]:

--- a/modal/serving.py
+++ b/modal/serving.py
@@ -52,11 +52,11 @@ async def _terminate(proc: Optional[SpawnProcess], output_mgr: OutputManager, ti
         proc.terminate()
         await asyncify(proc.join)(timeout)
         if proc.exitcode is not None:
-            output_mgr.print_if_visible(f"Serve process {proc.pid} terminated")
+            if output_mgr.is_visible():
+                output_mgr.print(f"Serve process {proc.pid} terminated")
         else:
-            output_mgr.print_if_visible(
-                f"[red]Serve process {proc.pid} didn't terminate after {timeout}s, killing it[/red]"
-            )
+            if output_mgr.is_visible():
+                output_mgr.print(f"[red]Serve process {proc.pid} didn't terminate after {timeout}s, killing it[/red]")
             proc.kill()
     except ProcessLookupError:
         pass  # Child process already finished
@@ -75,8 +75,9 @@ async def _run_watch_loop(
         " This can hopefully be fixed in a future version of Modal."
 
     if unsupported_msg:
-        async for _ in watcher:
-            output_mgr.print_if_visible(unsupported_msg)
+        if output_mgr.is_visible():
+            async for _ in watcher:
+                output_mgr.print(unsupported_msg)
     else:
         curr_proc = None
         try:


### PR DESCRIPTION
This is helpful since
1. This lets us check if the future `OutputManager` singleton exist, and if not, then the code can just shortcut the if-body
2. This way we can put Rich-specific stuff inside the if-body (makes it easier to not require it inside the container)
3. The previous code was pretty complex? I struggle with the `contextlib.nullcontext` stuff

