### PR TITLE
Add requested_at timestamps to output requests.

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1294,6 +1294,7 @@ message FunctionGetOutputsRequest {
   float timeout = 3;
   string last_entry_id = 6;
   bool clear_on_success = 7; // expires *any* remaining outputs soon after this call, not just the returned ones
+  double requested_at = 8; // Used for waypoints.
 }
 
 message FunctionGetOutputsResponse {
@@ -1426,6 +1427,7 @@ message FunctionPutOutputsItem {
 
 message FunctionPutOutputsRequest {
   repeated FunctionPutOutputsItem outputs = 4;
+  double requested_at = 5; // Used for waypoints.
 }
 
 message FunctionRetryPolicy {


### PR DESCRIPTION
## Describe your changes

The timestamps will be used to log waypoints in the server for debugging.

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---