### PR TITLE
(WIP) remove `ClientHello` from the client creation path

### DIFF
--- a/modal/client.py
+++ b/modal/client.py
@@ -159,11 +159,6 @@ class _Client:
 
     async def __aenter__(self):
         await self._open()
-        try:
-            await self.hello()
-        except BaseException:
-            await self._close()
-            raise
         return self
 
     async def __aexit__(self, exc_type, exc, tb):
@@ -179,7 +174,6 @@ class _Client:
         client = cls(server_url, api_pb2.CLIENT_TYPE_CLIENT, credentials=None)
         try:
             await client._open()
-            # Skip client.hello
             yield client
         finally:
             await client._close()
@@ -225,7 +219,6 @@ class _Client:
             client = _Client(server_url, client_type, credentials)
             await client._open()
             async_utils.on_shutdown(client._close())
-            await client.hello()
             cls._client_from_env = client
             return client
 
@@ -248,11 +241,6 @@ class _Client:
         credentials = (token_id, token_secret)
         client = _Client(server_url, client_type, credentials)
         await client._open()
-        try:
-            await client.hello()
-        except BaseException:
-            await client._close()
-            raise
         async_utils.on_shutdown(client._close())
         return client
 
@@ -310,7 +298,6 @@ class _Client:
             self.set_env_client(None)
             # TODO(elias): reset _cancellation_context in case ?
             await self._open()
-            # intentionally not doing self.hello since we should already be authenticated etc.
 
     async def _get_grpclib_method(self, method_name: str) -> Any:
         # safely get grcplib method that is bound to a valid channel


### PR DESCRIPTION
This should reduce the e2e latency of running ephemeral apps by about 100-250ms. It removes two server round trips sitting in the critical path (one locally, one in the container). It also simplifies the RPC protocol a bit, which seems useful (like if we want to add support for other languages).

Instead of relying on `ClientHello` to catch various connection issues, we now rely on any request.

TODO: This makes it slightly harder to print helpful things like "your client version is too old", which is I think the only real drawback here. I'll think about ways we can do this using other RPCs instead. However this might require moving a bunch of server code from the `ClientHello` method into the middleware.