### PR TITLE
Function `.spawn` should always return a `FunctionCall`, and the type checker should know that the returned value is not `None`

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1334,7 +1334,7 @@ class _Function(typing.Generic[P, R], _Object, type_prefix="fu"):
 
     @synchronizer.no_input_translation
     @live_method
-    async def spawn(self, *args: P.args, **kwargs: P.kwargs) -> Optional["_FunctionCall[R]"]:
+    async def spawn(self, *args: P.args, **kwargs: P.kwargs) -> "_FunctionCall[R]":
         """Calls the function with the given arguments, without waiting for the results.
 
         Returns a `modal.functions.FunctionCall` object, that can later be polled or
@@ -1345,10 +1345,9 @@ class _Function(typing.Generic[P, R], _Object, type_prefix="fu"):
         return a function handle for polling the result.
         """
         if self._is_generator:
-            await self._call_generator_nowait(args, kwargs)
-            return None
-
-        invocation = await self._call_function_nowait(args, kwargs)
+            invocation = await self._call_generator_nowait(args, kwargs)
+        else:
+            invocation = await self._call_function_nowait(args, kwargs)
         return _FunctionCall._new_hydrated(invocation.function_call_id, invocation.client, None)
 
     def get_raw_f(self) -> Callable[..., Any]:


### PR DESCRIPTION
Problem: `.spawn()` return type annotated as `Optional[FunctionCall]` rather than `FunctionCall`.

Say you want to do `outputs = modal.functions.gather(*[fn.spawn(input) for input in inputs])` - type-checker will call this wrong because `fn.spawn` can return `None`.

It's this way because apparently if the function is a generator then `.spawn()` should return `None`, mentioned [in docs](https://modal.com/docs/reference/modal.Function). But actually you over-engineered things, and even if it's a generator, the resulting `FunctionCall` is weird but fine.

I don't know how to generate your `functions.pyi` file from this PR but I hope it would turn the existing one

```python
class __spawn_spec(typing_extensions.Protocol[P_INNER, R_INNER]):
    def __call__(self, *args: P_INNER.args, **kwargs: P_INNER.kwargs) -> typing.Optional[FunctionCall[R_INNER]]: ...
    async def aio(
        self, *args: P_INNER.args, **kwargs: P_INNER.kwargs
    ) -> typing.Optional[FunctionCall[R_INNER]]: ...

spawn: __spa
```

into this, which tells my IDE, correctly, that `fn.spawn` returns a `FunctionCall`:

```python
class __spawn_spec(typing_extensions.Protocol[P_INNER, R_INNER]):
    def __call__(self, *args: P_INNER.args, **kwargs: P_INNER.kwargs) -> FunctionCall[R_INNER]: ...
    async def aio(
        self, *args: P_INNER.args, **kwargs: P_INNER.kwargs
    ) -> FunctionCall[R_INNER]: ...

```

I also don't know how to run [your `function_test.py` test](https://github.com/modal-labs/modal-client/blob/main/test/function_test.py) but I wrote a similar test that I think shows the `FunctionCall` returned for a generator with `.spawn` is fine:


```python
import modal

app = modal.App("testing")


@app.function()
def generator_function():
    yield "bar"
    yield "baz"
    yield "boo"


@app.local_entrypoint()
def main():
    normal_generator_output = [thing for thing in generator_function.remote_gen()]
    print(normal_generator_output)
    generator_fn_call = generator_function.spawn()
    generator_fn_call_output = generator_fn_call.get()
    print(generator_fn_call_output)
```

This prints:

```
['bar', 'baz', 'boo']
items_total: 3
```

so clearly the `FunctionCall` returned by `generator_function.spawn` is just fine. I don't know whether the `items_total` is just a placeholder but I don't think anyone's project will be ruined if you return this kind of `FunctionCall` and let `.spawn` return a `FunctionCall` (rather than `FunctionCall | None`).

Thanks, I hope you can make `.spawn` typing more precise. Overall the Modal client typing has been improving and I'm sure I'm not the only one who's noticed thanks for keeping things getting better! 🙏