### PR TITLE
Temporary fix for token issue

### DIFF
--- a/modal/client.py
+++ b/modal/client.py
@@ -31,7 +31,7 @@ from modal_version import __version__
 from ._utils import async_utils
 from ._utils.async_utils import TaskContext, synchronize_api
 from ._utils.grpc_utils import create_channel, retry_transient_errors
-from .config import _check_config, _is_remote, config, logger
+from .config import _check_config, config, logger
 from .exception import AuthError, ClientClosed, DeprecationError, VersionError
 
 HEARTBEAT_INTERVAL: float = config.get("heartbeat_interval")
@@ -206,14 +206,15 @@ class _Client:
             if cls._client_from_env:
                 return cls._client_from_env
 
+            task_secret = c["task_secret"]  # Only used to detect if we're running inside a "Modal container"
             token_id = c["token_id"]
             token_secret = c["token_secret"]
-            if token_id and token_secret:
-                client_type = api_pb2.CLIENT_TYPE_CLIENT
-                credentials = (token_id, token_secret)
-            elif _is_remote():
+            if task_secret:
                 client_type = api_pb2.CLIENT_TYPE_CONTAINER
                 credentials = None
+            elif token_id and token_secret:
+                client_type = api_pb2.CLIENT_TYPE_CLIENT
+                credentials = (token_id, token_secret)
             else:
                 raise AuthError(
                     "Token missing. Could not authenticate client."

--- a/modal/config.py
+++ b/modal/config.py
@@ -203,6 +203,7 @@ _SETTINGS = {
     "token_id": _Setting(),
     "token_secret": _Setting(),
     "task_id": _Setting(),
+    "task_secret": _Setting(),  # TODO(erikbern): delete very soon
     "serve_timeout": _Setting(transform=float),
     "sync_entrypoint": _Setting(),
     "logs_timeout": _Setting(10, float),

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -218,6 +218,12 @@ def test_from_env_container(servicer, container_env):
     # TODO(erikbern): once we no longer run ClientHello by default, add a ping here
 
 
+def test_from_env_container_with_tokens(servicer, container_env, token_env):
+    servicer.required_creds = {}  # Disallow default client creds
+    Client.from_env()
+    # TODO(erikbern): once we no longer run ClientHello by default, add a ping here
+
+
 def test_from_credentials_client(servicer, set_env_client, server_url_env, token_env):
     # Note: this explicitly uses a lot of fixtures to make sure those are ignored
     token_id = "ak-foo-1"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1837,6 +1837,7 @@ async def token_env(servicer, monkeypatch, credentials):
 async def container_env(servicer, monkeypatch):
     monkeypatch.setenv("MODAL_SERVER_URL", servicer.container_addr)
     monkeypatch.setenv("MODAL_TASK_ID", "ta-123")
+    monkeypatch.setenv("MODAL_TASK_SECRET", "1")  # TODO(erikbern): remove
     monkeypatch.setenv("MODAL_IS_REMOTE", "1")
     yield
 

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -81,6 +81,7 @@ def set_env_vars(restore_path, container_addr):
             "MODAL_SERVER_URL": container_addr,
             "MODAL_TASK_ID": "ta-123",
             "MODAL_IS_REMOTE": "1",
+            "MODAL_TASK_SECRET": "1",
         },
     ):
         yield

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -310,6 +310,7 @@ def _run_container(
         # These env vars are always present in containers
         env["MODAL_TASK_ID"] = "ta-123"
         env["MODAL_IS_REMOTE"] = "1"
+        env["MODAL_TASK_SECRET"] = "1"  # TODO(erikbern): fix
 
         # reset _App tracking state between runs
         _App._all_apps.clear()
@@ -1639,6 +1640,7 @@ def _run_container_process(
 
     # These env vars are always present in containers
     env["MODAL_TASK_ID"] = "ta-123"
+    env["MODAL_TASK_SECRET"] = "1"  # TODO(erikbern): remove
     env["MODAL_IS_REMOTE"] = "1"
 
     encoded_container_args = base64.b64encode(container_args.SerializeToString())


### PR DESCRIPTION
If `MODAL_TOKEN_ID` and `MODAL_TOKEN_SECRET` is set inside a container, ignore it in `.from_env`

This relies on the existence of a the `MODAL_TASK_SECRET` env var, which is being phased out – the reason it's needed it's it's set in "Modal containers" but not in sandboxes (unlike `MODAL_IS_REMOTE` which is set in both).

I'm going to roll out a worker change that adds a new env var, which will let me remove the use of `MODAL_TASK_SECRET`. But it will take a few days for that to be done.