### PR TITLE
Add proto for streaming raw bytes

### DIFF
--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -49,7 +49,12 @@ async def _container_process_logs_iterator(
             yield None
             break
         for item in batch.items:
-            yield item.message
+            # TODO(azliu): remove branching logic once all workers are updated
+            # This needs to be merged first because new workers will immediately start sending over message_bytes
+            if len(item.message) > 0:
+                yield item.message
+            else:
+                yield item.message_bytes.decode("utf-8")
 
 
 class _StreamReader:

--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -49,13 +49,7 @@ async def _container_process_logs_iterator(
             yield None
             break
         for item in batch.items:
-            # TODO(azliu): remove branching logic once all workers are updated
-            # This needs to be merged first because new workers will immediately start sending over message_bytes
-            if len(item.message) > 0:
-                yield item.message
-            else:
-                yield item.message_bytes.decode("utf-8")
-
+            yield item.message
 
 class _StreamReader:
     """Provides an interface to buffer and fetch logs from a stream (`stdout` or `stderr`).

--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -51,6 +51,7 @@ async def _container_process_logs_iterator(
         for item in batch.items:
             yield item.message
 
+
 class _StreamReader:
     """Provides an interface to buffer and fetch logs from a stream (`stdout` or `stderr`).
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2017,6 +2017,7 @@ message RuntimeOutputMessage {
   // only stdout / stderr is used
   FileDescriptor file_descriptor = 1;
   string message = 2;
+  bytes message_bytes = 3;
 }
 
 message S3Mount {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -740,6 +740,9 @@ message ContainerExecGetOutputRequest {
   float timeout = 2;
   uint64 last_batch_index = 3;
   FileDescriptor file_descriptor = 4;
+  // Old clients expect string output.
+  // New clients stream raw bytes.
+  bool bytes = 5;
 }
 
 message ContainerExecPutInputRequest {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2018,10 +2018,8 @@ message RuntimeOutputBatch {
 message RuntimeOutputMessage {
   // only stdout / stderr is used
   FileDescriptor file_descriptor = 1;
-  oneof message_oneof {
-    string message = 2;
-    bytes message_bytes = 3;
-  }
+  string message = 2;
+  bytes message_bytes = 3;
 }
 
 message S3Mount {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -740,8 +740,7 @@ message ContainerExecGetOutputRequest {
   float timeout = 2;
   uint64 last_batch_index = 3;
   FileDescriptor file_descriptor = 4;
-  // Old clients expect string output.
-  // New clients stream raw bytes.
+  // Old clients (up to 0.65.39) expect string output. Newer clients stream raw bytes
   bool bytes = 5;
 }
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -741,7 +741,7 @@ message ContainerExecGetOutputRequest {
   uint64 last_batch_index = 3;
   FileDescriptor file_descriptor = 4;
   // Old clients (up to 0.65.39) expect string output. Newer clients stream raw bytes
-  bool bytes = 5;
+  bool get_raw_bytes = 5;
 }
 
 message ContainerExecPutInputRequest {
@@ -2018,8 +2018,10 @@ message RuntimeOutputBatch {
 message RuntimeOutputMessage {
   // only stdout / stderr is used
   FileDescriptor file_descriptor = 1;
-  string message = 2;
-  bytes message_bytes = 3;
+  oneof message_oneof {
+    string message = 2;
+    bytes message_bytes = 3;
+  }
 }
 
 message S3Mount {


### PR DESCRIPTION
This change adds a proto field for serving raw bytes from the server rather than text. 

The upstream motivation for this is to eventually allow users more fine-grained control over streamed Sandbox output, e.g., by adding a `text` flag to choose to receive string (text) rather than raw bytes output. It didn't necessarily make sense to have the behavior for `text=False` to decode string back to bytes on the client.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>