### PR TITLE
Client to display the correct active environment, choosing between the server default, config default, and env var default

### DIFF
--- a/modal/cli/environment.py
+++ b/modal/cli/environment.py
@@ -42,12 +42,9 @@ def list(json: Optional[bool] = False):
 
     # determine which environment is currently active, prioritizing the local default
     # over the server default
-    cfg_default = config.get("environment")
-    active_env = None
+    active_env = config.get("environment")
     for env in envs:
-        if env.name == cfg_default:
-            active_env = env.name
-        elif env.default is True and active_env is None:
+        if env.default is True and active_env is None:
             active_env = env.name
 
     table_data = []

--- a/modal/cli/environment.py
+++ b/modal/cli/environment.py
@@ -1,6 +1,6 @@
 # Copyright Modal Labs 2023
 from os import environ
-from typing import Optional
+from typing import Optional, Text, Union, cast
 
 import typer
 from click import UsageError
@@ -42,21 +42,22 @@ def list(json: Optional[bool] = False):
     table_data = []
 
     env_var_default = environ.get("MODAL_ENVIRONMENT") or None
+    cfg_default = str(config.get("environment")) or None
     active_env_count = 0
     for item in envs:
-        is_active = item.name == config.get("environment") or item.default is True or item.name == env_var_default
+        is_active = item.name == cfg_default or item.default is True or item.name == env_var_default
         if is_active:
             active_env_count += 1
-        row = [item.name, item.webhook_suffix, is_active if json else RenderableBool(is_active)]
+        row = [item.name, item.webhook_suffix, cast(Union[Text, str], is_active if json else RenderableBool(is_active))]
         table_data.append(row)
 
     if active_env_count > 1:
         # set is_active column to false for all rows except for the env in config
-        active_env = env_var_default or config.get("environment")
+        active_env = env_var_default or cfg_default
         for i in range(0, len(table_data)):
             env = table_data[i]
             is_active = env[0] == active_env
-            env[2] = is_active if json else RenderableBool(is_active)
+            env[2] = cast(Union[Text, str], is_active if json else RenderableBool(is_active))
 
     display_table(["name", "web suffix", "active"], table_data, json=json)
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -924,6 +924,7 @@ message EnvironmentListItem {
   string name = 1;
   string webhook_suffix = 2;
   double created_at = 3;
+  bool default = 4;
 }
 
 message EnvironmentListResponse {


### PR DESCRIPTION
Display the correct active environment from modal CLI:
- request the server's current default in the EnvironmentListResponse
- display a single environment as active, prioritizing MODAL_ENVIRONMENT > config > server default

<details> <summary>Backward/forward compatibility checks</summary>

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
