### PR TITLE
Move fixture logic from ClientHello to the middleware

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -265,6 +265,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
                 raise GRPCError(Status.FAILED_PRECONDITION, f"Missing {header} header")
 
         client_version = event.metadata["x-modal-client-version"]
+        assert isinstance(client_version, str)
         if client_version == "unauthenticated":
             raise GRPCError(Status.UNAUTHENTICATED, "failed authentication")
         elif client_version == "timeout":

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -263,6 +263,17 @@ class MockClientServicer(api_grpc.ModalClientBase):
         ]:
             if header not in event.metadata:
                 raise GRPCError(Status.FAILED_PRECONDITION, f"Missing {header} header")
+
+        client_version = event.metadata["x-modal-client-version"]
+        if client_version == "unauthenticated":
+            raise GRPCError(Status.UNAUTHENTICATED, "failed authentication")
+        elif client_version == "timeout":
+            await asyncio.sleep(60)
+        elif client_version == "deprecated":
+            pass  # dumb magic fixture constant
+        elif pkg_resources.parse_version(client_version) < pkg_resources.parse_version(__version__):
+            raise GRPCError(Status.FAILED_PRECONDITION, "Old client")
+
         if event.metadata["x-modal-client-type"] == str(api_pb2.CLIENT_TYPE_CLIENT):
             if event.method_name in [
                 "/modal.client.ModalClient/TokenFlowCreate",
@@ -644,17 +655,9 @@ class MockClientServicer(api_grpc.ModalClientBase):
     async def ClientHello(self, stream):
         request: Empty = await stream.recv_message()
         self.requests.append(request)
-        client_version = stream.metadata["x-modal-client-version"]
         warning = ""
-        assert stream.user_agent.startswith(f"modal-client/{__version__} ")
-        if client_version == "unauthenticated":
-            raise GRPCError(Status.UNAUTHENTICATED, "failed authentication")
-        elif client_version == "deprecated":
+        if stream.metadata["x-modal-client-version"] == "deprecated":
             warning = "SUPER OLD"
-        elif client_version == "timeout":
-            await asyncio.sleep(60)
-        elif pkg_resources.parse_version(client_version) < pkg_resources.parse_version(__version__):
-            raise GRPCError(Status.FAILED_PRECONDITION, "Old client")
         resp = api_pb2.ClientHelloResponse(warning=warning)
         await stream.send_message(resp)
 


### PR DESCRIPTION
Broke this out of a PR I have that removes `ClientHello` just so I can merge it in a few smaller steps.