### PR TITLE
Adds new new enum `ProxyType`

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1082,7 +1082,8 @@ message Function {
   uint32 _experimental_buffer_containers = 69;
 
   // _experimental_proxy_ip -> ProxyInfo.proxy_ip
-  optional string _experimental_proxy_ip = 70 [deprecated=true];
+  // TODO: deprecate.
+  optional string _experimental_proxy_ip = 70;
 
   bool runtime_perf_record = 71; // For internal debugging use only.
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1075,7 +1075,8 @@ message Function {
 
   uint32 _experimental_buffer_containers = 69;
 
-  optional string _experimental_proxy_ip = 70;
+  // _experimental_proxy_ip -> ProxyInfo.proxy_ip
+  optional string _experimental_proxy_ip = 70 [deprecated=true];
 
   bool runtime_perf_record = 71; // For internal debugging use only.
 
@@ -1688,10 +1689,14 @@ message ProxyGetOrCreateResponse {
 }
 
 message ProxyInfo {
+  // old system
   string elastic_ip = 1;
   string proxy_key = 2;
   string remote_addr = 3;
   int32 remote_port = 4;
+
+  // new system
+  optional string proxy_ip = 5;
 }
 
 message ProxyIp {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1081,7 +1081,7 @@ message Function {
 
   uint32 _experimental_buffer_containers = 69;
 
-  // _experimental_proxy_ip -> ProxyInfo.proxy_ip
+  // _experimental_proxy_ip -> ProxyInfo
   // TODO: deprecate.
   optional string _experimental_proxy_ip = 70;
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -174,6 +174,12 @@ enum ProxyIpStatus {
   PROXY_IP_STATUS_UNHEALTHY = 4;
 }
 
+enum ProxyType {
+  PROXY_TYPE_UNSPECIFIED = 0;
+  PROXY_TYPE_LEGACY = 1;
+  PROXY_TYPE_VPROX = 2;
+}
+
 enum RateLimitInterval {
   RATE_LIMIT_INTERVAL_UNSPECIFIED = 0;
   RATE_LIMIT_INTERVAL_SECOND = 1;
@@ -1689,14 +1695,11 @@ message ProxyGetOrCreateResponse {
 }
 
 message ProxyInfo {
-  // old system
   string elastic_ip = 1;
   string proxy_key = 2;
   string remote_addr = 3;
   int32 remote_port = 4;
-
-  // new system
-  optional string proxy_ip = 5;
+  ProxyType proxy_type = 5;
 }
 
 message ProxyIp {


### PR DESCRIPTION
The new enum allows us to differentiate between the different proxy systems offered to users. The "legacy" proxy system is being deprecated and all new proxies will use the new system ("vprox"). 