### PR TITLE
cleanup: remove deprecated flag and broken deprecation msg

### DIFF
--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -1003,7 +1003,7 @@ class _ContainerIOManager:
         try:
             await self._client.stub.FunctionStartPtyShell(Empty())
         except Exception as e:
-            print("Error: Failed to start PTY shell.")
+            logger.error("Failed to start PTY shell.")
             raise e
 
     @property

--- a/modal/app.py
+++ b/modal/app.py
@@ -656,8 +656,6 @@ class _App:
         # With `max_inputs = 1`, containers will be single-use.
         max_inputs: Optional[int] = None,
         i6pn: Optional[bool] = None,  # Whether to enable IPv6 container networking within the region.
-        # The next group of parameters are deprecated; do not use in any new code
-        interactive: bool = False,  # Deprecated: use the `modal.interact()` hook instead
         # Parameters below here are experimental. Use with caution!
         _experimental_scheduler_placement: Optional[
             SchedulerPlacement
@@ -671,11 +669,6 @@ class _App:
             raise InvalidError("`image` needs to be a keyword argument: `@app.function(image=image)`.")
         if _warn_parentheses_missing:
             raise InvalidError("Did you forget parentheses? Suggestion: `@app.function()`.")
-
-        if interactive:
-            deprecation_error(
-                (2024, 5, 1), "interactive=True has been deprecated. Set MODAL_INTERACTIVE_FUNCTIONS=1 instead."
-            )
 
         if image is None:
             image = self._get_default_image()
@@ -722,9 +715,6 @@ class _App:
                 keep_warm = f.keep_warm or keep_warm
                 batch_max_size = f.batch_max_size
                 batch_wait_ms = f.batch_wait_ms
-
-                if webhook_config and interactive:
-                    raise InvalidError("interactive=True is not supported with web endpoint functions")
             else:
                 if not is_global_object(f.__qualname__) and not serialized:
                     raise InvalidError(
@@ -865,8 +855,6 @@ class _App:
         # Limits the number of inputs a container handles before shutting down.
         # Use `max_inputs = 1` for single-use containers.
         max_inputs: Optional[int] = None,
-        # The next group of parameters are deprecated; do not use in any new code
-        interactive: bool = False,  # Deprecated: use the `modal.interact()` hook instead
         # Parameters below here are experimental. Use with caution!
         _experimental_scheduler_placement: Optional[
             SchedulerPlacement
@@ -879,12 +867,6 @@ class _App:
         """
         if _warn_parentheses_missing:
             raise InvalidError("Did you forget parentheses? Suggestion: `@app.cls()`.")
-
-        # Argument validation
-        if interactive:
-            deprecation_error(
-                (2024, 5, 1), "interactive=True has been deprecated. Set MODAL_INTERACTIVE_FUNCTIONS=1 instead."
-            )
 
         scheduler_placement = _experimental_scheduler_placement
         if region:


### PR DESCRIPTION
## Describe your changes

I looked around and couldn't see examples of the suggested `MODAL_INTERACTIVE_FUNCTIONS` variable even working? All that's in Slack is https://modal-com.slack.com/archives/C069RAH7X4M/p1726794603999869. 

Parameter was originally deprecated in https://github.com/modal-labs/modal-client/pull/1322

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

Remove `interactive` parameter from `function` and `cls` decorators. `interactive` has been deprecated since May 2024. Instead of specifying Modal Functions as interactive, use `modal run --interactive`.