### PR TITLE
Fix empty client behavior with app-attached sandboxes

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -199,7 +199,7 @@ class _Sandbox(_Object, type_prefix="sb"):
             _experimental_gpus=_experimental_gpus,
         )
         if client is None:
-            if app:
+            if app and app._client:
                 client = app._client
             else:
                 client = await _Client.from_env()

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -37,6 +37,14 @@ def test_sandbox(client, servicer):
 
 
 @skip_non_linux
+def test_app_attached_from_env(set_env_client):
+    sb = Sandbox.create("echo", "hi", app=app)
+    sb.wait()
+
+    assert sb.stdout.read() == "hi\n"
+
+
+@skip_non_linux
 def test_sandbox_mount(client, servicer, tmpdir):
     tmpdir.join("a.py").write(b"foo")
 


### PR DESCRIPTION
## Describe your changes

Previously, if a clientless app was attached to a sandbox, it would error with NoneType. This commit checks app._client to make sure it exists before using it.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
