### PR TITLE
Remove all output mgmt from the resolver

### DIFF
--- a/modal/_output.py
+++ b/modal/_output.py
@@ -389,7 +389,7 @@ class OutputManager:
     @classmethod
     @contextlib.contextmanager
     def make_tree(cls):
-        # Construct a tree even if the output isn't visible, but don't show it
+        # Note: If the output isn't enabled, don't actually show the tree.
         cls._tree = Tree(step_progress("Creating objects..."), guide_style="gray50")
 
         if output_mgr := OutputManager.get():
@@ -402,6 +402,8 @@ class OutputManager:
 
     @classmethod
     def add_status_row(cls) -> "StatusRow":
+        # Return a status row to be used for object creation.
+        # If output isn't enabled, the status row might be invisible.
         assert cls._tree, "Output manager has no tree yet"
         return StatusRow(cls._tree)
 

--- a/modal/_output.py
+++ b/modal/_output.py
@@ -30,6 +30,7 @@ from rich.progress import (
 )
 from rich.spinner import Spinner
 from rich.text import Text
+from rich.tree import Tree
 
 from modal_proto import api_pb2
 
@@ -72,6 +73,24 @@ def step_completed(message: str) -> RenderableType:
 
 def substep_completed(message: str) -> RenderableType:
     return f"🔨 {message}"
+
+
+class StatusRow:
+    def __init__(self, progress: "Optional[Tree]"):
+        self._spinner = None
+        self._step_node = None
+        if progress is not None:
+            self._spinner = step_progress()
+            self._step_node = progress.add(self._spinner)
+
+    def message(self, message):
+        if self._spinner is not None:
+            self._spinner.update(text=message)
+
+    def finish(self, message):
+        if self._step_node is not None:
+            self._spinner.update(text=message)
+            self._step_node.label = substep_completed(message)
 
 
 def download_progress_bar() -> Progress:

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -12,33 +12,8 @@ from .config import logger
 from .exception import NotFoundError
 
 if TYPE_CHECKING:
-    from rich.tree import Tree
-
+    from modal._output import StatusRow
     from modal.object import _Object
-
-
-class StatusRow:
-    def __init__(self, progress: "Optional[Tree]"):
-        from ._output import (
-            step_progress,
-        )
-
-        self._spinner = None
-        self._step_node = None
-        if progress is not None:
-            self._spinner = step_progress()
-            self._step_node = progress.add(self._spinner)
-
-    def message(self, message):
-        if self._spinner is not None:
-            self._spinner.update(text=message)
-
-    def finish(self, message):
-        from ._output import substep_completed
-
-        if self._step_node is not None:
-            self._spinner.update(text=message)
-            self._step_node.label = substep_completed(message)
 
 
 class Resolver:
@@ -169,5 +144,7 @@ class Resolver:
         else:
             yield
 
-    def add_status_row(self) -> StatusRow:
+    def add_status_row(self) -> "StatusRow":
+        from ._output import StatusRow
+
         return StatusRow(self._tree)

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -1,6 +1,5 @@
 # Copyright Modal Labs 2023
 import asyncio
-import contextlib
 from asyncio import Future
 from typing import TYPE_CHECKING, Dict, Hashable, List, Optional
 
@@ -12,7 +11,6 @@ from .config import logger
 from .exception import NotFoundError
 
 if TYPE_CHECKING:
-    from modal._output import StatusRow
     from modal.object import _Object
 
 
@@ -30,12 +28,7 @@ class Resolver:
         environment_name: Optional[str] = None,
         app_id: Optional[str] = None,
     ):
-        from rich.tree import Tree
-
-        from ._output import step_progress
-
         self._local_uuid_to_future = {}
-        self._tree = Tree(step_progress("Creating objects..."), guide_style="gray50")
         self._client = client
         self._app_id = app_id
         self._environment_name = environment_name
@@ -130,21 +123,3 @@ class Resolver:
             obj = fut.result()
             unique_objects.setdefault(obj.object_id, obj)
         return list(unique_objects.values())
-
-    @contextlib.contextmanager
-    def display(self):
-        # TODO(erikbern): get rid of this wrapper
-        from ._output import OutputManager, step_completed
-
-        if output_mgr := OutputManager.get():
-            with output_mgr.make_live(self._tree):
-                yield
-            self._tree.label = step_completed("Created objects.")
-            output_mgr.print(self._tree)
-        else:
-            yield
-
-    def add_status_row(self) -> "StatusRow":
-        from ._output import StatusRow
-
-        return StatusRow(self._tree)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -353,7 +353,7 @@ class _Function(_Object, type_prefix="fu"):
                 existing_function_id=existing_object_id or method_bound_function.object_id or "",
             )
             assert resolver.client.stub is not None  # client should be connected when load is called
-            with FunctionCreationStatus(resolver, full_name) as function_creation_status:
+            with FunctionCreationStatus(full_name) as function_creation_status:
                 response = await resolver.client.stub.FunctionCreate(request)
                 method_bound_function._hydrate(
                     response.function_id,
@@ -715,7 +715,7 @@ class _Function(_Object, type_prefix="fu"):
 
         async def _load(self: _Function, resolver: Resolver, existing_object_id: Optional[str]):
             assert resolver.client and resolver.client.stub
-            with FunctionCreationStatus(resolver, tag) as function_creation_status:
+            with FunctionCreationStatus(tag) as function_creation_status:
                 if is_generator:
                     function_type = api_pb2.Function.FUNCTION_TYPE_GENERATOR
                 else:

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -2,7 +2,6 @@
 import asyncio
 import dataclasses
 import os
-from contextlib import contextmanager
 from multiprocessing.synchronize import Event
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Coroutine, Dict, List, Optional, TypeVar
 
@@ -101,15 +100,6 @@ async def _init_local_app_from_name(
         )
 
 
-@contextmanager
-def display():
-    if output_mgr := OutputManager.get():
-        with output_mgr.make_tree():
-            yield
-    else:
-        yield
-
-
 async def _create_all_objects(
     client: _Client,
     running_app: RunningApp,
@@ -126,7 +116,7 @@ async def _create_all_objects(
         environment_name=environment_name,
         app_id=running_app.app_id,
     )
-    with display():
+    with OutputManager.make_tree():
         # Get current objects, and reset all objects
         tag_to_object_id = running_app.tag_to_object_id
         running_app.tag_to_object_id = {}

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -2,6 +2,7 @@
 import asyncio
 import dataclasses
 import os
+from contextlib import contextmanager
 from multiprocessing.synchronize import Event
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Coroutine, Dict, List, Optional, TypeVar
 
@@ -100,6 +101,15 @@ async def _init_local_app_from_name(
         )
 
 
+@contextmanager
+def display():
+    if output_mgr := OutputManager.get():
+        with output_mgr.make_tree():
+            yield
+    else:
+        yield
+
+
 async def _create_all_objects(
     client: _Client,
     running_app: RunningApp,
@@ -116,7 +126,7 @@ async def _create_all_objects(
         environment_name=environment_name,
         app_id=running_app.app_id,
     )
-    with resolver.display():
+    with display():
         # Get current objects, and reset all objects
         tag_to_object_id = running_app.tag_to_object_id
         running_app.tag_to_object_id = {}


### PR DESCRIPTION
Instead of storing a Rich `Tree` on the resolver, create it on the output manager.

For convenience reasons it's useful to construct an _insivisble_ tree if output isn't enabled. That way everywhere we add status rows, we don't have to check if output is enabled. However this means we need to use a class variable since the singleton may not exist.

We might want to change this in the future if we don't want Rich to be a dependency. It's not, hard just need to add a bunch of `if` statements.