### PR TITLE
Add rollback_version to AppPublishRequest

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -337,6 +337,7 @@ message AppPublishRequest {
   map<string, string> function_ids = 5;  // function_name -> function_id
   map<string, string> class_ids = 6;  // class_name -> class_id
   map<string, string> definition_ids = 7;  // function_id -> definition_id
+  uint32 rollback_version = 8;  // Unused by client, but used internally
 }
 
 message AppPublishResponse {


### PR DESCRIPTION
This is maybe slightly weird -- we're not going to ever send this from the client, but we're going to use it internally because we're repurposing the `AppPublishRequest` message as a data structure we pass around the server including in the context of a rollback operation.


<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>