### PR TITLE
Allow `modal shell -c` to run a command

### DIFF
--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -339,7 +339,7 @@ def shell(
         ),
         metavar="FUNC_REF",
     ),
-    cmd: str = typer.Option(default="/bin/bash", help="Command to run inside the Modal image."),
+    cmd: str = typer.Option("/bin/bash", "-c", "--cmd", help="Command to run inside the Modal image."),
     env: str = ENV_OPTION,
     image: Optional[str] = typer.Option(
         default=None, help="Container image tag for inside the shell (if not using FUNC_REF)."


### PR DESCRIPTION
## Changelog

- `modal shell --cmd` now can be shortened to `modal shell -c`. This means you can write commands like `modal shell -c "uname -a"` to quickly run a command within the remote environment.
