### PR TITLE
Add user telemetry protos

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -112,6 +112,13 @@ enum DeploymentNamespace {
   DEPLOYMENT_NAMESPACE_GLOBAL = 3;
 }
 
+// Encoding type used for user telemetry data.
+enum EncodingType {
+  ENCODING_TYPE_UNSPECIFIED = 0;
+  ENCODING_TYPE_PROTOBUF = 1;
+  ENCODING_TYPE_JSON = 2;
+}
+
 enum ExecOutputOption {
   EXEC_OUTPUT_OPTION_UNSPECIFIED = 0;
   EXEC_OUTPUT_OPTION_DEVNULL = 1;
@@ -152,6 +159,12 @@ enum GPUType {
   GPU_TYPE_L4 = 9;
   GPU_TYPE_H100 = 10;
   GPU_TYPE_L40S = 11;
+}
+
+enum InstrumentationType {
+  INSTRUMENTATION_TYPE_UNSPECIFIED = 0;
+  INSTRUMENTATION_TYPE_METRICS = 1;
+  INSTRUMENTATION_TYPE_TRACE = 2;
 }
 
 enum ObjectCreationType {
@@ -1554,6 +1567,12 @@ message FunctionPutOutputsRequest {
   double requested_at = 5; // Used for waypoints.
 }
 
+message FunctionPutUserTelemetryRequest {
+  bytes data = 1;
+  EncodingType encoding_type = 2;
+  InstrumentationType instrumentation_type = 3;
+}
+
 message FunctionRetryPolicy {
   float backoff_coefficient = 1;
   uint32 initial_delay_ms = 2;
@@ -2654,6 +2673,7 @@ service ModalClient {
   rpc FunctionPrecreate(FunctionPrecreateRequest) returns (FunctionPrecreateResponse);
   rpc FunctionPutInputs(FunctionPutInputsRequest) returns (FunctionPutInputsResponse);
   rpc FunctionPutOutputs(FunctionPutOutputsRequest) returns (google.protobuf.Empty);  // For containers to return result
+  rpc FunctionPutUserTelemetry(FunctionPutUserTelemetryRequest) returns (google.protobuf.Empty);
   rpc FunctionStartPtyShell(google.protobuf.Empty) returns (google.protobuf.Empty);
   rpc FunctionUpdateSchedulingParams(FunctionUpdateSchedulingParamsRequest) returns (FunctionUpdateSchedulingParamsResponse);
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -112,13 +112,6 @@ enum DeploymentNamespace {
   DEPLOYMENT_NAMESPACE_GLOBAL = 3;
 }
 
-// Encoding type used for user telemetry data.
-enum TelemetryEncodingType {
-  TELEMETRY_ENCODING_TYPE_UNSPECIFIED = 0;
-  TELEMETRY_ENCODING_TYPE_PROTOBUF = 1;
-  TELEMETRY_ENCODING_TYPE_JSON = 2;
-}
-
 enum ExecOutputOption {
   EXEC_OUTPUT_OPTION_UNSPECIFIED = 0;
   EXEC_OUTPUT_OPTION_DEVNULL = 1;
@@ -251,6 +244,13 @@ enum TaskState {
   TASK_STATE_PREEMPTIBLE = 9;
   TASK_STATE_PREEMPTED = 10;
   TASK_STATE_LOADING_CHECKPOINT_IMAGE = 11;
+}
+
+// Encoding type used for user telemetry data.
+enum TelemetryEncodingType {
+  TELEMETRY_ENCODING_TYPE_UNSPECIFIED = 0;
+  TELEMETRY_ENCODING_TYPE_PROTOBUF = 1;
+  TELEMETRY_ENCODING_TYPE_JSON = 2;
 }
 
 enum VolumeFsVersion {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -113,10 +113,10 @@ enum DeploymentNamespace {
 }
 
 // Encoding type used for user telemetry data.
-enum EncodingType {
-  ENCODING_TYPE_UNSPECIFIED = 0;
-  ENCODING_TYPE_PROTOBUF = 1;
-  ENCODING_TYPE_JSON = 2;
+enum TelemetryEncodingType {
+  TELEMETRY_ENCODING_TYPE_UNSPECIFIED = 0;
+  TELEMETRY_ENCODING_TYPE_PROTOBUF = 1;
+  TELEMETRY_ENCODING_TYPE_JSON = 2;
 }
 
 enum ExecOutputOption {
@@ -1569,7 +1569,7 @@ message FunctionPutOutputsRequest {
 
 message FunctionPutUserTelemetryRequest {
   bytes data = 1;
-  EncodingType encoding_type = 2;
+  TelemetryEncodingType encoding_type = 2;
   InstrumentationType instrumentation_type = 3;
 }
 


### PR DESCRIPTION
## Adds protos for sending user telemetry data to the worker.

- This PR resolves WRK-483

<details>
---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>