### PR TITLE
Remove Rich and dependencies from 2024.10 image builder requirements

### DIFF
--- a/modal/requirements/2024.10.txt
+++ b/modal/requirements/2024.10.txt
@@ -14,15 +14,11 @@ h2==4.1.0
 hpack==4.0.0
 hyperframe==6.0.1
 idna==3.6
-markdown-it-py==3.0.0
-mdurl==0.1.2
 multidict==6.0.5
 protobuf==4.25.3
 pydantic==2.6.4
 pydantic_core==2.16.3
-Pygments==2.17.2
 python-multipart==0.0.9
-rich==13.7.1
 sniffio==1.3.1
 starlette==0.36.3
 typing_extensions==4.10.0


### PR DESCRIPTION
Closes MOD-3730

I'll be doing lots more live testing (in my own workspace, and then eventually in modal-labs apps) to further derisk this, beyond the "can we import the container entrypoint" tests that we run in CI.