### PR TITLE
Add environment field to sandboxes

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -132,7 +132,9 @@ class _Sandbox(_Object, type_prefix="sb"):
             )
 
             # Note - `resolver.app_id` will be `None` for app-less sandboxes
-            create_req = api_pb2.SandboxCreateRequest(app_id=resolver.app_id, definition=definition)
+            create_req = api_pb2.SandboxCreateRequest(
+                app_id=resolver.app_id, definition=definition, environment_name=resolver.environment_name
+            )
             create_resp = await retry_transient_errors(resolver.client.stub.SandboxCreate, create_req)
 
             sandbox_id = create_resp.sandbox_id

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1782,6 +1782,7 @@ message Sandbox {
 message SandboxCreateRequest {
   string app_id = 1 [ (modal.options.audit_target_attr) = true ];
   Sandbox definition = 2;
+  string environment_name = 3;
 }
 
 message SandboxCreateResponse {


### PR DESCRIPTION
## Describe your changes

- Part of MOD-3656: Make sandboxes environment-scoped. App-less sandboxes should still be tied to an environment.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
