### PR TITLE
Add arguments from Sandbox.create to exec protos

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -742,6 +742,9 @@ message ContainerExecRequest {
   bool runtime_debug = 5; // For internal debugging use only.
   ExecOutputOption stdout_output = 6;
   ExecOutputOption stderr_output = 7;
+  uint32 timeout_secs = 8;
+  optional string workdir = 9;
+  repeated string secret_ids = 10;
 }
 
 message ContainerExecResponse {


### PR DESCRIPTION
## Describe your changes

In an effort to provide all the functionality in `Sandbox.create` to `Sandbox.exec`, this commit adds proto definitions for timeouts, secrets, and a working directory.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>
