### PR TITLE
Remove flaky now that warning has been fixed

### DIFF
--- a/test/async_utils_test.py
+++ b/test/async_utils_test.py
@@ -194,7 +194,6 @@ async def test_queue_batch_iterator():
         assert len(drained_items) == 3
 
 
-@pytest.mark.flaky(max_runs=3)
 @pytest.mark.asyncio
 async def test_warn_if_generator_is_not_consumed(caplog):
     @warn_if_generator_is_not_consumed()


### PR DESCRIPTION
Fix in https://github.com/modal-labs/modal-client/pull/2209 should hopefully prevent random warning leakage (due to delayed garbage collection of pending tasks) that we had before