### PR TITLE
Add proto definitions to support tunneled sandboxes

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1563,6 +1563,15 @@ message PTYInfo {
   PTYType pty_type = 7;
 }
 
+message PortSpec {
+  uint32 port = 1;
+  bool unencrypted = 2;
+}
+
+message PortSpecs {
+  repeated PortSpec ports = 1;
+}
+
 message ProxyGetOrCreateRequest {
   string deployment_name = 1 [ (modal.options.audit_target_attr) = true ];
   DeploymentNamespace namespace = 2;
@@ -1750,6 +1759,9 @@ message Sandbox {
   repeated Resources _experimental_resources = 18; // overrides `resources` field above
 
   string worker_id = 19; // for internal debugging use only
+  oneof open_ports_oneof {
+    PortSpecs open_ports = 20;
+  }
 }
 
 message SandboxCreateRequest {
@@ -1774,6 +1786,15 @@ message SandboxGetTaskIdRequest {
 
 message SandboxGetTaskIdResponse {
   string task_id = 1;
+}
+
+message SandboxGetTunnelsRequest {
+  bool poll = 1;
+  string sandbox_id = 2;
+}
+
+message SandboxGetTunnelsResponse {
+  repeated TunnelData tunnels = 1;
 }
 
 message SandboxHandleMetadata {
@@ -2070,6 +2091,13 @@ message TokenFlowWaitResponse {
   string workspace_username = 4;
 }
 
+message TunnelData {
+  string host = 1;
+  uint32 port = 2;
+  optional string unencrypted_host = 3;
+  optional uint32 unencrypted_port = 4;
+}
+
 message TunnelStartRequest {
   uint32 port = 1;
   bool unencrypted = 2;
@@ -2349,6 +2377,7 @@ service ModalClient {
   rpc SandboxCreate(SandboxCreateRequest) returns (SandboxCreateResponse);
   rpc SandboxGetLogs(SandboxGetLogsRequest) returns (stream TaskLogsBatch);
   rpc SandboxGetTaskId(SandboxGetTaskIdRequest) returns (SandboxGetTaskIdResponse); // needed for modal container exec
+  rpc SandboxGetTunnels(SandboxGetTunnelsRequest) returns (SandboxGetTunnelsResponse);
   rpc SandboxList(SandboxListRequest) returns (SandboxListResponse);
   rpc SandboxStdinWrite(SandboxStdinWriteRequest) returns (SandboxStdinWriteResponse);
   rpc SandboxTerminate(SandboxTerminateRequest) returns (SandboxTerminateResponse);


### PR DESCRIPTION
## Describe your changes

This commit adds proto definitions that allow sandboxes to be created with open ports specified. It also adds an RPC definition for getting the tunnels once established.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
