### PR TITLE
Adds `Proxy` proto object

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1795,6 +1795,13 @@ message PortSpecs {
   repeated PortSpec ports = 1;
 }
 
+message Proxy {
+  string name = 1;
+  double created_at = 2;
+  string environment_name = 3;
+  repeated ProxyIp proxy_ips = 4;
+}
+
 message ProxyDeleteRequest {
   string proxy_id = 1 [ (modal.options.audit_target_attr) = true ];
 }
@@ -1843,7 +1850,7 @@ message ProxyIpListResponse {
 }
 
 message ProxyListResponse {
-  repeated ProxyIp proxies = 1;
+  repeated Proxy proxies = 1;
 }
 
 message QueueClearRequest {


### PR DESCRIPTION
Establishes a clear relationship between proxies and proxy IPs--a proxy can eventually have multiple proxy IPs. 