### PR TITLE
deprecation: remove _allow_background_volume_commits experimental flag

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -544,7 +544,6 @@ class _App:
         interactive: bool = False,  # Deprecated: use the `modal.interact()` hook instead
         secret: Optional[_Secret] = None,  # Deprecated: use `secrets`
         # Parameters below here are experimental. Use with caution!
-        _allow_background_volume_commits: None = None,
         _experimental_boost: None = None,  # Deprecated: lower latency function execution is now default.
         _experimental_scheduler_placement: Optional[
             SchedulerPlacement
@@ -676,7 +675,6 @@ class _App:
                 webhook_config=webhook_config,
                 enable_memory_snapshot=enable_memory_snapshot,
                 checkpointing_enabled=checkpointing_enabled,
-                allow_background_volume_commits=_allow_background_volume_commits,
                 block_network=block_network,
                 max_inputs=max_inputs,
                 scheduler_placement=scheduler_placement,
@@ -723,7 +721,6 @@ class _App:
         enable_memory_snapshot: bool = False,  # Enable memory checkpointing for faster cold starts.
         checkpointing_enabled: Optional[bool] = None,  # Deprecated
         block_network: bool = False,  # Whether to block network access
-        _allow_background_volume_commits: None = None,
         # Limits the number of inputs a container handles before shutting down.
         # Use `max_inputs = 1` for single-use containers.
         max_inputs: Optional[int] = None,
@@ -809,7 +806,6 @@ class _App:
                 cloud=cloud,
                 enable_memory_snapshot=enable_memory_snapshot,
                 checkpointing_enabled=checkpointing_enabled,
-                allow_background_volume_commits=_allow_background_volume_commits,
                 block_network=block_network,
                 max_inputs=max_inputs,
                 scheduler_placement=scheduler_placement,
@@ -867,7 +863,6 @@ class _App:
         volumes: Dict[
             Union[str, PurePosixPath], Union[_Volume, _CloudBucketMount]
         ] = {},  # Mount points for Modal Volumes and CloudBucketMounts
-        _allow_background_volume_commits: None = None,
         pty_info: Optional[api_pb2.PTYInfo] = None,
         _experimental_scheduler_placement: Optional[
             SchedulerPlacement
@@ -890,21 +885,6 @@ class _App:
         if not self._running_app:
             raise InvalidError("`app.spawn_sandbox` requires a running app.")
 
-        if _allow_background_volume_commits is False:
-            deprecation_error(
-                (2024, 5, 13),
-                "Disabling volume background commits is now deprecated. "
-                "Remove _allow_background_volume_commits=False to enable the functionality.",
-            )
-        elif _allow_background_volume_commits is True:
-            deprecation_warning(
-                (2024, 7, 18),
-                "Setting volume background commits is deprecated. "
-                "The functionality is now unconditionally enabled (set to True).",
-            )
-        elif _allow_background_volume_commits is None:
-            _allow_background_volume_commits = True
-
         return await _Sandbox.create(
             *entrypoint_args,
             app=self,
@@ -923,7 +903,6 @@ class _App:
             block_network=block_network,
             volumes=volumes,
             pty_info=pty_info,
-            _allow_background_volume_commits=_allow_background_volume_commits,
             _experimental_scheduler_placement=_experimental_scheduler_placement,
             client=self._client,
         )

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -438,7 +438,6 @@ class _Cls(_Object, type_prefix="cs"):
         concurrency_limit: Optional[int] = None,
         allow_concurrent_inputs: Optional[int] = None,
         container_idle_timeout: Optional[int] = None,
-        allow_background_volume_commits: Optional[bool] = None,
     ) -> "_Cls":
         """
         Beta: Allows for the runtime modification of a modal.Cls's configuration.
@@ -464,7 +463,7 @@ class _Cls(_Object, type_prefix="cs"):
             api_pb2.VolumeMount(
                 mount_path=path,
                 volume_id=volume.object_id,
-                allow_background_commits=allow_background_volume_commits,
+                allow_background_commits=True,
             )
             for path, volume in validate_volumes(volumes)
         ]

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -504,7 +504,6 @@ class _Function(typing.Generic[P, R], _Object, type_prefix="fu"):
         is_auto_snapshot: bool = False,
         enable_memory_snapshot: bool = False,
         checkpointing_enabled: Optional[bool] = None,
-        allow_background_volume_commits: Optional[bool] = None,
         block_network: bool = False,
         max_inputs: Optional[int] = None,
         ephemeral_disk: Optional[int] = None,
@@ -532,21 +531,6 @@ class _Function(typing.Generic[P, R], _Object, type_prefix="fu"):
                 "The argument `checkpointing_enabled` is now deprecated. Use `enable_memory_snapshot` instead.",
             )
             enable_memory_snapshot = checkpointing_enabled
-
-        if allow_background_volume_commits is False:
-            deprecation_error(
-                (2024, 5, 13),
-                "Disabling volume background commits is now deprecated. "
-                "Remove _allow_background_volume_commits=False to enable the functionality.",
-            )
-        elif allow_background_volume_commits is True:
-            deprecation_warning(
-                (2024, 7, 18),
-                "Setting volume background commits is deprecated. "
-                "The functionality is now unconditionally enabled (set to True).",
-            )
-        elif allow_background_volume_commits is None:
-            allow_background_volume_commits = True
 
         explicit_mounts = mounts
 
@@ -775,7 +759,7 @@ class _Function(typing.Generic[P, R], _Object, type_prefix="fu"):
                     api_pb2.VolumeMount(
                         mount_path=path,
                         volume_id=volume.object_id,
-                        allow_background_commits=bool(allow_background_volume_commits),
+                        allow_background_commits=True,
                     )
                     for path, volume in validated_volumes
                 ]


### PR DESCRIPTION
## Describe your changes

🧹 clean up. 

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself


---

</details>

## Changelog

* The experimental `allow_background_volume_commits` argument, previously deprecated, is now removed.
