### PR TITLE
Enforce the deprecation of `conda` methods on Image

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -984,85 +984,9 @@ class _Image(_Object, type_prefix="im"):
         )
 
     @staticmethod
-    def conda(python_version: Optional[str] = None, force_build: bool = False) -> "_Image":
-        """
-        DEPRECATED A Conda base image, using miniconda3.
-
-        This constructor has been deprecated in favor of [`Image.micromamba()`](/docs/reference/modal.Image#micromamba),
-        which can be used with [`micromamba_install`](/docs/reference/modal.Image#micromamba_install).
-        Images will build faster and more reliably with `micromamba`.
-        """
-        msg = (
-            "The `Image.conda` constructor has deprecated in favor of the faster and more reliable `Image.micromamba`."
-        )
-        deprecation_warning((2024, 5, 2), msg)
-
-        def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:
-            nonlocal python_version
-            if version == "2023.12" and python_version is None:
-                python_version = "3.9"  # Backcompat for old hardcoded default param
-            validated_python_version = _validate_python_version(python_version)
-            debian_codename = _dockerhub_debian_codename(version)
-            requirements_path = _get_modal_requirements_path(version, python_version)
-            context_files = {CONTAINER_REQUIREMENTS_PATH: requirements_path}
-
-            # Doesn't use the official continuumio/miniconda3 image as a base. That image has maintenance
-            # issues (https://github.com/ContinuumIO/docker-images/issues) and building our own is more flexible.
-            conda_install_script = "https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh"
-            commands = [
-                f"FROM debian:{debian_codename}",  # the -slim images lack files required by Conda.
-                # Temporarily add utility packages for conda installation.
-                "RUN apt-get --quiet update && apt-get --quiet --yes install curl bzip2 \\",
-                f"&& curl --silent --show-error --location {conda_install_script} --output /tmp/miniconda.sh \\",
-                # Install miniconda to a filesystem location on the $PATH of Modal container tasks.
-                # -b = install in batch mode w/o manual intervention.
-                # -f = allow install prefix to already exist.
-                # -p = the install prefix location.
-                "&& bash /tmp/miniconda.sh -bfp /usr/local \\ ",
-                "&& rm -rf /tmp/miniconda.sh",
-                # Biggest and most stable community-led Conda channel.
-                "RUN conda config --add channels conda-forge \\ ",
-                # softlinking can put conda in a broken state, surfacing error on uninstall like:
-                # `No such device or address: '/usr/local/lib/libz.so' -> '/usr/local/lib/libz.so.c~'`
-                "&& conda config --set allow_softlinks false \\ ",
-                # Install requested Python version from conda-forge channel; base debian image has only 3.7.
-                f"&& conda install --yes --channel conda-forge python={validated_python_version} \\ ",
-                "&& conda update conda \\ ",
-                # Remove now unneeded packages and files.
-                "&& apt-get --quiet --yes remove curl bzip2 \\ ",
-                "&& apt-get --quiet --yes autoremove \\ ",
-                "&& apt-get autoclean \\ ",
-                "&& rm -rf /var/lib/apt/lists/* /var/log/dpkg.log \\ ",
-                "&& conda clean --all --yes",
-                # Setup .bashrc for conda.
-                "RUN conda init bash --verbose",
-                f"COPY {CONTAINER_REQUIREMENTS_PATH} {CONTAINER_REQUIREMENTS_PATH}",
-                # .bashrc is explicitly sourced because RUN is a non-login shell and doesn't run bash.
-                "RUN . /root/.bashrc && conda activate base \\ ",
-                # Ensure that packaging tools are up to date and install client dependenices
-                f"&& python -m pip install --upgrade {'pip' if version == '2023.12' else 'pip wheel uv'} \\ ",
-                f"&& python -m {_get_modal_requirements_command(version)}",
-            ]
-            if version > "2023.12":
-                commands.append(f"RUN rm {CONTAINER_REQUIREMENTS_PATH}")
-            return DockerfileSpec(commands=commands, context_files=context_files)
-
-        base = _Image._from_args(
-            dockerfile_function=build_dockerfile,
-            force_build=force_build,
-            _namespace=api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL,
-        )
-
-        return base.dockerfile_commands(
-            [
-                "ENV CONDA_EXE=/usr/local/bin/conda",
-                "ENV CONDA_PREFIX=/usr/local",
-                "ENV CONDA_PROMPT_MODIFIER=(base)",
-                "ENV CONDA_SHLVL=1",
-                "ENV CONDA_PYTHON_EXE=/usr/local/bin/python",
-                "ENV CONDA_DEFAULT_ENV=base",
-            ]
-        )
+    def conda(python_version: Optional[str] = None, force_build: bool = False):
+        """DEPRECATED: Removed in favor of the faster and more reliable `Image.micromamba` constructor."""
+        deprecation_error((2024, 5, 2), _Image.conda.__doc__ or "")
 
     def conda_install(
         self,
@@ -1071,42 +995,9 @@ class _Image(_Object, type_prefix="im"):
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
         secrets: Sequence[_Secret] = [],
         gpu: GPU_T = None,
-    ) -> "_Image":
-        """DEPRECATED Install additional packages using Conda.
-
-        Deprecated in favor of [`micromamba_install`](/docs/reference/modal.Image#micromamba_install),
-        which should be used with the [`Image.micromamba()`](/docs/reference/modal.Image#micromamba) constructor.
-        Images will build faster and more reliably with `micromamba`.
-        """
-
-        msg = (
-            "The `Image.conda_install` method has deprecated in favor of the faster "
-            "and more reliable `Image.micromamba_install`."
-        )
-        deprecation_warning((2024, 5, 2), msg)
-
-        pkgs = _flatten_str_args("conda_install", "packages", packages)
-        if not pkgs:
-            return self
-
-        def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:
-            package_args = " ".join(shlex.quote(pkg) for pkg in pkgs)
-            channel_args = "".join(f" -c {channel}" for channel in channels)
-
-            commands = [
-                "FROM base",
-                f"RUN conda install {package_args}{channel_args} --yes \\ ",
-                "&& conda clean --yes --index-cache --tarballs --tempfiles --logfiles",
-            ]
-            return DockerfileSpec(commands=commands, context_files={})
-
-        return _Image._from_args(
-            base_images={"base": self},
-            dockerfile_function=build_dockerfile,
-            force_build=self.force_build or force_build,
-            secrets=secrets,
-            gpu_config=parse_gpu_config(gpu),
-        )
+    ):
+        """DEPRECATED: Removed in favor of the faster and more reliable `Image.micromamba_install` method."""
+        deprecation_error((2024, 5, 2), _Image.conda_install.__doc__ or "")
 
     def conda_update_from_environment(
         self,
@@ -1115,36 +1006,9 @@ class _Image(_Object, type_prefix="im"):
         *,
         secrets: Sequence[_Secret] = [],
         gpu: GPU_T = None,
-    ) -> "_Image":
-        """DEPRECATED Update a Conda environment using dependencies from a given environment.yml file.
-
-        This method has been deprecated in favor of the faster and more reliable `Image.micromamba_install`
-        method and its `spec_file` parameter.
-        """
-        msg = (
-            "The `Image.conda_install_update_from_environment` method has deprecated in favor of the faster"
-            " and more reliable `Image.micromamba_install` and its `spec_file` parameter."
-        )
-        deprecation_warning((2024, 5, 2), msg)
-
-        def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:
-            context_files = {"/environment.yml": os.path.expanduser(environment_yml)}
-
-            commands = [
-                "FROM base",
-                "COPY /environment.yml /environment.yml",
-                "RUN conda env update --name base -f /environment.yml \\ ",
-                "&& conda clean --yes --index-cache --tarballs --tempfiles --logfiles",
-            ]
-            return DockerfileSpec(commands=commands, context_files=context_files)
-
-        return _Image._from_args(
-            base_images={"base": self},
-            dockerfile_function=build_dockerfile,
-            force_build=self.force_build or force_build,
-            secrets=secrets,
-            gpu_config=parse_gpu_config(gpu),
-        )
+    ):
+        """DEPRECATED: Removed in favor of the `Image.micromamba_install` method (using the `spec_file` parameter)."""
+        deprecation_warning((2024, 5, 2), _Image.conda_update_from_environment.__doc__ or "")
 
     @staticmethod
     def micromamba(

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -350,35 +350,6 @@ def test_dockerfile_image(builder_version, servicer, client):
         assert any("RUN pip install numpy" in cmd for cmd in layers[1].dockerfile_commands)
 
 
-def test_conda_install(builder_version, servicer, client):
-    with pytest.warns(DeprecationError, match="Image.micromamba"):
-        image = Image.conda().pip_install("numpy").conda_install("pymc3", "theano").pip_install("scikit-learn")
-    app = App(image=image)
-    app.function(image=image)(dummy)
-
-    with app.run(client=client):
-        layers = get_image_layers(image.object_id, servicer)
-
-        assert any("pip install scikit-learn" in cmd for cmd in layers[0].dockerfile_commands)
-        assert any("conda install pymc3 theano --yes" in cmd for cmd in layers[1].dockerfile_commands)
-        assert any("pip install numpy" in cmd for cmd in layers[2].dockerfile_commands)
-
-
-def test_conda_update_from_environment(builder_version, servicer, client):
-    path = os.path.join(os.path.dirname(__file__), "supports/test-conda-environment.yml")
-
-    with pytest.warns(DeprecationError, match="Image.micromamba"):
-        app = App(image=Image.conda().conda_update_from_environment(path))
-
-    app.function()(dummy)
-    with app.run(client=client):
-        layers = get_image_layers(app.image.object_id, servicer)
-
-        assert any("RUN conda env update" in cmd for cmd in layers[0].dockerfile_commands)
-        assert any(b"foo=1.0" in f.data for f in layers[0].context_files)
-        assert any(b"bar=2.1" in f.data for f in layers[0].context_files)
-
-
 def test_micromamba_install(builder_version, servicer, client):
     spec_file = os.path.join(os.path.dirname(__file__), "supports/test-conda-environment.yml")
     image = (
@@ -986,19 +957,11 @@ def test_image_stability_on_2023_12(force_2023_12, servicer, client, test_dir):
         img = Image.from_registry("ubuntu:22.04")
         assert get_hash(img) == "b5f1cc544a412d1b23a5ebf9a8859ea9a86975ecbc7325b83defc0ce3fe956d3"
 
-        with pytest.warns(DeprecationError):
-            img = Image.conda()
-        assert get_hash(img) == "f69d6af66fb5f1a2372a61836e6166ce79ebe2cd628d12addea8e8e80cc98dc1"
-
         img = Image.micromamba()
         assert get_hash(img) == "fa883741544ea191ecd197c8f83a1ffe9912575faa8c107c66b3dda761b2e401"
 
         img = Image.from_dockerfile(test_dir / "supports" / "test-dockerfile")
         assert get_hash(img) == "0aec2f66f28ee7511c1b36604214ae7b40d9bc1fa3e6b8883001e933a966ff78"
-
-    with pytest.warns(DeprecationError):
-        img = Image.conda(python_version="3.12")
-    assert get_hash(img) == "c4b3f7350116d323dded29c9c9b78b62593f0fc943ccf83a09b27185bfdc2a07"
 
     img = Image.micromamba(python_version="3.12")
     assert get_hash(img) == "468befe16f703a3ae1a794dfe54c1a3445ca0ffda233f55f1d66c45ad608e8aa"
@@ -1011,16 +974,8 @@ def test_image_stability_on_2023_12(force_2023_12, servicer, client, test_dir):
     img = base.pip_install("torch~=2.2", "transformers==4.23.0", pre=True, index_url="agi.se")
     assert get_hash(img) == "2a4fa8e3b32c70a41b3a3efd5416540b1953430543f6c27c984e7f969c2ca874"
 
-    with pytest.warns(DeprecationError):
-        img = base.conda_install("torch=2.2", "transformers<4.23.0", channels=["conda-forge", "my-channel"])
-    assert get_hash(img) == "dd6f27f636293996a64a98c250161d8092cb23d02629d9070493f00aad8d7266"
-
     img = base.pip_install_from_requirements(test_dir / "supports" / "test-requirements.txt")
     assert get_hash(img) == "69d41e699d4ecef399e51e8460f8857aa0ec57f71f00eca81c8886ec062e5c2b"
-
-    with pytest.warns(DeprecationError):
-        img = base.conda_update_from_environment(test_dir / "supports" / "test-conda-environment.yml")
-    assert get_hash(img) == "00940e0ee2998bfe0a337f51a5fdf5f4b29bf9d42dda3635641d44bfeb42537e"
 
     img = base.poetry_install_from_file(
         test_dir / "supports" / "test-pyproject.toml",
@@ -1061,18 +1016,6 @@ def test_image_stability_on_2024_04(force_2024_04, servicer, client, test_dir):
     img = Image.from_dockerfile(test_dir / "supports" / "test-dockerfile")
     assert get_hash(img) == "a683ed2a2fd9ca960d818aebd7459932494da63aa27d5d84443c578a5ba3fe05"
 
-    with pytest.warns(DeprecationError):
-        img = Image.conda()
-    if sys.version_info[:2] == (3, 11):
-        assert get_hash(img) == "404e1d80bd639321d1115ae00b8d1b6f3d257be7d400bad46d3c39da09c193c8"
-    elif sys.version_info[:2] == (3, 10):
-        # Assert that we follow the local Python, which is a new behavior in 2024.04
-        assert get_hash(img) == "9299b7935461e021ea6a3749adac8ea4de333fd443e74192739fbdd60da3b0b5"
-
-    with pytest.warns(DeprecationError):
-        img = Image.conda(python_version="3.12")
-    assert get_hash(img) == "113d959483ff099ba161438f02a370322bc53a68d5c5989245f4002b08e3be9d"
-
     img = Image.micromamba()
     if sys.version_info[:2] == (3, 11):
         assert get_hash(img) == "8c0a30c7d14eb709953161cae39aa7d39afe3bb5014b7c6cf5dd93de56dcb32b"
@@ -1091,16 +1034,8 @@ def test_image_stability_on_2024_04(force_2024_04, servicer, client, test_dir):
     img = base.pip_install("torch~=2.2", "transformers==4.23.0", pre=True, index_url="agi.se")
     assert get_hash(img) == "4e8cea916369fc545a5139312a9633691f7624ec2b6d4075014a7602b23584c0"
 
-    with pytest.warns(DeprecationError):
-        img = base.conda_install("torch=2.2", "transformers<4.23.0", channels=["conda-forge", "my-channel"])
-    assert get_hash(img) == "bd9fb2b86a39886d618b37950d1a7c4d8826048f191fa00c5f87c71be88bf8f7"
-
     img = base.pip_install_from_requirements(test_dir / "supports" / "test-requirements.txt")
     assert get_hash(img) == "78392aca4ea135ab53b9d183eedbb2a7e32f9b3c0cfb42b03a7bd7c4f013f3c8"
-
-    with pytest.warns(DeprecationError):
-        img = base.conda_update_from_environment(test_dir / "supports" / "test-conda-environment.yml")
-    assert get_hash(img) == "4bb5fd232956050e66256d7e00c088e1c7cd4d7217bc0d15bcc4fbd08aa2f3b6"
 
     img = base.micromamba_install(
         "torch=2.2",


### PR DESCRIPTION
## Changelog

- The `Image.conda`, `Image.conda_install`, and `Image.conda_update_from_environment` methods are now fully deprecated. We recommend using `micromamba` (via `Image.micromamba` and `Image.micromamba_install`) instead, or manually installing and using conda with `Image.run_commands` when strictly necessary.