### PR TITLE
Add R2 to the list of allowed bucket URLs

### DIFF
--- a/modal/_utils/blob_utils.py
+++ b/modal/_utils/blob_utils.py
@@ -401,7 +401,7 @@ def use_md5(url: str) -> bool:
     https://github.com/spulec/moto/issues/816
     """
     host = urlparse(url).netloc.split(":")[0]
-    if host.endswith(".amazonaws.com"):
+    if host.endswith(".amazonaws.com") or host.endswith(".r2.cloudflarestorage.com"):
         return True
     elif host in ["127.0.0.1", "localhost", "172.21.0.1"]:
         return False


### PR DESCRIPTION
This commit adds R2 to the list of allowed bucket URLs so that we can support pulling inputs and outputs from both R2 and S3.

## Describe your changes

We are migrating some workloads to R2, so we need to update our validation to support this URL.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

---

</details>

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
