### PR TITLE
Add created_at field to EnvironmentListItem proto

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -910,6 +910,7 @@ message EnvironmentDeleteRequest {
 message EnvironmentListItem {
   string name = 1;
   string webhook_suffix = 2;
+  double created_at = 3;
 }
 
 message EnvironmentListResponse {


### PR DESCRIPTION
## Describe your changes

Part of MOD-3533.

We are adding a `created_by` field to the Environments table. This PR adds that field to the proto object so it will be included in `EnvironmentListResponse`. 

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
