### PR TITLE
Pass type signatures through retry_transient_errors helper

### DIFF
--- a/modal/_utils/grpc_utils.py
+++ b/modal/_utils/grpc_utils.py
@@ -26,6 +26,10 @@ from modal_version import __version__
 
 from .logger import logger
 
+RequestType = TypeVar("RequestType", bound=Message)
+ResponseType = TypeVar("ResponseType", bound=Message)
+
+
 # Monkey patches grpclib to have a Modal User Agent header.
 grpclib.client.USER_AGENT = "modal-client/{version} ({sys}; {py}/{py_ver})'".format(
     version=__version__,
@@ -120,7 +124,7 @@ async def unary_stream(
 
 
 async def retry_transient_errors(
-    fn,
+    fn: grpclib.client.UnaryUnaryMethod[RequestType, ResponseType],
     *args,
     base_delay: float = 0.1,
     max_delay: float = 1,
@@ -130,7 +134,7 @@ async def retry_transient_errors(
     attempt_timeout: Optional[float] = None,  # timeout for each attempt
     total_timeout: Optional[float] = None,  # timeout for the entire function call
     attempt_timeout_floor=2.0,  # always have at least this much timeout (only for total_timeout)
-):
+) -> ResponseType:
     """Retry on transient gRPC failures with back-off until max_retries is reached.
     If max_retries is None, retry forever."""
 

--- a/tasks.py
+++ b/tasks.py
@@ -86,6 +86,7 @@ def lint_protos(ctx):
 
 @task
 def type_check(ctx):
+    type_stubs(ctx)
     # mypy will not check the *implementation* (.py) for files that also have .pyi type stubs
     ctx.run(
         "mypy . --exclude=playground --exclude=venv311 --exclude=venv38 "


### PR DESCRIPTION
Affords better IDE hints and type checking.

Had to fix a small thing that popped up after enabling this.

Also updated the `inv type-check` task to run `inv type-stubs` automatically to avoid confusion.