### PR TITLE
Add proto definitions for exec output options

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -111,6 +111,13 @@ enum DeploymentNamespace {
   DEPLOYMENT_NAMESPACE_GLOBAL = 3;
 }
 
+enum ExecOutputOption {
+  EXEC_OUTPUT_OPTION_UNSPECIFIED = 0;
+  EXEC_OUTPUT_OPTION_DEVNULL = 1;
+  EXEC_OUTPUT_OPTION_PIPE = 2;
+  EXEC_OUTPUT_OPTION_STDOUT = 3;
+}
+
 enum FileDescriptor {
   FILE_DESCRIPTOR_UNSPECIFIED = 0;
   FILE_DESCRIPTOR_STDOUT = 1;
@@ -703,6 +710,8 @@ message ContainerExecRequest {
   // Send SIGTERM to running container on exit of exec command.
   bool terminate_container_on_exit = 4;
   bool runtime_debug = 5; // For internal debugging use only.
+  ExecOutputOption stdout_output = 6;
+  ExecOutputOption stderr_output = 7;
 }
 
 message ContainerExecResponse {


### PR DESCRIPTION
## Describe your changes

When running an exec, we block the process if its stdout or stderr has not been consumed. This can be surprising behavior because if a user blindly execs, their process could hang without them knowing. This commit adds proto definitions enabling subprocess-like selection of output style.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

