### PR TITLE
Add a runtime_perf_record flag for internal debugging purposes

### DIFF
--- a/modal/config.py
+++ b/modal/config.py
@@ -212,6 +212,7 @@ _SETTINGS = {
     "heartbeat_interval": _Setting(15, float),
     "function_runtime": _Setting(),
     "function_runtime_debug": _Setting(False, transform=_to_boolean),  # For internal debugging use.
+    "runtime_perf_record": _Setting(False, transform=_to_boolean),  # For internal debugging use.
     "environment": _Setting(),
     "default_cloud": _Setting(None, transform=lambda x: x if x else None),
     "worker_id": _Setting(),  # For internal debugging use.

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -821,6 +821,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                     warm_pool_size=keep_warm or 0,
                     runtime=config.get("function_runtime"),
                     runtime_debug=config.get("function_runtime_debug"),
+                    runtime_perf_record=config.get("runtime_perf_record"),
                     app_name=app_name,
                     is_builder_function=is_builder_function,
                     target_concurrent_inputs=allow_concurrent_inputs or 0,

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1117,6 +1117,8 @@ message Function {
   uint32 _experimental_buffer_containers = 69;
 
   optional string _experimental_proxy_ip = 70;
+
+  bool runtime_perf_record = 71; // For internal debugging use only.
 }
 
 message FunctionBindParamsRequest {


### PR DESCRIPTION
## Describe your changes

- MOD-3816: Add a client-side flag for enabling server-side runtime perf recording.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
