### PR TITLE
Replaces `ProxyGetOrCreate` with `ProxyGet`

### DIFF
--- a/modal/proxy.py
+++ b/modal/proxy.py
@@ -26,8 +26,8 @@ class _Proxy(_Object, type_prefix="pr"):
                 name=label,
                 environment_name=_get_environment_name(environment_name, resolver),
             )
-            response = await resolver.client.stub.ProxyGet(req)
-            self._hydrate(response.proxy_id, resolver.client, None)
+            response: api_pb2.ProxyGetResponse = await resolver.client.stub.ProxyGet(req)
+            self._hydrate(response.proxy.proxy_id, resolver.client, None)
 
         return _Proxy._from_loader(_load, "Proxy()", is_another_app=True)
 

--- a/modal/proxy.py
+++ b/modal/proxy.py
@@ -22,12 +22,11 @@ class _Proxy(_Object, type_prefix="pr"):
         environment_name: Optional[str] = None,
     ) -> "_Proxy":
         async def _load(self: _Proxy, resolver: Resolver, existing_object_id: Optional[str]):
-            req = api_pb2.ProxyGetOrCreateRequest(
-                deployment_name=label,
-                namespace=namespace,
+            req = api_pb2.ProxyGetRequest(
+                name=label,
                 environment_name=_get_environment_name(environment_name, resolver),
             )
-            response = await resolver.client.stub.ProxyGetOrCreate(req)
+            response = await resolver.client.stub.ProxyGet(req)
             self._hydrate(response.proxy_id, resolver.client, None)
 
         return _Proxy._from_loader(_load, "Proxy()", is_another_app=True)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1196,6 +1196,10 @@ class MockClientServicer(api_grpc.ModalClientBase):
         await stream.recv_message()
         await stream.send_message(api_pb2.ProxyGetOrCreateResponse(proxy_id="pr-123"))
 
+    async def ProxyGet(self, stream):
+        await stream.recv_message()
+        await stream.send_message(api_pb2.ProxyGetResponse(proxy=api_pb2.Proxy(proxy_id="pr-123")))
+
     ### Queue
 
     async def QueueClear(self, stream):


### PR DESCRIPTION
Companion client PR to https://github.com/modal-labs/modal/pull/17120. This replaces the use of `ProxyGetOrCreate` with `ProxyGet` to hydrate `Proxy` objects.