### PR TITLE
Remove FastAPI and dependencies from container requirements on 2024.10

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -96,7 +96,9 @@ jobs:
           deactivate
 
       - name: Check entrypoint import
-        run: python -c 'import modal._container_entrypoint; import fastapi'
+        run: |
+          python -c 'import modal._container_entrypoint'
+          if [ "${{ matrix.image-builder-version }}" == "2024.04" ]; then python -c 'import fastapi'; fi
 
   publish-base-images:
     name: |

--- a/modal/_asgi.py
+++ b/modal/_asgi.py
@@ -221,9 +221,15 @@ def wsgi_app_wrapper(wsgi_app, container_io_manager):
 
 def webhook_asgi_app(fn: Callable[..., Any], method: str, docs: bool):
     """Return a FastAPI app wrapping a function handler."""
-    # Pulls in `fastapi` module, which is slow to import.
-    from fastapi import FastAPI
-    from fastapi.middleware.cors import CORSMiddleware
+    try:
+        from fastapi import FastAPI
+        from fastapi.middleware.cors import CORSMiddleware
+    except ImportError as exc:
+        message = (
+            "Modal web_endpoint functions require FastAPI to be installed in the modal.Image."
+            ' Please update your Image definition code, e.g. with `.pip_install("fastapi[standard]")`.'
+        )
+        raise InvalidError(message) from exc
 
     app = FastAPI(openapi_url="/openapi.json" if docs else None)  # disabling openapi spec disables all docs
     app.add_middleware(

--- a/modal/requirements/2024.10.txt
+++ b/modal/requirements/2024.10.txt
@@ -1,13 +1,9 @@
 aiohttp==3.9.3
 aiosignal==1.3.1
 aiostream==0.5.2
-annotated-types==0.6.0
-anyio==4.3.0
 async-timeout==4.0.3 ; python_version < "3.11"
 attrs==23.2.0
 certifi==2024.2.2
-exceptiongroup==1.2.0 ; python_version < "3.11"
-fastapi==0.110.0
 frozenlist==1.4.1
 grpclib==0.4.7
 h2==4.1.0
@@ -16,10 +12,5 @@ hyperframe==6.0.1
 idna==3.6
 multidict==6.0.5
 protobuf==4.25.3
-pydantic==2.6.4
-pydantic_core==2.16.3
-python-multipart==0.0.9
-sniffio==1.3.1
-starlette==0.36.3
 typing_extensions==4.10.0
 yarl==1.9.4


### PR DESCRIPTION
Slims down the 2024.10 container requirements to remove FastAPI and its dependencies, which is required only when the `modal.web_endpoint` feature is used.

I added a more informative error when we fail to import it, although we plan to primarily handle that case server-side by comparing the function and image definitions.

I'll add documentation to the `modal.web_endpoint` when we document and publicize the forthcoming image builder version release. We'll also need to update our examples that use `web_endpoint`.

Closes MOD-4004
