### PR TITLE
infinite_loop support for functools.partial

### DIFF
--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -171,7 +171,10 @@ class TaskContext:
     def infinite_loop(
         self, async_f, timeout: Optional[float] = 90, sleep: float = 10, log_exception: bool = True
     ) -> asyncio.Task:
-        function_name = async_f.__qualname__
+        if isinstance(async_f, functools.partial):
+            function_name = async_f.func.__qualname__
+        else:
+            function_name = async_f.__qualname__
 
         async def loop_coro() -> None:
             logger.debug(f"Starting infinite loop {function_name}")

--- a/test/async_utils_test.py
+++ b/test/async_utils_test.py
@@ -1,5 +1,6 @@
 # Copyright Modal Labs 2022
 import asyncio
+import functools
 import logging
 import os
 import platform
@@ -97,6 +98,17 @@ async def test_task_context_infinite_loop():
     assert not t.cancelled()
     assert t.done()
     assert counter == 4  # should be exited immediately
+
+
+@skip_github_non_linux
+@pytest.mark.asyncio
+async def test_task_context_infinite_loop_non_functions():
+    async with TaskContext(grace=0.01) as task_context:
+        async def f(x):
+            pass
+
+        task_context.infinite_loop(lambda: f(123))
+        task_context.infinite_loop(functools.partial(f, 123))
 
 
 @pytest.mark.asyncio

--- a/test/async_utils_test.py
+++ b/test/async_utils_test.py
@@ -195,7 +195,6 @@ async def test_warn_if_generator_is_not_consumed(caplog):
     assert "list" in caplog.text
 
 
-@pytest.mark.asyncio
 def test_warn_if_generator_is_not_consumed_sync(caplog):
     @warn_if_generator_is_not_consumed()
     def my_generator():


### PR DESCRIPTION
This is slightly nicer for debuggability vs lambdas which just print something like `Loop attempt failed for ResourceSolverPool.start.<locals>.<lambda>`

It will make it possible to use functools.partial for those instead