### PR TITLE
Use timeout in the SandboxGetTunnels request

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1795,8 +1795,8 @@ message SandboxGetTaskIdResponse {
 }
 
 message SandboxGetTunnelsRequest {
-  bool poll = 1;
-  string sandbox_id = 2;
+  string sandbox_id = 1;
+  float timeout = 2;
 }
 
 message SandboxGetTunnelsResponse {


### PR DESCRIPTION
## Describe your changes

This commit swaps out the `poll` variable for a `timeout` variable which can be used to control the length of blocking for the SandboxGetTunnels RPC.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- ~[ ] Client+Server: this change is compatible with old servers~
- ~[ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself~

This change is not backwards compatible, but this is fine as nothing is using this data.

---

</details>

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
