### PR TITLE
Protobuf for flexible concurrent inputs

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1136,13 +1136,13 @@ message FunctionGetCallGraphResponse {
   repeated FunctionCallCallGraphInfo function_calls = 2;
 }
 
-message FunctionGetConcurrencyRequest{
+message FunctionGetDynamicConcurrencyRequest{
   string function_id = 1;
   uint32 target_concurrency = 2;
   uint32 max_concurrency = 3;
 }
 
-message FunctionGetConcurrencyResponse {
+message FunctionGetDynamicConcurrencyResponse {
   uint32 concurrency = 1;
 }
 
@@ -2310,7 +2310,7 @@ service ModalClient {
   rpc FunctionCreate(FunctionCreateRequest) returns (FunctionCreateResponse);
   rpc FunctionGet(FunctionGetRequest) returns (FunctionGetResponse);
   rpc FunctionGetCallGraph(FunctionGetCallGraphRequest) returns (FunctionGetCallGraphResponse);
-  rpc FunctionGetConcurrency(FunctionGetConcurrencyRequest) returns (FunctionGetConcurrencyResponse);
+  rpc FunctionGetDynamicConcurrency(FunctionGetDynamicConcurrencyRequest) returns (FunctionGetDynamicConcurrencyResponse);
   rpc FunctionGetCurrentStats(FunctionGetCurrentStatsRequest) returns (FunctionStats);
   rpc FunctionGetInputs(FunctionGetInputsRequest) returns (FunctionGetInputsResponse);  // For containers to request next call
   rpc FunctionGetOutputs(FunctionGetOutputsRequest) returns (FunctionGetOutputsResponse);  // Returns the next result(s) for an entire function call (FunctionMap)

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1135,6 +1135,10 @@ message FunctionGetCallGraphResponse {
   repeated FunctionCallCallGraphInfo function_calls = 2;
 }
 
+message FunctionGetCurrentStatsRequest {
+  string function_id = 1;
+}
+
 message FunctionGetDynamicConcurrencyRequest{
   string function_id = 1;
   uint32 target_concurrency = 2;
@@ -1143,10 +1147,6 @@ message FunctionGetDynamicConcurrencyRequest{
 
 message FunctionGetDynamicConcurrencyResponse {
   uint32 concurrency = 1;
-}
-
-message FunctionGetCurrentStatsRequest {
-  string function_id = 1;
 }
 
 message FunctionGetInputsItem {
@@ -2309,8 +2309,8 @@ service ModalClient {
   rpc FunctionCreate(FunctionCreateRequest) returns (FunctionCreateResponse);
   rpc FunctionGet(FunctionGetRequest) returns (FunctionGetResponse);
   rpc FunctionGetCallGraph(FunctionGetCallGraphRequest) returns (FunctionGetCallGraphResponse);
-  rpc FunctionGetDynamicConcurrency(FunctionGetDynamicConcurrencyRequest) returns (FunctionGetDynamicConcurrencyResponse);
   rpc FunctionGetCurrentStats(FunctionGetCurrentStatsRequest) returns (FunctionStats);
+  rpc FunctionGetDynamicConcurrency(FunctionGetDynamicConcurrencyRequest) returns (FunctionGetDynamicConcurrencyResponse);
   rpc FunctionGetInputs(FunctionGetInputsRequest) returns (FunctionGetInputsResponse);  // For containers to request next call
   rpc FunctionGetOutputs(FunctionGetOutputsRequest) returns (FunctionGetOutputsResponse);  // Returns the next result(s) for an entire function call (FunctionMap)
   rpc FunctionGetSerialized(FunctionGetSerializedRequest) returns (FunctionGetSerializedResponse);

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1048,6 +1048,7 @@ message Function {
   uint64 batch_linger_ms = 61; // Miliseconds to block before a response is needed
   bool i6pn_enabled = 62;
   bool _experimental_concurrent_cancellations = 63;
+  uint32 max_concurrent_inputs = 64; // Maximum when attempting to override input concurrency TODO: name change
 }
 
 message FunctionBindParamsRequest {
@@ -1135,9 +1136,20 @@ message FunctionGetCallGraphResponse {
   repeated FunctionCallCallGraphInfo function_calls = 2;
 }
 
+message FunctionGetConcurrencyRequest{
+  string function_id = 1;
+  uint32 target_concurrency = 2;
+  uint32 max_concurrency = 3;
+}
+
+message FunctionGetConcurrencyResponse {
+  uint32 concurrency = 1;
+}
+
 message FunctionGetCurrentStatsRequest {
   string function_id = 1;
 }
+
 message FunctionGetInputsItem {
   string input_id = 1;
   FunctionInput input = 2;
@@ -2299,6 +2311,7 @@ service ModalClient {
   rpc FunctionGet(FunctionGetRequest) returns (FunctionGetResponse);
   rpc FunctionGetCallGraph(FunctionGetCallGraphRequest) returns (FunctionGetCallGraphResponse);
   rpc FunctionGetCurrentStats(FunctionGetCurrentStatsRequest) returns (FunctionStats);
+  rpc FunctionGetConcurrency(FunctionGetConcurrencyRequest) returns (FunctionGetConcurrencyResponse);
   rpc FunctionGetInputs(FunctionGetInputsRequest) returns (FunctionGetInputsResponse);  // For containers to request next call
   rpc FunctionGetOutputs(FunctionGetOutputsRequest) returns (FunctionGetOutputsResponse);  // Returns the next result(s) for an entire function call (FunctionMap)
   rpc FunctionGetSerialized(FunctionGetSerializedRequest) returns (FunctionGetSerializedResponse);

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -739,14 +739,6 @@ message ContainerStopRequest {
 message ContainerStopResponse {
 }
 
-message ContainerConcurrencyStatusRequest{
-  uint32 max_concurrency = 1;
-}
-
-message ContainerConcurrencyStatusResponse {
-  uint32 concurrency = 1;
-}
-
 message CustomDomainConfig {
   string name = 1;
 }
@@ -2318,8 +2310,8 @@ service ModalClient {
   rpc FunctionCreate(FunctionCreateRequest) returns (FunctionCreateResponse);
   rpc FunctionGet(FunctionGetRequest) returns (FunctionGetResponse);
   rpc FunctionGetCallGraph(FunctionGetCallGraphRequest) returns (FunctionGetCallGraphResponse);
-  rpc FunctionGetCurrentStats(FunctionGetCurrentStatsRequest) returns (FunctionStats);
   rpc FunctionGetConcurrency(FunctionGetConcurrencyRequest) returns (FunctionGetConcurrencyResponse);
+  rpc FunctionGetCurrentStats(FunctionGetCurrentStatsRequest) returns (FunctionStats);
   rpc FunctionGetInputs(FunctionGetInputsRequest) returns (FunctionGetInputsResponse);  // For containers to request next call
   rpc FunctionGetOutputs(FunctionGetOutputsRequest) returns (FunctionGetOutputsResponse);  // Returns the next result(s) for an entire function call (FunctionMap)
   rpc FunctionGetSerialized(FunctionGetSerializedRequest) returns (FunctionGetSerializedResponse);


### PR DESCRIPTION
## Describe your changes

Added rpc for client to get desired concurrency from server.
---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

