### PR TITLE
Add IP allowlisting for sandboxes

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1262,7 +1262,10 @@ class MockClientServicer(api_grpc.ModalClientBase):
         await stream.send_message(Empty())
 
     async def SandboxTerminate(self, stream):
-        self.sandbox.terminate()
+        try:
+            self.sandbox.terminate()
+        except ProcessLookupError:
+            pass
         await stream.send_message(api_pb2.SandboxTerminateResponse())
 
     async def SandboxGetTaskId(self, stream):


### PR DESCRIPTION
## Describe your changes

This commit allows users to specify a list of CIDRs that their sandbox is allowed to reach out to.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Sandboxes now have a `cidr_allowlist` argument, enabling controlled access to certain IP ranges. When not used (and with `block_network=False`), the sandbox process will have open network access.