### PR TITLE
Revert "Updates path to Proxy docs (#2488)"

### DIFF
--- a/modal/proxy.py
+++ b/modal/proxy.py
@@ -12,7 +12,7 @@ class _Proxy(_Object, type_prefix="pr"):
     """Proxy objects give your Modal containers a static outbound IP address.
 
     This can be used for connecting to a remote address with network whitelist, for example
-    a database. See [the guide](/docs/guide/proxy) for more information.
+    a database. See [the guide](/docs/guide/proxy-ips) for more information.
     """
 
     @staticmethod


### PR DESCRIPTION
This reverts commit a1c1181d669d88d9e5cb45e6865fc166589aa436.

CC: @luiscape reverting because the link path doesn't exist on Modal monorepo so the build is failing. 