### PR TITLE
Add back build_function_def and build_function_globals

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1624,6 +1624,9 @@ message Image {
   GPUConfig gpu_config = 16;
   ImageRegistryConfig image_registry_config = 17;
 
+  string build_function_def = 14; // deprecated after 0.58.96
+  bytes build_function_globals = 18; // deprecated after 0.58.96
+
   // If set, overrides the runtime used by the function. Specify either "runc" or "gvisor".
   string runtime = 19;
   // Not included in image definition checksum as debug features do not affect built image.


### PR DESCRIPTION
Trying to unbreak internal code quickly