### PR TITLE
Combine `GroupedFunction` with `Function`

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -52,7 +52,6 @@ from .cls import Cls, Obj
 from .config import logger
 from .exception import ExecutionError, InputCancellation, InvalidError, deprecation_warning
 from .execution_context import _set_current_context_ids
-from .experimental import GroupedFunction
 from .functions import Function, _Function
 from .partial_function import (
     _find_callables_for_obj,
@@ -544,8 +543,6 @@ def import_single_function_service(
             # This is a function
             cls = None
             f = getattr(module, qual_name)
-            if isinstance(f, GroupedFunction):
-                f = f.get_underlying_function()
             if isinstance(f, Function):
                 function = synchronizer._translate_in(f)
                 user_defined_callable = function.get_raw_f()

--- a/modal/app.py
+++ b/modal/app.py
@@ -36,7 +36,6 @@ from .cloud_bucket_mount import _CloudBucketMount
 from .cls import _Cls, parameter
 from .config import logger
 from .exception import InvalidError, deprecation_error, deprecation_warning
-from .experimental import _GroupedFunction
 from .functions import Function, _Function
 from .gpu import GPU_T
 from .image import _Image
@@ -817,12 +816,6 @@ class _App:
             )
 
             self._add_function(function, webhook_config is not None)
-
-            # Experimental: Grouped functions
-            if group_size is not None:
-                if group_size <= 0:
-                    raise InvalidError("Group size must be positive")
-                function = _GroupedFunction(function, group_size)
 
             return function
 

--- a/modal/experimental.py
+++ b/modal/experimental.py
@@ -46,8 +46,13 @@ def grouped(size: int):
 
     The underlying function is wrapper with _network to ensure that container
     i6pn addresses are synchronized across all machines.
-    When wrapped with app.function(), a _GroupedFunction will be produced instead of
-    a Function. The call logic for a _GroupedFunction is defined above.
+
+    Usage:
+
+    @app.function()
+    @modal.experimental.grouped(size=2)
+    def grouped_function():
+        ...
     """
 
     def wrapper(raw_f: Callable[..., Any]) -> _PartialFunction:

--- a/test/i6pn_group_test.py
+++ b/test/i6pn_group_test.py
@@ -47,9 +47,4 @@ def test_spawn_experimental_group(client, servicer, monkeypatch):
         return sum(args)
 
     with app.run(client=client):
-        # Needed for type checker to be happy. This isn't the best solution, but
-        # the feature is experimental anyway...
-        assert isinstance(f1, modal.experimental.GroupedFunction)
-        f1.client = client
-
-        assert f1.remote(2, 4) == [6] * 2
+        assert f1.remote_grouped(2, 4) == [6] * 2


### PR DESCRIPTION
This PR combines `GroupedFunction` with `Function`. The logic to handle grouped functions now resides in Function rather than GroupedFunction. This should make it easier to resolve a lot of bugs like `modal shell` and `modal run` not working with grouped functions.