### PR TITLE
Run / deploy apps via new AppPublish RPC

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -779,7 +779,6 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
         if function_def.is_checkpointing_function:
             container_io_manager.memory_snapshot()
 
-
         # Install hooks for interactive functions.
         if function_def.pty_info.pty_type != api_pb2.PTYInfo.PTY_TYPE_UNSPECIFIED:
 

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -278,10 +278,10 @@ def run(ctx, detach, quiet, interactive, env):
 
 def deploy(
     app_ref: str = typer.Argument(..., help="Path to a Python file with an app."),
-    name: str = typer.Option(None, help="Name of the deployment."),
+    name: str = typer.Option("", help="Name of the deployment."),
     env: str = ENV_OPTION,
     stream_logs: bool = typer.Option(False, help="Stream logs from the app upon deployment."),
-    tag: str = typer.Option(None, help="Tag the deployment with a version."),
+    tag: str = typer.Option("", help="Tag the deployment with a version."),
 ):
     # this ensures that `modal.lookup()` without environment specification uses the same env as specified
     env = ensure_env(env)
@@ -292,7 +292,7 @@ def deploy(
         name = app.name
 
     with enable_output():
-        res = deploy_app(app, name=name, environment_name=env, tag=tag)
+        res = deploy_app(app, name=name, environment_name=env or "", tag=tag)
 
     if stream_logs:
         stream_app_logs(res.app_id)

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -274,6 +274,16 @@ class _Cls(_Object, type_prefix="cs"):
                     )
                 )
             resp = await resolver.client.stub.ClassCreate(req)
+            # Even though we already have the function_handle_metadata for this method locally,
+            # The RPC is going to replace it with function_handle_metadata derived from the server.
+            # We need to overwrite the definition_id sent back from the server here with the definition_id
+            # previously stored in function metadata, which may have been sent back from FunctionCreate.
+            # The problem is that this metadata propagates back and overwrites the metadata on the Function
+            # object itself. This is really messy. Maybe better to exclusively populate the method metadata
+            # from the function metadata we already have locally? Really a lot to clean up here...
+            for method in resp.handle_metadata.methods:
+                f_metadata = self._method_functions[method.function_name]._get_metadata()
+                method.function_handle_metadata.definition_id = f_metadata.definition_id
             self._hydrate(resp.class_id, resolver.client, resp.handle_metadata)
 
         rep = f"Cls({user_cls.__name__})"

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1100,6 +1100,7 @@ class _Function(_Object, type_prefix="fu"):
         self._use_function_id = metadata.use_function_id
         self._use_method_name = metadata.use_method_name
         self._class_parameter_info = metadata.class_parameter_info
+        self._definition_id = metadata.definition_id
 
     def _invocation_function_id(self) -> str:
         return self._use_function_id or self.object_id

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1120,6 +1120,7 @@ class _Function(_Object, type_prefix="fu"):
             use_function_id=self._use_function_id,
             is_method=self._is_method,
             class_parameter_info=self._class_parameter_info,
+            definition_id=self._definition_id,
         )
 
     def _set_mute_cancellation(self, value: bool = True):

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1092,7 +1092,7 @@ class _Function(_Object, type_prefix="fu"):
 
     def _hydrate_metadata(self, metadata: Optional[Message]):
         # Overridden concrete implementation of base class method
-        assert metadata and isinstance(metadata, (api_pb2.Function, api_pb2.FunctionHandleMetadata))
+        assert metadata and isinstance(metadata, api_pb2.FunctionHandleMetadata)
         self._is_generator = metadata.function_type == api_pb2.Function.FUNCTION_TYPE_GENERATOR
         self._web_url = metadata.web_url
         self._function_name = metadata.function_name

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -171,11 +171,9 @@ async def _publish_app(
     # The entity prefixes are defined in the monorepo; is there any way to share them here?
     function_ids = filter_values(running_app.tag_to_object_id, lambda v: v.startswith("fu-"))
     class_ids = filter_values(running_app.tag_to_object_id, lambda v: v.startswith("cs-"))
-    function_objs = filter_values(indexed_objects, lambda v: v.object_id in function_ids.values())
 
-    function_metadata = {obj.object_id: obj._get_metadata() for obj in function_objs.values()}
-    assert all(isinstance(obj, api_pb2.FunctionHandleMetadata) for obj in function_objs.values())
-    definition_ids = {object_id: metadata.definition_id for object_id, metadata in function_metadata}
+    function_objs = filter_values(indexed_objects, lambda v: v.object_id in function_ids.values())
+    definition_ids = {obj.object_id: obj._get_metadata().definition_id for obj in function_objs.values()}  # type: ignore
 
     request = api_pb2.AppPublishRequest(
         app_id=running_app.app_id,

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -161,15 +161,15 @@ async def _publish_app(
     name: str = "",  # Only relevant for deployments
     tag: str = "",  # Only relevant for deployments
 ) -> str:
-    def filter_dict(full_dict: Dict[str, V], condition: Callable[[str, V], bool]) -> Dict[str, V]:
-        return {k: v for k, v in full_dict.items() if condition(k, v)}
+    def filter_dict(full_dict: Dict[str, V], condition: Callable[[V], bool]) -> Dict[str, V]:
+        return {k: v for k, v in full_dict.items() if condition(v)}
 
     # The entity prefixes are defined in the monorepo; is there any way to share them here?
-    function_ids = filter_dict(running_app.tag_to_object_id, lambda k, v: v.startswith("fu-"))
-    class_ids = filter_dict(running_app.tag_to_object_id, lambda k, v: v.startswith("cs-"))
+    function_ids = filter_dict(running_app.tag_to_object_id, lambda v: v.startswith("fu-"))
+    class_ids = filter_dict(running_app.tag_to_object_id, lambda v: v.startswith("cs-"))
 
-    function_objs = filter_dict(indexed_objects, lambda k, v: k in function_ids.values())
-    definition_ids = {obj_id: obj.handle_metadata.definition_id for obj_id, obj in function_objs.items()}
+    function_objs = filter_dict(indexed_objects, lambda v: v.object_id in function_ids.values())
+    definition_ids = {obj.object_id: obj._definition_id for obj in function_objs.values()}
 
     request = api_pb2.AppPublishRequest(
         app_id=running_app.app_id,

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -3,7 +3,7 @@ import asyncio
 import dataclasses
 import os
 from multiprocessing.synchronize import Event
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Coroutine, Dict, List, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Coroutine, Dict, List, Optional, TypeVar
 
 from grpclib import GRPCError, Status
 from rich.console import Console
@@ -37,6 +37,9 @@ if TYPE_CHECKING:
     from .app import _App
 else:
     _App = TypeVar("_App")
+
+
+V = TypeVar("V")
 
 
 async def _heartbeat(client: _Client, app_id: str) -> None:
@@ -104,7 +107,6 @@ async def _create_all_objects(
     client: _Client,
     running_app: RunningApp,
     indexed_objects: Dict[str, _Object],
-    new_app_state: int,
     environment_name: str,
 ) -> None:
     """Create objects that have been defined but not created on the server."""
@@ -150,21 +152,44 @@ async def _create_all_objects(
 
         await TaskContext.gather(*(_load(tag, obj) for tag, obj in indexed_objects.items()))
 
-    # Create the app (and send a list of all tagged obs)
-    # TODO(erikbern): we should delete objects from a previous version that are no longer needed
-    # We just delete them from the app, but the actual objects will stay around
-    indexed_object_ids = running_app.tag_to_object_id
-    assert indexed_object_ids == running_app.tag_to_object_id
-    all_objects = resolver.objects()
 
-    unindexed_object_ids = list(set(obj.object_id for obj in all_objects) - set(running_app.tag_to_object_id.values()))
-    req_set = api_pb2.AppSetObjectsRequest(
+async def _publish_app(
+    client: _Client,
+    running_app: RunningApp,
+    app_state: int,  # api_pb2.AppState.value
+    indexed_objects: Dict[str, _Object],
+    name: str = "",  # Only relevant for deployments
+    tag: str = "",  # Only relevant for deployments
+) -> str:
+    def filter_dict(full_dict: Dict[str, V], condition: Callable[[str, V], bool]) -> Dict[str, V]:
+        return {k: v for k, v in full_dict.items() if condition(k, v)}
+
+    # The entity prefixes are defined in the monorepo; is there any way to share them here?
+    function_ids = filter_dict(running_app.tag_to_object_id, lambda k, v: v.startswith("fu-"))
+    class_ids = filter_dict(running_app.tag_to_object_id, lambda k, v: v.startswith("cs-"))
+
+    function_objs = filter_dict(indexed_objects, lambda k, v: k in function_ids.values())
+    definition_ids = {obj_id: obj.handle_metadata.definition_id for obj_id, obj in function_objs.items()}
+
+    request = api_pb2.AppPublishRequest(
         app_id=running_app.app_id,
-        indexed_object_ids=indexed_object_ids,
-        unindexed_object_ids=unindexed_object_ids,
-        new_app_state=new_app_state,  # type: ignore
+        name=name,
+        deployment_tag=tag,
+        app_state=app_state,  # type: ignore  : should be a api_pb2.AppState.value
+        function_ids=function_ids,
+        class_ids=class_ids,
+        definition_ids=definition_ids,
     )
-    await retry_transient_errors(client.stub.AppSetObjects, req_set)
+    try:
+        response = await retry_transient_errors(client.stub.AppPublish, request)
+    except GRPCError as exc:
+        if exc.status == Status.INVALID_ARGUMENT:
+            raise InvalidError(exc.message)
+        if exc.status == Status.FAILED_PRECONDITION:
+            raise InvalidError(exc.message)
+        raise
+
+    return response.url
 
 
 async def _disconnect(
@@ -252,7 +277,10 @@ async def _run_app(
         exc_info: Optional[BaseException] = None
         try:
             # Create all members
-            await _create_all_objects(client, running_app, app._indexed_objects, app_state, environment_name)
+            await _create_all_objects(client, running_app, app._indexed_objects, environment_name)
+
+            # Publish the app
+            await _publish_app(client, running_app, app_state, app._indexed_objects)
 
             # Show logs from dynamically created images.
             # TODO: better way to do this
@@ -337,9 +365,11 @@ async def _serve_update(
             client,
             running_app,
             app._indexed_objects,
-            api_pb2.APP_STATE_UNSPECIFIED,
             environment_name,
         )
+
+        # Publish the updated app
+        await _publish_app(client, running_app, api_pb2.APP_STATE_UNSPECIFIED, app._indexed_objects)
 
         # Communicate to the parent process
         is_ready.set()
@@ -361,7 +391,7 @@ async def _deploy_app(
     namespace: Any = api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
     client: Optional[_Client] = None,
     environment_name: Optional[str] = None,
-    tag: Optional[str] = None,
+    tag: str = "",
 ) -> DeployResult:
     """Deploy an app and export its objects persistently.
 
@@ -387,9 +417,8 @@ async def _deploy_app(
     if environment_name is None:
         environment_name = config.get("environment")
 
-    if name is None:
-        name = app.name
-    if name is None:
+    name = name or app.name
+    if not name:
         raise InvalidError(
             "You need to either supply an explicit deployment name to the deploy command, "
             "or have a name set on the app.\n"
@@ -402,9 +431,9 @@ async def _deploy_app(
     else:
         check_object_name(name, "App")
 
-    if tag is not None and not is_valid_tag(tag):
+    if tag and not is_valid_tag(tag):
         raise InvalidError(
-            f"Tag {tag} is invalid."
+            f"Deployment tag {tag!r} is invalid."
             "\n\nTags may only contain alphanumeric characters, dashes, periods, and underscores, "
             "and must be 50 characters or less"
         )
@@ -420,46 +449,27 @@ async def _deploy_app(
         # Start heartbeats loop to keep the client alive
         tc.infinite_loop(lambda: _heartbeat(client, running_app.app_id), sleep=HEARTBEAT_INTERVAL)
 
-        # Don't change the app state - deploy state is set by AppDeploy
-        post_init_state = api_pb2.APP_STATE_UNSPECIFIED
-
         try:
             # Create all members
             await _create_all_objects(
                 client,
                 running_app,
                 app._indexed_objects,
-                post_init_state,
                 environment_name=environment_name,
             )
 
-            # Deploy app
-            # TODO(erikbern): not needed if the app already existed
-            deploy_req = api_pb2.AppDeployRequest(
-                app_id=running_app.app_id,
-                name=name,
-                tag=tag,
-                namespace=namespace,
-                object_entity="ap",
-                visibility=api_pb2.APP_DEPLOY_VISIBILITY_WORKSPACE,
+            app_url = await _publish_app(
+                client, running_app, api_pb2.APP_STATE_DEPLOYED, app._indexed_objects, name, tag
             )
-            try:
-                deploy_response = await retry_transient_errors(client.stub.AppDeploy, deploy_req)
-            except GRPCError as exc:
-                if exc.status == Status.INVALID_ARGUMENT:
-                    raise InvalidError(exc.message)
-                if exc.status == Status.FAILED_PRECONDITION:
-                    raise InvalidError(exc.message)
-                raise
-            url = deploy_response.url
         except Exception as e:
+            # TODO(michael) figure out if we need to change anything in the disconnection logic
             # Note that AppClientDisconnect only stops the app if it's still initializing, and is a no-op otherwise.
             await _disconnect(client, running_app.app_id, reason=api_pb2.APP_DISCONNECT_REASON_DEPLOYMENT_EXCEPTION)
             raise e
 
     if output_mgr := OutputManager.get():
         output_mgr.print(step_completed("App deployed! 🎉"))
-        output_mgr.print(f"\nView Deployment: [magenta]{url}[/magenta]")
+        output_mgr.print(f"\nView Deployment: [magenta]{app_url}[/magenta]")
     return DeployResult(app_id=running_app.app_id)
 
 

--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -7,7 +7,7 @@ from ._version_generated import build_number
 major_number = 0
 
 # Bump this manually on breaking changes, then reset the number in _version_generated.py
-minor_number = 63
+minor_number = 64
 
 # Right now, automatically increment the patch number in CI
 __version__ = f"{major_number}.{minor_number}.{max(build_number, 0)}"

--- a/modal_version/_version_generated.py
+++ b/modal_version/_version_generated.py
@@ -1,4 +1,4 @@
 # Copyright Modal Labs 2024
 
 # Note: Reset this value to -1 whenever you make a minor `0.X` release of the client.
-build_number = 90  # git: 0bc7824
+build_number = -1

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -302,8 +302,8 @@ def test_hydrated_other_app_object_gets_referenced(servicer, client):
         with Volume.ephemeral(client=client) as vol:
             app.function(volumes={"/vol": vol})(dummy)  # implicitly load vol
             deploy_app(app, client=client)
-            app_set_objects_req = ctx.pop_request("AppSetObjects")
-            assert vol.object_id in app_set_objects_req.unindexed_object_ids
+            function_create_req: api_pb2.FunctionCreateRequest = ctx.pop_request("FunctionCreate")
+            assert vol.object_id in {obj.object_id for obj in function_create_req.function.object_dependencies}
 
 
 def test_hasattr():

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -171,6 +171,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.app_client_disconnect_count = 0
         self.app_get_logs_initial_count = 0
         self.app_set_objects_count = 0
+        self.app_publish_count = 0
 
         self.volume_counter = 0
         # Volume-id -> commit/reload count
@@ -310,8 +311,17 @@ class MockClientServicer(api_grpc.ModalClientBase):
         object_ids = self.app_objects.get(request.app_id, {})
         objects = list(object_ids.items())
         if request.include_unindexed:
-            unindexed_object_ids = self.app_unindexed_objects.get(request.app_id, [])
+            unindexed_object_ids = set()
+            for object_id in object_ids.values():
+                if object_id.startswith("fu-"):
+                    definition = self.app_functions[object_id]
+                    unindexed_object_ids |= {obj.object_id for obj in definition.object_dependencies}
             objects += [(None, object_id) for object_id in unindexed_object_ids]
+            # TODO(michael) This perpetuates a hack! The container_test tests rely on hardcoded unindexed_object_ids
+            # but we now look those up dynamically from the indexed objects in (the real) AppGetObjects. But the
+            # container tests never actually set indexed objects on the app. We need a total rewrite here.
+            if (None, "im-1") not in objects:
+                objects.append((None, "im-1"))
         items = [
             api_pb2.AppGetObjectsItem(tag=tag, object=self.get_object_metadata(object_id)) for tag, object_id in objects
         ]
@@ -333,6 +343,17 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.deployed_apps[request.name] = request.app_id
         self.app_state_history[request.app_id].append(api_pb2.APP_STATE_DEPLOYED)
         await stream.send_message(api_pb2.AppDeployResponse(url="http://test.modal.com/foo/bar"))
+
+    async def AppPublish(self, stream):
+        request: api_pb2.AppPublishRequest = await stream.recv_message()
+        self.app_publish_count += 1
+        self.app_objects[request.app_id] = {**request.function_ids, **request.class_ids}
+        self.app_state_history[request.app_id].append(request.app_state)
+        if request.app_state == api_pb2.AppState.APP_STATE_DEPLOYED:
+            self.deployed_apps[request.name] = request.app_id
+            await stream.send_message(api_pb2.AppPublishResponse(url="http://test.modal.com/foo/bar"))
+        else:
+            await stream.send_message(api_pb2.AppPublishResponse())
 
     async def AppGetByDeploymentName(self, stream):
         request: api_pb2.AppGetByDeploymentNameRequest = await stream.recv_message()
@@ -842,9 +863,9 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def ImageGetOrCreate(self, stream):
         request: api_pb2.ImageGetOrCreateRequest = await stream.recv_message()
-        for k in self.images:
-            if request.image.SerializeToString() == self.images[k].SerializeToString():
-                await stream.send_message(api_pb2.ImageGetOrCreateResponse(image_id=k))
+        for image_id, image in self.images.items():
+            if request.image.SerializeToString() == image.SerializeToString():
+                await stream.send_message(api_pb2.ImageGetOrCreateResponse(image_id=image_id))
                 return
         idx = len(self.images) + 1
         image_id = f"im-{idx}"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -346,6 +346,10 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def AppPublish(self, stream):
         request: api_pb2.AppPublishRequest = await stream.recv_message()
+        for key, val in request.definition_ids.items():
+            assert key.startswith("fu-")
+            assert val.startswith("de-")
+        # TODO(michael) add some other assertions once we make the mock server represent real RPCs more accurately
         self.app_publish_count += 1
         self.app_objects[request.app_id] = {**request.function_ids, **request.class_ids}
         self.app_state_history[request.app_id].append(request.app_state)
@@ -715,6 +719,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
                     web_url=function.web_url,
                     use_function_id=function.use_function_id or function_id,
                     use_method_name=function.use_method_name,
+                    definition_id=f"de-{self.n_functions}",
                 ),
             )
         )

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -132,7 +132,6 @@ def _container_args(
         )
     else:
         webhook_config = None
-
     function_def = api_pb2.Function(
         module_name=module_name,
         function_name=function_name,
@@ -723,7 +722,7 @@ def test_cls_web_endpoint(servicer):
 @skip_github_non_linux
 def test_cls_web_asgi_construction(servicer):
     servicer.app_objects.setdefault("ap-1", {}).setdefault("square", "fu-2")
-    servicer.app_functions["fu-2"] = api_pb2.FunctionHandleMetadata()
+    servicer.app_functions["fu-2"] = api_pb2.Function()
 
     inputs = _get_web_inputs(method_name="asgi_web")
     ret = _run_container(

--- a/test/live_reload_test.py
+++ b/test/live_reload_test.py
@@ -21,7 +21,7 @@ def app_ref(test_dir):
 async def test_live_reload(app_ref, server_url_env, servicer):
     async with serve_app.aio(app, app_ref):
         await asyncio.sleep(3.0)
-    assert servicer.app_set_objects_count == 1
+    assert servicer.app_publish_count == 1
     assert servicer.app_client_disconnect_count == 1
     assert servicer.app_get_logs_initial_count == 0
 
@@ -31,7 +31,7 @@ async def test_live_reload_with_logs(app_ref, server_url_env, servicer):
     with enable_output():
         async with serve_app.aio(app, app_ref):
             await asyncio.sleep(3.0)
-    assert servicer.app_set_objects_count == 1
+    assert servicer.app_publish_count == 1
     assert servicer.app_client_disconnect_count == 1
     assert servicer.app_get_logs_initial_count == 1
 
@@ -51,8 +51,8 @@ def test_file_changes_trigger_reloads(app_ref, server_url_env, servicer):
     # TODO ideally we would assert the specific expected number here, but this test
     # is consistently flaking in CI and I cannot reproduce locally to debug.
     # I'm relaxing the assertion for now to stop the test from blocking deployments.
-    # assert servicer.app_set_objects_count == 4  # 1 + number of file changes
-    assert servicer.app_set_objects_count > 1
+    # assert servicer.app_publish_count == 4  # 1 + number of file changes
+    assert servicer.app_publish_count > 1
     assert servicer.app_client_disconnect_count == 1
     foo = app.indexed_objects["foo"]
     assert isinstance(foo, Function)
@@ -69,7 +69,7 @@ async def test_no_change(app_ref, server_url_env, servicer):
     async with serve_app.aio(app, app_ref, _watcher=fake_watch()):
         pass
 
-    assert servicer.app_set_objects_count == 1  # Should create the initial app once
+    assert servicer.app_publish_count == 1  # Should create the initial app once
     assert servicer.app_client_disconnect_count == 1
 
 

--- a/test/runner_test.py
+++ b/test/runner_test.py
@@ -18,7 +18,7 @@ def test_run_app(servicer, client):
             pass
 
     ctx.pop_request("AppCreate")
-    ctx.pop_request("AppSetObjects")
+    ctx.pop_request("AppPublish")
     ctx.pop_request("AppClientDisconnect")
 
 


### PR DESCRIPTION
Client-side counterpart to https://github.com/modal-labs/modal/pull/14147. Ephemeral (and deployed) apps now go through `AppPublish` instead of `AppSetObjects` (and `AppDeploy`). That allows all mutations to be done server-side in one transaction and rolled back in the case of an error.

I believe this closes MOD-1549; although we don't have a very reliable repro of that behavior to test.

## Changelog

- App deployment events are now atomic, reducing the risk that a failed deploy will leave the App in a bad state.