### PR TITLE
Don't swallow exceptions in get_app_logs_loop

### DIFF
--- a/modal/_output.py
+++ b/modal/_output.py
@@ -633,9 +633,6 @@ async def get_app_logs_loop(
                     logger.debug("Lost connection. Retrying ...")
                     continue
             raise
-        except Exception as exc:
-            logger.exception(f"Failed to fetch logs: {exc}")
-            await asyncio.sleep(1)
 
         if last_log_batch_entry_id is None:
             break


### PR DESCRIPTION
If there's an exception in this loop, we just suppress it and try again. Since logging is disabled by default, it doesn't even print anything. This is a bit annoying for debugging reasons, and I think it's bad practice. Going forward any exception will cause the entire (ephemeral) app to stop and the exception will bubble up to the top level.