### PR TITLE
Don't log time elapsed for loop failures

### DIFF
--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -176,13 +176,11 @@ class TaskContext:
         async def loop_coro() -> None:
             logger.debug(f"Starting infinite loop {function_name}")
             while True:
-                t0 = time.time()
                 try:
                     await asyncio.wait_for(async_f(), timeout=timeout)
                 except Exception:
-                    time_elapsed = time.time() - t0
                     if log_exception:
-                        logger.exception(f"Loop attempt failed for {function_name} (time_elapsed={time_elapsed})")
+                        logger.exception(f"Loop attempt failed for {function_name}")
                 try:
                     await asyncio.wait_for(self._exited.wait(), timeout=sleep)
                 except asyncio.TimeoutError:


### PR DESCRIPTION
We use this in the backend in a few places and it's causing Sentry to not group exceptions properly.

I don't think this is useful information since it's always just the timeout plus a small epsilon