### PR TITLE
fix wrong formatting for changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ We appreciate your patience while we speedily work towards a stable release of t
 
 <!-- NEW CONTENT GENERATED BELOW. PLEASE PRESERVE THIS COMMENT. -->
 
+
 ### 0.64.87 (2024-09-05)
 
 Sandboxes now support port tunneling. Ports can be exposed via the `open_ports` argument, and a list of active tunnels can be retrieved via the `.tunnels()` method.
@@ -24,16 +25,19 @@ Sandboxes now support port tunneling. Ports can be exposed via the `open_ports` 
 ### 0.64.48 (2024-08-21)
 
 - Introduces new dataclass-style syntax for class parameterization (see updated [docs](https://modal.com/docs/guide/parameterized-functions))
-    ```py
+
+    ```python
     @app.cls()
     class MyCls:
         param_a: str = modal.parameter()
 
-
     MyCls(param_a="hello")  # synthesized constructor
     ```
+    
 - The new syntax enforces types (`str` or `int` for now) on all parameters
+
 - *When the new syntax is used*, any web endpoints (`web_endpoint`, `asgi_app`, `wsgi_app` or `web_server`) on the app will now also support parameterization through the use of query parameters matching the parameter names, e.g. `https://myfunc.modal.run/?param_a="hello` in the above example.
+
 - The old explicit `__init__` constructor syntax is still allowed, but could be deprecated in the future and doesn't work with web endpoint parameterization
 
 ### 0.64.38 (2024-08-16)
@@ -67,7 +71,7 @@ Sandboxes now support port tunneling. Ports can be exposed via the `open_ports` 
 
 - Added support for dynamic batching. Functions or class methods decorated with `@modal.batched` will now automatically batch their invocations together, up to a specified `max_batch_size`.  The batch will wait for a maximum of `wait_ms` for more invocations after the first invocation is made. See guide for more details.
 
-    ```
+    ```python
     @app.function()
     @modal.batched(max_batch_size=4, wait_ms=1000)
     async def batched_multiply(xs: list[int], ys: list[int]) -> list[int]:
@@ -81,7 +85,7 @@ Sandboxes now support port tunneling. Ports can be exposed via the `open_ports` 
     ```
 
     The batched function is called with individual inputs:
-    ```
+    ```python
     await batched_multiply.remote.aio(2, 3)
     ```
 
@@ -445,10 +449,10 @@ Sandboxes now support port tunneling. Ports can be exposed via the `open_ports` 
 
 - Added `Dict.delete` and `Queue.delete` as API methods for deleting named storage objects:
 
-    ```
+    ```python
     import modal
     modal.Queue.delete("my-job-queue")
-   ```
+    ```
 - Deprecated invoking `Volume.delete` as an instance method; it should now be invoked as a static method with the name of  the Volume to delete, as with the other methods.
 
 


### PR DESCRIPTION
Fix formatting error in https://github.com/modal-labs/modal-client/pull/2198 resulting in:
<img width="843" alt="Screenshot 2024-09-11 at 09 38 15" src="https://github.com/user-attachments/assets/c55d3e95-65e0-4368-93b1-657b1df85487">

now looks like:

<img width="838" alt="Screenshot 2024-09-11 at 09 39 11" src="https://github.com/user-attachments/assets/286e7bbb-b2c2-4fe1-a2a4-e9860ad87268">

