### PR TITLE
Add FunctionMeta message

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1275,6 +1275,44 @@ message FunctionMapResponse {
   repeated FunctionPutInputsResponseItem pipelined_inputs = 2;
 }
 
+message FunctionMeta {
+  // Subset of fields from Function message above that will get deprecated there
+  // and made authoritative here. Represents metadata about the function itself,
+  // stored inline with the function object, capturing data not specific to any
+  // particular underlying task. Something specific would be the kind of GPU
+  // used, for instance.
+
+  string module_name = 1;
+  string function_name = 2;
+
+  Function.FunctionType function_type = 3;
+
+  // Scheduling related fields.
+  uint32 warm_pool_size = 4;
+  uint32 concurrency_limit = 5;
+  uint32 task_idle_timeout_secs = 6;
+  string worker_id = 7; // for internal debugging use only
+  // TODO(irfansharif): Field to control whether [warm-pool-size,
+  // concurrency-limit] is in input-slot-units?
+
+  // Input timeout, applies across all underlying tasks.
+  uint32 timeout_secs = 8;
+
+  string web_url = 9;
+  repeated CustomDomainInfo custom_domain_info = 10;
+  WebhookConfig webhook_config = 11;
+
+  bool is_class = 12;  // if "Function" is actually a class grouping multiple methods - applies across all underlying tasks
+  ClassParameterInfo class_parameter_info = 13;
+
+  bool is_method = 14;
+  string use_function_id = 15; // used for methods
+  string use_method_name = 16; // used for methods
+
+  // TODO(irfansharif): Should we just expand FunctionHandleMetadata + persist
+  // instead?
+}
+
 message FunctionOptions {
   repeated string secret_ids = 1;
   repeated string mount_ids = 2; // Currently not supported


### PR DESCRIPTION
Precursor to using multiple underlying 'message Function' for a given @app.function, if it represents a group of @app.function-like things.