### PR TITLE
`_check_config` in `Client.from_env`

### DIFF
--- a/modal/client.py
+++ b/modal/client.py
@@ -138,7 +138,6 @@ class _Client:
     async def hello(self):
         """Connect to server and retrieve version information; raise appropriate error for various failures."""
         logger.debug(f"Client ({id(self)}): Starting")
-        _check_config()
         try:
             req = empty_pb2.Empty()
             resp = await retry_transient_errors(
@@ -190,6 +189,8 @@ class _Client:
         """mdmd:hidden
         Singleton that is instantiated from the Modal config and reused on subsequent calls.
         """
+        _check_config()
+
         if _override_config:
             # Only used for testing
             c = _override_config
@@ -241,6 +242,7 @@ class _Client:
         modal.Sandbox.create("echo", "hi", client=client, app=app)
         ```
         """
+        _check_config()
         server_url = config["server_url"]
         client_type = api_pb2.CLIENT_TYPE_CLIENT
         credentials = (token_id, token_secret)

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -165,10 +165,10 @@ def test_multiple_profile_error(servicer, modal_config):
     """
     with modal_config(config):
         with pytest.raises(InvalidError, match="More than one Modal profile is active"):
-            Client.verify(servicer.client_addr, None)
+            Client.from_env()
 
 
-def test_implicit_default_profile_warning(servicer, modal_config, credentials):
+def test_implicit_default_profile_warning(servicer, modal_config, server_url_env):
     config = """
     [default]
     token_id = 'ak-abc'
@@ -180,7 +180,7 @@ def test_implicit_default_profile_warning(servicer, modal_config, credentials):
     """
     with modal_config(config):
         with pytest.raises(DeprecationError, match="Support for using an implicit 'default' profile is deprecated."):
-            Client.verify(servicer.client_addr, None)
+            Client.from_env()
 
     config = """
     [default]
@@ -188,8 +188,9 @@ def test_implicit_default_profile_warning(servicer, modal_config, credentials):
     token_secret = 'as_xyz'
     """
     with modal_config(config):
+        servicer.required_creds = {("ak-abc", "as_xyz")}
         # A single profile should be fine, even if not explicitly active and named 'default'
-        Client.verify(servicer.client_addr, credentials)
+        Client.from_env()
 
 
 def test_import_modal_from_thread(supports_dir):


### PR DESCRIPTION
We shouldn't run `_check_config` in `Client.hello` but rather when we're reading config data – in `Client.from_env`

Had to fix a few tests – turns out at least one of them wasn't testing what it was supposed to (I think I accidentally caused that in an earlier change)

The point of this is to remove the need for `ClientHello`