### PR TITLE
PTY simplification 2

### DIFF
--- a/modal/_output.py
+++ b/modal/_output.py
@@ -353,28 +353,8 @@ class OutputManager:
         stream.write(log.data)
 
     async def put_raw_content(self, log: api_pb2.TaskLogs):
-        # TODO(erikbern): move this out of the OutputMgr?
-        if hasattr(self._stdout, "buffer"):
-            # If we're not showing progress, there's no need to buffer lines,
-            # because the progress spinner can't interfere with output.
-
-            data = log.data.encode("utf-8")
-            written = 0
-            n_retries = 0
-            while written < len(data):
-                try:
-                    written += self._stdout.buffer.write(data[written:])
-                    self._stdout.flush()
-                except BlockingIOError:
-                    if n_retries >= 5:
-                        raise
-                    n_retries += 1
-                    await asyncio.sleep(0.1)
-        else:
-            # `stdout` isn't always buffered (e.g. %%capture in Jupyter notebooks redirects it to
-            # io.StringIO).
-            self._stdout.write(log.data)
-            self._stdout.flush()
+        self._stdout.write(log.data)
+        self._stdout.flush()
 
     def flush_lines(self):
         for stream in self._line_buffers.values():

--- a/modal/_output.py
+++ b/modal/_output.py
@@ -505,6 +505,8 @@ async def get_app_logs_loop(
     client: _Client, output_mgr: OutputManager, app_id: Optional[str] = None, task_id: Optional[str] = None
 ):
     last_log_batch_entry_id = ""
+
+    pty_shell_stdout = None
     pty_shell_finish_event: Optional[asyncio.Event] = None
     pty_shell_task_id: Optional[str] = None
 
@@ -536,12 +538,13 @@ async def get_app_logs_loop(
                 logger.debug(f"Received unrecognized progress type: {log.task_progress.progress_type}")
         elif log.data:
             if pty_shell_finish_event:
-                put_pty_content(log, output_mgr._stdout)
+                put_pty_content(log, pty_shell_stdout)
             else:
                 await output_mgr.put_log_content(log)
 
     async def _get_logs():
-        nonlocal last_log_batch_entry_id, pty_shell_finish_event, pty_shell_task_id
+        nonlocal last_log_batch_entry_id
+        nonlocal pty_shell_stdout, pty_shell_finish_event, pty_shell_task_id
 
         request = api_pb2.AppGetLogsRequest(
             app_id=app_id or "",
@@ -572,9 +575,10 @@ async def get_app_logs_loop(
                 if pty_shell_finish_event:
                     print("ERROR: concurrent PTY shells are not supported.")
                 else:
-                    output_mgr.disable()
+                    pty_shell_stdout = output_mgr._stdout
                     pty_shell_finish_event = asyncio.Event()
                     pty_shell_task_id = log_batch.task_id
+                    output_mgr.disable()
                     asyncio.create_task(stream_pty_shell_input(client, log_batch.pty_exec_id, pty_shell_finish_event))
             else:
                 for log in log_batch.items:


### PR DESCRIPTION
This is a slightly different approach versus https://github.com/modal-labs/modal-client/pull/2019 that retains the logic but gets rid of a bunch of complexity.

The other thing this accomplishes is that it moves pty output out of the OutputManager class. The reason this is useful is that it lets me "destroy" the future output manager singleton on a pty event. This simplifies turning the output manager into a singleton (which I intend to start working on next).

Afaict there's no need to buffer pty data written to stdout. My guess is that we had it there for historical reasons. It passes the test I added in #2022 and all integration tests. I've also verified manually that `modal run -i` works.
