### PR TITLE
[MOD-3624] fix: properly handle optional[bytes] in handle_input_exception

### DIFF
--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -759,6 +759,8 @@ class _ContainerIOManager:
                 repr_exc = repr_exc[: MAX_OBJECT_SIZE_BYTES - 1000]
                 repr_exc = f"{repr_exc}...\nTrimmed {trimmed_bytes} bytes from original exception"
 
+            data: bytes = self.serialize_exception(exc) or b""
+            data_result_part = await self.format_blob_data(data)
             results = [
                 api_pb2.GenericResult(
                     status=api_pb2.GenericResult.GENERIC_STATUS_FAILURE,
@@ -766,7 +768,7 @@ class _ContainerIOManager:
                     traceback=traceback.format_exc(),
                     serialized_tb=serialized_tb,
                     tb_line_cache=tb_line_cache,
-                    **await self.format_blob_data(self.serialize_exception(exc)),
+                    **data_result_part,
                 )
                 for _ in io_context.input_ids
             ]


### PR DESCRIPTION
## Describe your changes

- MOD-3624

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

