### PR TITLE
Delete a bunch of old proto endpoints

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1584,17 +1584,6 @@ message InputInfo {
   bool task_first_input = 7;
 }
 
-message MountBuildRequest {
-  string app_id = 2 [ (modal.options.audit_target_attr) = true ];
-  string existing_mount_id = 3;
-  repeated MountFile files = 4;
-}
-
-message MountBuildResponse {
-  string mount_id = 1;
-  MountHandleMetadata handle_metadata = 2;
-}
-
 message MountFile {
   string filename = 1;
   string sha256_hex = 3; // SHA-256 checksum of the file.

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -816,16 +816,6 @@ message DictContentsRequest {
   bool values = 3;
 }
 
-message DictCreateRequest {  // Will be superseded by DictGetOrCreateRequest
-  repeated DictEntry data = 1;
-  string app_id = 2  [ (modal.options.audit_target_attr) = true ];
-  string existing_dict_id = 3;
-}
-
-message DictCreateResponse {  // Will be superseded by DictGetOrCreateResponse
-  string dict_id = 1;
-}
-
 message DictDeleteRequest {
   string dict_id = 1;
 }
@@ -1761,15 +1751,6 @@ message QueueClearRequest {
   bool all_partitions = 3;
 }
 
-message QueueCreateRequest {
-  string app_id = 1 [ (modal.options.audit_target_attr) = true ];
-  string existing_queue_id = 2;
-}
-
-message QueueCreateResponse {
-  string queue_id = 1;
-}
-
 message QueueDeleteRequest {
   string queue_id = 1 [ (modal.options.audit_target_attr) = true ];
 }
@@ -2106,15 +2087,6 @@ message SecretListResponse {
   string environment_name = 2; // the environment that was listed (useful when relying on "default" logic)
 }
 
-message SharedVolumeCreateRequest {
-  string app_id = 1 [ (modal.options.audit_target_attr) = true ];
-  CloudProvider cloud_provider = 2;
-}
-
-message SharedVolumeCreateResponse {
-  string shared_volume_id = 1;
-}
-
 message SharedVolumeGetFileRequest {
   string shared_volume_id = 1;
   string path = 2;
@@ -2336,16 +2308,6 @@ message VolumeCopyFilesRequest {
   bool recursive = 4;
 }
 
-message VolumeCreateRequest {
-  string app_id = 1 [ (modal.options.audit_target_attr) = true ];
-  VolumeFsVersion version = 2;
-}
-
-message VolumeCreateResponse {
-  string volume_id = 1;
-  VolumeFsVersion version = 2;
-}
-
 message VolumeDeleteRequest {
   string volume_id = 1;
   string environment_name = 2 [deprecated=true];
@@ -2509,7 +2471,6 @@ service ModalClient {
   rpc DictClear(DictClearRequest) returns (google.protobuf.Empty);
   rpc DictContains(DictContainsRequest) returns (DictContainsResponse);
   rpc DictContents(DictContentsRequest) returns (stream DictEntry);
-  rpc DictCreate(DictCreateRequest) returns (DictCreateResponse);  // Will be superseded by DictGetOrCreate
   rpc DictDelete(DictDeleteRequest) returns (google.protobuf.Empty);
   rpc DictGet(DictGetRequest) returns (DictGetResponse);
   rpc DictGetOrCreate(DictGetOrCreateRequest) returns (DictGetOrCreateResponse);
@@ -2558,7 +2519,6 @@ service ModalClient {
   rpc ImageJoinStreaming(ImageJoinStreamingRequest) returns (stream ImageJoinStreamingResponse);
 
   // Mounts
-  rpc MountBuild(MountBuildRequest) returns (MountBuildResponse);
   rpc MountGetOrCreate(MountGetOrCreateRequest) returns (MountGetOrCreateResponse);
   rpc MountPutFile(MountPutFileRequest) returns (MountPutFileResponse);
 
@@ -2572,7 +2532,6 @@ service ModalClient {
 
   // Queues
   rpc QueueClear(QueueClearRequest) returns (google.protobuf.Empty);
-  rpc QueueCreate(QueueCreateRequest) returns (QueueCreateResponse);
   rpc QueueDelete(QueueDeleteRequest) returns (google.protobuf.Empty);
   rpc QueueGet(QueueGetRequest) returns (QueueGetResponse);
   rpc QueueGetOrCreate(QueueGetOrCreateRequest) returns (QueueGetOrCreateResponse);
@@ -2594,12 +2553,10 @@ service ModalClient {
   rpc SandboxWait(SandboxWaitRequest) returns (SandboxWaitResponse);
 
   // Secrets
-  rpc SecretCreate(SecretCreateRequest) returns (SecretCreateResponse);  // Not used by client anymore
   rpc SecretGetOrCreate(SecretGetOrCreateRequest) returns (SecretGetOrCreateResponse);
   rpc SecretList(SecretListRequest) returns (SecretListResponse);
 
   // SharedVolumes
-  rpc SharedVolumeCreate(SharedVolumeCreateRequest) returns (SharedVolumeCreateResponse);
   rpc SharedVolumeGetFile(SharedVolumeGetFileRequest) returns (SharedVolumeGetFileResponse);
   rpc SharedVolumeGetOrCreate(SharedVolumeGetOrCreateRequest) returns (SharedVolumeGetOrCreateResponse);
   rpc SharedVolumeHeartbeat(SharedVolumeHeartbeatRequest) returns (google.protobuf.Empty);
@@ -2625,7 +2582,6 @@ service ModalClient {
   // Volumes
   rpc VolumeCommit(VolumeCommitRequest) returns (VolumeCommitResponse);
   rpc VolumeCopyFiles(VolumeCopyFilesRequest) returns (google.protobuf.Empty);
-  rpc VolumeCreate(VolumeCreateRequest) returns (VolumeCreateResponse);
   rpc VolumeDelete(VolumeDeleteRequest) returns (google.protobuf.Empty);
   rpc VolumeGetFile(VolumeGetFileRequest) returns (VolumeGetFileResponse);
   rpc VolumeGetOrCreate(VolumeGetOrCreateRequest) returns (VolumeGetOrCreateResponse);

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -658,23 +658,6 @@ message ClassParameterValue {
   }
 }
 
-message ClientCreateRequest {
-  ClientType client_type = 1  [ (modal.options.audit_target_attr) = true ];
-  string version = 2;
-}
-
-message ClientCreateResponse {
-  string client_id = 1;
-  string error = 2;
-  string deprecation_warning = 3;
-}
-
-message ClientHeartbeatRequest {
-  string client_id = 1;
-  string current_input_id = 3;
-  double current_input_started_at = 4;
-}
-
 message ClientHelloResponse {
   string warning = 1;
   string image_builder_version = 2;  // Deprecated, no longer used in client
@@ -2453,8 +2436,6 @@ service ModalClient {
   rpc ClassGet(ClassGetRequest) returns (ClassGetResponse);
 
   // Clients
-  rpc ClientCreate(ClientCreateRequest) returns (ClientCreateResponse);
-  rpc ClientHeartbeat(ClientHeartbeatRequest) returns (google.protobuf.Empty);
   rpc ClientHello(google.protobuf.Empty) returns (ClientHelloResponse);
 
   // Container

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -680,15 +680,6 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     ### Dict
 
-    async def DictCreate(self, stream):
-        request: api_pb2.DictCreateRequest = await stream.recv_message()
-        if request.existing_dict_id:
-            dict_id = request.existing_dict_id
-        else:
-            dict_id = f"di-{len(self.dicts)}"
-            self.dicts[dict_id] = {}
-        await stream.send_message(api_pb2.DictCreateResponse(dict_id=dict_id))
-
     async def DictGetOrCreate(self, stream):
         request: api_pb2.DictGetOrCreateRequest = await stream.recv_message()
         k = (request.deployment_name, request.namespace, request.environment_name)
@@ -1146,15 +1137,6 @@ class MockClientServicer(api_grpc.ModalClientBase):
                 self.queue[request.partition_key] = []
         await stream.send_message(Empty())
 
-    async def QueueCreate(self, stream):
-        request: api_pb2.QueueCreateRequest = await stream.recv_message()
-        if request.existing_queue_id:
-            queue_id = request.existing_queue_id
-        else:
-            self.n_queues += 1
-            queue_id = f"qu-{self.n_queues}"
-        await stream.send_message(api_pb2.QueueCreateResponse(queue_id=queue_id))
-
     async def QueueGetOrCreate(self, stream):
         request: api_pb2.QueueGetOrCreateRequest = await stream.recv_message()
         k = (request.deployment_name, request.namespace, request.environment_name)
@@ -1375,11 +1357,6 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     ### Network File System (née Shared volume)
 
-    async def SharedVolumeCreate(self, stream):
-        nfs_id = f"sv-{len(self.nfs_files)}"
-        self.nfs_files[nfs_id] = {}
-        await stream.send_message(api_pb2.SharedVolumeCreateResponse(shared_volume_id=nfs_id))
-
     async def SharedVolumeGetOrCreate(self, stream):
         request: api_pb2.SharedVolumeGetOrCreateRequest = await stream.recv_message()
         k = (request.deployment_name, request.namespace, request.environment_name)
@@ -1482,14 +1459,6 @@ class MockClientServicer(api_grpc.ModalClientBase):
         await stream.send_message(api_pb2.TunnelStopResponse(exists=True))
 
     ### Volume
-
-    async def VolumeCreate(self, stream):
-        req = await stream.recv_message()
-        self.requests.append(req)
-        self.volume_counter += 1
-        volume_id = f"vo-{self.volume_counter}"
-        self.volume_files[volume_id] = {}
-        await stream.send_message(api_pb2.VolumeCreateResponse(volume_id=volume_id))
 
     async def VolumeGetOrCreate(self, stream):
         request: api_pb2.VolumeGetOrCreateRequest = await stream.recv_message()


### PR DESCRIPTION
The old endpoints for creating objects are no longer used. I randomly noticed `ClientCreate` and `ClientHeartbeat` could be deleted as well – they haven't been used for at least a year.