### PR TITLE
Quickfix for Ctrl-C during function execution emitting a bunch of ugly tracebacks (+ tests

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -61,6 +61,7 @@ from .client import _Client
 from .cloud_bucket_mount import _CloudBucketMount, cloud_bucket_mounts_to_proto
 from .config import config
 from .exception import (
+    ClientClosed,
     ExecutionError,
     InvalidError,
     NotFoundError,
@@ -1268,7 +1269,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         )
         try:
             return await invocation.run_function()
-        except asyncio.CancelledError:
+        except (asyncio.CancelledError, ClientClosed):
             # this can happen if the user terminates a program, triggering a cancellation cascade
             if not self._mute_cancellation:
                 raise

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -969,7 +969,7 @@ def _run_subprocess(cli_cmd: List[str]) -> subprocess.Popen:
     return p
 
 
-@pytest.mark.timeout(5)
+@pytest.mark.timeout(10)
 @pytest.mark.skip("not fixed yet!")
 def test_keyboard_interrupt_during_app_load(servicer, server_url_env, supports_dir):
     ctx: InterceptionContext
@@ -990,7 +990,7 @@ def test_keyboard_interrupt_during_app_load(servicer, server_url_env, supports_d
         assert "Traceback" not in err
 
 
-@pytest.mark.timeout(5)
+@pytest.mark.timeout(10)
 def test_keyboard_interrupt_during_app_run(servicer, server_url_env, supports_dir):
     ctx: InterceptionContext
     waiting_for_output = threading.Event()
@@ -1010,7 +1010,7 @@ def test_keyboard_interrupt_during_app_run(servicer, server_url_env, supports_di
         assert "Traceback" not in err
 
 
-@pytest.mark.timeout(5)
+@pytest.mark.timeout(10)
 def test_keyboard_interrupt_during_app_run_detach(servicer, server_url_env, supports_dir):
     ctx: InterceptionContext
     waiting_for_output = threading.Event()

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -962,7 +962,7 @@ def test_call_update_environment_suffix(servicer, set_env_client):
     _run(["environment", "update", "main", "--set-web-suffix", "_"])
 
 
-def _run_subprocess(cli_cmd: list[str]) -> subprocess.Popen:
+def _run_subprocess(cli_cmd: List[str]) -> subprocess.Popen:
     p = subprocess.Popen(
         [sys.executable, "-m", "modal"] + cli_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf8"
     )
@@ -970,6 +970,7 @@ def _run_subprocess(cli_cmd: list[str]) -> subprocess.Popen:
 
 
 @pytest.mark.timeout(5)
+@pytest.mark.skip("not fixed yet!")
 def test_keyboard_interrupt_during_app_load(servicer, server_url_env, supports_dir):
     ctx: InterceptionContext
     creating_function = threading.Event()

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -982,7 +982,7 @@ def test_keyboard_interrupt_during_app_load(servicer, server_url_env, supports_d
     with servicer.intercept() as ctx:
         ctx.set_responder("FunctionCreate", stalling_function_create)
 
-        p = _run_subprocess(["run", f"{supports_dir / 'functions.py'}::square", "--x", "10"])
+        p = _run_subprocess(["run", f"{supports_dir / 'hello.py'}::hello"])
         creating_function.wait()
         p.send_signal(signal.SIGINT)
         out, err = p.communicate(timeout=1)
@@ -1002,7 +1002,7 @@ def test_keyboard_interrupt_during_app_run(servicer, server_url_env, supports_di
     with servicer.intercept() as ctx:
         ctx.set_responder("FunctionGetOutputs", stalling_function_get_output)
 
-        p = _run_subprocess(["run", f"{supports_dir / 'functions.py'}::square", "--x", "10"])
+        p = _run_subprocess(["run", f"{supports_dir / 'hello.py'}::hello"])
         waiting_for_output.wait()
         p.send_signal(signal.SIGINT)
         out, err = p.communicate(timeout=1)
@@ -1022,7 +1022,7 @@ def test_keyboard_interrupt_during_app_run_detach(servicer, server_url_env, supp
     with servicer.intercept() as ctx:
         ctx.set_responder("FunctionGetOutputs", stalling_function_get_output)
 
-        p = _run_subprocess(["run", "--detach", f"{supports_dir / 'functions.py'}::square", "--x", "10"])
+        p = _run_subprocess(["run", "--detach", f"{supports_dir / 'hello.py'}::hello"])
         waiting_for_output.wait()
         p.send_signal(signal.SIGINT)
         out, err = p.communicate(timeout=1)

--- a/test/supports/functions.py
+++ b/test/supports/functions.py
@@ -28,7 +28,7 @@ app = App()
 
 
 @app.function()
-def square(x):
+def square(x: int):
     return x * x
 
 


### PR DESCRIPTION
Holding off on this ugly fix as it might get superseded by https://github.com/modal-labs/modal-client/pull/2298 if that PR works out!

## Describe your changes

* Adds tests for sigints/Ctr-C during different parts of the `modal run` lifecycle with assertions that output matches expectation (i.e. no tracebacks, good error messages)
* Adds a quickfix for Cltr-C during remote function execution (muting exceptions for ClientStopped in addition to CancelledErrors).

This doesn't fix sigints during other phases of execution (like during app setup and other synchronicity blocking calls). I have another upcoming fix for synchronicity which fixes the underlying issues of KeyboardInterrupts not propagating as cancellations to underlying tasks. Might also get rid of ClientClosed in favor of just using task cancellation + logging the reason, since CancelledErrors are "quiet" during event loop shutdown...

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
