### PR TITLE
Replace macos-12 CI runner with macos-13

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,6 +28,9 @@ jobs:
         os: ["ubuntu-20.04"]
         proto-version: ["latest"]
         include:
+          - os: "macos-13" # x86-64
+            python-version: "3.10"
+            proto-version: "latest"
           - os: "macos-14" # ARM64 (M1)
             python-version: "3.10"
             proto-version: "latest"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   client-test:
     name: Unit tests on ${{ matrix.python-version }} and ${{ matrix.os }} (protobuf=${{ matrix.proto-version }})
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false # run all variants across python versions/os to completion

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,9 +28,6 @@ jobs:
         os: ["ubuntu-20.04"]
         proto-version: ["latest"]
         include:
-          - os: "macos-12" # x86-64
-            python-version: "3.10"
-            proto-version: "latest"
           - os: "macos-14" # ARM64 (M1)
             python-version: "3.10"
             proto-version: "latest"


### PR DESCRIPTION
[maco-12 runner is being deprecated](https://github.com/actions/runner-images/issues/10721) with brownouts scheduled beforehand -- all jobs running on the runner will fail and block our CICD

Replacing it with macos-13 which also runs on `x86-64`