### PR TITLE
Remove old container heartbeat fields and add new ones.

### DIFF
--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -381,7 +381,7 @@ class _ContainerIOManager:
 
             request = api_pb2.ContainerHeartbeatRequest(canceled_inputs_return_outputs=True)
             response = await retry_transient_errors(
-                self._client.stub.ContainerHeartbeat, request, attempt_timeout=HEARTBEAT_TIMEOUT, max_retries=None
+                self._client.stub.ContainerHeartbeat, request, attempt_timeout=HEARTBEAT_TIMEOUT
             )
 
         if response.HasField("cancel_input_event"):

--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -371,13 +371,6 @@ class _ContainerIOManager:
     async def _heartbeat_handle_cancellations(self) -> bool:
         # Return True if a cancellation event was received, in that case
         # we shouldn't wait too long for another heartbeat
-
-        request = api_pb2.ContainerHeartbeatRequest(supports_graceful_input_cancellation=True)
-        if self.current_input_id is not None:
-            request.current_input_id = self.current_input_id
-        if self.current_input_started_at is not None:
-            request.current_input_started_at = self.current_input_started_at
-
         async with self.heartbeat_condition:
             # Continuously wait until `waiting_for_memory_snapshot` is false.
             # TODO(matt): Verify that a `while` is necessary over an `if`. Spurious
@@ -386,9 +379,9 @@ class _ContainerIOManager:
             while self._waiting_for_memory_snapshot:
                 await self.heartbeat_condition.wait()
 
-            # TODO(erikbern): capture exceptions?
+            request = api_pb2.ContainerHeartbeatRequest(canceled_inputs_return_outputs=True)
             response = await retry_transient_errors(
-                self._client.stub.ContainerHeartbeat, request, attempt_timeout=HEARTBEAT_TIMEOUT
+                self._client.stub.ContainerHeartbeat, request, attempt_timeout=HEARTBEAT_TIMEOUT, max_retries=None
             )
 
         if response.HasField("cancel_input_event"):

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -827,9 +827,9 @@ message ContainerFilesystemExecResponse {
 }
 
 message ContainerHeartbeatRequest {
-  string current_input_id = 1;
-  double current_input_started_at = 2;
-  bool supports_graceful_input_cancellation = 3; // implicitly also means we support long polling. Can be removed once v0.57 is no longer supported
+  bool canceled_inputs_return_outputs = 4;
+
+  reserved 1, 2, 3;
 }
 
 message ContainerHeartbeatResponse {


### PR DESCRIPTION
Prereq for WRK-11.

This cleans up fields that are no longer used on the server or by any client version. We also report whether the client supports returning terminated outputs for canceled inputs, so we can avoid killing the task.

There's also indefinite retries for the container heartbeat since the canceled inputs should be idempotent.

Won't submit till after [e0508fa](https://github.com/modal-labs/modal/pull/16889) is in all workers.