### PR TITLE
Proper KeyboardInterrupt handling as part of run_app (MOD-3937, MOD-3525)

### DIFF
--- a/modal/_output.py
+++ b/modal/_output.py
@@ -619,13 +619,6 @@ async def get_app_logs_loop(
     while True:
         try:
             await _get_logs()
-        except asyncio.CancelledError:
-            view_logs_url = app_logs_url if app_logs_url else "https://modal.com/logs/"
-            output_mgr.print(
-                f"[red]Timed out waiting for logs. "
-                f"[grey70]View logs at [underline]{view_logs_url}[/underline] for remaining output.[/grey70]"
-            )
-            raise
         except (GRPCError, StreamTerminatedError, socket.gaierror, AttributeError) as exc:
             if isinstance(exc, GRPCError):
                 if exc.status in RETRYABLE_GRPC_STATUS_CODES:

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -61,6 +61,7 @@ from .client import _Client
 from .cloud_bucket_mount import _CloudBucketMount, cloud_bucket_mounts_to_proto
 from .config import config
 from .exception import (
+    ClientClosed,
     ExecutionError,
     InvalidError,
     NotFoundError,
@@ -1268,7 +1269,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         )
         try:
             return await invocation.run_function()
-        except asyncio.CancelledError:
+        except (asyncio.CancelledError, ClientClosed):
             # this can happen if the user terminates a program, triggering a cancellation cascade
             if not self._mute_cancellation:
                 raise

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -3,6 +3,7 @@ import asyncio
 import dataclasses
 import os
 import time
+import typing
 from multiprocessing.synchronize import Event
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Dict, List, Optional, TypeVar
 
@@ -63,14 +64,14 @@ async def _init_local_app_existing(client: _Client, existing_app_id: str) -> Run
 async def _init_local_app_new(
     client: _Client,
     description: str,
-    app_state: int,
+    app_state: int,  # ValueType
     environment_name: str = "",
     interactive: bool = False,
 ) -> RunningApp:
     app_req = api_pb2.AppCreateRequest(
         description=description,
         environment_name=environment_name,
-        app_state=app_state,
+        app_state=app_state,  # type: ignore
     )
     app_resp = await retry_transient_errors(client.stub.AppCreate, app_req)
     logger.debug(f"Created new app with id {app_resp.app_id}")
@@ -217,6 +218,30 @@ async def _disconnect(
     logger.debug("App disconnected")
 
 
+async def _status_based_disconnect(client: _Client, app_id: str, exc_info: Optional[BaseException] = None):
+    """Disconnect local session of a running app, sending relevant metadata
+
+    exc_info: Exception if an exception caused the disconnect
+    """
+    if isinstance(exc_info, (KeyboardInterrupt, asyncio.CancelledError)):
+        reason = api_pb2.APP_DISCONNECT_REASON_KEYBOARD_INTERRUPT
+    elif exc_info is not None:
+        if traceback_contains_remote_call(exc_info.__traceback__):
+            reason = api_pb2.APP_DISCONNECT_REASON_REMOTE_EXCEPTION
+        else:
+            reason = api_pb2.APP_DISCONNECT_REASON_LOCAL_EXCEPTION
+    else:
+        reason = api_pb2.APP_DISCONNECT_REASON_ENTRYPOINT_COMPLETED
+    if isinstance(exc_info, _CliUserExecutionError):
+        exc_str = repr(exc_info.__cause__)
+    elif exc_info:
+        exc_str = repr(exc_info)
+    else:
+        exc_str = ""
+
+    await _disconnect(client, app_id, reason, exc_str)
+
+
 @asynccontextmanager
 async def _run_app(
     app: _App,
@@ -228,7 +253,7 @@ async def _run_app(
 ) -> AsyncGenerator[_App, None]:
     """mdmd:hidden"""
     if environment_name is None:
-        environment_name = config.get("environment")
+        environment_name = typing.cast(str, config.get("environment"))
 
     if not is_local():
         raise InvalidError(
@@ -257,18 +282,21 @@ async def _run_app(
     app_state = api_pb2.APP_STATE_DETACHED if detach else api_pb2.APP_STATE_EPHEMERAL
     running_app: RunningApp = await _init_local_app_new(
         client,
-        app.description,
-        environment_name=environment_name,
+        app.description or "",
+        environment_name=environment_name or "",
         app_state=app_state,
         interactive=interactive,
     )
-    async with app._set_local_app(client, running_app), TaskContext(grace=config["logs_timeout"]) as tc:
+
+    logs_timeout = config["logs_timeout"]
+    async with app._set_local_app(client, running_app), TaskContext(grace=logs_timeout) as tc:
         # Start heartbeats loop to keep the client alive
         # we don't log heartbeat exceptions in detached mode
         # as losing the local connection will not affect the running app
         tc.infinite_loop(
             lambda: _heartbeat(client, running_app.app_id), sleep=HEARTBEAT_INTERVAL, log_exception=not detach
         )
+        logs_loop: Optional[asyncio.Task] = None
 
         if output_mgr := OutputManager.get():
             with output_mgr.make_live(step_progress("Initializing...")):
@@ -276,21 +304,29 @@ async def _run_app(
                     f"Initialized. [grey70]View run at [underline]{running_app.app_page_url}[/underline][/grey70]"
                 )
                 output_mgr.print(step_completed(initialized_msg))
-                output_mgr.update_app_page_url(running_app.app_page_url)
+                output_mgr.update_app_page_url(running_app.app_page_url or "ERROR:NO_APP_PAGE")
 
             # Start logs loop
             logs_loop = tc.create_task(
                 get_app_logs_loop(client, output_mgr, app_id=running_app.app_id, app_logs_url=running_app.app_logs_url)
             )
 
-        exc_info: Optional[BaseException] = None
         try:
             # Create all members
             await _create_all_objects(client, running_app, app._indexed_objects, environment_name)
 
             # Publish the app
             await _publish_app(client, running_app, app_state, app._indexed_objects)
+        except asyncio.CancelledError as e:
+            # this typically happens on sigint/ctrl-C during setup (they KeyboardInterrupt happens in the main thread)
+            if output_mgr := OutputManager.get():
+                output_mgr.print("Aborting app initialization...\n")
 
+            await _status_based_disconnect(client, running_app.app_id, e)
+            app._uncreate_all_objects()
+            raise
+
+        try:
             # Show logs from dynamically created images.
             # TODO: better way to do this
             if output_mgr := OutputManager.get():
@@ -303,11 +339,7 @@ async def _run_app(
             else:
                 yield app
         except KeyboardInterrupt as e:
-            exc_info = e
-            # mute cancellation errors on all function handles to prevent exception spam
-            for obj in app.registered_functions.values():
-                obj._set_mute_cancellation(True)
-
+            # this happens only if sigint comes in during the yield block above
             if detach:
                 if output_mgr := OutputManager.get():
                     output_mgr.print(step_completed("Shutting down Modal client."))
@@ -316,42 +348,37 @@ async def _run_app(
                         f"[magenta]{running_app.app_page_url}[/magenta]"
                         ""
                     )
+                if logs_loop:
                     logs_loop.cancel()
+                await _status_based_disconnect(client, running_app.app_id, e)
+                return
             else:
                 if output_mgr := OutputManager.get():
+                    output_mgr.print(
+                        "Disconnecting from Modal - This will terminate your Modal app in a few seconds.\n"
+                    )
+                await _status_based_disconnect(client, running_app.app_id, e)
+                if logs_loop:
+                    try:
+                        await asyncio.wait_for(logs_loop, timeout=logs_timeout)
+                    except asyncio.TimeoutError:
+                        logger.warning("Timed out waiting for final app logs.")
+
+                if output_mgr:
                     output_mgr.print(
                         step_completed(
                             "App aborted. "
                             f"[grey70]View run at [underline]{running_app.app_page_url}[/underline][/grey70]"
                         )
                     )
-                    output_mgr.print(
-                        "Disconnecting from Modal - This will terminate your Modal app in a few seconds.\n"
-                    )
         except BaseException as e:
-            exc_info = e
-            raise e
+            # TODO: unexpected error - log something?
+            await _status_based_disconnect(client, running_app.app_id, e)
+            raise
         finally:
-            if isinstance(exc_info, KeyboardInterrupt):
-                reason = api_pb2.APP_DISCONNECT_REASON_KEYBOARD_INTERRUPT
-            elif exc_info is not None:
-                if traceback_contains_remote_call(exc_info.__traceback__):
-                    reason = api_pb2.APP_DISCONNECT_REASON_REMOTE_EXCEPTION
-                else:
-                    reason = api_pb2.APP_DISCONNECT_REASON_LOCAL_EXCEPTION
-            else:
-                reason = api_pb2.APP_DISCONNECT_REASON_ENTRYPOINT_COMPLETED
-
-            if isinstance(exc_info, _CliUserExecutionError):
-                exc_str = repr(exc_info.__cause__)
-            elif exc_info:
-                exc_str = repr(exc_info)
-            else:
-                exc_str = ""
-
-            await _disconnect(client, running_app.app_id, reason, exc_str)
             app._uncreate_all_objects()
 
+    await _status_based_disconnect(client, running_app.app_id, exc_info=None)
     if output_mgr := OutputManager.get():
         output_mgr.print(
             step_completed(
@@ -429,7 +456,7 @@ async def _deploy_app(
       referred to and used by other apps.
     """
     if environment_name is None:
-        environment_name = config.get("environment")
+        environment_name = typing.cast(str, config.get("environment"))
 
     name = name or app.name
     if not name:

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
     grpclib==0.4.7
     protobuf>=3.19,<5.0,!=4.24.0
     rich>=12.0.0
-    synchronicity~=0.7.7
+    synchronicity~=0.8.0
     toml
     typer>=0.9
     types-certifi

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -970,7 +970,6 @@ def _run_subprocess(cli_cmd: List[str]) -> subprocess.Popen:
 
 
 @pytest.mark.timeout(5)
-@pytest.mark.skip("not fixed yet!")
 def test_keyboard_interrupt_during_app_load(servicer, server_url_env, supports_dir):
     ctx: InterceptionContext
     creating_function = threading.Event()
@@ -988,6 +987,7 @@ def test_keyboard_interrupt_during_app_load(servicer, server_url_env, supports_d
         out, err = p.communicate(timeout=1)
         print(out)
         assert "Traceback" not in err
+        assert "Aborting app initialization..." in out
 
 
 @pytest.mark.timeout(5)
@@ -1006,7 +1006,7 @@ def test_keyboard_interrupt_during_app_run(servicer, server_url_env, supports_di
         waiting_for_output.wait()
         p.send_signal(signal.SIGINT)
         out, err = p.communicate(timeout=1)
-        print(err)
+        assert "App aborted. View run at https://modaltest.com/apps/ap-123" in out
         assert "Traceback" not in err
 
 
@@ -1026,5 +1026,7 @@ def test_keyboard_interrupt_during_app_run_detach(servicer, server_url_env, supp
         waiting_for_output.wait()
         p.send_signal(signal.SIGINT)
         out, err = p.communicate(timeout=1)
-        print(err)
+        print(out)
+        assert "Shutting down Modal client." in out
+        assert "The detached app keeps running. You can track its progress at:" in out
         assert "Traceback" not in err

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -962,7 +962,7 @@ def test_call_update_environment_suffix(servicer, set_env_client):
     _run(["environment", "update", "main", "--set-web-suffix", "_"])
 
 
-def _run_subprocess(cli_cmd: list[str]) -> subprocess.Popen:
+def _run_subprocess(cli_cmd: List[str]) -> subprocess.Popen:
     p = subprocess.Popen(
         [sys.executable, "-m", "modal"] + cli_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf8"
     )
@@ -970,6 +970,7 @@ def _run_subprocess(cli_cmd: list[str]) -> subprocess.Popen:
 
 
 @pytest.mark.timeout(5)
+@pytest.mark.skip("not fixed yet!")
 def test_keyboard_interrupt_during_app_load(servicer, server_url_env, supports_dir):
     ctx: InterceptionContext
     creating_function = threading.Event()

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -985,6 +985,7 @@ def _run_subprocess(cli_cmd: List[str]) -> subprocess.Popen:
 
 
 @pytest.mark.timeout(10)
+@skip_windows("no sigint on windows")
 def test_keyboard_interrupt_during_app_load(servicer, server_url_env, supports_dir):
     ctx: InterceptionContext
     creating_function = threading.Event()
@@ -1006,6 +1007,7 @@ def test_keyboard_interrupt_during_app_load(servicer, server_url_env, supports_d
 
 
 @pytest.mark.timeout(10)
+@skip_windows("no sigint on windows")
 def test_keyboard_interrupt_during_app_run(servicer, server_url_env, supports_dir):
     ctx: InterceptionContext
     waiting_for_output = threading.Event()
@@ -1026,6 +1028,7 @@ def test_keyboard_interrupt_during_app_run(servicer, server_url_env, supports_di
 
 
 @pytest.mark.timeout(10)
+@skip_windows("no sigint on windows")
 def test_keyboard_interrupt_during_app_run_detach(servicer, server_url_env, supports_dir):
     ctx: InterceptionContext
     waiting_for_output = threading.Event()

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -996,7 +996,7 @@ def test_keyboard_interrupt_during_app_load(servicer, server_url_env, supports_d
     with servicer.intercept() as ctx:
         ctx.set_responder("FunctionCreate", stalling_function_create)
 
-        p = _run_subprocess(["run", f"{supports_dir / 'functions.py'}::square", "--x", "10"])
+        p = _run_subprocess(["run", f"{supports_dir / 'hello.py'}::hello"])
         creating_function.wait()
         p.send_signal(signal.SIGINT)
         out, err = p.communicate(timeout=1)
@@ -1017,7 +1017,7 @@ def test_keyboard_interrupt_during_app_run(servicer, server_url_env, supports_di
     with servicer.intercept() as ctx:
         ctx.set_responder("FunctionGetOutputs", stalling_function_get_output)
 
-        p = _run_subprocess(["run", f"{supports_dir / 'functions.py'}::square", "--x", "10"])
+        p = _run_subprocess(["run", f"{supports_dir / 'hello.py'}::hello"])
         waiting_for_output.wait()
         p.send_signal(signal.SIGINT)
         out, err = p.communicate(timeout=1)
@@ -1037,7 +1037,7 @@ def test_keyboard_interrupt_during_app_run_detach(servicer, server_url_env, supp
     with servicer.intercept() as ctx:
         ctx.set_responder("FunctionGetOutputs", stalling_function_get_output)
 
-        p = _run_subprocess(["run", "--detach", f"{supports_dir / 'functions.py'}::square", "--x", "10"])
+        p = _run_subprocess(["run", "--detach", f"{supports_dir / 'hello.py'}::hello"])
         waiting_for_output.wait()
         p.send_signal(signal.SIGINT)
         out, err = p.communicate(timeout=1)

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -984,7 +984,7 @@ def _run_subprocess(cli_cmd: List[str]) -> subprocess.Popen:
     return p
 
 
-@pytest.mark.timeout(5)
+@pytest.mark.timeout(10)
 def test_keyboard_interrupt_during_app_load(servicer, server_url_env, supports_dir):
     ctx: InterceptionContext
     creating_function = threading.Event()
@@ -1005,7 +1005,7 @@ def test_keyboard_interrupt_during_app_load(servicer, server_url_env, supports_d
         assert "Aborting app initialization..." in out
 
 
-@pytest.mark.timeout(5)
+@pytest.mark.timeout(10)
 def test_keyboard_interrupt_during_app_run(servicer, server_url_env, supports_dir):
     ctx: InterceptionContext
     waiting_for_output = threading.Event()
@@ -1025,7 +1025,7 @@ def test_keyboard_interrupt_during_app_run(servicer, server_url_env, supports_di
         assert "Traceback" not in err
 
 
-@pytest.mark.timeout(5)
+@pytest.mark.timeout(10)
 def test_keyboard_interrupt_during_app_run_detach(servicer, server_url_env, supports_dir):
     ctx: InterceptionContext
     waiting_for_output = threading.Event()

--- a/test/supports/functions.py
+++ b/test/supports/functions.py
@@ -28,7 +28,7 @@ app = App()
 
 
 @app.function()
-def square(x):
+def square(x: int):
     return x * x
 
 


### PR DESCRIPTION
This uses https://github.com/modal-labs/synchronicity/pull/166 to have sigints trigger cancellations + related logic immediately, before the main thread goes on to the next call call or reraises KeyboardInterrupt.

This prevents tasks from getting cleaned up while they are still running during synchronizer shutdown as part of the interpreter shutdown. Since it changes a lot of error handling assumptions (strictly to the better imo) I also ended up refactoring a lot of the error handling in _run_app to conform to the new expectations.

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

---

</details>

## Changelog

* SIGINT/Ctrl-C/KeyboardInterrupt are now handled more gracefully in most contexts, hopefully preventing a lot of internal traceback info from leaking out into the client's stderr in expected exception paths