### PR TITLE
[MOD-3841]: run web server in separate thread

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -89,7 +89,9 @@ def construct_webhook_callable(
 
     elif webhook_config.type == api_pb2.WEBHOOK_TYPE_WEB_SERVER:
         # Function spawns an HTTP web server listening at a port.
-        user_defined_callable()
+
+        server_thread = threading.Thread(target=user_defined_callable, name="web_server", daemon=True)
+        server_thread.start()
 
         # We intentionally try to connect to the external interface instead of the loopback
         # interface here so users are forced to expose the server. This allows us to potentially


### PR DESCRIPTION
## Describe your changes

- _Provide Linear issue reference (e.g. MOD-1234) if available._

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
