### PR TITLE
Run all CI variants across python versions/os to completion

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,6 +22,7 @@ jobs:
     timeout-minutes: 20
 
     strategy:
+      fail-fast: false # run all variants across python versions/os to completion
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: ["ubuntu-20.04"]


### PR DESCRIPTION
Bit annoying to be fixing issues one CI run at a time.