### PR TITLE
Deprecation warning for app-less sandboxes

### DIFF
--- a/modal/client.py
+++ b/modal/client.py
@@ -275,7 +275,7 @@ class _Client:
         ```python notest
         client = modal.Client.from_credentials("my_token_id", "my_token_secret")
 
-        modal.Sandbox.create("echo", "hi", client=client)
+        modal.Sandbox.create("echo", "hi", client=client, app=app)
         ```
         """
         server_url = config["server_url"]

--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -65,7 +65,8 @@ class _StreamReader:
     sandbox = Sandbox.create(
         "bash",
         "-c",
-        "for i in $(seq 1 10); do echo foo; sleep 0.1; done"
+        "for i in $(seq 1 10); do echo foo; sleep 0.1; done",
+        app=app,
     )
     for message in sandbox.stdout:
         print(f"Message: {message}")
@@ -104,7 +105,7 @@ class _StreamReader:
         ```python
         from modal import Sandbox
 
-        sandbox = Sandbox.create("echo", "hello")
+        sandbox = Sandbox.create("echo", "hello", app=app)
         sandbox.wait()
 
         print(sandbox.stdout.read())
@@ -214,6 +215,7 @@ class _StreamWriter:
             "bash",
             "-c",
             "while read line; do echo $line; done",
+            app=app,
         )
         sandbox.stdin.write(b"foo\\n")
         sandbox.stdin.write(b"bar\\n")

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, AsyncGenerator, Dict, List, Optional, Sequence
 from google.protobuf.message import Message
 
 from modal.cloud_bucket_mount import _CloudBucketMount, cloud_bucket_mounts_to_proto
-from modal.exception import InvalidError, SandboxTerminatedError, SandboxTimeoutError
 from modal.volume import _Volume
 from modal_proto import api_pb2
 
@@ -19,7 +18,7 @@ from ._utils.mount_utils import validate_network_file_systems, validate_volumes
 from .client import _Client
 from .config import config
 from .container_process import _ContainerProcess
-from .exception import deprecation_warning
+from .exception import InvalidError, SandboxTerminatedError, SandboxTimeoutError, deprecation_warning
 from .gpu import GPU_T
 from .image import _Image
 from .io_streams import StreamReader, StreamWriter, _StreamReader, _StreamWriter
@@ -219,6 +218,16 @@ class _Sandbox(_Object, type_prefix="sb"):
         elif _App._container_app is not None:
             app_id = _App._container_app.app_id
             app_client = _App._container_app.client
+        else:
+            deprecation_warning(
+                (2024, 9, 14),
+                "Creating a `Sandbox` without an `App` is deprecated.\n"
+                "You may pass in an `App` object, or reference one by name with `App.lookup`:\n"
+                "```\n"
+                "app = modal.App.lookup('my-app', create_if_missing=True)\n"
+                "modal.Sandbox.create('echo', 'hi', app=app)\n"
+                "```",
+            )
 
         client = client or app_client or await _Client.from_env()
 

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -336,7 +336,9 @@ class _Sandbox(_Object, type_prefix="sb"):
         **Usage**
 
         ```python
-        sandbox = modal.Sandbox.create("sleep", "infinity")
+        app = modal.App.lookup("my-app", create_if_missing=True)
+
+        sandbox = modal.Sandbox.create("sleep", "infinity", app=app)
 
         process = sandbox.exec("bash", "-c", "for i in $(seq 1 10); do echo foo $i; sleep 0.5; done")
 


### PR DESCRIPTION
App-less sandboxes had a short run.

### Changelog

- Creating sandboxes without an associated `App` is deprecated. If you are spawning a `Sandbox` outside a Modal container, you can lookup an `App` by name to attach to the `Sandbox`:

```python
app = modal.App.lookup('my-app', create_if_missing=True)
modal.Sandbox.create('echo', 'hi', app=app)
```