### PR TITLE
Upgrade run_stub, deploy_stub, serve_stub from warnings to errors

### DIFF
--- a/modal/runner.py
+++ b/modal/runner.py
@@ -4,7 +4,7 @@ import dataclasses
 import os
 import time
 from multiprocessing.synchronize import Event
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Coroutine, Dict, List, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Dict, List, Optional, TypeVar
 
 from grpclib import GRPCError, Status
 from synchronicity.async_wrap import asynccontextmanager
@@ -27,7 +27,7 @@ from .exception import (
     InvalidError,
     RemoteError,
     _CliUserExecutionError,
-    deprecation_warning,
+    deprecation_error,
 )
 from .execution_context import is_local
 from .object import _Object
@@ -533,20 +533,18 @@ async def _interactive_shell(_app: _App, cmds: List[str], environment_name: str 
                 raise
 
 
-def _run_stub(*args: Any, **kwargs: Any) -> AsyncGenerator[_App, None]:
+def _run_stub(*args: Any, **kwargs: Any):
     """mdmd:hidden
     `run_stub` has been renamed to `run_app` and is deprecated. Please update your code.
     """
-    deprecation_warning(
+    deprecation_error(
         (2024, 5, 1), "`run_stub` has been renamed to `run_app` and is deprecated. Please update your code."
     )
-    return _run_app(*args, **kwargs)
 
 
-def _deploy_stub(*args: Any, **kwargs: Any) -> Coroutine[Any, Any, DeployResult]:
+def _deploy_stub(*args: Any, **kwargs: Any):
     """`deploy_stub` has been renamed to `deploy_app` and is deprecated. Please update your code."""
-    deprecation_warning((2024, 5, 1), str(_deploy_stub.__doc__))
-    return _deploy_app(*args, **kwargs)
+    deprecation_error((2024, 5, 1), str(_deploy_stub.__doc__))
 
 
 run_app = synchronize_api(_run_app)

--- a/modal/serving.py
+++ b/modal/serving.py
@@ -16,7 +16,7 @@ from ._watcher import watch
 from .cli.import_refs import import_app
 from .client import _Client
 from .config import config
-from .exception import deprecation_warning
+from .exception import deprecation_error
 from .runner import _run_app, serve_update
 
 if TYPE_CHECKING:
@@ -123,8 +123,7 @@ async def _serve_app(
 
 
 def _serve_stub(*args, **kwargs):
-    deprecation_warning((2024, 5, 1), "`serve_stub` is deprecated. Please use `serve_app` instead.")
-    return _run_app(*args, **kwargs)
+    deprecation_error((2024, 5, 1), "`serve_stub` is deprecated. Please use `serve_app` instead.")
 
 
 serve_app = synchronize_api(_serve_app)

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -338,7 +338,7 @@ def test_stub():
 def test_deploy_stub(servicer, client):
     app = App("xyz")
     deploy_app(app, client=client)
-    with pytest.warns(match="deploy_app"):
+    with pytest.raises(DeprecationError, match="deploy_app"):
         deploy_stub(app, client=client)
 
 


### PR DESCRIPTION
These have had deprecation warnings for 4 months and I don't think they are very commonly used, so let's bump them to errors.