### PR TITLE
Use uv to install client dependencies with 2024.10 image builder

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -130,17 +130,14 @@ def _get_modal_requirements_path(builder_version: ImageBuilderVersion, python_ve
 
 
 def _get_modal_requirements_command(version: ImageBuilderVersion) -> str:
-    if version <= "2024.04":
-        command = "pip install"
-    else:
-        command = "uv pip install --system --compile-bytecode"
+    if version == "2023.12":
+        prefix = "pip install"
+    elif version == "2024.04":
+        prefix = "pip install --no-cache --no-deps"
+    else:  # Currently, 2024.10+
+        prefix = "uv pip install --system --compile-bytecode --no-cache --no-deps"
 
-    if version <= "2023.12":
-        args = f"-r {CONTAINER_REQUIREMENTS_PATH}"
-    else:
-        args = f"--no-cache --no-deps -r {CONTAINER_REQUIREMENTS_PATH}"
-
-    return f"{command} {args}"
+    return f"{prefix} -r {CONTAINER_REQUIREMENTS_PATH}"
 
 
 def _flatten_str_args(function_name: str, arg_name: str, args: Tuple[Union[str, List[str]], ...]) -> List[str]:

--- a/modal/image.py
+++ b/modal/image.py
@@ -130,11 +130,16 @@ def _get_modal_requirements_path(builder_version: ImageBuilderVersion, python_ve
 
 
 def _get_modal_requirements_command(version: ImageBuilderVersion) -> str:
-    command = "pip install"
+    if version <= "2024.04":
+        command = "pip install"
+    else:
+        command = "uv pip install --system --compile-bytecode"
+
     if version <= "2023.12":
         args = f"-r {CONTAINER_REQUIREMENTS_PATH}"
     else:
         args = f"--no-cache --no-deps -r {CONTAINER_REQUIREMENTS_PATH}"
+
     return f"{command} {args}"
 
 

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -126,8 +126,13 @@ def test_image_base(builder_version, servicer, client, test_dir):
             if builder_version == "2023.12":
                 assert "pip install -r /modal_requirements.txt" in commands
             else:
-                assert "pip install --no-cache --no-deps -r /modal_requirements.txt" in commands
                 assert "rm /modal_requirements.txt" in commands
+                if builder_version == "2024.04":
+                    assert "pip install --no-cache --no-deps -r /modal_requirements.txt" in commands
+                else:
+                    assert (
+                        "uv pip install --system --compile-bytecode" " --no-cache --no-deps -r /modal_requirements.txt"
+                    ) in commands
 
 
 @pytest.mark.parametrize("python_version", [None, "3.10", "3.11.4"])


### PR DESCRIPTION
In practice we find that this doesn't achieve huge speedups over pip (mostly because we need to compile the bytecode) but it does save a handful of seconds for every custom base Image build.

Closes CLI-149