### PR TITLE
Modernize environment object creation interface; use to look up settings

### DIFF
--- a/modal/client.py
+++ b/modal/client.py
@@ -124,7 +124,6 @@ class _Client:
         self._credentials = credentials
         self.version = version
         self._authenticated = False
-        self.image_builder_version: Optional[str] = None
         self._closed = False
         self._channel: Optional[grpclib.client.Channel] = None
         self._stub: Optional[modal_api_grpc.ModalClientModal] = None
@@ -193,7 +192,6 @@ class _Client:
                 ALARM_EMOJI = chr(0x1F6A8)
                 warnings.warn(f"{ALARM_EMOJI} {resp.warning} {ALARM_EMOJI}", DeprecationError)
             self._authenticated = True
-            self.image_builder_version = resp.image_builder_version
         except GRPCError as exc:
             if exc.status == Status.FAILED_PRECONDITION:
                 raise VersionError(

--- a/modal/environments.py
+++ b/modal/environments.py
@@ -1,14 +1,112 @@
 # Copyright Modal Labs 2023
-from typing import List, Optional
+from dataclasses import dataclass
+from typing import Dict, List, Optional
 
 from google.protobuf.empty_pb2 import Empty
+from google.protobuf.message import Message
 from google.protobuf.wrappers_pb2 import StringValue
 
-from modal.client import _Client
-from modal.config import config
 from modal_proto import api_pb2
 
-from ._utils.async_utils import synchronizer
+from ._resolver import Resolver
+from ._utils.async_utils import synchronize_api, synchronizer
+from ._utils.grpc_utils import retry_transient_errors
+from ._utils.name_utils import check_object_name
+from .client import _Client
+from .config import config, logger
+from .object import _Object
+
+
+@dataclass(frozen=True)
+class EnvironmentSettings:
+    image_builder_version: str  # Ideally would be typed with ImageBuilderVersion literal
+    webhook_suffix: str
+
+
+class _Environment(_Object, type_prefix="en"):
+    _settings: EnvironmentSettings
+
+    def __init__(self):
+        """mdmd:hidden"""
+        raise RuntimeError(
+            "`Environment(...)` constructor is not allowed."
+            " Please use `Environment.from_name` or `Environment.lookup` instead."
+        )
+
+    # TODO(michael) Keeping this private for now until we decide what else should be in it
+    # And what the rules should be about updates / mutability
+    # @property
+    # def settings(self) -> EnvironmentSettings:
+    #     return self._settings
+
+    def _hydrate_metadata(self, metadata: Message):
+        # Overridden concrete implementation of base class method
+        assert metadata and isinstance(metadata, api_pb2.EnvironmentMetadata)
+        # TODO(michael) should probably expose the `name` from the metadata
+        # as the way to discover the name of the "default" environment
+
+        # Is there a simpler way to go Message -> Dataclass?
+        self._settings = EnvironmentSettings(
+            image_builder_version=metadata.settings.image_builder_version,
+            webhook_suffix=metadata.settings.webhook_suffix,
+        )
+
+    @staticmethod
+    async def from_name(
+        label: str,
+        create_if_missing: bool = False,
+    ):
+        if label:
+            # Allow null labels for the case where we want to look up the "default" environment,
+            # which is defined by the server. It feels messy to have "from_name" without a name, though?
+            # We're adding this mostly for internal use right now. We could consider an environment-only
+            # alternate constructor, like `Environment.get_default`, rather than exposing "unnamed"
+            # environments as part of public API when we make this class more useful.
+            check_object_name(label, "Environment")
+
+        async def _load(self: _Environment, resolver: Resolver, existing_object_id: Optional[str]):
+            request = api_pb2.EnvironmentGetOrCreateRequest(
+                deployment_name=label,
+                object_creation_type=(
+                    api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING
+                    if create_if_missing
+                    else api_pb2.OBJECT_CREATION_TYPE_UNSPECIFIED
+                ),
+            )
+            response = await retry_transient_errors(resolver.client.stub.EnvironmentGetOrCreate, request)
+            logger.debug(f"Created environment with id {response.environment_id}")
+            self._hydrate(response.environment_id, resolver.client, response.metadata)
+
+        # TODO environment name (and id?) in the repr? (We should make reprs consistently more useful)
+        return _Environment._from_loader(_load, "Environment()", is_another_app=True, hydrate_lazily=True)
+
+    @staticmethod
+    async def lookup(
+        label: str,
+        client: Optional[_Client] = None,
+        create_if_missing: bool = False,
+    ):
+        obj = await _Environment.from_name(label, create_if_missing=create_if_missing)
+        if client is None:
+            client = await _Client.from_env()
+        resolver = Resolver(client=client)
+        await resolver.load(obj)
+        return obj
+
+
+Environment = synchronize_api(_Environment)
+
+
+# Needs to be after definition; synchronicity interferes with forward references?
+ENVIRONMENT_CACHE: Dict[str, _Environment] = {}
+
+
+async def _get_environment_cached(name: str, client: _Client) -> _Environment:
+    if name in ENVIRONMENT_CACHE:
+        return ENVIRONMENT_CACHE[name]
+    environment = await _Environment.lookup(name, client)
+    ENVIRONMENT_CACHE[name] = environment
+    return environment
 
 
 @synchronizer.create_blocking

--- a/modal/image.py
+++ b/modal/image.py
@@ -287,12 +287,6 @@ class _Image(_Object, type_prefix="im"):
     force_build: bool
     inside_exceptions: List[Exception]
 
-    # Use a cache for the builder version associated with each environment so we only need to look
-    # it up from the server once. This feels pretty messy; I think that ideally we would assocaite
-    # an Environment object with an App at the time that we creat the App? But currently the way we
-    # manage state during App setup is fairly complex and error prone.
-    _builder_versions: Dict[Optional[str], ImageBuilderVersion] = {}
-
     def _initialize_from_empty(self):
         self.inside_exceptions = []
 

--- a/modal/image.py
+++ b/modal/image.py
@@ -9,7 +9,21 @@ import warnings
 from dataclasses import dataclass
 from inspect import isfunction
 from pathlib import Path, PurePosixPath
-from typing import Any, AsyncGenerator, Callable, Dict, List, Literal, Optional, Sequence, Set, Tuple, Union, get_args
+from typing import (
+    Any,
+    AsyncGenerator,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+    cast,
+    get_args,
+)
 
 from google.protobuf.message import Message
 from grpclib.exceptions import GRPCError, StreamTerminatedError
@@ -24,6 +38,7 @@ from ._utils.function_utils import FunctionInfo
 from ._utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES, retry_transient_errors
 from .cloud_bucket_mount import _CloudBucketMount
 from .config import config, logger, user_config_path
+from .environments import _get_environment_cached
 from .exception import InvalidError, NotFoundError, RemoteError, VersionError, deprecation_error, deprecation_warning
 from .gpu import GPU_T, parse_gpu_config
 from .mount import _Mount, python_standalone_mount_name
@@ -207,20 +222,20 @@ def _make_pip_install_args(
     return args
 
 
-def _get_image_builder_version(client_version: str) -> ImageBuilderVersion:
-    if config_version := config.get("image_builder_version"):
-        version = config_version
+def _get_image_builder_version(server_version: ImageBuilderVersion) -> ImageBuilderVersion:
+    if local_config_version := config.get("image_builder_version"):
+        version = local_config_version
         if (env_var := "MODAL_IMAGE_BUILDER_VERSION") in os.environ:
             version_source = f" (based on your `{env_var}` environment variable)"
         else:
             version_source = f" (based on your local config file at `{user_config_path}`)"
     else:
-        version = client_version
         version_source = ""
+        version = server_version
 
     supported_versions: Set[ImageBuilderVersion] = set(get_args(ImageBuilderVersion))
     if version not in supported_versions:
-        if config_version is not None:
+        if local_config_version is not None:
             update_suggestion = "or remove your local configuration"
         elif version < min(supported_versions):
             update_suggestion = "your image builder version using the Modal dashboard"
@@ -271,6 +286,12 @@ class _Image(_Object, type_prefix="im"):
 
     force_build: bool
     inside_exceptions: List[Exception]
+
+    # Use a cache for the builder version associated with each environment so we only need to look
+    # it up from the server once. This feels pretty messy; I think that ideally we would assocaite
+    # an Environment object with an App at the time that we creat the App? But currently the way we
+    # manage state during App setup is fairly complex and error prone.
+    _builder_versions: Dict[Optional[str], ImageBuilderVersion] = {}
 
     def _initialize_from_empty(self):
         self.inside_exceptions = []
@@ -323,7 +344,10 @@ class _Image(_Object, type_prefix="im"):
             return deps
 
         async def _load(self: _Image, resolver: Resolver, existing_object_id: Optional[str]):
-            builder_version = _get_image_builder_version(resolver.client.image_builder_version)
+            environment = await _get_environment_cached(resolver.environment_name or "", resolver.client)
+            # A bit hacky,but assume that the environment provides a valid builder version
+            image_builder_version = cast(ImageBuilderVersion, environment._settings.image_builder_version)
+            builder_version = _get_image_builder_version(image_builder_version)
 
             if dockerfile_function is None:
                 dockerfile = DockerfileSpec(commands=[], context_files={})

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -22,6 +22,7 @@ from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name, is_valid_tag
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, _Client
 from .config import config, logger
+from .environments import _get_environment_cached
 from .exception import (
     ExecutionError,
     InteractiveTimeoutError,
@@ -54,10 +55,14 @@ async def _heartbeat(client: _Client, app_id: str) -> None:
     await retry_transient_errors(client.stub.AppHeartbeat, request, attempt_timeout=HEARTBEAT_TIMEOUT)
 
 
-async def _init_local_app_existing(client: _Client, existing_app_id: str) -> RunningApp:
+async def _init_local_app_existing(client: _Client, existing_app_id: str, environment_name: str) -> RunningApp:
     # Get all the objects first
     obj_req = api_pb2.AppGetObjectsRequest(app_id=existing_app_id)
-    obj_resp = await retry_transient_errors(client.stub.AppGetObjects, obj_req)
+    obj_resp, _ = await asyncio.gather(
+        retry_transient_errors(client.stub.AppGetObjects, obj_req),
+        # Cache the environment associated with the app now as we will use it later
+        _get_environment_cached(environment_name, client),
+    )
     app_page_url = f"https://modal.com/apps/{existing_app_id}"  # TODO (elias): this should come from the backend
     object_ids = {item.tag: item.object.object_id for item in obj_resp.items}
     return RunningApp(existing_app_id, app_page_url=app_page_url, tag_to_object_id=object_ids, client=client)
@@ -75,7 +80,11 @@ async def _init_local_app_new(
         environment_name=environment_name,
         app_state=app_state,  # type: ignore
     )
-    app_resp = await retry_transient_errors(client.stub.AppCreate, app_req)
+    app_resp, _ = await asyncio.gather(
+        retry_transient_errors(client.stub.AppCreate, app_req),
+        # Cache the environment associated with the app now as we will use it later
+        _get_environment_cached(environment_name, client),
+    )
     logger.debug(f"Created new app with id {app_resp.app_id}")
     return RunningApp(
         app_resp.app_id,
@@ -104,7 +113,7 @@ async def _init_local_app_from_name(
 
     # Grab the app
     if existing_app_id is not None:
-        return await _init_local_app_existing(client, existing_app_id)
+        return await _init_local_app_existing(client, existing_app_id, environment_name)
     else:
         return await _init_local_app_new(
             client, name, api_pb2.APP_STATE_INITIALIZING, environment_name=environment_name
@@ -407,7 +416,7 @@ async def _serve_update(
     # Used by child process to reinitialize a served app
     client = await _Client.from_env()
     try:
-        running_app: RunningApp = await _init_local_app_existing(client, existing_app_id)
+        running_app: RunningApp = await _init_local_app_existing(client, existing_app_id, environment_name)
 
         # Create objects
         await _create_all_objects(

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -10,7 +10,7 @@ from tempfile import NamedTemporaryFile
 from typing import List, Literal, get_args
 from unittest import mock
 
-from modal import App, Image, Mount, Secret, build, gpu, method
+from modal import App, Image, Mount, Secret, build, environments, gpu, method
 from modal._serialization import serialize
 from modal.client import Client
 from modal.exception import DeprecationError, InvalidError, VersionError
@@ -68,6 +68,13 @@ def builder_version(request, server_url_env, modal_config):
     with modal_config():
         with mock.patch("test.conftest.ImageBuilderVersion", Literal[version]):  # type: ignore
             yield version
+
+
+@pytest.fixture(autouse=True)
+def clear_environment_cache():
+    # Clear the environment cache so we can mock the server returning different image builder versions
+    # Alternatively could rewrite some of those tests to use different environments?
+    environments.ENVIRONMENT_CACHE.clear()
 
 
 def test_python_version_validation():


### PR DESCRIPTION
This PR does a few things:

- Adds a `modal.Environment` object with `Environment.from_name` and `Environment.lookup` so we treat the "environment" concept more like other objects
- Uses the `settings` metadata attached to the environment object as the source of truth for the `image_builder_version`; removes that as an attribute of the Client
- Adds an "environment cache" so we only need to look up each environment settings once
- Looks up the environment settings concurrently with creating an app for "normal" app creation workflows (but notably *not* when creating a sandbox) to minimize the penalty on image loading

Loose threads:
- I really don't love the `ENVIRONMENT_CACHE` implementation. I think all of the code around creating an App, initializing a "resolver", etc. would benefit from a thorough refactor so that it happens in a consistent way and we can rethink what state we need to pass around. Making sandboxes less of an odd duck here would be good.
- The `modal environment create` command still goes through the`EnvironmentCreate` RPC, which has "error_if_exists" semantics. We potentially want to add a flag for that to `from_name` and then consolidate, but there's some slightly awkward API questions there, which I am deferring.

Closes MOD-3880

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>
