### PR TITLE
Upgrade CI runner to MacOS 13

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,7 +28,7 @@ jobs:
         os: ["ubuntu-20.04"]
         proto-version: ["latest"]
         include:
-          - os: "macos-12" # x86-64
+          - os: "macos-13" # x86-64
             python-version: "3.10"
             proto-version: "latest"
           - os: "macos-14" # ARM64 (M1)


### PR DESCRIPTION
The `macos-12` github actions runner is now deprecated. According to [this table](https://github.com/actions/runner-images?tab=readme-ov-file#available-images), `macos-13` uses `x86-64`, so we should use that instead.