### PR TITLE
Suppress some previously deprecated methods from API docs

### DIFF
--- a/modal/dict.py
+++ b/modal/dict.py
@@ -58,11 +58,12 @@ class _Dict(_Object, type_prefix="di"):
 
     @staticmethod
     def new(data: Optional[dict] = None):
-        """`Dict.new` is deprecated.
-
-        Please use `Dict.from_name` (for persisted) or `Dict.ephemeral` (for ephemeral) dicts.
-        """
-        deprecation_error((2024, 3, 19), Dict.new.__doc__)
+        """mdmd:hidden"""
+        message = (
+            "`Dict.new` is deprecated."
+            " Please use `Dict.from_name` (for persisted) or `Dict.ephemeral` (for ephemeral) dicts instead."
+        )
+        deprecation_error((2024, 3, 19), message)
 
     def __init__(self, data={}):
         """mdmd:hidden"""
@@ -144,8 +145,9 @@ class _Dict(_Object, type_prefix="di"):
 
     @staticmethod
     def persisted(label: str, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, environment_name: Optional[str] = None):
-        """Deprecated! Use `Dict.from_name(name, create_if_missing=True)`."""
-        deprecation_error((2024, 3, 1), _Dict.persisted.__doc__)
+        """mdmd:hidden"""
+        message = "`Dict.persisted` is deprecated. Please use `Dict.from_name(name, create_if_missing=True)` instead."
+        deprecation_error((2024, 3, 1), message)
 
     @staticmethod
     async def lookup(

--- a/modal/image.py
+++ b/modal/image.py
@@ -981,8 +981,12 @@ class _Image(_Object, type_prefix="im"):
 
     @staticmethod
     def conda(python_version: Optional[str] = None, force_build: bool = False):
-        """DEPRECATED: Removed in favor of the faster and more reliable `Image.micromamba` constructor."""
-        deprecation_error((2024, 5, 2), _Image.conda.__doc__ or "")
+        """mdmd:hidden"""
+        message = (
+            "`Image.conda` is deprecated."
+            " Please use the faster and more reliable `Image.micromamba` constructor instead."
+        )
+        deprecation_error((2024, 5, 2), message)
 
     def conda_install(
         self,
@@ -992,8 +996,12 @@ class _Image(_Object, type_prefix="im"):
         secrets: Sequence[_Secret] = [],
         gpu: GPU_T = None,
     ):
-        """DEPRECATED: Removed in favor of the faster and more reliable `Image.micromamba_install` method."""
-        deprecation_error((2024, 5, 2), _Image.conda_install.__doc__ or "")
+        """mdmd:hidden"""
+        message = (
+            "`Image.conda_install` is deprecated."
+            " Please use the faster and more reliable `Image.micromamba_install` instead."
+        )
+        deprecation_error((2024, 5, 2), message)
 
     def conda_update_from_environment(
         self,
@@ -1003,8 +1011,12 @@ class _Image(_Object, type_prefix="im"):
         secrets: Sequence[_Secret] = [],
         gpu: GPU_T = None,
     ):
-        """DEPRECATED: Removed in favor of the `Image.micromamba_install` method (using the `spec_file` parameter)."""
-        deprecation_error((2024, 5, 2), _Image.conda_update_from_environment.__doc__ or "")
+        """mdmd:hidden"""
+        message = (
+            "Image.conda_update_from_environment` is deprecated."
+            " Please use the `Image.micromamba_install` method (with the `spec_file` parameter) instead."
+        )
+        deprecation_error((2024, 5, 2), message)
 
     @staticmethod
     def micromamba(

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -90,12 +90,13 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
 
     @staticmethod
     def new(cloud: Optional[str] = None):
-        """`NetworkFileSystem.new` is deprecated.
-
-        Please use `NetworkFileSystem.from_name` (for persisted) or `NetworkFileSystem.ephemeral`
-        (for ephemeral) network filesystems.
-        """
-        deprecation_error((2024, 3, 20), NetworkFileSystem.new.__doc__)
+        """mdmd:hidden"""
+        message = (
+            "`NetworkFileSystem.new` is deprecated."
+            " Please use `NetworkFileSystem.from_name` (for persisted)"
+            " or `NetworkFileSystem.ephemeral` (for ephemeral) network filesystems instead."
+        )
+        deprecation_error((2024, 3, 20), message)
 
     @staticmethod
     def from_name(
@@ -175,8 +176,12 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         environment_name: Optional[str] = None,
         cloud: Optional[str] = None,
     ):
-        """Deprecated! Use `NetworkFileSystem.from_name(name, create_if_missing=True)`."""
-        deprecation_error((2024, 3, 1), _NetworkFileSystem.persisted.__doc__)
+        """mdmd:hidden"""
+        message = (
+            "`NetworkFileSystem.persisted` is deprecated."
+            " Please use `NetworkFileSystem.from_name(name, create_if_missing=True)` instead."
+        )
+        deprecation_error((2024, 3, 1), message)
 
     def persist(
         self,
@@ -185,9 +190,12 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         environment_name: Optional[str] = None,
         cloud: Optional[str] = None,
     ):
-        """`NetworkFileSystem().persist("my-volume")` is deprecated.
-        Use `NetworkFileSystem.from_name("my-volume", create_if_missing=True)` instead."""
-        deprecation_error((2024, 2, 29), _NetworkFileSystem.persist.__doc__)
+        """mdmd:hidden"""
+        message = (
+            "`NetworkFileSystem().persist('my-volume')` is deprecated."
+            " Please use `NetworkFileSystem.from_name('my-volume', create_if_missing=True)` instead."
+        )
+        deprecation_error((2024, 2, 29), message)
 
     @staticmethod
     async def lookup(

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -88,11 +88,12 @@ class _Queue(_Object, type_prefix="qu"):
 
     @staticmethod
     def new():
-        """`Queue.new` is deprecated.
-
-        Please use `Queue.from_name` (for persisted) or `Queue.ephemeral` (for ephemeral) queues.
-        """
-        deprecation_error((2024, 3, 19), Queue.new.__doc__)
+        """mdmd:hidden"""
+        message = (
+            "`Queue.new` is deprecated."
+            " Please use `Queue.from_name` (for persisted) or `Queue.ephemeral` (for ephemeral) queues instead."
+        )
+        deprecation_error((2024, 3, 19), message)
 
     def __init__(self):
         """mdmd:hidden"""
@@ -176,8 +177,9 @@ class _Queue(_Object, type_prefix="qu"):
 
     @staticmethod
     def persisted(label: str, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, environment_name: Optional[str] = None):
-        """Deprecated! Use `Queue.from_name(name, create_if_missing=True)`."""
-        deprecation_error((2024, 3, 1), _Queue.persisted.__doc__)
+        """mdmd:hidden"""
+        message = "`Queue.persisted` is deprecated. Please use `Queue.from_name(name, create_if_missing=True)` instead."
+        deprecation_error((2024, 3, 1), message)
 
     @staticmethod
     async def lookup(

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -615,8 +615,9 @@ def _run_stub(*args: Any, **kwargs: Any):
 
 
 def _deploy_stub(*args: Any, **kwargs: Any):
-    """`deploy_stub` has been renamed to `deploy_app` and is deprecated. Please update your code."""
-    deprecation_error((2024, 5, 1), str(_deploy_stub.__doc__))
+    """mdmd:hidden"""
+    message = "`deploy_stub` has been renamed to `deploy_app`. Please update your code."
+    deprecation_error((2024, 5, 1), message)
 
 
 run_app = synchronize_api(_run_app)

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -142,11 +142,12 @@ class _Volume(_Object, type_prefix="vo"):
 
     @staticmethod
     def new():
-        """`Volume.new` is deprecated.
-
-        Please use `Volume.from_name` (for persisted) or `Volume.ephemeral` (for ephemeral) volumes.
-        """
-        deprecation_error((2024, 3, 20), Volume.new.__doc__)  # type: ignore
+        """mdmd:hidden"""
+        message = (
+            "`Volume.new` is deprecated."
+            " Please use `Volume.from_name` (for persisted) or `Volume.ephemeral` (for ephemeral) volumes instead."
+        )
+        deprecation_error((2024, 3, 20), message)
 
     @staticmethod
     def from_name(
@@ -228,8 +229,11 @@ class _Volume(_Object, type_prefix="vo"):
         environment_name: Optional[str] = None,
         cloud: Optional[str] = None,
     ):
-        """Deprecated! Use `Volume.from_name(name, create_if_missing=True)`."""
-        deprecation_error((2024, 3, 1), _Volume.persisted.__doc__)
+        """mdmd:hidden"""
+        message = (
+            "`Volume.persisted` is deprecated. Please use `Volume.from_name(name, create_if_missing=True)` instead."
+        )
+        deprecation_error((2024, 3, 1), message)
 
     @staticmethod
     async def lookup(


### PR DESCRIPTION
Housekeeping PR to hide some fully-deprecated (i.e., erroring out) methods from our API docs. I also standardized some of the messages and reformatted a few to show up better in the AST-based `inv show-deprecations` helper.