### PR TITLE
[WRK-200] memory snapshot causes clientclosed error for webapp

### DIFF
--- a/modal/client.py
+++ b/modal/client.py
@@ -148,7 +148,7 @@ class _Client:
         self._owner_pid = os.getpid()
 
     async def _close(self, prep_for_restore: bool = False):
-        logger.debug(f"Client({id(self)}): closing")
+        logger.debug(f"Client ({id(self)}): closing")
         self._closed = True
         await self._cancellation_context.__aexit__(None, None, None)  # wait for all rpcs to be finished/cancelled
         if self._channel is not None:
@@ -162,7 +162,7 @@ class _Client:
 
     async def _init(self):
         """Connect to server and retrieve version information; raise appropriate error for various failures."""
-        logger.debug("Client: Starting")
+        logger.debug(f"Client ({id(self)}): Starting")
         _check_config()
         try:
             req = empty_pb2.Empty()

--- a/modal/client.py
+++ b/modal/client.py
@@ -443,5 +443,8 @@ class UnaryStreamWrapper(Generic[RequestType, ResponseType]):
         request,
         metadata: Optional[Any] = None,
     ):
+        if self.client._snapshotted:
+            logger.debug(f"refreshing client after snapshot for {self._wrapped_method_name}")
+            self.client = await _Client.from_env
         async for response in self.client._call_stream(self._wrapped_method_name, request, metadata=metadata):
             yield response

--- a/modal/client.py
+++ b/modal/client.py
@@ -420,6 +420,9 @@ class UnaryUnaryWrapper(Generic[RequestType, ResponseType]):
         timeout: Optional[float] = None,
         metadata: Optional[_MetadataLike] = None,
     ) -> ResponseType:
+        if self.client._snapshotted:
+            logger.debug(f"refreshing client after snapshot for {self._wrapped_method_name}")
+            self.client = await _Client.from_env()
         return await self.client._call_unary(self._wrapped_method_name, req, timeout=timeout, metadata=metadata)
 
 


### PR DESCRIPTION
## Describe your changes

- WRK-200

https://github.com/modal-labs/modal-client/pull/2178 introduced a regression in snapshots that wasn't caught by our tests. PR 16550 in the monorepo adds a regression integration test.

`UnaryUnaryWrapper` and `UnaryStreamWrapper` began capturing references to clients which became stale on snapshot. When these stale and _closed_ snapshots were used on restore exceptions we thrown. 

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

