### PR TITLE
Infer sandbox app if spawned from inside container

### DIFF
--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -442,6 +442,7 @@ class _ContainerIOManager:
             environment_name=self._environment_name,
             tag_to_object_id=tag_to_object_id,
             object_handle_metadata=object_handle_metadata,
+            client=self._client,
         )
 
     async def get_serialized_function(self) -> Tuple[Optional[Any], Optional[Callable[..., Any]]]:

--- a/modal/app.py
+++ b/modal/app.py
@@ -124,6 +124,7 @@ class _App:
     """
 
     _all_apps: ClassVar[Dict[Optional[str], List["_App"]]] = {}
+    _container_app: ClassVar[Optional[RunningApp]] = None
 
     _name: Optional[str]
     _description: Optional[str]
@@ -140,8 +141,6 @@ class _App:
     _app_id: Optional[str]  # Kept after app finishes
     _running_app: Optional[RunningApp]  # Various app info
     _client: Optional[_Client]
-
-    _container_app: ClassVar[Optional[RunningApp]] = None
 
     def __init__(
         self,

--- a/modal/app.py
+++ b/modal/app.py
@@ -141,6 +141,8 @@ class _App:
     _running_app: Optional[RunningApp]  # Various app info
     _client: Optional[_Client]
 
+    _container_app: ClassVar[Optional[RunningApp]] = None
+
     def __init__(
         self,
         name: Optional[str] = None,
@@ -211,6 +213,10 @@ class _App:
     def description(self) -> Optional[str]:
         """The App's `name`, if available, or a fallback descriptive identifier."""
         return self._description
+
+    @property
+    def client(self) -> Optional[_Client]:
+        return self._client
 
     def set_description(self, description: str):
         self._description = description
@@ -428,6 +434,8 @@ class _App:
         self._app_id = running_app.app_id
         self._running_app = running_app
         self._client = client
+
+        _App._container_app = running_app
 
         # Hydrate objects on app
         for tag, object_id in running_app.tag_to_object_id.items():

--- a/modal/app.py
+++ b/modal/app.py
@@ -213,10 +213,6 @@ class _App:
         """The App's `name`, if available, or a fallback descriptive identifier."""
         return self._description
 
-    @property
-    def client(self) -> Optional[_Client]:
-        return self._client
-
     def set_description(self, description: str):
         self._description = description
 

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -57,7 +57,7 @@ async def _init_local_app_existing(client: _Client, existing_app_id: str) -> Run
     obj_resp = await retry_transient_errors(client.stub.AppGetObjects, obj_req)
     app_page_url = f"https://modal.com/apps/{existing_app_id}"  # TODO (elias): this should come from the backend
     object_ids = {item.tag: item.object.object_id for item in obj_resp.items}
-    return RunningApp(existing_app_id, app_page_url=app_page_url, tag_to_object_id=object_ids)
+    return RunningApp(existing_app_id, app_page_url=app_page_url, tag_to_object_id=object_ids, client=client)
 
 
 async def _init_local_app_new(
@@ -76,6 +76,7 @@ async def _init_local_app_new(
     logger.debug(f"Created new app with id {app_resp.app_id}")
     return RunningApp(
         app_resp.app_id,
+        client=client,
         app_page_url=app_resp.app_page_url,
         app_logs_url=app_resp.app_logs_url,
         environment_name=environment_name,

--- a/modal/running_app.py
+++ b/modal/running_app.py
@@ -4,6 +4,8 @@ from typing import Dict, Optional
 
 from google.protobuf.message import Message
 
+from .client import _Client
+
 
 @dataclass
 class RunningApp:
@@ -14,3 +16,4 @@ class RunningApp:
     tag_to_object_id: Dict[str, str] = field(default_factory=dict)
     object_handle_metadata: Dict[str, Optional[Message]] = field(default_factory=dict)
     interactive: bool = False
+    client: Optional[_Client] = None

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -192,6 +192,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.volume_reloads: Dict[str, int] = defaultdict(lambda: 0)
 
         self.sandbox_defs = []
+        self.sandbox_app_id = None
         self.sandbox: asyncio.subprocess.Process = None
         self.sandbox_result: Optional[api_pb2.GenericResult] = None
 
@@ -1181,6 +1182,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
             stdin=asyncio.subprocess.PIPE,
         )
 
+        self.sandbox_app_id = request.app_id
         self.sandbox_defs.append(request.definition)
 
         await stream.send_message(api_pb2.SandboxCreateResponse(sandbox_id="sb-123"))

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -2065,3 +2065,9 @@ def test_max_concurrency(servicer):
 
     outputs = [deserialize(item.result.data, ret.client) for item in ret.items]
     assert n_inputs in outputs
+
+
+@skip_github_non_linux
+def test_sandbox_infers_app(servicer, event_loop):
+    _run_container(servicer, "test.supports.sandbox", "spawn_sandbox")
+    assert servicer.sandbox_app_id == "ap-1"

--- a/test/supports/sandbox.py
+++ b/test/supports/sandbox.py
@@ -1,3 +1,4 @@
+# Copyright Modal Labs 2024
 import modal
 
 app = modal.App()

--- a/test/supports/sandbox.py
+++ b/test/supports/sandbox.py
@@ -1,0 +1,8 @@
+import modal
+
+app = modal.App()
+
+
+@app.function()
+def spawn_sandbox(x):
+    modal.Sandbox.create("bash", "-c", "echo bar")


### PR DESCRIPTION
Right now `Sandbox.create()` doesn't associate the `Sandbox` with the `App`, even if it's spawned from inside a Modal function (which is overwhelmingly the case). This PR starts storing the `container_app` as a `ClassVar` to fix this.
