### PR TITLE
Add enum to FunctionMapRequest indicating if client will block

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -113,7 +113,7 @@ class _Invocation:
         kwargs,
         *,
         client: _Client,
-        invoke_type: api_pb2.FunctionMapRequest.InvokeType.ValueType,
+        function_call_invocation_type: api_pb2.FunctionCallInvocationType.ValueType,
     ) -> "_Invocation":
         assert client.stub
         function_id = function._invocation_function_id()
@@ -124,7 +124,7 @@ class _Invocation:
             parent_input_id=current_input_id() or "",
             function_call_type=api_pb2.FUNCTION_CALL_TYPE_UNARY,
             pipelined_inputs=[item],
-            invoke_type=invoke_type,
+            function_call_invocation_type=function_call_invocation_type,
         )
         response = await retry_transient_errors(client.stub.FunctionMap, request)
         function_call_id = response.function_call_id
@@ -1194,7 +1194,11 @@ class _Function(typing.Generic[P, R], _Object, type_prefix="fu"):
 
     async def _call_function(self, args, kwargs) -> R:
         invocation = await _Invocation.create(
-            self, args, kwargs, client=self._client, invoke_type=api_pb2.FunctionMapRequest.INVOKE_TYPE_SYNC
+            self,
+            args,
+            kwargs,
+            client=self._client,
+            function_call_invocation_type=api_pb2.FUNCTION_CALL_INVOCATION_TYPE_SYNC_LEGACY,
         )
         try:
             return await invocation.run_function()
@@ -1207,7 +1211,11 @@ class _Function(typing.Generic[P, R], _Object, type_prefix="fu"):
 
     async def _call_function_nowait(self, args, kwargs) -> _Invocation:
         return await _Invocation.create(
-            self, args, kwargs, client=self._client, invoke_type=api_pb2.FunctionMapRequest.INVOKE_TYPE_ASYNC
+            self,
+            args,
+            kwargs,
+            client=self._client,
+            function_call_invocation_type=api_pb2.FUNCTION_CALL_INVOCATION_TYPE_ASYNC_LEGACY,
         )
 
     @warn_if_generator_is_not_consumed()
@@ -1215,7 +1223,11 @@ class _Function(typing.Generic[P, R], _Object, type_prefix="fu"):
     @synchronizer.no_input_translation
     async def _call_generator(self, args, kwargs):
         invocation = await _Invocation.create(
-            self, args, kwargs, client=self._client, invoke_type=api_pb2.FunctionMapRequest.INVOKE_TYPE_SYNC
+            self,
+            args,
+            kwargs,
+            client=self._client,
+            function_call_invocation_type=api_pb2.FUNCTION_CALL_INVOCATION_TYPE_SYNC_LEGACY,
         )
         async for res in invocation.run_generator():
             yield res
@@ -1223,7 +1235,11 @@ class _Function(typing.Generic[P, R], _Object, type_prefix="fu"):
     @synchronizer.no_io_translation
     async def _call_generator_nowait(self, args, kwargs):
         return await _Invocation.create(
-            self, args, kwargs, client=self._client, invoke_type=api_pb2.FunctionMapRequest.INVOKE_TYPE_ASYNC
+            self,
+            args,
+            kwargs,
+            client=self._client,
+            function_call_invocation_type=api_pb2.FUNCTION_CALL_INVOCATION_TYPE_ASYNC_LEGACY,
         )
 
     @synchronizer.no_io_translation

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1194,7 +1194,7 @@ class _Function(typing.Generic[P, R], _Object, type_prefix="fu"):
 
     async def _call_function(self, args, kwargs) -> R:
         invocation = await _Invocation.create(
-            self, args, kwargs, client=self._client, invoke_type=api_pb2.FunctionMapRequest.INVOKE_SYNC
+            self, args, kwargs, client=self._client, invoke_type=api_pb2.FunctionMapRequest.INVOKE_TYPE_SYNC
         )
         try:
             return await invocation.run_function()
@@ -1207,7 +1207,7 @@ class _Function(typing.Generic[P, R], _Object, type_prefix="fu"):
 
     async def _call_function_nowait(self, args, kwargs) -> _Invocation:
         return await _Invocation.create(
-            self, args, kwargs, client=self._client, invoke_type=api_pb2.FunctionMapRequest.INVOKE_ASYNC
+            self, args, kwargs, client=self._client, invoke_type=api_pb2.FunctionMapRequest.INVOKE_TYPE_ASYNC
         )
 
     @warn_if_generator_is_not_consumed()
@@ -1215,7 +1215,7 @@ class _Function(typing.Generic[P, R], _Object, type_prefix="fu"):
     @synchronizer.no_input_translation
     async def _call_generator(self, args, kwargs):
         invocation = await _Invocation.create(
-            self, args, kwargs, client=self._client, invoke_type=api_pb2.FunctionMapRequest.INVOKE_SYNC
+            self, args, kwargs, client=self._client, invoke_type=api_pb2.FunctionMapRequest.INVOKE_TYPE_SYNC
         )
         async for res in invocation.run_generator():
             yield res
@@ -1223,7 +1223,7 @@ class _Function(typing.Generic[P, R], _Object, type_prefix="fu"):
     @synchronizer.no_io_translation
     async def _call_generator_nowait(self, args, kwargs):
         return await _Invocation.create(
-            self, args, kwargs, client=self._client, invoke_type=api_pb2.FunctionMapRequest.INVOKE_ASYNC
+            self, args, kwargs, client=self._client, invoke_type=api_pb2.FunctionMapRequest.INVOKE_TYPE_ASYNC
         )
 
     @synchronizer.no_io_translation

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -107,7 +107,14 @@ class _Invocation:
         self.function_call_id = function_call_id  # TODO: remove and use only input_id
 
     @staticmethod
-    async def create(function: "_Function", args, kwargs, *, client: _Client) -> "_Invocation":
+    async def create(
+        function: "_Function",
+        args,
+        kwargs,
+        *,
+        client: _Client,
+        invoke_type: api_pb2.FunctionMapRequest.InvokeType.ValueType,
+    ) -> "_Invocation":
         assert client.stub
         function_id = function._invocation_function_id()
         item = await _create_input(args, kwargs, client, method_name=function._use_method_name)
@@ -117,6 +124,7 @@ class _Invocation:
             parent_input_id=current_input_id() or "",
             function_call_type=api_pb2.FUNCTION_CALL_TYPE_UNARY,
             pipelined_inputs=[item],
+            invoke_type=invoke_type,
         )
         response = await retry_transient_errors(client.stub.FunctionMap, request)
         function_call_id = response.function_call_id
@@ -1185,7 +1193,9 @@ class _Function(typing.Generic[P, R], _Object, type_prefix="fu"):
             yield item
 
     async def _call_function(self, args, kwargs) -> R:
-        invocation = await _Invocation.create(self, args, kwargs, client=self._client)
+        invocation = await _Invocation.create(
+            self, args, kwargs, client=self._client, invoke_type=api_pb2.FunctionMapRequest.INVOKE_SYNC
+        )
         try:
             return await invocation.run_function()
         except asyncio.CancelledError:
@@ -1196,19 +1206,25 @@ class _Function(typing.Generic[P, R], _Object, type_prefix="fu"):
             return  # type: ignore
 
     async def _call_function_nowait(self, args, kwargs) -> _Invocation:
-        return await _Invocation.create(self, args, kwargs, client=self._client)
+        return await _Invocation.create(
+            self, args, kwargs, client=self._client, invoke_type=api_pb2.FunctionMapRequest.INVOKE_ASYNC
+        )
 
     @warn_if_generator_is_not_consumed()
     @live_method_gen
     @synchronizer.no_input_translation
     async def _call_generator(self, args, kwargs):
-        invocation = await _Invocation.create(self, args, kwargs, client=self._client)
+        invocation = await _Invocation.create(
+            self, args, kwargs, client=self._client, invoke_type=api_pb2.FunctionMapRequest.INVOKE_SYNC
+        )
         async for res in invocation.run_generator():
             yield res
 
     @synchronizer.no_io_translation
     async def _call_generator_nowait(self, args, kwargs):
-        return await _Invocation.create(self, args, kwargs, client=self._client)
+        return await _Invocation.create(
+            self, args, kwargs, client=self._client, invoke_type=api_pb2.FunctionMapRequest.INVOKE_ASYNC
+        )
 
     @synchronizer.no_io_translation
     @live_method

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -113,7 +113,7 @@ class _Invocation:
         kwargs,
         *,
         client: _Client,
-        function_call_invocation_type: api_pb2.FunctionCallInvocationType.ValueType,
+        function_call_invocation_type: "api_pb2.FunctionCallInvocationType.ValueType",
     ) -> "_Invocation":
         assert client.stub
         function_id = function._invocation_function_id()

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1253,11 +1253,17 @@ message FunctionInput {
 }
 
 message FunctionMapRequest {
+  enum InvokeType {
+    INVOKE_TYPE_UNSPECIFIED = 0;
+    INVOKE_TYPE_SYNC = 2;
+    INVOKE_TYPE_ASYNC = 1;
+  }
   string function_id = 1;
   string parent_input_id = 2;
   bool return_exceptions = 3;
   FunctionCallType function_call_type = 4;
   repeated FunctionPutInputsItem pipelined_inputs = 5;
+  InvokeType invoke_type = 6;
 }
 
 message FunctionMapResponse {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1259,7 +1259,6 @@ message FunctionInput {
 }
 
 message FunctionMapRequest {
-
   string function_id = 1;
   string parent_input_id = 2;
   bool return_exceptions = 3;

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1112,6 +1112,12 @@ message FunctionCallPutDataRequest {
   repeated DataChunk data_chunks = 2;
 }
 
+enum FunctionCallInvocationType {
+  FUNCTION_CALL_INVOCATION_TYPE_UNSPECIFIED = 0;
+  FUNCTION_CALL_INVOCATION_TYPE_SYNC_LEGACY = 1;
+  FUNCTION_CALL_INVOCATION_TYPE_ASYNC_LEGACY = 2;
+}
+
 message FunctionCreateRequest {
   Function function = 1;
   string app_id = 2  [ (modal.options.audit_target_attr) = true ];
@@ -1253,17 +1259,13 @@ message FunctionInput {
 }
 
 message FunctionMapRequest {
-  enum InvokeType {
-    INVOKE_TYPE_UNSPECIFIED = 0;
-    INVOKE_TYPE_SYNC = 2;
-    INVOKE_TYPE_ASYNC = 1;
-  }
+
   string function_id = 1;
   string parent_input_id = 2;
   bool return_exceptions = 3;
   FunctionCallType function_call_type = 4;
   repeated FunctionPutInputsItem pipelined_inputs = 5;
-  InvokeType invoke_type = 6;
+  FunctionCallInvocationType function_call_invocation_type = 6;
 }
 
 message FunctionMapResponse {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -118,6 +118,12 @@ enum FileDescriptor {
   FILE_DESCRIPTOR_INFO = 3;
 }
 
+enum FunctionCallInvocationType {
+  FUNCTION_CALL_INVOCATION_TYPE_UNSPECIFIED = 0;
+  FUNCTION_CALL_INVOCATION_TYPE_SYNC_LEGACY = 1;
+  FUNCTION_CALL_INVOCATION_TYPE_ASYNC_LEGACY = 2;
+}
+
 enum FunctionCallType {
   FUNCTION_CALL_TYPE_UNSPECIFIED = 0;
   FUNCTION_CALL_TYPE_UNARY = 1;
@@ -1110,12 +1116,6 @@ message FunctionCallListResponse {
 message FunctionCallPutDataRequest {
   string function_call_id = 1;
   repeated DataChunk data_chunks = 2;
-}
-
-enum FunctionCallInvocationType {
-  FUNCTION_CALL_INVOCATION_TYPE_UNSPECIFIED = 0;
-  FUNCTION_CALL_INVOCATION_TYPE_SYNC_LEGACY = 1;
-  FUNCTION_CALL_INVOCATION_TYPE_ASYNC_LEGACY = 2;
 }
 
 message FunctionCreateRequest {


### PR DESCRIPTION
MOD-3589

Add FunctionCallInvocationType enum which indicates if client will wait for the function to complete, or continue on immediately. For example, calls to .remote() will block, but calls to .spawn() will not.

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [X] Client+Server: this change is compatible with old servers
- [X] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
