### PR TITLE
Replace logger.warn with logger.warning

### DIFF
--- a/modal/cloud_bucket_mount.py
+++ b/modal/cloud_bucket_mount.py
@@ -129,7 +129,7 @@ def cloud_bucket_mounts_to_proto(mounts: List[Tuple[str, _CloudBucketMount]]) ->
             elif parse_result.hostname.endswith("storage.googleapis.com"):
                 bucket_type = api_pb2.CloudBucketMount.BucketType.GCP
             else:
-                logger.warn(
+                logger.warning(
                     "CloudBucketMount received unrecognized bucket endpoint URL. "
                     "Assuming AWS S3 configuration as fallback."
                 )


### PR DESCRIPTION
## Describe your changes

- `logger.warn` has been deprecated since Python 3.3, this replaces it with `logger.warning`.
- This is the only instance of `logger.warn` in our client codebase
- Resolves CLI-206

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
