### PR TITLE
Adds `_experimental_proxy_ip` function interface

### DIFF
--- a/modal/config.py
+++ b/modal/config.py
@@ -222,7 +222,6 @@ _SETTINGS = {
     "strict_parameters": _Setting(False, transform=_to_boolean),  # For internal/experimental use
     "i6pn_enabled": _Setting(False, transform=_to_boolean),  # For internal/experimental use
     "spawn_extended": _Setting(False, transform=_to_boolean),
-    "vprox_id": _Setting(),  # For internal/experimental use
 }
 
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -520,6 +520,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         max_inputs: Optional[int] = None,
         ephemeral_disk: Optional[int] = None,
         _experimental_buffer_containers: Optional[int] = None,
+        _experimental_proxy_ip: Optional[str] = None,
     ) -> None:
         """mdmd:hidden"""
         tag = info.get_tag()
@@ -842,7 +843,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                     _experimental_group_size=group_size or 0,  # Experimental: Container Networking
                     _experimental_concurrent_cancellations=True,
                     _experimental_buffer_containers=_experimental_buffer_containers or 0,
-                    _experimental_vprox_id=config.get("vprox_id"),
+                    _experimental_proxy_ip=_experimental_proxy_ip,
                 )
 
                 if isinstance(gpu, list):

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1101,7 +1101,7 @@ message Function {
 
   uint32 _experimental_buffer_containers = 69;
 
-  optional string _experimental_vprox_id = 70;
+  optional string _experimental_proxy_ip = 70;
 }
 
 message FunctionBindParamsRequest {


### PR DESCRIPTION
Experimental interface for using vprox proxies. 

```python
@modal.function(proxy_ip="1.2.3.4", ...)
def f(): ...
```