### PR TITLE
Make it possible to use the Resolver without rich installed

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import builtins
 import contextlib
 import dataclasses
 import datetime
@@ -19,6 +20,7 @@ import traceback
 import uuid
 from collections import defaultdict
 from pathlib import Path
+from types import ModuleType
 from typing import Any, Dict, Iterator, List, Optional, Tuple, get_args
 
 import aiohttp.web
@@ -1964,3 +1966,17 @@ async def set_env_client(client):
         yield
     finally:
         Client.set_env_client(None)
+
+
+@pytest.fixture
+def no_rich(monkeypatch):
+    normal_import = __import__
+
+    def import_fail_for_rich(name: str, *args, **kwargs) -> ModuleType:
+        if name.startswith("rich"):
+            raise ModuleNotFoundError("No module named 'rich'")
+        else:
+            return normal_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_fail_for_rich)
+    yield

--- a/test/resolver_test.py
+++ b/test/resolver_test.py
@@ -54,3 +54,10 @@ async def test_multi_resolve_concurrent_loads_once(client):
     await asyncio.gather(resolver.load(obj), resolver.load(obj))
     assert 0.08 < time.monotonic() - t0 < 0.17
     assert load_count == 1
+
+
+def test_resolver_without_rich(no_rich, client):
+    resolver = Resolver(client, environment_name="", app_id=None)
+    resolver.add_status_row()
+    with resolver.display():
+        pass


### PR DESCRIPTION
The `Resolver` object uses some tools from `rich` directly, and it imports some utilities from the non-rich-safe `modal._output` module. This doesn't affect minimal apps but it is relevant for apps that use lazily-hydrated objects, which instantiate a `Resolver` when they get hydrated.

This PR adds some more guardrails around the imports so that we can hydrate objects remotely without rich. It's not my preferred solution — I don't think the `Resolver` should need to touch `rich` at all — but it's some more duct tape until we can more thoroughly refactor the output pipeline.

Also added a test that mocks an environment without `rich`. We could potentially use it in more places too.

- Fixes CLI-222