### PR TITLE
[MOD-4000] Allow sleep=0 to exit TaskContext gracefully

### DIFF
--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -178,7 +178,7 @@ class TaskContext:
 
         async def loop_coro() -> None:
             logger.debug(f"Starting infinite loop {function_name}")
-            while True:
+            while not self.exited:
                 try:
                     await asyncio.wait_for(async_f(), timeout=timeout)
                 except Exception as exc:
@@ -192,9 +192,8 @@ class TaskContext:
                     await asyncio.wait_for(self._exited.wait(), timeout=sleep)
                 except asyncio.TimeoutError:
                     continue
-                # Only reached if self._exited got set.
-                logger.debug(f"Exiting infinite loop for {function_name}")
-                break
+
+            logger.debug(f"Exiting infinite loop for {function_name}")
 
         t = self.create_task(loop_coro())
         t.set_name(f"{function_name} loop")


### PR DESCRIPTION
`await asyncio.wait_for(self._exited.wait(), timeout=sleep)` will always raise a `TimeoutError` even if `exited` is set, meaning that the loop will never terminate gracefully.