### PR TITLE
Small fixes to modal.interact

### DIFF
--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -813,26 +813,16 @@ class _ContainerIOManager:
             else:
                 logger.debug(f"modal.Volume background commit success for {volume_id}.")
 
-    async def interact(self):
+    async def interact(self, from_breakpoint: bool = False):
         if self._is_interactivity_enabled:
             # Currently, interactivity is enabled forever
             return
         self._is_interactivity_enabled = True
 
-        if not self.function_def.pty_info:
-            raise InvalidError(
-                "Interactivity is not enabled in this function. "
-                "Use MODAL_INTERACTIVE_FUNCTIONS=1 to enable interactivity."
-            )
+        if not self.function_def.pty_info.pty_type:
+            trigger = "breakpoint()" if from_breakpoint else "modal.interact()"
+            raise InvalidError(f"Cannot use {trigger} without running Modal in interactive mode.")
 
-        if self.function_def.concurrency_limit > 1:
-            print(
-                "Warning: Interactivity is not supported on functions with concurrency > 1. "
-                "You may experience unexpected behavior."
-            )
-
-        # todo(nathan): add warning if concurrency limit > 1. but idk how to check this here
-        # todo(nathan): check if function interactivity is enabled
         try:
             await self._client.stub.FunctionStartPtyShell(Empty())
         except Exception as e:


### PR DESCRIPTION
- No longer print a warning when function has `concurrency_limit` set. While it is true that running interact from within a function that has multiple containers can cause problems, the check used for the previous warning was wrong (as the default `concurrency_limit = None` does not preclude concurrent containers), it's not always a problem, and we also print an error message when multiple streams are connected to the local PTY, which is a better signal of an actual problem.
- Fix the check for whether we tried to use `modal.interact()` without doing `modal run -i`; previously this was always passing because we were evaluating the truthiness of a protofuf _message_, which is always True even when undefined.
- Improve the error message for the check mentioned above, where we were directing the user to a since-deprecated environment variable. I changed this to a more general message (note that googling "modal interactive mode" pulls up exactly the right documentation) and also added some information to indicate whether the user tried to use `modal.interact()` directly or indirectly through `breakpoint()`
- Always set the `sys.breakpointhook` in `container_entrypoint` to run through out `interact` system so that we can error out informatively when the user forgot to do `modal run -i`.
- Add a test for the error regarding modal interactive mode.