### PR TITLE
Inject the token ID, secret, and environment into modal shell

### DIFF
--- a/modal/runner.py
+++ b/modal/runner.py
@@ -513,7 +513,7 @@ async def _interactive_shell(_app: _App, cmds: List[str], environment_name: str 
     modal shell script.py --cmd /bin/bash
     ```
 
-    When calling programmatically, `kwargs` will are passed to `Sandbox.create()`.
+    When calling programmatically, `kwargs` are passed to `Sandbox.create()`.
     """
 
     client = await _Client.from_env()

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -524,12 +524,13 @@ async def _interactive_shell(_app: _App, cmds: List[str], environment_name: str 
             "MODAL_TOKEN_SECRET": config["token_secret"],
             "MODAL_ENVIRONMENT": _get_environment_name(),
         }
+        secrets = kwargs.pop("secrets", []) + [_Secret.from_dict(sandbox_env)]
         with OutputManager.enable_output():  # show any image build logs
             sandbox = await _Sandbox.create(
                 "sleep",
                 "100000",
-                secrets=[_Secret.from_dict(sandbox_env)],
                 app=_app,
+                secrets=secrets,
                 **kwargs,
             )
 

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -33,6 +33,7 @@ from .execution_context import is_local
 from .object import _get_environment_name, _Object
 from .running_app import RunningApp
 from .sandbox import _Sandbox
+from .secret import _Secret
 
 if TYPE_CHECKING:
     from .app import _App
@@ -527,7 +528,7 @@ async def _interactive_shell(_app: _App, cmds: List[str], environment_name: str 
             sandbox = await _Sandbox.create(
                 "sleep",
                 "100000",
-                secrets=[modal.Secret.from_dict(sandbox_env)],
+                secrets=[_Secret.from_dict(sandbox_env)],
                 app=_app,
                 **kwargs,
             )

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -446,6 +446,21 @@ def test_shell_cmd(servicer, set_env_client, test_dir, mock_shell_pty):
     assert captured_out == [(1, shell_prompt), (1, expected_output)]
 
 
+@skip_windows("modal shell is not supported on Windows.")
+def test_shell_preserve_token(servicer, set_env_client, mock_shell_pty, monkeypatch):
+    monkeypatch.setenv("MODAL_TOKEN_ID", "my-token-id")
+
+    fake_stdin, captured_out = mock_shell_pty
+    shell_prompt = servicer.shell_prompt.encode("utf-8")
+
+    fake_stdin.clear()
+    fake_stdin.extend([b'echo "$MODAL_TOKEN_ID"\n', b"exit\n"])
+    _run(["shell"])
+
+    expected_output = b"my-token-id\n"
+    assert captured_out == [(1, shell_prompt), (1, expected_output)]
+
+
 def test_shell_unsuported_cmds_fails_on_windows(servicer, set_env_client, mock_shell_pty):
     expected_exit_code = 1 if platform.system() == "Windows" else 0
     res = _run(["shell"], expected_exit_code=expected_exit_code)


### PR DESCRIPTION
Resolves MOD-3936.

I made this PR fully from the GitHub web editor, forgive any typos or bugs.

<img width="934" alt="image" src="https://github.com/user-attachments/assets/935175fb-6a81-4b22-afa2-231b3e00137b">


## Changelog

- `modal shell` now preserves your logged-in Modal session within the container.
