### PR TITLE
Add required_keys to client proto

### DIFF
--- a/modal/secret.py
+++ b/modal/secret.py
@@ -165,6 +165,7 @@ class _Secret(_Object, type_prefix="st"):
         label: str,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
+        required_keys: List[str] = [],
     ) -> "_Secret":
         """Create a reference to a persisted Secret
 
@@ -182,6 +183,7 @@ class _Secret(_Object, type_prefix="st"):
                 deployment_name=label,
                 namespace=namespace,
                 environment_name=_get_environment_name(environment_name, resolver),
+                required_keys=required_keys,
             )
             try:
                 response = await resolver.client.stub.SecretGetOrCreate(req)

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1854,6 +1854,7 @@ message SecretGetOrCreateRequest {
   ObjectCreationType object_creation_type = 4;  // Not used atm
   map<string, string> env_dict = 5;
   string app_id = 6;  // only used with OBJECT_CREATION_TYPE_ANONYMOUS_OWNED_BY_APP
+  repeated string required_keys = 7;
 }
 
 message SecretGetOrCreateResponse {


### PR DESCRIPTION
Simple thing that I think will make some examples a bit more ergonomic, since it causes the code to be a bit more self-documenting.

We can also use this to pre-fill the secrets UI.

For instance for the [cloud bucket docs](https://modal.com/docs/guide/cloud-bucket-mounts), we currently have a an example that encourages somewhat dangerous inlining of tokens into the code:

```python


import modal
import subprocess

app = modal.App()

s3_bucket_name = "s3-bucket-name"  # Bucket name not ARN.
s3_access_credentials = modal.Secret.from_dict({
    "AWS_ACCESS_KEY_ID": "...",
    "AWS_SECRET_ACCESS_KEY": "...",
    "AWS_REGION": "..."
})

@app.function(
    volumes={
        "/my-mount": modal.CloudBucketMount(s3_bucket_name, secret=s3_access_credentials)
    }
)
def f():
    subprocess.run(["ls", "/my-mount"])
```

I think this one would be a bit nicer this way, which would also make it self-contained (needing no modifications to run):

```python
import modal
import subprocess

app = modal.App()

s3_bucket_name = "s3-bucket-name"  # Bucket name not ARN.
s3_access_credentials = modal.Secret.from_name(
    "aws-secret",
    required_keys=["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION"]
)

@app.function(
    volumes={
        "/my-mount": modal.CloudBucketMount(s3_bucket_name, secret=s3_access_credentials)
    }
)
def f():
    subprocess.run(["ls", "/my-mount"])
```

We already link to a creation URL if the secret is missing:

```
╭─ Error ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Could not find secret: 'aws-secret'. You can create it here: https://modal.com/secrets/modal-labs/main/create?secret_name=aws-secret                                 │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

with these things we could also pass then as query strings and use them in the UI
