### PR TITLE
Don't rely on MODAL_TASK_SECRET anymore

### DIFF
--- a/modal/client.py
+++ b/modal/client.py
@@ -31,7 +31,7 @@ from modal_version import __version__
 from ._utils import async_utils
 from ._utils.async_utils import TaskContext, synchronize_api
 from ._utils.grpc_utils import create_channel, retry_transient_errors
-from .config import _check_config, config, logger
+from .config import _check_config, _is_remote, config, logger
 from .exception import AuthError, ClientClosed, DeprecationError, VersionError
 
 HEARTBEAT_INTERVAL: float = config.get("heartbeat_interval")
@@ -206,10 +206,9 @@ class _Client:
             if cls._client_from_env:
                 return cls._client_from_env
 
-            task_secret = c["task_secret"]  # Only used to detect if we're running inside a "Modal container"
             token_id = c["token_id"]
             token_secret = c["token_secret"]
-            if task_secret:
+            if _is_remote():
                 if token_id or token_secret:
                     warnings.warn(
                         "Modal tokens provided by MODAL_TOKEN_ID and MODAL_TOKEN_SECRET"

--- a/modal/config.py
+++ b/modal/config.py
@@ -203,7 +203,6 @@ _SETTINGS = {
     "token_id": _Setting(),
     "token_secret": _Setting(),
     "task_id": _Setting(),
-    "task_secret": _Setting(),  # TODO(erikbern): delete very soon
     "serve_timeout": _Setting(transform=float),
     "sync_entrypoint": _Setting(),
     "logs_timeout": _Setting(10, float),

--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -7,7 +7,7 @@ from ._version_generated import build_number
 major_number = 0
 
 # Bump this manually on breaking changes, then reset the number in _version_generated.py
-minor_number = 64
+minor_number = 65
 
 # Right now, automatically increment the patch number in CI
 __version__ = f"{major_number}.{minor_number}.{max(build_number, 0)}"

--- a/modal_version/_version_generated.py
+++ b/modal_version/_version_generated.py
@@ -1,4 +1,4 @@
 # Copyright Modal Labs 2024
 
 # Note: Reset this value to -1 whenever you make a minor `0.X` release of the client.
-build_number = 235  # git: 3839d67
+build_number = -1

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -151,14 +151,14 @@ def test_client_from_env_client(servicer, credentials):
         Client.set_env_client(None)
 
 
-def test_client_token_auth_in_container(servicer, credentials, monkeypatch) -> None:
-    """Ensure that clients can connect with token credentials inside a container.
+def test_client_token_auth_in_sandbox(servicer, credentials, monkeypatch) -> None:
+    """Ensure that clients can connect with token credentials inside a sandbox.
 
     This test is needed so that modal.com/playground works, since it relies on
     running a sandbox with token credentials. Also, `modal shell` uses this to
     preserve its auth context inside the shell.
     """
-    monkeypatch.setenv("MODAL_IS_REMOTE", "1")
+    monkeypatch.setenv("MODAL_TASK_ID", "ta-123")
     _client = client_from_env(servicer.client_addr, credentials)
     assert servicer.last_metadata["x-modal-client-type"] == str(api_pb2.CLIENT_TYPE_CLIENT)
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1838,7 +1838,6 @@ async def token_env(servicer, monkeypatch, credentials):
 async def container_env(servicer, monkeypatch):
     monkeypatch.setenv("MODAL_SERVER_URL", servicer.container_addr)
     monkeypatch.setenv("MODAL_TASK_ID", "ta-123")
-    monkeypatch.setenv("MODAL_TASK_SECRET", "1")  # TODO(erikbern): remove
     monkeypatch.setenv("MODAL_IS_REMOTE", "1")
     yield
 

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -81,7 +81,6 @@ def set_env_vars(restore_path, container_addr):
             "MODAL_SERVER_URL": container_addr,
             "MODAL_TASK_ID": "ta-123",
             "MODAL_IS_REMOTE": "1",
-            "MODAL_TASK_SECRET": "1",
         },
     ):
         yield

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -310,7 +310,6 @@ def _run_container(
         # These env vars are always present in containers
         env["MODAL_TASK_ID"] = "ta-123"
         env["MODAL_IS_REMOTE"] = "1"
-        env["MODAL_TASK_SECRET"] = "1"  # TODO(erikbern): fix
 
         # reset _App tracking state between runs
         _App._all_apps.clear()
@@ -1640,7 +1639,6 @@ def _run_container_process(
 
     # These env vars are always present in containers
     env["MODAL_TASK_ID"] = "ta-123"
-    env["MODAL_TASK_SECRET"] = "1"  # TODO(erikbern): remove
     env["MODAL_IS_REMOTE"] = "1"
 
     encoded_container_args = base64.b64encode(container_args.SerializeToString())


### PR DESCRIPTION
We can rely on the fact that `MODAL_IS_REMOTE` is set in Python containers but not in sandboxes since a few days ago.

Also bumping the client version to 0.65, mostly since we haven't bumped it for a long time, but also partly because we can use that to know when we don't have to expose dummy task secret environment variables any longer.