### PR TITLE
Add `modal app rollback` CLI

### DIFF
--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -123,10 +123,10 @@ def logs(
 async def rollback(
     app_id: str = Argument(""),
     *,
-    version: int = Option(
+    version: int = typer.Option(
         -1, "-v", "--version", help="Target version (if positive) or number of versions to rollback (if negative)"
     ),
-    name: str = Option("", "-n", "--name", help="Look up a deployed App by its name"),
+    name: str = NAME_OPTION,
     env: Optional[str] = ENV_OPTION,
 ):
     """Redeploy a previous version of an App.

--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -2,6 +2,7 @@
 import re
 from typing import List, Optional, Union
 
+import rich
 import typer
 from click import UsageError
 from rich.table import Column
@@ -166,6 +167,7 @@ async def rollback(
             raise UsageError(f"Invalid version specifer: {version}")
     req = api_pb2.AppRollbackRequest(app_id=app_id, version=version_number)
     await client.stub.AppRollback(req)
+    rich.print("[green]✓[/green] Deployment rollback successful!")
 
 
 @app_cli.command("stop", no_args_is_help=True)

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -816,9 +816,15 @@ def test_app_rollback(servicer, mock_dir, set_env_client):
         # Deploy multiple times
         for _ in range(4):
             _run(["deploy", "myapp.py", "--name", "my_app"])
-    _run(["app", "rollback", "--name", "my_app", "--version", "-2"])
+    _run(["app", "rollback", "my_app"])
+    app_id = servicer.deployed_apps.get("my_app")
+    assert servicer.app_deployment_history[app_id][-1]["rollback_version"] == 3
+
+    _run(["app", "rollback", "my_app", "v2"])
     app_id = servicer.deployed_apps.get("my_app")
     assert servicer.app_deployment_history[app_id][-1]["rollback_version"] == 2
+
+    _run(["app", "rollback", "my_app", "2"], expected_exit_code=2)
 
 
 def test_dict_create_list_delete(servicer, server_url_env, set_env_client):


### PR DESCRIPTION
Going to hold off on merging until we ship the UI changes as well.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
---

</details>

## Changelog

- Added a `modal app rollback` CLI command for rolling back an App deployment to a previous version.