### PR TITLE
Adds experimental vprox interface

### DIFF
--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -31,6 +31,7 @@ try:
     from .scheduler_placement import SchedulerPlacement
     from .secret import Secret
     from .volume import Volume
+    from .vprox import VproxLink
 except Exception:
     print()
     print("#" * 80)
@@ -54,6 +55,7 @@ __all__ = [
     "NetworkFileSystem",
     "Period",
     "Proxy",
+    "VproxLink",
     "Queue",
     "Retries",
     "CloudBucketMount",

--- a/modal/vprox.py
+++ b/modal/vprox.py
@@ -9,7 +9,7 @@ from .object import _get_environment_name, _Object
 
 
 class _VproxLink(_Object, type_prefix="pr"):
-    """
+    """mdmd:hidden
     `modal.VproxLink` creates a secure connection mechanism between Modal
     containers and exit nodes with static IPs. This allows for you to allow list
     static IPs in your firewall. This is useful if you need Modal Functions to

--- a/modal/vprox.py
+++ b/modal/vprox.py
@@ -1,0 +1,42 @@
+# Copyright Modal Labs 2024
+from typing import Optional
+
+from modal_proto import api_pb2
+
+from ._resolver import Resolver
+from ._utils.async_utils import synchronize_api
+from .object import _get_environment_name, _Object
+
+
+class _VproxLink(_Object, type_prefix="pr"):
+    """
+    `modal.VproxLink` creates a secure connection mechanism between Modal
+    containers and exit nodes with static IPs. This allows for you to allow list
+    static IPs in your firewall. This is useful if you need Modal Functions to
+    access a database, for example.
+
+    `modal.VproxLink` are experimental.
+
+    Currently `modal.VproxLink` objects must be setup with the assistance of
+    Modal staff. If you require a vprox link please contact us.
+    """
+
+    @staticmethod
+    def from_name(
+        label: str,
+        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        environment_name: Optional[str] = None,
+    ) -> "_VproxLink":
+        async def _load(self: _VproxLink, resolver: Resolver, existing_object_id: Optional[str]):
+            req = api_pb2.VproxLinkGetOrCreateRequest(
+                deployment_name=label,
+                namespace=namespace,
+                environment_name=_get_environment_name(environment_name, resolver),
+            )
+            response = await resolver.client.stub.VproxLinkGetOrCreateRequest(req)
+            self._hydrate(response.proxy_id, resolver.client, None)
+
+        return _VproxLink._from_loader(_load, "VproxLink()", is_another_app=True)
+
+
+VproxLink = synchronize_api(_VproxLink, target_module=__name__)

--- a/modal/vprox.py
+++ b/modal/vprox.py
@@ -33,8 +33,8 @@ class _VproxLink(_Object, type_prefix="pr"):
                 namespace=namespace,
                 environment_name=_get_environment_name(environment_name, resolver),
             )
-            response = await resolver.client.stub.VproxLinkGetOrCreateRequest(req)
-            self._hydrate(response.proxy_id, resolver.client, None)
+            response = await resolver.client.stub.VproxLinkGetOrCreate(req)
+            self._hydrate(response.vprox_node_id, resolver.client, None)
 
         return _VproxLink._from_loader(_load, "VproxLink()", is_another_app=True)
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1699,6 +1699,21 @@ message ProxyInfo {
   int32 remote_port = 4;
 }
 
+message VproxLinkGetOrCreateRequest {
+  string deployment_name = 1 [ (modal.options.audit_target_attr) = true ];
+  DeploymentNamespace namespace = 2;
+  string environment_name = 3;
+  ObjectCreationType object_creation_type = 4;  // must be UNSPECIFIED
+}
+
+message VproxLinkGetOrCreateResponse {
+  string vprox_node_id = 1;
+}
+
+message VproxLinkInfo {
+  string vprox_node_id = 1;
+}
+
 message QueueClearRequest {
   string queue_id = 1;
   bytes partition_key = 2;
@@ -2505,6 +2520,9 @@ service ModalClient {
 
   // Proxies
   rpc ProxyGetOrCreate(ProxyGetOrCreateRequest) returns (ProxyGetOrCreateResponse);
+
+  // Vprox links
+  rpc VproxLinkGetOrCreate(VproxLinkGetOrCreateRequest) returns (VproxLinkGetOrCreateResponse);
 
   // Queues
   rpc QueueClear(QueueClearRequest) returns (google.protobuf.Empty);

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1699,21 +1699,6 @@ message ProxyInfo {
   int32 remote_port = 4;
 }
 
-message VproxLinkGetOrCreateRequest {
-  string deployment_name = 1 [ (modal.options.audit_target_attr) = true ];
-  DeploymentNamespace namespace = 2;
-  string environment_name = 3;
-  ObjectCreationType object_creation_type = 4;  // must be UNSPECIFIED
-}
-
-message VproxLinkGetOrCreateResponse {
-  string vprox_node_id = 1;
-}
-
-message VproxLinkInfo {
-  string vprox_node_id = 1;
-}
-
 message QueueClearRequest {
   string queue_id = 1;
   bytes partition_key = 2;
@@ -2396,6 +2381,22 @@ message VolumeRemoveFileRequest {
   bool recursive = 3;
 }
 
+message VproxLinkGetOrCreateRequest {
+  string deployment_name = 1 [ (modal.options.audit_target_attr) = true ];
+  DeploymentNamespace namespace = 2;
+  string environment_name = 3;
+  ObjectCreationType object_creation_type = 4;  // must be UNSPECIFIED
+}
+
+message VproxLinkGetOrCreateResponse {
+  string vprox_node_id = 1;
+}
+
+message VproxLinkInfo {
+  string vprox_node_id = 1;
+}
+
+
 message WebUrlInfo {
   bool truncated = 1;
   bool has_unique_hash = 2 [deprecated=true];
@@ -2521,9 +2522,6 @@ service ModalClient {
   // Proxies
   rpc ProxyGetOrCreate(ProxyGetOrCreateRequest) returns (ProxyGetOrCreateResponse);
 
-  // Vprox links
-  rpc VproxLinkGetOrCreate(VproxLinkGetOrCreateRequest) returns (VproxLinkGetOrCreateResponse);
-
   // Queues
   rpc QueueClear(QueueClearRequest) returns (google.protobuf.Empty);
   rpc QueueCreate(QueueCreateRequest) returns (QueueCreateResponse);
@@ -2589,6 +2587,9 @@ service ModalClient {
   rpc VolumePutFiles(VolumePutFilesRequest) returns (google.protobuf.Empty);
   rpc VolumeReload(VolumeReloadRequest) returns (google.protobuf.Empty);
   rpc VolumeRemoveFile(VolumeRemoveFileRequest) returns (google.protobuf.Empty);
+
+  // Vprox links
+  rpc VproxLinkGetOrCreate(VproxLinkGetOrCreateRequest) returns (VproxLinkGetOrCreateResponse);
 
   // Workspaces
   rpc WorkspaceNameLookup(google.protobuf.Empty) returns (WorkspaceNameLookupResponse);


### PR DESCRIPTION
I am naming these `VproxLink`s because, different than our `Proxy` objects, we now create a network interface using [vprox](https://github.com/modal-labs/vprox) and route container traffic through it. We are "linking" the container network interface to a vprox server interface. 