### PR TITLE
Adapt to typer 0.13 deprecation of `is_flag`

### DIFF
--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -57,7 +57,7 @@ def logs(container_id: str = typer.Argument(help="Container ID")):
 async def exec(
     container_id: str = typer.Argument(help="Container ID"),
     command: List[str] = typer.Argument(help="A command to run inside the container."),
-    pty: bool = typer.Option(is_flag=True, default=True, help="Run the command using a PTY."),
+    pty: bool = typer.Option(default=True, help="Run the command using a PTY."),
 ):
     """Execute a command in a container."""
 


### PR DESCRIPTION
Typer 0.13 deprecates the `is_flag` parameter of `typer.Option`. We use that in one place. As far as I can tell, this has no effect when the type of the option parameter is `bool`, as is the case where we use it. So it seems like a straightforward fix to remove it.

Closes CLI-234