### PR TITLE
volume put: double put timeout to 60m

### DIFF
--- a/modal/volume.py
+++ b/modal/volume.py
@@ -47,7 +47,7 @@ from .object import EPHEMERAL_OBJECT_HEARTBEAT_SLEEP, _get_environment_name, _Ob
 
 # Max duration for uploading to volumes files
 # As a guide, files >40GiB will take >10 minutes to upload.
-VOLUME_PUT_FILE_CLIENT_TIMEOUT = 30 * 60
+VOLUME_PUT_FILE_CLIENT_TIMEOUT = 60 * 60
 
 
 class FileEntryType(enum.IntEnum):


### PR DESCRIPTION
## Describe your changes

User is running into this timeout when trying to upload 60GiB. 

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
    - changing this constant does nothing to break compatibilty
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
    - changing this constant does nothing to break compatibilty