### PR TITLE
Ensure we clean up asgi fetch_data_in task on cancellation MOD-3537

### DIFF
--- a/modal/_asgi.py
+++ b/modal/_asgi.py
@@ -126,9 +126,9 @@ def asgi_app_wrapper(asgi_app, container_io_manager) -> Tuple[Callable[..., Asyn
             # immediately after starting the ASGI app's function call. If it is not received, that
             # indicates a request cancellation or other abnormal circumstance.
             message_gen = container_io_manager.get_data_in.aio(function_call_id)
+            first_message_task = asyncio.create_task(message_gen.__anext__())
 
             try:
-                first_message_task = asyncio.create_task(message_gen.__anext__())
                 # we are intentionally shielding + manually cancelling first_message_task, since cancellations
                 # can otherwise get ignored in case the cancellation and an awaited future resolve gets
                 # triggered in the same sequence before handing back control to the event loop.

--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -141,23 +141,17 @@ class TaskContext:
                 except asyncio.CancelledError:
                     pass
 
-            cancelled_tasks = []
             for task in self._tasks:
                 if task.done() and not task.cancelled():
                     # Raise any exceptions if they happened.
                     # Only tasks without a done_callback will still be present in self._tasks
                     task.result()
 
+                if task.done() or task in self._loops:  # Note: Legacy code, we can probably cancel loops.
+                    continue
+
                 # Cancel any remaining unfinished tasks.
                 task.cancel()
-                cancelled_tasks.append(task)
-
-            # make sure to actually listen to the task's cancellations
-            for task in cancelled_tasks:
-                try:
-                    await task
-                except asyncio.CancelledError:
-                    pass
 
     async def __aexit__(self, exc_type, value, tb):
         await self.stop()

--- a/test/asgi_wrapper_test.py
+++ b/test/asgi_wrapper_test.py
@@ -242,7 +242,7 @@ async def test_cancellation_while_waiting_for_first_input():
     # fetch_data_in task, causing either warnings on shutdown or even infinite stalling on
     # shutdown.
     _set_current_context_ids(["in-123"], ["fc-123"])
-    fut = asyncio.Future()
+    fut: asyncio.Future[None] = asyncio.Future()
 
     class StreamingIOManager:
         class get_data_in:
@@ -254,7 +254,7 @@ async def test_cancellation_while_waiting_for_first_input():
     wrapped_app, _ = asgi_app_wrapper(app, StreamingIOManager())
     asgi_scope = _asgi_get_scope("/async_reading_body", "POST")
 
-    first_app_output = asyncio.create_task(wrapped_app(asgi_scope).__anext__())
+    first_app_output = asyncio.create_task(wrapped_app(asgi_scope).__anext__())  # type: ignore
     await asyncio.sleep(0.1)  # ensure we are in wait_for(first_message_task)
     first_app_output.cancel()
     await asyncio.sleep(0.1)  # resume event loop to resolve tasks if possible
@@ -269,7 +269,7 @@ async def test_cancellation_when_first_input_arrives():
     # fetch_data_in task, causing either warnings on shutdown or even infinite stalling on
     # shutdown.
     _set_current_context_ids(["in-123"], ["fc-123"])
-    fut = asyncio.Future()
+    fut: asyncio.Future[None] = asyncio.Future()
 
     class StreamingIOManager:
         class get_data_in:
@@ -283,7 +283,7 @@ async def test_cancellation_when_first_input_arrives():
     wrapped_app, _ = asgi_app_wrapper(app, StreamingIOManager())
     asgi_scope = _asgi_get_scope("/async_reading_body", "POST")
 
-    first_app_output = asyncio.create_task(wrapped_app(asgi_scope).__anext__())
+    first_app_output = asyncio.create_task(wrapped_app(asgi_scope).__anext__())  # type: ignore
     await asyncio.sleep(0.1)  # ensure we are in wait_for(first_message_task)
     # now lets unblock get_data_in, supplying a request to the waiting asgi app
     # fut.set_result(None)


### PR DESCRIPTION
Superficially, this should prevent the `Task was destroyed but it is pending!` warnings that get printed frequently for asgi apps shutting down.

In addition this would also remove some unnecessary gcpc streams from zombie fetch_data_in tasks running in asgi containers with cancelled inputs (specifically for inputs that get cancelled at the same time that they are scheduled to receive their first asgi payload)
