### PR TITLE
Adds ProxyCreate proto definition

### DIFF
--- a/modal/proxy.py
+++ b/modal/proxy.py
@@ -17,13 +17,12 @@ class _Proxy(_Object, type_prefix="pr"):
 
     @staticmethod
     def from_name(
-        label: str,
-        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        name: str,
         environment_name: Optional[str] = None,
     ) -> "_Proxy":
         async def _load(self: _Proxy, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.ProxyGetRequest(
-                name=label,
+                name=name,
                 environment_name=_get_environment_name(environment_name, resolver),
             )
             response: api_pb2.ProxyGetResponse = await resolver.client.stub.ProxyGet(req)

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1857,9 +1857,8 @@ message Proxy {
   repeated ProxyIp proxy_ips = 4;
 }
 message ProxyCreateRequest {
-  string deployment_name = 1 [ (modal.options.audit_target_attr) = true ];
-  DeploymentNamespace namespace = 2;
-  string environment_name = 3;
+  string name = 1 [ (modal.options.audit_target_attr) = true ];
+  string environment_name = 2;
 }
 
 message ProxyCreateResponse {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1856,6 +1856,15 @@ message Proxy {
   string proxy_id = 5;
   repeated ProxyIp proxy_ips = 4;
 }
+message ProxyCreateRequest {
+  string deployment_name = 1 [ (modal.options.audit_target_attr) = true ];
+  DeploymentNamespace namespace = 2;
+  string environment_name = 3;
+}
+
+message ProxyCreateResponse {
+  Proxy proxy = 1;
+}
 
 message ProxyDeleteRequest {
   string proxy_id = 1 [ (modal.options.audit_target_attr) = true ];
@@ -2717,6 +2726,7 @@ service ModalClient {
   rpc MountPutFile(MountPutFileRequest) returns (MountPutFileResponse);
 
   // Proxies
+  rpc ProxyCreate(ProxyCreateRequest) returns (ProxyCreateRequest);
   rpc ProxyDelete(ProxyDeleteRequest) returns (google.protobuf.Empty);
   rpc ProxyGet(ProxyGetRequest) returns (ProxyGetResponse);
   rpc ProxyGetOrCreate(ProxyGetOrCreateRequest) returns (ProxyGetOrCreateResponse);


### PR DESCRIPTION
This adds `ProxyCreate` for creating proxies. This has the same motivations of https://github.com/modal-labs/modal-client/pull/2469: I am splitting the `ProxyGetOrCreate` RPC into two RPCs because the DX for creating proxies disallow them to be created lazily with `ProxyGetOrCreate`.