### PR TITLE
Propagate terminate_containers in CancelInputEvent

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -451,7 +451,7 @@ def call_function(
                         "This shuts down the container, causing concurrently running inputs to be "
                         "rescheduled in other containers."
                     )
-                    signal.raise_signal(signal.SIGINT)  # raises KeyboardInterrupt in main thread
+                    os.kill(os.getpid(), signal.SIGINT)
 
             async def run_concurrent_inputs():
                 # all run_input coroutines will have completed by the time we leave the execution context

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -451,7 +451,7 @@ def call_function(
                         "This shuts down the container, causing concurrently running inputs to be "
                         "rescheduled in other containers."
                     )
-                    os.kill(os.getpid(), signal.SIGINT)  # raises KeyboardInterrupt in main thread
+                    signal.raise_signal(signal.SIGINT)  # raises KeyboardInterrupt in main thread
 
             async def run_concurrent_inputs():
                 # all run_input coroutines will have completed by the time we leave the execution context

--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -389,7 +389,7 @@ class _ContainerIOManager:
             if response.cancel_input_event.terminate_containers:
                 # This should typically never happen since the task should have been killed
                 logger.warning("Force-terminating container due to input cancellation")
-                signal.raise_signal(signal.SIGINT)
+                os.kill(os.getpid(), signal.SIGINT)
 
             if input_ids_to_cancel:
                 if self._max_concurrency > 1:
@@ -406,7 +406,7 @@ class _ContainerIOManager:
                     # SIGUSR1 signal should interrupt the main thread where user code is running,
                     # raising an InputCancellation() exception. On async functions, the signal should
                     # reach a handler in SignalHandlingEventLoop, which cancels the task.
-                    signal.raise_signal(signal.SIGUSR1)
+                    os.kill(os.getpid(), signal.SIGUSR1)
             return True
         return False
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -559,6 +559,7 @@ message BuildFunction {
 
 message CancelInputEvent {
   repeated string input_ids = 1;
+  bool terminate_containers = 2;
 }
 
 message CheckpointInfo {


### PR DESCRIPTION
Should typically never get back to the container if it's set to true (since the worker will sigint the container first in that case) but just in case we also make sure to handle that case by self-siginting