### PR TITLE
Add fine-grained network access protos

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1550,6 +1550,17 @@ message MultiPartUpload {
   string completion_url = 3;
 }
 
+message NetworkAccess {
+  enum NetworkAccessType {
+    UNSPECIFIED = 0;
+    OPEN = 1;
+    BLOCKED = 2;
+    ALLOWLIST = 3;
+  }
+  NetworkAccessType network_access_type = 1;
+  repeated string allowed_cidrs = 2;
+}
+
 message Object {
   string object_id = 1;
   oneof handle_metadata_oneof {
@@ -1780,6 +1791,9 @@ message Sandbox {
   }
 
   bool i6pn_enabled = 21;
+
+  // Network access configuration beyond simple allow/block.
+  NetworkAccess network_access = 22;
 }
 
 message SandboxCreateRequest {


### PR DESCRIPTION
## Describe your changes

This commit adds a new NetworkAccess protobuf definition that allows users to list CIDRs that they want to allow their container to talk to.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
