### PR TITLE
Add warnings on app publish response proto

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -412,6 +412,7 @@ message AppPublishRequest {
 
 message AppPublishResponse {
   string url = 1;
+  repeated string warnings = 2;
 }
 
 message AppRollbackRequest {


### PR DESCRIPTION
## Add warning on app publish proto for deployed limits

- See SVC-88

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>
