### PR TITLE
Fix queue put_many not respecting infinite timeout

### DIFF
--- a/modal/queue.py
+++ b/modal/queue.py
@@ -379,6 +379,7 @@ class _Queue(_Object, type_prefix="qu"):
                 # A full queue will return this status.
                 additional_status_codes=[Status.RESOURCE_EXHAUSTED],
                 max_delay=30.0,
+                max_retries=None,
                 total_timeout=timeout,
             )
         except GRPCError as exc:


### PR DESCRIPTION
I noticed this issue when trying to parallelize renaming 1.2 million S3 objects with Modal queues :(

## Changelog

Fixes a bug where `Queue.put` and `Queue.put_many` would throw `queue.Full` even if `timeout=None`.