### PR TITLE
Keep supported Python series in expected order

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -61,7 +61,7 @@ ImageBuilderVersion = Literal["2023.12", "2024.04", "2024.10"]
 # so that we fail fast / clearly in unsupported containers. Additionally, we enumerate the supported
 # Python versions in mount.py where we specify the "standalone Python versions" we create mounts for.
 # Consider consolidating these multiple sources of truth?
-SUPPORTED_PYTHON_SERIES: Set[str] = {"3.8", "3.9", "3.10", "3.11", "3.12"}
+SUPPORTED_PYTHON_SERIES: List[str] = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
 LOCAL_REQUIREMENTS_DIR = Path(__file__).parent / "requirements"
 CONTAINER_REQUIREMENTS_PATH = "/modal_requirements.txt"

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -33,7 +33,7 @@ def dummy():
 
 
 def test_supported_python_series():
-    assert SUPPORTED_PYTHON_SERIES == PYTHON_STANDALONE_VERSIONS.keys()
+    assert SUPPORTED_PYTHON_SERIES == list(PYTHON_STANDALONE_VERSIONS)
 
 
 def get_image_layers(image_id: str, servicer) -> List[api_pb2.Image]:


### PR DESCRIPTION
@charlesfrye pointed out that these show up in a random order when we print an error message about an unsupported version, since we use a set type. The supported version lookup is not performance critical, so it's easier to just store them in a list than to deal with the correct sorting at error time.