### PR TITLE
[MOD-3547] pass-through cloud ID

### DIFF
--- a/modal/_location.py
+++ b/modal/_location.py
@@ -19,7 +19,7 @@ def parse_cloud_provider(value: str) -> "modal_proto.api_pb2.CloudProvider.V":
     except KeyError:
         # provider's int identifier may be directly specified
         try:
-            return int(value)
+            return int(value)  # type: ignore
         except ValueError:
             pass
 

--- a/modal/_location.py
+++ b/modal/_location.py
@@ -17,6 +17,12 @@ def parse_cloud_provider(value: str) -> "modal_proto.api_pb2.CloudProvider.V":
     try:
         cloud_provider = CloudProvider[value.upper()]
     except KeyError:
+        # provider's int identifier may be directly specified
+        try:
+            return int(value)
+        except ValueError:
+            pass
+
         raise InvalidError(
             f"Invalid cloud provider: {value}. "
             f"Value must be one of {[x.name.lower() for x in CloudProvider]} (case-insensitive)."


### PR DESCRIPTION
## Describe your changes

Allow passing `int` as cloud provider ID. Validated on the server-side now. 

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself