### PR TITLE
Proto changes for FunctionPrecreate RPC changes

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1205,7 +1205,7 @@ message Function {
 
   bool snapshot_debug = 73; // For internal debugging use only.
 
-  // Mapping of method names to method definitions
+  // Mapping of method names to method definitions, only non-empty for class service functions
   map<string, MethodDefinition> method_definitions = 74;
   bool method_definitions_set = 75;
 }
@@ -1459,6 +1459,8 @@ message FunctionHandleMetadata {
   string use_method_name = 41; // used for methods
   string definition_id = 42;
   ClassParameterInfo class_parameter_info = 43;
+  // Mapping of method names to their metadata, only non-empty for class service functions
+  map<string, FunctionHandleMetadata> method_handle_metadata = 44;
 }
 
 message FunctionInput {
@@ -1509,6 +1511,8 @@ message FunctionPrecreateRequest {
   WebhookConfig webhook_config = 5;
   string use_function_id = 6;  // for class methods - use this function id instead for invocations - the *referenced* function should have is_class=True
   string use_method_name = 7;  // for class methods - this method name needs to be included in the FunctionInput
+  // Mapping of method names to method definitions, only non-empty for class service functions
+  map<string, MethodDefinition> method_definitions = 8;
 }
 
 message FunctionPrecreateResponse {


### PR DESCRIPTION
## Describe your changes

Adding proto changes for incoming server-side `FunctionPrecreate` RPC changes as part of method placeholder function removal work.

`FunctionPrecreate` currently returns the web url for a function, I believe this is for serialized functions (see [here](https://modal-com.slack.com/archives/C056CGAANRM/p1715751532504479?thread_ts=1715717908.647609&cid=C056CGAANRM)).

Now that deploying classes will only create a class service function and no method placeholder functions, the response from pre-creating the class service function needs to include the web url for each web endpoint method on the class.

`FunctionPrecreateRequest` will take the method definitions for each method, which contain the webhook configs necessary to derive the webhook urls.

`FunctionHandleMetadata` now includes a mapping between method names and `FunctionHandleMetadata`s. The returned `FunctionHandleMetadata` for a method will be used to hydrate its client-side `_Function` handle (e.g. `MyClass.foo`) with the appropriate metadata.