### PR TITLE
`infinite_loop` logging thing

### DIFF
--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -181,9 +181,13 @@ class TaskContext:
             while True:
                 try:
                     await asyncio.wait_for(async_f(), timeout=timeout)
-                except Exception:
-                    if log_exception:
-                        logger.exception(f"Loop attempt failed for {function_name}")
+                except Exception as exc:
+                    if log_exception and isinstance(exc, asyncio.TimeoutError):
+                        # Asyncio sends an empty message in this case, so let's use logger.error
+                        logger.error(f"Loop attempt for {function_name} timed out")
+                    elif log_exception:
+                        # Propagate the exception to the logger
+                        logger.exception(f"Loop attempt for {function_name} failed")
                 try:
                     await asyncio.wait_for(self._exited.wait(), timeout=sleep)
                 except asyncio.TimeoutError:

--- a/test/async_utils_test.py
+++ b/test/async_utils_test.py
@@ -111,6 +111,20 @@ async def test_task_context_infinite_loop_non_functions():
         task_context.infinite_loop(functools.partial(f, 123))
 
 
+@skip_github_non_linux
+@pytest.mark.asyncio
+async def test_task_context_infinite_loop_timeout(caplog):
+    async with TaskContext(grace=0.01) as task_context:
+        async def f():
+            await asyncio.sleep(5.0)
+
+        task_context.infinite_loop(f, timeout=0.1)
+        await asyncio.sleep(0.15)
+
+    assert len(caplog.records) == 1
+    assert "timed out" in caplog.text
+
+
 @pytest.mark.asyncio
 async def test_task_context_gather():
     state = "none"


### PR DESCRIPTION
Minor improvement to logging for timeouts in `infinite_loop`

We have a lot of this in the Modal backend