### PR TITLE
Allow sandboxes to be created without an entrypoint

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -206,6 +206,12 @@ class _Sandbox(_Object, type_prefix="sb"):
 
         environment_name = _get_environment_name(environment_name)
 
+        # If there are no entrypoint args, we'll sleep forever so that the sandbox will stay
+        # alive long enough for the user to interact with it.
+        if len(entrypoint_args) == 0:
+            max_sleep_time = 60 * 60 * 24 * 2  # 2 days is plenty since workers roll every 24h
+            entrypoint_args = ("sleep", str(max_sleep_time))
+
         # TODO(erikbern): Get rid of the `_new` method and create an already-hydrated object
         obj = _Sandbox._new(
             entrypoint_args,

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -298,3 +298,15 @@ def test_sandbox_network_access(client, servicer):
     assert servicer.sandbox_defs[2].network_access.network_access_type == api_pb2.NetworkAccess.NetworkAccessType.OPEN
     assert len(servicer.sandbox_defs[2].network_access.allowed_cidrs) == 0
     sb.terminate()
+
+
+@skip_non_linux
+def test_sandbox_no_entrypoint(client, servicer):
+    sb = Sandbox.create(client=client, app=app)
+
+    p = sb.exec("echo", "hi")
+    p.wait()
+    assert p.returncode == 0
+    assert p.stdout.read() == "hi\n"
+
+    sb.terminate()


### PR DESCRIPTION
## Describe your changes

This allows users to create long-lived sandboxes whose only purpose is to have .exec called inside them.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

Sandboxes can now be created without an entrypoint command. If they are created like this, they will stay alive up until their set timeout. This is useful if you want to keep a long-lived sandbox and execute code in it later.