### PR TITLE
follow-up #2261 (gpu fallbacks)

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -616,7 +616,7 @@ class _App:
         schedule: Optional[Schedule] = None,  # An optional Modal Schedule for the function
         secrets: Sequence[_Secret] = (),  # Optional Modal Secret objects with environment variables for the container
         gpu: Union[
-            GPU_T, Sequence[GPU_T]
+            GPU_T, List[GPU_T]
         ] = None,  # GPU request as string ("any", "T4", ...), object (`modal.GPU.A100()`, ...), or a list of either
         serialized: bool = False,  # Whether to send the function over using cloudpickle.
         mounts: Sequence[_Mount] = (),  # Modal Mounts added to the container
@@ -850,7 +850,7 @@ class _App:
         image: Optional[_Image] = None,  # The image to run as the container for the function
         secrets: Sequence[_Secret] = (),  # Optional Modal Secret objects with environment variables for the container
         gpu: Union[
-            GPU_T, Sequence[GPU_T]
+            GPU_T, List[GPU_T]
         ] = None,  # GPU request as string ("any", "T4", ...), object (`modal.GPU.A100()`, ...), or a list of either
         serialized: bool = False,  # Whether to send the function over using cloudpickle.
         mounts: Sequence[_Mount] = (),

--- a/modal/image.py
+++ b/modal/image.py
@@ -1531,7 +1531,7 @@ class _Image(_Object, type_prefix="im"):
         raw_f: Callable[..., Any],
         secrets: Sequence[_Secret] = (),  # Optional Modal Secret objects with environment variables for the container
         gpu: Union[
-            GPU_T, Sequence[GPU_T]
+            GPU_T, List[GPU_T]
         ] = None,  # GPU request as string ("any", "T4", ...), object (`modal.GPU.A100()`, ...), or a list of either
         mounts: Sequence[_Mount] = (),  # Mounts attached to the function
         volumes: Dict[Union[str, PurePosixPath], Union[_Volume, _CloudBucketMount]] = {},  # Volume mount paths

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -85,6 +85,12 @@ class _Sandbox(_Object, type_prefix="sb"):
                 raise InvalidError("`region` and `_experimental_scheduler_placement` cannot be used together")
             scheduler_placement = SchedulerPlacement(region=region)
 
+        if isinstance(gpu, list):
+            raise InvalidError(
+                "Sandboxes do not support configuring a list of GPUs. "
+                "Specify a single GPU configuration, e.g. gpu='a10g'"
+            )
+
         # Validate volumes
         validated_volumes = validate_volumes(volumes)
         cloud_bucket_mounts = [(k, v) for k, v in validated_volumes if isinstance(v, _CloudBucketMount)]

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -311,4 +311,4 @@ def test_sandbox_no_entrypoint(client, servicer):
 @skip_non_linux
 def test_sandbox_gpu_fallbacks_support(client, servicer):
     with pytest.raises(InvalidError, match="do not support"):
-        Sandbox.create(client=client, gpu=["t4", "a100"])
+        Sandbox.create(client=client, gpu=["t4", "a100"])  # type: ignore

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -306,3 +306,9 @@ def test_sandbox_no_entrypoint(client, servicer):
     assert p.stdout.read() == "hi\n"
 
     sb.terminate()
+
+
+@skip_non_linux
+def test_sandbox_gpu_fallbacks_support(client, servicer):
+    with pytest.raises(InvalidError, match="do not support"):
+        Sandbox.create(client=client, gpu=["t4", "a100"])


### PR DESCRIPTION
## Describe your changes

Follow-up to https://github.com/modal-labs/modal-client/pull/2261

**Demo**

text version of Irfan's example

```python
import subprocess

import modal

app = modal.App()


@app.function(gpu=["t4", "a10g"], max_inputs=1)
def fallback():
    subprocess.run("nvidia-smi --list-gpus", shell=True, check=True)


@app.local_entrypoint()
def main():
    for i in range(30):
        fallback.remote()
```

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

* `modal.Function` and `modal.Cls` now support specifying a `list` of GPU configurations, allowing the Function's container pool to scale across each GPU configuration in preference order. 
