### PR TITLE
Revert "Run / deploy apps via new AppPublish RPC (#2043)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,6 @@ We appreciate your patience while we speedily work towards a stable release of t
 
 <!-- NEW CONTENT GENERATED BELOW. PLEASE PRESERVE THIS COMMENT. -->
 
-### 0.64.0 (2024-07-29)
-
-- App deployment events are now atomic, reducing the risk that a failed deploy will leave the App in a bad state.
-
-
 
 ### 0.63.87 (2024-07-24)
 

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -278,10 +278,10 @@ def run(ctx, detach, quiet, interactive, env):
 
 def deploy(
     app_ref: str = typer.Argument(..., help="Path to a Python file with an app."),
-    name: str = typer.Option("", help="Name of the deployment."),
+    name: str = typer.Option(None, help="Name of the deployment."),
     env: str = ENV_OPTION,
     stream_logs: bool = typer.Option(False, help="Stream logs from the app upon deployment."),
-    tag: str = typer.Option("", help="Tag the deployment with a version."),
+    tag: str = typer.Option(None, help="Tag the deployment with a version."),
 ):
     # this ensures that `modal.lookup()` without environment specification uses the same env as specified
     env = ensure_env(env)
@@ -292,7 +292,7 @@ def deploy(
         name = app.name
 
     with enable_output():
-        res = deploy_app(app, name=name, environment_name=env or "", tag=tag)
+        res = deploy_app(app, name=name, environment_name=env, tag=tag)
 
     if stream_logs:
         stream_app_logs(res.app_id)

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -274,16 +274,6 @@ class _Cls(_Object, type_prefix="cs"):
                     )
                 )
             resp = await resolver.client.stub.ClassCreate(req)
-            # Even though we already have the function_handle_metadata for this method locally,
-            # The RPC is going to replace it with function_handle_metadata derived from the server.
-            # We need to overwrite the definition_id sent back from the server here with the definition_id
-            # previously stored in function metadata, which may have been sent back from FunctionCreate.
-            # The problem is that this metadata propagates back and overwrites the metadata on the Function
-            # object itself. This is really messy. Maybe better to exclusively populate the method metadata
-            # from the function metadata we already have locally? Really a lot to clean up here...
-            for method in resp.handle_metadata.methods:
-                f_metadata = self._method_functions[method.function_name]._get_metadata()
-                method.function_handle_metadata.definition_id = f_metadata.definition_id
             self._hydrate(resp.class_id, resolver.client, resp.handle_metadata)
 
         rep = f"Cls({user_cls.__name__})"

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1092,7 +1092,7 @@ class _Function(_Object, type_prefix="fu"):
 
     def _hydrate_metadata(self, metadata: Optional[Message]):
         # Overridden concrete implementation of base class method
-        assert metadata and isinstance(metadata, api_pb2.FunctionHandleMetadata)
+        assert metadata and isinstance(metadata, (api_pb2.Function, api_pb2.FunctionHandleMetadata))
         self._is_generator = metadata.function_type == api_pb2.Function.FUNCTION_TYPE_GENERATOR
         self._web_url = metadata.web_url
         self._function_name = metadata.function_name
@@ -1100,7 +1100,6 @@ class _Function(_Object, type_prefix="fu"):
         self._use_function_id = metadata.use_function_id
         self._use_method_name = metadata.use_method_name
         self._class_parameter_info = metadata.class_parameter_info
-        self._definition_id = metadata.definition_id
 
     def _invocation_function_id(self) -> str:
         return self._use_function_id or self.object_id
@@ -1120,7 +1119,6 @@ class _Function(_Object, type_prefix="fu"):
             use_function_id=self._use_function_id,
             is_method=self._is_method,
             class_parameter_info=self._class_parameter_info,
-            definition_id=self._definition_id,
         )
 
     def _set_mute_cancellation(self, value: bool = True):

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -3,7 +3,7 @@ import asyncio
 import dataclasses
 import os
 from multiprocessing.synchronize import Event
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Coroutine, Dict, List, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Coroutine, Dict, List, Optional, TypeVar
 
 from grpclib import GRPCError, Status
 from rich.console import Console
@@ -37,9 +37,6 @@ if TYPE_CHECKING:
     from .app import _App
 else:
     _App = TypeVar("_App")
-
-
-V = TypeVar("V")
 
 
 async def _heartbeat(client: _Client, app_id: str) -> None:
@@ -107,6 +104,7 @@ async def _create_all_objects(
     client: _Client,
     running_app: RunningApp,
     indexed_objects: Dict[str, _Object],
+    new_app_state: int,
     environment_name: str,
 ) -> None:
     """Create objects that have been defined but not created on the server."""
@@ -152,46 +150,21 @@ async def _create_all_objects(
 
         await TaskContext.gather(*(_load(tag, obj) for tag, obj in indexed_objects.items()))
 
+    # Create the app (and send a list of all tagged obs)
+    # TODO(erikbern): we should delete objects from a previous version that are no longer needed
+    # We just delete them from the app, but the actual objects will stay around
+    indexed_object_ids = running_app.tag_to_object_id
+    assert indexed_object_ids == running_app.tag_to_object_id
+    all_objects = resolver.objects()
 
-async def _publish_app(
-    client: _Client,
-    running_app: RunningApp,
-    app_state: int,  # api_pb2.AppState.value
-    indexed_objects: Dict[str, _Object],
-    name: str = "",  # Only relevant for deployments
-    tag: str = "",  # Only relevant for deployments
-) -> str:
-    """Wrapper for AppPublish RPC."""
-
-    # Could simplify this function some changing the internal representation to use
-    # function_ids / class_ids rather than the current tag_to_object_id (i.e. "indexed_objects")
-    def filter_values(full_dict: Dict[str, V], condition: Callable[[V], bool]) -> Dict[str, V]:
-        return {k: v for k, v in full_dict.items() if condition(v)}
-
-    # The entity prefixes are defined in the monorepo; is there any way to share them here?
-    function_ids = filter_values(running_app.tag_to_object_id, lambda v: v.startswith("fu-"))
-    class_ids = filter_values(running_app.tag_to_object_id, lambda v: v.startswith("cs-"))
-
-    function_objs = filter_values(indexed_objects, lambda v: v.object_id in function_ids.values())
-    definition_ids = {obj.object_id: obj._get_metadata().definition_id for obj in function_objs.values()}  # type: ignore
-
-    request = api_pb2.AppPublishRequest(
+    unindexed_object_ids = list(set(obj.object_id for obj in all_objects) - set(running_app.tag_to_object_id.values()))
+    req_set = api_pb2.AppSetObjectsRequest(
         app_id=running_app.app_id,
-        name=name,
-        deployment_tag=tag,
-        app_state=app_state,  # type: ignore  : should be a api_pb2.AppState.value
-        function_ids=function_ids,
-        class_ids=class_ids,
-        definition_ids=definition_ids,
+        indexed_object_ids=indexed_object_ids,
+        unindexed_object_ids=unindexed_object_ids,
+        new_app_state=new_app_state,  # type: ignore
     )
-    try:
-        response = await retry_transient_errors(client.stub.AppPublish, request)
-    except GRPCError as exc:
-        if exc.status == Status.INVALID_ARGUMENT or exc.status == Status.FAILED_PRECONDITION:
-            raise InvalidError(exc.message)
-        raise
-
-    return response.url
+    await retry_transient_errors(client.stub.AppSetObjects, req_set)
 
 
 async def _disconnect(
@@ -279,10 +252,7 @@ async def _run_app(
         exc_info: Optional[BaseException] = None
         try:
             # Create all members
-            await _create_all_objects(client, running_app, app._indexed_objects, environment_name)
-
-            # Publish the app
-            await _publish_app(client, running_app, app_state, app._indexed_objects)
+            await _create_all_objects(client, running_app, app._indexed_objects, app_state, environment_name)
 
             # Show logs from dynamically created images.
             # TODO: better way to do this
@@ -367,11 +337,9 @@ async def _serve_update(
             client,
             running_app,
             app._indexed_objects,
+            api_pb2.APP_STATE_UNSPECIFIED,
             environment_name,
         )
-
-        # Publish the updated app
-        await _publish_app(client, running_app, api_pb2.APP_STATE_UNSPECIFIED, app._indexed_objects)
 
         # Communicate to the parent process
         is_ready.set()
@@ -393,7 +361,7 @@ async def _deploy_app(
     namespace: Any = api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
     client: Optional[_Client] = None,
     environment_name: Optional[str] = None,
-    tag: str = "",
+    tag: Optional[str] = None,
 ) -> DeployResult:
     """Deploy an app and export its objects persistently.
 
@@ -419,8 +387,9 @@ async def _deploy_app(
     if environment_name is None:
         environment_name = config.get("environment")
 
-    name = name or app.name
-    if not name:
+    if name is None:
+        name = app.name
+    if name is None:
         raise InvalidError(
             "You need to either supply an explicit deployment name to the deploy command, "
             "or have a name set on the app.\n"
@@ -433,9 +402,9 @@ async def _deploy_app(
     else:
         check_object_name(name, "App")
 
-    if tag and not is_valid_tag(tag):
+    if tag is not None and not is_valid_tag(tag):
         raise InvalidError(
-            f"Deployment tag {tag!r} is invalid."
+            f"Tag {tag} is invalid."
             "\n\nTags may only contain alphanumeric characters, dashes, periods, and underscores, "
             "and must be 50 characters or less"
         )
@@ -451,18 +420,38 @@ async def _deploy_app(
         # Start heartbeats loop to keep the client alive
         tc.infinite_loop(lambda: _heartbeat(client, running_app.app_id), sleep=HEARTBEAT_INTERVAL)
 
+        # Don't change the app state - deploy state is set by AppDeploy
+        post_init_state = api_pb2.APP_STATE_UNSPECIFIED
+
         try:
             # Create all members
             await _create_all_objects(
                 client,
                 running_app,
                 app._indexed_objects,
+                post_init_state,
                 environment_name=environment_name,
             )
 
-            app_url = await _publish_app(
-                client, running_app, api_pb2.APP_STATE_DEPLOYED, app._indexed_objects, name, tag
+            # Deploy app
+            # TODO(erikbern): not needed if the app already existed
+            deploy_req = api_pb2.AppDeployRequest(
+                app_id=running_app.app_id,
+                name=name,
+                tag=tag,
+                namespace=namespace,
+                object_entity="ap",
+                visibility=api_pb2.APP_DEPLOY_VISIBILITY_WORKSPACE,
             )
+            try:
+                deploy_response = await retry_transient_errors(client.stub.AppDeploy, deploy_req)
+            except GRPCError as exc:
+                if exc.status == Status.INVALID_ARGUMENT:
+                    raise InvalidError(exc.message)
+                if exc.status == Status.FAILED_PRECONDITION:
+                    raise InvalidError(exc.message)
+                raise
+            url = deploy_response.url
         except Exception as e:
             # Note that AppClientDisconnect only stops the app if it's still initializing, and is a no-op otherwise.
             await _disconnect(client, running_app.app_id, reason=api_pb2.APP_DISCONNECT_REASON_DEPLOYMENT_EXCEPTION)
@@ -470,7 +459,7 @@ async def _deploy_app(
 
     if output_mgr := OutputManager.get():
         output_mgr.print(step_completed("App deployed! 🎉"))
-        output_mgr.print(f"\nView Deployment: [magenta]{app_url}[/magenta]")
+        output_mgr.print(f"\nView Deployment: [magenta]{url}[/magenta]")
     return DeployResult(app_id=running_app.app_id)
 
 

--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -7,7 +7,7 @@ from ._version_generated import build_number
 major_number = 0
 
 # Bump this manually on breaking changes, then reset the number in _version_generated.py
-minor_number = 64
+minor_number = 63
 
 # Right now, automatically increment the patch number in CI
 __version__ = f"{major_number}.{minor_number}.{max(build_number, 0)}"

--- a/modal_version/_version_generated.py
+++ b/modal_version/_version_generated.py
@@ -1,4 +1,4 @@
 # Copyright Modal Labs 2024
 
 # Note: Reset this value to -1 whenever you make a minor `0.X` release of the client.
-build_number = 0  # git: d8f403b
+build_number = 90  # git: 0bc7824

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -302,8 +302,8 @@ def test_hydrated_other_app_object_gets_referenced(servicer, client):
         with Volume.ephemeral(client=client) as vol:
             app.function(volumes={"/vol": vol})(dummy)  # implicitly load vol
             deploy_app(app, client=client)
-            function_create_req: api_pb2.FunctionCreateRequest = ctx.pop_request("FunctionCreate")
-            assert vol.object_id in {obj.object_id for obj in function_create_req.function.object_dependencies}
+            app_set_objects_req = ctx.pop_request("AppSetObjects")
+            assert vol.object_id in app_set_objects_req.unindexed_object_ids
 
 
 def test_hasattr():

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -132,6 +132,7 @@ def _container_args(
         )
     else:
         webhook_config = None
+
     function_def = api_pb2.Function(
         module_name=module_name,
         function_name=function_name,
@@ -722,7 +723,7 @@ def test_cls_web_endpoint(servicer):
 @skip_github_non_linux
 def test_cls_web_asgi_construction(servicer):
     servicer.app_objects.setdefault("ap-1", {}).setdefault("square", "fu-2")
-    servicer.app_functions["fu-2"] = api_pb2.Function()
+    servicer.app_functions["fu-2"] = api_pb2.FunctionHandleMetadata()
 
     inputs = _get_web_inputs(method_name="asgi_web")
     ret = _run_container(

--- a/test/live_reload_test.py
+++ b/test/live_reload_test.py
@@ -21,7 +21,7 @@ def app_ref(test_dir):
 async def test_live_reload(app_ref, server_url_env, servicer):
     async with serve_app.aio(app, app_ref):
         await asyncio.sleep(3.0)
-    assert servicer.app_publish_count == 1
+    assert servicer.app_set_objects_count == 1
     assert servicer.app_client_disconnect_count == 1
     assert servicer.app_get_logs_initial_count == 0
 
@@ -31,7 +31,7 @@ async def test_live_reload_with_logs(app_ref, server_url_env, servicer):
     with enable_output():
         async with serve_app.aio(app, app_ref):
             await asyncio.sleep(3.0)
-    assert servicer.app_publish_count == 1
+    assert servicer.app_set_objects_count == 1
     assert servicer.app_client_disconnect_count == 1
     assert servicer.app_get_logs_initial_count == 1
 
@@ -51,8 +51,8 @@ def test_file_changes_trigger_reloads(app_ref, server_url_env, servicer):
     # TODO ideally we would assert the specific expected number here, but this test
     # is consistently flaking in CI and I cannot reproduce locally to debug.
     # I'm relaxing the assertion for now to stop the test from blocking deployments.
-    # assert servicer.app_publish_count == 4  # 1 + number of file changes
-    assert servicer.app_publish_count > 1
+    # assert servicer.app_set_objects_count == 4  # 1 + number of file changes
+    assert servicer.app_set_objects_count > 1
     assert servicer.app_client_disconnect_count == 1
     foo = app.indexed_objects["foo"]
     assert isinstance(foo, Function)
@@ -69,7 +69,7 @@ async def test_no_change(app_ref, server_url_env, servicer):
     async with serve_app.aio(app, app_ref, _watcher=fake_watch()):
         pass
 
-    assert servicer.app_publish_count == 1  # Should create the initial app once
+    assert servicer.app_set_objects_count == 1  # Should create the initial app once
     assert servicer.app_client_disconnect_count == 1
 
 

--- a/test/runner_test.py
+++ b/test/runner_test.py
@@ -18,7 +18,7 @@ def test_run_app(servicer, client):
             pass
 
     ctx.pop_request("AppCreate")
-    ctx.pop_request("AppPublish")
+    ctx.pop_request("AppSetObjects")
     ctx.pop_request("AppClientDisconnect")
 
 


### PR DESCRIPTION
This reverts commit d8f403bc1447ddbb9aa2e5fa89a98f65c6638f5e.

Rolls back the v0.64 release temporarily as it's breaking some of our internal tests.