### PR TITLE
Support dynamic max_concurrency in client concurrency logic

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -211,9 +211,6 @@ class DaemonizedThreadPool:
     # Used instead of ThreadPoolExecutor, since the latter won't allow
     # the interpreter to shut down before the currently running tasks
     # have finished
-    def __init__(self, max_threads):
-        self.max_threads = max_threads
-
     def __enter__(self):
         self.spawned_workers = 0
         self.inputs: queue.Queue[Any] = queue.Queue()
@@ -246,9 +243,8 @@ class DaemonizedThreadPool:
                     logger.exception(f"Exception raised by {_func} in DaemonizedThreadPool worker!")
                 self.inputs.task_done()
 
-        if self.spawned_workers < self.max_threads:
-            threading.Thread(target=worker_thread, daemon=True).start()
-            self.spawned_workers += 1
+        threading.Thread(target=worker_thread, daemon=True).start()
+        self.spawned_workers += 1
 
         self.inputs.put((func, args))
 
@@ -321,9 +317,9 @@ def call_function(
     user_code_event_loop: UserCodeEventLoop,
     container_io_manager: "modal._container_io_manager.ContainerIOManager",
     finalized_functions: Dict[str, FinalizedFunction],
-    input_concurrency: int,
-    batch_max_size: Optional[int],
-    batch_wait_ms: Optional[int],
+    target_input_concurrency: int,
+    batch_max_size: int,
+    batch_wait_ms: int,
 ):
     async def run_input_async(io_context: IOContext) -> None:
         started_at = time.time()
@@ -416,8 +412,8 @@ def call_function(
                 )
         reset_context()
 
-    if input_concurrency > 1:
-        with DaemonizedThreadPool(max_threads=input_concurrency) as thread_pool:
+    if target_input_concurrency > 1:
+        with DaemonizedThreadPool() as thread_pool:
 
             def make_async_cancel_callback(task):
                 def f():
@@ -448,7 +444,7 @@ def call_function(
                 # for them to resolve gracefully:
                 async with TaskContext(0.01) as task_context:
                     async for io_context in container_io_manager.run_inputs_outputs.aio(
-                        finalized_functions, input_concurrency, batch_max_size, batch_wait_ms
+                        finalized_functions, batch_max_size, batch_wait_ms
                     ):
                         # Note that run_inputs_outputs will not return until the concurrency semaphore has
                         # released all its slots so that they can be acquired by the run_inputs_outputs finalizer
@@ -464,9 +460,7 @@ def call_function(
 
             user_code_event_loop.run(run_concurrent_inputs())
     else:
-        for io_context in container_io_manager.run_inputs_outputs(
-            finalized_functions, input_concurrency, batch_max_size, batch_wait_ms
-        ):
+        for io_context in container_io_manager.run_inputs_outputs(finalized_functions, batch_max_size, batch_wait_ms):
             if io_context.finalized_function.is_async:
                 user_code_event_loop.run(run_input_async(io_context))
             else:
@@ -717,7 +711,6 @@ def deserialize_params(serialized_params: bytes, function_def: api_pb2.Function,
 def main(container_args: api_pb2.ContainerArguments, client: Client):
     # This is a bit weird but we need both the blocking and async versions of ContainerIOManager.
     # At some point, we should fix that by having built-in support for running "user code"
-    container_io_manager = ContainerIOManager(container_args, client)
     active_app: Optional[_App] = None
     service: Service
     function_def = container_args.function_def
@@ -727,6 +720,21 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
     is_snapshotting_function = (
         function_def.is_checkpointing_function and os.environ.get("MODAL_ENABLE_SNAP_RESTORE", "0") == "1"
     )
+
+    # Container can fetch multiple inputs simultaneously
+    if function_def.pty_info.pty_type == api_pb2.PTYInfo.PTY_TYPE_SHELL:
+        # Concurrency and batching doesn't apply for `modal shell`.
+        target_concurrency = 1
+        max_concurrency = 0
+        batch_max_size = 0
+        batch_wait_ms = 0
+    else:
+        target_concurrency = function_def.allow_concurrent_inputs or 1
+        max_concurrency = function_def.max_concurrent_inputs or 0
+        batch_max_size = function_def.batch_max_size or 0
+        batch_wait_ms = function_def.batch_linger_ms or 0
+
+    container_io_manager = ContainerIOManager(container_args, client, target_concurrency, max_concurrency)
 
     _client: _Client = synchronizer._translate_in(client)  # TODO(erikbern): ugly
 
@@ -766,17 +774,6 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
             if active_app is None:
                 # if the app can't be inferred by the imported function, use name-based fallback
                 active_app = get_active_app_fallback(function_def)
-
-        # Container can fetch multiple inputs simultaneously
-        if function_def.pty_info.pty_type == api_pb2.PTYInfo.PTY_TYPE_SHELL:
-            # Concurrency and batching doesn't apply for `modal shell`.
-            input_concurrency = 1
-            batch_max_size = 0
-            batch_wait_ms = 0
-        else:
-            input_concurrency = function_def.allow_concurrent_inputs or 1
-            batch_max_size = function_def.batch_max_size or 0
-            batch_wait_ms = function_def.batch_linger_ms or 0
 
         # Get ids and metadata for objects (primarily functions and classes) on the app
         container_app: RunningApp = container_io_manager.get_app_objects()
@@ -842,7 +839,7 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
                 event_loop,
                 container_io_manager,
                 finalized_functions,
-                input_concurrency,
+                target_concurrency,
                 batch_max_size,
                 batch_wait_ms,
             )

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -69,7 +69,7 @@ if TYPE_CHECKING:
 def construct_webhook_callable(
     user_defined_callable: Callable,
     webhook_config: api_pb2.WebhookConfig,
-    container_io_manager: "modal._container_io_manager.ContainerIOManager",
+    container_io_manager: ContainerIOManager,
 ):
     # For webhooks, the user function is used to construct an asgi app:
     if webhook_config.type == api_pb2.WEBHOOK_TYPE_ASGI_APP:

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -447,21 +447,20 @@ def call_function(
                 # but the wrapping *tasks* may not yet have been resolved, so we add a 0.01s
                 # for them to resolve gracefully:
                 async with TaskContext(0.01) as task_context:
-                    with container_io_manager.dynamic_concurrency_manager():
-                        async for io_context in container_io_manager.run_inputs_outputs.aio(
-                            finalized_functions, batch_max_size, batch_wait_ms
-                        ):
-                            # Note that run_inputs_outputs will not return until the concurrency semaphore has
-                            # released all its slots so that they can be acquired by the run_inputs_outputs finalizer
-                            # This prevents leaving the task_context before outputs have been created
-                            # TODO: refactor to make this a bit more easy to follow?
-                            if io_context.finalized_function.is_async:
-                                input_task = task_context.create_task(run_input_async(io_context))
-                                io_context.set_cancel_callback(make_async_cancel_callback(input_task))
-                            else:
-                                # run sync input in thread
-                                thread_pool.submit(run_input_sync, io_context)
-                                io_context.set_cancel_callback(cancel_callback_sync)
+                    async for io_context in container_io_manager.run_inputs_outputs.aio(
+                        finalized_functions, batch_max_size, batch_wait_ms
+                    ):
+                        # Note that run_inputs_outputs will not return until the concurrency manager has
+                        # released all its slots so that they can be acquired by the run_inputs_outputs finalizer
+                        # This prevents leaving the task_context before outputs have been created
+                        # TODO: refactor to make this a bit more easy to follow?
+                        if io_context.finalized_function.is_async:
+                            input_task = task_context.create_task(run_input_async(io_context))
+                            io_context.set_cancel_callback(make_async_cancel_callback(input_task))
+                        else:
+                            # run sync input in thread
+                            thread_pool.submit(run_input_sync, io_context)
+                            io_context.set_cancel_callback(cancel_callback_sync)
 
             user_code_event_loop.run(run_concurrent_inputs())
     else:

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -246,7 +246,7 @@ class DaemonizedThreadPool:
                     logger.exception(f"Exception raised by {_func} in DaemonizedThreadPool worker!")
                 self.inputs.task_done()
 
-        if self.spawned_workers < self.concurrency_manager.get_input_concurrency():
+        if self.spawned_workers < self.container_io_manager.get_input_concurrency():
             threading.Thread(target=worker_thread, daemon=True).start()
             self.spawned_workers += 1
 
@@ -734,7 +734,7 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
         batch_wait_ms = 0
     else:
         target_concurrency = function_def.allow_concurrent_inputs or 1
-        max_concurrency = 0  # TODO(cathy) add this with interface
+        max_concurrency = function_def.max_concurrent_inputs or 0
         batch_max_size = function_def.batch_max_size or 0
         batch_wait_ms = function_def.batch_linger_ms or 0
 

--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -280,7 +280,7 @@ class _ContainerIOManager:
             max_concurrency = 0
         else:
             target_concurrency = container_args.function_def.allow_concurrent_inputs or 1
-            max_concurrency = container_args.function_def.max_concurrent_inputs or 0
+            max_concurrency = container_args.function_def.max_concurrent_inputs or target_concurrency
 
         self._target_concurrency = target_concurrency
         self._max_concurrency = max_concurrency
@@ -939,6 +939,10 @@ class _ContainerIOManager:
     @property
     def target_concurrency(self) -> int:
         return self._target_concurrency
+
+    @property
+    def max_concurrency(self) -> int:
+        return self._max_concurrency
 
     @classmethod
     def get_input_concurrency(cls) -> int:

--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -403,7 +403,6 @@ class _ContainerIOManager:
     async def _dynamic_concurrency_loop(self):
         logger.debug(f"Starting dynamic concurrency loop for task {self.task_id}")
         while 1:
-            t0 = time.monotonic()
             try:
                 request = api_pb2.FunctionGetDynamicConcurrencyRequest(
                     function_id=self.function_id,
@@ -422,9 +421,7 @@ class _ContainerIOManager:
             except Exception as exc:
                 logger.debug(f"Failed to get dynamic concurrency for task {self.task_id}, {exc}")
 
-            duration = time.monotonic() - t0
-            time_until_next = max(0.0, DYNAMIC_CONCURRENCY_INTERVAL_SECS - duration)
-            await asyncio.sleep(time_until_next)
+            await asyncio.sleep(DYNAMIC_CONCURRENCY_INTERVAL_SECS)
 
     async def get_app_objects(self) -> RunningApp:
         req = api_pb2.AppGetObjectsRequest(app_id=self.app_id, include_unindexed=True)

--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -8,7 +8,7 @@ import signal
 import sys
 import time
 import traceback
-from contextlib import nullcontext
+from contextlib import AsyncExitStack
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, AsyncGenerator, AsyncIterator, Callable, ClassVar, Dict, List, Optional, Tuple
@@ -627,7 +627,7 @@ class _ContainerIOManager:
         # - if no input is fetched, release the concurrency_manager.
         # - or, when the output for the fetched input is sent, release the concurrency_manager.
         dynamic_concurrency_manager = (
-            self.dynamic_concurrency_manager() if self._max_concurrency > self._target_concurrency else nullcontext()
+            self.dynamic_concurrency_manager() if self._max_concurrency > self._target_concurrency else AsyncExitStack()
         )
         async with dynamic_concurrency_manager:
             async for inputs in self._generate_inputs(batch_max_size, batch_wait_ms):

--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -263,7 +263,6 @@ class ConcurrencyManager(asyncio.Semaphore):
             super().release()
 
     def get_concurrency(self) -> int:
-        # Return 0 if concurrency manager not initialized
         return self._concurrency or 0
 
     def set_concurrency(self, new_concurrency: int) -> None:

--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -181,10 +181,15 @@ class IOContext:
 class ConcurrencyManager:
     """A semaphore that allows dynamically adjusting the concurrency."""
 
+    active: int
+    value: int
+    waiter: Optional[asyncio.Future]
+    closed: bool
+
     def __init__(self, value: int) -> None:
         self.active = 0
         self.value = value
-        self.waiter: asyncio.Future | None = None
+        self.waiter = None
         self.closed = False
 
     async def acquire(self) -> None:
@@ -410,7 +415,7 @@ class _ContainerIOManager:
                     resp = await retry_transient_errors(
                         self._client.stub.FunctionGetDynamicConcurrency,
                         request,
-                        attempt_timeout=DYNAMIC_CONCURRENCY_INTERVAL_SECS,
+                        attempt_timeout=DYNAMIC_CONCURRENCY_TIMEOUT_SECS,
                     )
 
                     self._concurrency_manager.set_value(resp.concurrency)

--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -954,8 +954,10 @@ class _ContainerIOManager:
         assert cls._singleton
         cls._singleton._fetching_inputs = False
 
-    def get_input_concurrency(self) -> int:
-        return self._concurrency_manager.get_concurrency()
+    @classmethod
+    def get_input_concurrency(cls) -> int:
+        io_manager = cls._singleton
+        return io_manager._concurrency_manager.get_concurrency()
 
 
 ContainerIOManager = synchronize_api(_ContainerIOManager)

--- a/modal/experimental.py
+++ b/modal/experimental.py
@@ -7,3 +7,9 @@ def stop_fetching_inputs():
     The container will exit gracefully after the current input is processed."""
 
     _ContainerIOManager.stop_fetching_inputs()
+
+
+def get_local_input_concurrency():
+    """Return the container's local input concurrency."""
+
+    return _ContainerIOManager.get_input_concurrency()

--- a/modal/experimental.py
+++ b/modal/experimental.py
@@ -10,6 +10,6 @@ def stop_fetching_inputs():
 
 
 def get_local_input_concurrency():
-    """Return the container's local input concurrency."""
+    """Get the container's local input concurrency. Return 0 if the container is not running."""
 
     return _ContainerIOManager.get_input_concurrency()

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1048,6 +1048,7 @@ message Function {
   uint64 batch_linger_ms = 61; // Miliseconds to block before a response is needed
   bool i6pn_enabled = 62;
   bool _experimental_concurrent_cancellations = 63;
+  uint32 max_concurrent_inputs = 64;
 }
 
 message FunctionBindParamsRequest {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1138,6 +1138,17 @@ message FunctionGetCallGraphResponse {
 message FunctionGetCurrentStatsRequest {
   string function_id = 1;
 }
+
+message FunctionGetDynamicConcurrencyRequest{
+  string function_id = 1;
+  uint32 target_concurrency = 2;
+  uint32 max_concurrency = 3;
+}
+
+message FunctionGetDynamicConcurrencyResponse {
+  uint32 concurrency = 1;
+}
+
 message FunctionGetInputsItem {
   string input_id = 1;
   FunctionInput input = 2;
@@ -2299,6 +2310,7 @@ service ModalClient {
   rpc FunctionGet(FunctionGetRequest) returns (FunctionGetResponse);
   rpc FunctionGetCallGraph(FunctionGetCallGraphRequest) returns (FunctionGetCallGraphResponse);
   rpc FunctionGetCurrentStats(FunctionGetCurrentStatsRequest) returns (FunctionStats);
+  rpc FunctionGetDynamicConcurrency(FunctionGetDynamicConcurrencyRequest) returns (FunctionGetDynamicConcurrencyResponse);
   rpc FunctionGetInputs(FunctionGetInputsRequest) returns (FunctionGetInputsResponse);  // For containers to request next call
   rpc FunctionGetOutputs(FunctionGetOutputsRequest) returns (FunctionGetOutputsResponse);  // Returns the next result(s) for an entire function call (FunctionMap)
   rpc FunctionGetSerialized(FunctionGetSerializedRequest) returns (FunctionGetSerializedResponse);

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -763,6 +763,9 @@ class MockClientServicer(api_grpc.ModalClientBase):
         yield self.put_outputs_barrier
         self.put_outputs_barrier = threading.Barrier(1)
 
+    async def FunctionGetDynamicConcurrency(self, stream):
+        await stream.send_message(api_pb2.FunctionGetDynamicConcurrencyResponse(concurrency=5))
+
     async def FunctionGetInputs(self, stream):
         await asyncio.get_running_loop().run_in_executor(None, self.get_inputs_barrier.wait)
         request: api_pb2.FunctionGetInputsRequest = await stream.recv_message()

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -63,7 +63,7 @@ async def test_container_function_lazily_imported(container_client):
 async def test_container_snapshot_restore(container_client, tmpdir, servicer):
     # Get a reference to a Client instance in memory
     old_client = container_client
-    io_manager = ContainerIOManager(api_pb2.ContainerArguments(), container_client, 1, 0)
+    io_manager = ContainerIOManager(api_pb2.ContainerArguments(), container_client)
     restore_path = temp_restore_path(tmpdir)
     with mock.patch.dict(
         os.environ, {"MODAL_RESTORE_STATE_PATH": str(restore_path), "MODAL_SERVER_URL": servicer.container_addr}
@@ -77,7 +77,7 @@ async def test_container_snapshot_restore(container_client, tmpdir, servicer):
 async def test_container_snapshot_restore_heartbeats(tmpdir, servicer):
     client = _Client(servicer.container_addr, api_pb2.CLIENT_TYPE_CONTAINER, ("ta-123", "task-secret"))
     async with client as async_client:
-        io_manager = _ContainerIOManager(api_pb2.ContainerArguments(), async_client, 1, 0)
+        io_manager = _ContainerIOManager(api_pb2.ContainerArguments(), async_client)
         restore_path = temp_restore_path(tmpdir)
 
         # Ensure that heartbeats only run after the snapshot
@@ -102,7 +102,7 @@ async def test_container_snapshot_restore_heartbeats(tmpdir, servicer):
 @pytest.mark.asyncio
 async def test_container_debug_snapshot(container_client, tmpdir, servicer):
     # Get an IO manager, where restore takes place
-    io_manager = ContainerIOManager(api_pb2.ContainerArguments(), container_client, 1, 0)
+    io_manager = ContainerIOManager(api_pb2.ContainerArguments(), container_client)
     restore_path = tmpdir.join("fake-restore-state.json")
     # Write the restore file to start a debugger
     restore_path.write_text(
@@ -154,7 +154,7 @@ def weird_torch_module():
 
 @pytest.mark.asyncio
 async def test_container_snapshot_patching(fake_torch_module, container_client, tmpdir, servicer):
-    io_manager = ContainerIOManager(api_pb2.ContainerArguments(), container_client, 1, 0)
+    io_manager = ContainerIOManager(api_pb2.ContainerArguments(), container_client)
 
     # bring fake torch into scope and call the utility fn
     import torch
@@ -174,7 +174,7 @@ async def test_container_snapshot_patching(fake_torch_module, container_client, 
 
 @pytest.mark.asyncio
 async def test_container_snapshot_patching_err(weird_torch_module, container_client, tmpdir, servicer):
-    io_manager = ContainerIOManager(api_pb2.ContainerArguments(), container_client, 1, 0)
+    io_manager = ContainerIOManager(api_pb2.ContainerArguments(), container_client)
     restore_path = temp_restore_path(tmpdir)
 
     # bring weird torch into scope and call the utility fn
@@ -191,7 +191,7 @@ async def test_container_snapshot_patching_err(weird_torch_module, container_cli
 def test_interact(container_client, servicer):
     # Initialize container singleton
     function_def = api_pb2.Function(pty_info=api_pb2.PTYInfo(pty_type=api_pb2.PTYInfo.PTY_TYPE_SHELL))
-    ContainerIOManager(api_pb2.ContainerArguments(function_def=function_def), container_client, 1, 0)
+    ContainerIOManager(api_pb2.ContainerArguments(function_def=function_def), container_client)
     with servicer.intercept() as ctx:
         ctx.add_response("FunctionStartPtyShell", Empty())
         interact()
@@ -199,6 +199,6 @@ def test_interact(container_client, servicer):
 
 def test_interact_no_pty_error(container_client, servicer):
     # Initialize container singleton
-    ContainerIOManager(api_pb2.ContainerArguments(), container_client, 1, 0)
+    ContainerIOManager(api_pb2.ContainerArguments(), container_client)
     with pytest.raises(InvalidError, match=r"modal.interact\(\) without running Modal in interactive mode"):
         interact()

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -63,7 +63,7 @@ async def test_container_function_lazily_imported(container_client):
 async def test_container_snapshot_restore(container_client, tmpdir, servicer):
     # Get a reference to a Client instance in memory
     old_client = container_client
-    io_manager = ContainerIOManager(api_pb2.ContainerArguments(), container_client)
+    io_manager = ContainerIOManager(api_pb2.ContainerArguments(), container_client, 1, 0)
     restore_path = temp_restore_path(tmpdir)
     with mock.patch.dict(
         os.environ, {"MODAL_RESTORE_STATE_PATH": str(restore_path), "MODAL_SERVER_URL": servicer.container_addr}
@@ -77,7 +77,7 @@ async def test_container_snapshot_restore(container_client, tmpdir, servicer):
 async def test_container_snapshot_restore_heartbeats(tmpdir, servicer):
     client = _Client(servicer.container_addr, api_pb2.CLIENT_TYPE_CONTAINER, ("ta-123", "task-secret"))
     async with client as async_client:
-        io_manager = _ContainerIOManager(api_pb2.ContainerArguments(), async_client)
+        io_manager = _ContainerIOManager(api_pb2.ContainerArguments(), async_client, 1, 0)
         restore_path = temp_restore_path(tmpdir)
 
         # Ensure that heartbeats only run after the snapshot
@@ -102,7 +102,7 @@ async def test_container_snapshot_restore_heartbeats(tmpdir, servicer):
 @pytest.mark.asyncio
 async def test_container_debug_snapshot(container_client, tmpdir, servicer):
     # Get an IO manager, where restore takes place
-    io_manager = ContainerIOManager(api_pb2.ContainerArguments(), container_client)
+    io_manager = ContainerIOManager(api_pb2.ContainerArguments(), container_client, 1, 0)
     restore_path = tmpdir.join("fake-restore-state.json")
     # Write the restore file to start a debugger
     restore_path.write_text(
@@ -154,7 +154,7 @@ def weird_torch_module():
 
 @pytest.mark.asyncio
 async def test_container_snapshot_patching(fake_torch_module, container_client, tmpdir, servicer):
-    io_manager = ContainerIOManager(api_pb2.ContainerArguments(), container_client)
+    io_manager = ContainerIOManager(api_pb2.ContainerArguments(), container_client, 1, 0)
 
     # bring fake torch into scope and call the utility fn
     import torch
@@ -174,7 +174,7 @@ async def test_container_snapshot_patching(fake_torch_module, container_client, 
 
 @pytest.mark.asyncio
 async def test_container_snapshot_patching_err(weird_torch_module, container_client, tmpdir, servicer):
-    io_manager = ContainerIOManager(api_pb2.ContainerArguments(), container_client)
+    io_manager = ContainerIOManager(api_pb2.ContainerArguments(), container_client, 1, 0)
     restore_path = temp_restore_path(tmpdir)
 
     # bring weird torch into scope and call the utility fn
@@ -191,7 +191,7 @@ async def test_container_snapshot_patching_err(weird_torch_module, container_cli
 def test_interact(container_client, servicer):
     # Initialize container singleton
     function_def = api_pb2.Function(pty_info=api_pb2.PTYInfo(pty_type=api_pb2.PTYInfo.PTY_TYPE_SHELL))
-    ContainerIOManager(api_pb2.ContainerArguments(function_def=function_def), container_client)
+    ContainerIOManager(api_pb2.ContainerArguments(function_def=function_def), container_client, 1, 0)
     with servicer.intercept() as ctx:
         ctx.add_response("FunctionStartPtyShell", Empty())
         interact()
@@ -199,6 +199,6 @@ def test_interact(container_client, servicer):
 
 def test_interact_no_pty_error(container_client, servicer):
     # Initialize container singleton
-    ContainerIOManager(api_pb2.ContainerArguments(), container_client)
+    ContainerIOManager(api_pb2.ContainerArguments(), container_client, 1, 0)
     with pytest.raises(InvalidError, match=r"modal.interact\(\) without running Modal in interactive mode"):
         interact()

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -2089,7 +2089,6 @@ def test_max_concurrency(servicer, function_name, monkeypatch):
 
     async def patch_concurrency_loop(self):
         self._concurrency_manager.set_value(n_inputs)
-        self._concurrency = n_inputs
         await asyncio.sleep(2)
 
     monkeypatch.setattr(

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -2048,9 +2048,8 @@ async def test_input_slots():
     assert slots.value == 10
 
 
-@pytest.mark.parametrize("function_name", ["get_input_concurrency"])
 @skip_github_non_linux
-def test_max_concurrency(servicer, function_name, monkeypatch):
+def test_max_concurrency(servicer):
     n_inputs = 5
     target_concurrency = 2
     max_concurrency = 10
@@ -2058,9 +2057,9 @@ def test_max_concurrency(servicer, function_name, monkeypatch):
     ret = _run_container(
         servicer,
         "test.supports.functions",
-        function_name,
+        "get_input_concurrency",
         inputs=_get_inputs(((1,), {}), n=n_inputs),
-        allow_concurrent_inputs=target_concurrency,
+        target_concurrent_inputs=target_concurrency,
         max_concurrent_inputs=max_concurrency,
     )
 

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -2059,7 +2059,7 @@ def test_max_concurrency(servicer):
         "test.supports.functions",
         "get_input_concurrency",
         inputs=_get_inputs(((1,), {}), n=n_inputs),
-        target_concurrent_inputs=target_concurrency,
+        allow_concurrent_inputs=target_concurrency,
         max_concurrent_inputs=max_concurrency,
     )
 

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -2056,6 +2056,7 @@ async def test_concurrency_manager():
 
 
 @skip_github_non_linux
+@pytest.mark.usefixtures("server_url_env")
 def test_max_concurrency_error(servicer):
     n_inputs = 15
     target_concurrency = 10

--- a/test/supports/functions.py
+++ b/test/supports/functions.py
@@ -21,6 +21,7 @@ from modal import (
     wsgi_app,
 )
 from modal.exception import deprecation_warning
+from modal.experimental import get_local_input_concurrency
 
 SLEEP_DELAY = 0.1
 
@@ -478,3 +479,9 @@ def is_local_f(x):
 def raise_large_unicode_exception():
     byte_str = (b"k" * 120_000_000) + b"\x99"
     byte_str.decode("utf-8")
+
+
+@app.function()
+def get_input_concurrency(timeout: int):
+    time.sleep(timeout)
+    return get_local_input_concurrency()


### PR DESCRIPTION
## Describe your changes

Refactored concurrency semaphore to a dynamic semaphore in Concurrency Manager. When max_concurrency specified, client will send RPC request to get the desired concurrency from server and change its concurrency.

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

