### PR TITLE
Error on creating `Sandbox` with an uninitialized `App`

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -6,7 +6,7 @@ def pytest_markdown_docs_globals():
 
     return {
         "modal": modal,
-        "app": modal.App(),
+        "app": modal.App.lookup("my-app", create_if_missing=True),
         "math": math,
         "__name__": "runtest",
         "web_endpoint": modal.web_endpoint,

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -244,6 +244,7 @@ class _Sandbox(_Object, type_prefix="sb"):
                     "App has not been initialized yet. To create an App lazily, use `App.lookup`: \n"
                     "app = modal.App.lookup('my-app', create_if_missing=True)\n"
                     "modal.Sandbox.create('echo', 'hi', app=app)\n"
+                    "In order to initialize an existing `App` object, refer to our docs: https://modal.com/docs/guide/apps"
                 )
 
             app_id = app.app_id

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -239,6 +239,13 @@ class _Sandbox(_Object, type_prefix="sb"):
         app_client: Optional[_Client] = None
 
         if app is not None:
+            if app.app_id is None:
+                raise ValueError(
+                    "App has not been initialized yet. To create an App lazily, use `App.lookup`: \n"
+                    "app = modal.App.lookup('my-app', create_if_missing=True)\n"
+                    "modal.Sandbox.create('echo', 'hi', app=app)\n"
+                )
+
             app_id = app.app_id
             app_client = app._client
         elif _App._container_app is not None:


### PR DESCRIPTION
We need to explain the whole uninitialized `App` concept better, but for now this prevents this footgun:

```python
app = modal.App("peyton-sb-test")

sandbox = modal.Sandbox.create(timeout=10, app=app)
```