### PR TITLE
Adding i6pn flag to client

### DIFF
--- a/modal/config.py
+++ b/modal/config.py
@@ -220,6 +220,7 @@ _SETTINGS = {
     "traceback": _Setting(False, transform=_to_boolean),
     "image_builder_version": _Setting(),
     "strict_parameters": _Setting(False, transform=_to_boolean),  # For internal/experimental use
+    "i6pn_enabled": _Setting(False, transform=_to_boolean),
 }
 
 

--- a/modal/config.py
+++ b/modal/config.py
@@ -220,7 +220,7 @@ _SETTINGS = {
     "traceback": _Setting(False, transform=_to_boolean),
     "image_builder_version": _Setting(),
     "strict_parameters": _Setting(False, transform=_to_boolean),  # For internal/experimental use
-    "i6pn_enabled": _Setting(False, transform=_to_boolean),
+    "i6pn_enabled": _Setting(False, transform=_to_boolean),  # For internal/experimental use
 }
 
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -841,6 +841,7 @@ class _Function(typing.Generic[P, R], _Object, type_prefix="fu"):
                         )
                         for _experimental_gpu in _experimental_gpus
                     ],
+                    i6pn_enabled=config.get("i6pn_enabled"),
                 )
                 assert resolver.app_id
                 request = api_pb2.FunctionCreateRequest(

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1044,6 +1044,8 @@ message Function {
   reserved 59;
   uint32 batch_max_size = 60; // Maximum number of inputs to fetch at once
   uint64 batch_linger_ms = 61; // Miliseconds to block before a response is needed
+
+  bool i6pn_enabled = 62;
 }
 
 message FunctionBindParamsRequest {


### PR DESCRIPTION
## Describe your changes

Adding i6pn flag to client.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

This change does not affect the prior protobuf message state. This protobuf change is designed to accept future revisions of i6pn.

## Changelog
