### PR TITLE
Connect socket in create_channel

### DIFF
--- a/modal/_utils/grpc_utils.py
+++ b/modal/_utils/grpc_utils.py
@@ -70,7 +70,7 @@ RETRYABLE_GRPC_STATUS_CODES = [
 ]
 
 
-def create_channel(
+async def create_channel(
     server_url: str,
     metadata: Dict[str, str] = {},
 ) -> grpclib.client.Channel:
@@ -111,6 +111,10 @@ def create_channel(
         logger.debug(f"Sending request to {event.method_name}")
 
     grpclib.events.listen(channel, grpclib.events.SendRequest, send_request)
+
+    # Open socket
+    await channel.__connect__()
+
     return channel
 
 

--- a/modal/_utils/grpc_utils.py
+++ b/modal/_utils/grpc_utils.py
@@ -70,7 +70,7 @@ RETRYABLE_GRPC_STATUS_CODES = [
 ]
 
 
-async def create_channel(
+def create_channel(
     server_url: str,
     metadata: Dict[str, str] = {},
 ) -> grpclib.client.Channel:
@@ -112,10 +112,12 @@ async def create_channel(
 
     grpclib.events.listen(channel, grpclib.events.SendRequest, send_request)
 
-    # Open socket
-    await channel.__connect__()
-
     return channel
+
+
+async def connect_channel(channel: grpclib.client.Channel):
+    """Connects socket (potentially raising errors raising to connectivity."""
+    await channel.__connect__()
 
 
 if typing.TYPE_CHECKING:

--- a/modal/client.py
+++ b/modal/client.py
@@ -32,7 +32,7 @@ from ._utils import async_utils
 from ._utils.async_utils import TaskContext, synchronize_api
 from ._utils.grpc_utils import create_channel, retry_transient_errors
 from .config import _check_config, _is_remote, config, logger
-from .exception import AuthError, ClientClosed, DeprecationError, VersionError
+from .exception import AuthError, ClientClosed, ConnectionError, DeprecationError, VersionError
 
 HEARTBEAT_INTERVAL: float = config.get("heartbeat_interval")
 HEARTBEAT_TIMEOUT: float = HEARTBEAT_INTERVAL + 0.1
@@ -114,7 +114,10 @@ class _Client:
         self._closed = False
         assert self._stub is None
         metadata = _get_metadata(self.client_type, self._credentials, self.version)
-        self._channel = create_channel(self.server_url, metadata=metadata)
+        try:
+            self._channel = await create_channel(self.server_url, metadata=metadata)
+        except OSError as exc:
+            raise ConnectionError(str(exc))
         self._cancellation_context = TaskContext(grace=0.5)  # allow running rpcs to finish in 0.5s when closing client
         self._cancellation_context_event_loop = asyncio.get_running_loop()
         await self._cancellation_context.__aenter__()

--- a/test/grpc_utils_test.py
+++ b/test/grpc_utils_test.py
@@ -5,7 +5,7 @@ import time
 from grpclib import GRPCError, Status
 
 from modal._utils.async_utils import synchronize_api
-from modal._utils.grpc_utils import create_channel, retry_transient_errors
+from modal._utils.grpc_utils import connect_channel, create_channel, retry_transient_errors
 from modal_proto import api_grpc, api_pb2
 
 from .supports.skip import skip_windows_unix_socket
@@ -22,7 +22,7 @@ async def test_http_channel(servicer, credentials):
         "x-modal-token-secret": token_secret,
     }
     assert servicer.client_addr.startswith("http://")
-    channel = await create_channel(servicer.client_addr)
+    channel = create_channel(servicer.client_addr)
     client_stub = api_grpc.ModalClientStub(channel)
 
     req = api_pb2.BlobCreateRequest()
@@ -41,7 +41,7 @@ async def test_unix_channel(servicer):
         "x-modal-client-version": "0.99",
     }
     assert servicer.container_addr.startswith("unix://")
-    channel = await create_channel(servicer.container_addr)
+    channel = create_channel(servicer.container_addr)
     client_stub = api_grpc.ModalClientStub(channel)
 
     req = api_pb2.BlobCreateRequest()
@@ -53,8 +53,9 @@ async def test_unix_channel(servicer):
 
 @pytest.mark.asyncio
 async def test_http_broken_channel():
+    ch = create_channel("https://xyz.invalid")
     with pytest.raises(OSError):
-        await create_channel("https://xyz.invalid")
+        await connect_channel(ch)
 
 
 @pytest.mark.asyncio

--- a/test/grpc_utils_test.py
+++ b/test/grpc_utils_test.py
@@ -22,7 +22,7 @@ async def test_http_channel(servicer, credentials):
         "x-modal-token-secret": token_secret,
     }
     assert servicer.client_addr.startswith("http://")
-    channel = create_channel(servicer.client_addr)
+    channel = await create_channel(servicer.client_addr)
     client_stub = api_grpc.ModalClientStub(channel)
 
     req = api_pb2.BlobCreateRequest()
@@ -41,7 +41,7 @@ async def test_unix_channel(servicer):
         "x-modal-client-version": "0.99",
     }
     assert servicer.container_addr.startswith("unix://")
-    channel = create_channel(servicer.container_addr)
+    channel = await create_channel(servicer.container_addr)
     client_stub = api_grpc.ModalClientStub(channel)
 
     req = api_pb2.BlobCreateRequest()
@@ -49,6 +49,12 @@ async def test_unix_channel(servicer):
     assert resp.blob_id
 
     channel.close()
+
+
+@pytest.mark.asyncio
+async def test_http_broken_channel():
+    with pytest.raises(OSError):
+        await create_channel("https://xyz.invalid")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
`grpclib` connects the socket lazily, but we can force it to connect on creation (and not on the first call) by calling an internal method. This solves a weird test failure in https://github.com/modal-labs/modal-client/pull/2439#pullrequestreview-2412843577

Once we remove `ClientHello`, checking connection upfront is I think a bit better since it will fail in the proper context and not later. It means we can still fail fail on client construction in many cases (although some issues like failing credentials will be raised lazily). It means we can remove a few dummy hello calls in tests in #2439 