### PR TITLE
Don't explicity check that the client is authenticated

### DIFF
--- a/modal/client.py
+++ b/modal/client.py
@@ -115,7 +115,6 @@ class _Client:
         self.client_type = client_type
         self._credentials = credentials
         self.version = version
-        self._authenticated = False
         self._closed = False
         self._channel: Optional[grpclib.client.Channel] = None
         self._stub: Optional[modal_api_grpc.ModalClientModal] = None
@@ -124,10 +123,6 @@ class _Client:
 
     def is_closed(self) -> bool:
         return self._closed
-
-    @property
-    def authenticated(self):
-        return self._authenticated
 
     @property
     def stub(self) -> modal_api_grpc.ModalClientModal:
@@ -174,7 +169,6 @@ class _Client:
             if resp.warning:
                 ALARM_EMOJI = chr(0x1F6A8)
                 warnings.warn(f"{ALARM_EMOJI} {resp.warning} {ALARM_EMOJI}", DeprecationError)
-            self._authenticated = True
         except GRPCError as exc:
             if exc.status == Status.FAILED_PRECONDITION:
                 raise VersionError(

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -25,7 +25,6 @@ from .cls import _Cls
 from .config import config, logger
 from .environments import _get_environment_cached
 from .exception import (
-    ExecutionError,
     InteractiveTimeoutError,
     InvalidError,
     RemoteError,
@@ -289,9 +288,6 @@ async def _run_app(
     if client is None:
         client = await _Client.from_env()
 
-    if not client.authenticated:
-        raise ExecutionError("Objects cannot be created with an unauthenticated client")
-
     app_state = api_pb2.APP_STATE_DETACHED if detach else api_pb2.APP_STATE_EPHEMERAL
     running_app: RunningApp = await _init_local_app_new(
         client,
@@ -502,9 +498,6 @@ async def _deploy_app(
 
     if client is None:
         client = await _Client.from_env()
-
-    if not client.authenticated:
-        raise ExecutionError("Objects cannot be created with an unauthenticated client")
 
     t0 = time.time()
 

--- a/test/runner_test.py
+++ b/test/runner_test.py
@@ -2,9 +2,10 @@
 import pytest
 import typing
 
+from grpclib import GRPCError, Status
+
 import modal
 from modal.client import Client
-from modal.exception import ExecutionError
 from modal.runner import run_app
 from modal_proto import api_pb2
 
@@ -25,9 +26,10 @@ def test_run_app(servicer, client):
 def test_run_app_unauthenticated(servicer):
     dummy_app = modal.App()
     with Client.anonymous(servicer.client_addr) as client:
-        with pytest.raises(ExecutionError, match=".+unauthenticated client"):
+        with pytest.raises(GRPCError) as excinfo:
             with run_app(dummy_app, client=client):
                 pass
+        assert excinfo.value.status == Status.UNAUTHENTICATED
 
 
 def dummy():


### PR DESCRIPTION
We don't need an explicit check for this – the GRPC routes will fail properly anyway. And I can't think of a single realistic scenario where this could actually happen.

This helps us remove `ClientHello`