### PR TITLE
Static types: fix @exit decoration of async methods indicating a type error

### DIFF
--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -595,10 +595,12 @@ def _enter(
 
 
 ExitHandlerType = Union[
+    # NOTE: return types of these callables should be `Union[None, Awaitable[None]]` but
+    #       synchronicity type stubs would strip Awaitable so we use Any for now
     # Original, __exit__ style method signature (now deprecated)
-    Callable[[Any, Optional[Type[BaseException]], Optional[BaseException], Any], None],
+    Callable[[Any, Optional[Type[BaseException]], Optional[BaseException], Any], Any],
     # Forward-looking unparameterized method
-    Callable[[Any], None],
+    Callable[[Any], Any],
 ]
 
 


### PR DESCRIPTION
Quick and slightly ugly fix for static type errors when decorating async methods with `@modal.exit`

I was pretty sure I looked at this a good while back and we had already fixed this but apparently not 🤷 