### PR TITLE
Concurrent Logging Protobuf changes

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -731,6 +731,11 @@ message ContainerHeartbeatResponse {
   optional CancelInputEvent cancel_input_event = 1;
 }
 
+message ContainerLogRequest {
+  string message = 1;
+  string input_id = 2;
+}
+
 message ContainerStopRequest {
   string task_id = 1 [ (modal.options.audit_target_attr) = true ];
 }
@@ -2254,6 +2259,7 @@ service ModalClient {
   rpc ContainerExecPutInput(ContainerExecPutInputRequest) returns (google.protobuf.Empty);
   rpc ContainerExecWait(ContainerExecWaitRequest) returns (ContainerExecWaitResponse);
   rpc ContainerHeartbeat(ContainerHeartbeatRequest) returns (ContainerHeartbeatResponse);
+  rpc ContainerLog(ContainerLogRequest) returns (google.protobuf.Empty);
   rpc ContainerStop(ContainerStopRequest) returns (ContainerStopResponse);
 
   // Dicts


### PR DESCRIPTION
## Describe your changes

Add rpc for logging concurrent inputs.

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

