### PR TITLE
s/priority/rank in TaskTemplate

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -832,7 +832,7 @@ class _Function(typing.Generic[P, R], _Object, type_prefix="fu"):
                     _experimental_concurrent_cancellations=True,
                     _experimental_task_templates=[
                         api_pb2.TaskTemplate(
-                            priority=1,
+                            rank=1,
                             resources=convert_fn_config_to_resources_config(
                                 cpu=cpu, memory=memory, gpu=_experimental_gpu, ephemeral_disk=ephemeral_disk
                             ),

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2081,9 +2081,10 @@ message TaskStats {
 }
 
 message TaskTemplate {
-  uint32 priority = 1;
+  uint32 rank = 1;
   Resources resources = 2;
-  uint32 concurrent_inputs = 3;
+  uint32 target_concurrent_inputs = 3;
+  uint32 max_concurrent_inputs = 4;
 }
 
 message TokenFlowCreateRequest {


### PR DESCRIPTION
Purely internal, proto name change. Working through some backend refactors and this naming avoids a conflict with another notion of inter-function priorities in the scheduler. Also align naming with new {target,max}-concurrent-inputs spec (on a per task-template basis).
