### PR TITLE
Don't use credentials in container

### DIFF
--- a/modal/config.py
+++ b/modal/config.py
@@ -203,7 +203,6 @@ _SETTINGS = {
     "token_id": _Setting(),
     "token_secret": _Setting(),
     "task_id": _Setting(),
-    "task_secret": _Setting(),
     "serve_timeout": _Setting(transform=float),
     "sync_entrypoint": _Setting(),
     "logs_timeout": _Setting(10, float),

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -61,20 +61,6 @@ async def test_container_function_lazily_imported(container_client):
     assert await my_f_container.remote.aio(42) == 1764  # type: ignore
 
 
-@pytest.mark.asyncio
-async def test_container_snapshot_restore(container_client, tmpdir, servicer):
-    # Get a reference to a Client instance in memory
-    old_client = container_client
-    io_manager = ContainerIOManager(api_pb2.ContainerArguments(), container_client)
-    restore_path = temp_restore_path(tmpdir)
-    with mock.patch.dict(
-        os.environ, {"MODAL_RESTORE_STATE_PATH": str(restore_path), "MODAL_SERVER_URL": servicer.container_addr}
-    ):
-        io_manager.memory_snapshot()
-        # In-memory Client instance should have updated credentials, not old credentials
-        assert old_client.credentials == ("ta-i-am-restored", "ts-i-am-restored")
-
-
 def square(x):
     pass
 


### PR DESCRIPTION
There's no need to read environment variables and set metadata in the container anymore – we inject it in the worker

SVC-164