### PR TITLE
Increase SandboxStdinWrite max buffer size to 2MiB from 128KiB

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -151,7 +151,7 @@ class _LogsReader:
         return value.data
 
 
-MAX_BUFFER_SIZE = 128 * 1024
+MAX_BUFFER_SIZE = 2 * 1024 * 1024
 
 
 class _StreamWriter:


### PR DESCRIPTION
## Describe your changes

The underlying gRPC request should be able to comfortably handle a 2MiB payload. 
This is a 16x increase which should dramatically lower the number of required RPC roundtrips. 

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
