### PR TITLE
Remove vestigial deprecation layer around object names

### DIFF
--- a/modal/_utils/name_utils.py
+++ b/modal/_utils/name_utils.py
@@ -30,19 +30,14 @@ def is_valid_tag(tag: str) -> bool:
     return bool(re.match(pattern, tag))
 
 
-def check_object_name(name: str, object_type: str, warn: bool = False) -> None:
+def check_object_name(name: str, object_type: str) -> None:
     message = (
         f"Invalid {object_type} name: '{name}'."
         "\n\nNames may contain only alphanumeric characters, dashes, periods, and underscores,"
         " and must be shorter than 64 characters."
     )
-    if warn:
-        message += "\n\nThis will become an error in the future. Please rename your object to preserve access to it."
     if not is_valid_object_name(name):
-        if warn:
-            deprecation_warning((2024, 4, 30), message, show_source=False)
-        else:
-            raise InvalidError(message)
+        raise InvalidError(message)
 
 
 def check_environment_name(name: str, warn: bool = False) -> None:

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -13,7 +13,7 @@ from modal._utils.name_utils import (
     is_valid_tag,
 )
 from modal._utils.package_utils import parse_major_minor_version
-from modal.exception import DeprecationError, InvalidError
+from modal.exception import InvalidError
 
 
 def test_subdomain_label():
@@ -32,8 +32,6 @@ def test_object_name():
     assert not is_valid_object_name("a" * 65)
     with pytest.raises(InvalidError, match="Invalid Volume name: 'foo/bar'"):
         check_object_name("foo/bar", "Volume")
-    with pytest.warns(DeprecationError, match="Invalid Volume name: 'foo/bar'"):
-        check_object_name("foo/bar", "Volume", warn=True)
 
 
 def test_environment_name():


### PR DESCRIPTION
We expired this deprecation a while back.