### PR TITLE
[WRK-462] Allow setting custom CPU limits

### DIFF
--- a/modal/_resources.py
+++ b/modal/_resources.py
@@ -9,13 +9,28 @@ from .gpu import GPU_T, parse_gpu_config
 
 def convert_fn_config_to_resources_config(
     *,
-    cpu: Optional[float],
+    cpu: Optional[Union[float, Tuple[float, float]]],
     memory: Optional[Union[int, Tuple[int, int]]],
     gpu: GPU_T,
     ephemeral_disk: Optional[int],
 ) -> api_pb2.Resources:
     gpu_config = parse_gpu_config(gpu)
-    milli_cpu = int(1000 * cpu) if cpu is not None else None
+    if cpu and isinstance(cpu, tuple):
+        if not cpu[0]:
+            raise InvalidError("CPU request in tuple must not be None")
+        elif not cpu[1]:
+            raise InvalidError("CPU limit in tuple must not be None")
+        milli_cpu = int(1000 * cpu[0])
+        milli_cpu_max = int(1000 * cpu[1])
+        if milli_cpu_max < milli_cpu:
+            raise InvalidError(f"Cannot specify a CPU limit lower than request: {milli_cpu_max} < {milli_cpu}")
+    elif cpu and isinstance(cpu, (float, int)):
+        milli_cpu = int(1000 * cpu)
+        milli_cpu_max = None
+    else:
+        milli_cpu = None
+        milli_cpu_max = None
+
     if memory and isinstance(memory, int):
         memory_mb = memory
         memory_mb_max = 0  # no limit
@@ -28,6 +43,7 @@ def convert_fn_config_to_resources_config(
         memory_mb_max = 0
     return api_pb2.Resources(
         milli_cpu=milli_cpu,
+        milli_cpu_max=milli_cpu_max,
         gpu_config=gpu_config,
         memory_mb=memory_mb,
         memory_mb_max=memory_mb_max,

--- a/modal/_resources.py
+++ b/modal/_resources.py
@@ -17,9 +17,9 @@ def convert_fn_config_to_resources_config(
     gpu_config = parse_gpu_config(gpu)
     if cpu and isinstance(cpu, tuple):
         if not cpu[0]:
-            raise InvalidError("CPU request in tuple must not be None")
+            raise InvalidError("CPU request must be a positive number")
         elif not cpu[1]:
-            raise InvalidError("CPU limit in tuple must not be None")
+            raise InvalidError("CPU limit must be a positive number")
         milli_cpu = int(1000 * cpu[0])
         milli_cpu_max = int(1000 * cpu[1])
         if milli_cpu_max < milli_cpu:

--- a/modal/app.py
+++ b/modal/app.py
@@ -628,7 +628,10 @@ class _App:
             Union[str, PurePosixPath], Union[_Volume, _CloudBucketMount]
         ] = {},  # Mount points for Modal Volumes & CloudBucketMounts
         allow_cross_region_volumes: bool = False,  # Whether using network file systems from other regions is allowed.
-        cpu: Optional[float] = None,  # How many CPU cores to request. This is a soft limit.
+        # Specify, in fractional CPU cores, how many CPU cores to request.
+        # Or, pass (request, limit) to additionally specify a hard limit in fractional CPU cores.
+        # CPU throttling will prevent a container from exceeding its specified limit.
+        cpu: Optional[Union[float, Tuple[float, float]]] = None,
         # Specify, in MiB, a memory request which is the minimum memory required.
         # Or, pass (request, limit) to additionally specify a hard limit in MiB.
         memory: Optional[Union[int, Tuple[int, int]]] = None,
@@ -838,7 +841,10 @@ class _App:
             Union[str, PurePosixPath], Union[_Volume, _CloudBucketMount]
         ] = {},  # Mount points for Modal Volumes & CloudBucketMounts
         allow_cross_region_volumes: bool = False,  # Whether using network file systems from other regions is allowed.
-        cpu: Optional[float] = None,  # How many CPU cores to request. This is a soft limit.
+        # Specify, in fractional CPU cores, how many CPU cores to request.
+        # Or, pass (request, limit) to additionally specify a hard limit in fractional CPU cores.
+        # CPU throttling will prevent a container from exceeding its specified limit.
+        cpu: Optional[Union[float, Tuple[float, float]]] = None,
         # Specify, in MiB, a memory request which is the minimum memory required.
         # Or, pass (request, limit) to additionally specify a hard limit in MiB.
         memory: Optional[Union[int, Tuple[int, int]]] = None,
@@ -961,7 +967,10 @@ class _App:
         gpu: GPU_T = None,
         cloud: Optional[str] = None,
         region: Optional[Union[str, Sequence[str]]] = None,  # Region or regions to run the sandbox on.
-        cpu: Optional[float] = None,  # How many CPU cores to request. This is a soft limit.
+        # Specify, in fractional CPU cores, how many CPU cores to request.
+        # Or, pass (request, limit) to additionally specify a hard limit in fractional CPU cores.
+        # CPU throttling will prevent a container from exceeding its specified limit.
+        cpu: Optional[Union[float, Tuple[float, float]]] = None,
         # Specify, in MiB, a memory request which is the minimum memory required.
         # Or, pass (request, limit) to additionally specify a hard limit in MiB.
         memory: Optional[Union[int, Tuple[int, int]]] = None,

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -438,7 +438,7 @@ class _Cls(_Object, type_prefix="cs"):
 
     def with_options(
         self: "_Cls",
-        cpu: Optional[float] = None,
+        cpu: Optional[Union[float, Tuple[float, float]]] = None,
         memory: Optional[Union[int, Tuple[int, int]]] = None,
         gpu: GPU_T = None,
         secrets: Collection[_Secret] = (),


### PR DESCRIPTION
## Describe your changes

- WRK-462


```
@app.function(cpu=(1, 8))
def f_cpu(n=5000):
    import numpy
    ...
```

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
    - Old servers will ignore `milli_cpu_max`
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

* Specifying a hard CPU limit for a `modal.Function` is now supported. Pass a tuple of `cpu=(request, limit)`. Above the limit, which is specified in fractional CPU cores, a Function's container CPU usage will be throttled.
