### PR TITLE
Aggregate StreamReader output into full lines

### DIFF
--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -79,9 +79,9 @@ class _StreamReader:
         object_id: str,
         object_type: Literal["sandbox", "container_process"],
         client: _Client,
+        raw: bool = True,  # if False, streamed logs are further processed into complete lines.
     ) -> None:
         """mdmd:hidden"""
-
         self._file_descriptor = file_descriptor
         self._object_type = object_type
         self._object_id = object_id
@@ -89,6 +89,7 @@ class _StreamReader:
         self._stream = None
         self._last_entry_id = None
         self._buffer = ""
+        self._raw = raw
         # Whether the reader received an EOF. Once EOF is True, it returns
         # an empty string for any subsequent reads (including async for)
         self.eof = False
@@ -185,10 +186,10 @@ class _StreamReader:
 
     def __aiter__(self):
         """mdmd:hidden"""
-        if self._object_type == "sandbox":
-            self._stream = self._get_logs()
-        else:
+        if self._raw:
             self._stream = self._get_logs_raw()
+        else:
+            self._stream = self._get_logs()
         return self
 
     async def __anext__(self):

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -276,8 +276,8 @@ class _Sandbox(_Object, type_prefix="sb"):
         return obj
 
     def _hydrate_metadata(self, handle_metadata: Optional[Message]):
-        self._stdout = StreamReader(api_pb2.FILE_DESCRIPTOR_STDOUT, self.object_id, "sandbox", self._client)
-        self._stderr = StreamReader(api_pb2.FILE_DESCRIPTOR_STDERR, self.object_id, "sandbox", self._client)
+        self._stdout = StreamReader(api_pb2.FILE_DESCRIPTOR_STDOUT, self.object_id, "sandbox", self._client, raw=False)
+        self._stderr = StreamReader(api_pb2.FILE_DESCRIPTOR_STDERR, self.object_id, "sandbox", self._client, raw=False)
         self._stdin = StreamWriter(self.object_id, "sandbox", self._client)
         self._result = None
 

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -276,8 +276,12 @@ class _Sandbox(_Object, type_prefix="sb"):
         return obj
 
     def _hydrate_metadata(self, handle_metadata: Optional[Message]):
-        self._stdout = StreamReader(api_pb2.FILE_DESCRIPTOR_STDOUT, self.object_id, "sandbox", self._client, raw=False)
-        self._stderr = StreamReader(api_pb2.FILE_DESCRIPTOR_STDERR, self.object_id, "sandbox", self._client, raw=False)
+        self._stdout = StreamReader(
+            api_pb2.FILE_DESCRIPTOR_STDOUT, self.object_id, "sandbox", self._client, by_line=True
+        )
+        self._stderr = StreamReader(
+            api_pb2.FILE_DESCRIPTOR_STDERR, self.object_id, "sandbox", self._client, by_line=True
+        )
         self._stdin = StreamWriter(self.object_id, "sandbox", self._client)
         self._result = None
 

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -446,7 +446,7 @@ def test_shell_cmd(servicer, set_env_client, test_dir, mock_shell_pty):
     shell_prompt = servicer.shell_prompt.encode("utf-8")
     _run(["shell", "--cmd", "pwd", app_file.as_posix() + "::foo"])
     expected_output = subprocess.run(["pwd"], capture_output=True, check=True).stdout
-    assert captured_out == [(1, shell_prompt), (1, expected_output)]
+    assert captured_out == [(1, shell_prompt + expected_output)]
 
 
 @skip_windows("modal shell is not supported on Windows.")

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -421,21 +421,21 @@ def test_shell(servicer, set_env_client, test_dir, mock_shell_pty):
     _run(["shell", app_file.as_posix() + "::foo"])
 
     # first captured message is the empty message the mock server sends
-    assert captured_out == [(1, shell_prompt), (1, b"Hello World\n")]
+    assert captured_out == [(1, shell_prompt + b"Hello World\n")]
     captured_out.clear()
 
     # Function is explicitly specified
     _run(["shell", webhook_app_file.as_posix() + "::foo"])
-    assert captured_out == [(1, shell_prompt), (1, b"Hello World\n")]
+    assert captured_out == [(1, shell_prompt + b"Hello World\n")]
     captured_out.clear()
 
     # Function must be inferred
     _run(["shell", webhook_app_file.as_posix()])
-    assert captured_out == [(1, shell_prompt), (1, b"Hello World\n")]
+    assert captured_out == [(1, shell_prompt + b"Hello World\n")]
     captured_out.clear()
 
     _run(["shell", cls_app_file.as_posix()])
-    assert captured_out == [(1, shell_prompt), (1, b"Hello World\n")]
+    assert captured_out == [(1, shell_prompt + b"Hello World\n")]
     captured_out.clear()
 
 

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -421,21 +421,21 @@ def test_shell(servicer, set_env_client, test_dir, mock_shell_pty):
     _run(["shell", app_file.as_posix() + "::foo"])
 
     # first captured message is the empty message the mock server sends
-    assert captured_out == [(1, shell_prompt + b"Hello World\n")]
+    assert captured_out == [(1, shell_prompt), (1, b"Hello World\n")]
     captured_out.clear()
 
     # Function is explicitly specified
     _run(["shell", webhook_app_file.as_posix() + "::foo"])
-    assert captured_out == [(1, shell_prompt + b"Hello World\n")]
+    assert captured_out == [(1, shell_prompt), (1, b"Hello World\n")]
     captured_out.clear()
 
     # Function must be inferred
     _run(["shell", webhook_app_file.as_posix()])
-    assert captured_out == [(1, shell_prompt + b"Hello World\n")]
+    assert captured_out == [(1, shell_prompt), (1, b"Hello World\n")]
     captured_out.clear()
 
     _run(["shell", cls_app_file.as_posix()])
-    assert captured_out == [(1, shell_prompt + b"Hello World\n")]
+    assert captured_out == [(1, shell_prompt), (1, b"Hello World\n")]
     captured_out.clear()
 
 
@@ -446,7 +446,7 @@ def test_shell_cmd(servicer, set_env_client, test_dir, mock_shell_pty):
     shell_prompt = servicer.shell_prompt.encode("utf-8")
     _run(["shell", "--cmd", "pwd", app_file.as_posix() + "::foo"])
     expected_output = subprocess.run(["pwd"], capture_output=True, check=True).stdout
-    assert captured_out == [(1, shell_prompt + expected_output)]
+    assert captured_out == [(1, shell_prompt), (1, expected_output)]
 
 
 @skip_windows("modal shell is not supported on Windows.")

--- a/test/io_streams_test.py
+++ b/test/io_streams_test.py
@@ -1,0 +1,43 @@
+# Copyright Modal Labs 2024
+from modal import enable_output
+from modal.io_streams import StreamReader
+from modal_proto import api_pb2
+
+
+def test_stream_reader(servicer, client):
+    lines = ["foo\n", "bar\n", "baz\n"]
+
+    async def sandbox_get_logs(servicer, stream):
+        await stream.recv_message()
+
+        # Data with multiple lines
+        log1 = api_pb2.TaskLogs(
+            data="".join(lines),
+            file_descriptor=api_pb2.FILE_DESCRIPTOR_STDOUT,
+        )
+        await stream.send_message(api_pb2.TaskLogsBatch(entry_id="0", items=[log1]))
+
+        # Data with single lines sent separately
+        for i, line in enumerate(lines):
+            log = api_pb2.TaskLogs(data=line, file_descriptor=api_pb2.FILE_DESCRIPTOR_STDOUT)
+            await stream.send_message(api_pb2.TaskLogsBatch(entry_id=str(i + 1), items=[log]))
+
+        # Send EOF
+        await stream.send_message(api_pb2.TaskLogsBatch(eof=True))
+
+    with servicer.intercept() as ctx:
+        ctx.set_responder("SandboxGetLogs", sandbox_get_logs)
+
+        with enable_output():
+            stdout = StreamReader(
+                file_descriptor=api_pb2.FILE_DESCRIPTOR_STDOUT,
+                object_id="sb-123",
+                object_type="sandbox",
+                client=client,
+            )
+
+            out = []
+            for line in stdout:
+                out.append(line)
+
+            assert out == lines * 2

--- a/test/io_streams_test.py
+++ b/test/io_streams_test.py
@@ -37,7 +37,7 @@ def test_stream_reader(servicer, client):
 
 
 def test_stream_reader_processed(servicer, client):
-    """Tests that the stream reader with processed logs works with clean inputs."""
+    """Tests that the stream reader with logs by line works with clean inputs."""
     lines = ["foo\n", "bar\n", "baz\n"]
 
     async def sandbox_get_logs(servicer, stream):
@@ -59,7 +59,7 @@ def test_stream_reader_processed(servicer, client):
                 object_id="sb-123",
                 object_type="sandbox",
                 client=client,
-                raw=False,
+                by_line=True,
             )
 
             out = []
@@ -70,7 +70,7 @@ def test_stream_reader_processed(servicer, client):
 
 
 def test_stream_reader_processed_multiple(servicer, client):
-    """Tests that the stream reader with processed logs splits multiple lines."""
+    """Tests that the stream reader with logs by line splits multiple lines."""
 
     async def sandbox_get_logs(servicer, stream):
         await stream.recv_message()
@@ -93,7 +93,7 @@ def test_stream_reader_processed_multiple(servicer, client):
                 object_id="sb-123",
                 object_type="sandbox",
                 client=client,
-                raw=False,
+                by_line=True,
             )
 
             out = []
@@ -104,7 +104,7 @@ def test_stream_reader_processed_multiple(servicer, client):
 
 
 def test_stream_reader_processed_partial_lines(servicer, client):
-    """Test that the stream reader with processed logs joins partial lines together."""
+    """Test that the stream reader with logs by line joins partial lines together."""
 
     async def sandbox_get_logs(servicer, stream):
         await stream.recv_message()
@@ -139,7 +139,7 @@ def test_stream_reader_processed_partial_lines(servicer, client):
                 object_id="sb-123",
                 object_type="sandbox",
                 client=client,
-                raw=False,
+                by_line=True,
             )
 
             out = []

--- a/test/io_streams_test.py
+++ b/test/io_streams_test.py
@@ -5,24 +5,17 @@ from modal_proto import api_pb2
 
 
 def test_stream_reader(servicer, client):
+    """Tests that the stream reader works with clean inputs."""
     lines = ["foo\n", "bar\n", "baz\n"]
 
     async def sandbox_get_logs(servicer, stream):
         await stream.recv_message()
 
-        # Data with multiple lines
-        log1 = api_pb2.TaskLogs(
-            data="".join(lines),
-            file_descriptor=api_pb2.FILE_DESCRIPTOR_STDOUT,
-        )
-        await stream.send_message(api_pb2.TaskLogsBatch(entry_id="0", items=[log1]))
-
-        # Data with single lines sent separately
-        for i, line in enumerate(lines):
+        for line in lines:
             log = api_pb2.TaskLogs(data=line, file_descriptor=api_pb2.FILE_DESCRIPTOR_STDOUT)
-            await stream.send_message(api_pb2.TaskLogsBatch(entry_id=str(i + 1), items=[log]))
+            await stream.send_message(api_pb2.TaskLogsBatch(entry_id=line, items=[log]))
 
-        # Send EOF
+        # send EOF
         await stream.send_message(api_pb2.TaskLogsBatch(eof=True))
 
     with servicer.intercept() as ctx:
@@ -40,4 +33,82 @@ def test_stream_reader(servicer, client):
             for line in stdout:
                 out.append(line)
 
-            assert out == lines * 2
+            assert out == lines
+
+
+def test_stream_reader_multiple(servicer, client):
+    """Tests that the stream reader splits multiple lines."""
+
+    async def sandbox_get_logs(servicer, stream):
+        await stream.recv_message()
+
+        log = api_pb2.TaskLogs(
+            data="foo\nbar\nbaz",
+            file_descriptor=api_pb2.FILE_DESCRIPTOR_STDOUT,
+        )
+        await stream.send_message(api_pb2.TaskLogsBatch(entry_id="0", items=[log]))
+
+        # send EOF
+        await stream.send_message(api_pb2.TaskLogsBatch(eof=True))
+
+    with servicer.intercept() as ctx:
+        ctx.set_responder("SandboxGetLogs", sandbox_get_logs)
+
+        with enable_output():
+            stdout = StreamReader(
+                file_descriptor=api_pb2.FILE_DESCRIPTOR_STDOUT,
+                object_id="sb-123",
+                object_type="sandbox",
+                client=client,
+            )
+
+            out = []
+            for line in stdout:
+                out.append(line)
+
+            assert out == ["foo\n", "bar\n", "baz"]
+
+
+def test_stream_reader_partial_lines(servicer, client):
+    """Test that the stream reader joins partial lines together."""
+
+    async def sandbox_get_logs(servicer, stream):
+        await stream.recv_message()
+
+        log1 = api_pb2.TaskLogs(
+            data="foo",
+            file_descriptor=api_pb2.FILE_DESCRIPTOR_STDOUT,
+        )
+        await stream.send_message(api_pb2.TaskLogsBatch(entry_id="0", items=[log1]))
+
+        log2 = api_pb2.TaskLogs(
+            data="bar\n",
+            file_descriptor=api_pb2.FILE_DESCRIPTOR_STDOUT,
+        )
+        await stream.send_message(api_pb2.TaskLogsBatch(entry_id="1", items=[log2]))
+
+        log3 = api_pb2.TaskLogs(
+            data="baz",
+            file_descriptor=api_pb2.FILE_DESCRIPTOR_STDOUT,
+        )
+        await stream.send_message(api_pb2.TaskLogsBatch(entry_id="2", items=[log3]))
+
+        # send EOF
+        await stream.send_message(api_pb2.TaskLogsBatch(eof=True))
+
+    with servicer.intercept() as ctx:
+        ctx.set_responder("SandboxGetLogs", sandbox_get_logs)
+
+        with enable_output():
+            stdout = StreamReader(
+                file_descriptor=api_pb2.FILE_DESCRIPTOR_STDOUT,
+                object_id="sb-123",
+                object_type="sandbox",
+                client=client,
+            )
+
+            out = []
+            for line in stdout:
+                out.append(line)
+
+            assert out == ["foobar\n", "baz"]

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -171,7 +171,7 @@ def test_sandbox_stdout(app, servicer):
     assert out == [f"foo {i}\n" for i in range(1, N + 1)] + ["\n"]
 
     # echo a single newline
-    sb = Sandbox.create("bash", "-c", "echo", app=app)
+    sb = Sandbox.create("bash", "-c", "echo -n $'\n'", app=app)
     out = []
     for line in sb.stdout:
         out.append(line)

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -153,6 +153,32 @@ def test_sandbox_stdin_write_after_eof(app, servicer):
 
 
 @skip_non_linux
+def test_sandbox_stdout(app, servicer):
+    N = 5
+    # echo N separate times
+    sb = Sandbox.create("bash", "-c", f"for i in $(seq 1 {N}); do echo foo $i; done", app=app)
+    out = []
+    for line in sb.stdout:
+        out.append(line)
+    assert out == [f"foo {i}\n" for i in range(1, N + 1)]
+
+    # echo a single time with newlines in between
+    input = "".join(f"foo {i}\n" for i in range(1, N + 1))
+    sb = Sandbox.create("bash", "-c", f"echo '{input}'", app=app)
+    out = []
+    for line in sb.stdout:
+        out.append(line)
+    assert out == [f"foo {i}\n" for i in range(1, N + 1)] + ["\n"]
+
+    # echo a single newline
+    sb = Sandbox.create("bash", "-c", "echo", app=app)
+    out = []
+    for line in sb.stdout:
+        out.append(line)
+    assert out == ["\n"]
+
+
+@skip_non_linux
 @pytest.mark.asyncio
 async def test_sandbox_async_for(app, servicer):
     sb = await Sandbox.create.aio("bash", "-c", "echo hello && echo world && echo bye >&2", app=app)


### PR DESCRIPTION
## Describe your changes

Fixes MOD-4075.

Adds attribute `by_line` to StreamReader that changes whether the iterator returns raw logs (default behavior) or logs that are split by line. Default behavior for sandboxes is to return line-by-line logs.

## Changelog

Adds attribute `by_line` to StreamReader. When `by_line` is `False` (default), the behavior is unchanged. When `by_line` is `True`, logs will read one full line at a time, rather than partial or multiple lines.
