### PR TITLE
Add FunctionCreateRequest.defer_updates flag

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1066,6 +1066,10 @@ message FunctionCreateRequest {
   string app_id = 2  [ (modal.options.audit_target_attr) = true ];
   Schedule schedule = 6;
   string existing_function_id = 7;
+  // This flag tells the server to avoid doing updates in FunctionCreate that should now
+  // be done in AppPublish. Provides a smoother migration onto atomic deployments with 0.64,
+  // and can be deprecated once we no longer support ealier versions.
+  bool defer_updates = 8;
 }
 
 message FunctionCreateResponse {


### PR DESCRIPTION
Going to use this to toggle behavior related to atomic deployments in the server, which will be more robust than relying on the client version.