### PR TITLE
Include 'group size' in Function protos

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -828,6 +828,7 @@ class _App:
                 scheduler_placement=scheduler_placement,
                 _experimental_boost=_experimental_boost,
                 container_networking=container_networking,  # Experimental: Container Networking
+                group_size=group_size,  # Experimental: Container Networking
             )
 
             self._add_function(function, webhook_config is not None)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -517,6 +517,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         checkpointing_enabled: Optional[bool] = None,
         block_network: bool = False,
         container_networking: bool = False,  # Experimental: Container Networking
+        group_size: Optional[int] = None,  # Experimental: Container Networking
         max_inputs: Optional[int] = None,
         ephemeral_disk: Optional[int] = None,
     ) -> None:
@@ -831,6 +832,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                     class_parameter_info=info.class_parameter_info(),
                     i6pn_enabled=config.get("i6pn_enabled")
                     or container_networking,  # Experimental: Container Networking
+                    _experimental_group_size=group_size or 0,  # Experimental: Container Networking
                     _experimental_concurrent_cancellations=True,
                 )
                 assert resolver.app_id

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1072,6 +1072,10 @@ message Function {
   bool _experimental_concurrent_cancellations = 63;
   uint32 max_concurrent_inputs = 64;
 
+  // When the function is a "grouped" one, this records the # of tasks we want
+  // to schedule in tandem.
+  uint32 _experimental_group_size = 67;
+
   // TODO(irfansharif): Remove, once https://github.com/modal-labs/modal/pull/15645 lands.
   bool _experimental_task_templates_enabled = 65;  // forces going through the new gpu-fallbacks integration path, even if no fallback options are specified
   repeated TaskTemplate _experimental_task_templates = 66;  // for fallback options, where the first/most-preferred "template" is derived from fields above
@@ -1187,6 +1191,10 @@ message FunctionData {
   bool is_method = 15;
   string use_function_id = 16; // used for methods
   string use_method_name = 17; // used for methods
+
+  // When the function is a "grouped" one, this records the # of tasks we want
+  // to schedule in tandem.
+  uint32 _experimental_group_size = 19;
 
   message RankedFunction {
     uint32 rank = 1;

--- a/test/experimental_group_test.py
+++ b/test/experimental_group_test.py
@@ -1,0 +1,28 @@
+# Copyright Modal Labs 2024
+import modal
+import modal.experimental
+from modal import App
+
+app = App()
+
+
+@app.function()
+@modal.experimental.grouped(size=2)
+def f1():
+    pass
+
+
+@app.function()
+def f2():
+    pass
+
+
+def test_experimental_group(servicer, client):
+    with app.run(client=client):
+        assert len(servicer.app_functions) == 2
+
+        fn1 = servicer.app_functions["fu-1"]  # f1
+        assert fn1._experimental_group_size == 2
+
+        fn2 = servicer.app_functions["fu-2"]  # f2
+        assert not fn2._experimental_group_size


### PR DESCRIPTION
We'll use these in the scheduler for for scheduling grouped tasks (i.e. N tasks in tandem). Part of https://www.notion.so/modal-com/Multi-node-scheduling-e2aa5049895545c89da137119f91c0b3.