### PR TITLE
[WIP] Image updates to support Python 3.13

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false # run all variants across python versions/os to completion
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: ["ubuntu-20.04"]
         proto-version: ["latest"]
         include:
@@ -77,7 +77,7 @@ jobs:
     strategy:
       matrix:
         image-builder-version: ["2024.04", "2024.10"]
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.8", "3.13"]
     steps:
       - uses: actions/checkout@v3
 
@@ -113,7 +113,7 @@ jobs:
       MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         image-builder-version: ["2023.12", "2024.04"]
         image-name: ["debian_slim", "micromamba"]
 

--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -3,7 +3,7 @@ import sys
 
 if sys.version_info[:2] < (3, 8):
     raise RuntimeError("This version of Modal requires at least Python 3.8")
-if sys.version_info[:2] >= (3, 13):
+if sys.version_info[:2] >= (3, 14):
     raise RuntimeError("This version of Modal does not support Python 3.13+")
 
 from modal_version import __version__

--- a/modal/image.py
+++ b/modal/image.py
@@ -61,38 +61,46 @@ ImageBuilderVersion = Literal["2023.12", "2024.04", "2024.10"]
 # so that we fail fast / clearly in unsupported containers. Additionally, we enumerate the supported
 # Python versions in mount.py where we specify the "standalone Python versions" we create mounts for.
 # Consider consolidating these multiple sources of truth?
-SUPPORTED_PYTHON_SERIES: Set[str] = {"3.8", "3.9", "3.10", "3.11", "3.12"}
+SUPPORTED_PYTHON_SERIES: Dict[ImageBuilderVersion, Set[str]] = {
+    "2024.10": {"3.8", "3.9", "3.10", "3.11", "3.12", "3.13"},
+    "2024.04": {"3.8", "3.9", "3.10", "3.11", "3.12"},
+    "2023.12": {"3.8", "3.9", "3.10", "3.11", "3.12"},
+}
 
 CONTAINER_REQUIREMENTS_PATH = "/modal_requirements.txt"
 
 
-def _validate_python_version(version: Optional[str], allow_micro_granularity: bool = True) -> str:
-    if version is None:
+def _validate_python_version(
+    python_version: Optional[str], builder_version: ImageBuilderVersion, allow_micro_granularity: bool = True
+) -> str:
+    if python_version is None:
         # If Python version is unspecified, match the local version, up to the minor component
-        version = series_version = "{0}.{1}".format(*sys.version_info)
-    elif not isinstance(version, str):
-        raise InvalidError(f"Python version must be specified as a string, not {type(version).__name__}")
-    elif not re.match(r"^3(?:\.\d{1,2}){1,2}$", version):
-        raise InvalidError(f"Invalid Python version: {version!r}")
+        python_version = series_version = "{0}.{1}".format(*sys.version_info)
+    elif not isinstance(python_version, str):
+        raise InvalidError(f"Python version must be specified as a string, not {type(python_version).__name__}")
+    elif not re.match(r"^3(?:\.\d{1,2}){1,2}(rc\d*)?$", python_version):
+        raise InvalidError(f"Invalid Python version: {python_version!r}")
     else:
-        components = version.split(".")
+        components = python_version.split(".")
         if len(components) == 3 and not allow_micro_granularity:
             raise InvalidError(
                 "Python version must be specified as 'major.minor' for this interface;"
-                f" micro-level specification ({version!r}) is not valid."
+                f" micro-level specification ({python_version!r}) is not valid."
             )
         series_version = "{0}.{1}".format(*components)
 
-    if series_version not in SUPPORTED_PYTHON_SERIES:
+    supported_series = SUPPORTED_PYTHON_SERIES[builder_version]
+    if series_version not in supported_series:
         raise InvalidError(
-            f"Unsupported Python version: {version!r}."
-            f" Modal supports versions in the following series: {SUPPORTED_PYTHON_SERIES!r}."
+            f"Unsupported Python version: {python_version!r}."
+            f" When using the {builder_version!r} Image builder, Modal supports the following series:"
+            f" {supported_series!r}."
         )
-    return version
+    return python_version
 
 
 def _dockerhub_python_version(builder_version: ImageBuilderVersion, python_version: Optional[str] = None) -> str:
-    python_version = _validate_python_version(python_version)
+    python_version = _validate_python_version(python_version, builder_version)
     version_components = python_version.split(".")
 
     # When user specifies a full Python version, use that
@@ -1009,7 +1017,7 @@ class _Image(_Object, type_prefix="im"):
             nonlocal python_version
             if version == "2023.12" and python_version is None:
                 python_version = "3.9"  # Backcompat for old hardcoded default param
-            validated_python_version = _validate_python_version(python_version)
+            validated_python_version = _validate_python_version(python_version, version)
             micromamba_version = _base_image_versions("micromamba", version)
             debian_codename = _dockerhub_debian_codename(version)
             tag = f"mambaorg/micromamba:{micromamba_version}-{debian_codename}-slim"
@@ -1079,7 +1087,7 @@ class _Image(_Object, type_prefix="im"):
     ) -> List[str]:
         add_python_commands: List[str] = []
         if add_python:
-            _validate_python_version(add_python, allow_micro_granularity=False)
+            _validate_python_version(add_python, builder_version, allow_micro_granularity=False)
             add_python_commands = [
                 "COPY /python/. /usr/local",
                 "RUN ln -s /usr/local/bin/python3 /usr/local/bin/python",

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -43,6 +43,7 @@ PYTHON_STANDALONE_VERSIONS: typing.Dict[str, typing.Tuple[str, str]] = {
     "3.10": ("20230826", "3.10.13"),
     "3.11": ("20230826", "3.11.5"),
     "3.12": ("20240107", "3.12.1"),
+    "3.13": ("20241002", "3.13.0rc0"),  # TODO(michael) update to stable release
 }
 
 

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -33,7 +33,8 @@ def dummy():
 
 
 def test_supported_python_series():
-    assert SUPPORTED_PYTHON_SERIES == PYTHON_STANDALONE_VERSIONS.keys()
+    for builder_version in get_args(ImageBuilderVersion):
+        assert SUPPORTED_PYTHON_SERIES[builder_version] <= PYTHON_STANDALONE_VERSIONS.keys()
 
 
 def get_image_layers(image_id: str, servicer) -> List[api_pb2.Image]:
@@ -77,25 +78,26 @@ def clear_environment_cache():
     environments.ENVIRONMENT_CACHE.clear()
 
 
-def test_python_version_validation():
-    assert _validate_python_version(None) == "{0}.{1}".format(*sys.version_info)
-    assert _validate_python_version("3.12") == "3.12"
-    assert _validate_python_version("3.12.0") == "3.12.0"
+@pytest.mark.parametrize("builder_version", get_args(ImageBuilderVersion))
+def test_python_version_validation(builder_version):
+    assert _validate_python_version(None, builder_version) == "{0}.{1}".format(*sys.version_info)
+    assert _validate_python_version("3.12", builder_version) == "3.12"
+    assert _validate_python_version("3.12.0", builder_version) == "3.12.0"
 
     with pytest.raises(InvalidError, match="Unsupported Python version"):
-        _validate_python_version("3.7")
+        _validate_python_version("3.7", builder_version)
 
     with pytest.raises(InvalidError, match="Python version must be specified as a string"):
-        _validate_python_version(3.10)  # type: ignore
+        _validate_python_version(3.10, builder_version)  # type: ignore
 
     with pytest.raises(InvalidError, match="Invalid Python version"):
-        _validate_python_version("3.10.2.9")
+        _validate_python_version("3.10.2.9", builder_version)
 
     with pytest.raises(InvalidError, match="Invalid Python version"):
-        _validate_python_version("3.10.x")
+        _validate_python_version("3.10.x", builder_version)
 
     with pytest.raises(InvalidError, match="Python version must be specified as 'major.minor'"):
-        _validate_python_version("3.10.5", allow_micro_granularity=False)
+        _validate_python_version("3.10.5", builder_version, allow_micro_granularity=False)
 
 
 def test_dockerhub_python_version(builder_version):


### PR DESCRIPTION
Won't merge until 3.13 is officially out (scheduled for October 7) but this has most of what we should need to support it.

Note that we'll need to gate 3.13 support behind the 2024.10 image builder version as the pinned version of `aiohttp` does not build properly on it.

There's a few loose threads here:
- [ ] Confirm `micromamba` support for 3.13 or handle that as unsupported for now
- [ ] Bump the standalone Python pin to at least stable `3.13.0`.
- [ ] Update the modal library metadata to declare support

- Towards MOD-3990