### PR TITLE
[MOD-3657] fix logs user msg

### DIFF
--- a/modal/_output.py
+++ b/modal/_output.py
@@ -525,7 +525,11 @@ async def put_pty_content(log: api_pb2.TaskLogs, stdout):
 
 
 async def get_app_logs_loop(
-    client: _Client, output_mgr: OutputManager, app_id: Optional[str] = None, task_id: Optional[str] = None
+    client: _Client,
+    output_mgr: OutputManager,
+    app_id: Optional[str] = None,
+    task_id: Optional[str] = None,
+    app_page_url: Optional[str] = None,
 ):
     last_log_batch_entry_id = ""
 
@@ -616,8 +620,8 @@ async def get_app_logs_loop(
         try:
             await _get_logs()
         except asyncio.CancelledError:
-            # TODO: this should come from the backend maybe
-            app_logs_url = f"https://modal.com/logs/{app_id}"
+            # TODO: this should be alink to the logs page specifically, not the app overview.
+            app_logs_url = app_page_url if app_page_url else "https://modal.com/logs/"
             output_mgr.print(
                 f"[red]Timed out waiting for logs. "
                 f"[grey70]View logs at [underline]{app_logs_url}[/underline] for remaining output.[/grey70]"

--- a/modal/_output.py
+++ b/modal/_output.py
@@ -529,7 +529,7 @@ async def get_app_logs_loop(
     output_mgr: OutputManager,
     app_id: Optional[str] = None,
     task_id: Optional[str] = None,
-    app_page_url: Optional[str] = None,
+    app_logs_url: Optional[str] = None,
 ):
     last_log_batch_entry_id = ""
 
@@ -620,11 +620,10 @@ async def get_app_logs_loop(
         try:
             await _get_logs()
         except asyncio.CancelledError:
-            # TODO: this should be alink to the logs page specifically, not the app overview.
-            app_logs_url = app_page_url if app_page_url else "https://modal.com/logs/"
+            view_logs_url = app_logs_url if app_logs_url else "https://modal.com/logs/"
             output_mgr.print(
                 f"[red]Timed out waiting for logs. "
-                f"[grey70]View logs at [underline]{app_logs_url}[/underline] for remaining output.[/grey70]"
+                f"[grey70]View logs at [underline]{view_logs_url}[/underline] for remaining output.[/grey70]"
             )
             raise
         except (GRPCError, StreamTerminatedError, socket.gaierror, AttributeError) as exc:

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -296,7 +296,7 @@ def deploy(
         res = deploy_app(app, name=name, environment_name=env or "", tag=tag)
 
     if stream_logs:
-        stream_app_logs(app_id=res.app_id, app_page_url=res.app_page_url)
+        stream_app_logs(app_id=res.app_id, app_logs_url=res.app_logs_url)
 
 
 def serve(

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -296,7 +296,7 @@ def deploy(
         res = deploy_app(app, name=name, environment_name=env or "", tag=tag)
 
     if stream_logs:
-        stream_app_logs(res.app_id)
+        stream_app_logs(app_id=res.app_id, app_page_url=res.app_page_url)
 
 
 def serve(

--- a/modal/cli/utils.py
+++ b/modal/cli/utils.py
@@ -21,12 +21,14 @@ from ..exception import NotFoundError
 
 
 @synchronizer.create_blocking
-async def stream_app_logs(app_id: Optional[str] = None, task_id: Optional[str] = None):
+async def stream_app_logs(
+    app_id: Optional[str] = None, task_id: Optional[str] = None, app_page_url: Optional[str] = None
+):
     client = await _Client.from_env()
     output_mgr = OutputManager(status_spinner_text=f"Tailing logs for {app_id}")
     try:
         with output_mgr.show_status_spinner():
-            await get_app_logs_loop(client, output_mgr, app_id, task_id)
+            await get_app_logs_loop(client, output_mgr, app_id=app_id, task_id=task_id, app_page_url=app_page_url)
     except asyncio.CancelledError:
         pass
     except GRPCError as exc:

--- a/modal/cli/utils.py
+++ b/modal/cli/utils.py
@@ -22,13 +22,13 @@ from ..exception import NotFoundError
 
 @synchronizer.create_blocking
 async def stream_app_logs(
-    app_id: Optional[str] = None, task_id: Optional[str] = None, app_page_url: Optional[str] = None
+    app_id: Optional[str] = None, task_id: Optional[str] = None, app_logs_url: Optional[str] = None
 ):
     client = await _Client.from_env()
     output_mgr = OutputManager(status_spinner_text=f"Tailing logs for {app_id}")
     try:
         with output_mgr.show_status_spinner():
-            await get_app_logs_loop(client, output_mgr, app_id=app_id, task_id=task_id, app_page_url=app_page_url)
+            await get_app_logs_loop(client, output_mgr, app_id=app_id, task_id=task_id, app_logs_url=app_logs_url)
     except asyncio.CancelledError:
         pass
     except GRPCError as exc:

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -275,7 +275,9 @@ async def _run_app(
                 output_mgr.update_app_page_url(running_app.app_page_url)
 
             # Start logs loop
-            logs_loop = tc.create_task(get_app_logs_loop(client, output_mgr, running_app.app_id))
+            logs_loop = tc.create_task(
+                get_app_logs_loop(client, output_mgr, app_id=running_app.app_id, app_page_url=running_app.app_page_url)
+            )
 
         exc_info: Optional[BaseException] = None
         try:
@@ -389,6 +391,7 @@ class DeployResult:
     """Dataclass representing the result of deploying an app."""
 
     app_id: str
+    app_page_url: str
 
 
 async def _deploy_app(
@@ -478,7 +481,7 @@ async def _deploy_app(
         t = time.time() - t0
         output_mgr.print(step_completed(f"App deployed in {t:.3f}s! 🎉"))
         output_mgr.print(f"\nView Deployment: [magenta]{app_url}[/magenta]")
-    return DeployResult(app_id=running_app.app_id)
+    return DeployResult(app_id=running_app.app_id, app_page_url=running_app.app_page_url)
 
 
 async def _interactive_shell(_app: _App, cmds: List[str], environment_name: str = "", **kwargs: Any) -> None:

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -73,10 +73,13 @@ async def _init_local_app_new(
         app_state=app_state,
     )
     app_resp = await retry_transient_errors(client.stub.AppCreate, app_req)
-    app_page_url = app_resp.app_logs_url
     logger.debug(f"Created new app with id {app_resp.app_id}")
     return RunningApp(
-        app_resp.app_id, app_page_url=app_page_url, environment_name=environment_name, interactive=interactive
+        app_resp.app_id,
+        app_page_url=app_resp.app_page_url,
+        app_logs_url=app_resp.app_logs_url,
+        environment_name=environment_name,
+        interactive=interactive,
     )
 
 
@@ -276,7 +279,7 @@ async def _run_app(
 
             # Start logs loop
             logs_loop = tc.create_task(
-                get_app_logs_loop(client, output_mgr, app_id=running_app.app_id, app_page_url=running_app.app_page_url)
+                get_app_logs_loop(client, output_mgr, app_id=running_app.app_id, app_logs_url=running_app.app_logs_url)
             )
 
         exc_info: Optional[BaseException] = None

--- a/modal/running_app.py
+++ b/modal/running_app.py
@@ -10,6 +10,7 @@ class RunningApp:
     app_id: str
     environment_name: Optional[str] = None
     app_page_url: Optional[str] = None
+    app_logs_url: Optional[str] = None
     tag_to_object_id: Dict[str, str] = field(default_factory=dict)
     object_handle_metadata: Dict[str, Optional[Message]] = field(default_factory=dict)
     interactive: bool = False


### PR DESCRIPTION
## Describe your changes

Last night when dog-fooding I hit a broken link: 

```
Stopping app - keyboard interrupt received. Use `modal run --detach` to prevent KeyboardInterrupts from killing apps.
Timed out waiting for logs. View logs at https://modal.com/logs/ap-n6SUuGWdBCufjNisSwx2Ep for remaining output.
```

This has been enabled by reworking the protos: #2185 

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

