### PR TITLE
Expire the deprecation of `web_endpoint(wait_for_response=False)`

### DIFF
--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -272,10 +272,10 @@ def _web_endpoint(
     method: str = "GET",  # REST method for the created endpoint.
     label: Optional[str] = None,  # Label for created endpoint. Final subdomain will be <workspace>--<label>.modal.run.
     docs: bool = False,  # Whether to enable interactive documentation for this endpoint at /docs.
-    wait_for_response: bool = True,  # Whether requests should wait for and return the function response.
     custom_domains: Optional[
         Iterable[str]
     ] = None,  # Create an endpoint using a custom domain fully-qualified domain name (FQDN).
+    wait_for_response: bool = True,  # DEPRECATED: this must always be True now
 ) -> Callable[[Callable[P, ReturnType]], _PartialFunction[P, ReturnType, ReturnType]]:
     """Register a basic web endpoint with this application.
 
@@ -307,10 +307,10 @@ def _web_endpoint(
                 "@app.function()\n@app.web_endpoint()\ndef my_webhook():\n    ..."
             )
         if not wait_for_response:
-            deprecation_warning(
+            deprecation_error(
                 (2024, 5, 13),
                 "wait_for_response=False has been deprecated on web endpoints. See "
-                + "https://modal.com/docs/guide/webhook-timeouts#polling-solutions for alternatives",
+                "https://modal.com/docs/guide/webhook-timeouts#polling-solutions for alternatives.",
             )
             _response_mode = api_pb2.WEBHOOK_ASYNC_MODE_TRIGGER
         else:

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -312,9 +312,6 @@ def _web_endpoint(
                 "wait_for_response=False has been deprecated on web endpoints. See "
                 "https://modal.com/docs/guide/webhook-timeouts#polling-solutions for alternatives.",
             )
-            _response_mode = api_pb2.WEBHOOK_ASYNC_MODE_TRIGGER
-        else:
-            _response_mode = api_pb2.WEBHOOK_ASYNC_MODE_AUTO  # the default
 
         # self._loose_webhook_configs.add(raw_f)
 
@@ -326,7 +323,7 @@ def _web_endpoint(
                 method=method,
                 web_endpoint_docs=docs,
                 requested_suffix=label,
-                async_mode=_response_mode,
+                async_mode=api_pb2.WEBHOOK_ASYNC_MODE_AUTO,
                 custom_domains=_parse_custom_domains(custom_domains),
             ),
         )

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -212,9 +212,9 @@ enum VolumeFsVersion {
 enum WebhookAsyncMode {
   WEBHOOK_ASYNC_MODE_UNSPECIFIED = 0;
   reserved 1; // unused REDIRECT mode
-  WEBHOOK_ASYNC_MODE_DISABLED = 2; // no redirect, fail after timeout
-  WEBHOOK_ASYNC_MODE_TRIGGER = 3; // return immediately, roughly same as old wait_for_response=False
-  WEBHOOK_ASYNC_MODE_AUTO = 4; // redirect to polling endpoint if execution time nears the http timeout
+  WEBHOOK_ASYNC_MODE_DISABLED = 2; // No longer used by client
+  WEBHOOK_ASYNC_MODE_TRIGGER = 3; // No longer used by client (previously used when wait_for_response=False)
+  WEBHOOK_ASYNC_MODE_AUTO = 4; // The default
 }
 
 enum WebhookType {


### PR DESCRIPTION
This was deprecated >5 months ago.

## Changelog

- Passing `wait_for_response=False` with `modal.web_endpoint` is no longer supported. See [the docs](https://modal.com/docs/guide/webhook-timeouts#polling-solutions) for alternatives.