### PR TITLE
Add environment to SandboxListRequest

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1828,6 +1828,7 @@ message SandboxInfo {
 message SandboxListRequest {
   string app_id = 1;
   double before_timestamp = 2;
+  string environment_name = 3;
 }
 
 message SandboxListResponse {


### PR DESCRIPTION
## Describe your changes

- Part of MOD-3626. `modal-web` will use this RPC to display a list of all sandboxes in an environment. We also want to add a CLI command to do the same thing (maybe `modal sandboxes list`?)

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>
