### PR TITLE
Prevent `asyncio.InvalidStateError` in weird edge case

### DIFF
--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -223,8 +223,7 @@ class InputSlots:
 
     def _wake_waiter(self) -> None:
         if self.active < self.value and self.waiter is not None:
-            if not self.waiter.cancelled():  # could have been cancelled during interpreter shutdown
-                self.waiter.set_result(None)
+            self.waiter.set_result(None)
             self.waiter = None
             self.active += 1
 

--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -223,7 +223,8 @@ class InputSlots:
 
     def _wake_waiter(self) -> None:
         if self.active < self.value and self.waiter is not None:
-            self.waiter.set_result(None)
+            if not self.waiter.cancelled():  # could have been cancelled during interpreter shutdown
+                self.waiter.set_result(None)
             self.waiter = None
             self.active += 1
 

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -1644,32 +1644,18 @@ def _run_container_process(
 @skip_github_non_linux
 @pytest.mark.usefixtures("server_url_env")
 @pytest.mark.parametrize(
-    [
-        "function_name",
-        "input_args",
-        "cancelled_input_ids",
-        "terminate_containers",
-        "expected_container_output",
-        "live_cancellations",
-    ],
+    ["function_name", "input_args", "cancelled_input_ids", "expected_container_output", "live_cancellations"],
     [
         # the 10 second inputs here are to be cancelled:
-        ("delay", [0.01, 20, 0.02], ["in-001"], False, [0.01, 0.02], 1),  # cancel second input
-        ("delay_async", [0.01, 20, 0.02], ["in-001"], False, [0.01, 0.02], 1),  # async variant
-        ("delay_async", [0.01, 20, 0.02], ["in-001"], True, [0.01, 0.02], 1),  # async variant
+        ("delay", [0.01, 20, 0.02], ["in-001"], [0.01, 0.02], 1),  # cancel second input
+        ("delay_async", [0.01, 20, 0.02], ["in-001"], [0.01, 0.02], 1),  # async variant
         # cancel first input, but it has already been processed, so all three should come through:
-        ("delay", [0.01, 0.5, 0.03], ["in-000"], False, [0.01, 0.5, 0.03], 0),
-        ("delay_async", [0.01, 0.5, 0.03], ["in-000"], False, [0.01, 0.5, 0.03], 0),
+        ("delay", [0.01, 0.5, 0.03], ["in-000"], [0.01, 0.5, 0.03], 0),
+        ("delay_async", [0.01, 0.5, 0.03], ["in-000"], [0.01, 0.5, 0.03], 0),
     ],
 )
 def test_cancellation_aborts_current_input_on_match(
-    servicer,
-    function_name,
-    input_args,
-    cancelled_input_ids,
-    terminate_containers,
-    expected_container_output,
-    live_cancellations,
+    servicer, function_name, input_args, cancelled_input_ids, expected_container_output, live_cancellations
 ):
     # NOTE: for a cancellation to actually happen in this test, it needs to be
     #    triggered while the relevant input is being processed. A future input
@@ -1694,16 +1680,9 @@ def test_cancellation_aborts_current_input_on_match(
     assert num_prior_outputs == 1  # the second input shouldn't have completed yet
 
     servicer.container_heartbeat_return_now(
-        api_pb2.ContainerHeartbeatResponse(
-            cancel_input_event=api_pb2.CancelInputEvent(
-                input_ids=cancelled_input_ids, terminate_containers=terminate_containers
-            )
-        )
+        api_pb2.ContainerHeartbeatResponse(cancel_input_event=api_pb2.CancelInputEvent(input_ids=cancelled_input_ids))
     )
     stdout, stderr = container_process.communicate()
-    print("Process output")
-    print(stdout.decode())
-    print(stderr.decode())
     assert stderr.decode().count("Received a cancellation signal") == live_cancellations
     assert "Traceback" not in stderr.decode()
     assert container_process.returncode == 0  # wait for container to exit

--- a/test/supports/functions.py
+++ b/test/supports/functions.py
@@ -50,6 +50,14 @@ async def delay_async(t):
 
 
 @app.function()
+async def async_cancel_doesnt_reraise(t):
+    try:
+        await asyncio.sleep(t)
+    except asyncio.CancelledError:
+        pass
+
+
+@app.function()
 async def square_async(x):
     await asyncio.sleep(SLEEP_DELAY)
     return x * x


### PR DESCRIPTION
There was a weird edge case (possibly non-weird cases too?) where if:
* function is async
* function doesn't reraise CancelledError
* container runs w/ concurrent inputs
* container is sigint:ed by worker

Then an asyncio.InvalidStateError is raised in each asyncio task currently processing inputs, since the internal `waiter` used by the dynamic batcher (regardless if dynamic batching is actually used) will try to set a result on an already cancelled future.

This adds a rather contrived reproduction of this case and assertion that it doesn't cause this error + adds a oneliner fix :)