### PR TITLE
Add timeout, workdir, secrets to sandbox exec

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -93,6 +93,9 @@ class _Sandbox(_Object, type_prefix="sb"):
                 "Specify a single GPU configuration, e.g. gpu='a10g'"
             )
 
+        if workdir is not None and not workdir.startswith("/"):
+            raise InvalidError(f"workdir must be an absolute path, got: {workdir}")
+
         # Validate volumes
         validated_volumes = validate_volumes(volumes)
         cloud_bucket_mounts = [(k, v) for k, v in validated_volumes if isinstance(v, _CloudBucketMount)]
@@ -404,6 +407,9 @@ class _Sandbox(_Object, type_prefix="sb"):
         pty_info: Optional[api_pb2.PTYInfo] = None,
         stdout: StreamType = StreamType.PIPE,
         stderr: StreamType = StreamType.PIPE,
+        timeout: Optional[int] = None,
+        workdir: Optional[str] = None,
+        secrets: Sequence[_Secret] = (),
         # Internal option to set terminal size and metadata
         _pty_info: Optional[api_pb2.PTYInfo] = None,
     ):
@@ -424,6 +430,13 @@ class _Sandbox(_Object, type_prefix="sb"):
         ```
         """
 
+        if workdir is not None and not workdir.startswith("/"):
+            raise InvalidError(f"workdir must be an absolute path, got: {workdir}")
+
+        # Force secret resolution so we can pass the secret IDs to the backend.
+        for secret in secrets:
+            await secret.resolve()
+
         task_id = await self._get_task_id()
         resp = await self._client.stub.ContainerExec(
             api_pb2.ContainerExecRequest(
@@ -431,6 +444,9 @@ class _Sandbox(_Object, type_prefix="sb"):
                 command=cmds,
                 pty_info=_pty_info or pty_info,
                 runtime_debug=config.get("function_runtime_debug"),
+                timeout_secs=timeout or 0,
+                workdir=workdir,
+                secret_ids=[secret.object_id for secret in secrets],
             )
         )
         return _ContainerProcess(resp.exec_id, self._client, stdout=stdout, stderr=stderr)

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -75,7 +75,7 @@ class _Secret(_Object, type_prefix="st"):
             self._hydrate(resp.secret_id, resolver.client, None)
 
         rep = f"Secret.from_dict([{', '.join(env_dict.keys())}])"
-        return _Secret._from_loader(_load, rep)
+        return _Secret._from_loader(_load, rep, hydrate_lazily=True)
 
     @staticmethod
     def from_local_environ(
@@ -158,7 +158,7 @@ class _Secret(_Object, type_prefix="st"):
 
             self._hydrate(resp.secret_id, resolver.client, None)
 
-        return _Secret._from_loader(_load, "Secret.from_dotenv()")
+        return _Secret._from_loader(_load, "Secret.from_dotenv()", hydrate_lazily=True)
 
     @staticmethod
     def from_name(
@@ -196,7 +196,7 @@ class _Secret(_Object, type_prefix="st"):
                     raise
             self._hydrate(response.secret_id, resolver.client, None)
 
-        return _Secret._from_loader(_load, "Secret()")
+        return _Secret._from_loader(_load, "Secret()", hydrate_lazily=True)
 
     @staticmethod
     async def lookup(


### PR DESCRIPTION
## Describe your changes

- This change aligns the sandbox exec interface with the create interface, allowing timeout, workdir, and secrets to be provided.

Resolves WRK-424

<details> <summary>Backward/forward compatibility checks</summary>

---

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

---

</details>

## Changelog

`Sandbox.exec` can now accept `timeout`, `workdir`, and `secrets`. See the `Sandbox.create` function for context on how to use these arguments.
