### PR TITLE
Redact token_secret in default `modal config show` output

### DIFF
--- a/modal/cli/config.py
+++ b/modal/cli/config.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2022
-import pprint
-
 import typer
+from rich.console import Console
 
 from modal.config import _profile, _store_user_config, config
 
@@ -17,10 +16,15 @@ config_cli = typer.Typer(
 )
 
 
-@config_cli.command(help="Show configuration values for the current profile (debug command).")
-def show():
+@config_cli.command(help="Show current configuration values (debugging command).")
+def show(redact: bool = typer.Option(True, help="Redact the `token_secret` value.")):
     # This is just a test command
-    pprint.pprint(config.to_dict())
+    config_dict = config.to_dict()
+    if redact and "token_secret" in config_dict:
+        config_dict["token_secret"] = "..."
+
+    console = Console()
+    console.print(config_dict)
 
 
 SET_DEFAULT_ENV_HELP = """Set the default Modal environment for the active profile

--- a/modal/cli/config.py
+++ b/modal/cli/config.py
@@ -21,7 +21,7 @@ def show(redact: bool = typer.Option(True, help="Redact the `token_secret` value
     # This is just a test command
     config_dict = config.to_dict()
     if redact and config_dict.get("token_secret"):
-        config_dict["token_secret"] = "..."
+        config_dict["token_secret"] = "***"
 
     console = Console()
     console.print(config_dict)

--- a/modal/cli/config.py
+++ b/modal/cli/config.py
@@ -20,7 +20,7 @@ config_cli = typer.Typer(
 def show(redact: bool = typer.Option(True, help="Redact the `token_secret` value.")):
     # This is just a test command
     config_dict = config.to_dict()
-    if redact and "token_secret" in config_dict:
+    if redact and config_dict.get("token_secret"):
         config_dict["token_secret"] = "..."
 
     console = Console()

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -789,6 +789,19 @@ def test_profile_list(servicer, server_url_env, modal_config):
                 del os.environ["MODAL_TOKEN_SECRET"]
 
 
+def test_config_show(servicer, server_url_env, modal_config):
+    config = """
+    [test-profile]
+    token_id = "ak-abc"
+    token_secret = "as-xyz"
+    active = true
+    """
+    with modal_config(config):
+        res = _run(["config", "show"])
+        assert "'token_id': 'ak-abc'" in res.stdout
+        assert "'token_secret': '...'" in res.stdout
+
+
 def test_app_list(servicer, mock_dir, set_env_client):
     res = _run(["app", "list"])
     assert "my_app_foo" not in res.stdout

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -799,7 +799,7 @@ def test_config_show(servicer, server_url_env, modal_config):
     with modal_config(config):
         res = _run(["config", "show"])
         assert "'token_id': 'ak-abc'" in res.stdout
-        assert "'token_secret': '...'" in res.stdout
+        assert "'token_secret': '***'" in res.stdout
 
 
 def test_app_list(servicer, mock_dir, set_env_client):

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -35,7 +35,7 @@ def _cli(args, env={}):
 
 
 def _get_config(env={}):
-    stdout = _cli(["config", "show"], env=env)
+    stdout = _cli(["config", "show", "--no-redact"], env=env)
     return eval(stdout)
 
 


### PR DESCRIPTION
`modal config show` prints config values by default which almost always include the modal token + secret. It's easy to accidentally leak your credentials this way.

This adds a default-enabled switch that redacts the token secret by printing it as `"..."`. I've keep the token itself in the output. In the event that users need to debug an issue with the secret, they can pass `--no-redact` to see it.

I also switched the printing to use `rich` instead of `pprint` to align better with the rest of our CLI.