### PR TITLE
Fix NCCL initialization when i6pn runc containers are scheduled on the same machine

### DIFF
--- a/modal/experimental.py
+++ b/modal/experimental.py
@@ -157,8 +157,12 @@ def _networked(func):
         import os
         import socket
 
+        def get_i6pn():
+            """Returns the ipv6 address assigned to this container."""
+            socket.getaddrinfo("i6pn.modal.local", None, socket.AF_INET6)[0][4][0]
+
         hostname = socket.gethostname()
-        addr_info = socket.getaddrinfo("i6pn.modal.local", None, socket.AF_INET6)[0][4][0]
+        addr_info = get_i6pn()
         # nccl's default host ID is $(hostname)$(cat /proc/sys/kernel/random/boot_id).
         # on runc, if two i6pn-linked containers get scheduled on the same worker,
         # their boot ID and hostname will both be identical, causing nccl to break.


### PR DESCRIPTION
Resolves MOD-4067

NCCL with multiple containers on the same machine with the runc runtime doesn't work, crashing upon initialization. This occurs if a grouped function is scheduled on the same machine.

nccl [uses a host hash](https://github.com/NVIDIA/nccl/blob/48bb7fec7953112ff37499a272317f6663f8f600/src/graph/topo.cc#L654) to determine if two GPUs are on the same machine.

The [host hash](https://github.com/NVIDIA/nccl/blob/48bb7fec7953112ff37499a272317f6663f8f600/src/misc/utils.cc#L86) evaluates to `$(hostname)$(cat /proc/sys/kernel/random/boot_id)`.

[gvisor patches boot_id](https://github.com/google/gvisor/blob/47dade3f98b2e7d1d00c4ba79c7f4bdfc28bd805/pkg/sentry/fsimpl/proc/tasks_sys.go#L56) to be unique, but runc does not.

Therefore in runc, nccl thinks the two GPUs are on the same machine and crashes when it's not able to access them.

Luckily there's a magical NCCL_HOSTID environment variable that can override this.

For more context: https://modal-com.slack.com/archives/C07BWUF5JKW/p1728437710487689?thread_ts=1728428627.889669&cid=C07BWUF5JKW