### PR TITLE
Move some logic from `ClientHello` into `grpc_utils`

### DIFF
--- a/modal/client.py
+++ b/modal/client.py
@@ -134,7 +134,7 @@ class _Client:
         # Remove cached client.
         self.set_env_client(None)
 
-    async def _init(self):
+    async def hello(self):
         """Connect to server and retrieve version information; raise appropriate error for various failures."""
         logger.debug("Client: Starting")
         _check_config()
@@ -160,7 +160,7 @@ class _Client:
     async def __aenter__(self):
         await self._open()
         try:
-            await self._init()
+            await self.hello()
         except BaseException:
             await self._close()
             raise
@@ -179,7 +179,7 @@ class _Client:
         client = cls(server_url, api_pb2.CLIENT_TYPE_CLIENT, credentials=None)
         try:
             await client._open()
-            # Skip client._init
+            # Skip client.hello
             yield client
         finally:
             await client._close()
@@ -223,7 +223,7 @@ class _Client:
             client = _Client(server_url, client_type, credentials)
             await client._open()
             async_utils.on_shutdown(client._close())
-            await client._init()
+            await client.hello()
             cls._client_from_env = client
             return client
 
@@ -246,7 +246,7 @@ class _Client:
         client = _Client(server_url, client_type, credentials)
         await client._open()
         try:
-            await client._init()
+            await client.hello()
         except BaseException:
             await client._close()
             raise
@@ -307,7 +307,7 @@ class _Client:
             self.set_env_client(None)
             # TODO(elias): reset _cancellation_context in case ?
             await self._open()
-            # intentionally not doing self._init since we should already be authenticated etc.
+            # intentionally not doing self.hello since we should already be authenticated etc.
 
     async def _get_grpclib_method(self, method_name: str) -> Any:
         # safely get grcplib method that is bound to a valid channel

--- a/modal/client.py
+++ b/modal/client.py
@@ -19,7 +19,6 @@ from typing import (
 )
 
 import grpclib.client
-from aiohttp import ClientConnectorError, ClientResponseError
 from google.protobuf import empty_pb2
 from google.protobuf.message import Message
 from grpclib import GRPCError, Status
@@ -32,7 +31,6 @@ from modal_version import __version__
 from ._utils import async_utils
 from ._utils.async_utils import TaskContext, synchronize_api
 from ._utils.grpc_utils import create_channel, retry_transient_errors
-from ._utils.http_utils import ClientSessionRegistry
 from .config import _check_config, _is_remote, config, logger
 from .exception import AuthError, ClientClosed, ConnectionError, DeprecationError, VersionError
 
@@ -67,24 +65,6 @@ def _get_metadata(client_type: int, credentials: Optional[Tuple[str, str]], vers
             }
         )
     return metadata
-
-
-async def _http_check(url: str, timeout: float) -> str:
-    # Used for sanity checking connection issues
-    try:
-        async with ClientSessionRegistry.get_session().get(url) as resp:
-            return f"HTTP status: {resp.status}"
-    except ClientResponseError as exc:
-        return f"HTTP status: {exc.status}"
-    except ClientConnectorError as exc:
-        return f"HTTP exception: {exc.os_error.__class__.__name__}"
-    except Exception as exc:
-        return f"HTTP exception: {exc.__class__.__name__}"
-
-
-async def _grpc_exc_string(exc: GRPCError, method_name: str, server_url: str, timeout: float) -> str:
-    http_status = await _http_check(server_url, timeout=timeout)
-    return f"{method_name}: {exc.message} [gRPC status: {exc.status.name}, {http_status}]"
 
 
 ReturnType = TypeVar("ReturnType")
@@ -177,8 +157,7 @@ class _Client:
             elif exc.status == Status.UNAUTHENTICATED:
                 raise AuthError(exc.message)
             else:
-                exc_string = await _grpc_exc_string(exc, "ClientHello", self.server_url, CLIENT_CREATE_TOTAL_TIMEOUT)
-                raise ConnectionError(exc_string)
+                raise exc
         except (OSError, asyncio.TimeoutError) as exc:
             raise ConnectionError(str(exc))
 

--- a/modal/client.py
+++ b/modal/client.py
@@ -32,7 +32,7 @@ from ._utils import async_utils
 from ._utils.async_utils import TaskContext, synchronize_api
 from ._utils.grpc_utils import create_channel, retry_transient_errors
 from .config import _check_config, _is_remote, config, logger
-from .exception import AuthError, ClientClosed, ConnectionError, DeprecationError, VersionError
+from .exception import AuthError, ClientClosed, DeprecationError, VersionError
 
 HEARTBEAT_INTERVAL: float = config.get("heartbeat_interval")
 HEARTBEAT_TIMEOUT: float = HEARTBEAT_INTERVAL + 0.1
@@ -154,12 +154,8 @@ class _Client:
                 raise VersionError(
                     f"The client version ({self.version}) is too old. Please update (pip install --upgrade modal)."
                 )
-            elif exc.status == Status.UNAUTHENTICATED:
-                raise AuthError(exc.message)
             else:
                 raise exc
-        except (OSError, asyncio.TimeoutError) as exc:
-            raise ConnectionError(str(exc))
 
     async def __aenter__(self):
         await self._open()

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 
 from google.protobuf.empty_pb2 import Empty
+from grpclib import GRPCError
 
 import modal.exception
 from modal import Client
@@ -86,11 +87,9 @@ async def test_client_connection_timeout(servicer, monkeypatch):
 @pytest.mark.asyncio
 @pytest.mark.timeout(TEST_TIMEOUT)
 async def test_client_server_error(servicer):
-    with pytest.raises(ConnectionError) as excinfo:
-        async with Client("https://github.com", api_pb2.CLIENT_TYPE_CLIENT, None):
+    with pytest.raises(GRPCError):
+        async with Client("https://modal.com", api_pb2.CLIENT_TYPE_CLIENT, None):
             pass
-    # Can't connect over gRPC, but the HTTP lookup should succeed
-    assert "HTTP status: 200" in str(excinfo.value)
 
 
 @pytest.mark.asyncio

--- a/test/runner_test.py
+++ b/test/runner_test.py
@@ -2,10 +2,9 @@
 import pytest
 import typing
 
-from grpclib import GRPCError, Status
-
 import modal
 from modal.client import Client
+from modal.exception import AuthError
 from modal.runner import run_app
 from modal_proto import api_pb2
 
@@ -26,10 +25,9 @@ def test_run_app(servicer, client):
 def test_run_app_unauthenticated(servicer):
     dummy_app = modal.App()
     with Client.anonymous(servicer.client_addr) as client:
-        with pytest.raises(GRPCError) as excinfo:
+        with pytest.raises(AuthError):
             with run_app(dummy_app, client=client):
                 pass
-        assert excinfo.value.status == Status.UNAUTHENTICATED
 
 
 def dummy():


### PR DESCRIPTION
Requesting feedback on this change. I want to remove the need for `ClientHello` so as a part of that change, I moved some logic into `grpc_utils` for handling common errors in `retry_transient_errors` instead.

The end goal here is to get rid of `ClientHello`. We currently raise a few exceptions like `AuthError` and `ConnectionError` during that operation, and I don't want to break any user who catch those exceptions. Once we remove `ClientHello`, those exceptions will be raised in _other_ RPC calls, but it seems nice to retain the exception type.

Moving logic this way is nice because I only had to update two tests! I'm treating the number of test changes as an arguable proxy for what how much user code we could expect to break. My expectation is that very few customers rely on these custom exception types though.

### Slightly more general question about mapping grpc error codes in `grpc_utils`

We have a lot of code in the client of the form

```python
try:                                             
    resp = await retry_transient_errors(self._client.stub.VolumeCommit, req, max_retries=90)
except GRPCError as exc:
    raise RuntimeError(exc.message) if exc.status in (Status.FAILED_PRECONDITION, Status.NOT_FOUND) else exc
```

I tend to think it would be nice if `retry_transient_errors` could do _more_ of the error mapping but I think there's arguments on both sides. This change adds a handler for one particular status code (`UNAUTHENTICATED` so it's a step in that direction).