### PR TITLE
Remove some of the output logic on the resolver

### DIFF
--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -6,8 +6,6 @@ from typing import TYPE_CHECKING, Dict, Hashable, List, Optional
 
 from grpclib import GRPCError, Status
 
-from modal_proto import api_pb2
-
 from ._utils.async_utils import TaskContext
 from .client import _Client
 from .config import logger
@@ -178,10 +176,3 @@ class Resolver:
 
     def add_status_row(self) -> StatusRow:
         return StatusRow(self._tree)
-
-    async def console_write(self, log: api_pb2.TaskLogs):
-        # TODO(erikbern): get rid of this wrapper
-        from ._output import OutputManager
-
-        if output_mgr := OutputManager.get():
-            await output_mgr.put_log_content(log)

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -185,10 +185,3 @@ class Resolver:
 
         if output_mgr := OutputManager.get():
             await output_mgr.put_log_content(log)
-
-    def console_flush(self):
-        # TODO(erikbern): get rid of this wrapper
-        from ._output import OutputManager
-
-        if output_mgr := OutputManager.get():
-            output_mgr.flush_lines()

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -192,10 +192,3 @@ class Resolver:
 
         if output_mgr := OutputManager.get():
             output_mgr.flush_lines()
-
-    def image_snapshot_update(self, image_id: str, task_progress: api_pb2.TaskProgress):
-        # TODO(erikbern): get rid of this wrapper
-        from ._output import OutputManager
-
-        if output_mgr := OutputManager.get():
-            output_mgr.update_snapshot_progress(image_id, task_progress)

--- a/modal/image.py
+++ b/modal/image.py
@@ -425,7 +425,8 @@ class _Image(_Object, type_prefix="im"):
                                 output_mgr.update_snapshot_progress(image_id, task_log.task_progress)
                         elif task_log.data:
                             await resolver.console_write(task_log)
-                resolver.console_flush()
+                if output_mgr := OutputManager.get():
+                    output_mgr.flush_lines()
 
             # Handle up to n exceptions while fetching logs
             retry_count = 0

--- a/modal/image.py
+++ b/modal/image.py
@@ -424,7 +424,8 @@ class _Image(_Object, type_prefix="im"):
                             if output_mgr := OutputManager.get():
                                 output_mgr.update_snapshot_progress(image_id, task_log.task_progress)
                         elif task_log.data:
-                            await resolver.console_write(task_log)
+                            if output_mgr := OutputManager.get():
+                                await output_mgr.put_log_content(task_log)
                 if output_mgr := OutputManager.get():
                     output_mgr.flush_lines()
 

--- a/modal/image.py
+++ b/modal/image.py
@@ -16,6 +16,7 @@ from grpclib.exceptions import GRPCError, StreamTerminatedError
 
 from modal_proto import api_pb2
 
+from ._output import OutputManager
 from ._resolver import Resolver
 from ._serialization import serialize
 from ._utils.async_utils import synchronize_api
@@ -420,7 +421,8 @@ class _Image(_Object, type_prefix="im"):
                     for task_log in response.task_logs:
                         if task_log.task_progress.pos or task_log.task_progress.len:
                             assert task_log.task_progress.progress_type == api_pb2.IMAGE_SNAPSHOT_UPLOAD
-                            resolver.image_snapshot_update(image_id, task_log.task_progress)
+                            if output_mgr := OutputManager.get():
+                                output_mgr.update_snapshot_progress(image_id, task_log.task_progress)
                         elif task_log.data:
                             await resolver.console_write(task_log)
                 resolver.console_flush()


### PR DESCRIPTION
Hit the singleton directly from the image.

One out of several simplifications we can do since #2030
