### PR TITLE
Begin defining 2024.10 image builder version

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -71,19 +71,19 @@ jobs:
         run: pytest -v --markdown-docs -m markdown-docs modal
 
   container-dependencies:
-    name: Check minimal container dependencies for ${{ matrix.python-version }}
+    name: Check minimal container dependencies for ${{ matrix.python-version }} / ${{ matrix.image-builder-version }}
     runs-on: ubuntu-20.04
     timeout-minutes: 4
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        # TODO matrix over image builder version too? Maybe only min/max Python?
+        image-builder-version: ["2024.04", "2024.10"]
+        python-version: ["3.8", "3.12"]
     steps:
       - uses: actions/checkout@v3
 
       - name: Install dependencies
         run: |
-          pip install -r modal/requirements/2024.10.txt
+          pip install -r modal/requirements/${{ matrix.image-builder-version }}.txt
           pip install synchronicity
 
       - name: Compile protos

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -77,12 +77,13 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        # TODO matrix over image builder version too? Maybe only min/max Python?
     steps:
       - uses: actions/checkout@v3
 
       - name: Install dependencies
         run: |
-          pip install -r modal/requirements/2024.04.txt
+          pip install -r modal/requirements/2024.10.txt
           pip install synchronicity
 
       - name: Compile protos

--- a/modal/image.py
+++ b/modal/image.py
@@ -39,7 +39,7 @@ if typing.TYPE_CHECKING:
 
 
 # This is used for both type checking and runtime validation
-ImageBuilderVersion = Literal["2023.12", "2024.04"]
+ImageBuilderVersion = Literal["2023.12", "2024.04", "2024.10"]
 
 # Note: we also define supported Python versions via logic at the top of the package __init__.py
 # so that we fail fast / clearly in unsupported containers. Additionally, we enumerate the supported
@@ -100,6 +100,13 @@ def _dockerhub_python_version(builder_version: ImageBuilderVersion, python_versi
             "3.9": "19",
             "3.8": "19",
         },
+        "2024.10": {
+            "3.12": "6",
+            "3.11": "10",
+            "3.10": "15",
+            "3.9": "20",
+            "3.8": "20",
+        },
     }
     python_series = "{0}.{1}".format(*components)
     micro_version = latest_micro_version[builder_version][python_series]
@@ -108,7 +115,7 @@ def _dockerhub_python_version(builder_version: ImageBuilderVersion, python_versi
 
 
 def _dockerhub_debian_codename(builder_version: ImageBuilderVersion) -> str:
-    return {"2023.12": "bullseye", "2024.04": "bookworm"}[builder_version]
+    return {"2023.12": "bullseye", "2024.04": "bookworm", "2024.10": "bookworm"}[builder_version]
 
 
 def _get_modal_requirements_path(builder_version: ImageBuilderVersion, python_version: Optional[str] = None) -> str:
@@ -1133,7 +1140,7 @@ class _Image(_Object, type_prefix="im"):
             if version == "2023.12" and python_version is None:
                 python_version = "3.9"  # Backcompat for old hardcoded default param
             validated_python_version = _validate_python_version(python_version)
-            micromamba_version = {"2023.12": "1.3.1", "2024.04": "1.5.8"}[version]
+            micromamba_version = {"2023.12": "1.3.1", "2024.04": "1.5.8", "2024.10": "1.5.10"}[version]
             debian_codename = _dockerhub_debian_codename(version)
             tag = f"mambaorg/micromamba:{micromamba_version}-{debian_codename}-slim"
             setup_commands = [

--- a/modal/requirements/2024.10.txt
+++ b/modal/requirements/2024.10.txt
@@ -1,0 +1,25 @@
+aiohttp==3.9.3
+aiosignal==1.3.1
+aiostream==0.5.2
+annotated-types==0.6.0
+anyio==4.3.0
+async-timeout==4.0.3 ; python_version < "3.11"
+attrs==23.2.0
+certifi==2024.2.2
+exceptiongroup==1.2.0 ; python_version < "3.11"
+fastapi==0.110.0
+frozenlist==1.4.1
+grpclib==0.4.7
+h2==4.1.0
+hpack==4.0.0
+hyperframe==6.0.1
+idna==3.6
+multidict==6.0.5
+protobuf==4.25.3
+pydantic==2.6.4
+pydantic_core==2.16.3
+python-multipart==0.0.9
+sniffio==1.3.1
+starlette==0.36.3
+typing_extensions==4.10.0
+yarl==1.9.4

--- a/modal/requirements/2024.10.txt
+++ b/modal/requirements/2024.10.txt
@@ -14,11 +14,15 @@ h2==4.1.0
 hpack==4.0.0
 hyperframe==6.0.1
 idna==3.6
+markdown-it-py==3.0.0
+mdurl==0.1.2
 multidict==6.0.5
 protobuf==4.25.3
 pydantic==2.6.4
 pydantic_core==2.16.3
+Pygments==2.17.2
 python-multipart==0.0.9
+rich==13.7.1
 sniffio==1.3.1
 starlette==0.36.3
 typing_extensions==4.10.0

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -94,7 +94,7 @@ def test_python_version_validation():
 def test_dockerhub_python_version(builder_version):
     assert _dockerhub_python_version(builder_version, "3.9.1") == "3.9.1"
 
-    expected_39_full = {"2023.12": "3.9.15", "2024.04": "3.9.19"}[builder_version]
+    expected_39_full = {"2023.12": "3.9.15", "2024.04": "3.9.19", "2024.10": "3.9.20"}[builder_version]
     assert _dockerhub_python_version(builder_version, "3.9") == expected_39_full
 
     v = _dockerhub_python_version(builder_version, None).split(".")


### PR DESCRIPTION
Begins defining the next image builder version (`2024.10`):

- Appends new version to `ImageBuilderVersion` literal
- Adds a requirements file (**without** updating any versions)
- Updates the base image tags for `debian_slim` and `micromamba`
- Updates the container requirements import test to cover the new version

- Part of MOD-3702
