### PR TITLE
Make tag parameter non-optional in from_name and lookup for Function and Cls

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -383,7 +383,7 @@ class _Cls(_Object, type_prefix="cs"):
     def from_name(
         cls: Type["_Cls"],
         app_name: str,
-        tag: Optional[str] = None,
+        tag: str,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
         workspace: Optional[str] = None,
@@ -498,7 +498,7 @@ class _Cls(_Object, type_prefix="cs"):
     @staticmethod
     async def lookup(
         app_name: str,
-        tag: Optional[str] = None,
+        tag: str,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1057,7 +1057,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
     def from_name(
         cls: Type["_Function"],
         app_name: str,
-        tag: Optional[str] = None,
+        tag: str,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
     ) -> "_Function":
@@ -1072,7 +1072,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
             assert resolver.client and resolver.client.stub
             request = api_pb2.FunctionGetRequest(
                 app_name=app_name,
-                object_tag=tag or "",
+                object_tag=tag,
                 namespace=namespace,
                 environment_name=_get_environment_name(environment_name, resolver) or "",
             )
@@ -1092,7 +1092,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
     @staticmethod
     async def lookup(
         app_name: str,
-        tag: Optional[str] = None,
+        tag: str,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,


### PR DESCRIPTION
Make tag parameter non-optional in from_name and lookup for Function and Cls

Neither `FunctionGet` nor `ClassGet` support `request.object_tag=None`.