### PR TITLE
[MOD-3775] Allow users to set tags on sandboxes and filter by those tags when listing

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -249,6 +249,19 @@ class _Sandbox(_Object, type_prefix="sb"):
 
         return obj
 
+    async def set_tags(self, tags: Dict[str, str], *, client: Optional[_Client] = None):
+        """Set tags (key-value pairs) on the sandbox to help with filtering."""
+        environment_name = _get_environment_name()
+        if client is None:
+            client = await _Client.from_env()
+
+        req = api_pb2.SandboxTagsSetRequest(
+            environment_name=environment_name,
+            sandbox_id=self.object_id,
+            tags=[api_pb2.SandboxTag(tag_name=name, tag_value=value) for name, value in tags.items()],
+        )
+        await retry_transient_errors(client.stub.SandboxTagsSet, req)
+
     # Live handle methods
 
     async def wait(self, raise_on_termination: bool = True):

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -250,7 +250,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         return obj
 
     async def set_tags(self, tags: Dict[str, str], *, client: Optional[_Client] = None):
-        """Set tags (key-value pairs) on the sandbox to help with filtering."""
+        """Set tags (key-value pairs) on the Sandbox. Tags can be used to filter results in `Sandbox.list`."""
         environment_name = _get_environment_name()
         if client is None:
             client = await _Client.from_env()

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -255,10 +255,12 @@ class _Sandbox(_Object, type_prefix="sb"):
         if client is None:
             client = await _Client.from_env()
 
+        tags_list = [api_pb2.SandboxTag(tag_name=name, tag_value=value) for name, value in tags.items()]
+
         req = api_pb2.SandboxTagsSetRequest(
             environment_name=environment_name,
             sandbox_id=self.object_id,
-            tags=[api_pb2.SandboxTag(tag_name=name, tag_value=value) for name, value in tags.items()],
+            tags=tags_list,
         )
         await retry_transient_errors(client.stub.SandboxTagsSet, req)
 
@@ -402,7 +404,7 @@ class _Sandbox(_Object, type_prefix="sb"):
 
     @staticmethod
     async def list(
-        *, app_id: Optional[str] = None, client: Optional[_Client] = None
+        *, app_id: Optional[str] = None, tags: Optional[Dict[str, str]] = None, client: Optional[_Client] = None
     ) -> AsyncGenerator["_Sandbox", None]:
         """List all sandboxes for the current environment or app ID (if specified). Returns an iterator over `Sandbox`
         objects."""
@@ -411,12 +413,15 @@ class _Sandbox(_Object, type_prefix="sb"):
         if client is None:
             client = await _Client.from_env()
 
+        tags_list = [api_pb2.SandboxTag(tag_name=name, tag_value=value) for name, value in tags.items()] if tags else []
+
         while True:
             req = api_pb2.SandboxListRequest(
                 app_id=app_id,
                 before_timestamp=before_timestamp,
                 environment_name=environment_name,
                 include_finished=False,
+                tags=tags_list,
             )
 
             # Fetches a batch of sandboxes.

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2539,6 +2539,7 @@ service ModalClient {
   rpc SandboxGetTunnels(SandboxGetTunnelsRequest) returns (SandboxGetTunnelsResponse);
   rpc SandboxList(SandboxListRequest) returns (SandboxListResponse);
   rpc SandboxStdinWrite(SandboxStdinWriteRequest) returns (SandboxStdinWriteResponse);
+  rpc SandboxTagsSet(SandboxTagsSetRequest) returns (google.protobuf.Empty);
   rpc SandboxTerminate(SandboxTerminateRequest) returns (SandboxTerminateResponse);
   rpc SandboxWait(SandboxWaitRequest) returns (SandboxWaitResponse);
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1233,7 +1233,11 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def SandboxList(self, stream):
         request: api_pb2.SandboxListRequest = await stream.recv_message()
+<<<<<<< HEAD
         if self.sandbox.returncode or request.before_timestamp == 1:
+=======
+        if self.sandbox.returncode:
+>>>>>>> bef71a39 (Test sandbox listing.)
             await stream.send_message(api_pb2.SandboxListResponse(sandboxes=[]))
             return
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1233,11 +1233,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def SandboxList(self, stream):
         request: api_pb2.SandboxListRequest = await stream.recv_message()
-<<<<<<< HEAD
         if self.sandbox.returncode or request.before_timestamp == 1:
-=======
-        if self.sandbox.returncode:
->>>>>>> bef71a39 (Test sandbox listing.)
             await stream.send_message(api_pb2.SandboxListResponse(sandboxes=[]))
             return
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1241,6 +1241,11 @@ class MockClientServicer(api_grpc.ModalClientBase):
             await stream.send_message(api_pb2.SandboxListResponse(sandboxes=[]))
             return
 
+        for tag in request.tags:
+            if self.sandbox_tags.get(tag.tag_name) != tag.tag_value:
+                await stream.send_message(api_pb2.SandboxListResponse(sandboxes=[]))
+                return
+
         await stream.send_message(
             api_pb2.SandboxListResponse(
                 sandboxes=[
@@ -1250,6 +1255,11 @@ class MockClientServicer(api_grpc.ModalClientBase):
                 ]
             )
         )
+
+    async def SandboxTagsSet(self, stream):
+        request: api_pb2.SandboxTagsSetRequest = await stream.recv_message()
+        self.sandbox_tags = {tag.tag_name: tag.tag_value for tag in request.tags}
+        await stream.send_message(Empty())
 
     async def SandboxTerminate(self, stream):
         self.sandbox.terminate()

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -229,6 +229,7 @@ def test_sandbox_exec_wait(client, servicer):
 
 
 @skip_non_linux
+
 def test_sandbox_on_app_lookup(client, servicer):
     app = App.lookup("my-app", create_if_missing=True, client=client)
     sb = Sandbox.create("echo", "hi", app=app)
@@ -237,12 +238,19 @@ def test_sandbox_on_app_lookup(client, servicer):
     assert servicer.sandbox_app_id == app.app_id
 
 
+<<<<<<< HEAD
 @skip_non_linux
+=======
+>>>>>>> bef71a39 (Test sandbox listing.)
 def test_sandbox_list_env(client, servicer):
     sb = Sandbox.create("bash", "-c", "sleep 10000", client=client)
     assert len(list(Sandbox.list(client=client))) == 1
     sb.terminate()
+<<<<<<< HEAD
     assert not list(Sandbox.list(client=client))
+=======
+    assert len(list(Sandbox.list(client=client))) == 0
+>>>>>>> bef71a39 (Test sandbox listing.)
 
 
 @skip_non_linux
@@ -257,4 +265,8 @@ def test_sandbox_list_app(client, servicer):
             sb = app.spawn_sandbox("bash", "-c", "sleep 10000", image=image, secrets=[secret], mounts=[mount])
             assert len(list(Sandbox.list(app_id=app.app_id, client=client))) == 1
             sb.terminate()
+<<<<<<< HEAD
             assert not list(Sandbox.list(app_id=app.app_id, client=client))
+=======
+            assert len(list(Sandbox.list(app_id=app.app_id, client=client))) == 0
+>>>>>>> bef71a39 (Test sandbox listing.)

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -258,3 +258,13 @@ def test_sandbox_list_app(client, servicer):
             assert len(list(Sandbox.list(app_id=app.app_id, client=client))) == 1
             sb.terminate()
             assert not list(Sandbox.list(app_id=app.app_id, client=client))
+
+
+@skip_non_linux
+def test_sandbox_list_tags(client, servicer):
+    sb = Sandbox.create("bash", "-c", "sleep 10000", client=client)
+    sb.set_tags({"foo": "bar", "baz": "qux"}, client=client)
+    assert len(list(Sandbox.list(tags={"foo": "bar"}, client=client))) == 1
+    assert not list(Sandbox.list(tags={"foo": "notbar"}, client=client))
+    sb.terminate()
+    assert not list(Sandbox.list(tags={"baz": "qux"}, client=client))

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -229,7 +229,6 @@ def test_sandbox_exec_wait(client, servicer):
 
 
 @skip_non_linux
-
 def test_sandbox_on_app_lookup(client, servicer):
     app = App.lookup("my-app", create_if_missing=True, client=client)
     sb = Sandbox.create("echo", "hi", app=app)
@@ -238,19 +237,12 @@ def test_sandbox_on_app_lookup(client, servicer):
     assert servicer.sandbox_app_id == app.app_id
 
 
-<<<<<<< HEAD
 @skip_non_linux
-=======
->>>>>>> bef71a39 (Test sandbox listing.)
 def test_sandbox_list_env(client, servicer):
     sb = Sandbox.create("bash", "-c", "sleep 10000", client=client)
     assert len(list(Sandbox.list(client=client))) == 1
     sb.terminate()
-<<<<<<< HEAD
     assert not list(Sandbox.list(client=client))
-=======
-    assert len(list(Sandbox.list(client=client))) == 0
->>>>>>> bef71a39 (Test sandbox listing.)
 
 
 @skip_non_linux
@@ -265,8 +257,4 @@ def test_sandbox_list_app(client, servicer):
             sb = app.spawn_sandbox("bash", "-c", "sleep 10000", image=image, secrets=[secret], mounts=[mount])
             assert len(list(Sandbox.list(app_id=app.app_id, client=client))) == 1
             sb.terminate()
-<<<<<<< HEAD
             assert not list(Sandbox.list(app_id=app.app_id, client=client))
-=======
-            assert len(list(Sandbox.list(app_id=app.app_id, client=client))) == 0
->>>>>>> bef71a39 (Test sandbox listing.)


### PR DESCRIPTION
# Changelog
- Sandboxes can now be associated with tags `modal.Sandbox.set_tags(self, tags)`.
- To list running sandboxes associated with the current environment, an app ID, and/or some set of tags, use `modal.Sandbox.list(*, app_id, tags)`.

```
sandbox = modal.Sandbox.create("sleep", "infinity")
sandbox.set_tags({"version": "0", "user": "foo"})
modal.Sandbox.list(tags={"version": "0"})
```