### PR TITLE
Remove complex logging code

### DIFF
--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -181,7 +181,7 @@ class Resolver:
         return StatusRow(self._tree)
 
     async def console_write(self, log: api_pb2.TaskLogs):
-        if self._output_mgr is not None:
+        if self._output_mgr is not None and self._output_mgr.is_visible():
             await self._output_mgr.put_log_content(log)
 
     def console_flush(self):


### PR DESCRIPTION
I don't think this is needed anymore, since we don't pass custom buffers to the OutputManager since recently.

In all the places where we call `put_log_content`, I made sure to check that the output is visible.

Passes integration tests as well
