### PR TITLE
Fix app history version sorting

### DIFF
--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -193,5 +193,5 @@ async def history(
     if deployments_with_tags:
         columns.append("Tag")
 
-    rows = sorted(rows, key=lambda x: str(x[0]), reverse=True)
+    rows = sorted(rows, key=lambda x: int(str(x[0])[1:]), reverse=True)
     display_table(columns, rows, json)


### PR DESCRIPTION
Fixes version sorting once we go past 9 versions:

<img width="458" alt="image" src="https://github.com/user-attachments/assets/47d41c0f-7a6b-4f50-9680-9edaa01eb642">
