### PR TITLE
[Multi Node] Add `TaskClusterHello` RPC

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2375,9 +2375,8 @@ message TaskClusterHelloRequest {
 
 message TaskClusterHelloResponse {
   string cluster_id = 1;
-  uint32 cluster_size = 2;
-  uint32 cluster_rank = 3;
-  repeated string container_ips = 4;
+  uint32 cluster_rank = 2;
+  repeated string container_ips = 3;
 }
 
 message TaskCurrentInputsResponse {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2368,6 +2368,18 @@ message SystemErrorMessage {
   string error_message = 2;
 }
 
+message TaskClusterHelloRequest {
+  string task_id = 1;
+  string container_ip = 2;
+}
+
+message TaskClusterHelloResponse {
+  string cluster_id = 1;
+  uint32 cluster_size = 2;
+  uint32 cluster_rank = 3;
+  repeated string container_ips = 4;
+}
+
 message TaskCurrentInputsResponse {
   repeated string input_ids = 1;
 }
@@ -2778,6 +2790,7 @@ service ModalClient {
   rpc SharedVolumeRemoveFile(SharedVolumeRemoveFileRequest) returns (google.protobuf.Empty);
 
   // Tasks
+  rpc TaskClusterHello(TaskClusterHelloRequest) returns (TaskClusterHelloResponse);
   rpc TaskCurrentInputs(google.protobuf.Empty) returns (TaskCurrentInputsResponse);
   rpc TaskList(TaskListRequest) returns (TaskListResponse);
   rpc TaskResult(TaskResultRequest) returns (google.protobuf.Empty);

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2376,6 +2376,7 @@ message TaskClusterHelloRequest {
 message TaskClusterHelloResponse {
   string cluster_id = 1;
   uint32 cluster_rank = 2;
+  // All IP addresses in cluster, ordered by cluster rank
   repeated string container_ips = 3;
 }
 


### PR DESCRIPTION
This PR adds the `TaskClusterHello` RPC needed for multi-node clusters. See #2465 for more details.