### PR TITLE
POC: lazy hydrated Cls.from_name

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -89,12 +89,11 @@ class _RemoteObj:
 
     def __getattr__(self, name) -> _Function:
         async def _load(method: "_Function", resolver: Resolver, existing_object_id: Optional[str]):
+            # haxx
             obj = await self._get_obj()
             obj_method = getattr(obj, name)
             await obj_method.resolve()
-            # return obj_method
-            method._hydrate_from_other(obj_method)  # needed?
-            # return method
+            method._hydrate_from_other(obj_method)
 
         return _Function._from_loader(_load, f"MaybeRemoteMethod({name})", hydrate_lazily=True)
 


### PR DESCRIPTION
Quick hack/draft to see if I could make `Cls.from_name` lazy, which seems doable. My hope is that we can do it much more cleanly letting us get rid of a bunch of the complicated logic in Cls/Obj...

Keeping this as a draft for now

## Describe your changes

- _Provide Linear issue reference (e.g. MOD-1234) if available._

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
