### PR TITLE
Add container filesystem for sandboxes

### DIFF
--- a/modal/exception.py
+++ b/modal/exception.py
@@ -214,3 +214,11 @@ class ModuleNotMountable(Exception):
 
 class ClientClosed(Error):
     pass
+
+
+class UnsupportedOperation(Error):
+    """Raised when an unsupported operation is performed on a file descriptor."""
+
+
+class FilesystemExecutionError(Error):
+    """Raised when an error occurs during a container filesystem operation."""

--- a/modal/exception.py
+++ b/modal/exception.py
@@ -216,9 +216,5 @@ class ClientClosed(Error):
     pass
 
 
-class UnsupportedOperation(Error):
-    """Raised when an unsupported operation is performed on a file descriptor."""
-
-
 class FilesystemExecutionError(Error):
-    """Raised when an error occurs during a container filesystem operation."""
+    """Raised when an unknown error is thrown during a container filesystem operation."""

--- a/modal/file_io.py
+++ b/modal/file_io.py
@@ -1,11 +1,12 @@
 # Copyright Modal Labs 2024
+import io
 from typing import AsyncIterator, Optional, Tuple, Union
 
 from modal_proto import api_pb2
 
 from ._utils.async_utils import synchronize_api
 from .client import _Client
-from .exception import FilesystemExecutionError, UnsupportedOperation
+from .exception import FilesystemExecutionError
 
 
 # The Sandbox file handling API is designed to mimic Python's io.FileIO
@@ -254,20 +255,20 @@ class _FileIO:
         """Flush the buffer and close the file."""
         await self._close()
 
-    # This is also validated in the runner, but we check in the client to catch errors early
+    # also validated in the runner, but checked in the client to catch errors early
     def _check_writable(self) -> None:
         if not self._writable:
-            raise UnsupportedOperation("File is not writable. Add 'w' to the file mode to make it writable.")
+            raise io.UnsupportedOperation("not writeable")
 
-    # This is also validated in the runner, but we check in the client to catch errors early
+    # also validated in the runner, but checked in the client to catch errors early
     def _check_readable(self) -> None:
         if not self._readable:
-            raise UnsupportedOperation("File is not readable. Add 'r' to the file mode to make it readable.")
+            raise io.UnsupportedOperation("not readable")
 
-    # This is also validated in the runner, but we check in the client to catch errors early
+    # also validated in the runner, but checked in the client to catch errors early
     def _check_closed(self) -> None:
         if self._closed:
-            raise ValueError("Cannot perform I/O on a closed file")
+            raise ValueError("I/O operation on closed file")
 
     def __enter__(self) -> "_FileIO":
         self._check_closed()

--- a/modal/file_io.py
+++ b/modal/file_io.py
@@ -1,0 +1,201 @@
+# Copyright Modal Labs 2024
+from typing import AsyncIterator, Optional, Tuple
+
+from modal_proto import api_pb2
+
+from ._utils.async_utils import synchronize_api
+from .client import _Client
+from .exception import FilesystemExecutionError, UnsupportedOperation
+
+
+# The Sandbox file handling API is designed to mimic Python's io.FileIO
+# See https://github.com/python/cpython/blob/main/Lib/_pyio.py#L1459
+# Unlike io.FileIO, it also implements some higher level APIs, like `delete` and `write_replace`.
+# TODO: add delete to the entire file
+# TODO: add list_dir to the Sandbox
+class _FileIO:
+    _readable = False
+    _writable = False
+    _appended = False
+    _seekable = False
+    _closed = True
+
+    _exec_id: Optional[str] = None
+
+    def _validate_mode(self, mode: str) -> None:
+        valid_modes = ["r", "w", "a", "x", "r+", "w+", "a+", "x+"]
+        if mode not in valid_modes:
+            raise ValueError(f"Unsupported file mode: {mode}")
+        self._readable = any(m in mode for m in ["r", "r+", "w+", "a+", "x+"])
+        self._writable = any(m in mode for m in ["w", "w+", "a", "a+", "x", "x+"])
+        self._seekable = any(m in mode for m in ["r+", "w+", "a+", "x+"])
+        self._appended = "a" in mode
+
+    async def _consume_output(self, exec_id: str, file_descriptor: int) -> AsyncIterator[Tuple[Optional[str], int]]:
+        req = api_pb2.ContainerExecGetOutputRequest(
+            exec_id=exec_id,
+            timeout=55,
+            last_batch_index=0,
+            file_descriptor=file_descriptor,
+        )
+        async for batch in self._client.stub.ContainerExecGetOutput.unary_stream(req):
+            if batch.HasField("exit_code"):
+                yield (None, batch.exit_code)
+                break
+            for item in batch.items:
+                yield (item.message, batch.batch_index)
+
+    async def _wait(self, exec_id: str) -> str:
+        stdout = ""
+        stderr = ""
+        # The filesystem API shouldn't involve any long-running processes,
+        # so it should be safe to consume output/err separately here.
+        errored = False
+        async for data, exit_code in self._consume_output(exec_id, api_pb2.FILE_DESCRIPTOR_STDOUT):
+            if data is None:
+                errored = exit_code != 0
+                break
+            stdout += data
+        async for data, exit_code in self._consume_output(exec_id, api_pb2.FILE_DESCRIPTOR_STDERR):
+            if data is None:
+                errored = exit_code != 0
+                break
+            stderr += data
+        if errored:
+            raise FilesystemExecutionError(f"Error executing filesystem command: {stderr}")
+        return stdout
+
+    async def _open_file(self, path: str, mode: str) -> None:
+        resp = await self._client.stub.ContainerOpenFile(api_pb2.ContainerOpenFileRequest(path=path, mode=mode))
+        self._exec_id = resp.exec_id
+        await self._wait(self._exec_id)
+
+    @classmethod
+    async def create(cls, path: str, mode: str, client: _Client) -> "_FileIO":
+        self = cls.__new__(cls)
+        self._validate_mode(mode)
+        await self._open_file(path, mode)
+        self._closed = False
+        return self
+
+    # TODO
+    async def read(self, n: int = -1) -> bytes:
+        """Read n bytes from the current position. Returns the entire remaining file if n < 0."""
+        self._check_readable()
+        await self._client.stub.ContainerReadFile(api_pb2.ContainerReadFileRequest(exec_id=self._exec_id, n=n))
+        return await self._wait(self._exec_id)
+
+    # TODO
+    async def readline(self) -> bytes:
+        """Read a single line from the current position."""
+        self._check_readable()
+        await self._client.stub.ContainerReadFileLine(api_pb2.ContainerReadFileLineRequest(exec_id=self._exec_id))
+        return await self._wait(self._exec_id)
+
+    # TODO
+    async def readlines(self) -> list[bytes]:
+        """Read all lines from the current position."""
+        self._check_readable()
+        return await self.read().split(b"\n")
+
+    # TODO
+    async def write(self, data: bytes) -> None:
+        """Write data to the current position.
+
+        NOTE: Writes may not appear until the entire buffer is flushed, which
+        can be done manually with `flush()` or automatically when the file is
+        closed.
+        """
+        self._check_writable()
+        await self._client.stub.ContainerWriteFile(api_pb2.ContainerWriteFileRequest(exec_id=self._exec_id, data=data))
+        await self._wait(self._exec_id)
+
+    # TODO
+    async def flush(self) -> None:
+        """Flush the buffer to disk."""
+        self._check_writable()
+        await self._client.stub.ContainerFlushFile(api_pb2.ContainerFlushFileRequest(exec_id=self._exec_id))
+        await self._wait(self._exec_id)
+
+    # TODO
+    async def seek(self, offset: int, whence: int = 0) -> None:
+        """Move to a new position in the file.
+
+        `whence` defaults to 0 (absolute file positioning); other values are 1
+        (relative to the current position) and 2 (relative to the file's end).
+        """
+        self._check_seekable()
+        await self._client.stub.ContainerSeekFile(
+            api_pb2.ContainerSeekFileRequest(exec_id=self._exec_id, offset=offset, whence=whence)
+        )
+        await self._wait(self._exec_id)
+
+    # TODO
+    async def delete_bytes(self, start_inclusive: int = -1, end_exclusive: int = -1) -> None:
+        """Delete a range of bytes from the file.
+
+        `start_inclusive` and `end_exclusive` are byte offsets. If either is
+        -1, the start or end of the file is used, respectively.
+        """
+        self._check_seekable()
+        await self._client.stub.ContainerDeleteBytes(
+            api_pb2.ContainerDeleteBytesRequest(
+                exec_id=self._exec_id, start_inclusive=start_inclusive, end_exclusive=end_exclusive
+            )
+        )
+        await self._wait(self._exec_id)
+
+    # TODO
+    async def write_replace_bytes(self, data: bytes, start_inclusive: int = -1, end_exclusive: int = -1) -> None:
+        """Replace a range of bytes in the file with new data.
+
+        `start_inclusive` and `end_exclusive` are byte offsets. If either is
+        -1, the start or end of the file is used, respectively.
+        """
+        self._check_seekable()
+        await self._client.stub.ContainerWriteReplaceBytes(
+            api_pb2.ContainerWriteReplaceBytesRequest(
+                exec_id=self._exec_id, data=data, start_inclusive=start_inclusive, end_exclusive=end_exclusive
+            )
+        )
+        await self._wait(self._exec_id)
+
+    async def _close(self) -> None:
+        # Buffer is flushed by the runner on close
+        await self._client.stub.ContainerCloseFile(api_pb2.ContainerCloseFileRequest(exec_id=self._exec_id))
+        await self._wait(self._exec_id)
+        self._closed = True
+
+    async def close(self) -> None:
+        """Flush the buffer and close the file."""
+        await self._close()
+
+    # This is also validated in the runner, but we check in the client to catch errors early
+    def _check_writable(self) -> None:
+        if not self._writable:
+            raise UnsupportedOperation("File is not writable. Add 'w' to the file mode to make it writable.")
+
+    # This is also validated in the runner, but we check in the client to catch errors early
+    def _check_readable(self) -> None:
+        if not self._readable:
+            raise UnsupportedOperation("File is not readable. Add 'r' to the file mode to make it readable.")
+
+    # This is also validated in the runner, but we check in the client to catch errors early
+    def _check_closed(self) -> None:
+        if self._closed:
+            raise ValueError("Cannot perform I/O on a closed file")
+
+    # This is also validated in the runner, but we check in the client to catch errors early
+    def _check_seekable(self) -> None:
+        if not self._seekable:
+            raise UnsupportedOperation("File is not seekable. Add '+' to the file mode to make it seekable.")
+
+    def __enter__(self) -> "_FileIO":
+        self._check_closed()
+        return self
+
+    async def __exit__(self, exc_type, exc_value, traceback) -> None:
+        await self._close()
+
+
+FileIO = synchronize_api(_FileIO)

--- a/modal/file_io.py
+++ b/modal/file_io.py
@@ -65,7 +65,7 @@ class _FileIO:
         error_class = ERROR_MAPPING.get(error.error_code, FilesystemExecutionError)
         raise error_class(error.error_message)
 
-    async def _consume_output(self, exec_id: str) -> AsyncIterator[Optional[str]]:
+    async def _consume_output(self, exec_id: str) -> AsyncIterator[Optional[bytes]]:
         req = api_pb2.ContainerFilesystemExecGetOutputRequest(
             exec_id=exec_id,
             timeout=55,
@@ -81,14 +81,14 @@ class _FileIO:
                 yield message
 
     async def _wait(self, exec_id: str) -> Union[bytes, str]:
-        output = ""
+        output = b""
         async for data in self._consume_output(exec_id):
             if data is None:
                 break
             output += data
         if self._binary:
-            return output.encode("utf-8")
-        return output
+            return output
+        return output.decode("utf-8")
 
     def _validate_type(self, data: Union[bytes, str]) -> None:
         if self._binary and isinstance(data, str):

--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -146,7 +146,7 @@ class _StreamReader:
                     iterator = _sandbox_logs_iterator(
                         self._object_id, self._file_descriptor, self._last_entry_id, self._client
                     )
-                else:
+                elif self._object_type == "container_process":
                     iterator = _container_process_logs_iterator(
                         self._object_id, self._file_descriptor, self._last_entry_id, self._client
                     )

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -21,6 +21,7 @@ from .client import _Client
 from .config import config
 from .container_process import _ContainerProcess
 from .exception import InvalidError, SandboxTerminatedError, SandboxTimeoutError, deprecation_warning
+from .file_io import _FileIO
 from .gpu import GPU_T
 from .image import _Image
 from .io_streams import StreamReader, StreamWriter, _StreamReader, _StreamWriter
@@ -424,6 +425,9 @@ class _Sandbox(_Object, type_prefix="sb"):
             )
         )
         return _ContainerProcess(resp.exec_id, self._client)
+
+    def open(self, path: str, mode: str) -> _FileIO:
+        return _FileIO(path, mode, self._client)
 
     @property
     def stdout(self) -> _StreamReader:

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -426,8 +426,9 @@ class _Sandbox(_Object, type_prefix="sb"):
         )
         return _ContainerProcess(resp.exec_id, self._client)
 
-    def open(self, path: str, mode: str) -> _FileIO:
-        return _FileIO(path, mode, self._client)
+    async def open(self, path: str, mode: str = "r") -> _FileIO:
+        task_id = await self._get_task_id()
+        return await _FileIO.create(path, mode, self._client, task_id)
 
     @property
     def stdout(self) -> _StreamReader:

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1852,7 +1852,7 @@ message RuntimeOutputBatch {
 }
 
 message FilesystemRuntimeOutputBatch {
-  repeated string output = 1;
+  repeated bytes output = 1;
   optional SystemErrorMessage error = 2;
   uint64 batch_index = 3;
   bool eof = 4;

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2048,11 +2048,17 @@ message ContainerFilesystemGetOutputRequest {
   uint64 last_batch_index = 3;
 }
 
+enum SeekWhence {
+  SEEK_SET = 0;
+  SEEK_CUR = 1;
+  SEEK_END = 2;
+}
+
 message ContainerFileSeekRequest {
   string task_id = 1;
   string file_descriptor = 2;
-  int32 offset = 3;
-  int32 whence = 4;
+  uint32 offset = 3;
+  SeekWhence whence = 4;
 }
 
 message ContainerFileSeekResponse {
@@ -2062,8 +2068,8 @@ message ContainerFileSeekResponse {
 message ContainerFileDeleteBytesRequest {
   string task_id = 1;
   string file_descriptor = 2;
-  int32 start_inclusive = 3;
-  int32 end_exclusive = 4;
+  optional uint32 start_inclusive = 3;
+  optional uint32 end_exclusive = 4;
 }
 
 message ContainerFileDeleteBytesResponse {
@@ -2073,8 +2079,8 @@ message ContainerFileDeleteBytesResponse {
 message ContainerFileWriteReplaceBytesRequest {
   string task_id = 1;
   bytes data = 2;
-  int32 start_inclusive = 3;
-  int32 end_exclusive = 4;
+  optional uint32 start_inclusive = 3;
+  optional uint32 end_exclusive = 4;
 }
 
 message ContainerFileWriteReplaceBytesResponse {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1982,51 +1982,51 @@ message SandboxWaitResponse {
   GenericResult result = 1;
 }
 
-message ContainerWriteFileRequest {
+message ContainerFileWriteRequest {
   string exec_id = 1;
   bytes data = 2;
 }
 
-message ContainerWriteFileResponse {
+message ContainerFileWriteResponse {
 }
 
-message ContainerReadFileRequest {
+message ContainerFileReadRequest {
   string exec_id = 1;
-  int32 n = 2;
+  optional uint32 n = 2;
 }
 
-message ContainerReadFileResponse {
+message ContainerFileReadResponse {
 }
 
-message ContainerFlushFileRequest {
-  string exec_id = 1;
-}
-
-message ContainerFlushFileResponse {
-}
-
-message ContainerReadFileLineRequest {
+message ContainerFileFlushRequest {
   string exec_id = 1;
 }
 
-message ContainerReadFileLineResponse {
+message ContainerFileFlushResponse {
 }
 
-message ContainerOpenFileRequest {
-  string task_id = 1;
+message ContainerFileReadLineRequest {
+  string exec_id = 1;
+}
+
+message ContainerFileReadLineResponse {
+}
+
+message ContainerFileOpenRequest {
+  string exec_id = 1;
   string path = 2;
   string mode = 3;
 }
 
-message ContainerOpenFileResponse {
+message ContainerFileOpenResponse {
 }
 
-message ContainerCloseFileRequest {
-  string task_id = 1;
+message ContainerFileCloseRequest {
+  string exec_id = 1;
   string file_descriptor = 2;
 }
 
-message ContainerCloseFileResponse {
+message ContainerFileCloseResponse {
 }
 
 message ContainerFilesystemGetOutputRequest {
@@ -2035,32 +2035,32 @@ message ContainerFilesystemGetOutputRequest {
   uint64 last_batch_index = 3;
 }
 
-message ContainerSeekFileRequest {
+message ContainerFileSeekRequest {
   string exec_id = 1;
   int32 offset = 2;
   int32 whence = 3;
 }
 
-message ContainerSeekFileResponse {
+message ContainerFileSeekResponse {
 }
 
-message ContainerDeleteBytesRequest {
+message ContainerFileDeleteBytesRequest {
   string exec_id = 1;
   int32 start_inclusive = 2;
   int32 end_exclusive = 3;
 }
 
-message ContainerDeleteBytesResponse {
+message ContainerFileDeleteBytesResponse {
 }
 
-message ContainerWriteReplaceBytesRequest {
+message ContainerFileWriteReplaceBytesRequest {
   string exec_id = 1;
   bytes data = 2;
   int32 start_inclusive = 3;
   int32 end_exclusive = 4;
 }
 
-message ContainerWriteReplaceBytesResponse {
+message ContainerFileWriteReplaceBytesResponse {
 }
 
 message Schedule {
@@ -2512,21 +2512,21 @@ service ModalClient {
 
   // Container
   rpc ContainerCheckpoint(ContainerCheckpointRequest) returns (google.protobuf.Empty);
-  rpc ContainerCloseFile(ContainerCloseFileRequest) returns (ContainerCloseFileResponse);
-  rpc ContainerDeleteBytes(ContainerDeleteBytesRequest) returns (ContainerDeleteBytesResponse);
+  rpc ContainerFileClose(ContainerFileCloseRequest) returns (ContainerFileCloseResponse);
+  rpc ContainerFileDeleteBytes(ContainerFileDeleteBytesRequest) returns (ContainerFileDeleteBytesResponse);
   rpc ContainerExec(ContainerExecRequest) returns (ContainerExecResponse);
   rpc ContainerExecGetOutput(ContainerExecGetOutputRequest) returns (stream RuntimeOutputBatch);
   rpc ContainerExecPutInput(ContainerExecPutInputRequest) returns (google.protobuf.Empty);
   rpc ContainerExecWait(ContainerExecWaitRequest) returns (ContainerExecWaitResponse);
   rpc ContainerHeartbeat(ContainerHeartbeatRequest) returns (ContainerHeartbeatResponse);
   rpc ContainerLog(ContainerLogRequest) returns (google.protobuf.Empty);
-  rpc ContainerOpenFile(ContainerOpenFileRequest) returns (ContainerOpenFileResponse);
-  rpc ContainerReadFile(ContainerReadFileRequest) returns (ContainerReadFileResponse);
-  rpc ContainerReadFileLine(ContainerReadFileLineRequest) returns (ContainerReadFileLineResponse);
-  rpc ContainerSeekFile(ContainerSeekFileRequest) returns (ContainerSeekFileResponse);
+  rpc ContainerFileOpen(ContainerFileOpenRequest) returns (ContainerFileOpenResponse);
+  rpc ContainerFileRead(ContainerFileReadRequest) returns (ContainerFileReadResponse);
+  rpc ContainerFileReadLine(ContainerFileReadLineRequest) returns (ContainerFileReadLineResponse);
+  rpc ContainerFileSeek(ContainerFileSeekRequest) returns (ContainerFileSeekResponse);
   rpc ContainerStop(ContainerStopRequest) returns (ContainerStopResponse);
-  rpc ContainerWriteFile(ContainerWriteFileRequest) returns (ContainerWriteFileResponse);
-  rpc ContainerWriteReplaceBytes(ContainerWriteReplaceBytesRequest) returns (ContainerWriteReplaceBytesResponse);
+  rpc ContainerFileWrite(ContainerFileWriteRequest) returns (ContainerFileWriteResponse);
+  rpc ContainerFileWriteReplaceBytes(ContainerFileWriteReplaceBytesRequest) returns (ContainerFileWriteReplaceBytesResponse);
 
   // Dicts
   rpc DictClear(DictClearRequest) returns (google.protobuf.Empty);

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2075,7 +2075,7 @@ enum SeekWhence {
 
 message ContainerFileSeekRequest {
   string file_descriptor = 1;
-  uint32 offset = 2;
+  int32 offset = 2;
   SeekWhence whence = 3;
 }
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1982,6 +1982,87 @@ message SandboxWaitResponse {
   GenericResult result = 1;
 }
 
+message ContainerWriteFileRequest {
+  string exec_id = 1;
+  bytes data = 2;
+}
+
+message ContainerWriteFileResponse {
+}
+
+message ContainerReadFileRequest {
+  string exec_id = 1;
+  int32 n = 2;
+}
+
+message ContainerReadFileResponse {
+}
+
+message ContainerFlushFileRequest {
+  string exec_id = 1;
+}
+
+message ContainerFlushFileResponse {
+}
+
+message ContainerReadFileLineRequest {
+  string exec_id = 1;
+}
+
+message ContainerReadFileLineResponse {
+}
+
+message ContainerOpenFileRequest {
+  string task_id = 1;
+  string path = 2;
+  string mode = 3;
+}
+
+message ContainerOpenFileResponse {
+}
+
+message ContainerCloseFileRequest {
+  string task_id = 1;
+  string file_descriptor = 2;
+}
+
+message ContainerCloseFileResponse {
+}
+
+message ContainerFilesystemGetOutputRequest {
+  string exec_id = 1;
+  float timeout = 2;
+  uint64 last_batch_index = 3;
+}
+
+message ContainerSeekFileRequest {
+  string exec_id = 1;
+  int32 offset = 2;
+  int32 whence = 3;
+}
+
+message ContainerSeekFileResponse {
+}
+
+message ContainerDeleteBytesRequest {
+  string exec_id = 1;
+  int32 start_inclusive = 2;
+  int32 end_exclusive = 3;
+}
+
+message ContainerDeleteBytesResponse {
+}
+
+message ContainerWriteReplaceBytesRequest {
+  string exec_id = 1;
+  bytes data = 2;
+  int32 start_inclusive = 3;
+  int32 end_exclusive = 4;
+}
+
+message ContainerWriteReplaceBytesResponse {
+}
+
 message Schedule {
   message Cron {
     string cron_string = 1;
@@ -2431,13 +2512,21 @@ service ModalClient {
 
   // Container
   rpc ContainerCheckpoint(ContainerCheckpointRequest) returns (google.protobuf.Empty);
+  rpc ContainerCloseFile(ContainerCloseFileRequest) returns (ContainerCloseFileResponse);
+  rpc ContainerDeleteBytes(ContainerDeleteBytesRequest) returns (ContainerDeleteBytesResponse);
   rpc ContainerExec(ContainerExecRequest) returns (ContainerExecResponse);
   rpc ContainerExecGetOutput(ContainerExecGetOutputRequest) returns (stream RuntimeOutputBatch);
   rpc ContainerExecPutInput(ContainerExecPutInputRequest) returns (google.protobuf.Empty);
   rpc ContainerExecWait(ContainerExecWaitRequest) returns (ContainerExecWaitResponse);
   rpc ContainerHeartbeat(ContainerHeartbeatRequest) returns (ContainerHeartbeatResponse);
   rpc ContainerLog(ContainerLogRequest) returns (google.protobuf.Empty);
+  rpc ContainerOpenFile(ContainerOpenFileRequest) returns (ContainerOpenFileResponse);
+  rpc ContainerReadFile(ContainerReadFileRequest) returns (ContainerReadFileResponse);
+  rpc ContainerReadFileLine(ContainerReadFileLineRequest) returns (ContainerReadFileLineResponse);
+  rpc ContainerSeekFile(ContainerSeekFileRequest) returns (ContainerSeekFileResponse);
   rpc ContainerStop(ContainerStopRequest) returns (ContainerStopResponse);
+  rpc ContainerWriteFile(ContainerWriteFileRequest) returns (ContainerWriteFileResponse);
+  rpc ContainerWriteReplaceBytes(ContainerWriteReplaceBytesRequest) returns (ContainerWriteReplaceBytesResponse);
 
   // Dicts
   rpc DictClear(DictClearRequest) returns (google.protobuf.Empty);

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -129,6 +129,7 @@ enum SystemErrorCode {
   SYSTEM_ERROR_CODE_EXIST = 17;         // EEXIST: File exists
   SYSTEM_ERROR_CODE_NOTDIR = 20;        // ENOTDIR: Not a directory
   SYSTEM_ERROR_CODE_ISDIR = 21;         // EISDIR: Is a directory
+  SYSTEM_ERROR_CODE_INVAL = 22;         // EINVAL: Invalid argument
   SYSTEM_ERROR_CODE_MFILE = 24;         // EMFILE: Too many open files
   SYSTEM_ERROR_CODE_FBIG = 27;          // EFBIG: File too large
   SYSTEM_ERROR_CODE_NOSPC = 28;         // ENOSPC: No space left on device
@@ -711,7 +712,6 @@ message ContainerFilesystemExecGetOutputRequest {
   string exec_id = 1;
   float timeout = 2;
   uint64 last_batch_index = 3;
-  FileDescriptor file_descriptor = 4;
 }
 
 message ContainerExecPutInputRequest {
@@ -1853,7 +1853,7 @@ message RuntimeOutputBatch {
 
 message FilesystemRuntimeOutputBatch {
   repeated string output = 1;
-  SystemErrorMessage error = 2;
+  optional SystemErrorMessage error = 2;
   uint64 batch_index = 3;
   bool eof = 4;
 }

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2078,9 +2078,10 @@ message ContainerFileDeleteBytesResponse {
 
 message ContainerFileWriteReplaceBytesRequest {
   string task_id = 1;
-  bytes data = 2;
-  optional uint32 start_inclusive = 3;
-  optional uint32 end_exclusive = 4;
+  string file_descriptor = 2;
+  bytes data = 3;
+  optional uint32 start_inclusive = 4;
+  optional uint32 end_exclusive = 5;
 }
 
 message ContainerFileWriteReplaceBytesResponse {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -118,6 +118,22 @@ enum FileDescriptor {
   FILE_DESCRIPTOR_INFO = 3;
 }
 
+enum SystemErrorCode {
+  SYSTEM_ERROR_CODE_UNSPECIFIED = 0;
+  SYSTEM_ERROR_CODE_PERM = 1;           // EPERM: Operation not permitted
+  SYSTEM_ERROR_CODE_NOENT = 2;          // ENOENT: No such file or directory
+  SYSTEM_ERROR_CODE_IO = 5;             // EIO: Input/output error
+  SYSTEM_ERROR_CODE_NXIO = 6;           // ENXIO: No such device or address
+  SYSTEM_ERROR_CODE_NOMEM = 12;         // ENOMEM: Out of memory
+  SYSTEM_ERROR_CODE_ACCES = 13;         // EACCES: Permission denied
+  SYSTEM_ERROR_CODE_EXIST = 17;         // EEXIST: File exists
+  SYSTEM_ERROR_CODE_NOTDIR = 20;        // ENOTDIR: Not a directory
+  SYSTEM_ERROR_CODE_ISDIR = 21;         // EISDIR: Is a directory
+  SYSTEM_ERROR_CODE_MFILE = 24;         // EMFILE: Too many open files
+  SYSTEM_ERROR_CODE_FBIG = 27;          // EFBIG: File too large
+  SYSTEM_ERROR_CODE_NOSPC = 28;         // ENOSPC: No space left on device
+}
+
 enum FunctionCallInvocationType {
   FUNCTION_CALL_INVOCATION_TYPE_UNSPECIFIED = 0;
   FUNCTION_CALL_INVOCATION_TYPE_SYNC_LEGACY = 1;
@@ -1836,22 +1852,20 @@ message RuntimeOutputBatch {
 }
 
 message FilesystemRuntimeOutputBatch {
-  repeated FilesystemRuntimeOutputMessage output = 1;
-  repeated FilesystemRuntimeOutputMessage error = 2;
+  repeated string output = 1;
+  SystemErrorMessage error = 2;
   uint64 batch_index = 3;
-  optional int32 exit_code = 4;
+  bool eof = 4;
+}
+
+message SystemErrorMessage {
+  SystemErrorCode error_code = 1;
+  string error_message = 2;
 }
 
 // Used for `modal container exec`, `modal shell`, and Sandboxes
 message RuntimeOutputMessage {
   // only stdout / stderr is used
-  FileDescriptor file_descriptor = 1;
-  string message = 2;
-}
-
-message FilesystemRuntimeOutputMessage {
-  // using FileDescriptor isn't totally correct here,
-  // we just need to distinguish between true output and error output
   FileDescriptor file_descriptor = 1;
   string message = 2;
 }

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1983,84 +1983,102 @@ message SandboxWaitResponse {
 }
 
 message ContainerFileWriteRequest {
-  string exec_id = 1;
-  bytes data = 2;
+  string task_id = 1;
+  string file_descriptor = 2;
+  bytes data = 3;
 }
 
 message ContainerFileWriteResponse {
+  string exec_id = 1;
 }
 
 message ContainerFileReadRequest {
-  string exec_id = 1;
-  optional uint32 n = 2;
+  string task_id = 1;
+  string file_descriptor = 2; 
+  optional uint32 n = 3;
 }
 
 message ContainerFileReadResponse {
+  string exec_id = 1;
 }
 
 message ContainerFileFlushRequest {
-  string exec_id = 1;
+  string task_id = 1;
+  string file_descriptor = 2;
 }
 
 message ContainerFileFlushResponse {
+  string exec_id = 1;
 }
 
 message ContainerFileReadLineRequest {
-  string exec_id = 1;
+  string task_id = 1;
+  string file_descriptor = 2;
 }
 
 message ContainerFileReadLineResponse {
+  string exec_id = 1;
 }
 
 message ContainerFileOpenRequest {
-  string exec_id = 1;
-  string path = 2;
-  string mode = 3;
+  string task_id = 1;
+  // file descriptor is hydrated when sent from server -> worker
+  optional string file_descriptor = 2;
+  string path = 3;
+  string mode = 4;
 }
 
 message ContainerFileOpenResponse {
-}
-
-message ContainerFileCloseRequest {
   string exec_id = 1;
   string file_descriptor = 2;
 }
 
+message ContainerFileCloseRequest {
+  string task_id = 1;
+  string file_descriptor = 2;
+}
+
 message ContainerFileCloseResponse {
+  string exec_id = 1;
 }
 
 message ContainerFilesystemGetOutputRequest {
-  string exec_id = 1;
+  string task_id = 1;
   float timeout = 2;
   uint64 last_batch_index = 3;
 }
 
 message ContainerFileSeekRequest {
-  string exec_id = 1;
-  int32 offset = 2;
-  int32 whence = 3;
+  string task_id = 1;
+  string file_descriptor = 2;
+  int32 offset = 3;
+  int32 whence = 4;
 }
 
 message ContainerFileSeekResponse {
+  string exec_id = 1;
 }
 
 message ContainerFileDeleteBytesRequest {
-  string exec_id = 1;
-  int32 start_inclusive = 2;
-  int32 end_exclusive = 3;
+  string task_id = 1;
+  string file_descriptor = 2;
+  int32 start_inclusive = 3;
+  int32 end_exclusive = 4;
 }
 
 message ContainerFileDeleteBytesResponse {
+  string exec_id = 1;
 }
 
 message ContainerFileWriteReplaceBytesRequest {
-  string exec_id = 1;
+  string task_id = 1;
   bytes data = 2;
   int32 start_inclusive = 3;
   int32 end_exclusive = 4;
 }
 
 message ContainerFileWriteReplaceBytesResponse {
+  string exec_id = 1;
 }
 
 message Schedule {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2028,18 +2028,9 @@ message ContainerFileOpenRequest {
   string mode = 4;
 }
 
-message ContainerFileOpenResponse {
-  string exec_id = 1;
-  string file_descriptor = 2;
-}
-
 message ContainerFileCloseRequest {
   string task_id = 1;
   string file_descriptor = 2;
-}
-
-message ContainerFileCloseResponse {
-  string exec_id = 1;
 }
 
 message ContainerFilesystemGetOutputRequest {
@@ -2061,19 +2052,11 @@ message ContainerFileSeekRequest {
   SeekWhence whence = 4;
 }
 
-message ContainerFileSeekResponse {
-  string exec_id = 1;
-}
-
 message ContainerFileDeleteBytesRequest {
   string task_id = 1;
   string file_descriptor = 2;
   optional uint32 start_inclusive = 3;
   optional uint32 end_exclusive = 4;
-}
-
-message ContainerFileDeleteBytesResponse {
-  string exec_id = 1;
 }
 
 message ContainerFileWriteReplaceBytesRequest {
@@ -2084,8 +2067,24 @@ message ContainerFileWriteReplaceBytesRequest {
   optional uint32 end_exclusive = 5;
 }
 
-message ContainerFileWriteReplaceBytesResponse {
+message ContainerFilesystemExecRequest {
+  oneof file_exec_request_oneof {
+    ContainerFileOpenRequest file_open_request = 1;
+    ContainerFileWriteRequest file_write_request = 2;
+    ContainerFileReadRequest file_read_request = 3;
+    ContainerFileFlushRequest file_flush_request = 4;
+    ContainerFileReadLineRequest file_read_line_request = 5;
+    ContainerFileSeekRequest file_seek_request = 6;
+    ContainerFileDeleteBytesRequest file_delete_bytes_request = 7;
+    ContainerFileWriteReplaceBytesRequest file_write_replace_bytes_request = 8;
+    ContainerFileCloseRequest file_close_request = 9;
+  }
+}
+
+message ContainerFilesystemExecResponse {
   string exec_id = 1;
+  // only set when the request opens a new file, i.e., ContainerFileOpenRequest
+  optional string file_descriptor = 2;
 }
 
 message Schedule {
@@ -2537,21 +2536,14 @@ service ModalClient {
 
   // Container
   rpc ContainerCheckpoint(ContainerCheckpointRequest) returns (google.protobuf.Empty);
-  rpc ContainerFileClose(ContainerFileCloseRequest) returns (ContainerFileCloseResponse);
-  rpc ContainerFileDeleteBytes(ContainerFileDeleteBytesRequest) returns (ContainerFileDeleteBytesResponse);
   rpc ContainerExec(ContainerExecRequest) returns (ContainerExecResponse);
   rpc ContainerExecGetOutput(ContainerExecGetOutputRequest) returns (stream RuntimeOutputBatch);
   rpc ContainerExecPutInput(ContainerExecPutInputRequest) returns (google.protobuf.Empty);
+  rpc ContainerFilesystemExec(ContainerFilesystemExecRequest) returns (ContainerFilesystemExecResponse);
   rpc ContainerExecWait(ContainerExecWaitRequest) returns (ContainerExecWaitResponse);
   rpc ContainerHeartbeat(ContainerHeartbeatRequest) returns (ContainerHeartbeatResponse);
   rpc ContainerLog(ContainerLogRequest) returns (google.protobuf.Empty);
-  rpc ContainerFileOpen(ContainerFileOpenRequest) returns (ContainerFileOpenResponse);
-  rpc ContainerFileRead(ContainerFileReadRequest) returns (ContainerFileReadResponse);
-  rpc ContainerFileReadLine(ContainerFileReadLineRequest) returns (ContainerFileReadLineResponse);
-  rpc ContainerFileSeek(ContainerFileSeekRequest) returns (ContainerFileSeekResponse);
   rpc ContainerStop(ContainerStopRequest) returns (ContainerStopResponse);
-  rpc ContainerFileWrite(ContainerFileWriteRequest) returns (ContainerFileWriteResponse);
-  rpc ContainerFileWriteReplaceBytes(ContainerFileWriteReplaceBytesRequest) returns (ContainerFileWriteReplaceBytesResponse);
 
   // Dicts
   rpc DictClear(DictClearRequest) returns (google.protobuf.Empty);

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -691,6 +691,13 @@ message ContainerExecGetOutputRequest {
   FileDescriptor file_descriptor = 4;
 }
 
+message ContainerFilesystemExecGetOutputRequest {
+  string exec_id = 1;
+  float timeout = 2;
+  uint64 last_batch_index = 3;
+  FileDescriptor file_descriptor = 4;
+}
+
 message ContainerExecPutInputRequest {
   string exec_id = 1;
   RuntimeInputMessage input = 2;
@@ -1828,9 +1835,23 @@ message RuntimeOutputBatch {
   repeated RuntimeOutputMessage info = 6;
 }
 
+message FilesystemRuntimeOutputBatch {
+  repeated FilesystemRuntimeOutputMessage output = 1;
+  repeated FilesystemRuntimeOutputMessage error = 2;
+  uint64 batch_index = 3;
+  optional int32 exit_code = 4;
+}
+
 // Used for `modal container exec`, `modal shell`, and Sandboxes
 message RuntimeOutputMessage {
   // only stdout / stderr is used
+  FileDescriptor file_descriptor = 1;
+  string message = 2;
+}
+
+message FilesystemRuntimeOutputMessage {
+  // using FileDescriptor isn't totally correct here,
+  // we just need to distinguish between true output and error output
   FileDescriptor file_descriptor = 1;
   string message = 2;
 }
@@ -1983,9 +2004,8 @@ message SandboxWaitResponse {
 }
 
 message ContainerFileWriteRequest {
-  string task_id = 1;
-  string file_descriptor = 2;
-  bytes data = 3;
+  string file_descriptor = 1;
+  bytes data = 2;
 }
 
 message ContainerFileWriteResponse {
@@ -1993,9 +2013,8 @@ message ContainerFileWriteResponse {
 }
 
 message ContainerFileReadRequest {
-  string task_id = 1;
-  string file_descriptor = 2; 
-  optional uint32 n = 3;
+  string file_descriptor = 1; 
+  optional uint32 n = 2;
 }
 
 message ContainerFileReadResponse {
@@ -2003,8 +2022,7 @@ message ContainerFileReadResponse {
 }
 
 message ContainerFileFlushRequest {
-  string task_id = 1;
-  string file_descriptor = 2;
+  string file_descriptor = 1;
 }
 
 message ContainerFileFlushResponse {
@@ -2012,8 +2030,7 @@ message ContainerFileFlushResponse {
 }
 
 message ContainerFileReadLineRequest {
-  string task_id = 1;
-  string file_descriptor = 2;
+  string file_descriptor = 1;
 }
 
 message ContainerFileReadLineResponse {
@@ -2021,22 +2038,19 @@ message ContainerFileReadLineResponse {
 }
 
 message ContainerFileOpenRequest {
-  string task_id = 1;
   // file descriptor is hydrated when sent from server -> worker
-  optional string file_descriptor = 2;
-  string path = 3;
-  string mode = 4;
+  optional string file_descriptor = 1;
+  string path = 2;
+  string mode = 3;
 }
 
 message ContainerFileCloseRequest {
-  string task_id = 1;
-  string file_descriptor = 2;
+  string file_descriptor = 1;
 }
 
 message ContainerFilesystemGetOutputRequest {
-  string task_id = 1;
-  float timeout = 2;
-  uint64 last_batch_index = 3;
+  float timeout = 1;
+  uint64 last_batch_index = 2;
 }
 
 enum SeekWhence {
@@ -2046,25 +2060,22 @@ enum SeekWhence {
 }
 
 message ContainerFileSeekRequest {
-  string task_id = 1;
-  string file_descriptor = 2;
-  uint32 offset = 3;
-  SeekWhence whence = 4;
+  string file_descriptor = 1;
+  uint32 offset = 2;
+  SeekWhence whence = 3;
 }
 
 message ContainerFileDeleteBytesRequest {
-  string task_id = 1;
-  string file_descriptor = 2;
-  optional uint32 start_inclusive = 3;
-  optional uint32 end_exclusive = 4;
+  string file_descriptor = 1;
+  optional uint32 start_inclusive = 2;
+  optional uint32 end_exclusive = 3;
 }
 
 message ContainerFileWriteReplaceBytesRequest {
-  string task_id = 1;
-  string file_descriptor = 2;
-  bytes data = 3;
-  optional uint32 start_inclusive = 4;
-  optional uint32 end_exclusive = 5;
+  string file_descriptor = 1;
+  bytes data = 2;
+  optional uint32 start_inclusive = 3;
+  optional uint32 end_exclusive = 4;
 }
 
 message ContainerFilesystemExecRequest {
@@ -2079,6 +2090,7 @@ message ContainerFilesystemExecRequest {
     ContainerFileWriteReplaceBytesRequest file_write_replace_bytes_request = 8;
     ContainerFileCloseRequest file_close_request = 9;
   }
+  string task_id = 10;
 }
 
 message ContainerFilesystemExecResponse {
@@ -2540,6 +2552,7 @@ service ModalClient {
   rpc ContainerExecGetOutput(ContainerExecGetOutputRequest) returns (stream RuntimeOutputBatch);
   rpc ContainerExecPutInput(ContainerExecPutInputRequest) returns (google.protobuf.Empty);
   rpc ContainerFilesystemExec(ContainerFilesystemExecRequest) returns (ContainerFilesystemExecResponse);
+  rpc ContainerFilesystemExecGetOutput(ContainerFilesystemExecGetOutputRequest) returns (stream FilesystemRuntimeOutputBatch);
   rpc ContainerExecWait(ContainerExecWaitRequest) returns (ContainerExecWaitResponse);
   rpc ContainerHeartbeat(ContainerHeartbeatRequest) returns (ContainerHeartbeatResponse);
   rpc ContainerLog(ContainerLogRequest) returns (google.protobuf.Empty);


### PR DESCRIPTION
## Describe your changes

Resolves WRK-414 by adding a new container filesystem API. 

This API is designed to closely follow `io.FileIO`, supporting most of the major functions (`open`, `read`, `readline`, `readlines`, `write`, `seek`, `flush`, `close`) along with a few higher-level functions (`delete_bytes`, `write_replace_bytes`) to help make Sandboxes a bit easier to use.

All file modes (e.g. text, bytes, r/w/a/x, etc.) should also be supported, as well as most common errors/exceptions. If an unknown exception is thrown, then a new `modal.exception.FilesystemExecutionError` is thrown instead.

Example usage:
```
app = modal.App.lookup("sandbox-fs", create_if_missing=True)
sb = modal.Sandbox.create(app=app)

with sb.open("test.txt", "w") as f:
  f.write("Hello World\n")

f = sb.open("test.txt", "rb")
print(f.read())
```

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

Add filesystem support for Sandboxes.
