### PR TITLE
Hydrate Function.from_name lazily

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1088,7 +1088,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
             self._hydrate(response.function_id, resolver.client, response.handle_metadata)
 
         rep = f"Ref({app_name})"
-        return cls._from_loader(_load_remote, rep, is_another_app=True)
+        return cls._from_loader(_load_remote, rep, is_another_app=True, hydrate_lazily=True)
 
     @staticmethod
     async def lookup(


### PR DESCRIPTION
I don't see why we _don't_ do this – I _think_ it should always work.

After this change:
```python
>>> f = modal.Function.from_name("example-get-started", "square")
>>> f.remote(123)
15129
>>> 
```