### PR TITLE
MOD-2454: remove aiostream dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ packages = find:
 python_requires = >=3.8
 install_requires =
     aiohttp
-    aiostream~=0.5.2
     certifi
     click>=8.1.0
     fastapi


### PR DESCRIPTION
Removes aiostream as a package dependency. Depends on:

- [x] https://github.com/modal-labs/modal-client/pull/2422
- [x] https://github.com/modal-labs/modal-client/pull/2421
- [x] https://github.com/modal-labs/modal-client/pull/2418
- [x] internal removal