### PR TITLE
cleanup: remove _experimental_boost

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -656,7 +656,6 @@ class _App:
         # The next group of parameters are deprecated; do not use in any new code
         interactive: bool = False,  # Deprecated: use the `modal.interact()` hook instead
         # Parameters below here are experimental. Use with caution!
-        _experimental_boost: None = None,  # Deprecated: lower latency function execution is now default.
         _experimental_scheduler_placement: Optional[
             SchedulerPlacement
         ] = None,  # Experimental controls over fine-grained scheduling (alpha).
@@ -672,11 +671,6 @@ class _App:
         if interactive:
             deprecation_error(
                 (2024, 5, 1), "interactive=True has been deprecated. Set MODAL_INTERACTIVE_FUNCTIONS=1 instead."
-            )
-
-        if _experimental_boost is not None:
-            deprecation_warning(
-                (2024, 7, 23), "`_experimental_boost` is now always-on. This argument is no longer needed."
             )
 
         if image is None:
@@ -830,7 +824,6 @@ class _App:
                 block_network=block_network,
                 max_inputs=max_inputs,
                 scheduler_placement=scheduler_placement,
-                _experimental_boost=_experimental_boost,
                 _experimental_buffer_containers=_experimental_buffer_containers,
                 container_networking=container_networking,  # Experimental: Container Networking
                 group_size=group_size,  # Experimental: Container Networking
@@ -887,7 +880,6 @@ class _App:
         # The next group of parameters are deprecated; do not use in any new code
         interactive: bool = False,  # Deprecated: use the `modal.interact()` hook instead
         # Parameters below here are experimental. Use with caution!
-        _experimental_boost: None = None,  # Deprecated: lower latency function execution is now default.
         _experimental_scheduler_placement: Optional[
             SchedulerPlacement
         ] = None,  # Experimental controls over fine-grained scheduling (alpha).
@@ -899,11 +891,6 @@ class _App:
         if interactive:
             deprecation_error(
                 (2024, 5, 1), "interactive=True has been deprecated. Set MODAL_INTERACTIVE_FUNCTIONS=1 instead."
-            )
-
-        if _experimental_boost is not None:
-            deprecation_warning(
-                (2024, 7, 23), "`_experimental_boost` is now always-on. This argument is no longer needed."
             )
 
         if image is None:
@@ -969,7 +956,6 @@ class _App:
                 block_network=block_network,
                 max_inputs=max_inputs,
                 scheduler_placement=scheduler_placement,
-                _experimental_boost=_experimental_boost,
                 # class service function, so the following attributes which relate to
                 # the callable itself are invalid and set to defaults:
                 webhook_config=None,

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -509,7 +509,6 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         cpu: Optional[float] = None,
         keep_warm: Optional[int] = None,  # keep_warm=True is equivalent to keep_warm=1
         cloud: Optional[str] = None,
-        _experimental_boost: None = None,
         scheduler_placement: Optional[SchedulerPlacement] = None,
         is_builder_function: bool = False,
         is_auto_snapshot: bool = False,
@@ -835,7 +834,6 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                     block_network=block_network,
                     max_inputs=max_inputs or 0,
                     cloud_bucket_mounts=cloud_bucket_mounts_to_proto(cloud_bucket_mounts),
-                    _experimental_boost=bool(_experimental_boost),
                     scheduler_placement=scheduler_placement.proto if scheduler_placement else None,
                     is_class=info.is_service_class(),
                     class_parameter_info=info.class_parameter_info(),


### PR DESCRIPTION
## Describe your changes

Follow-up to https://github.com/modal-labs/modal-client/pull/2044 (July 23rd 2024)

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- The deprecated `_experimental_boost` argument is now removed. (Deprecated in late July.)
