### PR TITLE
Improve the display of gRPC errors in CLI output

### DIFF
--- a/modal/__main__.py
+++ b/modal/__main__.py
@@ -34,12 +34,40 @@ def main():
         if config.get("traceback"):
             raise
 
+        from grpclib import GRPCError, Status
         from rich.console import Console
         from rich.panel import Panel
         from rich.text import Text
 
+        if isinstance(exc, GRPCError):
+            status_map = {
+                Status.ABORTED: "Aborted",
+                Status.ALREADY_EXISTS: "Already exists",
+                Status.CANCELLED: "Cancelled",
+                Status.DATA_LOSS: "Data loss",
+                Status.DEADLINE_EXCEEDED: "Deadline exceeded",
+                Status.FAILED_PRECONDITION: "Failed precondition",
+                Status.INTERNAL: "Internal",
+                Status.INVALID_ARGUMENT: "Invalid",
+                Status.NOT_FOUND: "Not found",
+                Status.OUT_OF_RANGE: "Out of range",
+                Status.PERMISSION_DENIED: "Permission denied",
+                Status.RESOURCE_EXHAUSTED: "Resource exhausted",
+                Status.UNAUTHENTICATED: "Unauthenticaed",
+                Status.UNAVAILABLE: "Unavailable",
+                Status.UNIMPLEMENTED: "Unimplemented",
+                Status.UNKNOWN: "Unknown",
+            }
+            title = f"Error: {status_map.get(exc.status, 'Unknown')}"
+            content = str(exc.message)
+            if exc.details:
+                content += f"\n\nDetails: {exc.details}"
+        else:
+            title = "Error"
+            content = str(exc)
+
         console = Console(stderr=True)
-        panel = Panel(Text(str(exc)), border_style="red", title="Error", title_align="left")
+        panel = Panel(Text(content), title=title, title_align="left", border_style="red")
         console.print(panel, highlight=False)
         sys.exit(1)
 


### PR DESCRIPTION
Small polishing PR that cleans up how we display gRPC errors when they end the local client process.

Before:

<img width="662" alt="image" src="https://github.com/user-attachments/assets/e173db7c-8491-4573-8c4f-4d3d6784f1ef">

After:
<img width="665" alt="image" src="https://github.com/user-attachments/assets/3198f8a3-53c0-4a06-addc-6cf3b3c97f64">

We could potentially create more mappings to increase the informativeness of the panel title for non-gRPC errors but I'll leave that for a subsequent PR.