### PR TITLE
MOD-2454: add async cancellation handling for async_utils

### DIFF
--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -544,7 +544,15 @@ async def async_zip(*generators):
             pass
 
         for gen in generators:
-            await gen.aclose()
+            first_exception = None
+            try:
+                await gen.aclose()
+            except BaseException as e:
+                if first_exception is None:
+                    first_exception = e
+                logger.exception(f"Error closing async generator: {e}")
+        if first_exception is not None:
+            raise first_exception
 
 
 @dataclass

--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -10,7 +10,6 @@ from dataclasses import dataclass
 from typing import (
     Any,
     AsyncGenerator,
-    AsyncIterable,
     Awaitable,
     Callable,
     Iterable,
@@ -492,20 +491,20 @@ async def aclosing(
         await agen.aclose()
 
 
-async def sync_or_async_iter(iterable: Union[Iterable[T], AsyncIterable[T]]) -> AsyncGenerator[T, None]:
-    if hasattr(iterable, "__aiter__"):
-        agen = typing.cast(AsyncGenerator[T, None], iterable)
+async def sync_or_async_iter(iter: Union[Iterable[T], AsyncGenerator[T, None]]) -> AsyncGenerator[T, None]:
+    if hasattr(iter, "__aiter__"):
+        agen = typing.cast(AsyncGenerator[T, None], iter)
         try:
             async for item in agen:
                 yield item
         finally:
             await agen.aclose()
     else:
-        assert hasattr(iterable, "__iter__"), "sync_or_async_iter requires an iterable or async iterable"
+        assert hasattr(iter, "__iter__"), "sync_or_async_iter requires an Iterable or AsyncGenerator"
         # This intentionally could block the event loop for the duration of calling __iter__ and __next__,
         # so in non-trivial cases (like passing lists and ranges) this could be quite a foot gun for users #
         # w/ async code (but they can work around it by always using async iterators)
-        for item in typing.cast(Iterable[T], iterable):
+        for item in typing.cast(Iterable[T], iter):
             yield item
 
 

--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -543,8 +543,8 @@ async def async_zip(*generators):
         except asyncio.CancelledError:
             pass
 
+        first_exception = None
         for gen in generators:
-            first_exception = None
             try:
                 await gen.aclose()
             except BaseException as e:

--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -562,9 +562,7 @@ STOP_SENTINEL = StopSentinelType()
 
 
 async def async_merge(*iterables: Union[AsyncIterable[T], Iterable[T]]) -> AsyncGenerator[T, None]:
-    queue: asyncio.Queue[Union[ValueWrapper[T], ExceptionWrapper, StopSentinelType]] = asyncio.Queue(
-        maxsize=len(iterables) * 10
-    )
+    queue: asyncio.Queue[Union[ValueWrapper[T], ExceptionWrapper]] = asyncio.Queue(maxsize=len(iterables) * 10)
 
     async def producer(iterable: Union[AsyncIterable[T], Iterable[T]]):
         try:

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -210,8 +210,11 @@ class _Invocation:
         items_received = 0
         items_total: Union[int, None] = None  # populated when self.run_function() completes
         async with aclosing(
-            _stream_function_call_data(self.client, self.function_call_id, variant="data_out")
-        ) as data_stream, aclosing(async_merge(data_stream, callable_to_agen(self.run_function))) as streamer:
+            async_merge(
+                _stream_function_call_data(self.client, self.function_call_id, variant="data_out"),
+                callable_to_agen(self.run_function),
+            )
+        ) as streamer:
             async for item in streamer:
                 if isinstance(item, api_pb2.GeneratorDone):
                     items_total = item.items_total

--- a/modal/parallel_map.py
+++ b/modal/parallel_map.py
@@ -251,9 +251,7 @@ async def _map_invocation(
 
         assert len(received_outputs) == 0
 
-    async with aclosing(drain_input_generator()) as drainer, aclosing(pump_inputs()) as pump, aclosing(
-        poll_outputs()
-    ) as poller, aclosing(async_merge(drainer, pump, poller)) as streamer:
+    async with aclosing(async_merge(drain_input_generator(), pump_inputs(), poll_outputs())) as streamer:
         async for response in streamer:
             if response is not None:
                 yield response.value

--- a/modal/parallel_map.py
+++ b/modal/parallel_map.py
@@ -338,7 +338,7 @@ async def _map_async(
 
     async def feed_queue():
         # This runs in a main thread event loop, so it doesn't block the synchronizer loop
-        async with aclosing(async_zip(*input_iterators)) as streamer:
+        async with aclosing(async_zip(*[sync_or_async_iter(it) for it in input_iterators])) as streamer:
             async for args in streamer:
                 await raw_input_queue.put.aio((args, kwargs))
         await raw_input_queue.put.aio(None)  # end-of-input sentinel

--- a/test/async_utils_test.py
+++ b/test/async_utils_test.py
@@ -369,7 +369,7 @@ async def test_sync_or_async_iter_async_gen():
     # test that things are cleaned up when we exit the context manager without fully exhausting the generator
     result.clear()
     states.clear()
-    async with aclosing(async_gen()) as agen, aclosing(sync_or_async_iter(agen)) as stream:
+    async with aclosing(sync_or_async_iter(async_gen())) as stream:
         async for _ in stream:
             break
     assert states == ["enter", "exit"]
@@ -427,8 +427,7 @@ async def test_async_zip_different_lengths():
             await asyncio.sleep(0)
             states.append("exit long")
 
-    # wrapping the longer generator with aclosing as it will not be exhausted otherwise
-    async with aclosing(gen_long()) as g2, aclosing(async_zip(gen_short(), g2)) as stream:
+    async with aclosing(async_zip(gen_short(), gen_long())) as stream:
         async for item in stream:
             result.append(item)
 
@@ -454,8 +453,7 @@ async def test_async_zip_exception():
             states.append(f"exit {x}")
 
     with pytest.raises(SampleException):
-        # wrapping the longer generator with aclosing as it will not be exhausted otherwise
-        async with aclosing(gen(5)) as g5, aclosing(async_zip(gen(1), g5)) as stream:
+        async with aclosing(async_zip(gen(1), gen(5))) as stream:
             async for item in stream:
                 result.append(item)
 

--- a/test/async_utils_test.py
+++ b/test/async_utils_test.py
@@ -391,9 +391,7 @@ async def test_async_zip():
             await asyncio.sleep(0)
             states.append(f"exit {x}")
 
-    async with aclosing(gen(1)) as g1, aclosing(gen(5)) as g2, aclosing(gen(10)) as g3, aclosing(
-        async_zip(g1, g2, g3)
-    ) as stream:
+    async with aclosing(async_zip(gen(1), gen(5), gen(10))) as stream:
         async for item in stream:
             result.append(item)
 
@@ -429,7 +427,7 @@ async def test_async_zip_different_lengths():
             await asyncio.sleep(0)
             states.append("exit long")
 
-    async with aclosing(gen_short()) as g1, aclosing(gen_long()) as g2, aclosing(async_zip(g1, g2)) as stream:
+    async with aclosing(async_zip(gen_short(), gen_long())) as stream:
         async for item in stream:
             result.append(item)
 
@@ -455,7 +453,7 @@ async def test_async_zip_exception():
             states.append(f"exit {x}")
 
     with pytest.raises(SampleException):
-        async with aclosing(gen(1)) as g1, aclosing(gen(5)) as g2, aclosing(async_zip(g1, g2)) as stream:
+        async with aclosing(async_zip(gen(1), gen(5))) as stream:
             async for item in stream:
                 result.append(item)
 

--- a/test/async_utils_test.py
+++ b/test/async_utils_test.py
@@ -490,6 +490,52 @@ async def test_async_zip_parallel():
 
 
 @pytest.mark.asyncio
+async def test_async_zip_cancellation():
+    ev = asyncio.Event()
+
+    async def gen1():
+        await asyncio.sleep(0.1)
+        yield 1
+        await ev.wait()
+        raise asyncio.CancelledError()
+        yield 2
+
+    async def gen2():
+        yield 3
+        await asyncio.sleep(0.1)
+        yield 4
+
+    async def zip_coro():
+        async for _ in async_zip(gen1(), gen2()):
+            pass
+
+    zip_task = asyncio.create_task(zip_coro())
+    await asyncio.sleep(0.1)
+    zip_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await zip_task
+
+
+@pytest.mark.asyncio
+async def test_async_zip_producer_cancellation():
+    async def gen1():
+        await asyncio.sleep(0.1)
+        yield 1
+        raise asyncio.CancelledError()
+        yield 2
+
+    async def gen2():
+        yield 3
+        await asyncio.sleep(0.1)
+        yield 4
+
+    await asyncio.sleep(0.1)
+    with pytest.raises(asyncio.CancelledError):
+        async for _ in async_zip(gen1(), gen2()):
+            pass
+
+
+@pytest.mark.asyncio
 async def test_async_merge():
     result = []
     states = []
@@ -564,15 +610,15 @@ async def test_async_merge_cleanup():
             await asyncio.sleep(0)
             states.append("gen2 exit")
 
-    async with aclosing(gen1()) as g1, aclosing(gen2()) as g2, aclosing(async_merge(g1, g2)) as stream:
+    async with aclosing(async_merge(gen1(), gen2())) as stream:
         async for _ in stream:
             break
 
-    assert states == [
+    assert sorted(states) == [
         "gen1 enter",
+        "gen1 exit",
         "gen2 enter",
         "gen2 exit",
-        "gen1 exit",
     ]
 
 
@@ -612,6 +658,51 @@ async def test_async_merge_exception():
         "gen2 enter",
         "gen2 exit",
     ]
+
+
+@pytest.mark.asyncio
+async def test_async_merge_cancellation():
+    ev = asyncio.Event()
+
+    async def gen1():
+        await asyncio.sleep(0.1)
+        yield 1
+        await ev.wait()
+        yield 2
+
+    async def gen2():
+        yield 3
+        await asyncio.sleep(0.1)
+        yield 4
+
+    async def merge_coro():
+        async for _ in async_merge(gen1(), gen2()):
+            pass
+
+    merge_task = asyncio.create_task(merge_coro())
+    await asyncio.sleep(0.1)
+    merge_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await merge_task
+
+
+@pytest.mark.asyncio
+async def test_async_merge_producer_cancellation():
+    async def gen1():
+        await asyncio.sleep(0.1)
+        yield 1
+        raise asyncio.CancelledError()
+        yield 2
+
+    async def gen2():
+        yield 3
+        await asyncio.sleep(0.1)
+        yield 4
+
+    await asyncio.sleep(0.1)
+    with pytest.raises(asyncio.CancelledError):
+        async for _ in async_merge(gen1(), gen2()):
+            pass
 
 
 @pytest.mark.asyncio

--- a/test/async_utils_test.py
+++ b/test/async_utils_test.py
@@ -506,8 +506,9 @@ async def test_async_zip_cancellation():
         yield 4
 
     async def zip_coro():
-        async for _ in async_zip(gen1(), gen2()):
-            pass
+        async with aclosing(async_zip(gen1(), gen2())) as stream:
+            async for _ in stream:
+                pass
 
     zip_task = asyncio.create_task(zip_coro())
     await asyncio.sleep(0.1)
@@ -531,8 +532,9 @@ async def test_async_zip_producer_cancellation():
 
     await asyncio.sleep(0.1)
     with pytest.raises(asyncio.CancelledError):
-        async for _ in async_zip(gen1(), gen2()):
-            pass
+        async with aclosing(async_zip(gen1(), gen2())) as stream:
+            async for _ in stream:
+                pass
 
 
 @pytest.mark.asyncio
@@ -676,8 +678,9 @@ async def test_async_merge_cancellation():
         yield 4
 
     async def merge_coro():
-        async for _ in async_merge(gen1(), gen2()):
-            pass
+        async with aclosing(async_merge(gen1(), gen2())) as stream:
+            async for _ in stream:
+                pass
 
     merge_task = asyncio.create_task(merge_coro())
     await asyncio.sleep(0.1)
@@ -701,8 +704,9 @@ async def test_async_merge_producer_cancellation():
 
     await asyncio.sleep(0.1)
     with pytest.raises(asyncio.CancelledError):
-        async for _ in async_merge(gen1(), gen2()):
-            pass
+        async with aclosing(async_merge(gen1(), gen2())) as stream:
+            async for _ in stream:
+                pass
 
 
 @pytest.mark.asyncio

--- a/test/async_utils_test.py
+++ b/test/async_utils_test.py
@@ -427,7 +427,8 @@ async def test_async_zip_different_lengths():
             await asyncio.sleep(0)
             states.append("exit long")
 
-    async with aclosing(async_zip(gen_short(), gen_long())) as stream:
+    # wrapping the longer generator with aclosing as it will not be exhausted otherwise
+    async with aclosing(gen_long()) as g2, aclosing(async_zip(gen_short(), g2)) as stream:
         async for item in stream:
             result.append(item)
 
@@ -453,7 +454,8 @@ async def test_async_zip_exception():
             states.append(f"exit {x}")
 
     with pytest.raises(SampleException):
-        async with aclosing(async_zip(gen(1), gen(5))) as stream:
+        # wrapping the longer generator with aclosing as it will not be exhausted otherwise
+        async with aclosing(gen(5)) as g5, aclosing(async_zip(gen(1), g5)) as stream:
             async for item in stream:
                 result.append(item)
 


### PR DESCRIPTION
Adds fix to `async_merge` to make it handle cancellation errors in the input generator, adds max size to the queue and adds tests