### PR TITLE
Add vprox node id to `ProxyInfo`

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1697,6 +1697,7 @@ message ProxyInfo {
   string proxy_key = 2;
   string remote_addr = 3;
   int32 remote_port = 4;
+  optional string vprox_node_id = 5;
 }
 
 message QueueClearRequest {


### PR DESCRIPTION
Allows container arguments to include information about vprox nodes in case a proxy was setup using vprox instead of legacy proxy.
