### PR TITLE
MOD-2454: remove aiostream dependency: async_zip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ venv/
 build/
 *.pyi
 **/*.txt
+**/.DS_Store

--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -463,3 +463,13 @@ def run_generator_sync(
         except BaseException as err:
             exc = err
     loop.close()
+
+
+@asynccontextmanager
+async def aclosing(
+    agen: AsyncGenerator[T, None],
+) -> AsyncGenerator[AsyncGenerator[T, None], None]:
+    try:
+        yield agen
+    finally:
+        await agen.aclose()

--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -492,10 +492,10 @@ async def aclosing(
 
 async def sync_or_async_iter(iterator: Union[Iterable[T], AsyncIterable[T]]) -> AsyncGenerator[T, None]:
     if hasattr(iterator, "__aiter__"):
-        async for item in iterator:
+        async for item in typing.cast(AsyncIterable[T], iterator):
             yield item
     else:
-        for item in iterator:
+        for item in typing.cast(Iterable[T], iterator):
             yield item
 
 

--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -495,6 +495,9 @@ async def sync_or_async_iter(iterator: Union[Iterable[T], AsyncIterable[T]]) -> 
         async for item in typing.cast(AsyncIterable[T], iterator):
             yield item
     else:
+        # This intentionally could block the event loop for the duration of calling __iter__ and __next__,
+        # so in non-trivial cases (like passing lists and ranges) this could be quite a foot gun for users #
+        # w/ async code (but they can work around it by always using async iterators)
         for item in typing.cast(Iterable[T], iterator):
             yield item
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -38,6 +38,7 @@ from ._resources import convert_fn_config_to_resources_config
 from ._serialization import serialize, serialize_proto_params
 from ._utils.async_utils import (
     TaskContext,
+    aclosing,
     synchronize_api,
     synchronizer,
     warn_if_generator_is_not_consumed,
@@ -210,7 +211,7 @@ class _Invocation:
 
         items_received = 0
         items_total: Union[int, None] = None  # populated when self.run_function() completes
-        async with combined_stream.stream() as streamer:
+        async with aclosing(combined_stream) as streamer:
             async for item in streamer:
                 if isinstance(item, api_pb2.GeneratorDone):
                     items_total = item.items_total

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -211,7 +211,7 @@ class _Invocation:
 
         items_received = 0
         items_total: Union[int, None] = None  # populated when self.run_function() completes
-        async with aclosing(combined_stream) as streamer:
+        async with aclosing(combined_stream) as streamer:  # type: ignore[reportArgumentType]
             async for item in streamer:
                 if isinstance(item, api_pb2.GeneratorDone):
                     items_total = item.items_total

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -38,7 +38,6 @@ from ._resources import convert_fn_config_to_resources_config
 from ._serialization import serialize, serialize_proto_params
 from ._utils.async_utils import (
     TaskContext,
-    aclosing,
     synchronize_api,
     synchronizer,
     warn_if_generator_is_not_consumed,
@@ -211,7 +210,7 @@ class _Invocation:
 
         items_received = 0
         items_total: Union[int, None] = None  # populated when self.run_function() completes
-        async with aclosing(combined_stream) as streamer:  # type: ignore[reportArgumentType]
+        async with combined_stream.stream() as streamer:
             async for item in streamer:
                 if isinstance(item, api_pb2.GeneratorDone):
                     items_total = item.items_total

--- a/modal/parallel_map.py
+++ b/modal/parallel_map.py
@@ -11,6 +11,7 @@ from grpclib import GRPCError, Status
 from modal._utils.async_utils import (
     AsyncOrSyncIterable,
     aclosing,
+    async_zip,
     queue_batch_iterator,
     synchronize_api,
     synchronizer,
@@ -118,7 +119,7 @@ async def _map_invocation(
             ordered=True,
             task_limit=BLOB_MAX_PARALLELISM,
         )
-        async with aclosing(proto_input_stream) as streamer:
+        async with proto_input_stream.stream() as streamer:
             async for item in streamer:
                 await input_queue.put(item)
 
@@ -233,7 +234,7 @@ async def _map_invocation(
         received_outputs = {}
         output_idx = 0
 
-        async with aclosing(outputs_fetched) as streamer:
+        async with outputs_fetched.stream() as streamer:
             async for idx, output in streamer:
                 count_update()
                 if not order_outputs:
@@ -250,7 +251,7 @@ async def _map_invocation(
 
     response_gen = stream.merge(drain_input_generator(), pump_inputs(), poll_outputs())
 
-    async with aclosing(response_gen) as streamer:
+    async with response_gen.stream() as streamer:
         async for response in streamer:
             if response is not None:
                 yield response.value
@@ -337,7 +338,7 @@ async def _map_async(
 
     async def feed_queue():
         # This runs in a main thread event loop, so it doesn't block the synchronizer loop
-        async with aclosing(stream.zip(*[stream.iterate(it) for it in input_iterators])) as streamer:
+        async with aclosing(async_zip(*input_iterators)) as streamer:
             async for args in streamer:
                 await raw_input_queue.put.aio((args, kwargs))
         await raw_input_queue.put.aio(None)  # end-of-input sentinel
@@ -387,7 +388,7 @@ async def _starmap_async(
 
     async def feed_queue():
         # This runs in a main thread event loop, so it doesn't block the synchronizer loop
-        async with aclosing(stream.iterate(input_iterator)) as streamer:
+        async with stream.iterate(input_iterator).stream() as streamer:
             async for args in streamer:
                 await raw_input_queue.put.aio((args, kwargs))
         await raw_input_queue.put.aio(None)  # end-of-input sentinel

--- a/test/async_utils_test.py
+++ b/test/async_utils_test.py
@@ -360,3 +360,25 @@ async def test_async_zip():
         result.append(item)
 
     assert result == [(1, 5, 6), (2, 6, 7)]
+
+
+@pytest.mark.asyncio
+async def test_async_zip_parallel():
+    ev = asyncio.Event()
+    ev2 = asyncio.Event()
+
+    async def gen1():
+        ev.set()
+        await ev2.wait()
+        yield 1
+
+    async def gen2():
+        await ev.wait()
+        ev2.set()
+        yield 2
+
+    result = []
+    async for item in async_zip(gen1(), gen2()):
+        result.append(item)
+
+    assert result == [(1, 2)]


### PR DESCRIPTION
Splitting #2320 up into multiple PRs as it grew quite big. This adds `async_zip` and a helper `aclosing` function necessary for other async functions to close generators even if they're exited early, should probably use this in multiple places in the code where we use `async for` Should unblock #2322 too