### PR TITLE
Deprecate setting _allow_background_volume_commits, ahead of removal

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -507,7 +507,7 @@ class _App:
         interactive: bool = False,  # Deprecated: use the `modal.interact()` hook instead
         secret: Optional[_Secret] = None,  # Deprecated: use `secrets`
         # Parameters below here are experimental. Use with caution!
-        _allow_background_volume_commits: Optional[bool] = None,
+        _allow_background_volume_commits: None = None,
         _experimental_boost: bool = False,  # Experimental flag for lower latency function execution (alpha).
         _experimental_scheduler_placement: Optional[
             SchedulerPlacement
@@ -675,7 +675,7 @@ class _App:
         enable_memory_snapshot: bool = False,  # Enable memory checkpointing for faster cold starts.
         checkpointing_enabled: Optional[bool] = None,  # Deprecated
         block_network: bool = False,  # Whether to block network access
-        _allow_background_volume_commits: Optional[bool] = None,
+        _allow_background_volume_commits: None = None,
         # Limits the number of inputs a container handles before shutting down.
         # Use `max_inputs = 1` for single-use containers.
         max_inputs: Optional[int] = None,
@@ -800,7 +800,7 @@ class _App:
         volumes: Dict[
             Union[str, PurePosixPath], Union[_Volume, _CloudBucketMount]
         ] = {},  # Mount points for Modal Volumes and CloudBucketMounts
-        _allow_background_volume_commits: Optional[bool] = None,
+        _allow_background_volume_commits: None = None,
         pty_info: Optional[api_pb2.PTYInfo] = None,
         _experimental_scheduler_placement: Optional[
             SchedulerPlacement
@@ -824,9 +824,16 @@ class _App:
             raise InvalidError("`app.spawn_sandbox` requires a running app.")
 
         if _allow_background_volume_commits is False:
-            deprecation_warning(
+            deprecation_error(
                 (2024, 5, 13),
-                "Disabling volume background commits is now deprecated. Set _allow_background_volume_commits=True.",
+                "Disabling volume background commits is now deprecated. "
+                "Remove this argument to enable the functionality.",
+            )
+        elif _allow_background_volume_commits is True:
+            deprecation_warning(
+                (2024, 7, 18),
+                "Setting volume background commits is deprecated. "
+                "The functionality is now unconditionally enabled (set to True).",
             )
         elif _allow_background_volume_commits is None:
             _allow_background_volume_commits = True

--- a/modal/app.py
+++ b/modal/app.py
@@ -827,7 +827,7 @@ class _App:
             deprecation_error(
                 (2024, 5, 13),
                 "Disabling volume background commits is now deprecated. "
-                "Remove this argument to enable the functionality.",
+                "Remove _allow_background_volume_commits=False to enable the functionality.",
             )
         elif _allow_background_volume_commits is True:
             deprecation_warning(

--- a/modal/cli/programs/run_jupyter.py
+++ b/modal/cli/programs/run_jupyter.py
@@ -63,7 +63,6 @@ def wait_for_port(url: str, q: Queue):
     mounts=mounts,
     volumes=volumes,
     concurrency_limit=1 if volume else None,
-    _allow_background_volume_commits=True,
 )
 def run_jupyter(q: Queue):
     os.makedirs("/root/lab", exist_ok=True)

--- a/modal/cli/programs/vscode.py
+++ b/modal/cli/programs/vscode.py
@@ -63,7 +63,6 @@ def wait_for_port(data: Tuple[str, str], q: Queue):
     mounts=mounts,
     volumes=volumes,
     concurrency_limit=1 if volume else None,
-    _allow_background_volume_commits=True,
 )
 def run_vscode(q: Queue):
     os.chdir("/home/coder")

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -410,7 +410,6 @@ def shell(
             memory=function_spec.memory,
             volumes=function_spec.volumes,
             region=function_spec.scheduler_placement.proto.regions if function_spec.scheduler_placement else None,
-            _allow_background_volume_commits=True,
             _experimental_gpus=function_spec._experimental_gpus,
         )
     else:

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -533,7 +533,7 @@ class _Function(_Object, type_prefix="fu"):
             deprecation_error(
                 (2024, 5, 13),
                 "Disabling volume background commits is now deprecated. "
-                "Remove this argument to enable the functionality.",
+                "Remove _allow_background_volume_commits=False to enable the functionality.",
             )
         elif allow_background_volume_commits is True:
             deprecation_warning(

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -530,9 +530,16 @@ class _Function(_Object, type_prefix="fu"):
             enable_memory_snapshot = checkpointing_enabled
 
         if allow_background_volume_commits is False:
-            deprecation_warning(
+            deprecation_error(
                 (2024, 5, 13),
-                "Disabling volume background commits is now deprecated. Set _allow_background_volume_commits=True.",
+                "Disabling volume background commits is now deprecated. "
+                "Remove this argument to enable the functionality.",
+            )
+        elif allow_background_volume_commits is True:
+            deprecation_warning(
+                (2024, 7, 18),
+                "Setting volume background commits is deprecated. "
+                "The functionality is now unconditionally enabled (set to True).",
             )
         elif allow_background_volume_commits is None:
             allow_background_volume_commits = True

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -19,7 +19,7 @@ from ._utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES, retry_transient_erro
 from ._utils.mount_utils import validate_network_file_systems, validate_volumes
 from .client import _Client
 from .config import config
-from .exception import deprecation_warning
+from .exception import deprecation_error, deprecation_warning
 from .gpu import GPU_T
 from .image import _Image
 from .mount import _Mount
@@ -361,7 +361,7 @@ class _Sandbox(_Object, type_prefix="sb"):
             Union[str, os.PathLike], Union[_Volume, _CloudBucketMount]
         ] = {},  # Mount points for Modal Volumes and CloudBucketMounts
         pty_info: Optional[api_pb2.PTYInfo] = None,
-        _allow_background_volume_commits: Optional[bool] = None,
+        _allow_background_volume_commits: None = None,
         _experimental_scheduler_placement: Optional[
             SchedulerPlacement
         ] = None,  # Experimental controls over fine-grained scheduling (alpha).
@@ -369,9 +369,16 @@ class _Sandbox(_Object, type_prefix="sb"):
         _experimental_gpus: Sequence[GPU_T] = [],
     ) -> "_Sandbox":
         if _allow_background_volume_commits is False:
-            deprecation_warning(
+            deprecation_error(
                 (2024, 5, 13),
-                "Disabling volume background commits is now deprecated. Set _allow_background_volume_commits=True.",
+                "Disabling volume background commits is now deprecated. "
+                "Remove this argument to enable the functionality.",
+            )
+        elif _allow_background_volume_commits is True:
+            deprecation_warning(
+                (2024, 7, 18),
+                "Setting volume background commits is deprecated. "
+                "The functionality is now unconditionally enabled (set to True).",
             )
         elif _allow_background_volume_commits is None:
             _allow_background_volume_commits = True

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -372,7 +372,7 @@ class _Sandbox(_Object, type_prefix="sb"):
             deprecation_error(
                 (2024, 5, 13),
                 "Disabling volume background commits is now deprecated. "
-                "Remove this argument to enable the functionality.",
+                "Remove _allow_background_volume_commits=False to enable the functionality.",
             )
         elif _allow_background_volume_commits is True:
             deprecation_warning(


### PR DESCRIPTION
## Describe your changes

We need to remove `_allow_background_volume_commits` from the client but first we must give users notice about this if they're still doing `_allow_background_volume_commits=True`. 

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

---

</details>

## Changelog

* Setting `_allow_background_volume_commits` is no longer necessary and has been deprecated. Remove this argument in your decorators.
