### PR TITLE
Adding i6pn to sandboxes

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -129,6 +129,7 @@ class _Sandbox(_Object, type_prefix="sb"):
                 pty_info=pty_info,
                 scheduler_placement=scheduler_placement.proto if scheduler_placement else None,
                 worker_id=config.get("worker_id"),
+                i6pn_enabled=config.get("i6pn_enabled"),
             )
 
             # Note - `resolver.app_id` will be `None` for app-less sandboxes

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1777,6 +1777,8 @@ message Sandbox {
   oneof open_ports_oneof {
     PortSpecs open_ports = 20;
   }
+
+  bool i6pn_enabled = 21;
 }
 
 message SandboxCreateRequest {


### PR DESCRIPTION
## Describe your changes

Add i6pn support to sandboxes

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
