### PR TITLE
Add "method definitions" to function definition

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1204,6 +1204,10 @@ message Function {
   Schedule schedule = 72;
 
   bool snapshot_debug = 73; // For internal debugging use only.
+
+  // Mapping of method names to method definitions
+  map<string, MethodDefinition> method_definitions = 74;
+  bool method_definitions_set = 75;
 }
 
 message FunctionBindParamsRequest {
@@ -1700,6 +1704,14 @@ message InputInfo {
   double finished_at = 5;
   double task_startup_time = 6;
   bool task_first_input = 7;
+}
+
+message MethodDefinition {
+  string function_name = 1;
+  Function.FunctionType function_type = 2;
+  WebhookConfig webhook_config = 3;
+  string web_url = 4;
+  WebUrlInfo web_url_info = 5;
 }
 
 message MountFile {


### PR DESCRIPTION
## Describe your changes

Simple proto change, adding mapping between class method names and "method definitions", which contain information about a method including its function name, web endpoint config, and web endpoint URL and info.

This is being introduced because we are moving away from the creation and usage of method placeholder functions in classes. Only 1 function, the class service function, will be created for a class and it will be the mechanism for which we store method-level configuration info (like whether a method is a generator or not), since there won't be a function per method now.

Note that the function definition for normal standalone functions will have an empty `method_definitions`.

`method_definitions_set` will default to `False` and will be `True` for classes deployed with the new forthcoming client changes that only create a class service function.