### PR TITLE
Suppress local config during testing

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -41,6 +41,7 @@ from modal._utils.http_utils import run_temporary_http_server
 from modal._vendor import cloudpickle
 from modal.app import _App
 from modal.client import Client
+from modal.config import _user_config
 from modal.image import ImageBuilderVersion
 from modal.mount import client_mount_name
 from modal_proto import api_grpc, api_pb2
@@ -62,6 +63,13 @@ def set_env(monkeypatch):
 @pytest.fixture(scope="function", autouse=True)
 def disable_app_run_warning(monkeypatch):
     monkeypatch.setenv("MODAL_DISABLE_APP_RUN_OUTPUT_WARNING", "1")
+
+
+@pytest.fixture(scope="function", autouse=True)
+def ignore_local_config():
+    # When running tests locally, we don't want to pick up the local .modal.toml file
+    _user_config.clear()
+    yield
 
 
 class FunctionsRegistry:


### PR DESCRIPTION
Otherwise the tests might pick up spurious values