### PR TITLE
Fix conda deprecation warning->error

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -986,7 +986,7 @@ class _Image(_Object, type_prefix="im"):
         gpu: GPU_T = None,
     ):
         """DEPRECATED: Removed in favor of the `Image.micromamba_install` method (using the `spec_file` parameter)."""
-        deprecation_warning((2024, 5, 2), _Image.conda_update_from_environment.__doc__ or "")
+        deprecation_error((2024, 5, 2), _Image.conda_update_from_environment.__doc__ or "")
 
     @staticmethod
     def micromamba(


### PR DESCRIPTION
Removed the implementation here but forgot to upgrade the warning to an error!

(I did it correctly for the other two conda methods).