### PR TITLE
Update SandboxList proto to have an option to return finished tasks and remove definition

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1832,15 +1832,17 @@ message SandboxHandleMetadata {
 
 message SandboxInfo {
   string id = 1;
-  modal.client.Sandbox definition = 2;
   double created_at = 3;
   TaskInfo task_info = 4;
+
+  reserved 2; // modal.client.Sandbox definition
 }
 
 message SandboxListRequest {
   string app_id = 1;
   double before_timestamp = 2;
   string environment_name = 3;
+  bool include_finished = 4;
 }
 
 message SandboxListResponse {


### PR DESCRIPTION
By default, we only really care about unfinished sandboxes, which is what list in the client will return. However, we should have the option to see everything.

Nothing uses definition, so this should be safe to rip out.