### PR TITLE
Add protos for AppRollback

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -345,6 +345,11 @@ message AppPublishResponse {
   string url = 1;
 }
 
+message AppRollbackRequest {
+  string app_id = 1;
+  int32 version = 2;  // signed as we support negative "roll back n versions" requests
+}
+
 message AppSetObjectsRequest {
   string app_id = 1;
   map<string, string> indexed_object_ids = 2;
@@ -2192,6 +2197,7 @@ service ModalClient {
   rpc AppLookup(AppLookupRequest) returns (AppLookupResponse);
   rpc AppLookupObject(AppLookupObjectRequest) returns (AppLookupObjectResponse);
   rpc AppPublish(AppPublishRequest) returns (AppPublishResponse);
+  rpc AppRollback(AppRollbackRequest) returns (google.protobuf.Empty);
   rpc AppSetObjects(AppSetObjectsRequest) returns (google.protobuf.Empty);
   rpc AppStop(AppStopRequest) returns (google.protobuf.Empty);
 


### PR DESCRIPTION
Move the `AppRollbackRequest` and RPC definition out to the client so we can build a CLI.