### PR TITLE
fix: modal shell should show any modal.Image build logs (incl. errors)

### DIFF
--- a/modal/runner.py
+++ b/modal/runner.py
@@ -508,7 +508,8 @@ async def _interactive_shell(_app: _App, cmds: List[str], environment_name: str 
     client = await _Client.from_env()
     async with _run_app(_app, client=client, environment_name=environment_name):
         sandbox_cmds = cmds if len(cmds) > 0 else ["/bin/bash"]
-        sandbox = await _Sandbox.create("sleep", "100000", app=_app, **kwargs)
+        with OutputManager.enable_output():  # show any image build logs
+            sandbox = await _Sandbox.create("sleep", "100000", app=_app, **kwargs)
 
         container_process = await sandbox.exec(*sandbox_cmds, pty_info=get_pty_info(shell=True))
         try:


### PR DESCRIPTION
## Describe your changes

**Previous:**

<img width="850" alt="image" src="https://github.com/user-attachments/assets/ecb583b5-34ae-4216-ae36-47f2d0c43de8">


**New:**

<img width="1067" alt="image" src="https://github.com/user-attachments/assets/0ad6748d-c219-4fc1-945e-0021e9851eb5">

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
