### PR TITLE
Gracefully handle process forks MOD-3238

### DIFF
--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -15,7 +15,6 @@ from ..exception import InvalidError
 from .logger import logger
 
 synchronizer = synchronicity.Synchronizer()
-# atexit.register(synchronizer.close)
 
 
 def synchronize_api(obj, target_module=None):

--- a/modal/client.py
+++ b/modal/client.py
@@ -417,11 +417,11 @@ class UnaryUnaryWrapper(Generic[RequestType, ResponseType]):
     wrapped_method: grpclib.client.UnaryUnaryMethod[RequestType, ResponseType]
     client: _Client
 
-    def __init__(self, _wrapped_method: grpclib.client.UnaryUnaryMethod[RequestType, ResponseType], client: _Client):
-        # we pass in the _wrapped_method here to get the correct static types
+    def __init__(self, wrapped_method: grpclib.client.UnaryUnaryMethod[RequestType, ResponseType], client: _Client):
+        # we pass in the wrapped_method here to get the correct static types
         # but don't use the reference directly, see `def wrapped_method` below
-        self._wrapped_full_name = _wrapped_method.name
-        self._wrapped_method_name = _wrapped_method.name.rsplit("/", 1)[1]
+        self._wrapped_full_name = wrapped_method.name
+        self._wrapped_method_name = wrapped_method.name.rsplit("/", 1)[1]
         self.client = client
 
     @property
@@ -442,14 +442,18 @@ class UnaryStreamWrapper(Generic[RequestType, ResponseType]):
     wrapped_method: grpclib.client.UnaryStreamMethod[RequestType, ResponseType]
 
     def __init__(self, wrapped_method: grpclib.client.UnaryStreamMethod[RequestType, ResponseType], client: _Client):
-        self.wrapped_method = wrapped_method
+        self._wrapped_full_name = wrapped_method.name
+        self._wrapped_method_name = wrapped_method.name.rsplit("/", 1)[1]
         self.client = client
+
+    @property
+    def name(self) -> str:
+        return self._wrapped_full_name
 
     async def unary_stream(
         self,
         request,
         metadata: Optional[Any] = None,
     ):
-        await self.reset_on_pid_change()
         async for response in self.client._call_stream(self.wrapped_method, request, metadata=metadata):
             yield response

--- a/modal/client.py
+++ b/modal/client.py
@@ -357,9 +357,14 @@ class _Client:
 
     async def _reset_on_pid_change(self):
         if self._owner_pid and self._owner_pid != os.getpid():
-            assert self._authenticated
-            await self._close()
+            # not calling .close() since that would also interact with stale resources
+            # just reset the internal state
+            self._channel = None
             self._stub = None
+            self._grpclib_stub = None
+            self._owner_pid = None
+
+            self.set_env_client(None)
             # TODO(elias): reset _cancellation_context in case ?
             await self._open()
             # intentionally not doing self._init since we should already be authenticated etc.

--- a/modal/client.py
+++ b/modal/client.py
@@ -135,6 +135,10 @@ class _Client:
         return self._closed
 
     @property
+    def authenticated(self):
+        return self._authenticated
+
+    @property
     def stub(self) -> modal_api_grpc.ModalClientModal:
         """mdmd:hidden"""
         assert self._stub
@@ -452,5 +456,5 @@ class UnaryStreamWrapper(Generic[RequestType, ResponseType]):
         request,
         metadata: Optional[Any] = None,
     ):
-        async for response in self.client._call_stream(self.wrapped_method, request, metadata=metadata):
+        async for response in self.client._call_stream(self._wrapped_method_name, request, metadata=metadata):
             yield response

--- a/modal/object.py
+++ b/modal/object.py
@@ -118,10 +118,6 @@ class _Object:
         # the object_id is already provided by other means
         return
 
-    def _init_from_other(self, other: O):
-        # Transient use case, see Dict, Queue, and SharedVolume
-        self._init(other._rep, other._load, other._is_another_app, other._preload)
-
     def _validate_is_hydrated(self: O):
         if not self._is_hydrated:
             object_type = self.__class__.__name__.strip("_")

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     grpclib==0.4.7
     protobuf>=3.19,<5.0,!=4.24.0
     rich>=12.0.0
-    synchronicity~=0.7.6
+    synchronicity~=0.7.7
     toml
     typer>=0.9
     types-certifi

--- a/tasks.py
+++ b/tasks.py
@@ -171,6 +171,9 @@ def check_copyright(ctx, fix=False):
                 and "protoc_plugin" not in root
                 # third-party code (i.e., in a local venv) has a different copyright
                 and "/site-packages/" not in root
+                and "/build/" not in root
+                and "/.venv/" not in root
+                and not re.search(r"/venv[0-9]*/", root)
             )
         ]
         for fn in fns:

--- a/test/fork_test.py
+++ b/test/fork_test.py
@@ -1,8 +1,10 @@
 # Copyright Modal Labs 2024
 import subprocess
 import sys
+from test.supports.skip import skip_windows
 
 
+@skip_windows("fork not supported on windows")
 def test_process_fork(supports_dir, server_url_env):
     output = subprocess.check_output([sys.executable, supports_dir / "forking.py"], timeout=2, encoding="utf8")
 

--- a/test/fork_test.py
+++ b/test/fork_test.py
@@ -1,3 +1,4 @@
+# Copyright Modal Labs 2024
 import subprocess
 import sys
 

--- a/test/fork_test.py
+++ b/test/fork_test.py
@@ -1,0 +1,9 @@
+import subprocess
+import sys
+
+
+def test_process_fork(supports_dir, server_url_env):
+    output = subprocess.check_output([sys.executable, supports_dir / "forking.py"], timeout=2, encoding="utf8")
+
+    success_pids = set(int(x) for x in output.split())
+    assert len(success_pids) == 2

--- a/test/supports/forking.py
+++ b/test/supports/forking.py
@@ -1,0 +1,25 @@
+import os
+
+from modal._utils.async_utils import synchronize_api
+from modal.client import Client
+from modal_proto import api_pb2
+
+
+@synchronize_api
+async def list_volumes(method):
+    await method(api_pb2.VolumeListRequest(environment_name="main"))
+    print(os.getpid())
+
+
+def sub(api_stub):
+    list_volumes(api_stub)
+
+
+if __name__ == "__main__":
+    client = Client.from_env()
+    rpc_method = client.stub.VolumeList
+    sub(rpc_method)
+    if not (fork_pid := os.fork()):
+        list_volumes(rpc_method)
+    else:
+        os.waitpid(fork_pid, 0)

--- a/test/supports/forking.py
+++ b/test/supports/forking.py
@@ -1,3 +1,4 @@
+# Copyright Modal Labs 2024
 import os
 
 from modal._utils.async_utils import synchronize_api


### PR DESCRIPTION
Whenever an rpc call is made via our "safe" wrappers, we now check if the pid of the process has changed vs. what was used when the client was established.
If it has changed, we reconnect the client "internally", so the same client object instance will be usable in the new process.
This is bit more complicated than just setting up a new client, but allows for seamless reconnects using the same credentials as the original client and any references to the client object (or even rpc method stubs!) won't have to be switched out/refreshed.

This is achieved via a slightly hacky indirection layer of using the method name to look up the latest "connected" grpclib method whenever an rpc call takes place. We still maintain static type checking when using the API stub though