### PR TITLE
Allowing cloud selection in container networking jobs

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -735,7 +735,7 @@ class _App:
             if container_networking and not _experimental_scheduler_placement:
                 scheduler_placement = SchedulerPlacement(zone="us-east-1f")
 
-            if container_networking:
+            if container_networking and not cloud:
                 cloud = "aws"
 
             # END Experimental: Container Networking


### PR DESCRIPTION
## Describe your changes

Previously would set cloud to AWS for container networking jobs. User overrides are now accepted.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
