### PR TITLE
Add num_desired_tasks in FunctionStats

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1290,6 +1290,7 @@ message FunctionStats {
   uint32 backlog = 1;
   uint32 num_active_tasks = 2;
   uint32 num_total_tasks = 3;
+  uint32 num_desired_tasks = 4;
 }
 
 message FunctionUpdateSchedulingParamsRequest {


### PR DESCRIPTION
## Describe your changes
Add num_desired_tasks in FunctionStats protobuf, used for overriding `allow_concurrent_inputs` during container scaleup

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.
