### PR TITLE
Remove some cruft from name_utils

### DIFF
--- a/modal/_utils/name_utils.py
+++ b/modal/_utils/name_utils.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 import re
 
-from ..exception import InvalidError, deprecation_warning
+from ..exception import InvalidError
 
 # https://www.rfc-editor.org/rfc/rfc1035
 subdomain_regex = re.compile("^(?![0-9]+$)(?!-)[a-z0-9-]{,63}(?<!-)$")
@@ -47,20 +47,12 @@ def check_object_name(name: str, object_type: str) -> None:
         raise InvalidError(message)
 
 
-def check_environment_name(name: str, warn: bool = False) -> None:
+def check_environment_name(name: str) -> None:
     message = (
         f"Invalid environment name: '{name}'."
         "\n\nEnvironment names can only start with alphanumeric characters,"
         " may contain only alphanumeric characters, dashes, periods, and underscores,"
         " and must be shorter than 64 characters."
     )
-    if warn:
-        message += "\n\nThis will become an error in the future. Please rename your object to preserve access to it."
     if not is_valid_environment_name(name):
-        if warn:
-            deprecation_warning((2024, 4, 30), message, show_source=False)
-        else:
-            raise InvalidError(message)
-
-
-is_valid_app_name = is_valid_object_name  # TODO becaue we use the former in the server
+        raise InvalidError(message)


### PR DESCRIPTION
Removes an unused deprecation warning and an old name that we previously referenced in the server.