### PR TITLE
Fix issue with global output manager tree

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -30,6 +30,7 @@ from grpclib import GRPCError, Status
 import modal._serialization
 from modal import __version__, config
 from modal._container_io_manager import _ContainerIOManager
+from modal._output import OutputManager
 from modal._serialization import serialize_data_format
 from modal._utils.async_utils import asyncify, synchronize_api
 from modal._utils.grpc_testing import patch_mock_servicer
@@ -1549,6 +1550,12 @@ async def server_url_env(servicer, monkeypatch):
 @pytest_asyncio.fixture(scope="function", autouse=True)
 async def reset_default_client():
     Client.set_env_client(None)
+
+
+@pytest_asyncio.fixture(scope="function", autouse=True)
+async def reset_output_manager():
+    OutputManager._instance = None
+    OutputManager._tree = None
 
 
 @pytest.fixture(name="mock_dir", scope="session")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1555,7 +1555,6 @@ async def reset_default_client():
 @pytest_asyncio.fixture(scope="function", autouse=True)
 async def reset_output_manager():
     OutputManager._instance = None
-    OutputManager._tree = None
 
 
 @pytest.fixture(name="mock_dir", scope="session")


### PR DESCRIPTION
There's currently a bug related to the tree we show when building app. This bug didn't trigger because of test state leakage so I fixed that too.

This code is a bit hairy but I'll try to clean some of it up shortly.