### PR TITLE
Improve import stats performance by emitting start and end together

### DIFF
--- a/modal/_telemetry.py
+++ b/modal/_telemetry.py
@@ -139,7 +139,7 @@ class ImportInterceptor(importlib.abc.MetaPathFinder):
                 logger.debug(f"failed to send event: {e}")
 
     def install(self):
-        sys.meta_path = [self] + sys.meta_path  # type: ignore
+        sys.meta_path.insert(0, self)  # type: ignore
 
     def remove(self):
         sys.meta_path.remove(self)  # type: ignore

--- a/test/telemetry_test.py
+++ b/test/telemetry_test.py
@@ -62,9 +62,9 @@ class TelemetryConsumer:
         while not self.stopped:
             try:
                 conn, _ = self.server.accept()
+                self.connections.add(conn)
                 receiver = threading.Thread(target=self._recv, args=(conn,), daemon=True)
                 receiver.start()
-                self.connections.add(conn)
             except OSError as e:
                 logging.debug(f"listener got exception, exiting: {e}")
                 return

--- a/test/telemetry_test.py
+++ b/test/telemetry_test.py
@@ -102,9 +102,9 @@ def test_import_tracing(monkeypatch):
         from .telemetry import tracing_module_1  # noqa
 
         expected_messages: list[typing.Dict[str, typing.Any]] = [
-            {"event": "module_load_start", "attributes": {"name": "test.telemetry.tracing_module_1"}},
             {"event": "module_load_start", "attributes": {"name": "test.telemetry.tracing_module_2"}},
             {"event": "module_load_end", "attributes": {"name": "test.telemetry.tracing_module_2"}},
+            {"event": "module_load_start", "attributes": {"name": "test.telemetry.tracing_module_1"}},
             {"event": "module_load_end", "attributes": {"name": "test.telemetry.tracing_module_1"}},
         ]
 


### PR DESCRIPTION
Decrease lock contention on imports by sending start and end events all at once.