### PR TITLE
Show version numbers as v{number} in `modal app history` to match web UI

### DIFF
--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -178,7 +178,7 @@ async def history(
         style = "bold green" if idx == 0 else ""
 
         row = [
-            Text(str(app_stats.version), style=style),
+            Text(f"v{app_stats.version}", style=style),
             Text(timestamp_to_local(app_stats.deployed_at, json), style=style),
             Text(app_stats.client_version, style=style),
             Text(app_stats.deployed_by, style=style),

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -785,30 +785,30 @@ def test_list_apps(servicer, mock_dir, set_env_client):
     assert "my-vol" not in res.stdout
 
 
-def test_list_app_deployment_history(servicer, mock_dir, set_env_client):
+def test_app_history(servicer, mock_dir, set_env_client):
     with mock_dir({"myapp.py": dummy_app_file, "other_module.py": dummy_other_module_file}):
         _run(["deploy", "myapp.py", "--name", "my_app_foo"])
 
     # app should be deployed once it exists
     res = _run(["app", "history", "my_app_foo"])
-    assert "1" in res.stdout, res.stdout
+    assert "v1" in res.stdout, res.stdout
 
     res = _run(["app", "history", "my_app_foo", "--json"])
     assert json.loads(res.stdout)
 
-    # re-deploying an app should result in one app stopped and one app deployed
+    # re-deploying an app should result in a new row in the history table
     with mock_dir({"myapp.py": dummy_app_file, "other_module.py": dummy_other_module_file}):
         _run(["deploy", "myapp.py", "--name", "my_app_foo"])
 
-    res = _run(["app", "history", "my_app_foo", "--json"])
-    assert "1" in res.stdout
-    assert "2" in res.stdout, f"{res.stdout=}"
+    res = _run(["app", "history", "my_app_foo"])
+    assert "v1" in res.stdout
+    assert "v2" in res.stdout, f"{res.stdout=}"
 
     # can't fetch history for stopped apps
     with mock_dir({"myapp.py": dummy_app_file, "other_module.py": dummy_other_module_file}):
         _run(["app", "stop", "my_app_foo"])
 
-    res = _run(["app", "history", "my_app_foo", "--json"], 1)
+    res = _run(["app", "history", "my_app_foo", "--json"], expected_exit_code=1)
 
 
 def test_dict_create_list_delete(servicer, server_url_env, set_env_client):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -372,12 +372,15 @@ class MockClientServicer(api_grpc.ModalClientBase):
         else:
             await stream.send_message(api_pb2.AppPublishResponse())
 
-        # start new version
+        if current_history := self.app_deployment_history[request.app_id]:
+            current_version = current_history[-1]["version"]
+        else:
+            current_version = 0
         self.app_deployment_history[request.app_id].append(
             {
                 "app_id": request.app_id,
                 "deployed_at": datetime.datetime.now().timestamp(),
-                "version": 1,
+                "version": current_version + 1,
                 "client_version": str(pkg_resources.parse_version(__version__)),
                 "deployed_by": "foo-user",
                 "tag": "latest",


### PR DESCRIPTION
Small change to align better with the dashboard UI and reduce ambiguity about how to spell rollback versions on the CLI:

<img width="478" alt="image" src="https://github.com/user-attachments/assets/e3b56a67-e138-40a4-94c4-3c8e0e7985c3">

Also caught a bug in the tests for redeployments which were accidentally passing (just an issue with the mock servicer though).