### PR TITLE
MOD-3524: Add region and cloud selection to Image.run_function

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -1541,9 +1541,6 @@ class _Image(_Object, type_prefix="im"):
         secret: Optional[_Secret] = None,  # Deprecated: use `secrets`.
         cloud: Optional[str] = None,  # Cloud provider to run the function on. Possible values are aws, gcp, oci, auto.
         region: Optional[Union[str, Sequence[str]]] = None,  # Region or regions to run the function on.
-        _experimental_scheduler_placement: Optional[
-            SchedulerPlacement
-        ] = None,  # Experimental controls over fine-grained scheduling (alpha).
         args: Sequence[Any] = (),  # Positional arguments to the function.
         kwargs: Dict[str, Any] = {},  # Keyword arguments to the function.
     ) -> "_Image":
@@ -1582,11 +1579,7 @@ class _Image(_Object, type_prefix="im"):
             # It may be possible to support lambdas eventually, but for now we don't handle them well, so reject quickly
             raise InvalidError("Image.run_function does not support lambda functions.")
 
-        scheduler_placement: Optional[SchedulerPlacement] = _experimental_scheduler_placement
-        if region:
-            if scheduler_placement:
-                raise InvalidError("`region` and `_experimental_scheduler_placement` cannot be used together")
-            scheduler_placement = SchedulerPlacement(region=region)
+        scheduler_placement = SchedulerPlacement(region=region) if region else None
 
         info = FunctionInfo(raw_f)
 

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -565,6 +565,35 @@ def test_image_run_function_with_args(builder_version, servicer, client):
         assert input.args == serialize((("foo",), {"kwarg": "bar"}))
 
 
+def test_image_run_function_with_region_selection(servicer, client):
+    app = App()
+    app.image = Image.debian_slim().run_function(run_f, region="us-east")
+    app.function()(dummy)
+
+    with app.run(client=client):
+        pass
+
+    assert len(servicer.app_functions) == 2
+    func_def = next(iter(servicer.app_functions.values()))
+
+    assert func_def.scheduler_placement == api_pb2.SchedulerPlacement(
+        regions=["us-east"],
+    )
+
+
+def test_image_run_function_with_cloud_selection(servicer, client):
+    app = App()
+    app.image = Image.debian_slim().run_function(run_f, cloud="oci")
+    app.function()(dummy)
+
+    with app.run(client=client):
+        pass
+
+    assert len(servicer.app_functions) == 2
+    func_def = next(iter(servicer.app_functions.values()))
+    assert func_def.cloud_provider == api_pb2.CLOUD_PROVIDER_OCI
+
+
 def test_poetry(builder_version, servicer, client):
     path = os.path.join(os.path.dirname(__file__), "supports/pyproject.toml")
 


### PR DESCRIPTION
Adds region and cloud selection to `Image.run_function()` 

All clouds work, some regions do not work, namely:
```
"eu-north"
"ap-melbourne"
"me"
```