### PR TITLE
[CLI-215] Fix 10s delay when getting server side errors during app.run load

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -372,6 +372,7 @@ class _App:
         finally:
             self._running_app = None
             self._client = None
+            self._uncreate_all_objects()
 
     @asynccontextmanager
     async def run(

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -328,7 +328,7 @@ async def _run_app(
             # Publish the app
             await _publish_app(client, running_app, app_state, app._indexed_objects)
         except asyncio.CancelledError as e:
-            # this typically happens on sigint/ctrl-C during setup (they KeyboardInterrupt happens in the main thread)
+            # this typically happens on sigint/ctrl-C during setup (the KeyboardInterrupt happens in the main thread)
             if output_mgr := _get_output_manager():
                 output_mgr.print("Aborting app initialization...\n")
 
@@ -348,6 +348,8 @@ async def _run_app(
                     yield app
             else:
                 yield app
+            # successful completion!
+            await _status_based_disconnect(client, running_app.app_id, exc_info=None)
         except KeyboardInterrupt as e:
             # this happens only if sigint comes in during the yield block above
             if detach:

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -390,8 +390,6 @@ async def _run_app(
             await _status_based_disconnect(client, running_app.app_id, e)
             raise
 
-        # successful completion!
-        await _status_based_disconnect(client, running_app.app_id, exc_info=None)
         # wait for logs gracefully, even though the task context would do the same
         # this allows us to log a more specific warning in case the app doesn't
         # provide all logs before exit

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -62,17 +62,31 @@ def dummy():
 
 # Should exit without waiting for the "logs_timeout" grace period.
 @pytest.mark.timeout(5)
-def test_create_object_exception(servicer, client):
-    servicer.function_create_error = True
+def test_create_object_internal_exception(servicer, client):
+    servicer.function_create_error = GRPCError(Status.INTERNAL, "Function create failed")
 
     app = App()
     app.function()(dummy)
 
     with pytest.raises(GRPCError) as excinfo:
-        with app.run(client=client):
-            pass
+        with enable_output():  # this activates the log streaming loop, which could potentially hold up context exit
+            with app.run(client=client):
+                pass
 
     assert excinfo.value.status == Status.INTERNAL
+
+
+@pytest.mark.timeout(5)
+def test_create_object_invalid_exception(servicer, client):
+    servicer.function_create_error = GRPCError(Status.INVALID_ARGUMENT, "something was invalid")
+
+    app = App()
+    app.function()(dummy)
+
+    with pytest.raises(InvalidError, match="something was invalid"):  # error should be converted
+        with enable_output():  # this activates the log streaming loop, which could potentially hold up context exit
+            with app.run(client=client):
+                pass
 
 
 def test_deploy_falls_back_to_app_name(servicer, client):

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -76,6 +76,7 @@ def test_create_object_internal_exception(servicer, client):
 
     assert len(ctx.get_requests("FunctionCreate")) == 4  # some retries are applied to internal errors
     assert excinfo.value.status == Status.INTERNAL
+    assert len(ctx.get_requests("AppClientDisconnect")) == 1
 
 
 @pytest.mark.timeout(5)
@@ -91,6 +92,7 @@ def test_create_object_invalid_exception(servicer, client):
                 with app.run(client=client):
                     pass
     assert len(ctx.get_requests("FunctionCreate")) == 1  # no retries on an invalid request
+    assert len(ctx.get_requests("AppClientDisconnect")) == 1
 
 
 def test_deploy_falls_back_to_app_name(servicer, client):

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -68,11 +68,13 @@ def test_create_object_internal_exception(servicer, client):
     app = App()
     app.function()(dummy)
 
-    with pytest.raises(GRPCError) as excinfo:
-        with enable_output():  # this activates the log streaming loop, which could potentially hold up context exit
-            with app.run(client=client):
-                pass
+    with servicer.intercept() as ctx:
+        with pytest.raises(GRPCError) as excinfo:
+            with enable_output():  # this activates the log streaming loop, which could potentially hold up context exit
+                with app.run(client=client):
+                    pass
 
+    assert len(ctx.get_requests("FunctionCreate")) == 4  # some retries are applied to internal errors
     assert excinfo.value.status == Status.INTERNAL
 
 
@@ -83,10 +85,12 @@ def test_create_object_invalid_exception(servicer, client):
     app = App()
     app.function()(dummy)
 
-    with pytest.raises(InvalidError, match="something was invalid"):  # error should be converted
-        with enable_output():  # this activates the log streaming loop, which could potentially hold up context exit
-            with app.run(client=client):
-                pass
+    with servicer.intercept() as ctx:
+        with pytest.raises(InvalidError, match="something was invalid"):  # error should be converted
+            with enable_output():  # this activates the log streaming loop, which could potentially hold up context exit
+                with app.run(client=client):
+                    pass
+    assert len(ctx.get_requests("FunctionCreate")) == 1  # no retries on an invalid request
 
 
 def test_deploy_falls_back_to_app_name(servicer, client):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -171,7 +171,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.n_functions = 0
         self.n_schedules = 0
         self.function2schedule = {}
-        self.function_create_error = False
+        self.function_create_error: Optional[BaseException] = None
         self.heartbeat_status_code = None
         self.n_apps = 0
         self.classes = {}

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -911,7 +911,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
     async def FunctionCreate(self, stream):
         request: api_pb2.FunctionCreateRequest = await stream.recv_message()
         if self.function_create_error:
-            raise GRPCError(Status.INTERNAL, "Function create failed")
+            raise self.function_create_error
         if request.existing_function_id:
             function_id = request.existing_function_id
         else:


### PR DESCRIPTION
## Changelog

* Fix issue where `modal run` wouldn't exit for 10s if there was a failure during app creation