### PR TITLE
[MOD-3613] Improve client error message for asgi / wsgi apps that have non-nullary functions

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -42,9 +42,9 @@ from ._serialization import deserialize, deserialize_proto_params
 from ._utils.async_utils import TaskContext, synchronizer
 from ._utils.function_utils import (
     LocalFunctionError,
+    callable_has_non_self_params,
     is_async as get_is_async,
     is_global_object,
-    method_has_params,
 )
 from .app import App, _App
 from .client import Client, _Client
@@ -684,7 +684,7 @@ def call_lifecycle_functions(
         for func in funcs:
             # We are deprecating parameterized exit methods but want to gracefully handle old code.
             # We can remove this once the deprecation in the actual @exit decorator is enforced.
-            args = (None, None, None) if method_has_params(func) else ()
+            args = (None, None, None) if callable_has_non_self_params(func) else ()
             # in case func is non-async, it's executed here and sigint will by default
             # interrupt it using a KeyboardInterrupt exception
             res = func(*args)

--- a/modal/_utils/function_utils.py
+++ b/modal/_utils/function_utils.py
@@ -84,6 +84,17 @@ def is_async(function):
         raise RuntimeError(f"Function {function} is a strange type {type(function)}")
 
 
+def is_nullary_function(f: Callable[..., Any]) -> bool:
+    signature = inspect.signature(f)
+    for param in signature.parameters.values():
+        if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+            # variadic parameters are nullary
+            continue
+        if param.default is param.empty:
+            return False
+    return True
+
+
 class FunctionInfo:
     """Class that helps us extract a bunch of information about a function."""
 
@@ -308,16 +319,6 @@ class FunctionInfo:
 
     def get_tag(self):
         return self.function_name
-
-    def is_nullary(self):
-        signature = inspect.signature(self.raw_f)
-        for param in signature.parameters.values():
-            if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
-                # variadic parameters are nullary
-                continue
-            if param.default is param.empty:
-                return False
-        return True
 
 
 def method_has_params(f: Callable[..., Any]) -> bool:

--- a/modal/_utils/function_utils.py
+++ b/modal/_utils/function_utils.py
@@ -323,8 +323,7 @@ class FunctionInfo:
 def callable_has_non_self_params(f: Callable[..., Any]) -> bool:
     """Return True if a callable (function, bound method, or unbound method) has parameters other than self.
 
-    Used for deprecation of @exit() parameters and ensuring @asgi_app / @wsgi_app functions don't have non-default
-    parameters.
+    Used to ensure that @exit(), @asgi_app, and @wsgi_app functions don't have parameters.
     """
     return any(param.name != "self" for param in inspect.signature(f).parameters.values())
 
@@ -332,7 +331,7 @@ def callable_has_non_self_params(f: Callable[..., Any]) -> bool:
 def callable_has_non_self_non_default_params(f: Callable[..., Any]) -> bool:
     """Return True if a callable (function, bound method, or unbound method) has non-default parameters other than self.
 
-    Used for deprecation of default parameters in asgi / wsgi app functions.
+    Used for deprecation of default parameters in @asgi_app and @wsgi_app functions.
     """
     for param in inspect.signature(f).parameters.values():
         if param.name == "self":

--- a/modal/_utils/function_utils.py
+++ b/modal/_utils/function_utils.py
@@ -320,12 +320,29 @@ class FunctionInfo:
         return True
 
 
-def method_has_params(f: Callable[..., Any]) -> bool:
-    """Return True if a method (bound or unbound) has parameters other than self.
+def callable_has_non_self_params(f: Callable[..., Any]) -> bool:
+    """Return True if a callable (function, bound method, or unbound method) has parameters other than self.
 
-    Used for deprecation of @exit() parameters and ensuring asgi / wsgi app functions don't have args.
+    Used for deprecation of @exit() parameters and ensuring @asgi_app / @wsgi_app functions don't have non-default
+    parameters.
     """
     return any(param.name != "self" for param in inspect.signature(f).parameters.values())
+
+
+def callable_has_non_self_non_default_params(f: Callable[..., Any]) -> bool:
+    """Return True if a callable (function, bound method, or unbound method) has non-default parameters other than self.
+
+    Used for deprecation of default parameters in asgi / wsgi app functions.
+    """
+    for param in inspect.signature(f).parameters.values():
+        if param.name == "self":
+            continue
+
+        if param.default != inspect.Parameter.empty:
+            continue
+
+        return True
+    return False
 
 
 async def _stream_function_call_data(

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -523,7 +523,7 @@ class _Function(typing.Generic[P, R], _Object, type_prefix="fu"):
         if info.raw_f:
             raw_f = info.raw_f
             assert callable(raw_f)
-            if schedule is not None and not info.is_nullary:
+            if schedule is not None and not info.is_nullary():
                 raise InvalidError(
                     f"Function {raw_f} has a schedule, so it needs to support being called with no arguments"
                 )

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -52,6 +52,7 @@ from ._utils.function_utils import (
     _process_result,
     _stream_function_call_data,
     is_async,
+    is_nullary_function,
 )
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.mount_utils import validate_network_file_systems, validate_volumes
@@ -523,7 +524,7 @@ class _Function(typing.Generic[P, R], _Object, type_prefix="fu"):
         if info.raw_f:
             raw_f = info.raw_f
             assert callable(raw_f)
-            if schedule is not None and not info.is_nullary():
+            if schedule is not None and not is_nullary_function(raw_f):
                 raise InvalidError(
                     f"Function {raw_f} has a schedule, so it needs to support being called with no arguments"
                 )

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -52,7 +52,6 @@ from ._utils.function_utils import (
     _process_result,
     _stream_function_call_data,
     is_async,
-    is_nullary_function,
 )
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.mount_utils import validate_network_file_systems, validate_volumes
@@ -524,7 +523,7 @@ class _Function(typing.Generic[P, R], _Object, type_prefix="fu"):
         if info.raw_f:
             raw_f = info.raw_f
             assert callable(raw_f)
-            if schedule is not None and not is_nullary_function(raw_f):
+            if schedule is not None and not info.is_nullary:
                 raise InvalidError(
                     f"Function {raw_f} has a schedule, so it needs to support being called with no arguments"
                 )

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -343,13 +343,13 @@ def _asgi_app(
         if callable_has_non_self_params(raw_f):
             if callable_has_non_self_non_default_params(raw_f):
                 raise InvalidError(
-                    f"ASGI app function {raw_f.__name__} can't have arguments. See https://modal.com/docs/guide/webhooks#asgi."
+                    f"ASGI app function {raw_f.__name__} can't have parameters. See https://modal.com/docs/guide/webhooks#asgi."
                 )
             else:
                 deprecation_warning(
                     (2024, 9, 4),
-                    f"ASGI app function {raw_f.__name__} has default arguments - Modal will drop support for this in a"
-                    f" future release.",
+                    f"ASGI app function {raw_f.__name__} has default parameters, but shouldn't have any parameters - "
+                    f"Modal will drop support for default parameters in a future release.",
                 )
 
         if not wait_for_response:
@@ -415,13 +415,13 @@ def _wsgi_app(
         if callable_has_non_self_params(raw_f):
             if callable_has_non_self_non_default_params(raw_f):
                 raise InvalidError(
-                    f"WSGI app function {raw_f.__name__} can't have arguments. See https://modal.com/docs/guide/webhooks#wsgi."
+                    f"WSGI app function {raw_f.__name__} can't have parameters. See https://modal.com/docs/guide/webhooks#wsgi."
                 )
             else:
                 deprecation_warning(
                     (2024, 9, 4),
-                    f"WSGI app function {raw_f.__name__} has default arguments - Modal will drop support for this in a"
-                    f"future release.",
+                    f"WSGI app function {raw_f.__name__} has default parameters, but shouldn't have any parameters - "
+                    f"Modal will drop support for default parameters in a future release.",
                 )
 
         if not wait_for_response:

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -340,14 +340,8 @@ def _asgi_app(
         )
 
     def wrapper(raw_f: Callable[..., Any]) -> _PartialFunction:
-        def raw_f_wrapper(*args, **kwargs):
-            if len(args) + len(kwargs) != 0:
-                raise InvalidError(
-                    f"ASGI app functions expect no arguments, but {raw_f.__name__} received "
-                    f"positional arguments: {args} and keyword arguments: {kwargs}."
-                )
-
-            return raw_f()  # If we made it here, we're good to call the function without args.
+        if not raw_f.is_nullary():
+            raise InvalidError(f"ASGI app function {raw_f.__name__} can't have arguments.")
 
         if not wait_for_response:
             deprecation_warning(
@@ -360,7 +354,7 @@ def _asgi_app(
             _response_mode = api_pb2.WEBHOOK_ASYNC_MODE_AUTO  # the default
 
         return _PartialFunction(
-            raw_f_wrapper,
+            raw_f,
             _PartialFunctionFlags.FUNCTION,
             api_pb2.WebhookConfig(
                 type=api_pb2.WEBHOOK_TYPE_ASGI_APP,

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -18,7 +18,7 @@ import typing_extensions
 from modal_proto import api_pb2
 
 from ._utils.async_utils import synchronize_api, synchronizer
-from ._utils.function_utils import is_nullary_function, method_has_params
+from ._utils.function_utils import method_has_params
 from .config import logger
 from .exception import InvalidError, deprecation_error, deprecation_warning
 from .functions import _Function
@@ -340,7 +340,7 @@ def _asgi_app(
         )
 
     def wrapper(raw_f: Callable[..., Any]) -> _PartialFunction:
-        if not is_nullary_function(raw_f):
+        if method_has_params(raw_f):
             raise InvalidError(
                 f"ASGI app function {raw_f.__name__} can't have arguments. See https://modal.com/docs/guide/webhooks#asgi."
             )
@@ -405,7 +405,7 @@ def _wsgi_app(
         )
 
     def wrapper(raw_f: Callable[..., Any]) -> _PartialFunction:
-        if not is_nullary_function(raw_f):
+        if method_has_params(raw_f):
             raise InvalidError(
                 f"WSGI app function {raw_f.__name__} can't have arguments. See https://modal.com/docs/guide/webhooks#wsgi."
             )

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -191,7 +191,7 @@ def _method(
             ...
     ```
     """
-    if _warn_parentheses_missing:
+    if _warn_parentheses_missing is not None:
         raise InvalidError("Positional arguments are not allowed. Did you forget parentheses? Suggestion: `@method()`.")
 
     if keep_warm is not None:
@@ -264,7 +264,7 @@ def _web_endpoint(
     if isinstance(_warn_parentheses_missing, str):
         # Probably passing the method string as a positional argument.
         raise InvalidError('Positional arguments are not allowed. Suggestion: `@web_endpoint(method="GET")`.')
-    elif _warn_parentheses_missing:
+    elif _warn_parentheses_missing is not None:
         raise InvalidError(
             "Positional arguments are not allowed. Did you forget parentheses? Suggestion: `@web_endpoint()`."
         )
@@ -518,7 +518,7 @@ def _build(
             LlamaTokenizer.from_pretrained(base_model)
     ```
     """
-    if _warn_parentheses_missing:
+    if _warn_parentheses_missing is not None:
         raise InvalidError("Positional arguments are not allowed. Did you forget parentheses? Suggestion: `@build()`.")
 
     def wrapper(f: Union[Callable[[Any], Any], _PartialFunction]) -> _PartialFunction:
@@ -541,7 +541,7 @@ def _enter(
     """Decorator for methods which should be executed when a new container is started.
 
     See the [lifeycle function guide](https://modal.com/docs/guide/lifecycle-functions#enter) for more information."""
-    if _warn_parentheses_missing:
+    if _warn_parentheses_missing is not None:
         raise InvalidError("Positional arguments are not allowed. Did you forget parentheses? Suggestion: `@enter()`.")
 
     if snap:
@@ -571,7 +571,7 @@ def _exit(_warn_parentheses_missing=None) -> Callable[[ExitHandlerType], _Partia
     """Decorator for methods which should be executed when a container is about to exit.
 
     See the [lifeycle function guide](https://modal.com/docs/guide/lifecycle-functions#exit) for more information."""
-    if _warn_parentheses_missing:
+    if _warn_parentheses_missing is not None:
         raise InvalidError("Positional arguments are not allowed. Did you forget parentheses? Suggestion: `@exit()`.")
 
     def wrapper(f: ExitHandlerType) -> _PartialFunction:
@@ -611,7 +611,7 @@ def _batched(
 
     See the [dynamic batching guide](https://modal.com/docs/guide/dynamic-batching) for more information.
     """
-    if _warn_parentheses_missing:
+    if _warn_parentheses_missing is not None:
         raise InvalidError(
             "Positional arguments are not allowed. Did you forget parentheses? Suggestion: `@batched()`."
         )

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -18,7 +18,7 @@ import typing_extensions
 from modal_proto import api_pb2
 
 from ._utils.async_utils import synchronize_api, synchronizer
-from ._utils.function_utils import FunctionInfo, method_has_params
+from ._utils.function_utils import is_nullary_function, method_has_params
 from .config import logger
 from .exception import InvalidError, deprecation_error, deprecation_warning
 from .functions import _Function
@@ -340,7 +340,7 @@ def _asgi_app(
         )
 
     def wrapper(raw_f: Callable[..., Any]) -> _PartialFunction:
-        if not FunctionInfo(raw_f).is_nullary():
+        if not is_nullary_function(raw_f):
             raise InvalidError(
                 f"ASGI app function {raw_f.__name__} can't have arguments. See https://modal.com/docs/guide/webhooks#asgi."
             )
@@ -405,7 +405,7 @@ def _wsgi_app(
         )
 
     def wrapper(raw_f: Callable[..., Any]) -> _PartialFunction:
-        if not FunctionInfo(raw_f).is_nullary():
+        if not is_nullary_function(raw_f):
             raise InvalidError(
                 f"WSGI app function {raw_f.__name__} can't have arguments. See https://modal.com/docs/guide/webhooks#wsgi."
             )

--- a/test/function_utils_test.py
+++ b/test/function_utils_test.py
@@ -6,7 +6,7 @@ from grpclib import Status
 from modal import method, web_endpoint
 from modal._serialization import serialize_data_format
 from modal._utils import async_utils
-from modal._utils.function_utils import FunctionInfo, _stream_function_call_data, method_has_params
+from modal._utils.function_utils import _stream_function_call_data, is_nullary_function, method_has_params
 from modal_proto import api_pb2
 
 
@@ -27,10 +27,10 @@ def wildcard_args(*wildcard_list, **wildcard_dict):
 
 
 def test_is_nullary():
-    assert not FunctionInfo(hasarg).is_nullary()
-    assert FunctionInfo(noarg).is_nullary()
-    assert FunctionInfo(defaultarg).is_nullary()
-    assert FunctionInfo(wildcard_args).is_nullary()
+    assert not is_nullary_function(hasarg)
+    assert is_nullary_function(noarg)
+    assert is_nullary_function(defaultarg)
+    assert is_nullary_function(wildcard_args)
 
 
 class Cls:

--- a/test/function_utils_test.py
+++ b/test/function_utils_test.py
@@ -6,7 +6,12 @@ from grpclib import Status
 from modal import method, web_endpoint
 from modal._serialization import serialize_data_format
 from modal._utils import async_utils
-from modal._utils.function_utils import FunctionInfo, _stream_function_call_data, method_has_params
+from modal._utils.function_utils import (
+    FunctionInfo,
+    _stream_function_call_data,
+    callable_has_non_self_non_default_params,
+    callable_has_non_self_params,
+)
 from modal_proto import api_pb2
 
 
@@ -34,31 +39,57 @@ def test_is_nullary():
 
 
 class Cls:
-    def foo(self):
+    def f1(self):
         pass
 
-    def bar(self, x):
+    def f2(self, x):
         pass
 
-    def buz(self, *args):
+    def f3(self, *args):
+        pass
+
+    def f4(self, x=1):
         pass
 
 
-def test_method_has_params():
-    def qux():
-        pass
+def f5():
+    pass
 
-    def foobar(baz):
-        pass
 
-    assert not method_has_params(Cls.foo)
-    assert not method_has_params(Cls().foo)
-    assert method_has_params(Cls.bar)
-    assert method_has_params(Cls().bar)
-    assert method_has_params(Cls.buz)
-    assert method_has_params(Cls().buz)
-    assert not method_has_params(qux)
-    assert method_has_params(foobar)
+def f6(x):
+    pass
+
+
+def f7(x=1):
+    pass
+
+
+def test_callable_has_non_self_params():
+    assert not callable_has_non_self_params(Cls.f1)
+    assert not callable_has_non_self_params(Cls().f1)
+    assert callable_has_non_self_params(Cls.f2)
+    assert callable_has_non_self_params(Cls().f2)
+    assert callable_has_non_self_params(Cls.f3)
+    assert callable_has_non_self_params(Cls().f3)
+    assert callable_has_non_self_params(Cls.f4)
+    assert callable_has_non_self_params(Cls().f4)
+    assert not callable_has_non_self_params(f5)
+    assert callable_has_non_self_params(f6)
+    assert callable_has_non_self_params(f7)
+
+
+def test_callable_has_non_self_non_default_params():
+    assert not callable_has_non_self_non_default_params(Cls.f1)
+    assert not callable_has_non_self_non_default_params(Cls().f1)
+    assert callable_has_non_self_non_default_params(Cls.f2)
+    assert callable_has_non_self_non_default_params(Cls().f2)
+    assert callable_has_non_self_non_default_params(Cls.f3)
+    assert callable_has_non_self_non_default_params(Cls().f3)
+    assert not callable_has_non_self_non_default_params(Cls.f4)
+    assert not callable_has_non_self_non_default_params(Cls().f4)
+    assert not callable_has_non_self_non_default_params(f5)
+    assert callable_has_non_self_non_default_params(f6)
+    assert not callable_has_non_self_non_default_params(f7)
 
 
 class Foo:

--- a/test/function_utils_test.py
+++ b/test/function_utils_test.py
@@ -45,12 +45,20 @@ class Cls:
 
 
 def test_method_has_params():
+    def qux():
+        pass
+
+    def foobar(baz):
+        pass
+
     assert not method_has_params(Cls.foo)
     assert not method_has_params(Cls().foo)
     assert method_has_params(Cls.bar)
     assert method_has_params(Cls().bar)
     assert method_has_params(Cls.buz)
     assert method_has_params(Cls().buz)
+    assert not method_has_params(qux)
+    assert method_has_params(foobar)
 
 
 class Foo:

--- a/test/function_utils_test.py
+++ b/test/function_utils_test.py
@@ -6,7 +6,7 @@ from grpclib import Status
 from modal import method, web_endpoint
 from modal._serialization import serialize_data_format
 from modal._utils import async_utils
-from modal._utils.function_utils import _stream_function_call_data, is_nullary_function, method_has_params
+from modal._utils.function_utils import FunctionInfo, _stream_function_call_data, method_has_params
 from modal_proto import api_pb2
 
 
@@ -27,10 +27,10 @@ def wildcard_args(*wildcard_list, **wildcard_dict):
 
 
 def test_is_nullary():
-    assert not is_nullary_function(hasarg)
-    assert is_nullary_function(noarg)
-    assert is_nullary_function(defaultarg)
-    assert is_nullary_function(wildcard_args)
+    assert not FunctionInfo(hasarg).is_nullary()
+    assert FunctionInfo(noarg).is_nullary()
+    assert FunctionInfo(defaultarg).is_nullary()
+    assert FunctionInfo(wildcard_args).is_nullary()
 
 
 class Cls:

--- a/test/webhook_test.py
+++ b/test/webhook_test.py
@@ -134,13 +134,27 @@ async def test_asgi_wsgi(servicer, client):
 
     @app.function(serialized=True)
     @asgi_app()
-    async def my_asgi(x):
+    async def my_asgi():
         pass
 
     @app.function(serialized=True)
     @wsgi_app()
-    async def my_wsgi(x):
+    async def my_wsgi():
         pass
+
+    with pytest.raises(InvalidError, match="can't have arguments"):
+
+        @app.function(serialized=True)
+        @asgi_app()
+        async def my_invalid_asgi(x):
+            pass
+
+    with pytest.raises(InvalidError, match="can't have arguments"):
+
+        @app.function(serialized=True)
+        @wsgi_app()
+        async def my_invalid_wsgi(x):
+            pass
 
     async with app.run(client=client):
         pass

--- a/test/webhook_test.py
+++ b/test/webhook_test.py
@@ -142,28 +142,28 @@ async def test_asgi_wsgi(servicer, client):
     async def my_wsgi():
         pass
 
-    with pytest.raises(InvalidError, match="can't have arguments"):
+    with pytest.raises(InvalidError, match="can't have parameters"):
 
         @app.function(serialized=True)
         @asgi_app()
         async def my_invalid_asgi(x):
             pass
 
-    with pytest.raises(InvalidError, match="can't have arguments"):
+    with pytest.raises(InvalidError, match="can't have parameters"):
 
         @app.function(serialized=True)
         @wsgi_app()
         async def my_invalid_wsgi(x):
             pass
 
-    with pytest.warns(DeprecationError, match="default argument"):
+    with pytest.warns(DeprecationError, match="default parameters"):
 
         @app.function(serialized=True)
         @asgi_app()
         async def my_deprecated_default_params_asgi(x=1):
             pass
 
-    with pytest.warns(DeprecationError, match="default arguments"):
+    with pytest.warns(DeprecationError, match="default parameters"):
 
         @app.function(serialized=True)
         @wsgi_app()


### PR DESCRIPTION
## Describe your changes

MOD-3613

Clients now get a descriptive error quickly if their asgi / wsgi app has a function with arguments.

Also, fix a small bug that allowed 0 as an argument to various descriptors because of falsey-ness in Python.

---
