### PR TITLE
Remove progress bar for Image.run_function snapshot uploads

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -423,11 +423,7 @@ class _Image(_Object, type_prefix="im"):
                     if response.result.status:
                         result = response.result
                     for task_log in response.task_logs:
-                        if task_log.task_progress.pos or task_log.task_progress.len:
-                            assert task_log.task_progress.progress_type == api_pb2.IMAGE_SNAPSHOT_UPLOAD
-                            if output_mgr := _get_output_manager():
-                                output_mgr.update_snapshot_progress(image_id, task_log.task_progress)
-                        elif task_log.data:
+                        if task_log.data:
                             if output_mgr := _get_output_manager():
                                 await output_mgr.put_log_content(task_log)
                 if output_mgr := _get_output_manager():


### PR DESCRIPTION
I noticed that we show a live progress bar during the "Image snapshot" phase only for `Image.run_function` layers and not for other layer types. I can't quite follow the blame history, but it looks like the divergence may have been introduced in a refactor a while ago.

This PR removes the "Image snapshot progress" concept from the `OutputManager` altogether.

I can't think of a reason we'd want to only show it for `Image.run_function` layers, so I am assuming the special case is unintentional (looks like a side effect of populating the `ImageJoinStreamingResponse.task_logs` field). In my experience this step is pretty fast these days and doesn't benefit much from showing a progress bar. And, generally speaking, I would like to reduce the complexity of the `OutputManager`. So this feels like a net improvement.