### PR TITLE
Remove aiostream from the 2024.10 Image Builder requirements

### DIFF
--- a/modal/requirements/2024.10.txt
+++ b/modal/requirements/2024.10.txt
@@ -1,7 +1,6 @@
 aiohappyeyeballs==2.4.3
 aiohttp==3.10.8
 aiosignal==1.3.1
-aiostream==0.6.2
 async-timeout==4.0.3 ; python_version < "3.11"
 attrs==24.2.0
 certifi==2024.8.30


### PR DESCRIPTION
Part of CLI-1