### PR TITLE
Error when decorating async functions with `*sgi_app`

### DIFF
--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -382,6 +382,11 @@ def _asgi_app(
                     f"Modal will drop support for default parameters in a future release.",
                 )
 
+        if inspect.iscoroutinefunction(raw_f):
+            raise InvalidError(
+                f"ASGI app function {raw_f.__name__} is an async function. Only sync Python functions are supported."
+            )
+
         if not wait_for_response:
             deprecation_warning(
                 (2024, 5, 13),
@@ -453,6 +458,11 @@ def _wsgi_app(
                     f"WSGI app function {raw_f.__name__} has default parameters, but shouldn't have any parameters - "
                     f"Modal will drop support for default parameters in a future release.",
                 )
+
+        if inspect.iscoroutinefunction(raw_f):
+            raise InvalidError(
+                f"ASGI app function {raw_f.__name__} is an async function. Only sync Python functions are supported."
+            )
 
         if not wait_for_response:
             deprecation_warning(

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -461,7 +461,7 @@ def _wsgi_app(
 
         if inspect.iscoroutinefunction(raw_f):
             raise InvalidError(
-                f"ASGI app function {raw_f.__name__} is an async function. Only sync Python functions are supported."
+                f"WSGI app function {raw_f.__name__} is an async function. Only sync Python functions are supported."
             )
 
         if not wait_for_response:

--- a/test/webhook_test.py
+++ b/test/webhook_test.py
@@ -134,40 +134,54 @@ async def test_asgi_wsgi(servicer, client):
 
     @app.function(serialized=True)
     @asgi_app()
-    async def my_asgi():
+    def my_asgi():
         pass
 
     @app.function(serialized=True)
     @wsgi_app()
-    async def my_wsgi():
+    def my_wsgi():
         pass
 
     with pytest.raises(InvalidError, match="can't have parameters"):
 
         @app.function(serialized=True)
         @asgi_app()
-        async def my_invalid_asgi(x):
+        def my_invalid_asgi(x):
             pass
 
     with pytest.raises(InvalidError, match="can't have parameters"):
 
         @app.function(serialized=True)
         @wsgi_app()
-        async def my_invalid_wsgi(x):
+        def my_invalid_wsgi(x):
             pass
 
     with pytest.warns(DeprecationError, match="default parameters"):
 
         @app.function(serialized=True)
         @asgi_app()
-        async def my_deprecated_default_params_asgi(x=1):
+        def my_deprecated_default_params_asgi(x=1):
             pass
 
     with pytest.warns(DeprecationError, match="default parameters"):
 
         @app.function(serialized=True)
         @wsgi_app()
-        async def my_deprecated_default_params_wsgi(x=1):
+        def my_deprecated_default_params_wsgi(x=1):
+            pass
+
+    with pytest.raises(InvalidError, match="async function"):
+
+        @app.function(serialized=True)
+        @asgi_app()
+        async def my_async_asgi_function():
+            pass
+
+    with pytest.raises(InvalidError, match="async function"):
+
+        @app.function(serialized=True)
+        @wsgi_app()
+        async def my_async_wsgi_function():
             pass
 
     async with app.run(client=client):


### PR DESCRIPTION
Right now we just crash-loop silently which is not great. Considered just handling this in `_container_entrypoint.py` but seems wrong to add complexity there, when async behavior is very rarely needed for the wrapper function itself.