### PR TITLE
Add GenericResult to sandbox tunnels response

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1799,7 +1799,8 @@ message SandboxGetTunnelsRequest {
 }
 
 message SandboxGetTunnelsResponse {
-  repeated TunnelData tunnels = 1;
+  GenericResult result = 1;
+  repeated TunnelData tunnels = 2;
 }
 
 message SandboxHandleMetadata {


### PR DESCRIPTION
## Describe your changes

This allows us to know if the SandboxGetTunnels RPC returned because of a timeout or full data.

<details> <summary>Backward/forward compatibility checks</summary>

---

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

This is not a backwards-compatible proto change, but it's OK because there's no code (and there will be no code) that uses the old version.

---

</details>

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
