### PR TITLE
Warn if token id+secret are ignored in a container

### DIFF
--- a/modal/client.py
+++ b/modal/client.py
@@ -211,7 +211,10 @@ class _Client:
             token_secret = c["token_secret"]
             if task_secret:
                 if token_id or token_secret:
-                    warnings.warn("Modal token id and secret are ignored inside containers")
+                    warnings.warn(
+                        "Modal tokens provided by MODAL_TOKEN_ID and MODAL_TOKEN_SECRET"
+                        " (or through the config file) are ignored inside containers."
+                    )
                 client_type = api_pb2.CLIENT_TYPE_CONTAINER
                 credentials = None
             elif token_id and token_secret:

--- a/modal/client.py
+++ b/modal/client.py
@@ -210,6 +210,8 @@ class _Client:
             token_id = c["token_id"]
             token_secret = c["token_secret"]
             if task_secret:
+                if token_id or token_secret:
+                    warnings.warn("Modal token id and secret are ignored inside containers")
                 client_type = api_pb2.CLIENT_TYPE_CONTAINER
                 credentials = None
             elif token_id and token_secret:

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -219,8 +219,10 @@ def test_from_env_container(servicer, container_env):
 
 
 def test_from_env_container_with_tokens(servicer, container_env, token_env):
+    # Even if MODAL_TOKEN_ID and MODAL_TOKEN_SECRET are set, if we're in a containers, ignore those
     servicer.required_creds = {}  # Disallow default client creds
-    Client.from_env()
+    with pytest.warns(match="token"):
+        Client.from_env()
     # TODO(erikbern): once we no longer run ClientHello by default, add a ping here
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -247,6 +247,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
         token_id, token_secret = credentials
         self.required_creds = {token_id: token_secret}  # Any of this will be accepted
+        self.last_metadata = None
 
         @self.function_body
         def default_function_body(*args, **kwargs):
@@ -254,6 +255,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def recv_request(self, event: RecvRequest):
         # Make sure metadata is correct
+        self.last_metadata = event.metadata
         for header in [
             "x-modal-python-version",
             "x-modal-client-version",
@@ -642,7 +644,6 @@ class MockClientServicer(api_grpc.ModalClientBase):
     async def ClientHello(self, stream):
         request: Empty = await stream.recv_message()
         self.requests.append(request)
-        self.client_create_metadata = stream.metadata
         client_version = stream.metadata["x-modal-client-version"]
         warning = ""
         assert stream.user_agent.startswith(f"modal-client/{__version__} ")


### PR DESCRIPTION
Follow up to #2401 – I was thinking more about it and I think this is a bit of a weird case that at least deserves a warning if people try it. Maybe they think the container will inherit the creds or something.