### PR TITLE
Add cli command to open dashboard for deployed app

### DIFF
--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -282,8 +282,13 @@ async def dashboard(
     """
     env = ensure_env(env)
     client = await _Client.from_env()
-    app_id = await get_app_id.aio(app_identifier, env, client) if app_identifier else None
-    resp = await client.stub.WebDashboardLookup(api_pb2.WebDashboardLookupRequest(app_id=app_id, environment_name=env))
+    resp = await client.stub.WebDashboardLookup(
+        api_pb2.WebDashboardLookupRequest(
+            app_identifier=app_identifier if app_identifier else None,
+            namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+            environment_name=env,
+        )
+    )
 
     if _open_url(resp.url):
         rich.print(

--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -283,7 +283,7 @@ async def dashboard(
     env = ensure_env(env)
     client = await _Client.from_env()
     app_id = await get_app_id.aio(app_identifier, env, client) if app_identifier else None
-    resp = await client.stub.WebDashboardLookup(api_pb2.WebDashboardRequest(app_id=app_id, environment_name=env))
+    resp = await client.stub.WebDashboardLookup(api_pb2.WebDashboardLookupRequest(app_id=app_id, environment_name=env))
 
     if _open_url(resp.url):
         rich.print(

--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -283,7 +283,7 @@ async def dashboard(
     env = ensure_env(env)
     client = await _Client.from_env()
     app_id = await get_app_id.aio(app_identifier, env, client) if app_identifier else None
-    resp = await client.stub.WebDashboard(api_pb2.WebDashboardRequest(app_id=app_id, environment_name=env))
+    resp = await client.stub.WebDashboardLookup(api_pb2.WebDashboardRequest(app_id=app_id, environment_name=env))
 
     if _open_url(resp.url):
         rich.print(

--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -14,6 +14,7 @@ from modal.client import _Client
 from modal.environments import ensure_env
 from modal.exception import deprecation_warning
 from modal.object import _get_environment_name
+from modal.token_flow import _open_url
 from modal_proto import api_pb2
 
 from .utils import ENV_OPTION, display_table, get_app_id_from_name, stream_app_logs, timestamp_to_local
@@ -247,3 +248,44 @@ async def history(
 
     rows = sorted(rows, key=lambda x: int(str(x[0])[1:]), reverse=True)
     display_table(columns, rows, json)
+
+
+@app_cli.command("dashboard", no_args_is_help=True)
+@synchronizer.create_blocking
+async def dashboard(
+    app_identifier: str = APP_IDENTIFIER,
+    *,
+    env: Optional[str] = ENV_OPTION,
+):
+    """Open the dashboard for a deployed App in the web default browser.
+
+    **Examples:**
+
+    Open the dashboard based on an app ID:
+
+    ```bash
+    modal app dashboard ap-123456
+    ```
+
+    Open the dashboard based on its name:
+
+    ```bash
+    modal app dashboard my-app
+    ```
+
+    """
+    env = ensure_env(env)
+    client = await _Client.from_env()
+    app_id = await get_app_id.aio(app_identifier, env, client)
+    web_url = f"https://modal.com/apps/modal-labs/{env}/{app_id}"
+
+    if _open_url(web_url):
+        rich.print(
+            "The web browser should have opened for you to access your app's dashboard.\n"
+            "If it didn't, please copy this URL into your web browser manually:\n"
+        )
+    else:
+        rich.print(
+            "[red]Was not able to launch web browser[/red]\n" "Please go to this URL manually to view the dashboard:\n"
+        )
+    rich.print(f"[link={web_url}]{web_url}[/link]\n")

--- a/modal/cli/entry_point.py
+++ b/modal/cli/entry_point.py
@@ -8,7 +8,7 @@ from rich.rule import Rule
 
 from modal._utils.async_utils import synchronizer
 
-from . import run
+from . import app, run
 from .app import app_cli
 from .config import config_cli
 from .container import container_cli
@@ -105,6 +105,9 @@ entrypoint_cli_typer.add_typer(config_cli, rich_help_panel="Configuration")
 entrypoint_cli_typer.add_typer(environment_cli, rich_help_panel="Configuration")
 entrypoint_cli_typer.add_typer(profile_cli, rich_help_panel="Configuration")
 entrypoint_cli_typer.add_typer(token_cli, rich_help_panel="Configuration")
+
+# Web
+entrypoint_cli_typer.command("dashboard", help="Open the Modal web dashboard")(app.dashboard)
 
 # Hide setup from help as it's redundant with modal token new, but nicer for onboarding
 entrypoint_cli_typer.command("setup", help="Bootstrap Modal's configuration.", rich_help_panel="Onboarding")(setup)

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2192,6 +2192,15 @@ message VolumeRemoveFileRequest {
   bool recursive = 3;
 }
 
+message WebDashboardRequest {
+  optional string app_id = 1;
+  string environment_name = 2;
+}
+
+message WebDashboardResponse {
+  string url = 1;
+}
+
 message WebUrlInfo {
   bool truncated = 1;
   bool has_unique_hash = 2 [deprecated=true];
@@ -2380,4 +2389,7 @@ service ModalClient {
 
   // Workspaces
   rpc WorkspaceNameLookup(google.protobuf.Empty) returns (WorkspaceNameLookupResponse);
+
+  // Web
+  rpc WebDashboard(WebDashboardRequest) returns (WebDashboardResponse);
 }

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2192,15 +2192,6 @@ message VolumeRemoveFileRequest {
   bool recursive = 3;
 }
 
-message WebDashboardRequest {
-  optional string app_id = 1;
-  string environment_name = 2;
-}
-
-message WebDashboardResponse {
-  string url = 1;
-}
-
 message WebUrlInfo {
   bool truncated = 1;
   bool has_unique_hash = 2 [deprecated=true];
@@ -2386,9 +2377,6 @@ service ModalClient {
   rpc VolumePutFiles(VolumePutFilesRequest) returns (google.protobuf.Empty);
   rpc VolumeReload(VolumeReloadRequest) returns (google.protobuf.Empty);
   rpc VolumeRemoveFile(VolumeRemoveFileRequest) returns (google.protobuf.Empty);
-
-  // Web
-  rpc WebDashboard(WebDashboardRequest) returns (WebDashboardResponse);
 
   // Workspaces
   rpc WorkspaceNameLookup(google.protobuf.Empty) returns (WorkspaceNameLookupResponse);

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2387,9 +2387,9 @@ service ModalClient {
   rpc VolumeReload(VolumeReloadRequest) returns (google.protobuf.Empty);
   rpc VolumeRemoveFile(VolumeRemoveFileRequest) returns (google.protobuf.Empty);
 
-  // Workspaces
-  rpc WorkspaceNameLookup(google.protobuf.Empty) returns (WorkspaceNameLookupResponse);
-
   // Web
   rpc WebDashboard(WebDashboardRequest) returns (WebDashboardResponse);
+
+  // Workspaces
+  rpc WorkspaceNameLookup(google.protobuf.Empty) returns (WorkspaceNameLookupResponse);
 }

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -525,7 +525,7 @@ def test_app_dashboard(servicer, mock_dir, set_env_client):
     res = _run(["app", "list"])
     assert re.search("my_app .+ deployed", res.stdout)
 
-    res = _run(["app", "dashboard", "my_app"])
+    res = _run(["app", "my_app"])
     expected_url = "https://modal.com/apps/modal-labs/main/ap-1"
     assert expected_url in res.stdout
 

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -518,6 +518,18 @@ def test_app_stop(servicer, mock_dir, set_env_client):
     assert not re.search("my_app .+ deployed", res.stdout)
 
 
+def test_app_dashboard(servicer, mock_dir, set_env_client):
+    with mock_dir({"myapp.py": dummy_app_file, "other_module.py": dummy_other_module_file}):
+        _run(["deploy", "myapp"])
+
+    res = _run(["app", "list"])
+    assert re.search("my_app .+ deployed", res.stdout)
+
+    res = _run(["app", "dashboard", "my_app"])
+    expected_url = "https://modal.com/apps/modal-labs/main/ap-1"
+    assert expected_url in res.stdout
+
+
 def test_nfs_get(set_env_client, servicer):
     nfs_name = "my-shared-nfs"
     _run(["nfs", "create", nfs_name])


### PR DESCRIPTION
Allows you to write

```bash
modal dashboard <app-name>
```
or
```bash
modal dashboard <app-id>
```
to automatically open your app's dashboard page in the default browser

tbh not sure if we need this

- depends on proto PR: https://github.com/modal-labs/modal-client/pull/2141
- depends on rpc PR: https://github.com/modal-labs/modal/pull/15041