### PR TITLE
Adds client side ImageMetadata

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1706,21 +1706,6 @@ message ImageGetOrCreateResponse {
   string image_id = 1;
 }
 
-message PythonPackageVersions {
-  // wrapper around map to get presence for the field
-  map<string, string> packages = 1;
-}
-
-message ImageMetadata {
-  // The output of `python -VV. None if missing (not recently built, or failed collection)
-  optional string python_version_info = 1;
-  // Installed python packages, as listed by by `pip list`.
-  // package name -> version. Not present if missing
-  PythonPackageVersions python_packages = 2;
-  // The work directory of the image, defaulting to "/". None if missing
-  optional string workdir = 3;
-}
-
 message ImageJoinStreamingRequest {
   string image_id = 1;
   float timeout = 2;
@@ -1735,6 +1720,18 @@ message ImageJoinStreamingResponse {
   bool eof = 4;
   ImageMetadata metadata = 5;  // set on success
 }
+
+
+message ImageMetadata {
+  // The output of `python -VV. None if missing (not recently built, or failed collection)
+  optional string python_version_info = 1;
+  // Installed python packages, as listed by by `pip list`.
+  // package name -> version. Not present if missing
+  PythonPackageVersions python_packages = 2;
+  // The work directory of the image, defaulting to "/". None if missing
+  optional string workdir = 3;
+}
+
 
 message ImageRegistryConfig {
   RegistryAuthType registry_auth_type = 1;
@@ -1939,6 +1936,11 @@ message ProxyIpListResponse {
 
 message ProxyListResponse {
   repeated Proxy proxies = 1;
+}
+
+message PythonPackageVersions {
+  // wrapper around map to get presence for the field
+  map<string, string> packages = 1;
 }
 
 message QueueClearRequest {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1938,11 +1938,6 @@ message ProxyListResponse {
   repeated Proxy proxies = 1;
 }
 
-message PythonPackageVersions {
-  // wrapper around map to get presence for the field
-  map<string, string> packages = 1;
-}
-
 message QueueClearRequest {
   string queue_id = 1;
   bytes partition_key = 2;

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1706,6 +1706,21 @@ message ImageGetOrCreateResponse {
   string image_id = 1;
 }
 
+message PythonPackageVersions {
+  // wrapper around map to get presence for the field
+  map<string, string> packages = 1;
+}
+
+message ImageMetadata {
+  // The output of `python -VV. None if missing (not recently built, or failed collection)
+  optional string python_version_info = 1;
+  // Installed python packages, as listed by by `pip list`.
+  // package name -> version. Not present if missing
+  PythonPackageVersions python_packages = 2;
+  // The work directory of the image, defaulting to "/". None if missing
+  optional string workdir = 3;
+}
+
 message ImageJoinStreamingRequest {
   string image_id = 1;
   float timeout = 2;
@@ -1718,8 +1733,8 @@ message ImageJoinStreamingResponse {
   repeated TaskLogs task_logs = 2;
   string entry_id = 3;
   bool eof = 4;
+  ImageMetadata metadata = 5;  // set on success
 }
-
 
 message ImageRegistryConfig {
   RegistryAuthType registry_auth_type = 1;

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1723,12 +1723,12 @@ message ImageJoinStreamingResponse {
 
 
 message ImageMetadata {
-  // The output of `python -VV. None if missing (not recently built, or failed collection)
+  // The output of `python -VV. Not set if missing
   optional string python_version_info = 1;
   // Installed python packages, as listed by by `pip list`.
-  // package name -> version. Not present if missing
-  PythonPackageVersions python_packages = 2;
-  // The work directory of the image, defaulting to "/". None if missing
+  // package name -> version. Empty if missing
+  map<string, string> python_packages = 2;
+  // The work directory of the image, defaulting to "/". Not set if missing
   optional string workdir = 3;
 }
 


### PR DESCRIPTION
Prep for supplying image metadata from successful ImageJoins, which can be useful for the client to take conditional measures in subsequent build/run steps (like warning users of missing requirements, or adjusting commands based on workdir)

This somewhat matches the format of the metadata we already collect on the backend after @thecodingwizard 's recent patch, but unpacks the raw json-formatted info into structured proto, avoiding having to do that parsing in the client and allowing an easier migration if we want to change the format we store data data on the backend.