### PR TITLE
AppCreateResponse: add split between app page URL and logs page URL

### DIFF
--- a/modal/runner.py
+++ b/modal/runner.py
@@ -73,7 +73,7 @@ async def _init_local_app_new(
         app_state=app_state,
     )
     app_resp = await retry_transient_errors(client.stub.AppCreate, app_req)
-    app_page_url = app_resp.app_logs_url
+    app_page_url = app_resp.app_page_url
     logger.debug(f"Created new app with id {app_resp.app_id}")
     return RunningApp(
         app_resp.app_id, app_page_url=app_page_url, environment_name=environment_name, interactive=interactive

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -230,7 +230,8 @@ message AppCreateRequest {
 
 message AppCreateResponse {
   string app_id = 1;
-  string app_logs_url = 2;
+  string app_page_url = 2;
+  string app_logs_url = 3;
 }
 
 message AppDeployRequest {

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -292,7 +292,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         app_id = f"ap-{self.n_apps}"
         self.app_state_history[app_id].append(api_pb2.APP_STATE_INITIALIZING)
         await stream.send_message(
-            api_pb2.AppCreateResponse(app_id=app_id, app_logs_url="https://modaltest.com/apps/ap-123")
+            api_pb2.AppCreateResponse(app_id=app_id, app_page_url="https://modaltest.com/apps/ap-123")
         )
 
     async def AppClientDisconnect(self, stream):


### PR DESCRIPTION
## Describe your changes


Last night when dog-fooding I hit a broken link: 

```
Stopping app - keyboard interrupt received. Use `modal run --detach` to prevent KeyboardInterrupts from killing apps.
Timed out waiting for logs. View logs at https://modal.com/logs/ap-n6SUuGWdBCufjNisSwx2Ep for remaining output.
```

Sometimes the app overview page is best and sometimes we should take the client directly to the logs page (or tab, whichever). So I'm adding both URL options to the proto. 


- MOD-3658

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
    - yes, old servers will continue to send the `app_logs_url` on field 2, which is compatible data because this is just a rename.
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

