### PR TITLE
Align sandbox exec arguments with subprocess

### DIFF
--- a/modal/container_process.py
+++ b/modal/container_process.py
@@ -11,6 +11,7 @@ from ._utils.shell_utils import stream_from_stdin, write_to_fd
 from .client import _Client
 from .exception import InteractiveTimeoutError, InvalidError
 from .io_streams import _StreamReader, _StreamWriter
+from .stream_type import StreamType
 
 
 class _ContainerProcess:
@@ -20,11 +21,21 @@ class _ContainerProcess:
     _stdin: _StreamWriter
     _returncode: Optional[int] = None
 
-    def __init__(self, process_id: str, client: _Client) -> None:
+    def __init__(
+        self,
+        process_id: str,
+        client: _Client,
+        stdout: StreamType = StreamType.PIPE,
+        stderr: StreamType = StreamType.PIPE,
+    ) -> None:
         self._process_id = process_id
         self._client = client
-        self._stdout = _StreamReader(api_pb2.FILE_DESCRIPTOR_STDOUT, process_id, "container_process", self._client)
-        self._stderr = _StreamReader(api_pb2.FILE_DESCRIPTOR_STDERR, process_id, "container_process", self._client)
+        self._stdout = _StreamReader(
+            api_pb2.FILE_DESCRIPTOR_STDOUT, process_id, "container_process", self._client, stream_type=stdout
+        )
+        self._stderr = _StreamReader(
+            api_pb2.FILE_DESCRIPTOR_STDERR, process_id, "container_process", self._client, stream_type=stderr
+        )
         self._stdin = _StreamWriter(process_id, "container_process", self._client)
 
     @property

--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -1,15 +1,17 @@
 # Copyright Modal Labs 2022
 import asyncio
-from typing import TYPE_CHECKING, AsyncIterator, Literal, Optional, Tuple, Union
+from typing import TYPE_CHECKING, AsyncGenerator, Literal, Optional, Tuple, Union
 
 from grpclib import Status
 from grpclib.exceptions import GRPCError, StreamTerminatedError
 
+from modal.exception import ClientClosed, InvalidError
 from modal_proto import api_pb2
 
 from ._utils.async_utils import synchronize_api
 from ._utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES, retry_transient_errors
 from .client import _Client
+from .stream_type import StreamType
 
 if TYPE_CHECKING:
     pass
@@ -17,7 +19,7 @@ if TYPE_CHECKING:
 
 async def _sandbox_logs_iterator(
     sandbox_id: str, file_descriptor: int, last_entry_id: Optional[str], client: _Client
-) -> AsyncIterator[Tuple[Optional[api_pb2.TaskLogs], str]]:
+) -> AsyncGenerator[Tuple[Optional[str], str], None]:
     req = api_pb2.SandboxGetLogsRequest(
         sandbox_id=sandbox_id,
         file_descriptor=file_descriptor,
@@ -35,22 +37,19 @@ async def _sandbox_logs_iterator(
 
 
 async def _container_process_logs_iterator(
-    process_id: str, file_descriptor: int, last_entry_id: Optional[str], client: _Client
-):
+    process_id: str, file_descriptor: int, client: _Client
+) -> AsyncGenerator[Optional[str], None]:
     req = api_pb2.ContainerExecGetOutputRequest(
         exec_id=process_id,
         timeout=55,
-        last_batch_index=last_entry_id or 0,
         file_descriptor=file_descriptor,
     )
     async for batch in client.stub.ContainerExecGetOutput.unary_stream(req):
         if batch.HasField("exit_code"):
-            yield (None, batch.batch_index)
+            yield None
             break
         for item in batch.items:
-            # TODO: do this on the server.
-            if item.file_descriptor == file_descriptor:
-                yield (item.message, batch.batch_index)
+            yield item.message
 
 
 class _StreamReader:
@@ -80,20 +79,38 @@ class _StreamReader:
         object_id: str,
         object_type: Literal["sandbox", "container_process"],
         client: _Client,
+        stream_type: StreamType = StreamType.PIPE,
         by_line: bool = False,  # if True, streamed logs are further processed into complete lines.
     ) -> None:
         """mdmd:hidden"""
+
         self._file_descriptor = file_descriptor
         self._object_type = object_type
         self._object_id = object_id
         self._client = client
         self._stream = None
         self._last_entry_id = None
-        self._buffer = ""
+        self._line_buffer = ""
         self._by_line = by_line
         # Whether the reader received an EOF. Once EOF is True, it returns
         # an empty string for any subsequent reads (including async for)
         self.eof = False
+
+        if not isinstance(stream_type, StreamType):
+            raise TypeError(f"stream_type must be of type StreamType, got {type(stream_type)}")
+
+        # We only support piping sandbox logs because they're meant to be durable logs stored
+        # on the user's application.
+        if object_type == "sandbox" and stream_type != StreamType.PIPE:
+            raise ValueError("Sandbox streams must be piped.")
+        self._stream_type = stream_type
+
+        if self._object_type == "container_process":
+            # Container process streams need to be consumed as they are produced,
+            # otherwise the process will block. Use a buffer to store the stream
+            # until the client consumes it.
+            self._container_process_buffer = []
+            self._consume_container_process_task = asyncio.create_task(self._consume_container_process_stream())
 
     @property
     def file_descriptor(self):
@@ -124,7 +141,64 @@ class _StreamReader:
 
         return data
 
-    async def _get_logs(self) -> AsyncIterator[Optional[str]]:
+    async def _consume_container_process_stream(self):
+        """
+        Consumes the container process stream and stores the messages in the buffer.
+        """
+        if self._stream_type == StreamType.DEVNULL:
+            return
+
+        completed = False
+        retries_remaining = 10
+        while not completed:
+            try:
+                iterator = _container_process_logs_iterator(self._object_id, self._file_descriptor, self._client)
+
+                async for message in iterator:
+                    if self._stream_type == StreamType.STDOUT and message:
+                        print(message, end="")
+                    elif self._stream_type == StreamType.PIPE:
+                        self._container_process_buffer.append(message)
+                    if message is None:
+                        completed = True
+                        break
+
+            except (GRPCError, StreamTerminatedError, ClientClosed) as exc:
+                if retries_remaining > 0:
+                    retries_remaining -= 1
+                    if isinstance(exc, GRPCError):
+                        if exc.status in RETRYABLE_GRPC_STATUS_CODES:
+                            await asyncio.sleep(1.0)
+                            continue
+                    elif isinstance(exc, StreamTerminatedError):
+                        continue
+                    elif isinstance(exc, ClientClosed):
+                        # If the client was closed, the user has triggered a cleanup.
+                        break
+                raise exc
+
+    async def _stream_container_process(self) -> AsyncGenerator[Tuple[Optional[str], str], None]:
+        """mdmd:hidden
+        Streams the container process buffer to the reader.
+        """
+        entry_id = 0
+        if self._last_entry_id:
+            entry_id = int(self._last_entry_id) + 1
+
+        while True:
+            if entry_id >= len(self._container_process_buffer):
+                await asyncio.sleep(0.1)
+                continue
+
+            item = self._container_process_buffer[entry_id]
+
+            yield (item, str(entry_id))
+            if item is None:
+                break
+
+            entry_id += 1
+
+    async def _get_logs(self) -> AsyncGenerator[Optional[str], None]:
         """mdmd:hidden
         Streams sandbox or process logs from the server to the reader.
 
@@ -133,6 +207,9 @@ class _StreamReader:
         When the stream receives an EOF, it yields None. Once an EOF is received,
         subsequent invocations will not yield logs.
         """
+        if self._stream_type != StreamType.PIPE:
+            raise InvalidError("Logs can only be retrieved using the PIPE stream type.")
+
         if self.eof:
             yield None
             return
@@ -147,9 +224,7 @@ class _StreamReader:
                         self._object_id, self._file_descriptor, self._last_entry_id, self._client
                     )
                 else:
-                    iterator = _container_process_logs_iterator(
-                        self._object_id, self._file_descriptor, self._last_entry_id, self._client
-                    )
+                    iterator = self._stream_container_process()
 
                 async for message, entry_id in iterator:
                     self._last_entry_id = entry_id
@@ -169,28 +244,29 @@ class _StreamReader:
                         continue
                 raise
 
-    async def _get_logs_by_line(self) -> AsyncIterator[Optional[str]]:
+    async def _get_logs_by_line(self) -> AsyncGenerator[Optional[str], None]:
         """mdmd:hidden
         Processes logs from the server and yields complete lines only.
         """
         async for message in self._get_logs():
             if message is None:
-                if self._buffer:
-                    yield self._buffer
-                    self._buffer = ""
+                if self._line_buffer:
+                    yield self._line_buffer
+                    self._line_buffer = ""
                 yield None
             else:
-                self._buffer += message
-                while "\n" in self._buffer:
-                    line, self._buffer = self._buffer.split("\n", 1)
+                self._line_buffer += message
+                while "\n" in self._line_buffer:
+                    line, self._line_buffer = self._line_buffer.split("\n", 1)
                     yield line + "\n"
 
     def __aiter__(self):
         """mdmd:hidden"""
-        if self._by_line:
-            self._stream = self._get_logs_by_line()
-        else:
-            self._stream = self._get_logs()
+        if not self._stream:
+            if self._by_line:
+                self._stream = self._get_logs_by_line()
+            else:
+                self._stream = self._get_logs()
         return self
 
     async def __anext__(self):

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -29,6 +29,7 @@ from .network_file_system import _NetworkFileSystem, network_file_system_mount_p
 from .object import _get_environment_name, _Object
 from .scheduler_placement import SchedulerPlacement
 from .secret import _Secret
+from .stream_type import StreamType
 
 _default_image: _Image = _Image.debian_slim()
 
@@ -396,7 +397,16 @@ class _Sandbox(_Object, type_prefix="sb"):
                 await asyncio.sleep(0.5)
         return self._task_id
 
-    async def exec(self, *cmds: str, pty_info: Optional[api_pb2.PTYInfo] = None):
+    async def exec(
+        self,
+        *cmds: str,
+        # Deprecated: internal use only
+        pty_info: Optional[api_pb2.PTYInfo] = None,
+        stdout: StreamType = StreamType.PIPE,
+        stderr: StreamType = StreamType.PIPE,
+        # Internal option to set terminal size and metadata
+        _pty_info: Optional[api_pb2.PTYInfo] = None,
+    ):
         """Execute a command in the Sandbox and return
         a [`ContainerProcess`](/docs/reference/modal.ContainerProcess#modalcontainer_process) handle.
 
@@ -419,11 +429,11 @@ class _Sandbox(_Object, type_prefix="sb"):
             api_pb2.ContainerExecRequest(
                 task_id=task_id,
                 command=cmds,
-                pty_info=pty_info,
+                pty_info=_pty_info or pty_info,
                 runtime_debug=config.get("function_runtime_debug"),
             )
         )
-        return _ContainerProcess(resp.exec_id, self._client)
+        return _ContainerProcess(resp.exec_id, self._client, stdout=stdout, stderr=stderr)
 
     @property
     def stdout(self) -> _StreamReader:

--- a/modal/stream_type.py
+++ b/modal/stream_type.py
@@ -1,0 +1,15 @@
+# Copyright Modal Labs 2022
+import subprocess
+from enum import Enum
+
+
+class StreamType(Enum):
+    # Discard all logs from the stream.
+    DEVNULL = subprocess.DEVNULL
+    # Store logs in a pipe to be read by the client.
+    PIPE = subprocess.PIPE
+    # Print logs to stdout immediately.
+    STDOUT = subprocess.STDOUT
+
+    def __repr__(self):
+        return f"{self.__module__}.{self.__class__.__name__}.{self.name}"

--- a/test/telemetry/tracing_module_1.py
+++ b/test/telemetry/tracing_module_1.py
@@ -1,5 +1,5 @@
 # Copyright Modal Labs 2022
-from . import tracing_module_2 # noqa
+from . import tracing_module_2  # noqa
 
 
 def foo():

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -207,6 +207,7 @@ async def test_volume_upload_large_file(client, tmp_path, servicer, blob_server,
         _, blobs = blob_server
         assert blobs["bl-1"] == b"hello world, this is a lot of text"
 
+
 @pytest.mark.asyncio
 async def test_volume_upload_large_stream(client, servicer, blob_server, *args):
     with mock.patch("modal._utils.blob_utils.LARGE_FILE_LIMIT", 10):
@@ -223,6 +224,7 @@ async def test_volume_upload_large_stream(client, servicer, blob_server, *args):
 
         _, blobs = blob_server
         assert blobs["bl-1"] == b"hello world, this is a lot of text"
+
 
 @pytest.mark.asyncio
 async def test_volume_upload_file_timeout(client, tmp_path, servicer, blob_server, *args):


### PR DESCRIPTION
## Describe your changes

This commit adds new sandbox exec arguments, allowing the user to specify if they want to consume a stream directly, ignore the result, or consume it via a pipe.

Resolves WRK-422
Resolves WRK-413

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

I've tested this behavior out locally:

```python
import modal
from modal.io_streams import StreamType

app = modal.App("peyton-sb-test")

@app.local_entrypoint()
async def main():
    sandbox = modal.Sandbox.create(
        timeout=1000,
        app=app,
    )

    exc = sandbox.exec("echo", "hello", stdout=StreamType.PIPE)
    print(exc.stdout.read(), end="")

    exc = sandbox.exec("echo", "hi2", stdout=StreamType.DEVNULL)
    try:
        print(exc.stdout.read())
    except modal.exception.InvalidError as e:
        print(e)

    exc = sandbox.exec("echo", "hi3", stdout=StreamType.STDOUT)
    exc.wait()
    try:
        print(exc.stdout.read())
    except modal.exception.InvalidError as e:
        print(e)

    sandbox.terminate()
```

## Changelog

Output from `Sandbox.exec` can now be directed to `/dev/null`, `stdout`, or stored for consumption. This behavior can be controlled via the new `StreamType` arguments.