### PR TITLE
Add container port to tunnel data

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2104,6 +2104,7 @@ message TunnelData {
   uint32 port = 2;
   optional string unencrypted_host = 3;
   optional uint32 unencrypted_port = 4;
+  uint32 container_port = 5;
 }
 
 message TunnelStartRequest {


### PR DESCRIPTION
## Describe your changes

This allows the client to know which local port the remote port maps to.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself



---

</details>

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
