### PR TITLE
[MOD-2845] fix: prev. inadequate handling of stale in-mem clients

### DIFF
--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -747,6 +747,7 @@ class _ContainerIOManager:
         for key, value in restored_state.items():
             # Empty string indicates that value does not need to be updated.
             if value != "":
+                logger.debug(f"Updating config {key} = {value}")
                 config.override_locally(key, value)
 
         # Restore input to default state.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -855,6 +855,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
     async def FunctionMap(self, stream):
         self.fcidx += 1
         request: api_pb2.FunctionMapRequest = await stream.recv_message()
+        self.function_map_metadata = stream.metadata
         function_call_id = f"fc-{self.fcidx}"
         self.function_id_for_function_call[function_call_id] = request.function_id
         await stream.send_message(api_pb2.FunctionMapResponse(function_call_id=function_call_id))

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -118,10 +118,6 @@ async def test_container_snapshot_reference_capture(container_client, tmpdir, se
         os.environ, {"MODAL_RESTORE_STATE_PATH": str(restore_path), "MODAL_SERVER_URL": servicer.container_addr}
     ):
         io_manager.memory_snapshot()
-        # RPC should have used new credentials, not old credentials
-        await f.remote.aio()
-    creds = (servicer.function_map_metadata["x-modal-task-id"], servicer.function_map_metadata["x-modal-task-secret"])
-    assert creds == ("ta-i-am-restored", "ts-i-am-restored")
     # Stop the App, invalidating the fu- ID stored in `f`.
     assert await retry_transient_errors(client_stub.AppStop, api_pb2.AppStopRequest(app_id=app_id))
     # After snapshot-restore the previously looked-up Function should get refreshed and have the

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -60,7 +60,7 @@ async def test_container_function_lazily_imported(container_client):
 
 
 @pytest.mark.asyncio
-async def test_container_snapshot_restore(container_client, tmpdir, servicer):
+async def test_container_snapshot_restore_stale_credentials(container_client, tmpdir, servicer):
     # Get a reference to a Client instance in memory
     old_client = container_client
     io_manager = ContainerIOManager(api_pb2.ContainerArguments(), container_client)
@@ -71,6 +71,34 @@ async def test_container_snapshot_restore(container_client, tmpdir, servicer):
         io_manager.memory_snapshot()
         # In-memory Client instance should have update credentials, not old credentials
         assert old_client.credentials == ("ta-i-am-restored", "ts-i-am-restored")
+
+
+def square(x):
+    return x**2
+
+
+@pytest.mark.asyncio
+async def test_container_snapshot_restore_stale_credentials_in_stub(container_client, tmpdir, servicer):
+    app = App()
+    from modal import Function
+    from modal.runner import deploy_app
+
+    app.function()(square)
+    app_name = "my-app"
+    deploy_app(app, app_name, client=container_client).app_id
+    f = Function.lookup(app_name, "square", client=container_client)
+    await f.remote.aio()
+    print(servicer.function_map_metadata)
+    io_manager = ContainerIOManager(api_pb2.ContainerArguments(), container_client)
+    restore_path = temp_restore_path(tmpdir)
+    with mock.patch.dict(
+        os.environ, {"MODAL_RESTORE_STATE_PATH": str(restore_path), "MODAL_SERVER_URL": servicer.container_addr}
+    ):
+        io_manager.memory_snapshot()
+        # RPC should have use credentials, not old credentials
+        await f.remote.aio()
+    creds = (servicer.function_map_metadata["x-modal-task-id"], servicer.function_map_metadata["x-modal-task-secret"])
+    assert creds == ("ta-i-am-restored", "ts-i-am-restored")
 
 
 @pytest.mark.asyncio

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -95,7 +95,7 @@ async def test_container_snapshot_restore_stale_credentials_in_stub(container_cl
         os.environ, {"MODAL_RESTORE_STATE_PATH": str(restore_path), "MODAL_SERVER_URL": servicer.container_addr}
     ):
         io_manager.memory_snapshot()
-        # RPC should have use credentials, not old credentials
+        # RPC should have used new credentials, not old credentials
         await f.remote.aio()
     creds = (servicer.function_map_metadata["x-modal-task-id"], servicer.function_map_metadata["x-modal-task-secret"])
     assert creds == ("ta-i-am-restored", "ts-i-am-restored")


### PR DESCRIPTION
## Describe your changes

- MOD-2845

Got a local reproduction of some stale creds. Fix locally by clearing the Client's channel which was initialized with the old creds and left in-memory. In retrospect, this is an obvious problem 😖. 

<details> <summary>Backward/forward compatibility checks</summary>

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

---

</details>
