### PR TITLE
Show full tracebacks when error message is empty

### DIFF
--- a/modal/__main__.py
+++ b/modal/__main__.py
@@ -26,12 +26,18 @@ def main():
         if config.get("traceback"):
             raise
 
+        assert exc.__cause__  # We should always raise this class from another error
         tb = reduce_traceback_to_user_code(exc.__cause__.__traceback__, exc.user_source)
         sys.excepthook(type(exc.__cause__), exc.__cause__, tb)
         sys.exit(1)
 
     except Exception as exc:
-        if config.get("traceback"):
+        if (
+            # User has asked to alway see full tracebacks
+            config.get("traceback")
+            # The exception message is empty, so we need to provide _some_ actionable information
+            or not str(exc)
+        ):
             raise
 
         from grpclib import GRPCError, Status


### PR DESCRIPTION
We suppress tracebacks when exceptions arise from within modal code by default. Typically this is because the exception represents some form of input validation or maybe a server-side exception where the details of the calling stack aren't relevant to the user. But occasionally, we raise exceptions with an empty message, which leaves the user with no actionable information at all. This PR simply activates the "verbose traceback" mode in those cases.

While the errors are probably still not user-debuggable, the user experience should be less bewildering, and we'll likely be able to resolve the issue faster when the user reaches out for support.