### PR TITLE
Clarify that GCS is fully S3-compatible

### DIFF
--- a/modal/cloud_bucket_mount.py
+++ b/modal/cloud_bucket_mount.py
@@ -76,7 +76,7 @@ class _CloudBucketMount:
 
     **Google GCS Usage**
 
-    Google Cloud Storage (GCS) is partially [S3-compatible](https://cloud.google.com/storage/docs/interoperability).
+    Google Cloud Storage (GCS) is [S3-compatible](https://cloud.google.com/storage/docs/interoperability).
     GCS Buckets also require a secret with Google-specific key names (see below) populated with
     a [HMAC key](https://cloud.google.com/storage/docs/authentication/managing-hmackeys#create).
 


### PR DESCRIPTION
This disclaimer came from a time when we couldn't write to GCS buckets. We have fixed this bug, so this commit updates the docs.

## Describe your changes


<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
