### PR TITLE
Don't sleep before sending an exec request

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -388,8 +388,8 @@ class _Sandbox(_Object, type_prefix="sb"):
         while not self._task_id:
             resp = await self._client.stub.SandboxGetTaskId(api_pb2.SandboxGetTaskIdRequest(sandbox_id=self.object_id))
             self._task_id = resp.task_id
-            # TODO: debug why sending an exec right after a task ID exists fails silently
-            await asyncio.sleep(0.5)
+            if not self._task_id:
+                await asyncio.sleep(0.5)
         return self._task_id
 
     async def exec(self, *cmds: str, pty_info: Optional[api_pb2.PTYInfo] = None):


### PR DESCRIPTION
The underlying bug that requires this sleep has been fixed.

## Describe your changes

- Resolves MOD-4076

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>
