### PR TITLE
Simplify `from_env` test

### DIFF
--- a/test/client_test.py
+++ b/test/client_test.py
@@ -138,6 +138,13 @@ def test_client_from_env_failing(servicer, credentials):
         client_from_env("https://foo.invalid", credentials)
 
 
+def test_client_from_env_reset(servicer, credentials):
+    client_1 = client_from_env(servicer.client_addr, credentials)
+    Client.set_env_client(None)
+    client_2 = client_from_env(servicer.client_addr, credentials)
+    assert client_1 != client_2
+
+
 def test_client_token_auth_in_sandbox(servicer, credentials, monkeypatch) -> None:
     """Ensure that clients can connect with token credentials inside a sandbox.
 

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -126,29 +126,16 @@ def client_from_env(client_addr, credentials):
 
 
 def test_client_from_env_client(servicer, credentials):
-    try:
-        # First, a failing one
-        with pytest.raises(ConnectionError):
-            client_from_env("https://foo.invalid", credentials)
+    client_1 = client_from_env(servicer.client_addr, credentials)
+    client_2 = client_from_env(servicer.client_addr, credentials)
+    assert isinstance(client_1, Client)
+    assert isinstance(client_2, Client)
+    assert client_1 == client_2
 
-        # Make sure later clients can still succeed
-        client_1 = client_from_env(servicer.client_addr, credentials)
-        client_2 = client_from_env(servicer.client_addr, credentials)
-        assert isinstance(client_1, Client)
-        assert isinstance(client_2, Client)
-        assert client_1 == client_2
 
-    finally:
-        Client.set_env_client(None)
-
-    try:
-        # After stopping, creating a new client should return a new one
-        client_3 = client_from_env(servicer.client_addr, credentials)
-        client_4 = client_from_env(servicer.client_addr, credentials)
-        assert client_3 != client_1
-        assert client_4 == client_3
-    finally:
-        Client.set_env_client(None)
+def test_client_from_env_failing(servicer, credentials):
+    with pytest.raises(ConnectionError):
+        client_from_env("https://foo.invalid", credentials)
 
 
 def test_client_token_auth_in_sandbox(servicer, credentials, monkeypatch) -> None:


### PR DESCRIPTION
Break up big test in 3 tests

1. We reset the env client using an auto-fixture anyway, no need to reset it explicitly
2. With `ClientHello` going away in the future, we won't have the ability to "verify" an env client on creation, resetting it if it doesn't work. I think this is a bit of a weird use case anyway – in theory it's a singleton determined by its environment, so it shouldn't change – the user can always reset it manually if needed. We don't need to reset it automatically on connection failures.