### PR TITLE
Allow token auth inside container

### DIFF
--- a/modal/client.py
+++ b/modal/client.py
@@ -206,20 +206,20 @@ class _Client:
             if cls._client_from_env:
                 return cls._client_from_env
 
-            if _is_remote():
+            token_id = c["token_id"]
+            token_secret = c["token_secret"]
+            if token_id and token_secret:
+                client_type = api_pb2.CLIENT_TYPE_CLIENT
+                credentials = (token_id, token_secret)
+            elif _is_remote():
                 client_type = api_pb2.CLIENT_TYPE_CONTAINER
                 credentials = None
             else:
-                client_type = api_pb2.CLIENT_TYPE_CLIENT
-                token_id = c["token_id"]
-                token_secret = c["token_secret"]
-                if not token_id or not token_secret:
-                    raise AuthError(
-                        "Token missing. Could not authenticate client."
-                        " If you have token credentials, see modal.com/docs/reference/modal.config for setup help."
-                        " If you are a new user, register an account at modal.com, then run `modal token new`."
-                    )
-                credentials = (token_id, token_secret)
+                raise AuthError(
+                    "Token missing. Could not authenticate client."
+                    " If you have token credentials, see modal.com/docs/reference/modal.config for setup help."
+                    " If you are a new user, register an account at modal.com, then run `modal token new`."
+                )
 
             server_url = c["server_url"]
             client = _Client(server_url, client_type, credentials)

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -151,6 +151,18 @@ def test_client_from_env_client(servicer, credentials):
         Client.set_env_client(None)
 
 
+def test_client_token_auth_in_container(servicer, credentials, monkeypatch) -> None:
+    """Ensure that clients can connect with token credentials inside a container.
+
+    This test is needed so that modal.com/playground works, since it relies on
+    running a sandbox with token credentials. Also, `modal shell` uses this to
+    preserve its auth context inside the shell.
+    """
+    monkeypatch.setenv("MODAL_IS_REMOTE", "1")
+    _client = client_from_env(servicer.client_addr, credentials)
+    assert servicer.client_create_metadata["x-modal-client-type"] == str(api_pb2.CLIENT_TYPE_CLIENT)
+
+
 def test_multiple_profile_error(servicer, modal_config):
     config = """
     [prof-1]


### PR DESCRIPTION
Follow-up to #2374 that fixes a minor regression that breaks the https://modal.com/playground app. This adds a test that was failing previously and succeeds with the change.

```
pytest test/client_test.py -k test_client_token_auth_in_container
# 1 passed, 18 deselected in 0.04s

git stash push modal/client.py
pytest test/client_test.py -k test_client_token_auth_in_container
# 1 failed, 18 deselected in 0.10s
```


## Changelog

- Fix a regression introduced in client version 0.64.209, which affects client authentication within a container.
