### PR TITLE
Expose the `condition` parameter from the underlying `Mount` in `Image.copy_local_file`

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -523,13 +523,23 @@ class _Image(_Object, type_prefix="im"):
             context_mount=mount,
         )
 
-    def copy_local_dir(self, local_path: Union[str, Path], remote_path: Union[str, Path] = ".") -> "_Image":
+    def copy_local_dir(
+        self,
+        local_path: Union[str, Path],
+        remote_path: Union[str, Path] = ".",
+        condition: Optional[Callable[[str], bool]] = None,
+    ) -> "_Image":
         """Copy a directory into the image as a part of building the image.
 
         This works in a similar way to [`COPY`](https://docs.docker.com/engine/reference/builder/#copy)
         works in a `Dockerfile`.
+
+        A `condition` function can be used to filter the files that get copied. It should accept a filename
+        and return a boolean value. Note that the return value is treated as an _inclusion_ criterion.
+        Remember to negate the test if you want to express an exclusion (analagous to an "ignore file").
+
         """
-        mount = _Mount.from_local_dir(local_path, remote_path="/")
+        mount = _Mount.from_local_dir(local_path, remote_path="/", condition=condition)
 
         def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:
             return DockerfileSpec(commands=["FROM base", f"COPY . {remote_path}"], context_files={})

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -621,6 +621,7 @@ def test_poetry(builder_version, servicer, client):
 @pytest.fixture
 def tmp_path_with_content(tmp_path):
     (tmp_path / "data.txt").write_text("hello")
+    (tmp_path / "data.png").write_bytes(b"")
     (tmp_path / "data").mkdir()
     (tmp_path / "data" / "sub").write_text("world")
     return tmp_path
@@ -628,7 +629,9 @@ def tmp_path_with_content(tmp_path):
 
 def test_image_copy_local_dir(builder_version, servicer, client, tmp_path_with_content):
     app = App()
-    app.image = Image.debian_slim().copy_local_dir(tmp_path_with_content, remote_path="/dummy")
+    app.image = Image.debian_slim().copy_local_dir(
+        tmp_path_with_content, remote_path="/dummy", condition=lambda f: not f.endswith(".png")
+    )
     app.function()(dummy)
 
     with app.run(client=client):

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -643,7 +643,9 @@ def test_image_copy_local_dir(builder_version, servicer, client, tmp_path_with_c
 
 def test_image_docker_command_copy(builder_version, servicer, client, tmp_path_with_content):
     app = App()
-    data_mount = Mount.from_local_dir(tmp_path_with_content, remote_path="/")
+    data_mount = Mount.from_local_dir(
+        tmp_path_with_content, remote_path="/", condition=lambda f: not f.endswith(".png")
+    )
     app.image = Image.debian_slim().dockerfile_commands(["COPY . /dummy"], context_mount=data_mount)
     app.function()(dummy)
 
@@ -660,7 +662,9 @@ def test_image_dockerfile_copy(builder_version, servicer, client, tmp_path_with_
     dockerfile.close()
 
     app = App()
-    data_mount = Mount.from_local_dir(tmp_path_with_content, remote_path="/")
+    data_mount = Mount.from_local_dir(
+        tmp_path_with_content, remote_path="/", condition=lambda f: not f.endswith(".png")
+    )
     app.image = Image.debian_slim().from_dockerfile(dockerfile.name, context_mount=data_mount)
     app.function()(dummy)
 
@@ -671,7 +675,7 @@ def test_image_dockerfile_copy(builder_version, servicer, client, tmp_path_with_
         assert files == {"/data.txt": b"hello", "/data/sub": b"world"}
 
 
-def test_image_docker_command_entrypoint(builder_version, servicer, client, tmp_path_with_content):
+def test_image_docker_command_entrypoint(builder_version, servicer, client):
     app = App()
     app.image = Image.debian_slim().entrypoint([])
     app.function()(dummy)
@@ -681,7 +685,7 @@ def test_image_docker_command_entrypoint(builder_version, servicer, client, tmp_
         assert "ENTRYPOINT []" in layers[0].dockerfile_commands
 
 
-def test_image_docker_command_entrypoint_nonempty(builder_version, servicer, client, tmp_path_with_content):
+def test_image_docker_command_entrypoint_nonempty(builder_version, servicer, client):
     app = App()
     app.image = (
         Image.debian_slim()
@@ -702,7 +706,7 @@ def test_image_docker_command_entrypoint_nonempty(builder_version, servicer, cli
         assert 'ENTRYPOINT ["/temp.sh"]' in layers[0].dockerfile_commands
 
 
-def test_image_docker_command_shell(builder_version, servicer, client, tmp_path_with_content):
+def test_image_docker_command_shell(builder_version, servicer, client):
     app = App()
     app.image = Image.debian_slim().shell(["/bin/sh", "-c"])
     app.function()(dummy)


### PR DESCRIPTION
The `Image.copy_local_file` function is just a thin wrapper around a `Mount`, which has a "condition" concept that operates analogously (although inversely) to a Docker ignore file. This PR exposes the underlying `condition` so users don't need to instantiate a Mount directly just to leverage that feature.

Note that I think that condition being an _inclusion_ criterion is arguably confusing since most people find themselves looking for an _ignore_ operation. Not sure what to do about that, though, besides trying to document it well.

## Changelog

- The `Image.copy_local_dir` method now has a `condition` parameter, which can be used to select the files that should get copied.