### PR TITLE
fix: our breakpoint wrapper fn breaks locals() by changing scope

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -792,7 +792,9 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
                 interact()
                 import pdb
 
-                pdb.set_trace()
+                frame = inspect.currentframe().f_back
+
+                pdb.Pdb().set_trace(frame)
 
             sys.breakpointhook = breakpoint_wrapper
 


### PR DESCRIPTION
## Describe your changes

**Context:** https://modal-com.slack.com/archives/C069RAH7X4M/p1723963688238749

We really should have a test for this. 

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

* Fix scope bug in Modal's `--interactive` / `breakpoint()` functionality.
