### PR TITLE
Expire deprecation of `modal volume delete --confirm`

### DIFF
--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -19,7 +19,6 @@ from modal.cli._download import _volume_download
 from modal.cli.utils import ENV_OPTION, YES_OPTION, display_table, timestamp_to_local
 from modal.client import _Client
 from modal.environments import ensure_env
-from modal.exception import deprecation_warning
 from modal.volume import _Volume, _VolumeUploadContextManager
 from modal_proto import api_pb2
 
@@ -278,17 +277,8 @@ async def cp(
 async def delete(
     volume_name: str = Argument(help="Name of the modal.Volume to be deleted. Case sensitive"),
     yes: bool = YES_OPTION,
-    confirm: bool = Option(default=False, help="DEPRECATED: See `--yes` option"),
     env: Optional[str] = ENV_OPTION,
 ):
-    if confirm:
-        deprecation_warning(
-            (2024, 4, 24),
-            "The `--confirm` option is deprecated; use `--yes` to delete without prompting.",
-            show_source=False,
-        )
-        yes = True
-
     if not yes:
         typer.confirm(
             f"Are you sure you want to irrevocably delete the modal.Volume '{volume_name}'?",

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -522,6 +522,8 @@ class _Volume(_Object, type_prefix="vo"):
         # TODO(michael) Upon enforcement of this deprecation, remove *args and the default argument for label=.
         if args:
             if isinstance(self := args[0], _Volume):
+                # TODO(michael) we have some second-thoughts about whether deletion methods
+                # should be static or instance. We might revert this, but there isn't consensus.
                 msg = (
                     "Calling Volume.delete as an instance method is deprecated."
                     " Please update your code to call it as a static method, passing"


### PR DESCRIPTION
## Changelog

- The previously-deprecated `--confirm` flag has been removed from the `modal volume delete` CLI. Use `--yes` to force deletion without a confirmation prompt.