### PR TITLE
Fix i6pn main address being None (typo)

### DIFF
--- a/modal/experimental.py
+++ b/modal/experimental.py
@@ -159,7 +159,7 @@ def _networked(func):
 
         def get_i6pn():
             """Returns the ipv6 address assigned to this container."""
-            socket.getaddrinfo("i6pn.modal.local", None, socket.AF_INET6)[0][4][0]
+            return socket.getaddrinfo("i6pn.modal.local", None, socket.AF_INET6)[0][4][0]
 
         hostname = socket.gethostname()
         addr_info = get_i6pn()
@@ -179,6 +179,7 @@ def _networked(func):
         elif rank == 0:
             q.put_many([addr_info for _ in range(size)])
         main_ip = q.get()
+        assert main_ip is not None, "Failed to get main i6pn address"
 
         os.environ["MODAL_MAIN_I6PN"] = f"{main_ip}"
         os.environ["MODAL_WORLD_SIZE"] = f"{size}"


### PR DESCRIPTION
I forgot to add a `return` statement.

This wasn't caught in code review because I made the change after the PR was approved and somehow didn't catch the error myself :(

e2e tests failed on the main Modal repo, which is how I noticed this issue.