### PR TITLE
snapshots: add snapshot_debug flag for debugging

### DIFF
--- a/modal/config.py
+++ b/modal/config.py
@@ -220,6 +220,7 @@ _SETTINGS = {
     "traceback": _Setting(False, transform=_to_boolean),
     "image_builder_version": _Setting(),
     "strict_parameters": _Setting(False, transform=_to_boolean),  # For internal/experimental use
+    "snapshot_debug": _Setting(False, transform=_to_boolean),
 }
 
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -846,6 +846,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                     class_parameter_info=info.class_parameter_info(),
                     i6pn_enabled=i6pn_enabled,
                     schedule=schedule.proto_message if schedule is not None else None,
+                    snapshot_debug=config.get("snapshot_debug"),
                     _experimental_group_size=group_size or 0,  # Experimental: Grouped functions
                     _experimental_concurrent_cancellations=True,
                     _experimental_buffer_containers=_experimental_buffer_containers or 0,

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1081,6 +1081,7 @@ message Function {
 
   Schedule schedule = 72;
 
+  bool snapshot_debug = 73; // For internal debugging use only.
 }
 
 message FunctionBindParamsRequest {


### PR DESCRIPTION
## Describe your changes

Add the ability to create a snapshot on an ephemeral App and thus get a debugger on restore. 

```
MODAL_SNAPSHOT_DEBUG=1 modal run --interactive wrk197.py
```

This was very helpful today in debugging WRK-197. 

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
    - old servers will ignore the field
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
