### PR TITLE
Raise error when max_inputs is invalid

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -663,6 +663,14 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         if container_idle_timeout is not None and container_idle_timeout <= 0:
             raise InvalidError("`container_idle_timeout` must be > 0")
 
+        if max_inputs is not None:
+            if not isinstance(max_inputs, int):
+                raise InvalidError(f"`max_inputs` must be an int, not {type(max_inputs).__name__}")
+            if max_inputs <= 0:
+                raise InvalidError("`max_inputs` must be positive")
+            if max_inputs > 1:
+                raise InvalidError("Only `max_inputs=1` is currently supported")
+
         # Validate volumes
         validated_volumes = validate_volumes(volumes)
         cloud_bucket_mounts = [(k, v) for k, v in validated_volumes if isinstance(v, _CloudBucketMount)]


### PR DESCRIPTION
Right now we only support `max_inputs=1` or `max_inputs=None` (no maximum)