### PR TITLE
Escape ANSI codes in volume file list

### DIFF
--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -160,7 +160,7 @@ async def ls(
                 filetype = "file"
             rows.append(
                 (
-                    entry.path,
+                    entry.path.encode("unicode_escape").decode("utf-8"),
                     filetype,
                     timestamp_to_local(entry.mtime, False),
                     humanize_filesize(entry.size),


### PR DESCRIPTION
Addresses security vulnerability `MOD-Q324-13` where ANSI codes such as console codes can lead to unexpected behavior (and potentially remote code execution in certain terminals) when listing file paths with `modal volume ls`.

<img width="637" alt="Screenshot 2024-09-19 at 10 09 59 AM" src="https://github.com/user-attachments/assets/b9f5a98d-ff2a-4c9f-a12a-bfa6475260ad">

Solution is to display them as unicode so that it doesn't interfere with the terminal output. 

<img width="816" alt="Screenshot 2024-09-19 at 10 11 04 AM" src="https://github.com/user-attachments/assets/2be571bb-eb6c-479d-8a58-70fe9ab1f3be">
