### PR TITLE
Use unique server credentials in every unit test

### DIFF
--- a/test/app_composition_test.py
+++ b/test/app_composition_test.py
@@ -2,8 +2,8 @@
 from test.helpers import deploy_app_externally
 
 
-def test_app_composition_includes_all_functions(servicer, supports_dir, monkeypatch, client):
-    print(deploy_app_externally(servicer, "main.py", cwd=supports_dir / "multifile_project"))
+def test_app_composition_includes_all_functions(servicer, credentials, supports_dir, monkeypatch, client):
+    print(deploy_app_externally(servicer, credentials, "main.py", cwd=supports_dir / "multifile_project"))
     assert servicer.n_functions == 3
     assert {"/root/main.py", "/root/a.py", "/root/b.py", "/root/c.py"} == set(servicer.files_name2sha.keys())
     assert len(servicer.secrets) == 1  # secret from B should be included

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -127,7 +127,7 @@ def test_container_snapshot_restore_heartbeats(tmpdir, servicer, container_clien
 
 
 @pytest.mark.asyncio
-async def test_container_debug_snapshot(container_client, tmpdir, servicer):
+async def test_container_debug_snapshot(container_client, tmpdir, servicer, credentials):
     # Get an IO manager, where restore takes place
     io_manager = ContainerIOManager(api_pb2.ContainerArguments(), container_client)
     restore_path = tmpdir.join("fake-restore-state.json")
@@ -140,13 +140,15 @@ async def test_container_debug_snapshot(container_client, tmpdir, servicer):
     # Test that the breakpoint was called
     test_breakpoint = mock.Mock()
     with mock.patch("sys.breakpointhook", test_breakpoint):
+        # TODO(erikbern): we should use a container client w/o credentials here
+        token_id, token_secret = credentials
         with mock.patch.dict(
             os.environ,
             {
                 "MODAL_RESTORE_STATE_PATH": str(restore_path),
                 "MODAL_SERVER_URL": servicer.container_addr,
-                "MODAL_TOKEN_ID": "ak-123",
-                "MODAL_TOKEN_SECRET": "as-123",
+                "MODAL_TOKEN_ID": token_id,
+                "MODAL_TOKEN_SECRET": token_secret,
             },
         ):
             io_manager.memory_snapshot()

--- a/test/e2e_test.py
+++ b/test/e2e_test.py
@@ -6,13 +6,14 @@ import sys
 from typing import Tuple
 
 
-def _cli(args, server_url, extra_env={}, check=True) -> Tuple[int, str, str]:
+def _cli(args, server_url, credentials, extra_env={}, check=True) -> Tuple[int, str, str]:
     lib_dir = pathlib.Path(__file__).parent.parent
     args = [sys.executable] + args
+    token_id, token_secret = credentials
     env = {
         "MODAL_SERVER_URL": server_url,
-        "MODAL_TOKEN_ID": "ak-123",
-        "MODAL_TOKEN_SECRET": "as-123",
+        "MODAL_TOKEN_ID": token_id,
+        "MODAL_TOKEN_SECRET": token_secret,
         **os.environ,
         "PYTHONUTF8": "1",  # For windows
         **extra_env,
@@ -26,13 +27,13 @@ def _cli(args, server_url, extra_env={}, check=True) -> Tuple[int, str, str]:
     return ret.returncode, stdout, stderr
 
 
-def test_run_e2e(servicer):
-    _, _, err = _cli(["-m", "test.supports.script"], servicer.client_addr)
+def test_run_e2e(servicer, credentials):
+    _, _, err = _cli(["-m", "test.supports.script"], servicer.client_addr, credentials)
     assert err == ""
 
 
-def test_run_progress_info(servicer):
-    returncode, stdout, stderr = _cli(["-m", "test.supports.progress_info"], servicer.client_addr)
+def test_run_progress_info(servicer, credentials):
+    returncode, stdout, stderr = _cli(["-m", "test.supports.progress_info"], servicer.client_addr, credentials)
     assert returncode == 0
     assert stderr == ""
     lines = stdout.splitlines()
@@ -40,24 +41,25 @@ def test_run_progress_info(servicer):
     assert "App completed" in lines[-1]
 
 
-def test_run_profiler(servicer):
-    _cli(["-m", "cProfile", "-m", "test.supports.script"], servicer.client_addr)
+def test_run_profiler(servicer, credentials):
+    _cli(["-m", "cProfile", "-m", "test.supports.script"], servicer.client_addr, credentials)
 
 
-def test_run_unconsumed_map(servicer):
-    _, _, err = _cli(["-m", "test.supports.unconsumed_map"], servicer.client_addr)
+def test_run_unconsumed_map(servicer, credentials):
+    _, _, err = _cli(["-m", "test.supports.unconsumed_map"], servicer.client_addr, credentials)
     assert "map" in err
     assert "for-loop" in err
 
-    _, _, err = _cli(["-m", "test.supports.consumed_map"], servicer.client_addr)
+    _, _, err = _cli(["-m", "test.supports.consumed_map"], servicer.client_addr, credentials)
     assert "map" not in err
     assert "for-loop" not in err
 
 
-def test_auth_failure_last_line(servicer):
+def test_auth_failure_last_line(servicer, credentials):
     returncode, out, err = _cli(
         ["-m", "test.supports.script"],
         servicer.client_addr,
+        credentials,
         extra_env={"MODAL_TOKEN_ID": "bad", "MODAL_TOKEN_SECRET": "bad"},
         check=False,
     )

--- a/test/grpc_utils_test.py
+++ b/test/grpc_utils_test.py
@@ -10,17 +10,17 @@ from modal_proto import api_grpc, api_pb2
 
 from .supports.skip import skip_windows_unix_socket
 
-metadata = {
-    "x-modal-client-type": "1",
-    "x-modal-python-version": "3.12.1",
-    "x-modal-client-version": "0.99",
-    "x-modal-token-id": "ak-123",
-    "x-modal-token-secret": "as-123",
-}
-
 
 @pytest.mark.asyncio
-async def test_http_channel(servicer):
+async def test_http_channel(servicer, credentials):
+    token_id, token_secret = credentials
+    metadata = {
+        "x-modal-client-type": str(api_pb2.CLIENT_TYPE_CLIENT),
+        "x-modal-python-version": "3.12.1",
+        "x-modal-client-version": "0.99",
+        "x-modal-token-id": token_id,
+        "x-modal-token-secret": token_secret,
+    }
     assert servicer.client_addr.startswith("http://")
     channel = create_channel(servicer.client_addr)
     client_stub = api_grpc.ModalClientStub(channel)
@@ -35,6 +35,11 @@ async def test_http_channel(servicer):
 @skip_windows_unix_socket
 @pytest.mark.asyncio
 async def test_unix_channel(servicer):
+    metadata = {
+        "x-modal-client-type": str(api_pb2.CLIENT_TYPE_CONTAINER),
+        "x-modal-python-version": "3.12.1",
+        "x-modal-client-version": "0.99",
+    }
     assert servicer.container_addr.startswith("unix://")
     channel = create_channel(servicer.container_addr)
     client_stub = api_grpc.ModalClientStub(channel)

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -3,11 +3,12 @@ import os
 import pathlib
 import subprocess
 import sys
-from typing import Optional
+from typing import Optional, Tuple
 
 
 def deploy_app_externally(
     servicer,
+    credentials: Tuple[str, str],
     file_or_module: str,
     app_variable: Optional[str] = None,
     deployment_name="Deployment",
@@ -26,11 +27,12 @@ def deploy_app_externally(
             **{"PYTHONUTF8": "1"},
         }  # windows apparently needs a bunch of env vars to start python...
 
+    token_id, token_secret = credentials
     env = {
         **windows_support,
         "MODAL_SERVER_URL": servicer.client_addr,
-        "MODAL_TOKEN_ID": "ak-123",
-        "MODAL_TOKEN_SECRET": "as-123",
+        "MODAL_TOKEN_ID": token_id,
+        "MODAL_TOKEN_SECRET": token_secret,
         "MODAL_ENVIRONMENT": "main",
         **env,
     }

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -894,7 +894,7 @@ def test_get_modal_requirements_path(builder_version, python_version):
         assert path.endswith(f"{builder_version}.txt")
 
 
-def test_image_builder_version(servicer, test_dir, modal_config):
+def test_image_builder_version(servicer, credentials, test_dir, modal_config):
     app = App(image=Image.debian_slim())
     app.function()(dummy)
 
@@ -913,7 +913,7 @@ def test_image_builder_version(servicer, test_dir, modal_config):
             with mock.patch("modal.image._base_image_config", mock_base_image_config):
                 with mock.patch("test.conftest.ImageBuilderVersion", Literal["2000.01"]):
                     with mock.patch("modal.image.ImageBuilderVersion", Literal["2000.01"]):
-                        with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, ("ak-123", "as-123")) as client:
+                        with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, credentials) as client:
                             with modal_config():
                                 with app.run(client=client):
                                     assert servicer.image_builder_versions
@@ -921,7 +921,7 @@ def test_image_builder_version(servicer, test_dir, modal_config):
                                         assert version == "2000.01"
 
 
-def test_image_builder_supported_versions(servicer):
+def test_image_builder_supported_versions(servicer, credentials):
     app = App(image=Image.debian_slim())
     app.function()(dummy)
 
@@ -929,7 +929,7 @@ def test_image_builder_supported_versions(servicer):
     with pytest.raises(VersionError, match=r"This version of the modal client supports.+{'2000.01'}"):
         with mock.patch("modal.image.ImageBuilderVersion", Literal["2000.01"]):
             with mock.patch("test.conftest.ImageBuilderVersion", Literal["2023.11"]):
-                with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, ("ak-123", "as-123")) as client:
+                with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, credentials) as client:
                     with app.run(client=client):
                         pass
 

--- a/test/mounted_files_test.py
+++ b/test/mounted_files_test.py
@@ -53,8 +53,8 @@ async def env_mount_files():
     return filenames
 
 
-def test_mounted_files_script(servicer, supports_dir, env_mount_files, server_url_env):
-    helpers.deploy_app_externally(servicer, script_path, cwd=supports_dir)
+def test_mounted_files_script(servicer, credentials, supports_dir, env_mount_files, server_url_env):
+    helpers.deploy_app_externally(servicer, credentials, script_path, cwd=supports_dir)
     files = set(servicer.files_name2sha.keys()) - set(env_mount_files)
 
     # Assert we include everything from `pkg_a` and `pkg_b` but not `pkg_c`:
@@ -72,8 +72,8 @@ def test_mounted_files_script(servicer, supports_dir, env_mount_files, server_ur
 serialized_fn_path = "pkg_a/serialized_fn.py"
 
 
-def test_mounted_files_serialized(servicer, supports_dir, env_mount_files, server_url_env):
-    helpers.deploy_app_externally(servicer, serialized_fn_path, cwd=supports_dir)
+def test_mounted_files_serialized(servicer, credentials, supports_dir, env_mount_files, server_url_env):
+    helpers.deploy_app_externally(servicer, credentials, serialized_fn_path, cwd=supports_dir)
     files = set(servicer.files_name2sha.keys()) - set(env_mount_files)
 
     # Assert we include everything from `pkg_a` and `pkg_b` but not `pkg_c`:
@@ -202,8 +202,8 @@ def test_mounted_files_config(servicer, supports_dir, env_mount_files, server_ur
     }
 
 
-def test_e2e_modal_run_py_file_mounts(servicer, supports_dir):
-    helpers.deploy_app_externally(servicer, "hello.py", cwd=supports_dir)
+def test_e2e_modal_run_py_file_mounts(servicer, credentials, supports_dir):
+    helpers.deploy_app_externally(servicer, credentials, "hello.py", cwd=supports_dir)
     # Reactivate the following mount assertions when we remove auto-mounting of dev-installed packages
     # assert len(servicer.files_name2sha) == 1
     # assert servicer.n_mounts == 1  # there should be a single mount
@@ -211,8 +211,8 @@ def test_e2e_modal_run_py_file_mounts(servicer, supports_dir):
     assert "/root/hello.py" in servicer.files_name2sha
 
 
-def test_e2e_modal_run_py_module_mounts(servicer, supports_dir):
-    helpers.deploy_app_externally(servicer, "hello", cwd=supports_dir)
+def test_e2e_modal_run_py_module_mounts(servicer, credentials, supports_dir):
+    helpers.deploy_app_externally(servicer, credentials, "hello", cwd=supports_dir)
     # Reactivate the following mount assertions when we remove auto-mounting of dev-installed packages
     # assert len(servicer.files_name2sha) == 1
     # assert servicer.n_mounts == 1  # there should be a single mount
@@ -252,7 +252,7 @@ def test_mounts_are_not_traversed_on_declaration(test_dir, monkeypatch, client, 
     assert __file__ in files  # this test file should have been included
 
 
-def test_mount_dedupe(servicer, test_dir, server_url_env):
+def test_mount_dedupe(servicer, credentials, test_dir, server_url_env):
     supports_dir = test_dir / "supports"
     normally_not_included_file = supports_dir / "pkg_a" / "normally_not_included.pyc"
     normally_not_included_file.touch(exist_ok=True)
@@ -260,6 +260,7 @@ def test_mount_dedupe(servicer, test_dir, server_url_env):
         helpers.deploy_app_externally(
             # no explicit mounts, rely on auto-mounting
             servicer,
+            credentials,
             "mount_dedupe.py",
             cwd=test_dir / "supports",
             env={"USE_EXPLICIT": "0"},
@@ -273,7 +274,7 @@ def test_mount_dedupe(servicer, test_dir, server_url_env):
     assert "/root/pkg_a/normally_not_included.pyc" not in pkg_a_mount.keys()
 
 
-def test_mount_dedupe_explicit(servicer, test_dir, server_url_env):
+def test_mount_dedupe_explicit(servicer, credentials, test_dir, server_url_env):
     supports_dir = test_dir / "supports"
     normally_not_included_file = supports_dir / "pkg_a" / "normally_not_included.pyc"
     normally_not_included_file.touch(exist_ok=True)
@@ -281,6 +282,7 @@ def test_mount_dedupe_explicit(servicer, test_dir, server_url_env):
         helpers.deploy_app_externally(
             # two explicit mounts of the same package
             servicer,
+            credentials,
             "mount_dedupe.py",
             cwd=supports_dir,
             env={"USE_EXPLICIT": "1"},

--- a/test/shutdown_test.py
+++ b/test/shutdown_test.py
@@ -22,10 +22,10 @@ def close_client_soon(client):
 
 
 @pytest.mark.timeout(5)
-def test_client_shutdown_raises_client_closed(servicer):
+def test_client_shutdown_raises_client_closed(servicer, credentials):
     # Queue.get() loops rpc calls until it gets a response - make sure it shuts down
     # if the client is closed and doesn't stay in an indefinite retry loop
-    with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, ("ak-123", "as-123")) as client:
+    with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, credentials) as client:
         with modal.Queue.ephemeral(client=client) as q:
             close_client_soon(client)  # simulate an early shutdown of the client
             with pytest.raises(modal.exception.ClientClosed):
@@ -40,7 +40,7 @@ def test_client_shutdown_raises_client_closed(servicer):
 
 @pytest.mark.timeout(5)
 @pytest.mark.asyncio
-async def test_client_shutdown_raises_client_closed_streaming(servicer, caplog):
+async def test_client_shutdown_raises_client_closed_streaming(servicer, credentials, caplog):
     # Queue.get() loops rpc calls until it gets a response - make sure it shuts down
     # if the client is closed and doesn't stay in an indefinite retry loop
 
@@ -56,14 +56,14 @@ async def test_client_shutdown_raises_client_closed_streaming(servicer, caplog):
 
     sync_log_loop = synchronize_api(_mocked_logs_loop)
 
-    with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, ("ak-123", "as-123")) as client:
+    with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, credentials) as client:
         t = asyncio.create_task(sync_log_loop.aio(client, "ap-1"))
         await asyncio.sleep(0.1)  # in loop
 
     with pytest.raises(ClientClosed):
         await t
 
-    with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, ("ak-123", "as-123")) as client:
+    with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, credentials) as client:
         t = asyncio.create_task(_mocked_logs_loop(client, "ap-1"))
         await asyncio.sleep(0.1)  # in loop
 
@@ -76,8 +76,8 @@ async def test_client_shutdown_raises_client_closed_streaming(servicer, caplog):
 
 @pytest.mark.timeout(5)
 @pytest.mark.asyncio
-async def test_client_close_cancellation_context_only_used_in_correct_event_loop(servicer, caplog):
-    with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, ("ak-123", "as-123")) as client:
+async def test_client_close_cancellation_context_only_used_in_correct_event_loop(servicer, credentials, caplog):
+    with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, credentials) as client:
         with modal.Queue.ephemeral(client=client) as q:
             request = api_pb2.QueueGetRequest(
                 queue_id=q.object_id,


### PR DESCRIPTION
Instead of hardcoded `("ak-123", "as-123")`, use a unique one for each test. This ensures we don't have state leakage between tests. Almost disappointed it didn't catch anything.

Was easier than I thought. Came out of https://github.com/modal-labs/modal-client/pull/2368