### PR TITLE
`OutputManager` singleton

### DIFF
--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -9,6 +9,7 @@ if sys.version_info[:2] >= (3, 13):
 from modal_version import __version__
 
 try:
+    from ._output import enable_output
     from ._tunnel import Tunnel, forward
     from .app import App, Stub
     from .client import Client
@@ -66,6 +67,7 @@ __all__ = [
     "build",
     "current_function_call_id",
     "current_input_id",
+    "enable_output",
     "enter",
     "exit",
     "forward",

--- a/modal/_output.py
+++ b/modal/_output.py
@@ -10,7 +10,7 @@ import re
 import socket
 import sys
 from datetime import timedelta
-from typing import Callable, ClassVar, Dict, Optional, Tuple
+from typing import Callable, ClassVar, Dict, Generator, Optional, Tuple
 
 from grpclib.exceptions import GRPCError, StreamTerminatedError
 from rich.console import Console, Group, RenderableType
@@ -196,7 +196,7 @@ class OutputManager:
 
     @classmethod
     @contextlib.contextmanager
-    def enable_output(cls, show_progress: bool = True):
+    def enable_output(cls, show_progress: bool = True) -> Generator[None, None, None]:
         if show_progress:
             cls._instance = OutputManager()
         try:
@@ -698,3 +698,9 @@ class FunctionCreationStatus:
                 )
         else:
             self.status_row.finish(f"Created function {self.tag}.")
+
+
+@contextlib.contextmanager
+def enable_output(show_progress: bool = True) -> Generator[None, None, None]:
+    with OutputManager.enable_output(show_progress):
+        yield

--- a/modal/_output.py
+++ b/modal/_output.py
@@ -702,5 +702,20 @@ class FunctionCreationStatus:
 
 @contextlib.contextmanager
 def enable_output(show_progress: bool = True) -> Generator[None, None, None]:
+    """Context manager that enable output when using the Python SDK.
+
+    This will print to stdout and stderr things such as
+    1. Logs from running functions
+    2. Status of creating objects
+    3. Map progress
+
+    Example:
+    ```python
+    app = modal.App()
+    with modal.enable_output():
+        with app.run():
+            ...
+    ```
+    """
     with OutputManager.enable_output(show_progress):
         yield

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -56,7 +56,6 @@ class Resolver:
         self,
         client=None,
         *,
-        output_mgr=None,
         environment_name: Optional[str] = None,
         app_id: Optional[str] = None,
     ):
@@ -64,7 +63,6 @@ class Resolver:
 
         from ._output import step_progress
 
-        self._output_mgr = output_mgr
         self._local_uuid_to_future = {}
         self._tree = Tree(step_progress("Creating objects..."), guide_style="gray50")
         self._client = client
@@ -167,27 +165,37 @@ class Resolver:
 
     @contextlib.contextmanager
     def display(self):
-        from ._output import step_completed
+        # TODO(erikbern): get rid of this wrapper
+        from ._output import OutputManager, step_completed
 
-        if self._output_mgr is None or not self._output_mgr.is_visible():
-            yield
-        else:
-            with self._output_mgr.make_live(self._tree):
+        if output_mgr := OutputManager.get():
+            with output_mgr.make_live(self._tree):
                 yield
             self._tree.label = step_completed("Created objects.")
-            self._output_mgr.print(self._tree)
+            output_mgr.print(self._tree)
+        else:
+            yield
 
     def add_status_row(self) -> StatusRow:
         return StatusRow(self._tree)
 
     async def console_write(self, log: api_pb2.TaskLogs):
-        if self._output_mgr is not None and self._output_mgr.is_visible():
-            await self._output_mgr.put_log_content(log)
+        # TODO(erikbern): get rid of this wrapper
+        from ._output import OutputManager
+
+        if output_mgr := OutputManager.get():
+            await output_mgr.put_log_content(log)
 
     def console_flush(self):
-        if self._output_mgr is not None:
-            self._output_mgr.flush_lines()
+        # TODO(erikbern): get rid of this wrapper
+        from ._output import OutputManager
+
+        if output_mgr := OutputManager.get():
+            output_mgr.flush_lines()
 
     def image_snapshot_update(self, image_id: str, task_progress: api_pb2.TaskProgress):
-        if self._output_mgr is not None:
-            self._output_mgr.update_snapshot_progress(image_id, task_progress)
+        # TODO(erikbern): get rid of this wrapper
+        from ._output import OutputManager
+
+        if output_mgr := OutputManager.get():
+            output_mgr.update_snapshot_progress(image_id, task_progress)

--- a/modal/_watcher.py
+++ b/modal/_watcher.py
@@ -64,7 +64,7 @@ async def _watch_paths(paths: Set[Path], watch_filter: AppFilesFilter) -> AsyncG
         pass
 
 
-def _print_watched_paths(paths: Set[Path], output_mgr: OutputManager):
+def _print_watched_paths(paths: Set[Path], output_mgr: Optional[OutputManager]):
     msg = "️️⚡️ Serving... hit Ctrl-C to stop!"
 
     output_tree = Tree(msg, guide_style="gray50")
@@ -72,7 +72,7 @@ def _print_watched_paths(paths: Set[Path], output_mgr: OutputManager):
     for path in paths:
         output_tree.add(f"Watching {path}.")
 
-    if output_mgr.is_visible():
+    if output_mgr and output_mgr.is_visible():
         output_mgr.print(output_tree)
 
 
@@ -94,7 +94,7 @@ def _watch_args_from_mounts(mounts: List[_Mount]) -> Tuple[Set[Path], AppFilesFi
     return paths, watch_filter
 
 
-async def watch(mounts: List[_Mount], output_mgr: OutputManager) -> AsyncGenerator[Set[str], None]:
+async def watch(mounts: List[_Mount], output_mgr: Optional[OutputManager]) -> AsyncGenerator[Set[str], None]:
     paths, watch_filter = _watch_args_from_mounts(mounts)
 
     _print_watched_paths(paths, output_mgr)

--- a/modal/_watcher.py
+++ b/modal/_watcher.py
@@ -64,7 +64,7 @@ async def _watch_paths(paths: Set[Path], watch_filter: AppFilesFilter) -> AsyncG
         pass
 
 
-def _print_watched_paths(paths: Set[Path], output_mgr: Optional[OutputManager]):
+def _print_watched_paths(paths: Set[Path]):
     msg = "️️⚡️ Serving... hit Ctrl-C to stop!"
 
     output_tree = Tree(msg, guide_style="gray50")
@@ -72,7 +72,7 @@ def _print_watched_paths(paths: Set[Path], output_mgr: Optional[OutputManager]):
     for path in paths:
         output_tree.add(f"Watching {path}.")
 
-    if output_mgr and output_mgr.is_visible():
+    if output_mgr := OutputManager.get():
         output_mgr.print(output_tree)
 
 
@@ -94,10 +94,10 @@ def _watch_args_from_mounts(mounts: List[_Mount]) -> Tuple[Set[Path], AppFilesFi
     return paths, watch_filter
 
 
-async def watch(mounts: List[_Mount], output_mgr: Optional[OutputManager]) -> AsyncGenerator[Set[str], None]:
+async def watch(mounts: List[_Mount]) -> AsyncGenerator[Set[str], None]:
     paths, watch_filter = _watch_args_from_mounts(mounts)
 
-    _print_watched_paths(paths, output_mgr)
+    _print_watched_paths(paths)
 
     async for updated_paths in _watch_paths(paths, watch_filter):
         yield updated_paths

--- a/modal/app.py
+++ b/modal/app.py
@@ -1,5 +1,6 @@
 # Copyright Modal Labs 2022
 import inspect
+import os
 import typing
 import warnings
 from pathlib import PurePosixPath
@@ -335,17 +336,21 @@ class _App:
 
         # See Github discussion here: https://github.com/modal-labs/modal-client/pull/2030#issuecomment-2237266186
 
-        if show_progress is None:
-            if OutputManager.get() is None:
-                deprecation_warning((2024, 7, 18), dedent(enable_output_warning))
-        elif show_progress is True:
-            if OutputManager.get() is None:
-                deprecation_warning((2024, 7, 18), dedent(enable_output_warning))
-            else:
-                deprecation_warning((2024, 7, 18), "`show_progress=True` is deprecated and no longer needed.")
-        elif show_progress is False:
-            if OutputManager.get() is not None:
-                deprecation_warning((2024, 7, 18), "`show_progress=False` will have no effect since output is enabled.")
+        if "MODAL_DISABLE_APP_RUN_OUTPUT_WARNING" not in os.environ:
+            if show_progress is None:
+                if OutputManager.get() is None:
+                    deprecation_warning((2024, 7, 18), dedent(enable_output_warning))
+            elif show_progress is True:
+                if OutputManager.get() is None:
+                    deprecation_warning((2024, 7, 18), dedent(enable_output_warning))
+                else:
+                    deprecation_warning((2024, 7, 18), "`show_progress=True` is deprecated and no longer needed.")
+            elif show_progress is False:
+                if OutputManager.get() is not None:
+                    deprecation_warning(
+                        (2024, 7, 18), "`show_progress=False` will have no effect since output is enabled."
+                    )
+
         async with _run_app(self, client=client, detach=detach):
             yield self
 

--- a/modal/app.py
+++ b/modal/app.py
@@ -12,7 +12,6 @@ from synchronicity.async_wrap import asynccontextmanager
 from modal_proto import api_pb2
 
 from ._ipython import is_notebook
-from ._output import OutputManager
 from ._utils.async_utils import synchronize_api
 from ._utils.function_utils import FunctionInfo, is_global_object, is_top_level_function
 from ._utils.grpc_utils import unary_stream
@@ -306,7 +305,6 @@ class _App:
         client: Optional[_Client] = None,
         show_progress: bool = True,
         detach: bool = False,
-        output_mgr: Optional[OutputManager] = None,
     ) -> AsyncGenerator["_App", None]:
         """Context manager that runs an app on Modal.
 
@@ -319,7 +317,7 @@ class _App:
         objects. For backwards compatibility reasons, it returns the same app.
         """
         # TODO(erikbern): deprecate this one too?
-        async with _run_app(self, client, show_progress, detach, output_mgr):
+        async with _run_app(self, client=client, show_progress=show_progress, detach=detach):
             yield self
 
     def _get_default_image(self):

--- a/modal/app.py
+++ b/modal/app.py
@@ -303,7 +303,6 @@ class _App:
     async def run(
         self,
         client: Optional[_Client] = None,
-        show_progress: bool = True,
         detach: bool = False,
     ) -> AsyncGenerator["_App", None]:
         """Context manager that runs an app on Modal.
@@ -317,7 +316,7 @@ class _App:
         objects. For backwards compatibility reasons, it returns the same app.
         """
         # TODO(erikbern): deprecate this one too?
-        async with _run_app(self, client=client, show_progress=show_progress, detach=detach):
+        async with _run_app(self, client=client, detach=detach):
             yield self
 
     def _get_default_image(self):

--- a/modal/app.py
+++ b/modal/app.py
@@ -303,6 +303,7 @@ class _App:
     async def run(
         self,
         client: Optional[_Client] = None,
+        show_progress=None,
         detach: bool = False,
     ) -> AsyncGenerator["_App", None]:
         """Context manager that runs an app on Modal.
@@ -316,6 +317,13 @@ class _App:
         objects. For backwards compatibility reasons, it returns the same app.
         """
         # TODO(erikbern): deprecate this one too?
+        if show_progress is not None:
+            deprecation_error(
+                (2024, 7, 18),
+                "The argument `show_progress` is no longer supported."
+                " The default behavior is to NOT output anything."
+                " In order to enable output, use `with modal.enable_output():`",
+            )
         async with _run_app(self, client=client, detach=detach):
             yield self
 

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -17,7 +17,7 @@ from rich.console import Console
 from typing_extensions import TypedDict
 
 from .. import Cls
-from .._output import OutputManager
+from .._output import enable_output
 from ..app import App, LocalEntrypoint
 from ..config import config
 from ..environments import ensure_env
@@ -156,7 +156,7 @@ def _get_click_command_for_function(app: App, function_tag):
     @click.pass_context
     def f(ctx, **kwargs):
         show_progress: bool = ctx.obj["show_progress"]
-        with OutputManager.enable_output(show_progress):
+        with enable_output(show_progress):
             with run_app(
                 app,
                 detach=ctx.obj["detach"],
@@ -192,7 +192,7 @@ def _get_click_command_for_local_entrypoint(app: App, entrypoint: LocalEntrypoin
             )
 
         show_progress: bool = ctx.obj["show_progress"]
-        with OutputManager.enable_output(show_progress):
+        with enable_output(show_progress):
             with run_app(
                 app,
                 detach=ctx.obj["detach"],
@@ -291,7 +291,7 @@ def deploy(
     if name is None:
         name = app.name
 
-    with OutputManager.enable_output():
+    with enable_output():
         res = deploy_app(app, name=name, environment_name=env, tag=tag)
 
     if stream_logs:
@@ -317,7 +317,7 @@ def serve(
     if app.description is None:
         app.set_description(_get_clean_app_description(app_ref))
 
-    with OutputManager.enable_output():
+    with enable_output():
         with serve_app(app, app_ref, environment_name=env):
             if timeout is None:
                 timeout = config["serve_timeout"]

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -17,6 +17,7 @@ from rich.console import Console
 from typing_extensions import TypedDict
 
 from .. import Cls
+from .._output import OutputManager
 from ..app import App, LocalEntrypoint
 from ..config import config
 from ..environments import ensure_env
@@ -154,24 +155,25 @@ def _get_click_command_for_function(app: App, function_tag):
 
     @click.pass_context
     def f(ctx, **kwargs):
-        with run_app(
-            app,
-            detach=ctx.obj["detach"],
-            show_progress=ctx.obj["show_progress"],
-            environment_name=ctx.obj["env"],
-            interactive=ctx.obj["interactive"],
-        ):
-            if cls is None:
-                function.remote(**kwargs)
-            else:
-                # unpool class and method arguments
-                # TODO(erikbern): this code is a bit hacky
-                cls_kwargs = {k: kwargs[k] for k in cls_signature}
-                fun_kwargs = {k: kwargs[k] for k in fun_signature}
+        show_progress: bool = ctx.obj["show_progress"]
+        with OutputManager.enable_output(show_progress):
+            with run_app(
+                app,
+                detach=ctx.obj["detach"],
+                environment_name=ctx.obj["env"],
+                interactive=ctx.obj["interactive"],
+            ):
+                if cls is None:
+                    function.remote(**kwargs)
+                else:
+                    # unpool class and method arguments
+                    # TODO(erikbern): this code is a bit hacky
+                    cls_kwargs = {k: kwargs[k] for k in cls_signature}
+                    fun_kwargs = {k: kwargs[k] for k in fun_signature}
 
-                instance = cls(**cls_kwargs)
-                method: Function = getattr(instance, method_name)
-                method.remote(**fun_kwargs)
+                    instance = cls(**cls_kwargs)
+                    method: Function = getattr(instance, method_name)
+                    method.remote(**fun_kwargs)
 
     with_click_options = _add_click_options(f, signature)
     return click.command(with_click_options)
@@ -189,20 +191,21 @@ def _get_click_command_for_local_entrypoint(app: App, entrypoint: LocalEntrypoin
                 "triggered Modal function alive after the parent process has been killed or disconnected."
             )
 
-        with run_app(
-            app,
-            detach=ctx.obj["detach"],
-            show_progress=ctx.obj["show_progress"],
-            environment_name=ctx.obj["env"],
-            interactive=ctx.obj["interactive"],
-        ):
-            try:
-                if isasync:
-                    asyncio.run(func(*args, **kwargs))
-                else:
-                    func(*args, **kwargs)
-            except Exception as exc:
-                raise _CliUserExecutionError(inspect.getsourcefile(func)) from exc
+        show_progress: bool = ctx.obj["show_progress"]
+        with OutputManager.enable_output(show_progress):
+            with run_app(
+                app,
+                detach=ctx.obj["detach"],
+                environment_name=ctx.obj["env"],
+                interactive=ctx.obj["interactive"],
+            ):
+                try:
+                    if isasync:
+                        asyncio.run(func(*args, **kwargs))
+                    else:
+                        func(*args, **kwargs)
+                except Exception as exc:
+                    raise _CliUserExecutionError(inspect.getsourcefile(func)) from exc
 
     with_click_options = _add_click_options(f, _get_signature(func))
     return click.command(with_click_options)
@@ -288,7 +291,8 @@ def deploy(
     if name is None:
         name = app.name
 
-    res = deploy_app(app, name=name, environment_name=env, tag=tag)
+    with OutputManager.enable_output():
+        res = deploy_app(app, name=name, environment_name=env, tag=tag)
 
     if stream_logs:
         stream_app_logs(res.app_id)
@@ -313,15 +317,16 @@ def serve(
     if app.description is None:
         app.set_description(_get_clean_app_description(app_ref))
 
-    with serve_app(app, app_ref, environment_name=env):
-        if timeout is None:
-            timeout = config["serve_timeout"]
-        if timeout is None:
-            timeout = float("inf")
-        while timeout > 0:
-            t = min(timeout, 3600)
-            time.sleep(t)
-            timeout -= t
+    with OutputManager.enable_output():
+        with serve_app(app, app_ref, environment_name=env):
+            if timeout is None:
+                timeout = config["serve_timeout"]
+            if timeout is None:
+                timeout = float("inf")
+            while timeout > 0:
+                t = min(timeout, 3600)
+                time.sleep(t)
+                timeout -= t
 
 
 def shell(

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -106,7 +106,6 @@ async def _create_all_objects(
     indexed_objects: Dict[str, _Object],
     new_app_state: int,
     environment_name: str,
-    output_mgr: Optional[OutputManager] = None,
 ) -> None:
     """Create objects that have been defined but not created on the server."""
     if not client.authenticated:
@@ -116,7 +115,6 @@ async def _create_all_objects(
         client,
         environment_name=environment_name,
         app_id=running_app.app_id,
-        output_mgr=output_mgr,
     )
     with resolver.display():
         # Get current objects, and reset all objects

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -190,10 +190,10 @@ async def _disconnect(
 @asynccontextmanager
 async def _run_app(
     app: _App,
+    *,
     client: Optional[_Client] = None,
     show_progress: bool = True,
     detach: bool = False,
-    output_mgr: Optional[OutputManager] = None,
     environment_name: Optional[str] = None,
     interactive: bool = False,
 ) -> AsyncGenerator[_App, None]:
@@ -225,8 +225,7 @@ async def _run_app(
 
     if client is None:
         client = await _Client.from_env()
-    if output_mgr is None:
-        output_mgr = OutputManager(show_progress=show_progress)
+    output_mgr = OutputManager(show_progress=show_progress)
     app_state = api_pb2.APP_STATE_DETACHED if detach else api_pb2.APP_STATE_EPHEMERAL
     running_app: RunningApp = await _init_local_app_new(
         client,
@@ -509,7 +508,7 @@ async def _interactive_shell(_app: _App, cmds: List[str], environment_name: str 
     **kwargs will be passed into spawn_sandbox().
     """
     client = await _Client.from_env()
-    async with _run_app(_app, client, environment_name=environment_name, show_progress=False):
+    async with _run_app(_app, client=client, environment_name=environment_name, show_progress=False):
         console = Console()
         loading_status = console.status("Starting container...")
         loading_status.start()

--- a/modal/serving.py
+++ b/modal/serving.py
@@ -45,17 +45,17 @@ async def _restart_serve(
     return p
 
 
-async def _terminate(proc: Optional[SpawnProcess], output_mgr: Optional[OutputManager], timeout: float = 5.0):
+async def _terminate(proc: Optional[SpawnProcess], timeout: float = 5.0):
     if proc is None:
         return
     try:
         proc.terminate()
         await asyncify(proc.join)(timeout)
         if proc.exitcode is not None:
-            if output_mgr and output_mgr.is_visible():
+            if output_mgr := OutputManager.get():
                 output_mgr.print(f"Serve process {proc.pid} terminated")
         else:
-            if output_mgr and output_mgr.is_visible():
+            if output_mgr := OutputManager.get():
                 output_mgr.print(f"[red]Serve process {proc.pid} didn't terminate after {timeout}s, killing it[/red]")
             proc.kill()
     except ProcessLookupError:
@@ -65,7 +65,6 @@ async def _terminate(proc: Optional[SpawnProcess], output_mgr: Optional[OutputMa
 async def _run_watch_loop(
     app_ref: str,
     app_id: str,
-    output_mgr: Optional[OutputManager],
     watcher: AsyncGenerator[Set[str], None],
     environment_name: str,
 ):
@@ -75,7 +74,7 @@ async def _run_watch_loop(
         " This can hopefully be fixed in a future version of Modal."
 
     if unsupported_msg:
-        if output_mgr and output_mgr.is_visible():
+        if output_mgr := OutputManager.get():
             async for _ in watcher:
                 output_mgr.print(unsupported_msg)
     else:
@@ -83,10 +82,10 @@ async def _run_watch_loop(
         try:
             async for trigger_files in watcher:
                 logger.debug(f"The following files triggered an app update: {', '.join(trigger_files)}")
-                await _terminate(curr_proc, output_mgr)
+                await _terminate(curr_proc)
                 curr_proc = await _restart_serve(app_ref, existing_app_id=app_id, environment_name=environment_name)
         finally:
-            await _terminate(curr_proc, output_mgr)
+            await _terminate(curr_proc)
 
 
 def _get_clean_app_description(app_ref: str) -> str:
@@ -111,16 +110,15 @@ async def _serve_app(
 
     client = await _Client.from_env()
 
-    output_mgr = OutputManager.get()
     if _watcher is not None:
         watcher = _watcher  # Only used by tests
     else:
         mounts_to_watch = app._get_watch_mounts()
-        watcher = watch(mounts_to_watch, output_mgr)
+        watcher = watch(mounts_to_watch)
 
     async with _run_app(app, client=client, environment_name=environment_name):
         async with TaskContext(grace=0.1) as tc:
-            tc.create_task(_run_watch_loop(app_ref, app.app_id, output_mgr, watcher, environment_name))
+            tc.create_task(_run_watch_loop(app_ref, app.app_id, watcher, environment_name))
             yield app
 
 

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -7,7 +7,7 @@ import time
 from google.protobuf.empty_pb2 import Empty
 from grpclib import GRPCError, Status
 
-from modal import App, Dict, Image, Mount, Secret, Stub, Volume, web_endpoint
+from modal import App, Dict, Image, Mount, Secret, Stub, Volume, enable_output, web_endpoint
 from modal._output import OutputManager
 from modal.app import list_apps  # type: ignore
 from modal.exception import DeprecationError, ExecutionError, InvalidError, NotFoundError
@@ -400,8 +400,38 @@ def test_app_interactive(servicer, client, capsys):
     assert captured.out.endswith("\nsome data\n\r")
 
 
-def test_show_progress():
+def test_show_progress_deprecations(client):
     app = App()
-    with pytest.raises(DeprecationError, match="show_progress"):
-        with app.run(show_progress=True):
+
+    # If show_progress is not provided, and output is not enabled, warn
+    with pytest.warns(DeprecationError, match="enable_output"):
+        with app.run(client=client):
             pass
+
+    # If show_progress is not provided, and output is enabled, no warning
+    with enable_output():
+        with app.run(client=client):
+            pass
+
+    # If show_progress is set to True, and output is not enabled, warn
+    # This is the only one that I'm not sure about - should we auto-enable output for now?
+    with pytest.warns(DeprecationError, match="enable_output"):
+        with app.run(client=client, show_progress=True):
+            pass
+
+    # If show_progress is set to True, and output is enabled, warn the flag is superfluous
+    with pytest.warns(DeprecationError, match="`show_progress=True` is deprecated"):
+        with enable_output():
+            with app.run(client=client, show_progress=True):
+                pass
+
+    # If show_progress is set to False, and output is not enabled, no warning
+    # This mode is currently used to suppress deprecation warnings, but will in itself be deprecated later.
+    with app.run(client=client, show_progress=False):
+        pass
+
+    # If show_progress is set to False, and output is enabled, warn that it has no effect
+    with pytest.warns(DeprecationError, match="no effect"):
+        with enable_output():
+            with app.run(client=client, show_progress=False):
+                pass

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -400,7 +400,10 @@ def test_app_interactive(servicer, client, capsys):
     assert captured.out.endswith("\nsome data\n\r")
 
 
-def test_show_progress_deprecations(client):
+def test_show_progress_deprecations(client, monkeypatch):
+    # Unset env used to disable warning
+    monkeypatch.delenv("MODAL_DISABLE_APP_RUN_OUTPUT_WARNING")
+
     app = App()
 
     # If show_progress is not provided, and output is not enabled, warn

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -8,6 +8,7 @@ from google.protobuf.empty_pb2 import Empty
 from grpclib import GRPCError, Status
 
 from modal import App, Dict, Image, Mount, Secret, Stub, Volume, web_endpoint
+from modal._output import OutputManager
 from modal.app import list_apps  # type: ignore
 from modal.exception import DeprecationError, ExecutionError, InvalidError, NotFoundError
 from modal.partial_function import _parse_custom_domains
@@ -391,8 +392,9 @@ def test_app_interactive(servicer, client, capsys):
     with servicer.intercept() as ctx:
         ctx.set_responder("AppGetLogs", app_logs_pty)
 
-        with app.run(client=client):
-            time.sleep(0.1)
+        with OutputManager.enable_output():
+            with app.run(client=client):
+                time.sleep(0.1)
 
     captured = capsys.readouterr()
     assert captured.out.endswith("\nsome data\n\r")

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -409,7 +409,7 @@ def test_show_progress_deprecations(client, monkeypatch):
     # If show_progress is not provided, and output is not enabled, warn
     with pytest.warns(DeprecationError, match="enable_output"):
         with app.run(client=client):
-            pass
+            assert OutputManager.get() is not None  # Should be auto-enabled
 
     # If show_progress is not provided, and output is enabled, no warning
     with enable_output():
@@ -417,10 +417,9 @@ def test_show_progress_deprecations(client, monkeypatch):
             pass
 
     # If show_progress is set to True, and output is not enabled, warn
-    # This is the only one that I'm not sure about - should we auto-enable output for now?
     with pytest.warns(DeprecationError, match="enable_output"):
         with app.run(client=client, show_progress=True):
-            pass
+            assert OutputManager.get() is not None  # Should be auto-enabled
 
     # If show_progress is set to True, and output is enabled, warn the flag is superfluous
     with pytest.warns(DeprecationError, match="`show_progress=True` is deprecated"):
@@ -431,7 +430,7 @@ def test_show_progress_deprecations(client, monkeypatch):
     # If show_progress is set to False, and output is not enabled, no warning
     # This mode is currently used to suppress deprecation warnings, but will in itself be deprecated later.
     with app.run(client=client, show_progress=False):
-        pass
+        assert OutputManager.get() is None
 
     # If show_progress is set to False, and output is enabled, warn that it has no effect
     with pytest.warns(DeprecationError, match="no effect"):

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -398,3 +398,10 @@ def test_app_interactive(servicer, client, capsys):
 
     captured = capsys.readouterr()
     assert captured.out.endswith("\nsome data\n\r")
+
+
+def test_show_progress():
+    app = App()
+    with pytest.raises(DeprecationError, match="show_progress"):
+        with app.run(show_progress=True):
+            pass

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -55,6 +55,11 @@ def set_env(monkeypatch):
     monkeypatch.setenv("MODAL_ENVIRONMENT", "main")
 
 
+@pytest.fixture(scope="function", autouse=True)
+def disable_app_run_warning(monkeypatch):
+    monkeypatch.setenv("MODAL_DISABLE_APP_RUN_OUTPUT_WARNING", "1")
+
+
 @patch_mock_servicer
 class MockClientServicer(api_grpc.ModalClientBase):
     # TODO(erikbern): add more annotations

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -735,10 +735,10 @@ def test_no_state_reuse(client, servicer, supports_dir):
     app = App("reuse-mount-app")
     app.function(mounts=[mount_instance_1, mount_instance_2])(dummy)
 
-    deploy_app(app, client=client, show_progress=False)
+    deploy_app(app, client=client)
     first_deploy = {mount_instance_1.object_id, mount_instance_2.object_id}
 
-    deploy_app(app, client=client, show_progress=False)
+    deploy_app(app, client=client)
     second_deploy = {mount_instance_1.object_id, mount_instance_2.object_id}
 
     # mount ids should not overlap between first and second deploy

--- a/test/live_reload_test.py
+++ b/test/live_reload_test.py
@@ -23,7 +23,7 @@ async def test_live_reload(app_ref, server_url_env, servicer):
         await asyncio.sleep(3.0)
     assert servicer.app_set_objects_count == 1
     assert servicer.app_client_disconnect_count == 1
-    assert servicer.app_get_logs_initial_count == 1
+    # assert servicer.app_get_logs_initial_count == 1
 
 
 @skip_windows("live-reload not supported on windows")
@@ -44,7 +44,7 @@ def test_file_changes_trigger_reloads(app_ref, server_url_env, servicer):
     # assert servicer.app_set_objects_count == 4  # 1 + number of file changes
     assert servicer.app_set_objects_count > 1
     assert servicer.app_client_disconnect_count == 1
-    assert servicer.app_get_logs_initial_count == 1
+    # assert servicer.app_get_logs_initial_count == 1
     foo = app.indexed_objects["foo"]
     assert isinstance(foo, Function)
     assert foo.web_url.startswith("http://")
@@ -62,7 +62,7 @@ async def test_no_change(app_ref, server_url_env, servicer):
 
     assert servicer.app_set_objects_count == 1  # Should create the initial app once
     assert servicer.app_client_disconnect_count == 1
-    assert servicer.app_get_logs_initial_count == 1
+    # assert servicer.app_get_logs_initial_count == 1
 
 
 @pytest.mark.asyncio

--- a/test/live_reload_test.py
+++ b/test/live_reload_test.py
@@ -5,7 +5,7 @@ import threading
 import time
 from unittest import mock
 
-from modal import Function
+from modal import Function, enable_output
 from modal.serving import serve_app
 
 from .supports.app_run_tests.webhook import app
@@ -23,7 +23,17 @@ async def test_live_reload(app_ref, server_url_env, servicer):
         await asyncio.sleep(3.0)
     assert servicer.app_set_objects_count == 1
     assert servicer.app_client_disconnect_count == 1
-    # assert servicer.app_get_logs_initial_count == 1
+    assert servicer.app_get_logs_initial_count == 0
+
+
+@pytest.mark.asyncio
+async def test_live_reload_with_logs(app_ref, server_url_env, servicer):
+    with enable_output():
+        async with serve_app.aio(app, app_ref):
+            await asyncio.sleep(3.0)
+    assert servicer.app_set_objects_count == 1
+    assert servicer.app_client_disconnect_count == 1
+    assert servicer.app_get_logs_initial_count == 1
 
 
 @skip_windows("live-reload not supported on windows")
@@ -44,7 +54,6 @@ def test_file_changes_trigger_reloads(app_ref, server_url_env, servicer):
     # assert servicer.app_set_objects_count == 4  # 1 + number of file changes
     assert servicer.app_set_objects_count > 1
     assert servicer.app_client_disconnect_count == 1
-    # assert servicer.app_get_logs_initial_count == 1
     foo = app.indexed_objects["foo"]
     assert isinstance(foo, Function)
     assert foo.web_url.startswith("http://")
@@ -62,7 +71,6 @@ async def test_no_change(app_ref, server_url_env, servicer):
 
     assert servicer.app_set_objects_count == 1  # Should create the initial app once
     assert servicer.app_client_disconnect_count == 1
-    # assert servicer.app_get_logs_initial_count == 1
 
 
 @pytest.mark.asyncio

--- a/test/resolver_test.py
+++ b/test/resolver_test.py
@@ -4,7 +4,6 @@ import pytest
 import time
 from typing import Optional
 
-from modal._output import OutputManager
 from modal._resolver import Resolver
 from modal.object import _Object
 
@@ -12,8 +11,7 @@ from modal.object import _Object
 @pytest.mark.flaky(max_runs=2)
 @pytest.mark.asyncio
 async def test_multi_resolve_sequential_loads_once():
-    output_manager = OutputManager()
-    resolver = Resolver(None, output_mgr=output_manager, environment_name="", app_id=None)
+    resolver = Resolver(None, environment_name="", app_id=None)
 
     load_count = 0
 
@@ -38,8 +36,7 @@ async def test_multi_resolve_sequential_loads_once():
 
 @pytest.mark.asyncio
 async def test_multi_resolve_concurrent_loads_once():
-    output_manager = OutputManager()
-    resolver = Resolver(None, output_mgr=output_manager, environment_name="", app_id=None)
+    resolver = Resolver(None, environment_name="", app_id=None)
 
     load_count = 0
 

--- a/test/supports/notebooks/simple.notebook.py
+++ b/test/supports/notebooks/simple.notebook.py
@@ -34,6 +34,6 @@ def hello():
 
 # + tags=["main"]
 with client:
-    with app.run(client=client, show_progress=True):
+    with app.run(client=client):
         hello.remote()
 # -

--- a/test/supports/progress_info.py
+++ b/test/supports/progress_info.py
@@ -1,6 +1,9 @@
 # Copyright Modal Labs 2022
+from modal._output import OutputManager
+
 from .common import app, f
 
 if __name__ == "__main__":
-    with app.run(show_progress=True):
-        assert f.remote(2, 4) == 20  # type: ignore
+    with OutputManager.enable_output():  # TODO(erikbern): turn this into modal.enable_output()
+        with app.run():
+            assert f.remote(2, 4) == 20  # type: ignore

--- a/test/supports/progress_info.py
+++ b/test/supports/progress_info.py
@@ -1,9 +1,9 @@
 # Copyright Modal Labs 2022
-from modal._output import OutputManager
+from modal import enable_output
 
 from .common import app, f
 
 if __name__ == "__main__":
-    with OutputManager.enable_output():  # TODO(erikbern): turn this into modal.enable_output()
+    with enable_output():
         with app.run():
             assert f.remote(2, 4) == 20  # type: ignore


### PR DESCRIPTION
It works but apologies that this PR is more plus than negative. We're not reaping the benefits yet – I'm only taking advantage of it in a few places. In particular we can:

* Get rid of the `set_output_mgr` methods on functions/classes
* Get rid of a bunch of wrapper methods on the resolver

And a few more things. Will do those in subsequent PRs.

Note that this changes the behavior slightly with `app.run`. Previously this used to print output:

```python
with app.run():
    f.remote()
```

However going forward you need this:

```python
with enable_output():
    with app.run():
        f.remote()
```

This is intentional! IMO when using Modal "as a library" we should never output anything by default – libraries shouldn't do that. This is also the reason I added helper methods a few days ago to get logs programmatically. You can use `app._logs()` and `image._logs()` (although those are experimental still).

When using Modal "as a framework" we output by default though – `modal run` works just like usual.