### PR TITLE
Remove WRK-241 fix and rely on worker-side fix

### DIFF
--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -918,21 +918,6 @@ class _ContainerIOManager:
         self.current_input_id = None
         self.current_inputs = {}
         self.current_input_started_at = None
-
-        # Patch torch to ensure it doesn't return CUDA unavailibility due to
-        # cached queries that executed during snapshot process. ref: MOD-3257
-        #
-        # perf: scanning sys.modules keys before import to avoid slow PYTHONPATH scanning.
-        if "torch" in sys.modules:
-            try:
-                sys.modules["torch"].cuda.device_count = sys.modules["torch"].cuda._device_count_nvml
-            # Wide-open except to catch anything. We don't want to crash here.
-            except Exception as exc:
-                logger.warning(
-                    f"failed to patch 'torch.cuda.device_count' during snapshot restore: {exc}. "
-                    "CUDA device availability may be inaccurate."
-                )
-
         self._client = await _Client.from_env()
 
     async def memory_snapshot(self) -> None:


### PR DESCRIPTION
## Describe your changes

- See #17074 on the worker side. It's a much simpler way to fix this problem.
- 🚧 **Don't merge this** until worker-side change merges and rolls out.
   -  **Update:** Worker-side changed merged at 3:20 PM EST 5th Nov.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>