### PR TITLE
[WRK-200] fix mistaken missing parens

### DIFF
--- a/modal/client.py
+++ b/modal/client.py
@@ -409,6 +409,6 @@ class UnaryStreamWrapper(Generic[RequestType, ResponseType]):
     ):
         if self.client._snapshotted:
             logger.debug(f"refreshing client after snapshot for {self._wrapped_method_name}")
-            self.client = await _Client.from_env
+            self.client = await _Client.from_env()
         async for response in self.client._call_stream(self._wrapped_method_name, request, metadata=metadata):
             yield response


### PR DESCRIPTION
## Describe your changes

Test is pretty crap, but I found it pretty hard to get a good test of this within the client. It's a lot easier in integration tests when everything gets wired up as it is in prod. 

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
