### PR TITLE
Include checkpoint size in checkpoint info

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -544,6 +544,7 @@ message CancelInputEvent {
 
 message CheckpointInfo {
   string checksum = 1;
+  int64 size = 5;
   CheckpointStatus status = 2;
   string checkpoint_id = 3;
   string runtime_fingerprint = 4;

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -544,10 +544,10 @@ message CancelInputEvent {
 
 message CheckpointInfo {
   string checksum = 1;
-  int64 size = 5;
   CheckpointStatus status = 2;
   string checkpoint_id = 3;
   string runtime_fingerprint = 4;
+  int64 size = 5;
 }
 
 message ClassCreateRequest {


### PR DESCRIPTION
## Describe your changes

- _Provide Linear issue reference (e.g. MOD-1234) if available._

<details> <summary>We need the size of a gvisor checkpoint so we can restore it with imagefs (see MOD-3415). This proto lives in the client repo, but isn't actually read or written by the client (it is included in other protos used by the client; this should be fine though because extra fields are ignored).</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>
