### PR TITLE
[MOD-3802] Allow users to set input concurrency locally

### DIFF
--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -295,7 +295,7 @@ class _ContainerIOManager:
 
         if container_args.function_def.pty_info.pty_type == api_pb2.PTYInfo.PTY_TYPE_SHELL:
             target_concurrency = 1
-            max_concurrency = 0
+            max_concurrency = 1
         else:
             target_concurrency = container_args.function_def.target_concurrent_inputs or 1
             max_concurrency = container_args.function_def.max_concurrent_inputs or target_concurrency
@@ -303,6 +303,7 @@ class _ContainerIOManager:
         self._target_concurrency = target_concurrency
         self._max_concurrency = max_concurrency
         self._concurrency_loop = None
+        self._stop_concurrency_loop = False
         self._input_slots = InputSlots(target_concurrency)
 
         self._environment_name = container_args.environment_name
@@ -428,7 +429,7 @@ class _ContainerIOManager:
 
     async def _dynamic_concurrency_loop(self):
         logger.debug(f"Starting dynamic concurrency loop for task {self.task_id}")
-        while 1:
+        while not self._stop_concurrency_loop:
             try:
                 request = api_pb2.FunctionGetDynamicConcurrencyRequest(
                     function_id=self.function_id,
@@ -440,9 +441,9 @@ class _ContainerIOManager:
                     request,
                     attempt_timeout=DYNAMIC_CONCURRENCY_TIMEOUT_SECS,
                 )
-                if resp.concurrency != self._input_slots.value:
+                if resp.concurrency != self._input_slots.value and not self._stop_concurrency_loop:
                     logger.debug(f"Dynamic concurrency set from {self._input_slots.value} to {resp.concurrency}")
-                self._input_slots.set_value(resp.concurrency)
+                    self._input_slots.set_value(resp.concurrency)
 
             except Exception as exc:
                 logger.debug(f"Failed to get dynamic concurrency for task {self.task_id}, {exc}")
@@ -1015,6 +1016,7 @@ class _ContainerIOManager:
         """
         io_manager = cls._singleton
         assert io_manager
+        io_manager._stop_concurrency_loop = True
         concurrency = min(concurrency, io_manager._max_concurrency)
         io_manager._input_slots.set_value(concurrency)
 

--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -994,9 +994,29 @@ class _ContainerIOManager:
 
     @classmethod
     def get_input_concurrency(cls) -> int:
+        """
+        Returns the number of usable input slots.
+
+        If concurrency is reduced, active slots can exceed allotted slots. Returns the larger value
+        in this case.
+        """
+
         io_manager = cls._singleton
         assert io_manager
-        return io_manager._input_slots.value
+        return max(io_manager._input_slots.active, io_manager._input_slots.value)
+
+    @classmethod
+    def set_input_concurrency(cls, concurrency: int):
+        """
+        Edit the number of input slots.
+
+        This disables the background loop which automatically adjusts concurrency
+        within [target_concurrency, max_concurrency].
+        """
+        io_manager = cls._singleton
+        assert io_manager
+        concurrency = min(concurrency, io_manager._max_concurrency)
+        io_manager._input_slots.set_value(concurrency)
 
     @classmethod
     def stop_fetching_inputs(cls):

--- a/modal/experimental.py
+++ b/modal/experimental.py
@@ -29,9 +29,19 @@ def stop_fetching_inputs():
 
 
 def get_local_input_concurrency():
-    """Get the container's local input concurrency. Return 0 if the container is not running."""
+    """Get the container's local input concurrency.
+    If recently reduced to particular value, it can return a larger number than
+    set due to in-progress inputs."""
 
     return _ContainerIOManager.get_input_concurrency()
+
+
+def set_local_input_concurrency(concurrency: int):
+    """Set the container's local input concurrency. Dynamic concurrency will be disabled.
+    When setting to a smaller value, this method will not interrupt in-progress inputs.
+    """
+
+    _ContainerIOManager.set_input_concurrency(concurrency)
 
 
 # START Experimental: Container Networking

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -2210,19 +2210,22 @@ def test_max_concurrency(servicer):
 
 @skip_github_non_linux
 def test_set_local_input_concurrency(servicer):
-    n_inputs = 5
-    target_concurrency = 2
+    n_inputs = 6
+    target_concurrency = 3
+    max_concurrency = 6
 
+    now = time.time()
     ret = _run_container(
         servicer,
         "test.supports.functions",
         "set_input_concurrency",
-        inputs=_get_inputs(((1,), {}), n=n_inputs),
+        inputs=_get_inputs(((now,), {}), n=n_inputs),
         allow_concurrent_inputs=target_concurrency,
+        max_concurrent_inputs=max_concurrency,
     )
 
-    outputs = [deserialize(item.result.data, ret.client) for item in ret.items]
-    assert outputs == [20] * 5
+    outputs = [int(deserialize(item.result.data, ret.client)) for item in ret.items]
+    assert outputs == [1] * 3 + [2] * 3
 
 
 @skip_github_non_linux

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -2209,6 +2209,23 @@ def test_max_concurrency(servicer):
 
 
 @skip_github_non_linux
+def test_set_local_input_concurrency(servicer):
+    n_inputs = 5
+    target_concurrency = 2
+
+    ret = _run_container(
+        servicer,
+        "test.supports.functions",
+        "set_input_concurrency",
+        inputs=_get_inputs(((1,), {}), n=n_inputs),
+        allow_concurrent_inputs=target_concurrency,
+    )
+
+    outputs = [deserialize(item.result.data, ret.client) for item in ret.items]
+    assert outputs == [20] * 5
+
+
+@skip_github_non_linux
 def test_sandbox_infers_app(servicer, event_loop):
     _run_container(servicer, "test.supports.sandbox", "spawn_sandbox")
     assert servicer.sandbox_app_id == "ap-1"

--- a/test/supports/functions.py
+++ b/test/supports/functions.py
@@ -20,7 +20,7 @@ from modal import (
     wsgi_app,
 )
 from modal.exception import deprecation_warning
-from modal.experimental import get_local_input_concurrency
+from modal.experimental import get_local_input_concurrency, set_local_input_concurrency
 
 SLEEP_DELAY = 0.1
 
@@ -664,3 +664,10 @@ def raise_large_unicode_exception():
 def get_input_concurrency(timeout: int):
     time.sleep(timeout)
     return get_local_input_concurrency()
+
+
+@app.function()
+def set_input_concurrency(start: float):
+    set_local_input_concurrency(3)
+    time.sleep(1)
+    return time.time() - start


### PR DESCRIPTION
## Changelog

Introduce an experimental API to allow users to set the input concurrency for a container locally.
