### PR TITLE
Adds Proxy delete and list methods

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1822,6 +1822,7 @@ message ProxyIp {
   string proxy_ip = 1;
   ProxyIpStatus status = 2;
   double created_at = 3;
+  string environment_name = 4;
 }
 
 message ProxyIpDeleteRequest {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1795,6 +1795,10 @@ message PortSpecs {
   repeated PortSpec ports = 1;
 }
 
+message ProxyDeleteRequest {
+  string proxy_id = 1 [ (modal.options.audit_target_attr) = true ];
+}
+
 message ProxyGetOrCreateRequest {
   string deployment_name = 1 [ (modal.options.audit_target_attr) = true ];
   DeploymentNamespace namespace = 2;
@@ -1835,6 +1839,10 @@ message ProxyIpGetOrCreateResponse {
 
 message ProxyIpListResponse {
   repeated ProxyIp proxy_ips = 1;
+}
+
+message ProxyListResponse {
+  repeated ProxyIp proxies = 1;
 }
 
 message QueueClearRequest {
@@ -2632,13 +2640,17 @@ service ModalClient {
   rpc MountGetOrCreate(MountGetOrCreateRequest) returns (MountGetOrCreateResponse);
   rpc MountPutFile(MountPutFileRequest) returns (MountPutFileResponse);
 
-  // Proxies (legacy)
+  // Proxies
+  rpc ProxyDelete(ProxyDeleteRequest) returns (google.protobuf.Empty);
   rpc ProxyGetOrCreate(ProxyGetOrCreateRequest) returns (ProxyGetOrCreateResponse);
 
   // Proxy IPs
+  // TODO: remove all methods when migration from ProxyIp -> Proxy is complete.
   rpc ProxyIpDelete(ProxyIpDeleteRequest) returns (google.protobuf.Empty);
   rpc ProxyIpGetOrCreate(ProxyIpGetOrCreateRequest) returns (ProxyIpGetOrCreateResponse);
   rpc ProxyIpList(google.protobuf.Empty) returns (ProxyIpListResponse);
+
+  rpc ProxyList(google.protobuf.Empty) returns (ProxyListResponse);
 
   // Queues
   rpc QueueClear(QueueClearRequest) returns (google.protobuf.Empty);


### PR DESCRIPTION
Adds RPC methods for listing and deleting `Proxy` objects. `Proxy` supersedes `ProxyIp`s. 

This is part of the proxy ip -> proxy migration.