### PR TITLE
Strict credential authentication in tests

### DIFF
--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -113,14 +113,14 @@ def test_secret_list(servicer, set_env_client):
 
 
 def test_app_token_new(servicer, set_env_client, server_url_env, modal_config):
-    servicer.required_creds = ("abc", "xyz")
+    servicer.required_creds = {("abc", "xyz")}
     with modal_config() as config_file_path:
         _run(["token", "new", "--profile", "_test"])
         assert "_test" in toml.load(config_file_path)
 
 
 def test_app_setup(servicer, set_env_client, server_url_env, modal_config):
-    servicer.required_creds = ("abc", "xyz")
+    servicer.required_creds = {("abc", "xyz")}
     with modal_config() as config_file_path:
         _run(["setup", "--profile", "_test"])
         assert "_test" in toml.load(config_file_path)
@@ -474,7 +474,7 @@ def test_shell_unsuported_cmds_fails_on_windows(servicer, set_env_client, mock_s
         assert re.search("Windows", str(res.exception)), "exception message does not match expected string"
 
 
-def test_app_descriptions(servicer, server_url_env, test_dir):
+def test_app_descriptions(servicer, set_env_client, test_dir):
     app_file = test_dir / "supports" / "app_run_tests" / "prints_desc_app.py"
     _run(["run", "--detach", app_file.as_posix() + "::foo"])
 
@@ -756,6 +756,7 @@ def test_profile_list(servicer, server_url_env, modal_config):
     """
 
     with modal_config(config):
+        servicer.required_creds = {("ak-abc", "as-xyz"), ("ak-123", "as-789")}
         res = _run(["profile", "list"])
         table_rows = res.stdout.split("\n")
         assert re.search("Profile .+ Workspace", table_rows[1])
@@ -773,6 +774,7 @@ def test_profile_list(servicer, server_url_env, modal_config):
         orig_env_token_secret = os.environ.get("MODAL_TOKEN_SECRET")
         os.environ["MODAL_TOKEN_ID"] = "ak-abc"
         os.environ["MODAL_TOKEN_SECRET"] = "as-xyz"
+        servicer.required_creds = {("ak-abc", "as-xyz")}
         try:
             res = _run(["profile", "list"])
             assert "Using test-username workspace based on environment variables" in res.stdout
@@ -1010,7 +1012,7 @@ def test_keyboard_interrupt_during_app_load(servicer, server_url_env, supports_d
 
 @pytest.mark.timeout(10)
 @skip_windows("no sigint on windows")
-def test_keyboard_interrupt_during_app_run(servicer, server_url_env, supports_dir):
+def test_keyboard_interrupt_during_app_run(servicer, server_url_env, token_env, supports_dir):
     ctx: InterceptionContext
     waiting_for_output = threading.Event()
 
@@ -1031,7 +1033,7 @@ def test_keyboard_interrupt_during_app_run(servicer, server_url_env, supports_di
 
 @pytest.mark.timeout(10)
 @skip_windows("no sigint on windows")
-def test_keyboard_interrupt_during_app_run_detach(servicer, server_url_env, supports_dir):
+def test_keyboard_interrupt_during_app_run_detach(servicer, server_url_env, token_env, supports_dir):
     ctx: InterceptionContext
     waiting_for_output = threading.Event()
 

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -113,12 +113,14 @@ def test_secret_list(servicer, set_env_client):
 
 
 def test_app_token_new(servicer, set_env_client, server_url_env, modal_config):
+    servicer.required_creds = ("abc", "xyz")
     with modal_config() as config_file_path:
         _run(["token", "new", "--profile", "_test"])
         assert "_test" in toml.load(config_file_path)
 
 
 def test_app_setup(servicer, set_env_client, server_url_env, modal_config):
+    servicer.required_creds = ("abc", "xyz")
     with modal_config() as config_file_path:
         _run(["setup", "--profile", "_test"])
         assert "_test" in toml.load(config_file_path)

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -990,7 +990,7 @@ def _run_subprocess(cli_cmd: List[str]) -> subprocess.Popen:
 
 @pytest.mark.timeout(10)
 @skip_windows("no sigint on windows")
-def test_keyboard_interrupt_during_app_load(servicer, server_url_env, supports_dir):
+def test_keyboard_interrupt_during_app_load(servicer, server_url_env, token_env, supports_dir):
     ctx: InterceptionContext
     creating_function = threading.Event()
 

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -96,16 +96,14 @@ async def test_client_server_error(servicer):
 @pytest.mark.asyncio
 async def test_client_old_version(servicer):
     with pytest.raises(VersionError):
-        async with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, ("foo-id", "foo-secret"), version="0.0.0"):
+        async with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, ("ak-123", "as-123"), version="0.0.0"):
             pass
 
 
 @pytest.mark.asyncio
 async def test_client_deprecated(servicer):
     with pytest.warns(modal.exception.DeprecationError):
-        async with Client(
-            servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, ("foo-id", "foo-secret"), version="deprecated"
-        ):
+        async with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, ("ak-123", "as-123"), version="deprecated"):
             pass
 
 
@@ -119,8 +117,8 @@ async def test_client_unauthenticated(servicer):
 def client_from_env(client_addr):
     _override_config = {
         "server_url": client_addr,
-        "token_id": "foo-id",
-        "token_secret": "foo-secret",
+        "token_id": "ak-123",
+        "token_secret": "as-123",
         "task_id": None,
         "task_secret": None,
     }
@@ -191,7 +189,7 @@ def test_implicit_default_profile_warning(servicer, modal_config):
     """
     with modal_config(config):
         # A single profile should be fine, even if not explicitly active and named 'default'
-        Client.verify(servicer.client_addr, None)
+        Client.verify(servicer.client_addr, ("ak-123", "as-123"))
 
 
 def test_import_modal_from_thread(supports_dir):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -249,7 +249,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         if event.metadata["x-modal-client-type"] == "1":  # CLIENT_TYPE_CLIENT
             creds = (event.metadata["x-modal-token-id"], event.metadata["x-modal-token-secret"])
             if creds != ("ak-123", "as-123"):
-                raise GRPCError(Status.UNAUTHENTICATED, "Incorrect auth token")
+                raise GRPCError(Status.UNAUTHENTICATED, f"Incorrect auth token {creds}")
         elif event.metadata["x-modal-client-type"] == "3":  # CLIENT_TYPE_CONTAINER
             assert "x-modal-token-id" not in event.metadata
             assert "x-modal-token-secret" not in event.metadata

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -252,7 +252,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         ]:
             if header not in event.metadata:
                 raise GRPCError(Status.FAILED_PRECONDITION, f"Missing {header} header")
-        if event.metadata["x-modal-client-type"] == "1":  # CLIENT_TYPE_CLIENT
+        if event.metadata["x-modal-client-type"] == str(api_pb2.CLIENT_TYPE_CLIENT):
             if event.method_name in [
                 "/modal.client.ModalClient/TokenFlowCreate",
                 "/modal.client.ModalClient/TokenFlowWait",
@@ -264,7 +264,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
                     raise GRPCError(
                         Status.UNAUTHENTICATED, f"Incorrect auth token {creds} for method {event.method_name}"
                     )
-        elif event.metadata["x-modal-client-type"] == "3":  # CLIENT_TYPE_CONTAINER
+        elif event.metadata["x-modal-client-type"] == str(api_pb2.CLIENT_TYPE_CONTAINER):
             for header in [
                 "x-modal-token-id",
                 "x-modal-token-secret",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -237,7 +237,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
         self.image_join_sleep_duration = None
 
-        self.required_creds = ("ak-123", "as-123")
+        self.required_creds = {("ak-123", "as-123")}
 
         @self.function_body
         def default_function_body(*args, **kwargs):
@@ -260,7 +260,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
                 pass  # Methods that don't require authentication
             else:
                 creds = (event.metadata.get("x-modal-token-id"), event.metadata.get("x-modal-token-secret"))
-                if creds != self.required_creds:
+                if creds not in self.required_creds:
                     raise GRPCError(
                         Status.UNAUTHENTICATED, f"Incorrect auth token {creds} for method {event.method_name}"
                     )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -272,7 +272,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
                 "x-modal-task-secret",  # old
             ]:
                 if header in event.metadata:
-                    raise GRPCError(Status.FAILED_PRECONDITION, f"Container client should not header {header}")
+                    raise GRPCError(Status.FAILED_PRECONDITION, f"Container client should not set header {header}")
         else:
             raise GRPCError(Status.FAILED_PRECONDITION, "Unknown client type")
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1806,6 +1806,13 @@ async def server_url_env(servicer, monkeypatch):
     yield
 
 
+@pytest_asyncio.fixture(scope="function")
+async def token_env(servicer, monkeypatch):
+    monkeypatch.setenv("MODAL_TOKEN_ID", "ak-123")
+    monkeypatch.setenv("MODAL_TOKEN_SECRET", "as-123")
+    yield
+
+
 @pytest_asyncio.fixture(scope="function", autouse=True)
 async def reset_default_client():
     Client.set_env_client(None)

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -141,7 +141,13 @@ async def test_container_debug_snapshot(container_client, tmpdir, servicer):
     test_breakpoint = mock.Mock()
     with mock.patch("sys.breakpointhook", test_breakpoint):
         with mock.patch.dict(
-            os.environ, {"MODAL_RESTORE_STATE_PATH": str(restore_path), "MODAL_SERVER_URL": servicer.container_addr}
+            os.environ,
+            {
+                "MODAL_RESTORE_STATE_PATH": str(restore_path),
+                "MODAL_SERVER_URL": servicer.container_addr,
+                "MODAL_TOKEN_ID": "ak-123",
+                "MODAL_TOKEN_SECRET": "as-123",
+            },
         ):
             io_manager.memory_snapshot()
             test_breakpoint.assert_called_once()

--- a/test/e2e_test.py
+++ b/test/e2e_test.py
@@ -11,6 +11,8 @@ def _cli(args, server_url, extra_env={}, check=True) -> Tuple[int, str, str]:
     args = [sys.executable] + args
     env = {
         "MODAL_SERVER_URL": server_url,
+        "MODAL_TOKEN_ID": "ak-123",
+        "MODAL_TOKEN_SECRET": "as-123",
         **os.environ,
         "PYTHONUTF8": "1",  # For windows
         **extra_env,
@@ -61,7 +63,7 @@ def test_auth_failure_last_line(servicer):
     )
     try:
         assert returncode != 0
-        assert "bad bad bad" in err.strip().split("\n")[-1]  # err msg should be on the last line
+        assert "auth token" in err.strip().split("\n")[-1]  # err msg should be on the last line
     except Exception:
         print("out:", repr(out))
         print("err:", repr(err))

--- a/test/fork_test.py
+++ b/test/fork_test.py
@@ -5,7 +5,7 @@ from test.supports.skip import skip_windows
 
 
 @skip_windows("fork not supported on windows")
-def test_process_fork(supports_dir, server_url_env):
+def test_process_fork(supports_dir, server_url_env, token_env):
     output = subprocess.check_output([sys.executable, supports_dir / "forking.py"], timeout=2, encoding="utf8")
 
     success_pids = set(int(x) for x in output.split())

--- a/test/grpc_utils_test.py
+++ b/test/grpc_utils_test.py
@@ -10,6 +10,14 @@ from modal_proto import api_grpc, api_pb2
 
 from .supports.skip import skip_windows_unix_socket
 
+metadata = {
+    "x-modal-client-type": "1",
+    "x-modal-python-version": "3.12.1",
+    "x-modal-client-version": "0.99",
+    "x-modal-token-id": "ak-123",
+    "x-modal-token-secret": "as-123",
+}
+
 
 @pytest.mark.asyncio
 async def test_http_channel(servicer):
@@ -18,7 +26,7 @@ async def test_http_channel(servicer):
     client_stub = api_grpc.ModalClientStub(channel)
 
     req = api_pb2.BlobCreateRequest()
-    resp = await client_stub.BlobCreate(req)
+    resp = await client_stub.BlobCreate(req, metadata=metadata)
     assert resp.blob_id
 
     channel.close()
@@ -32,7 +40,7 @@ async def test_unix_channel(servicer):
     client_stub = api_grpc.ModalClientStub(channel)
 
     req = api_pb2.BlobCreateRequest()
-    resp = await client_stub.BlobCreate(req)
+    resp = await client_stub.BlobCreate(req, metadata=metadata)
     assert resp.blob_id
 
     channel.close()

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -26,7 +26,14 @@ def deploy_app_externally(
             **{"PYTHONUTF8": "1"},
         }  # windows apparently needs a bunch of env vars to start python...
 
-    env = {**windows_support, "MODAL_SERVER_URL": servicer.client_addr, "MODAL_ENVIRONMENT": "main", **env}
+    env = {
+        **windows_support,
+        "MODAL_SERVER_URL": servicer.client_addr,
+        "MODAL_TOKEN_ID": "ak-123",
+        "MODAL_TOKEN_SECRET": "as-123",
+        "MODAL_ENVIRONMENT": "main",
+        **env,
+    }
     if cwd is None:
         cwd = pathlib.Path(__file__).parent.parent
 

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -913,7 +913,7 @@ def test_image_builder_version(servicer, test_dir, modal_config):
             with mock.patch("modal.image._base_image_config", mock_base_image_config):
                 with mock.patch("test.conftest.ImageBuilderVersion", Literal["2000.01"]):
                     with mock.patch("modal.image.ImageBuilderVersion", Literal["2000.01"]):
-                        with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, ("ak-123", "as-xyz")) as client:
+                        with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, ("ak-123", "as-123")) as client:
                             with modal_config():
                                 with app.run(client=client):
                                     assert servicer.image_builder_versions
@@ -929,7 +929,7 @@ def test_image_builder_supported_versions(servicer):
     with pytest.raises(VersionError, match=r"This version of the modal client supports.+{'2000.01'}"):
         with mock.patch("modal.image.ImageBuilderVersion", Literal["2000.01"]):
             with mock.patch("test.conftest.ImageBuilderVersion", Literal["2023.11"]):
-                with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, ("ak-123", "as-xyz")) as client:
+                with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, ("ak-123", "as-123")) as client:
                     with app.run(client=client):
                         pass
 

--- a/test/live_reload_test.py
+++ b/test/live_reload_test.py
@@ -18,7 +18,7 @@ def app_ref(test_dir):
 
 
 @pytest.mark.asyncio
-async def test_live_reload(app_ref, server_url_env, servicer):
+async def test_live_reload(app_ref, server_url_env, token_env, servicer):
     async with serve_app.aio(app, app_ref):
         await asyncio.sleep(3.0)
     assert servicer.app_publish_count == 1
@@ -27,7 +27,7 @@ async def test_live_reload(app_ref, server_url_env, servicer):
 
 
 @pytest.mark.asyncio
-async def test_live_reload_with_logs(app_ref, server_url_env, servicer):
+async def test_live_reload_with_logs(app_ref, server_url_env, token_env, servicer):
     with enable_output():
         async with serve_app.aio(app, app_ref):
             await asyncio.sleep(3.0)
@@ -37,7 +37,7 @@ async def test_live_reload_with_logs(app_ref, server_url_env, servicer):
 
 
 @skip_windows("live-reload not supported on windows")
-def test_file_changes_trigger_reloads(app_ref, server_url_env, servicer):
+def test_file_changes_trigger_reloads(app_ref, server_url_env, token_env, servicer):
     watcher_done = threading.Event()
 
     async def fake_watch():
@@ -60,7 +60,7 @@ def test_file_changes_trigger_reloads(app_ref, server_url_env, servicer):
 
 
 @pytest.mark.asyncio
-async def test_no_change(app_ref, server_url_env, servicer):
+async def test_no_change(app_ref, server_url_env, token_env, servicer):
     async def fake_watch():
         # Iterator that returns immediately, yielding nothing
         if False:
@@ -74,7 +74,7 @@ async def test_no_change(app_ref, server_url_env, servicer):
 
 
 @pytest.mark.asyncio
-async def test_heartbeats(app_ref, server_url_env, servicer):
+async def test_heartbeats(app_ref, server_url_env, token_env, servicer):
     with mock.patch("modal.runner.HEARTBEAT_INTERVAL", 1):
         t0 = time.time()
         async with serve_app.aio(app, app_ref):

--- a/test/mounted_files_test.py
+++ b/test/mounted_files_test.py
@@ -92,7 +92,7 @@ def test_mounted_files_serialized(servicer, supports_dir, env_mount_files, serve
     }
 
 
-def test_mounted_files_package(supports_dir, env_mount_files, servicer, server_url_env):
+def test_mounted_files_package(supports_dir, env_mount_files, servicer, server_url_env, token_env):
     p = subprocess.run(["modal", "run", "pkg_a.package"], cwd=supports_dir)
     assert p.returncode == 0
 
@@ -113,7 +113,7 @@ def test_mounted_files_package(supports_dir, env_mount_files, servicer, server_u
     }
 
 
-def test_mounted_files_package_no_automount(supports_dir, env_mount_files, servicer, server_url_env):
+def test_mounted_files_package_no_automount(supports_dir, env_mount_files, servicer, server_url_env, token_env):
     # when triggered like a module, the target module should be put at the correct package path
     p = subprocess.run(
         ["modal", "run", "pkg_a.package"],
@@ -130,7 +130,7 @@ def test_mounted_files_package_no_automount(supports_dir, env_mount_files, servi
 
 
 @skip_windows("venvs behave differently on Windows.")
-def test_mounted_files_sys_prefix(servicer, supports_dir, venv_path, env_mount_files, server_url_env):
+def test_mounted_files_sys_prefix(servicer, supports_dir, venv_path, env_mount_files, server_url_env, token_env):
     # Run with venv activated, so it's on sys.prefix, and modal is dev-installed in the VM
     subprocess.run(
         [venv_path / "bin" / "modal", "run", script_path],
@@ -183,7 +183,7 @@ def symlinked_python_installation_venv_path(tmp_path, repo_root):
 
 @skip_windows("venvs behave differently on Windows.")
 def test_mounted_files_symlinked_python_install(
-    symlinked_python_installation_venv_path, supports_dir, server_url_env, servicer
+    symlinked_python_installation_venv_path, supports_dir, server_url_env, token_env, servicer
 ):
     subprocess.check_call(
         [symlinked_python_installation_venv_path / "bin" / "modal", "run", supports_dir / "imports_ast.py"]
@@ -191,7 +191,7 @@ def test_mounted_files_symlinked_python_install(
     assert "/root/ast.py" not in servicer.files_name2sha
 
 
-def test_mounted_files_config(servicer, supports_dir, env_mount_files, server_url_env):
+def test_mounted_files_config(servicer, supports_dir, env_mount_files, server_url_env, token_env):
     p = subprocess.run(
         ["modal", "run", "pkg_a/script.py"], cwd=supports_dir, env={**os.environ, "MODAL_AUTOMOUNT": "0"}
     )
@@ -312,7 +312,7 @@ def test_mount_dedupe_explicit(servicer, test_dir, server_url_env):
 
 @skip_windows("pip-installed pdm seems somewhat broken on windows")
 @skip_old_py("some weird issues w/ pdm and Python 3.9", min_version=(3, 10, 0))
-def test_pdm_cache_automount_exclude(tmp_path, monkeypatch, supports_dir, servicer, server_url_env):
+def test_pdm_cache_automount_exclude(tmp_path, monkeypatch, supports_dir, servicer, server_url_env, token_env):
     # check that `pdm`'s cached packages are not included in automounts
     project_dir = Path(__file__).parent.parent
     monkeypatch.chdir(tmp_path)
@@ -332,7 +332,7 @@ def test_pdm_cache_automount_exclude(tmp_path, monkeypatch, supports_dir, servic
     }
 
 
-def test_mount_directory_with_symlinked_file(path_with_symlinked_files, servicer, server_url_env):
+def test_mount_directory_with_symlinked_file(path_with_symlinked_files, servicer, server_url_env, token_env):
     path, files = path_with_symlinked_files
     mount = Mount.from_local_dir(path)
     mount._deploy("mo-1")

--- a/test/shutdown_test.py
+++ b/test/shutdown_test.py
@@ -25,7 +25,7 @@ def close_client_soon(client):
 def test_client_shutdown_raises_client_closed(servicer):
     # Queue.get() loops rpc calls until it gets a response - make sure it shuts down
     # if the client is closed and doesn't stay in an indefinite retry loop
-    with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, ("foo-id", "foo-secret")) as client:
+    with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, ("ak-123", "as-123")) as client:
         with modal.Queue.ephemeral(client=client) as q:
             close_client_soon(client)  # simulate an early shutdown of the client
             with pytest.raises(modal.exception.ClientClosed):
@@ -56,14 +56,14 @@ async def test_client_shutdown_raises_client_closed_streaming(servicer, caplog):
 
     sync_log_loop = synchronize_api(_mocked_logs_loop)
 
-    with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, ("foo-id", "foo-secret")) as client:
+    with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, ("ak-123", "as-123")) as client:
         t = asyncio.create_task(sync_log_loop.aio(client, "ap-1"))
         await asyncio.sleep(0.1)  # in loop
 
     with pytest.raises(ClientClosed):
         await t
 
-    with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, ("foo-id", "foo-secret")) as client:
+    with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, ("ak-123", "as-123")) as client:
         t = asyncio.create_task(_mocked_logs_loop(client, "ap-1"))
         await asyncio.sleep(0.1)  # in loop
 
@@ -77,7 +77,7 @@ async def test_client_shutdown_raises_client_closed_streaming(servicer, caplog):
 @pytest.mark.timeout(5)
 @pytest.mark.asyncio
 async def test_client_close_cancellation_context_only_used_in_correct_event_loop(servicer, caplog):
-    with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, ("foo-id", "foo-secret")) as client:
+    with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, ("ak-123", "as-123")) as client:
         with modal.Queue.ephemeral(client=client) as q:
             request = api_pb2.QueueGetRequest(
                 queue_id=q.object_id,


### PR DESCRIPTION
This makes the credential authentication in tests a lot more strict – it checks the token and secret on every request. Basically what the real production API already does.

This change will make it easier to remove `ClientHello` while retain tests for most/all of the logic (since we're going to rely on grpc errors from other routes instead).

Broken out of #2361 which conflated a bunch of different changes. Better to make tests stricter first.

Ended up being a much bigger change than I anticipated (lots of test that relied on no authentication).

Open question: should we create a random token for _each test_? That wouldn't be significantly harder and maybe it's an even stronger test.