### PR TITLE
Add a shim around OutputManager to avoid Rich imports

### DIFF
--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -9,7 +9,6 @@ if sys.version_info[:2] >= (3, 13):
 from modal_version import __version__
 
 try:
-    from ._output import enable_output
     from ._tunnel import Tunnel, forward
     from .app import App, Stub
     from .client import Client
@@ -22,6 +21,7 @@ try:
     from .image import Image
     from .mount import Mount
     from .network_file_system import NetworkFileSystem
+    from .output import enable_output
     from .partial_function import asgi_app, batched, build, enter, exit, method, web_endpoint, web_server, wsgi_app
     from .proxy import Proxy
     from .queue import Queue

--- a/modal/_output.py
+++ b/modal/_output.py
@@ -697,24 +697,3 @@ class FunctionCreationStatus:
                 )
         else:
             self.status_row.finish(f"Created function {self.tag}.")
-
-
-@contextlib.contextmanager
-def enable_output(show_progress: bool = True) -> Generator[None, None, None]:
-    """Context manager that enable output when using the Python SDK.
-
-    This will print to stdout and stderr things such as
-    1. Logs from running functions
-    2. Status of creating objects
-    3. Map progress
-
-    Example:
-    ```python
-    app = modal.App()
-    with modal.enable_output():
-        with app.run():
-            ...
-    ```
-    """
-    with OutputManager.enable_output(show_progress):
-        yield

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -157,9 +157,10 @@ class Resolver:
     @contextlib.contextmanager
     def display(self):
         # TODO(erikbern): get rid of this wrapper
-        from ._output import OutputManager, step_completed
+        from ._output import step_completed
+        from .output import _get_output_manager
 
-        if output_mgr := OutputManager.get():
+        if output_mgr := _get_output_manager():
             with output_mgr.make_live(self._tree):
                 yield
             self._tree.label = step_completed("Created objects.")

--- a/modal/_watcher.py
+++ b/modal/_watcher.py
@@ -8,7 +8,7 @@ from watchfiles import Change, DefaultFilter, awatch
 
 from modal.mount import _Mount
 
-from ._output import OutputManager
+from .output import _get_output_manager
 
 _TIMEOUT_SENTINEL = object()
 
@@ -72,7 +72,7 @@ def _print_watched_paths(paths: Set[Path]):
     for path in paths:
         output_tree.add(f"Watching {path}.")
 
-    if output_mgr := OutputManager.get():
+    if output_mgr := _get_output_manager():
         output_mgr.print(output_tree)
 
 

--- a/modal/app.py
+++ b/modal/app.py
@@ -27,7 +27,6 @@ from synchronicity.async_wrap import asynccontextmanager
 from modal_proto import api_pb2
 
 from ._ipython import is_notebook
-from ._output import OutputManager
 from ._utils.async_utils import synchronize_api
 from ._utils.function_utils import FunctionInfo, is_global_object, is_method_fn
 from ._utils.grpc_utils import retry_transient_errors
@@ -44,6 +43,7 @@ from .image import _Image
 from .mount import _Mount
 from .network_file_system import _NetworkFileSystem
 from .object import _get_environment_name, _Object
+from .output import _get_output_manager, enable_output
 from .partial_function import (
     PartialFunction,
     _find_partial_methods_for_user_cls,
@@ -447,23 +447,23 @@ class _App:
 
         if "MODAL_DISABLE_APP_RUN_OUTPUT_WARNING" not in os.environ:
             if show_progress is None:
-                if OutputManager.get() is None:
+                if _get_output_manager() is None:
                     deprecation_warning((2024, 7, 18), dedent(enable_output_warning))
                     auto_enable_output = True
             elif show_progress is True:
-                if OutputManager.get() is None:
+                if _get_output_manager() is None:
                     deprecation_warning((2024, 7, 18), dedent(enable_output_warning))
                     auto_enable_output = True
                 else:
                     deprecation_warning((2024, 7, 18), "`show_progress=True` is deprecated and no longer needed.")
             elif show_progress is False:
-                if OutputManager.get() is not None:
+                if _get_output_manager() is not None:
                     deprecation_warning(
                         (2024, 7, 18), "`show_progress=False` will have no effect since output is enabled."
                     )
 
         if auto_enable_output:
-            with OutputManager.enable_output():
+            with enable_output():
                 async with _run_app(self, client=client, detach=detach, interactive=interactive):
                     yield self
         else:

--- a/modal/cli/launch.py
+++ b/modal/cli/launch.py
@@ -8,9 +8,9 @@ from typing import Any, Dict, Optional
 
 from typer import Typer
 
-from .._output import enable_output
 from ..app import App
 from ..exception import _CliUserExecutionError
+from ..output import enable_output
 from ..runner import run_app
 from .import_refs import import_function
 

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -17,13 +17,13 @@ from rich.console import Console
 from typing_extensions import TypedDict
 
 from .. import Cls
-from .._output import enable_output
 from ..app import App, LocalEntrypoint
 from ..config import config
 from ..environments import ensure_env
 from ..exception import ExecutionError, InvalidError, _CliUserExecutionError
 from ..functions import Function, _FunctionSpec
 from ..image import Image
+from ..output import enable_output
 from ..runner import deploy_app, interactive_shell, run_app
 from ..serving import serve_app
 from ..volume import Volume

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -33,7 +33,6 @@ from modal_proto import api_pb2
 from modal_proto.modal_api_grpc import ModalClientModal
 
 from ._location import parse_cloud_provider
-from ._output import OutputManager
 from ._pty import get_pty_info
 from ._resolver import Resolver
 from ._resources import convert_fn_config_to_resources_config
@@ -73,6 +72,7 @@ from .image import _Image
 from .mount import _get_client_mount, _Mount, get_auto_mounts
 from .network_file_system import _NetworkFileSystem, network_file_system_mount_protos
 from .object import _get_environment_name, _Object, live_method, live_method_gen
+from .output import _get_output_manager
 from .parallel_map import (
     _for_each_async,
     _for_each_sync,
@@ -1236,7 +1236,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
             raise InvalidError("A generator function cannot be called with `.map(...)`.")
 
         assert self._function_name
-        if output_mgr := OutputManager.get():
+        if output_mgr := _get_output_manager():
             count_update_callback = output_mgr.function_progress_callback(self._function_name, total=None)
         else:
             count_update_callback = None

--- a/modal/image.py
+++ b/modal/image.py
@@ -16,7 +16,6 @@ from grpclib.exceptions import GRPCError, StreamTerminatedError
 
 from modal_proto import api_pb2
 
-from ._output import OutputManager
 from ._resolver import Resolver
 from ._serialization import serialize
 from ._utils.async_utils import synchronize_api
@@ -30,6 +29,7 @@ from .gpu import GPU_T, parse_gpu_config
 from .mount import _Mount, python_standalone_mount_name
 from .network_file_system import _NetworkFileSystem
 from .object import _Object, live_method_gen
+from .output import _get_output_manager
 from .scheduler_placement import SchedulerPlacement
 from .secret import _Secret
 from .volume import _Volume
@@ -429,12 +429,12 @@ class _Image(_Object, type_prefix="im"):
                     for task_log in response.task_logs:
                         if task_log.task_progress.pos or task_log.task_progress.len:
                             assert task_log.task_progress.progress_type == api_pb2.IMAGE_SNAPSHOT_UPLOAD
-                            if output_mgr := OutputManager.get():
+                            if output_mgr := _get_output_manager():
                                 output_mgr.update_snapshot_progress(image_id, task_log.task_progress)
                         elif task_log.data:
-                            if output_mgr := OutputManager.get():
+                            if output_mgr := _get_output_manager():
                                 await output_mgr.put_log_content(task_log)
-                if output_mgr := OutputManager.get():
+                if output_mgr := _get_output_manager():
                     output_mgr.flush_lines()
 
             # Handle up to n exceptions while fetching logs

--- a/modal/output.py
+++ b/modal/output.py
@@ -1,0 +1,45 @@
+# Copyright Modal Labs 2024
+"""Interface to Modal's OutputManager functionality.
+
+These functions live here so that Modal library code can import them without
+transitively importing Rich, as we do in global scope in _output.py. This allows
+us to avoid importing Rich for client code that runs in the container environment.
+
+"""
+import contextlib
+from typing import TYPE_CHECKING, Generator, Optional
+
+if TYPE_CHECKING:
+    from ._output import OutputManager
+
+
+@contextlib.contextmanager
+def enable_output(show_progress: bool = True) -> Generator[None, None, None]:
+    """Context manager that enable output when using the Python SDK.
+
+    This will print to stdout and stderr things such as
+    1. Logs from running functions
+    2. Status of creating objects
+    3. Map progress
+
+    Example:
+    ```python
+    app = modal.App()
+    with modal.enable_output():
+        with app.run():
+            ...
+    ```
+    """
+    from ._output import OutputManager
+
+    with OutputManager.enable_output(show_progress):
+        yield
+
+
+def _get_output_manager() -> Optional["OutputManager"]:
+    """Interface to the OutputManager with a deferred import."""
+    from ._output import OutputManager
+
+    # This will return None when output has not been enabled,
+    # as should generally be the case when using Modal in a container
+    return OutputManager.get()

--- a/modal/serving.py
+++ b/modal/serving.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING, AsyncGenerator, Optional, Set, TypeVar
 from synchronicity import Interface
 from synchronicity.async_wrap import asynccontextmanager
 
-from ._output import OutputManager
 from ._utils.async_utils import TaskContext, asyncify, synchronize_api, synchronizer
 from ._utils.logger import logger
 from ._watcher import watch
@@ -17,6 +16,7 @@ from .cli.import_refs import import_app
 from .client import _Client
 from .config import config
 from .exception import deprecation_error
+from .output import _get_output_manager
 from .runner import _run_app, serve_update
 
 if TYPE_CHECKING:
@@ -52,10 +52,10 @@ async def _terminate(proc: Optional[SpawnProcess], timeout: float = 5.0):
         proc.terminate()
         await asyncify(proc.join)(timeout)
         if proc.exitcode is not None:
-            if output_mgr := OutputManager.get():
+            if output_mgr := _get_output_manager():
                 output_mgr.print(f"Serve process {proc.pid} terminated")
         else:
-            if output_mgr := OutputManager.get():
+            if output_mgr := _get_output_manager():
                 output_mgr.print(f"[red]Serve process {proc.pid} didn't terminate after {timeout}s, killing it[/red]")
             proc.kill()
     except ProcessLookupError:
@@ -74,7 +74,7 @@ async def _run_watch_loop(
         " This can hopefully be fixed in a future version of Modal."
 
     if unsupported_msg:
-        if output_mgr := OutputManager.get():
+        if output_mgr := _get_output_manager():
             async for _ in watcher:
                 output_mgr.print(unsupported_msg)
     else:

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -8,8 +8,8 @@ from google.protobuf.empty_pb2 import Empty
 from grpclib import GRPCError, Status
 
 from modal import App, Dict, Image, Mount, Secret, Stub, Volume, enable_output, web_endpoint
-from modal._output import OutputManager
 from modal.exception import DeprecationError, ExecutionError, InvalidError, NotFoundError
+from modal.output import _get_output_manager
 from modal.partial_function import _parse_custom_domains
 from modal.runner import deploy_app, deploy_stub
 from modal_proto import api_pb2
@@ -375,7 +375,7 @@ def test_app_interactive(servicer, client, capsys):
     with servicer.intercept() as ctx:
         ctx.set_responder("AppGetLogs", app_logs_pty)
 
-        with OutputManager.enable_output():
+        with enable_output():
             with app.run(client=client):
                 time.sleep(0.1)
 
@@ -392,7 +392,7 @@ def test_show_progress_deprecations(client, monkeypatch):
     # If show_progress is not provided, and output is not enabled, warn
     with pytest.warns(DeprecationError, match="enable_output"):
         with app.run(client=client):
-            assert OutputManager.get() is not None  # Should be auto-enabled
+            assert _get_output_manager() is not None  # Should be auto-enabled
 
     # If show_progress is not provided, and output is enabled, no warning
     with enable_output():
@@ -402,7 +402,7 @@ def test_show_progress_deprecations(client, monkeypatch):
     # If show_progress is set to True, and output is not enabled, warn
     with pytest.warns(DeprecationError, match="enable_output"):
         with app.run(client=client, show_progress=True):
-            assert OutputManager.get() is not None  # Should be auto-enabled
+            assert _get_output_manager() is not None  # Should be auto-enabled
 
     # If show_progress is set to True, and output is enabled, warn the flag is superfluous
     with pytest.warns(DeprecationError, match="`show_progress=True` is deprecated"):
@@ -413,7 +413,7 @@ def test_show_progress_deprecations(client, monkeypatch):
     # If show_progress is set to False, and output is not enabled, no warning
     # This mode is currently used to suppress deprecation warnings, but will in itself be deprecated later.
     with app.run(client=client, show_progress=False):
-        assert OutputManager.get() is None
+        assert _get_output_manager() is None
 
     # If show_progress is set to False, and output is enabled, warn that it has no effect
     with pytest.warns(DeprecationError, match="no effect"):


### PR DESCRIPTION
Part of MOD-3730

This PR adds a thin shim around the `OutputManger` so that we don't need to import it directly in other modules, which means we don't transitively import all of the Rich stuff that's in the global scope of `modal/_output.py` for most uses of the Modal library.

Feels maybe slightly messy, but mostly alleviates us from needing to install Rich in the container requirements! Really, the `OutputManager` singleton refactor did most of the work here.