### PR TITLE
fix: multipart uploads broken by progress logging

### DIFF
--- a/modal/_output.py
+++ b/modal/_output.py
@@ -462,18 +462,21 @@ class ProgressHandler:
         reset: Optional[bool] = False,
         complete: Optional[bool] = False,
     ) -> Optional[TaskID]:
-        if task_id is not None:
-            if reset:
-                return self._reset_sub_task(task_id)
+        try:
+            if task_id is not None:
+                if reset:
+                    return self._reset_sub_task(task_id)
+                elif complete:
+                    return self._complete_sub_task(task_id)
+                elif advance is not None:
+                    return self._advance_sub_task(task_id, advance)
+            elif name is not None and size is not None:
+                return self._add_sub_task(name, size)
             elif complete:
-                return self._complete_sub_task(task_id)
-            elif advance is not None:
-                return self._advance_sub_task(task_id, advance)
-        elif name is not None and size is not None:
-            return self._add_sub_task(name, size)
-        elif complete:
-            return self._complete_progress()
-
+                return self._complete_progress()
+        except Exception as exc:
+            # Liberal exception handling to avoid crashing downloads and uploads.
+            logger.error(f"failed progress update: {exc}")
         raise NotImplementedError(
             "Unknown action to take with args: "
             + f"name={name} "

--- a/modal/_utils/blob_utils.py
+++ b/modal/_utils/blob_utils.py
@@ -114,8 +114,6 @@ class BytesIOSegmentPayload(BytesIOPayload):
             await writer.write(chunk)
             self.progress_report_cb(advance=len(chunk))
 
-        self.progress_report_cb(complete=True)
-
     def remaining_bytes(self):
         return self.segment_length - self.num_bytes_read
 
@@ -281,6 +279,9 @@ async def _blob_upload(
             # for single part uploads, we use server side md5 checksums
             content_md5_b64=upload_hashes.md5_base64,
         )
+
+    if progress_report_cb:
+        progress_report_cb(complete=True)
 
     return blob_id
 


### PR DESCRIPTION
## Describe your changes

Multi-part uploads broke in #1969.

```
$ dd if=/dev/zero of=/tmp/tempfile bs=1024 count=1423195
1423195+0 records in
1423195+0 records out
1457351680 bytes (1.5 GB, 1.4 GiB) copied, 1.77675 s, 820 MB/s
$ ls -la /tmp/tempfile
-rw-rw-r-- 1 ubuntu ubuntu 1457351680 Jul 22 16:29 /tmp/tempfile
$ MODAL_PROFILE=modal_labs modal volume put volumes-syn-mon /tmp/tempfile tempfile
╭─ Error ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ 0                                                                                                                                                                                     │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
(modal) ubuntu@ip-10-1-1-198:~/modal$ echo $?
1
```

The issue is that in a multipart upload the first part to finish completes the progress item which makes every subsequent progress update from the other tasks crash. When they crash the HTTP client produces an obscure error because it got an unexpected exception from the readable. 

@kramstrom actually suggested preventing these bugs from crashing uploads but I wanted them to crash so we'd find the bugs quicker: https://github.com/modal-labs/modal-client/pull/1969/files#r1678674924

I didn't realize though that the bugs would surface in suggest an obscure way:

```
ClientConnectionError("Failed to send bytes into the underlying connection Connection<ConnectionKey(host='modal-blobs.s3-accelerate.amazonaws.com', port=443, is_ssl=True, ssl=True
```

### Fixes

1. Now want to do the `try except` wrapping because we didn't catch this bug for ~1 week.
2. Move the completion of the progress item so that it happens only once per upload not once-per-part. 

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
    - no change to communication with server here
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
    - no change to IDL here

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

