### PR TITLE
Fixes typo with `ProxyCreate`

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1856,6 +1856,7 @@ message Proxy {
   string proxy_id = 5;
   repeated ProxyIp proxy_ips = 4;
 }
+
 message ProxyCreateRequest {
   string name = 1 [ (modal.options.audit_target_attr) = true ];
   string environment_name = 2;
@@ -2725,7 +2726,7 @@ service ModalClient {
   rpc MountPutFile(MountPutFileRequest) returns (MountPutFileResponse);
 
   // Proxies
-  rpc ProxyCreate(ProxyCreateRequest) returns (ProxyCreateRequest);
+  rpc ProxyCreate(ProxyCreateRequest) returns (ProxyCreateResponse);
   rpc ProxyDelete(ProxyDeleteRequest) returns (google.protobuf.Empty);
   rpc ProxyGet(ProxyGetRequest) returns (ProxyGetResponse);
   rpc ProxyGetOrCreate(ProxyGetOrCreateRequest) returns (ProxyGetOrCreateResponse);


### PR DESCRIPTION
Made the response be the request by accident. 