### PR TITLE
Add worker_id to sandboxes for restricted scheduling

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           python -m venv venv
           source venv/bin/activate
-          pip install grpcio-tools
+          pip install grpcio-tools==1.59.2
           python -m grpc_tools.protoc --python_out=. --grpclib_python_out=. --grpc_python_out=. -I . modal_proto/api.proto modal_proto/options.proto
           deactivate
 

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -135,6 +135,7 @@ class _Sandbox(_Object, type_prefix="sb"):
                     )
                     for _experimental_gpu in _experimental_gpus
                 ],
+                worker_id=config.get("worker_id"),
             )
 
             # Note - `resolver.app_id` will be `None` for app-less sandboxes

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1732,6 +1732,8 @@ message Sandbox {
   reserved 16; // _experimental_scheduler
   optional SchedulerPlacement scheduler_placement = 17;
   repeated Resources _experimental_resources = 18; // overrides `resources` field above
+
+  string worker_id = 19; // for internal debugging use only
 }
 
 message SandboxCreateRequest {


### PR DESCRIPTION
## Describe your changes

Add worker ID to sandbox creation so we can pin sandboxes to specific workers for testing.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
