### PR TITLE
Update protos to pass function schedule in definition, not create request

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1078,6 +1078,9 @@ message Function {
   optional string _experimental_proxy_ip = 70;
 
   bool runtime_perf_record = 71; // For internal debugging use only.
+
+  Schedule schedule = 72;
+
 }
 
 message FunctionBindParamsRequest {
@@ -1140,7 +1143,7 @@ message FunctionCallPutDataRequest {
 message FunctionCreateRequest {
   Function function = 1;
   string app_id = 2  [ (modal.options.audit_target_attr) = true ];
-  Schedule schedule = 6;
+  Schedule schedule = 6; // Deprecated: now passed in the Function definition
   string existing_function_id = 7;
   // This flag tells the server to avoid doing updates in FunctionCreate that should now
   // be done in AppPublish. Provides a smoother migration onto atomic deployments with 0.64,
@@ -1191,15 +1194,18 @@ message FunctionData {
   string use_function_id = 16; // used for methods
   string use_method_name = 17; // used for methods
 
-  // When the function is a "grouped" one, this records the # of tasks we want
-  // to schedule in tandem.
-  uint32 _experimental_group_size = 19;
-
   message RankedFunction {
     uint32 rank = 1;
     Function function = 2;
   }
   repeated RankedFunction ranked_functions = 18;
+
+  // When the function is a "grouped" one, this records the # of tasks we want
+  // to schedule in tandem.
+  uint32 _experimental_group_size = 19;
+
+  Schedule schedule = 20;
+
 }
 
 message FunctionExtended {


### PR DESCRIPTION
Storing the schedule in the Function definition will allow us to make schedule updates atomic with app redeployments.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>