### PR TITLE
Don't print token_secret from test fixture

### DIFF
--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -113,14 +113,14 @@ def test_secret_list(servicer, set_env_client):
 
 
 def test_app_token_new(servicer, set_env_client, server_url_env, modal_config):
-    servicer.required_creds = {("abc", "xyz")}
+    servicer.required_creds = {"abc": "xyz"}
     with modal_config() as config_file_path:
         _run(["token", "new", "--profile", "_test"])
         assert "_test" in toml.load(config_file_path)
 
 
 def test_app_setup(servicer, set_env_client, server_url_env, modal_config):
-    servicer.required_creds = {("abc", "xyz")}
+    servicer.required_creds = {"abc": "xyz"}
     with modal_config() as config_file_path:
         _run(["setup", "--profile", "_test"])
         assert "_test" in toml.load(config_file_path)
@@ -756,7 +756,7 @@ def test_profile_list(servicer, server_url_env, modal_config):
     """
 
     with modal_config(config):
-        servicer.required_creds = {("ak-abc", "as-xyz"), ("ak-123", "as-789")}
+        servicer.required_creds = {"ak-abc": "as-xyz", "ak-123": "as-789"}
         res = _run(["profile", "list"])
         table_rows = res.stdout.split("\n")
         assert re.search("Profile .+ Workspace", table_rows[1])
@@ -774,7 +774,7 @@ def test_profile_list(servicer, server_url_env, modal_config):
         orig_env_token_secret = os.environ.get("MODAL_TOKEN_SECRET")
         os.environ["MODAL_TOKEN_ID"] = "ak-abc"
         os.environ["MODAL_TOKEN_SECRET"] = "as-xyz"
-        servicer.required_creds = {("ak-abc", "as-xyz")}
+        servicer.required_creds = {"ak-abc": "as-xyz"}
         try:
             res = _run(["profile", "list"])
             assert "Using test-username workspace based on environment variables" in res.stdout

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -200,7 +200,7 @@ def test_implicit_default_profile_warning(servicer, modal_config, server_url_env
     token_secret = 'as_xyz'
     """
     with modal_config(config):
-        servicer.required_creds = {("ak-abc", "as_xyz")}
+        servicer.required_creds = {"ak-abc": "as_xyz"}
         # A single profile should be fine, even if not explicitly active and named 'default'
         Client.from_env()
 
@@ -220,14 +220,16 @@ def test_from_env_container(servicer, container_env):
 
 def test_from_credentials_client(servicer, set_env_client, server_url_env, token_env):
     # Note: this explicitly uses a lot of fixtures to make sure those are ignored
-    creds = ("ak-foo-1", "as-bar")
-    servicer.required_creds = {creds}
-    Client.from_credentials(*creds)
+    token_id = "ak-foo-1"
+    token_secret = "as-bar"
+    servicer.required_creds = {token_id: token_secret}
+    Client.from_credentials(token_id, token_secret)
     # TODO(erikbern): once we no longer run ClientHello by default, add a ping here
 
 
 def test_from_credentials_container(servicer, container_env):
-    creds = ("ak-foo-2", "as-bar")
-    servicer.required_creds = {creds}
-    Client.from_credentials(*creds)
+    token_id = "ak-foo-2"
+    token_secret = "as-bar"
+    servicer.required_creds = {token_id: token_secret}
+    Client.from_credentials(token_id, token_secret)
     # TODO(erikbern): once we no longer run ClientHello by default, add a ping here

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -53,7 +53,7 @@ def test_config_store_user(servicer, modal_config):
     with modal_config(show_on_error=True) as config_file_path:
         env = {"MODAL_SERVER_URL": servicer.client_addr}
 
-        servicer.required_creds = {("abc", "xyz"), ("foo", "bar1"), ("foo", "bar2"), ("ABC", "XYZ"), ("foo", "bar3")}
+        servicer.required_creds = {"abc": "xyz", "foo": "bar1", "foo2": "bar2", "ABC": "XYZ", "foo3": "bar3"}
 
         # No token by default
         config = _get_config(env=env)
@@ -72,9 +72,9 @@ def test_config_store_user(servicer, modal_config):
             env=env,
         )
 
-        # Set creds to foo / bar2 for the prof_2 profile (given as an env var)
+        # Set creds to foo2 / bar2 for the prof_2 profile (given as an env var)
         _cli(
-            ["token", "set", "--token-id", "foo", "--token-secret", "bar2", "--no-activate"],
+            ["token", "set", "--token-id", "foo2", "--token-secret", "bar2", "--no-activate"],
             env={"MODAL_PROFILE": "prof_2", **env},
         )
 
@@ -100,7 +100,7 @@ def test_config_store_user(servicer, modal_config):
 
         # Check that we can get the prof_2 env creds too
         config = _get_config(env={"MODAL_PROFILE": "prof_2", **env})
-        assert config["token_id"] == "foo"
+        assert config["token_id"] == "foo2"
         assert config["token_secret"] == "bar2"
 
         # Check that an empty string falls back to the active profile
@@ -120,7 +120,7 @@ def test_config_store_user(servicer, modal_config):
 
         # Check that we activate a profile by default while setting a token
         _cli(
-            ["token", "set", "--token-id", "foo", "--token-secret", "bar3", "--profile", "prof_3"],
+            ["token", "set", "--token-id", "foo3", "--token-secret", "bar3", "--profile", "prof_3"],
             env=env,
         )
         for profile, profile_config in toml.load(config_file_path).items():
@@ -145,7 +145,7 @@ def test_config_env_override_arbitrary_env():
 
 @pytest.mark.asyncio
 async def test_workspace_lookup(servicer, server_url_env):
-    servicer.required_creds = {("ak-abc", "as-xyz")}
+    servicer.required_creds = {"ak-abc": "as-xyz"}
     resp = await synchronize_api(_lookup_workspace).aio(servicer.client_addr, "ak-abc", "as-xyz")
     assert resp.username == "test-username"
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -246,7 +246,8 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
         self.image_join_sleep_duration = None
 
-        self.required_creds = {credentials}  # Any of this will be accepted
+        token_id, token_secret = credentials
+        self.required_creds = {token_id: token_secret}  # Any of this will be accepted
 
         @self.function_body
         def default_function_body(*args, **kwargs):
@@ -268,11 +269,14 @@ class MockClientServicer(api_grpc.ModalClientBase):
             ]:
                 pass  # Methods that don't require authentication
             else:
-                creds = (event.metadata.get("x-modal-token-id"), event.metadata.get("x-modal-token-secret"))
-                if creds not in self.required_creds:
-                    raise GRPCError(
-                        Status.UNAUTHENTICATED, f"Incorrect auth token {creds} for method {event.method_name}"
-                    )
+                token_id = event.metadata.get("x-modal-token-id")
+                token_secret = event.metadata.get("x-modal-token-secret")
+                if not token_id or not token_secret:
+                    raise GRPCError(Status.UNAUTHENTICATED, f"No credentials for method {event.method_name}")
+                elif token_id not in self.required_creds:
+                    raise GRPCError(Status.UNAUTHENTICATED, f"Invalid {token_id=!r} for method {event.method_name}")
+                elif self.required_creds[token_id] != token_secret:
+                    raise GRPCError(Status.UNAUTHENTICATED, f"Invalid token secret for for method {event.method_name}")
         elif event.metadata["x-modal-client-type"] == str(api_pb2.CLIENT_TYPE_CONTAINER):
             for header in [
                 "x-modal-token-id",

--- a/test/e2e_test.py
+++ b/test/e2e_test.py
@@ -65,7 +65,7 @@ def test_auth_failure_last_line(servicer, credentials):
     )
     try:
         assert returncode != 0
-        assert "auth token" in err.strip().split("\n")[-1]  # err msg should be on the last line
+        assert "token" in err.strip().split("\n")[-1]  # err msg should be on the last line
     except Exception:
         print("out:", repr(out))
         print("err:", repr(err))


### PR DESCRIPTION
Simplified the test code a bit by making `required_creds` a dict rather than a set of tuples