### PR TITLE
Allow StreamWriter to accept strings as input

### DIFF
--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -200,7 +200,7 @@ class _StreamWriter:
         self._index += 1
         return index
 
-    def write(self, data: Union[bytes, bytearray, memoryview]):
+    def write(self, data: Union[bytes, bytearray, memoryview, str]):
         """
         Writes data to stream's internal buffer, but does not drain/flush the write.
 
@@ -227,7 +227,9 @@ class _StreamWriter:
         """
         if self._is_closed:
             raise EOFError("Stdin is closed. Cannot write to it.")
-        if isinstance(data, (bytes, bytearray, memoryview)):
+        if isinstance(data, (bytes, bytearray, memoryview, str)):
+            if isinstance(data, str):
+                data = data.encode("utf-8")
             if len(self._buffer) + len(data) > MAX_BUFFER_SIZE:
                 raise BufferError("Buffer size exceed limit. Call drain to clear the buffer.")
             self._buffer.extend(data)

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -138,10 +138,20 @@ def test_sandbox_stdin(app, servicer):
 
 
 @skip_non_linux
-def test_sandbox_stdin_invalid_write(app, servicer):
-    sb = Sandbox.create("bash", "-c", "echo foo", app=app)
-    with pytest.raises(TypeError):
-        sb.stdin.write("foo\n")  # type: ignore
+def test_sandbox_stdin_write_str(app, servicer):
+    sb = Sandbox.create("bash", "-c", "while read line; do echo $line; done && exit 13", app=app)
+
+    sb.stdin.write("foo\n")
+    sb.stdin.write("bar\n")
+
+    sb.stdin.write_eof()
+
+    sb.stdin.drain()
+
+    sb.wait()
+
+    assert sb.stdout.read() == "foo\nbar\n"
+    assert sb.returncode == 13
 
 
 @skip_non_linux


### PR DESCRIPTION
## Describe your changes

Fixes MOD-4024.

Fixes the api inconsistency between Sandbox `read()` and `write()` by allowing `write()` to accept strings.

</details>

## Changelog

StreamWriters now accept strings as input.

