### PR TITLE
Add rpc for deleting secrets

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2018,6 +2018,10 @@ message SecretCreateResponse {  // Not used by client anymore
   string secret_id = 1;
 }
 
+message SecretDeleteRequest {
+  string secret_id = 1;
+}
+
 message SecretGetOrCreateRequest {
   string deployment_name = 1 [ (modal.options.audit_target_attr) = true ];
   DeploymentNamespace namespace = 2;
@@ -2512,6 +2516,7 @@ service ModalClient {
   rpc SandboxWait(SandboxWaitRequest) returns (SandboxWaitResponse);
 
   // Secrets
+  rpc SecretDelete(SecretDeleteRequest) returns (google.protobuf.Empty);
   rpc SecretGetOrCreate(SecretGetOrCreateRequest) returns (SecretGetOrCreateResponse);
   rpc SecretList(SecretListRequest) returns (SecretListResponse);
 


### PR DESCRIPTION
Realized we have no rpc for this (we rely on `AppStop` from the web UI).

I'm planning to change this between the web and the backend but I think it makes sense to put this in the client proto similar to other object types – it lets us add client/CLI support for deletions later

This is part of removing dummy apps server side.