### PR TITLE
Add _experimental_spawn function

### DIFF
--- a/modal/config.py
+++ b/modal/config.py
@@ -221,7 +221,6 @@ _SETTINGS = {
     "traceback": _Setting(False, transform=_to_boolean),
     "image_builder_version": _Setting(),
     "strict_parameters": _Setting(False, transform=_to_boolean),  # For internal/experimental use
-    "spawn_extended": _Setting(False, transform=_to_boolean),
 }
 
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1401,11 +1401,8 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         Returns a `modal.functions.FunctionCall` object, that can later be polled or
         waited for using `.get(timeout=...)`.
         Conceptually similar to `multiprocessing.pool.apply_async`, or a Future/Promise in other contexts.
-
-        *Note:* `.spawn()` on a modal generator function does call and execute the generator, but does not currently
-        return a function handle for polling the result.
         """
-        self._check_no_web_url("spawn")
+        self._check_no_web_url("_experimental_spawn")
         if self._is_generator:
             invocation = await self._call_generator_nowait(args, kwargs)
         else:
@@ -1425,21 +1422,14 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         Returns a `modal.functions.FunctionCall` object, that can later be polled or
         waited for using `.get(timeout=...)`.
         Conceptually similar to `multiprocessing.pool.apply_async`, or a Future/Promise in other contexts.
-
-        *Note:* `.spawn()` on a modal generator function does call and execute the generator, but does not currently
-        return a function handle for polling the result.
         """
         self._check_no_web_url("spawn")
         if self._is_generator:
             invocation = await self._call_generator_nowait(args, kwargs)
         else:
-            function_call_invocation_type = (
-                # This feature flag allows users to put a large number of inputs
-                api_pb2.FUNCTION_CALL_INVOCATION_TYPE_ASYNC
-                if config.get("spawn_extended")
-                else api_pb2.FUNCTION_CALL_INVOCATION_TYPE_ASYNC_LEGACY
+            invocation = await self._call_function_nowait(
+                args, kwargs, api_pb2.FUNCTION_CALL_INVOCATION_TYPE_ASYNC_LEGACY
             )
-            invocation = await self._call_function_nowait(args, kwargs, function_call_invocation_type)
 
         fc = _FunctionCall._new_hydrated(invocation.function_call_id, invocation.client, None)
         fc._is_generator = self._is_generator if self._is_generator else False

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1269,12 +1269,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         )
         return await invocation.run_function()
 
-    async def _call_function_nowait(self, args, kwargs) -> _Invocation:
-        # This feature flag allows users to put a large number of inputs
-        if config.get("spawn_extended"):
-            function_call_invocation_type = api_pb2.FUNCTION_CALL_INVOCATION_TYPE_ASYNC
-        else:
-            function_call_invocation_type = api_pb2.FUNCTION_CALL_INVOCATION_TYPE_ASYNC_LEGACY
+    async def _call_function_nowait(self, args, kwargs, function_call_invocation_type) -> _Invocation:
         return await _Invocation.create(
             self, args, kwargs, client=self._client, function_call_invocation_type=function_call_invocation_type
         )
@@ -1396,6 +1391,32 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
 
     @synchronizer.no_input_translation
     @live_method
+    async def _experimental_spawn(self, *args: P.args, **kwargs: P.kwargs) -> "_FunctionCall[ReturnType]":
+        """[Experimental] Calls the function with the given arguments, without waiting for the results.
+
+        This experimental version of the spawn method allows up to 1 million inputs to be spawned.
+
+        Returns a `modal.functions.FunctionCall` object, that can later be polled or
+        waited for using `.get(timeout=...)`.
+        Conceptually similar to `multiprocessing.pool.apply_async`, or a Future/Promise in other contexts.
+
+        *Note:* `.spawn()` on a modal generator function does call and execute the generator, but does not currently
+        return a function handle for polling the result.
+        """
+        self._check_no_web_url("spawn")
+        if self._is_generator:
+            invocation = await self._call_generator_nowait(args, kwargs)
+        else:
+            invocation = await self._call_function_nowait(
+                args, kwargs, function_call_invocation_type=api_pb2.FUNCTION_CALL_INVOCATION_TYPE_ASYNC
+            )
+
+        fc = _FunctionCall._new_hydrated(invocation.function_call_id, invocation.client, None)
+        fc._is_generator = self._is_generator if self._is_generator else False
+        return fc
+
+    @synchronizer.no_input_translation
+    @live_method
     async def spawn(self, *args: P.args, **kwargs: P.kwargs) -> "_FunctionCall[ReturnType]":
         """Calls the function with the given arguments, without waiting for the results.
 
@@ -1410,7 +1431,13 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         if self._is_generator:
             invocation = await self._call_generator_nowait(args, kwargs)
         else:
-            invocation = await self._call_function_nowait(args, kwargs)
+            function_call_invocation_type = (
+                # This feature flag allows users to put a large number of inputs
+                api_pb2.FUNCTION_CALL_INVOCATION_TYPE_ASYNC
+                if config.get("spawn_extended")
+                else api_pb2.FUNCTION_CALL_INVOCATION_TYPE_ASYNC_LEGACY
+            )
+            invocation = await self._call_function_nowait(args, kwargs, function_call_invocation_type)
 
         fc = _FunctionCall._new_hydrated(invocation.function_call_id, invocation.client, None)
         fc._is_generator = self._is_generator if self._is_generator else False

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1269,7 +1269,9 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         )
         return await invocation.run_function()
 
-    async def _call_function_nowait(self, args, kwargs, function_call_invocation_type) -> _Invocation:
+    async def _call_function_nowait(
+        self, args, kwargs, function_call_invocation_type: "api_pb2.FunctionCallInvocationType.ValueType"
+    ) -> _Invocation:
         return await _Invocation.create(
             self, args, kwargs, client=self._client, function_call_invocation_type=function_call_invocation_type
         )

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -993,3 +993,16 @@ def test_spawn_extended_feature_flag(client, servicer, monkeypatch, feature_flag
     else:
         expected_invocation_type = api_pb2.FUNCTION_CALL_INVOCATION_TYPE_ASYNC_LEGACY
     assert function_map.function_call_invocation_type == expected_invocation_type
+
+
+def test_experimental_spawn(client, servicer):
+    app = App()
+    dummy_modal = app.function()(dummy)
+
+    with servicer.intercept() as ctx:
+        with app.run(client=client):
+            dummy_modal._experimental_spawn(1, 2)
+
+    # Verify the correct invocation type is set
+    function_map = ctx.pop_request("FunctionMap")
+    assert function_map.function_call_invocation_type == api_pb2.FUNCTION_CALL_INVOCATION_TYPE_ASYNC

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -974,27 +974,6 @@ def test_batch_function_invalid_error():
             return [x_i**2 for x_i in x]
 
 
-@pytest.mark.parametrize("feature_flag", [True, False, None])
-def test_spawn_extended_feature_flag(client, servicer, monkeypatch, feature_flag):
-    app = App()
-    dummy_modal = app.function()(dummy)
-
-    if feature_flag is not None:
-        monkeypatch.setenv("MODAL_SPAWN_EXTENDED", str(feature_flag))
-
-    with servicer.intercept() as ctx:
-        with app.run(client=client):
-            dummy_modal.spawn(1, 2)
-
-    # Verify the correct invocation type is set based on the feature flag
-    function_map = ctx.pop_request("FunctionMap")
-    if feature_flag:
-        expected_invocation_type = api_pb2.FUNCTION_CALL_INVOCATION_TYPE_ASYNC
-    else:
-        expected_invocation_type = api_pb2.FUNCTION_CALL_INVOCATION_TYPE_ASYNC_LEGACY
-    assert function_map.function_call_invocation_type == expected_invocation_type
-
-
 def test_experimental_spawn(client, servicer):
     app = App()
     dummy_modal = app.function()(dummy)


### PR DESCRIPTION
## Describe your changes

Adds a new `_experimental_spawn` function to the client which allows users to spawn up to 1 million inputs.

Previously users could enable this functionality by setting the env var `MODAL_SPAWN_EXTENDED`, but setting env vars correctly can be tricky. By adding a new method, we hope to make it more explicit and less error prone.

I've left the `MODAL_SPAWN_EXTENDED` mechanism in place since we've already communicated to some users that it exists, but can remove if that's preferred.

Closes SVC-169.

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [X] Client+Server: this change is compatible with old servers
- [X] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
