### PR TITLE
Remove exception log when we get an error during object creation

### DIFF
--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -9,7 +9,6 @@ from grpclib import GRPCError, Status
 
 from ._utils.async_utils import TaskContext
 from .client import _Client
-from .config import logger
 from .exception import NotFoundError
 
 if TYPE_CHECKING:
@@ -139,11 +138,7 @@ class Resolver:
             self._local_uuid_to_future[obj.local_uuid] = cached_future
             if deduplication_key is not None:
                 self._deduplication_cache[deduplication_key] = cached_future
-        try:
-            return await cached_future
-        except:
-            logger.exception(f"Exception when resolving {obj}")
-            raise
+        return await cached_future
 
     def objects(self) -> List["_Object"]:
         unique_objects: Dict[str, "_Object"] = {}


### PR DESCRIPTION
Closes MOD-3506. See ticket for details.

I do think that the aim of making it easier to debug server-side exceptions during object creation is good, but this added way too much spam to the console output when running / deploying an App. I've opened a separate ticket to think about the object attribution problem further.