### PR TITLE
Catch and clearly reject filenames containing periods

### DIFF
--- a/modal/cli/import_refs.py
+++ b/modal/cli/import_refs.py
@@ -18,9 +18,8 @@ import click
 from rich.console import Console
 from rich.markdown import Markdown
 
-import modal
 from modal.app import App, LocalEntrypoint
-from modal.exception import _CliUserExecutionError, deprecation_warning
+from modal.exception import InvalidError, _CliUserExecutionError, deprecation_warning
 from modal.functions import Function
 
 
@@ -34,7 +33,7 @@ def parse_import_ref(object_ref: str) -> ImportRef:
     if object_ref.find("::") > 1:
         file_or_module, object_path = object_ref.split("::", 1)
     elif object_ref.find(":") > 1:
-        raise modal.exception.InvalidError(f"Invalid object reference: {object_ref}. Did you mean '::' instead of ':'?")
+        raise InvalidError(f"Invalid object reference: {object_ref}. Did you mean '::' instead of ':'?")
     else:
         file_or_module, object_path = object_ref, None
 
@@ -55,6 +54,11 @@ def import_file_or_module(file_or_module: str):
         # when using a script path, that scripts directory should also be on the path as it is
         # with `python some/script.py`
         full_path = Path(file_or_module).resolve()
+        if "." in full_path.name[:-3]:  # use removesuffix once we drop 3.8 support
+            raise InvalidError(
+                f"Invalid Modal source filename: {full_path.name!r}."
+                "\n\nSource filename cannot contain additional period characters."
+            )
         sys.path.insert(0, str(full_path.parent))
 
         module_name = inspect.getmodulename(file_or_module)

--- a/test/cli_imports_test.py
+++ b/test/cli_imports_test.py
@@ -9,6 +9,7 @@ from modal.cli.import_refs import (
     import_file_or_module,
     parse_import_ref,
 )
+from modal.exception import InvalidError
 
 # Some helper vars for import_stub tests:
 local_entrypoint_src = """
@@ -147,3 +148,8 @@ def test_get_by_object_path():
     # try to find item keys with periods in them (ugh).
     # this helps resolving lifecycled functions
     assert get_by_object_path(NS({"foo.bar": "baz"}), "foo.bar") == "baz"
+
+
+def test_invalid_source_file_exception():
+    with pytest.raises(InvalidError, match="Invalid Modal source filename: 'foo.bar.py'"):
+        import_file_or_module("path/to/foo.bar.py")


### PR DESCRIPTION
Closes MOD-3521

AFAICT we're not handling this incorrectly — it's a poorly handled edgecase in `importlib` itself. Better to fail quickly with a clear error message.