### PR TITLE
Miscellaneous cleanup of `@app.cls` code

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -879,6 +879,7 @@ class _App:
         if _warn_parentheses_missing:
             raise InvalidError("Did you forget parentheses? Suggestion: `@app.cls()`.")
 
+        # Argument validation
         if interactive:
             deprecation_error(
                 (2024, 5, 1), "interactive=True has been deprecated. Set MODAL_INTERACTIVE_FUNCTIONS=1 instead."

--- a/modal/app.py
+++ b/modal/app.py
@@ -951,10 +951,6 @@ class _App:
                 scheduler_placement=scheduler_placement,
                 _experimental_buffer_containers=_experimental_buffer_containers,
                 _experimental_proxy_ip=_experimental_proxy_ip,
-                # class service function, so the following attributes which relate to
-                # the callable itself are invalid and set to defaults:
-                webhook_config=None,
-                is_generator=False,
             )
 
             self._add_function(cls_func, is_web_endpoint=False)

--- a/modal/app.py
+++ b/modal/app.py
@@ -884,9 +884,6 @@ class _App:
                 (2024, 5, 1), "interactive=True has been deprecated. Set MODAL_INTERACTIVE_FUNCTIONS=1 instead."
             )
 
-        image = image or self._get_default_image()
-        secrets = [*self._secrets, *secrets]
-
         scheduler_placement = _experimental_scheduler_placement
         if region:
             if scheduler_placement:
@@ -926,8 +923,8 @@ class _App:
             cls_func = _Function.from_args(
                 info,
                 app=self,
-                image=image,
-                secrets=secrets,
+                image=image or self._get_default_image(),
+                secrets=[*self._secrets, *secrets],
                 gpu=gpu,
                 mounts=[*self._mounts, *mounts],
                 network_file_systems=network_file_systems,


### PR DESCRIPTION
Mostly nit-picks but miscellaneous cleanup of `@app.cls` code:

* Move initialization and validation of `scheduler_placement` outside of the `wrapper` function -- `@app.cls()` parameter validation can live outside of the decorator function
* co-locate class method validation logic (batched methods and snap=True methods)