### PR TITLE
Add RetryInputs endpoint to protos

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -131,6 +131,7 @@ enum FunctionCallInvocationType {
   FUNCTION_CALL_INVOCATION_TYPE_SYNC_LEGACY = 1;
   FUNCTION_CALL_INVOCATION_TYPE_ASYNC_LEGACY = 2;
   FUNCTION_CALL_INVOCATION_TYPE_ASYNC = 3;
+  FUNCTION_CALL_INVOCATION_TYPE_SYNC = 4;
 }
 
 enum FunctionCallType {
@@ -1507,6 +1508,8 @@ message FunctionMapRequest {
 message FunctionMapResponse {
   string function_call_id = 1;
   repeated FunctionPutInputsResponseItem pipelined_inputs = 2;
+  FunctionRetryPolicy retry_policy = 3;
+  string function_call_jwt = 4;
 }
 
 message FunctionOptions {
@@ -1559,6 +1562,7 @@ message FunctionPutInputsResponse {
 message FunctionPutInputsResponseItem {
   int32 idx = 1;
   string input_id = 2;
+  string input_jwt = 3;
 }
 
 message FunctionPutOutputsItem {
@@ -1578,6 +1582,21 @@ message FunctionPutUserTelemetryRequest {
   bytes data = 1;
   TelemetryEncodingType encoding_type = 2;
   InstrumentationType instrumentation_type = 3;
+}
+
+message FunctionRetryInputsItem {
+  string input_jwt = 1;
+  FunctionInput input = 2;
+}
+
+message FunctionRetryInputsRequest {
+  string function_call_jwt = 1;
+  repeated FunctionRetryInputsItem inputs = 2;
+}
+
+message FunctionRetryInputsResponse {
+  // TODO(ryan): Eventually this will return entry ids, which client
+  // will send back to server to check for lost inputs.
 }
 
 message FunctionRetryPolicy {
@@ -2685,6 +2704,7 @@ service ModalClient {
   rpc FunctionPutInputs(FunctionPutInputsRequest) returns (FunctionPutInputsResponse);
   rpc FunctionPutOutputs(FunctionPutOutputsRequest) returns (google.protobuf.Empty);  // For containers to return result
   rpc FunctionPutUserTelemetry(FunctionPutUserTelemetryRequest) returns (google.protobuf.Empty);
+  rpc FunctionRetryInputs(FunctionRetryInputsRequest) returns (FunctionRetryInputsResponse);
   rpc FunctionStartPtyShell(google.protobuf.Empty) returns (google.protobuf.Empty);
   rpc FunctionUpdateSchedulingParams(FunctionUpdateSchedulingParamsRequest) returns (FunctionUpdateSchedulingParamsResponse);
 


### PR DESCRIPTION
Part of SVC-191

Adding proto changes for new RetryInputs endpoint. Once this is merged we can implement it in the server, and then make the corresponding client changes.

The retry endpoint uses two types of JWTs - one for the function call, and one for each input in the function call.

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [X] Client+Server: this change is compatible with old servers
- [X] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!-- If relevant, include a brief user-facing description of what's new in this version. -->
