### PR TITLE
Adds experimental vprox `Function` property

### DIFF
--- a/modal/config.py
+++ b/modal/config.py
@@ -222,6 +222,7 @@ _SETTINGS = {
     "strict_parameters": _Setting(False, transform=_to_boolean),  # For internal/experimental use
     "i6pn_enabled": _Setting(False, transform=_to_boolean),  # For internal/experimental use
     "spawn_extended": _Setting(False, transform=_to_boolean),
+    "vprox_id": _Setting(),  # For internal/experimental use
 }
 
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -844,6 +844,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                     _experimental_group_size=group_size or 0,  # Experimental: Container Networking
                     _experimental_concurrent_cancellations=True,
                     _experimental_buffer_containers=_experimental_buffer_containers or 0,
+                    _experimental_vprox_id=config.get("vprox_id"),
                 )
                 assert resolver.app_id
                 request = api_pb2.FunctionCreateRequest(

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1085,6 +1085,8 @@ message Function {
   bool untrusted = 68;
 
   uint32 _experimental_buffer_containers = 69;
+
+  optional string _experimental_vprox_id = 70;
 }
 
 message FunctionBindParamsRequest {


### PR DESCRIPTION
Allows for the use of the `MODAL_VPROX_ID` env var for testing vprox. Simple interface for testing `vprox` end-to-end: 

```shell
MODAL_VPROX_ID=vn-88FHh3FuSrdITQtN5pXAMY modal run hello.py
```