### PR TITLE
Send schedule configuration in function definition, not request

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -843,6 +843,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                     is_class=info.is_service_class(),
                     class_parameter_info=info.class_parameter_info(),
                     i6pn_enabled=i6pn_enabled,
+                    schedule=schedule.proto_message if schedule is not None else None,
                     _experimental_group_size=group_size or 0,  # Experimental: Grouped functions
                     _experimental_concurrent_cancellations=True,
                     _experimental_buffer_containers=_experimental_buffer_containers or 0,
@@ -863,6 +864,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                         web_url_info=function_definition.web_url_info,
                         webhook_config=function_definition.webhook_config,
                         custom_domain_info=function_definition.custom_domain_info,
+                        schedule=schedule.proto_message if schedule is not None else None,
                         is_class=function_definition.is_class,
                         class_parameter_info=function_definition.class_parameter_info,
                         is_method=function_definition.is_method,
@@ -904,7 +906,6 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                     app_id=resolver.app_id,
                     function=function_definition,
                     function_data=function_data,
-                    schedule=schedule.proto_message if schedule is not None else None,
                     existing_function_id=existing_object_id or "",
                     defer_updates=True,
                 )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -870,8 +870,6 @@ class MockClientServicer(api_grpc.ModalClientBase):
         else:
             self.n_functions += 1
             function_id = f"fu-{self.n_functions}"
-        if request.schedule:
-            self.function2schedule[function_id] = request.schedule
 
         function: Optional[api_pb2.Function] = None
         function_data: Optional[api_pb2.FunctionData] = None
@@ -890,7 +888,11 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
         assert (function is None) != (function_data is None)
         function_defn = function or function_data
+        assert function_defn
         self.app_functions[function_id] = function_defn
+
+        if function_defn.schedule:
+            self.function2schedule[function_id] = function_defn.schedule
 
         await stream.send_message(
             api_pb2.FunctionCreateResponse(


### PR DESCRIPTION
This PR moves the schedule configuration into the `Function` definition; previously it was send as an additional field in the `FunctionCreateRequest`. Storing it in the definition allows us to make schedule updates atomically with the rest of function deployment.

Depends on https://github.com/modal-labs/modal-client/pull/2328

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Fixed a bug where app rollbacks would not restart a schedule that had been removed in an intervening deployment.