### PR TITLE
fix: cannot import text_unidecode, nemo-toolkit

### DIFF
--- a/modal/_telemetry.py
+++ b/modal/_telemetry.py
@@ -41,6 +41,28 @@ class InterceptedModuleLoader(importlib.abc.Loader):
         spec.loader = self
         return module
 
+    def get_data(self, path: str) -> bytes:
+        """
+        Implementation is required to support pkgutil.get_data.
+
+        > If the package cannot be located or loaded, or it uses a loader which does
+        > not support get_data, then None is returned.
+
+        ref: https://docs.python.org/3/library/pkgutil.html#pkgutil.get_data
+        """
+        return self.loader.get_data(path)
+
+    def get_resource_reader(self, fullname: str):
+        """
+        Support reading a binary artifact that is shipped within a package.
+
+        > Loaders that wish to support resource reading are expected to provide a method called
+        > get_resource_reader(fullname) which returns an object implementing this ABC’s interface.
+
+        ref: docs.python.org/3.10/library/importlib.html?highlight=traversableresources#importlib.abc.ResourceReader
+        """
+        return self.loader.get_resource_reader(fullname)
+
 
 class ImportInterceptor(importlib.abc.MetaPathFinder):
     loading: typing.Dict[str, typing.Tuple[str, float]]


### PR DESCRIPTION
## Describe your changes

Currently when Task tracing was turned on for a customer's `modal.App` the Task failed on startup due to errors in `importlib` machinery which do not occur normally. 

The first issue was https://github.com/pypa/setuptools/issues/4487. I could workaround that by doing `setuptools==70.3.0` but then I hit other issues. Those other issues are fixed by the changeset here. 

_There's almost certainly more to understand about how an intercepting `Loader` should work_ but I think this change shouldn't introduce regressions.

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
    - only an internal telemetry change
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
   - only an internal telemetry change
