### PR TITLE
Add split output fields

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1823,9 +1823,11 @@ message RuntimeOutputBatch {
   uint64 batch_index = 2;
   // if an exit code is given, this is the final message that will be sent.
   optional int32 exit_code = 3;
+  repeated RuntimeOutputMessage stdout = 4;
+  repeated RuntimeOutputMessage stderr = 5;
+  repeated RuntimeOutputMessage info = 6;
 }
 
-// Used for `modal container exec`
 message RuntimeOutputMessage {
   // only stdout / stderr is used
   FileDescriptor file_descriptor = 1;

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1828,6 +1828,7 @@ message RuntimeOutputBatch {
   repeated RuntimeOutputMessage info = 6;
 }
 
+// Used for `modal container exec`, `modal shell`, and Sandboxes
 message RuntimeOutputMessage {
   // only stdout / stderr is used
   FileDescriptor file_descriptor = 1;


### PR DESCRIPTION
Adds protobuf fields for handling output split on the worker side instead of server side

## Changelog

Adds protobuf fields for handling output split on the worker side instead of server side
