### PR TITLE
move import telemetry earlier in entrypoint

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -1,10 +1,18 @@
 # Copyright Modal Labs 2022
+# ruff: noqa: E402
+import os
+
+telemetry_socket = os.environ.get("MODAL_TELEMETRY_SOCKET")
+if telemetry_socket:
+    from ._telemetry import instrument_imports
+
+    instrument_imports(telemetry_socket)
+
 import asyncio
 import base64
 import concurrent.futures
 import importlib
 import inspect
-import os
 import queue
 import signal
 import sys
@@ -56,12 +64,6 @@ from .running_app import RunningApp
 if TYPE_CHECKING:
     import modal._container_io_manager
     import modal.object
-
-telemetry_socket = os.environ.get("MODAL_TELEMETRY_SOCKET")
-if telemetry_socket:
-    from ._telemetry import instrument_imports
-
-    instrument_imports(telemetry_socket)
 
 
 def construct_webhook_callable(


### PR DESCRIPTION
## Describe your changes

Installs telemetry as earlier as possible to provide tracing on more imports during startup.

**Before**

<kbd>
<img width="1859" alt="image" src="https://github.com/user-attachments/assets/9b0f8a63-7ca4-436f-bf2f-5ca1b4ae94f7">
</kbd>


**After**

<kbd>
<img width="1545" alt="image" src="https://github.com/user-attachments/assets/b8f7f897-a111-4912-9500-4fd148527c66">
</kbd>

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
