### PR TITLE
Fix Image.imports not re-raising when using a Cls

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -630,10 +630,16 @@ def import_class_service(
 
     if isinstance(cls, Cls):
         # The cls decorator is in global scope
-        method_partials = synchronizer._translate_in(cls._get_partial_functions())
+        _cls = synchronizer._translate_in(cls)
+        method_partials = _cls._get_partial_functions()
+        function = _cls._class_service_function
     else:
         # Undecorated user class - find all methods
         method_partials = _find_partial_methods_for_user_cls(cls, _PartialFunctionFlags.all())
+        function = None
+
+    if function:
+        code_deps = function.deps(only_explicit_mounts=True)
 
     user_cls_instance = get_user_class_instance(cls, cls_args, cls_kwargs)
 

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -1060,6 +1060,18 @@ def test_cls_enter_uses_event_loop(servicer):
 
 
 @skip_github_non_linux
+def test_cls_with_image(servicer):
+    ret = _run_container(
+        servicer,
+        "test.supports.class_with_image",
+        "ClassWithImage.*",
+        inputs=_get_inputs(((), {}), method_name="image_is_hydrated"),
+        is_class=True,
+    )
+    assert _unwrap_scalar(ret) == True
+
+
+@skip_github_non_linux
 def test_container_heartbeats(servicer):
     _run_container(servicer, "test.supports.functions", "square")
     assert any(isinstance(request, api_pb2.ContainerHeartbeatRequest) for request in servicer.requests)

--- a/test/supports/class_with_image.py
+++ b/test/supports/class_with_image.py
@@ -1,0 +1,12 @@
+# Copyright Modal Labs 2024
+import modal
+
+image = modal.Image.debian_slim()
+app = modal.App(image=image)
+
+
+@app.cls()
+class ClassWithImage:
+    @modal.method()
+    def image_is_hydrated(self):
+        return image.is_hydrated


### PR DESCRIPTION
Fixes CLI-210 (at least in the simple case! this code is pretty removed from the defective behavior so hard to say completely.)

The issue was that we were not including the `Image` that is a dependency of the "class service function" when importing a `Cls`, and we do the import error re-raising as part of `Image` metadata hydration.

## Changelog

- Fixed a bug where the `Image.imports` context manager would not correctly propagate ImportError when using a `modal.Cls`.