### PR TITLE
Type information for functions.gather 

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1487,7 +1487,7 @@ class _FunctionCall(typing.Generic[R], _Object, type_prefix="fc"):
 FunctionCall = synchronize_api(_FunctionCall)
 
 
-async def _gather(*function_calls: _FunctionCall):
+async def _gather(*function_calls: _FunctionCall[R]) -> typing.Sequence[R]:
     """Wait until all Modal function calls have results before returning
 
     Accepts a variable number of FunctionCall objects as returned by `Function.spawn()`.

--- a/test/supports/type_assertions.py
+++ b/test/supports/type_assertions.py
@@ -1,4 +1,6 @@
 # Copyright Modal Labs 2024
+import typing
+
 from typing_extensions import assert_type
 
 import modal
@@ -11,5 +13,15 @@ def typed_func(a: str) -> float:
     return 0.0
 
 
+@app.function()
+def other_func() -> str:
+    return "foo"
+
+
 ret = typed_func.remote(a="hello")
 assert_type(ret, float)
+
+ret2 = modal.functions.gather(typed_func.spawn("bar"), other_func.spawn())
+# This assertion doesn't work in mypy (it infers the more generic list[object]), but does work in pyright/vscode:
+# assert_type(ret2, typing.List[typing.Union[float, str]])
+mypy_compatible_ret: typing.Sequence[object] = ret2  # mypy infers to the broader "object" type instead


### PR DESCRIPTION
Adds generic type info to functions.gather

Works great on pyright and "ok" on mypy :)

Fixes https://github.com/modal-labs/modal-client/issues/2188