### PR TITLE
Adds `ProxyGet` to public API

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1831,6 +1831,15 @@ message ProxyGetOrCreateResponse {
   string proxy_id = 1;
 }
 
+message ProxyGetRequest {
+  string name = 1 [ (modal.options.audit_target_attr) = true ];
+  string environment_name = 2;
+}
+
+message ProxyGetResponse {
+  Proxy proxy = 1;
+}
+
 message ProxyInfo {
   string elastic_ip = 1;
   string proxy_key = 2;
@@ -2664,6 +2673,7 @@ service ModalClient {
 
   // Proxies
   rpc ProxyDelete(ProxyDeleteRequest) returns (google.protobuf.Empty);
+  rpc ProxyGet(ProxyGetRequest) returns (ProxyGetResponse);
   rpc ProxyGetOrCreate(ProxyGetOrCreateRequest) returns (ProxyGetOrCreateResponse);
 
   // Proxy IPs


### PR DESCRIPTION
Introduces `ProxyGet` to public API. This precedes an update to `Proxy.from_name("my-proxy")` to replace `ProxyGetOrCreate`.

I intended to have that RPC support both the client get method and internal proxy create methods but came to the conclusion that it is better to separate those methods because it is not desirable to create a Proxy lazily. (That's the case because it takes several seconds to create.)
