### PR TITLE
Add docs on how to use with app.run(): ... ctx manager

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -309,6 +309,28 @@ class _App:
         to Modal functions should be made within the scope of this context
         manager, and they will correspond to the current app.
 
+        **Example**
+
+        ```python
+        with app.run():
+            some_modal_function.remote()
+        ```
+
+        To enable output printing, use `modal.enable_output()`:
+
+        ```python
+        with modal.enable_output():
+            with app.run():
+                some_modal_function.remote()
+        ```
+
+        You can call the function using `modal run` directly from the CLI:
+
+        ```shell
+        modal run app_module.py
+        ```
+
+
         Note that this method used to return a separate "App" object. This is
         no longer useful since you can use the app itself for access to all
         objects. For backwards compatibility reasons, it returns the same app.

--- a/modal/app.py
+++ b/modal/app.py
@@ -324,10 +324,19 @@ class _App:
                 some_modal_function.remote()
         ```
 
-        You can call the function using `modal run` directly from the CLI:
+        Note that you cannot invoke this in global scope. If you want to run it as your entrypoint,
+        consider wrapping it:
+
+        ```python
+        if __name__ == "__main__":
+            with app.run():
+                some_modal_function.remote()
+        ```
+
+        You can then run your script with:
 
         ```shell
-        modal run app_module.py
+        python app_module.py
         ```
 
 

--- a/modal/app.py
+++ b/modal/app.py
@@ -324,8 +324,10 @@ class _App:
                 some_modal_function.remote()
         ```
 
-        Note that you cannot invoke this in global scope. If you want to run it as your entrypoint,
-        consider wrapping it:
+        Note that you cannot invoke this in global scope of a file where you have
+        Modal functions or Classes, since that would run the block when the function
+        or class is imported in your containers as well. If you want to run it as
+        your entrypoint, consider wrapping it:
 
         ```python
         if __name__ == "__main__":


### PR DESCRIPTION
Adds inline docs to `App.run` showing how to run app ephemerally:

```py
with app.run():
  ...
```