### PR TITLE
Accept App name as positional argument in modal app CLI

### DIFF
--- a/modal/cli/utils.py
+++ b/modal/cli/utils.py
@@ -102,5 +102,3 @@ Otherwise, raises an error if the workspace has multiple environments.
 ENV_OPTION = typer.Option(None, "-e", "--env", help=ENV_OPTION_HELP)
 
 YES_OPTION = typer.Option(False, "-y", "--yes", help="Run without pausing for confirmation.")
-
-NAME_OPTION = typer.Option("", "-n", "--name", help="Look up a deployed App by its name")


### PR DESCRIPTION
## Changelog

- Commands in the `modal app` CLI now accept an App name as a positional argument, in addition to an App ID:

    ```
    modal app history my-app
    ```

    Accordingly, the explicit `--name` option has been deprecated. Providing an name that can be confused with an App ID will also now raise an error.