### PR TITLE
[MOD-3200]: better error message when running cls.with_options without an app

### DIFF
--- a/modal/object.py
+++ b/modal/object.py
@@ -124,7 +124,17 @@ class _Object:
         """mdmd:hidden Clone a given hydrated object."""
 
         # Object to clone must already be hydrated, otherwise from_loader is more suitable.
-        assert self._is_hydrated
+        if not self._is_hydrated:
+            object_type = self.__class__.__name__.strip("_")
+            if hasattr(self, "_app") and getattr(self._app, "_running_app", "") is None:
+                # The most common cause of this error: e.g., user called a Function without using App.run()
+                reason = ", because the App it is defined on is not running."
+            else:
+                # Technically possible, but with an ambiguous cause.
+                reason = ""
+            raise ExecutionError(
+                f"{object_type} has not been hydrated with the metadata it needs to run on Modal{reason}."
+            )
 
         obj = _Object.__new__(type(self))
         obj._initialize_from_other(self)

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -107,7 +107,7 @@ def test_class_with_options(client, servicer):
 
 def test_class_with_options_need_hydrating(client, servicer):
     with pytest.raises(ExecutionError, match="hydrate"):
-        Foo.with_options()
+        Foo.with_options()  # type: ignore
 
 
 # Reusing the app runs into an issue with stale function handles.

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -105,6 +105,11 @@ def test_class_with_options(client, servicer):
         assert options.retry_policy.retries == 5
 
 
+def test_class_with_options_need_hydrating(client, servicer):
+    with pytest.raises(ExecutionError, match="hydrate"):
+        Foo.with_options()
+
+
 # Reusing the app runs into an issue with stale function handles.
 # TODO (akshat): have all the client tests use separate apps, and throw
 # an exception if the user tries to reuse an app.
@@ -682,6 +687,7 @@ def test_deprecated_sync_methods():
         _find_callables_for_obj(obj, _PartialFunctionFlags.EXIT)
 
     with pytest.raises(DeprecationError, match="Support for decorating parameterized methods with `@exit`"):
+
         class ClsWithDeprecatedSyncExitMethod:
             @exit()
             def my_exit(self, exc_type, exc, tb):
@@ -710,6 +716,7 @@ async def test_deprecated_async_methods():
         _find_callables_for_obj(obj, _PartialFunctionFlags.EXIT)
 
     with pytest.raises(DeprecationError, match="Support for decorating parameterized methods with `@exit`"):
+
         class ClsWithDeprecatedAsyncExitMethod:
             @exit()
             async def my_exit(self, exc_type, exc, tb):


### PR DESCRIPTION
Adds an error message (same as for `resolve()` [here](https://github.com/modal-labs/modal-client/blob/main/modal/object.py#L206-L216)) when running `SomeClass.with_options(...)` without associating an app