### PR TITLE
Add vscode config for client tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
+}


### PR DESCRIPTION
This adds a `settings.json` file which configures vscode to detect tests in the `test` directory. This way the tests will automatically appear in the Test Explorer tab.

<img width="1373" alt="image" src="https://github.com/user-attachments/assets/72c38865-c49d-4c8d-9f47-50031929fdcd">
