### PR TITLE
Fix MOD-4088

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -1291,7 +1291,6 @@ class _Image(_Object, type_prefix="im"):
         ```
 
         The context mount will allow a `COPY src/ src/` instruction to succeed in Modal's remote builder.
-        ```
         """
 
         # --- Build the base dockerfile


### PR DESCRIPTION
Image.debian_slim has no autogenerated documentation due to a syntax error in markdown.
