### PR TITLE
Expose experimental scaling factor to users

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -664,6 +664,7 @@ class _App:
         ] = None,  # Experimental controls over fine-grained scheduling (alpha).
         _experimental_buffer_containers: Optional[int] = None,  # Number of additional, idle containers to keep around.
         _experimental_proxy_ip: Optional[str] = None,  # IP address of proxy
+        _experimental_custom_scaling_factor: Optional[float] = None,  # Custom scaling factor
     ) -> _FunctionDecoratorType:
         """Decorator to register a new Modal [Function](/docs/reference/modal.Function) with this App."""
         if isinstance(_warn_parentheses_missing, _Image):
@@ -813,6 +814,7 @@ class _App:
                 _experimental_proxy_ip=_experimental_proxy_ip,
                 i6pn_enabled=i6pn_enabled,
                 group_size=group_size,  # Experimental: Grouped functions
+                _experimental_custom_scaling_factor=_experimental_custom_scaling_factor,
             )
 
             self._add_function(function, webhook_config is not None)
@@ -873,6 +875,7 @@ class _App:
         ] = None,  # Experimental controls over fine-grained scheduling (alpha).
         _experimental_buffer_containers: Optional[int] = None,  # Number of additional, idle containers to keep around.
         _experimental_proxy_ip: Optional[str] = None,  # IP address of proxy
+        _experimental_custom_scaling_factor: Optional[float] = None,  # Custom scaling factor
     ) -> Callable[[CLS_T], CLS_T]:
         """
         Decorator to register a new Modal [Cls](/docs/reference/modal.Cls) with this App.
@@ -951,6 +954,7 @@ class _App:
                 scheduler_placement=scheduler_placement,
                 _experimental_buffer_containers=_experimental_buffer_containers,
                 _experimental_proxy_ip=_experimental_proxy_ip,
+                _experimental_custom_scaling_factor=_experimental_custom_scaling_factor,
             )
 
             self._add_function(cls_func, is_web_endpoint=False)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -523,6 +523,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         ephemeral_disk: Optional[int] = None,
         _experimental_buffer_containers: Optional[int] = None,
         _experimental_proxy_ip: Optional[str] = None,
+        _experimental_custom_scaling_factor: Optional[float] = None,
     ) -> None:
         """mdmd:hidden"""
         tag = info.get_tag()
@@ -631,6 +632,11 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                 f"Function `{info.function_name}` has `{concurrency_limit=}`, "
                 f"strictly less than its `{keep_warm=}` parameter."
             )
+
+        if _experimental_custom_scaling_factor is not None and (
+            _experimental_custom_scaling_factor < 0 or _experimental_custom_scaling_factor > 1
+        ):
+            raise InvalidError("`_experimental_custom_scaling_factor` must be between 0.0 and 1.0 inclusive.")
 
         if not cloud and not is_builder_function:
             cloud = config.get("default_cloud")
@@ -842,6 +848,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                     _experimental_concurrent_cancellations=True,
                     _experimental_buffer_containers=_experimental_buffer_containers or 0,
                     _experimental_proxy_ip=_experimental_proxy_ip,
+                    _experimental_custom_scaling=_experimental_custom_scaling_factor is not None,
                 )
 
                 if isinstance(gpu, list):


### PR DESCRIPTION
```
import time

import modal

app = modal.App()

queue = modal.Queue.from_name("experimental_scaling_coordinator", create_if_missing=True)


# Scale to minimize latency based on peak traffic.
@app.cls(_experimental_custom_scaling_factor=1.0, container_idle_timeout=60)
# @app.cls(container_idle_timeout=60)
class M:
    @modal.enter()
    def enter(self):
        # Start-up is either 1 second or 10 seconds.
        t = queue.get()
        time.sleep(t)

    @modal.method()
    def f(self, i):
        return i


@app.local_entrypoint()
def main():
    queue.clear()
    queue.put(1)
    queue.put(10)

    M().f.spawn(1)
    M().f.spawn(2)

    time.sleep(20)

    print(
        "Are there 1 or 2 containers up after 20 seconds?",
        M().f.get_current_stats().num_total_runners,
    )
```

Results (before)
```
✓ Initialized. View run at https://modal.com/apps/gongy/main/ap-z4d806RDXJjwvxOjlP8OYM
✓ Created objects.
├── 🔨 Created mount /home/ec2-user/modal/.local/experimental_scaling.py
├── 🔨 Created mount /home/ec2-user/client/modal, /home/ec2-user/client/modal_proto, /home/ec2-user/client/modal_version, 
│   /home/ec2-user/modal/venv/lib64/python3.11/site-packages/synchronicity
├── 🔨 Created function M.*.
└── 🔨 Created function M.f.
Are there 1 or 2 containers up after 20 seconds? 1
Stopping app - local entrypoint completed.
✓ App completed. View run at https://modal.com/apps/gongy/main/ap-z4d806RDXJjwvxOjlP8OYM
```

Results (after)
```
✓ Initialized. View run at https://modal.com/apps/gongy/main/ap-QyXzVAb4YHNDv2f1km8evs
✓ Created objects.
├── 🔨 Created mount /home/ec2-user/modal/.local/experimental_scaling.py
├── 🔨 Created mount /home/ec2-user/client/modal, /home/ec2-user/client/modal_proto, /home/ec2-user/client/modal_version, 
│   /home/ec2-user/modal/venv/lib64/python3.11/site-packages/synchronicity
├── 🔨 Created function M.*.
└── 🔨 Created function M.f.
Are there 1 or 2 containers up after 20 seconds? 2
Stopping app - local entrypoint completed.
✓ App completed. View run at https://modal.com/apps/gongy/main/ap-QyXzVAb4YHNDv2f1km8evs
```