### PR TITLE
remove 'memory' GPU param, deprecated in May '24

### DIFF
--- a/modal/gpu.py
+++ b/modal/gpu.py
@@ -186,7 +186,7 @@ def _parse_gpu_config(value: GPU_T) -> Optional[_GPUConfig]:
                 raise InvalidError(f"Invalid GPU count: {count_str}. Value must be an integer.")
 
         if value.lower() == "a100-20g":
-            return A100(memory=20, count=count)  # Triggers unsupported error underneath.
+            return A100(size="20GB", count=count)  # Triggers unsupported error underneath.
         elif value.lower() == "a100-40gb":
             return A100(size="40GB", count=count)
         elif value.lower() == "a100-80gb":

--- a/modal/gpu.py
+++ b/modal/gpu.py
@@ -4,7 +4,7 @@ from typing import Optional, Union
 
 from modal_proto import api_pb2
 
-from .exception import InvalidError, deprecation_warning
+from .exception import InvalidError
 
 
 @dataclass(frozen=True)
@@ -68,28 +68,11 @@ class A100(_GPUConfig):
         self,
         *,
         count: int = 1,  # Number of GPUs per container. Defaults to 1.
-        memory: Optional[int] = None,  # Deprecated. Use `size` instead.
         size: Union[str, None] = None,  # Select GiB configuration of GPU device: "40GB" or "80GB". Defaults to "40GB".
     ):
-        allowed_memory_values = {40, 80}
         allowed_size_values = {"40GB", "80GB"}
 
-        if memory is not None:
-            deprecation_warning(
-                (2024, 5, 16),
-                "The `memory` parameter is deprecated. Use the `size='80GB'` parameter instead.",
-            )
-
-        if memory == 20:
-            raise ValueError(
-                "A100 20GB is unsupported, consider `modal.A10G`, `modal.A100(memory_gb='40')`, or `modal.H100` instead"
-            )
-        elif memory and size:
-            raise ValueError("Cannot specify both `memory` and `size`. Just specify `size`.")
-        elif memory:
-            if memory not in allowed_memory_values:
-                raise ValueError(f"A100s can only have memory values of {allowed_memory_values} => memory={memory}")
-        elif size:
+        if size:
             if size not in allowed_size_values:
                 raise ValueError(
                     f"size='{size}' is invalid. A100s can only have memory values of {allowed_size_values}."

--- a/test/gpu_test.py
+++ b/test/gpu_test.py
@@ -129,9 +129,6 @@ def test_gpu_unsupported_config():
     with pytest.raises(ValueError, match="size='20GB' is invalid"):
         app.function(gpu=modal.gpu.A100(size="20GB"))(dummy)
 
-    with pytest.warns(match="size='80GB'"):
-        app.function(gpu=modal.gpu.A100(memory=80))(dummy)
-
 
 @pytest.mark.parametrize("count", [1, 2, 3, 4])
 def test_gpu_type_selection_from_count(client, servicer, count):


### PR DESCRIPTION
## Describe your changes

- _Provide Linear issue reference (e.g. MOD-1234) if available._

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

* Deprecated `memory` parameter in `modal.gpu` constructors is removed. 
