### PR TITLE
doctrings: make Mount and Image method args clearer

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -1398,6 +1398,22 @@ class _Image(_Object, type_prefix="im"):
         ```python
         image = modal.Image.from_dockerfile("./Dockerfile", add_python="3.12")
         ```
+
+        If your Dockerfile uses `COPY` instructions which copy data from the local context of the
+        build into the image, this local data must be uploaded to Modal via a context mount:
+
+        ```python
+        image = modal.Image.from_dockerfile(
+            "./Dockerfile",
+            context_mount=modal.Mount.from_local_dir(
+                local_path="src",
+                remote_path=".",  # to current WORKDIR
+            ),
+        )
+        ```
+
+        The context mount will allow a `COPY src/ src/` instruction to succeed in Modal's remote builder.
+        ```
         """
 
         # --- Build the base dockerfile

--- a/modal/image.py
+++ b/modal/image.py
@@ -1375,11 +1375,13 @@ class _Image(_Object, type_prefix="im"):
 
     @staticmethod
     def from_dockerfile(
+        # Filepath to Dockerfile.
         path: Union[str, Path],
-        context_mount: Optional[
-            _Mount
-        ] = None,  # modal.Mount with local files to supply as build context for COPY commands
-        force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
+        # modal.Mount with local files to supply as build context for COPY commands.
+        # NOTE: The remote_path of the Mount should match the Dockerfile's WORKDIR.
+        context_mount: Optional[_Mount] = None,
+        # Ignore cached builds, similar to 'docker build --no-cache'
+        force_build: bool = False,
         *,
         secrets: Sequence[_Secret] = [],
         gpu: GPU_T = None,

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -301,7 +301,7 @@ class _Mount(_Object, type_prefix="mo"):
         *,
         # Where the directory is placed within in the mount
         remote_path: Union[str, PurePosixPath, None] = None,
-        # Predicate filter function for file selection; function should return `True` for inclusion, `False` otherwise.
+        # Predicate filter function for file selection, which should accept a filepath and return `True` for inclusion.
         # Defaults to including all files.
         condition: Optional[Callable[[str], bool]] = None,
         # add files from subdirectories as well
@@ -336,7 +336,7 @@ class _Mount(_Object, type_prefix="mo"):
         *,
         # Where the directory is placed within in the mount
         remote_path: Union[str, PurePosixPath, None] = None,
-        # Predicate filter function for file selection; function should return `True` for inclusion, `False` otherwise.
+        # Predicate filter function for file selection, which should accept a filepath and return `True` for inclusion.
         # Defaults to including all files.
         condition: Optional[Callable[[str], bool]] = None,
         # add files from subdirectories as well
@@ -524,7 +524,7 @@ class _Mount(_Object, type_prefix="mo"):
     def from_local_python_packages(
         *module_names: str,
         remote_dir: Union[str, PurePosixPath] = ROOT_DIR.as_posix(),
-        # Predicate filter function for file selection; function should return `True` for inclusion, `False` otherwise.
+        # Predicate filter function for file selection, which should accept a filepath and return `True` for inclusion.
         # Defaults to including all files.
         condition: Optional[Callable[[str], bool]] = None,
     ) -> "_Mount":

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -301,7 +301,8 @@ class _Mount(_Object, type_prefix="mo"):
         *,
         # Where the directory is placed within in the mount
         remote_path: Union[str, PurePosixPath, None] = None,
-        # Filter function for file selection; defaults to including all files
+        # Predicate filter function for file selection; function should return `True` for inclusion, `False` otherwise.
+        # Defaults to including all files.
         condition: Optional[Callable[[str], bool]] = None,
         # add files from subdirectories as well
         recursive: bool = True,
@@ -335,7 +336,8 @@ class _Mount(_Object, type_prefix="mo"):
         *,
         # Where the directory is placed within in the mount
         remote_path: Union[str, PurePosixPath, None] = None,
-        # Filter function for file selection - default all files
+        # Predicate filter function for file selection; function should return `True` for inclusion, `False` otherwise.
+        # Defaults to including all files.
         condition: Optional[Callable[[str], bool]] = None,
         # add files from subdirectories as well
         recursive: bool = True,
@@ -522,6 +524,8 @@ class _Mount(_Object, type_prefix="mo"):
     def from_local_python_packages(
         *module_names: str,
         remote_dir: Union[str, PurePosixPath] = ROOT_DIR.as_posix(),
+        # Predicate filter function for file selection; function should return `True` for inclusion, `False` otherwise.
+        # Defaults to including all files.
         condition: Optional[Callable[[str], bool]] = None,
     ) -> "_Mount":
         """


### PR DESCRIPTION
## Describe your changes

An initial follow-up to struggles a user had 'bringing their own `Dockerfile`. 

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
    - just docs
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
    - just docs
