### PR TITLE
Add untrusted flag to functions

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1072,13 +1072,16 @@ message Function {
   bool _experimental_concurrent_cancellations = 63;
   uint32 max_concurrent_inputs = 64;
 
+  // TODO(irfansharif): Remove, once https://github.com/modal-labs/modal/pull/15645 lands.
+  bool _experimental_task_templates_enabled = 65;  // forces going through the new gpu-fallbacks integration path, even if no fallback options are specified
+  repeated TaskTemplate _experimental_task_templates = 66;  // for fallback options, where the first/most-preferred "template" is derived from fields above
+
   // When the function is a "grouped" one, this records the # of tasks we want
   // to schedule in tandem.
   uint32 _experimental_group_size = 67;
 
-  // TODO(irfansharif): Remove, once https://github.com/modal-labs/modal/pull/15645 lands.
-  bool _experimental_task_templates_enabled = 65;  // forces going through the new gpu-fallbacks integration path, even if no fallback options are specified
-  repeated TaskTemplate _experimental_task_templates = 66;  // for fallback options, where the first/most-preferred "template" is derived from fields above
+  // If set, the function will be run in an untrusted environment.
+  bool untrusted = 68;
 }
 
 message FunctionBindParamsRequest {


### PR DESCRIPTION
## Describe your changes

This will allow the client to signal that the function is running user-provided/untrusted code.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

