### PR TITLE
Bump container requirement versions for 2024.10

### DIFF
--- a/modal/requirements/2024.10.txt
+++ b/modal/requirements/2024.10.txt
@@ -1,16 +1,17 @@
-aiohttp==3.9.3
+aiohappyeyeballs==2.4.3
+aiohttp==3.10.8
 aiosignal==1.3.1
-aiostream==0.5.2
+aiostream==0.6.2
 async-timeout==4.0.3 ; python_version < "3.11"
-attrs==23.2.0
-certifi==2024.2.2
+attrs==24.2.0
+certifi==2024.8.30
 frozenlist==1.4.1
 grpclib==0.4.7
 h2==4.1.0
 hpack==4.0.0
 hyperframe==6.0.1
-idna==3.6
-multidict==6.0.5
-protobuf==4.25.3
-typing_extensions==4.10.0
-yarl==1.9.4
+idna==3.10
+multidict==6.1.0
+protobuf>=3.20,<6
+typing_extensions==4.12.2
+yarl==1.13.1


### PR DESCRIPTION
Part of MOD-3702. Possibly subject to further refinement if broader testing surfaces any issues.