### PR TITLE
Reword log message when function raises a cancellation error

### DIFF
--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -517,7 +517,7 @@ class _ContainerIOManager:
             # just skip creating any output for this input and keep going with the next instead
             # it should have been marked as cancelled already in the backend at this point so it
             # won't be retried
-            logger.warning(f"The current input ({input_id=}) was cancelled by a user request")
+            logger.warning(f"Recevied a cancellation signal while processing input {input_id}")
             await self.complete_call(started_at)
             return
         except BaseException as exc:

--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -517,7 +517,7 @@ class _ContainerIOManager:
             # just skip creating any output for this input and keep going with the next instead
             # it should have been marked as cancelled already in the backend at this point so it
             # won't be retried
-            logger.warning(f"Recevied a cancellation signal while processing input {input_id}")
+            logger.warning(f"Received a cancellation signal while processing input {input_id}")
             await self.complete_call(started_at)
             return
         except BaseException as exc:

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -1312,7 +1312,7 @@ def test_cancellation_aborts_current_input_on_match(
         api_pb2.ContainerHeartbeatResponse(cancel_input_event=api_pb2.CancelInputEvent(input_ids=cancelled_input_ids))
     )
     stdout, stderr = container_process.communicate()
-    assert stderr.decode().count("Recevied a cancellation signal") == live_cancellations
+    assert stderr.decode().count("Received a cancellation signal") == live_cancellations
     assert "Traceback" not in stderr.decode()
     assert container_process.returncode == 0  # wait for container to exit
     duration = time.monotonic() - t0  # time from heartbeat to container exit

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -1312,7 +1312,7 @@ def test_cancellation_aborts_current_input_on_match(
         api_pb2.ContainerHeartbeatResponse(cancel_input_event=api_pb2.CancelInputEvent(input_ids=cancelled_input_ids))
     )
     stdout, stderr = container_process.communicate()
-    assert stderr.decode().count("was cancelled by a user request") == live_cancellations
+    assert stderr.decode().count("Recevied a cancellation signal") == live_cancellations
     assert "Traceback" not in stderr.decode()
     assert container_process.returncode == 0  # wait for container to exit
     duration = time.monotonic() - t0  # time from heartbeat to container exit


### PR DESCRIPTION
The previous log message was a bit misleading as we can get to this line for reasons other than the user explicitly cancelling a function call — for example if the function that spawned the function call hits its retry limit, or potentially anything else that causes an `asyncio.CancelledError` to bubble up.

Related to MOD-3132. Not sure if it closes it —  we may be able to do more here — but wanted to do a quick fix to make the message less actively confusing.