### PR TITLE
Ship i6pn networking for containers

### DIFF
--- a/modal/config.py
+++ b/modal/config.py
@@ -220,7 +220,6 @@ _SETTINGS = {
     "traceback": _Setting(False, transform=_to_boolean),
     "image_builder_version": _Setting(),
     "strict_parameters": _Setting(False, transform=_to_boolean),  # For internal/experimental use
-    "i6pn_enabled": _Setting(False, transform=_to_boolean),  # For internal/experimental use
     "spawn_extended": _Setting(False, transform=_to_boolean),
 }
 

--- a/modal/experimental.py
+++ b/modal/experimental.py
@@ -44,7 +44,7 @@ def set_local_input_concurrency(concurrency: int):
     _ContainerIOManager.set_input_concurrency(concurrency)
 
 
-# START Experimental: Container Networking
+# START Experimental: Grouped functions
 
 
 class _GroupedFunctionCall(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type_prefix="gc"):
@@ -171,4 +171,4 @@ def _networked(func):
     return wrapper
 
 
-# END Experimental: Container Networking
+# END Experimental: Grouped functions

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -515,8 +515,8 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         enable_memory_snapshot: bool = False,
         checkpointing_enabled: Optional[bool] = None,
         block_network: bool = False,
-        container_networking: bool = False,  # Experimental: Container Networking
-        group_size: Optional[int] = None,  # Experimental: Container Networking
+        i6pn_enabled: bool = False,
+        group_size: Optional[int] = None,  # Experimental: Grouped functions
         max_inputs: Optional[int] = None,
         ephemeral_disk: Optional[int] = None,
         _experimental_buffer_containers: Optional[int] = None,
@@ -838,9 +838,8 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                     scheduler_placement=scheduler_placement.proto if scheduler_placement else None,
                     is_class=info.is_service_class(),
                     class_parameter_info=info.class_parameter_info(),
-                    i6pn_enabled=config.get("i6pn_enabled")
-                    or container_networking,  # Experimental: Container Networking
-                    _experimental_group_size=group_size or 0,  # Experimental: Container Networking
+                    i6pn_enabled=i6pn_enabled,
+                    _experimental_group_size=group_size or 0,  # Experimental: Grouped functions
                     _experimental_concurrent_cancellations=True,
                     _experimental_buffer_containers=_experimental_buffer_containers or 0,
                     _experimental_proxy_ip=_experimental_proxy_ip,

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -35,7 +35,7 @@ class _PartialFunctionFlags(enum.IntFlag):
     ENTER_POST_SNAPSHOT: int = 8
     EXIT: int = 16
     BATCHED: int = 32
-    GROUPED: int = 64  # Experimental: Container Networking
+    GROUPED: int = 64  # Experimental: Grouped functions
 
     @staticmethod
     def all() -> int:
@@ -58,7 +58,7 @@ class _PartialFunction(typing.Generic[P, ReturnType, OriginalReturnType]):
     batch_max_size: Optional[int]
     batch_wait_ms: Optional[int]
     force_build: bool
-    group_size: Optional[int]  # Experimental: Container Networking
+    group_size: Optional[int]  # Experimental: Grouped functions
     build_timeout: Optional[int]
 
     def __init__(
@@ -70,7 +70,7 @@ class _PartialFunction(typing.Generic[P, ReturnType, OriginalReturnType]):
         keep_warm: Optional[int] = None,
         batch_max_size: Optional[int] = None,
         batch_wait_ms: Optional[int] = None,
-        group_size: Optional[int] = None,  # Experimental: Container Networking
+        group_size: Optional[int] = None,  # Experimental: Grouped functions
         force_build: bool = False,
         build_timeout: Optional[int] = None,
     ):
@@ -82,7 +82,7 @@ class _PartialFunction(typing.Generic[P, ReturnType, OriginalReturnType]):
         self.wrapped = False  # Make sure that this was converted into a FunctionHandle
         self.batch_max_size = batch_max_size
         self.batch_wait_ms = batch_wait_ms
-        self.group_size = group_size  # Experimental: Container Networking
+        self.group_size = group_size  # Experimental: Grouped functions
         self.force_build = force_build
         self.build_timeout = build_timeout
 

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -158,7 +158,6 @@ class _Sandbox(_Object, type_prefix="sb"):
                 pty_info=pty_info,
                 scheduler_placement=scheduler_placement.proto if scheduler_placement else None,
                 worker_id=config.get("worker_id"),
-                i6pn_enabled=config.get("i6pn_enabled"),
                 open_ports=api_pb2.PortSpecs(ports=open_ports),
                 network_access=network_access,
             )


### PR DESCRIPTION
This enables i6pn networking for containers. You can define a function with:

```python
import socket
import modal

app = modal.App()

@app.function(i6pn=True)
def func():
    worker_ip6 = socket.getaddrinfo("i6pn.modal.local", None, socket.AF_INET6)[0][4][0]
    print(worker_ip6)
```

And it will have an IPv6 address that can be used to communicate with other containers, _within the same cloud and region_.

Grouped functions need quite a bit more work before they can be made stable, including scheduler work, I'm just shipping i6pn for now so we can write some demos and docs.