### PR TITLE
Adds client support for cancelling concurrent async inputs

### DIFF
--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -114,6 +114,10 @@ class IOContext:
             cb = self._cancel_callback
             self._cancel_callback = None
             cb()
+        else:
+            # TODO (elias): This should not normally happen but there is a small chance of a race
+            #  between creating a new task for an input and attaching the cancellation callback
+            logger.warning("Unexpected: Could not cancel input")
 
     def _args_and_kwargs(self) -> Tuple[Tuple[Any, ...], Dict[str, List[Any]]]:
         if not self._is_batched:

--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -10,7 +10,7 @@ import time
 import traceback
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, AsyncGenerator, AsyncIterator, Callable, ClassVar, Dict, List, Optional, Set, Tuple
+from typing import Any, AsyncGenerator, AsyncIterator, Callable, ClassVar, Dict, List, Optional, Tuple
 
 from google.protobuf.empty_pb2 import Empty
 from google.protobuf.message import Message
@@ -60,6 +60,8 @@ class IOContext:
     function_call_ids: List[str]
     finalized_function: FinalizedFunction
 
+    _cancel_callback: Optional[Callable[[], None]] = None
+
     def __init__(
         self,
         input_ids: List[str],
@@ -103,6 +105,15 @@ class IOContext:
         # TODO(cathy) Performance decrease if we deserialize inputs later
         deserialized_args = [deserialize(input.args, client) if input.args else ((), {}) for input in inputs]
         return cls(input_ids, function_call_ids, finalized_function, deserialized_args, is_batched)
+
+    def set_cancel_callback(self, cb: Callable[[], None]):
+        self._cancel_callback = cb
+
+    def cancel(self):
+        if self._cancel_callback:
+            cb = self._cancel_callback
+            self._cancel_callback = None
+            cb()
 
     def _args_and_kwargs(self) -> Tuple[Tuple[Any, ...], Dict[str, List[Any]]]:
         if not self._is_batched:
@@ -169,7 +180,6 @@ class _ContainerIOManager:
     Then we could potentially move a bunch of the global functions onto it.
     """
 
-    cancelled_input_ids: Set[str]
     task_id: str
     function_id: str
     app_id: str
@@ -179,6 +189,7 @@ class _ContainerIOManager:
     calls_completed: int
     total_user_time: float
     current_input_id: Optional[str]
+    current_inputs: Dict[str, IOContext]  # input_id -> IOContext
     current_input_started_at: Optional[float]
 
     _input_concurrency: Optional[int]
@@ -197,7 +208,6 @@ class _ContainerIOManager:
     _singleton: ClassVar[Optional["_ContainerIOManager"]] = None
 
     def _init(self, container_args: api_pb2.ContainerArguments, client: _Client):
-        self.cancelled_input_ids = set()
         self.task_id = container_args.task_id
         self.function_id = container_args.function_id
         self.app_id = container_args.app_id
@@ -207,6 +217,7 @@ class _ContainerIOManager:
         self.calls_completed = 0
         self.total_user_time = 0.0
         self.current_input_id = None
+        self.current_inputs = {}
         self.current_input_started_at = None
 
         self._input_concurrency = None
@@ -283,19 +294,9 @@ class _ContainerIOManager:
             input_ids_to_cancel = response.cancel_input_event.input_ids
             if input_ids_to_cancel:
                 if self._input_concurrency > 1:
-                    logger.info(
-                        "Shutting down task to stop some subset of inputs "
-                        "(concurrent functions don't support fine-grained cancellation)"
-                    )
-                    # This is equivalent to a task cancellation or preemption from worker code,
-                    # except we do not send a SIGKILL to forcefully exit after 30 seconds.
-                    #
-                    # SIGINT always interrupts the main thread, but not any auxiliary threads. On a
-                    # sync function without concurrent inputs, this raises a KeyboardInterrupt. When
-                    # there are concurrent inputs, we cannot interrupt the thread pool, but the
-                    # interpreter stops waiting for daemon threads and exits. On async functions,
-                    # this signal lands outside the event loop, stopping `run_until_complete()`.
-                    os.kill(os.getpid(), signal.SIGINT)
+                    for input_id in input_ids_to_cancel:
+                        if input_id in self.current_inputs:
+                            self.current_inputs[input_id].cancel()
 
                 elif self.current_input_id in input_ids_to_cancel:
                     # This goes to a registered signal handler for sync Modal functions, or to the
@@ -495,8 +496,6 @@ class _ContainerIOManager:
                         if item.kill_switch:
                             logger.debug(f"Task {self.task_id} input kill signal input.")
                             return
-                        if item.input_id in self.cancelled_input_ids:
-                            continue
 
                         inputs.append((item.input_id, item.function_call_id, item.input))
                         if item.input.final_input:
@@ -533,6 +532,9 @@ class _ContainerIOManager:
 
         async for inputs in self._generate_inputs(batch_max_size, batch_wait_ms):
             io_context = await IOContext.create(self._client, finalized_functions, inputs, batch_max_size > 0)
+            for input_id in io_context.input_ids:
+                self.current_inputs[input_id] = io_context
+
             self.current_input_id, self.current_input_started_at = io_context.input_ids[0], time.time()
             yield io_context
             self.current_input_id, self.current_input_started_at = (None, None)
@@ -637,7 +639,7 @@ class _ContainerIOManager:
             # just skip creating any output for this input and keep going with the next instead
             # it should have been marked as cancelled already in the backend at this point so it
             # won't be retried
-            logger.warning(f"Received a cancellation signal while processing input {io_context.input_ids}")
+            logger.info(f"Received a cancellation signal while processing input {io_context.input_ids}")
             await self.exit_context(started_at)
             return
         except BaseException as exc:

--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -688,7 +688,7 @@ class _ContainerIOManager:
     async def exit_context(self, started_at, input_ids: List[str]):
         self.total_user_time += time.time() - started_at
         self.calls_completed += 1
-        self.current_input = None
+
         for input_id in input_ids:
             self.current_inputs.pop(input_id)
 

--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -639,7 +639,7 @@ class _ContainerIOManager:
             # just skip creating any output for this input and keep going with the next instead
             # it should have been marked as cancelled already in the backend at this point so it
             # won't be retried
-            logger.info(f"Received a cancellation signal while processing input {io_context.input_ids}")
+            logger.warning(f"Received a cancellation signal while processing input {io_context.input_ids}")
             await self.exit_context(started_at)
             return
         except BaseException as exc:

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1420,10 +1420,19 @@ class _FunctionCall(typing.Generic[R], _Object, type_prefix="fc"):
         response = await retry_transient_errors(self._client.stub.FunctionGetCallGraph, request)
         return _reconstruct_call_graph(response)
 
-    async def cancel(self):
+    async def cancel(
+        self,
+        terminate_containers: bool = False,  # if true, containers running the inputs are forcibly terminated
+    ):
         """Cancels the function call, which will stop its execution and mark its inputs as
-        [`TERMINATED`](/docs/reference/modal.call_graph#modalcall_graphinputstatus)."""
-        request = api_pb2.FunctionCallCancelRequest(function_call_id=self.object_id)
+        [`TERMINATED`](/docs/reference/modal.call_graph#modalcall_graphinputstatus).
+
+        If `terminate_containers=True` - the containers running the cancelled inputs are all terminated
+        causing any non-cancelled inputs on those containers to be rescheduled in new containers.
+        """
+        request = api_pb2.FunctionCallCancelRequest(
+            function_call_id=self.object_id, terminate_containers=terminate_containers
+        )
         assert self._client and self._client.stub
         await retry_transient_errors(self._client.stub.FunctionCallCancel, request)
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -848,6 +848,7 @@ class _Function(typing.Generic[P, R], _Object, type_prefix="fu"):
                         )
                         for _experimental_gpu in _experimental_gpus
                     ],
+                    _experimental_concurrent_cancellations=True,
                 )
                 assert resolver.app_id
                 request = api_pb2.FunctionCreateRequest(

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1044,6 +1044,8 @@ message Function {
   reserved 59;
   uint32 batch_max_size = 60; // Maximum number of inputs to fetch at once
   uint64 batch_linger_ms = 61; // Miliseconds to block before a response is needed
+
+  bool _experimental_concurrent_cancellations = 62;
 }
 
 message FunctionBindParamsRequest {
@@ -1067,6 +1069,7 @@ message FunctionCallCallGraphInfo {
 
 message FunctionCallCancelRequest {
   string function_call_id = 1;
+  bool terminate_containers = 2;
 }
 
 message FunctionCallGetDataRequest {

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -1569,7 +1569,9 @@ def test_cancellation_stops_task_with_concurrent_inputs(servicer, function_name)
     assert (
         len(servicer.container_outputs) == 0
     )  # should not fail the outputs, as they would have been cancelled in backend already
-    assert "Traceback" not in container_process.stderr.read().decode("utf8")
+    container_stderr = container_process.stderr.read().decode("utf8")
+    print(container_stderr)
+    assert "Traceback" not in container_stderr
     assert exit_code == 0  # container should exit gracefully
 
 

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -24,6 +24,7 @@ from grpclib.exceptions import GRPCError
 import modal
 from modal import Client, Queue, Volume, is_local
 from modal._container_entrypoint import UserException, main
+from modal._container_io_manager import ContainerIOManager, FinalizedFunction, IOContext
 from modal._serialization import (
     deserialize,
     deserialize_data_format,
@@ -1919,3 +1920,54 @@ def test_no_warn_on_remote_local_volume_mount(client, servicer, recwarn, set_env
         warning = str(recwarn.pop().message)
         assert "and will not have access to the mounted Volume or NetworkFileSystem data" not in warning
     assert len(recwarn) == 0
+
+
+@pytest.mark.parametrize("concurrency_limit", [1, 2])
+def test_container_io_manager_concurrency_tracking(client, servicer, concurrency_limit):
+    dummy_container_args = api_pb2.ContainerArguments(function_id="fu-123")
+    from modal._utils.async_utils import synchronizer
+
+    io_manager = ContainerIOManager(dummy_container_args, client)
+    _io_manager = synchronizer._translate_in(io_manager)
+
+    async def _func(x):
+        await asyncio.sleep(x)
+
+    fin_func = FinalizedFunction(_func, is_async=True, is_generator=False, data_format=api_pb2.DATA_FORMAT_PICKLE)
+
+    total_inputs = 5
+    servicer.container_inputs = _get_inputs(((42,), {}), n=total_inputs)
+    active_inputs: List[IOContext] = []
+    active_input_ids = set()
+    processed_inputs = 0
+    triggered_assertions = []
+    for io_context in io_manager.run_inputs_outputs(
+        finalized_functions={"": fin_func},
+        input_concurrency=concurrency_limit,
+    ):
+        assert len(io_context.input_ids) == 1  # for this test
+        active_inputs += [io_context]
+        active_input_ids |= set(io_context.input_ids)
+        processed_inputs += len(io_context.input_ids)
+
+        while active_inputs and (len(active_inputs) == concurrency_limit or processed_inputs == total_inputs):
+            input_to_process = active_inputs.pop(0)
+            send_failure = processed_inputs % 2 == 1
+            # return values for inputs
+            with io_manager.handle_input_exception(input_to_process, time.time()):
+                try:
+                    # can't raise assertions in here, since they are caught and forwarded as input exceptions
+                    assert set(_io_manager.current_inputs.keys()) == set(active_input_ids)
+                except AssertionError as assertion:
+                    triggered_assertions.append(assertion)
+                    raise
+
+                active_input_ids -= set(input_to_process.input_ids)
+
+                if send_failure:
+                    # trigger some errors
+                    raise Exception("Blah ")
+                else:
+                    # and some successes
+                    io_manager.push_outputs(input_to_process, 0, None, fin_func.data_format)
+    assert not triggered_assertions

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -1946,7 +1946,8 @@ def test_container_io_manager_concurrency_tracking(client, servicer, concurrency
         finalized_functions={"": fin_func},
         input_concurrency=concurrency_limit,
     ):
-        assert len(io_context.input_ids) == 1  # for this test
+        assert len(io_context.input_ids) == 1  # no batching in this test
+        assert _io_manager.current_input_id == io_context.input_ids[0]
         active_inputs += [io_context]
         peak_inputs = max(peak_inputs, len(active_inputs))
         active_input_ids |= set(io_context.input_ids)

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -1941,12 +1941,14 @@ def test_container_io_manager_concurrency_tracking(client, servicer, concurrency
     active_input_ids = set()
     processed_inputs = 0
     triggered_assertions = []
+    peak_inputs = 0
     for io_context in io_manager.run_inputs_outputs(
         finalized_functions={"": fin_func},
         input_concurrency=concurrency_limit,
     ):
         assert len(io_context.input_ids) == 1  # for this test
         active_inputs += [io_context]
+        peak_inputs = max(peak_inputs, len(active_inputs))
         active_input_ids |= set(io_context.input_ids)
         processed_inputs += len(io_context.input_ids)
 
@@ -1966,7 +1968,7 @@ def test_container_io_manager_concurrency_tracking(client, servicer, concurrency
 
                 if send_failure:
                     # trigger some errors
-                    raise Exception("Blah ")
+                    raise Exception("Blah")
                 else:
                     # and some successes
                     io_manager.push_outputs(input_to_process, 0, None, fin_func.data_format)


### PR DESCRIPTION
Feature unlocked by server based on a `_experimental_concurrent_cancellations` flag on the function definition.

Also adds a `terminate_containers` option for `FunctionCallCancel`, which can be used if a user wants to ensure that a non-cooperative input/function can still be terminated at the expense of having to rerun any concurrently running inputs in another container (also needs server support)

## Describe your changes

- _Provide Linear issue reference (e.g. MOD-1234) if available._

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>
