### PR TITLE
More tests for creating clients

### DIFF
--- a/test/client_test.py
+++ b/test/client_test.py
@@ -126,7 +126,7 @@ def client_from_env(client_addr, credentials):
     return Client.from_env(_override_config=_override_config)
 
 
-def test_client_from_env(servicer, credentials):
+def test_client_from_env_client(servicer, credentials):
     try:
         # First, a failing one
         with pytest.raises(ConnectionError):
@@ -198,3 +198,27 @@ def test_import_modal_from_thread(supports_dir):
     # For example, in Python <3.10, creating loop-bound asyncio primitives in global scope would
     # trigger an exception if there is no event loop in the thread (and it's not the main thread)
     subprocess.check_call([sys.executable, supports_dir / "import_modal_from_thread.py"])
+
+
+@pytest.mark.asyncio
+async def test_from_env_container(servicer, container_env):
+    servicer.required_creds = {}  # Disallow default client creds
+    await Client.from_env.aio()
+    # TODO(erikbern): once we no longer run ClientHello by default, add a ping here
+
+
+@pytest.mark.asyncio
+async def test_from_credentials_client(servicer, set_env_client, server_url_env, token_env):
+    # Note: this explicitly uses a lot of fixtures to make sure those are ignored
+    creds = ("ak-foo-1", "as-bar")
+    servicer.required_creds = {creds}
+    await Client.from_credentials.aio(*creds)
+    # TODO(erikbern): once we no longer run ClientHello by default, add a ping here
+
+
+@pytest.mark.asyncio
+async def test_from_credentials_container(servicer, container_env):
+    creds = ("ak-foo-2", "as-bar")
+    servicer.required_creds = {creds}
+    await Client.from_credentials.aio(*creds)
+    # TODO(erikbern): once we no longer run ClientHello by default, add a ping here

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -200,25 +200,22 @@ def test_import_modal_from_thread(supports_dir):
     subprocess.check_call([sys.executable, supports_dir / "import_modal_from_thread.py"])
 
 
-@pytest.mark.asyncio
-async def test_from_env_container(servicer, container_env):
+def test_from_env_container(servicer, container_env):
     servicer.required_creds = {}  # Disallow default client creds
-    await Client.from_env.aio()
+    Client.from_env()
     # TODO(erikbern): once we no longer run ClientHello by default, add a ping here
 
 
-@pytest.mark.asyncio
-async def test_from_credentials_client(servicer, set_env_client, server_url_env, token_env):
+def test_from_credentials_client(servicer, set_env_client, server_url_env, token_env):
     # Note: this explicitly uses a lot of fixtures to make sure those are ignored
     creds = ("ak-foo-1", "as-bar")
     servicer.required_creds = {creds}
-    await Client.from_credentials.aio(*creds)
+    Client.from_credentials(*creds)
     # TODO(erikbern): once we no longer run ClientHello by default, add a ping here
 
 
-@pytest.mark.asyncio
-async def test_from_credentials_container(servicer, container_env):
+def test_from_credentials_container(servicer, container_env):
     creds = ("ak-foo-2", "as-bar")
     servicer.required_creds = {creds}
-    await Client.from_credentials.aio(*creds)
+    Client.from_credentials(*creds)
     # TODO(erikbern): once we no longer run ClientHello by default, add a ping here

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1822,6 +1822,14 @@ async def token_env(servicer, monkeypatch, credentials):
     yield
 
 
+@pytest_asyncio.fixture(scope="function")
+async def container_env(servicer, monkeypatch):
+    monkeypatch.setenv("MODAL_SERVER_URL", servicer.container_addr)
+    monkeypatch.setenv("MODAL_TASK_ID", "ta-123")
+    monkeypatch.setenv("MODAL_IS_REMOTE", "1")
+    yield
+
+
 @pytest_asyncio.fixture(scope="function", autouse=True)
 async def reset_default_client():
     Client.set_env_client(None)


### PR DESCRIPTION
@mwaskom [was asking about `from_credentials` in a different PR](https://github.com/modal-labs/modal-client/pull/2374#issuecomment-2429143497) and I realized we have zero tests for this.

Also added a test for `Client.from_env` inside containers.