### PR TITLE
Break up put_log_content based on pty or not

### DIFF
--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -181,7 +181,7 @@ class Resolver:
         return StatusRow(self._tree)
 
     async def console_write(self, log: api_pb2.TaskLogs):
-        if self._output_mgr is not None:
+        if self._output_mgr is not None and self._output_mgr.is_visible():
             await self._output_mgr.put_log_content(log)
 
     def console_flush(self):


### PR DESCRIPTION
The `put_log_content` was using the property `_visible_progress` to switch modes. But this is sort of incidental to what `_visible_progress` is meant to do. We do disable it when we hit the PTY mode, which is why it worked, but you could imagine wanting to write pty output without an output mgr even being present or other weird cases.

In particular I want `.disable()` to _destroy_ the output manager later, which is why it's important to have a separate code path for pty output.