### PR TITLE
Protos for EnvironmentConfigGet

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -924,6 +924,21 @@ message DomainListResponse {
   repeated Domain domains = 1;
 }
 
+// Environment-scoped configuration, with workspace-level defaults.
+// Note that we use MergeFrom to combine workspace / environment config,
+// which will *append* any repeated fields!
+message EnvironmentConfig {
+  string image_builder_version = 1;
+}
+
+message EnvironmentConfigGetRequest {
+  string name = 1;
+}
+
+message EnvironmentConfigGetResponse {
+  EnvironmentConfig config = 1;
+}
+
 message EnvironmentCreateRequest {
   string name = 1 [ (modal.options.audit_target_attr) = true ];
 }


### PR DESCRIPTION
Opting to package the config settings in a message of their own rather than spelling them all out as fields of the `EnvironmentConfigGetResponse`. Could revert that if reviewers don't like it though.

~I included the existing `webhook_suffix` in here as I think it might make sense to migrate `EnvironmentListItem` to include this entire `Config` message. But I'll do that part later.~ Opting to leave this as a wholesale TODO instead of something that's confusingly only partially done (server-side, we only store the `webhook_suffix` in the durable table, but I'd like to make the RPC use only the ephemeral table when possible).

Part of MOD-3879

 
<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

