### PR TITLE
[skip ci] Fix docstring for forward()

### DIFF
--- a/modal/_tunnel.py
+++ b/modal/_tunnel.py
@@ -152,7 +152,7 @@ async def _forward(port: int, *, unencrypted: bool = False, client: Optional[_Cl
         with modal.forward(port=22, unencrypted=True) as tunnel:
             hostname, port = tunnel.tcp_socket
             connection_cmd = f'ssh -p {port} root@{hostname}'
-            print(f"ssh into container using:\n{connection_cmd}")
+            print(f"ssh into container using: {connection_cmd}")
             time.sleep(3600)  # keep alive for 1 hour or until killed
     ```
 


### PR DESCRIPTION
The docstring for tunnels / forward() has been broken since 2 months, since the `\n` in the docstring wasn't escaped and that broke inspect.cleandoc(), which trims consistent leading whitespace after the first line

Not going to tag elias because he's on PTO

https://modal.com/docs/reference/modal.forward