### PR TITLE
Add protos for grouped functions

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1140,6 +1140,7 @@ message FunctionCreateRequest {
   // be done in AppPublish. Provides a smoother migration onto atomic deployments with 0.64,
   // and can be deprecated once we no longer support ealier versions.
   bool defer_updates = 8;
+  FunctionData function_data = 9;  // supersedes 'function' field above
 }
 
 message FunctionCreateResponse {
@@ -1148,6 +1149,58 @@ message FunctionCreateResponse {
   Function function = 4;
   FunctionHandleMetadata handle_metadata = 5;
 }
+
+message FunctionData {
+  // Note: FunctionData pulls "up" a subset of fields from Function message that
+  // will get deprecated there and made authoritative here, at the top-level.
+  // All remaining fields will stay within the Function message itself and a
+  // single FunctionData will contain a list of such (ranked) Functions. The
+  // top-level fields capture data not specific to any particular underlying
+  // task (like warm-pool-size, applicable across all tasks), while fields
+  // specific to the task (like the resource request) will exist at the bottom
+  // level.
+
+  string module_name = 1;
+  string function_name = 2;
+
+  Function.FunctionType function_type = 3;
+
+  // Scheduling related fields.
+  uint32 warm_pool_size = 4;
+  uint32 concurrency_limit = 5;
+  uint32 task_idle_timeout_secs = 6;
+  string worker_id = 7; // for internal debugging use only
+
+  uint32 timeout_secs = 8;
+
+  string web_url = 9;
+  WebUrlInfo web_url_info = 10;
+  WebhookConfig webhook_config = 11;
+  repeated CustomDomainInfo custom_domain_info = 12;
+
+  bool is_class = 13;  // if "Function" is actually a class grouping multiple methods - applies across all underlying tasks
+  ClassParameterInfo class_parameter_info = 14;
+
+  bool is_method = 15;
+  string use_function_id = 16; // used for methods
+  string use_method_name = 17; // used for methods
+
+  message RankedFunction {
+    uint32 rank = 1;
+    Function function = 2;
+  }
+  repeated RankedFunction ranked_functions = 18;
+}
+
+message FunctionExtended {
+  // FunctionExtended is a union type that exists while we migrate between
+  // storage of FunctionData vs. Functions, internally.
+  oneof function_extended {
+      Function function_singleton = 1;
+      FunctionData function_data = 2;
+  }
+}
+
 
 message FunctionGetCallGraphRequest {
   // TODO: use input_id once we switch client submit API to return those.
@@ -1283,6 +1336,44 @@ message FunctionMapRequest {
 message FunctionMapResponse {
   string function_call_id = 1;
   repeated FunctionPutInputsResponseItem pipelined_inputs = 2;
+}
+
+message FunctionMeta {
+  // Subset of fields from Function message above that will get deprecated there
+  // and made authoritative here. Represents metadata about the function itself,
+  // stored inline with the function object, capturing data not specific to any
+  // particular underlying task. Something specific would be the kind of GPU
+  // used, for instance.
+
+  string module_name = 1;
+  string function_name = 2;
+
+  Function.FunctionType function_type = 3;
+
+  // Scheduling related fields.
+  uint32 warm_pool_size = 4;
+  uint32 concurrency_limit = 5;
+  uint32 task_idle_timeout_secs = 6;
+  string worker_id = 7; // for internal debugging use only
+  // TODO(irfansharif): Field to control whether [warm-pool-size,
+  // concurrency-limit] is in input-slot-units?
+
+  // Input timeout, applies across all underlying tasks.
+  uint32 timeout_secs = 8;
+
+  string web_url = 9;
+  repeated CustomDomainInfo custom_domain_info = 10;
+  WebhookConfig webhook_config = 11;
+
+  bool is_class = 12;  // if "Function" is actually a class grouping multiple methods - applies across all underlying tasks
+  ClassParameterInfo class_parameter_info = 13;
+
+  bool is_method = 14;
+  string use_function_id = 15; // used for methods
+  string use_method_name = 16; // used for methods
+
+  // TODO(irfansharif): Should we just expand FunctionHandleMetadata + persist
+  // instead?
 }
 
 message FunctionOptions {


### PR DESCRIPTION
Following the option 1 scheme from
https://www.notion.so/modal-com/Fragmenting-function-definitions-4cc63e66d80c4ccb82914c4da901e6fd. Precursor to using multiple underlying 'message Function' for a given @app.function, if it represents a group of @app.function-like things.