### PR TITLE
Don't take `OutputManager` as an argument

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -12,7 +12,6 @@ from synchronicity.async_wrap import asynccontextmanager
 from modal_proto import api_pb2
 
 from ._ipython import is_notebook
-from ._output import OutputManager
 from ._utils.async_utils import synchronize_api
 from ._utils.function_utils import FunctionInfo, is_global_object, is_top_level_function
 from ._utils.grpc_utils import unary_stream
@@ -306,7 +305,6 @@ class _App:
         client: Optional[_Client] = None,
         show_progress: bool = True,
         detach: bool = False,
-        output_mgr: Optional[OutputManager] = None,
     ) -> AsyncGenerator["_App", None]:
         """Context manager that runs an app on Modal.
 
@@ -319,7 +317,7 @@ class _App:
         objects. For backwards compatibility reasons, it returns the same app.
         """
         # TODO(erikbern): deprecate this one too?
-        async with _run_app(self, client, show_progress, detach, output_mgr):
+        async with _run_app(self, client=client, show_progress=show_progress, detach=detach):
             yield self
 
     def _get_default_image(self):

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -190,10 +190,10 @@ async def _disconnect(
 @asynccontextmanager
 async def _run_app(
     app: _App,
+    *,
     client: Optional[_Client] = None,
     show_progress: bool = True,
     detach: bool = False,
-    output_mgr: Optional[OutputManager] = None,
     environment_name: Optional[str] = None,
     interactive: bool = False,
 ) -> AsyncGenerator[_App, None]:
@@ -225,8 +225,7 @@ async def _run_app(
 
     if client is None:
         client = await _Client.from_env()
-    if output_mgr is None:
-        output_mgr = OutputManager(show_progress=show_progress)
+    output_mgr = OutputManager(show_progress=show_progress)
     app_state = api_pb2.APP_STATE_DETACHED if detach else api_pb2.APP_STATE_EPHEMERAL
     running_app: RunningApp = await _init_local_app_new(
         client,
@@ -509,7 +508,7 @@ async def _interactive_shell(_app: _App, cmds: List[str], environment_name: str 
     **kwargs will be passed into spawn_sandbox().
     """
     client = await _Client.from_env()
-    async with _run_app(_app, client, environment_name=environment_name, show_progress=False):
+    async with _run_app(_app, client=client, environment_name=environment_name, show_progress=False):
         console = Console()
         loading_status = console.status("Starting container...")
         loading_status.start()


### PR DESCRIPTION
This localizes the places where we create an `OutputManager` and also relies on the output manager to _exist_ for various output.

This will make it very easy to turn it into a singleton later.