### PR TITLE
Re-enable checkpointing with parameterized functions

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -33,7 +33,7 @@ from ._utils.grpc_utils import retry_transient_errors
 from ._utils.mount_utils import validate_volumes
 from .client import _Client
 from .cloud_bucket_mount import _CloudBucketMount
-from .cls import _Cls, _get_class_constructor_signature, parameter
+from .cls import _Cls, parameter
 from .config import logger
 from .exception import InvalidError, deprecation_error, deprecation_warning
 from .experimental import _GroupedFunction
@@ -964,16 +964,6 @@ class _App:
                 and not enable_memory_snapshot
             ):
                 raise InvalidError("A class must have `enable_memory_snapshot=True` to use `snap=True` on its methods.")
-
-            # Disallow enable_memory_snapshot for parameterized classes
-            # TODO(matt) Temporary fix for MOD-3048
-            if enable_memory_snapshot:
-                signature = _get_class_constructor_signature(user_cls)
-                if len(signature.parameters) > 0:
-                    name = user_cls.__name__
-                    raise InvalidError(
-                        f"Cannot use class parameterization in class {name} with `enable_memory_snapshot=True`."
-                    )
 
             tag: str = user_cls.__name__
             self._add_object(tag, cls)

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -932,22 +932,6 @@ class ParameterizedClass3:
         pass
 
 
-def test_disabled_parameterized_snap_cls():
-    with pytest.raises(InvalidError, match="Cannot use class parameterization in class"):
-        app.cls(enable_memory_snapshot=True)(ParameterizedClass1)
-
-    with pytest.raises(InvalidError, match="Cannot use class parameterization in class"):
-        app.cls(enable_memory_snapshot=True)(ParameterizedClass1Implicit)
-
-    with pytest.raises(InvalidError, match="Cannot use class parameterization in class"):
-        app.cls(enable_memory_snapshot=True)(ParameterizedClass2)
-
-    with pytest.raises(InvalidError, match="Cannot use class parameterization in class"):
-        app.cls(enable_memory_snapshot=True)(ParameterizedClass2Implicit)
-
-    app.cls(enable_memory_snapshot=True)(ParameterizedClass3)
-
-
 app_batched = App()
 
 


### PR DESCRIPTION
This feature works again.

## Describe your changes

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

Memory snapshotting can now be used with parameterized functions.