### PR TITLE
Add app deploy warning

### DIFF
--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -14,6 +14,7 @@ from typing import Any, Callable, Dict, Optional, get_type_hints
 import click
 import typer
 from rich.console import Console
+from rich.panel import Panel
 from typing_extensions import TypedDict
 
 from .. import Cls
@@ -294,6 +295,11 @@ def deploy(
 
     with enable_output():
         res = deploy_app(app, name=name, environment_name=env or "", tag=tag)
+        if res.warnings:
+            console = Console()
+            for warning in res.warnings:
+                panel = Panel(warning, title="Warning", title_align="left", border_style="yellow")
+                console.print(panel, highlight=False)
 
     if stream_logs:
         stream_app_logs(app_id=res.app_id, app_logs_url=res.app_logs_url)

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -5,7 +5,7 @@ import os
 import time
 import typing
 from multiprocessing.synchronize import Event
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Dict, List, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Dict, List, Optional, Tuple, TypeVar
 
 from grpclib import GRPCError, Status
 from synchronicity.async_wrap import asynccontextmanager
@@ -175,7 +175,7 @@ async def _publish_app(
     indexed_objects: Dict[str, _Object],
     name: str = "",  # Only relevant for deployments
     tag: str = "",  # Only relevant for deployments
-) -> tuple[str, List[str]]:
+) -> Tuple[str, List[str]]:
     """Wrapper for AppPublish RPC."""
 
     # Could simplify this function some changing the internal representation to use

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -8,6 +8,8 @@ from multiprocessing.synchronize import Event
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Dict, List, Optional, TypeVar
 
 from grpclib import GRPCError, Status
+from rich.console import Console
+from rich.panel import Panel
 from synchronicity.async_wrap import asynccontextmanager
 
 import modal_proto.api_pb2
@@ -204,6 +206,13 @@ async def _publish_app(
         if exc.status == Status.INVALID_ARGUMENT or exc.status == Status.FAILED_PRECONDITION:
             raise InvalidError(exc.message)
         raise
+
+    warnings = response.warnings
+    if warnings:
+        console = Console()
+        for warning in warnings:
+            panel = Panel(warning, title="Warning", title_align="left", border_style="yellow")
+            console.print(panel, highlight=False)
 
     return response.url
 


### PR DESCRIPTION
## Adds a console warning for apps approaching their deployment limit. 

<img width="901" alt="Screenshot 2024-11-07 at 1 27 51 PM" src="https://github.com/user-attachments/assets/aa68c159-b157-4d3a-a082-71e8eb555e60">

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
