### PR TITLE
Improve lookup/from_name docs on Modal objects

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -288,12 +288,14 @@ class _App:
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
     ) -> "_App":
-        """Look up an app with a given name. When `create_if_missing` is true,
-        the app will be created if it doesn't exist.
+        """Look up an App with a given name, creating a new App if necessary.
+
+        Note that Apps created through this method will be in a deployed state
+        but will not have any Functions or Classes assocaited with them. This
+        is mainly useful for creating an App to associate with a Sandbox:
 
         ```python
         app = modal.App.lookup("my-app", create_if_missing=True)
-
         modal.Sandbox.create("echo", "hi", app=app)
         ```
         """

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -388,7 +388,11 @@ class _Cls(_Object, type_prefix="cs"):
         environment_name: Optional[str] = None,
         workspace: Optional[str] = None,
     ) -> "_Cls":
-        """Retrieve a class with a given name and tag.
+        """Reference a Cls from a deployed App by its name.
+
+        In contrast to `modal.Cls.lookup`, this is a lazy method
+        that defers hydrating the local object with metadata from
+        Modal servers until the first time it is actually used.
 
         ```python
         Class = modal.Cls.from_name("other-app", "Class")
@@ -457,7 +461,6 @@ class _Cls(_Object, type_prefix="cs"):
         **Usage:**
 
         ```python notest
-        import modal
         Model = modal.Cls.lookup("my_app", "Model")
         ModelUsingGPU = Model.with_options(gpu="A100")
         ModelUsingGPU().generate.remote(42)  # will run with an A100 GPU
@@ -504,10 +507,14 @@ class _Cls(_Object, type_prefix="cs"):
         environment_name: Optional[str] = None,
         workspace: Optional[str] = None,
     ) -> "_Cls":
-        """Lookup a class with a given name and tag.
+        """Lookup a Cls from a deployed App by its name.
+
+        In contrast to `modal.Cls.from_name`, this is an eager method
+        that will hydrate the local object with metadata from Modal servers.
 
         ```python
         Class = modal.Cls.lookup("other-app", "Class")
+        obj = Class()
         ```
         """
         obj = _Cls.from_name(app_name, tag, namespace=namespace, environment_name=environment_name, workspace=workspace)

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -115,15 +115,15 @@ class _Dict(_Object, type_prefix="di"):
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
     ) -> "_Dict":
-        """Create a reference to a persisted Dict
+        """Reference a named Dict, creating if necessary.
 
-        **Examples**
+        In contrast to `modal.Dict.lookup`, this is a lazy method
+        that defers hydrating the local object with metadata from
+        Modal servers until the first time it is actually used.
 
         ```python
-        from modal import Dict
-
-        dict = Dict.from_name("my-dict", create_if_missing=True)
-        dict[123] = 456
+        d = modal.Dict.from_name("my-dict", create_if_missing=True)
+        d[123] = 456
         ```
         """
         check_object_name(label, "Dict")
@@ -158,12 +158,13 @@ class _Dict(_Object, type_prefix="di"):
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
     ) -> "_Dict":
-        """Lookup a dict with a given name and tag.
+        """Lookup a named Dict.
+
+        In contrast to `modal.Dict.from_name`, this is an eager method
+        that will hydrate the local object with metadata from Modal servers.
 
         ```python
-        from modal import Dict
-
-        d = Dict.lookup("my-dict")
+        d = modal.Dict.lookup("my-dict")
         d["xyz"] = 123
         ```
         """

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1064,10 +1064,14 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
     ) -> "_Function":
-        """Retrieve a function with a given name and tag.
+        """Reference a Function from a deployed App by its name.
+
+        In contast to `modal.Function.lookup`, this is a lazy method
+        that defers hydrating the local object with metadata from
+        Modal servers until the first time it is actually used.
 
         ```python
-        other_function = modal.Function.from_name("other-app", "function")
+        f = modal.Function.from_name("other-app", "function")
         ```
         """
 
@@ -1100,10 +1104,13 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
     ) -> "_Function":
-        """Lookup a function with a given name and tag.
+        """Lookup a Function from a deployed App by its name.
+
+        In contrast to `modal.Function.from_name`, this is an eager method
+        that will hydrate the local object with metadata from Modal servers.
 
         ```python
-        other_function = modal.Function.lookup("other-app", "function")
+        f = modal.Function.lookup("other-app", "function")
         ```
         """
         obj = _Function.from_name(app_name, tag, namespace=namespace, environment_name=environment_name)

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -586,6 +586,8 @@ class _Mount(_Object, type_prefix="mo"):
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
     ) -> "_Mount":
+        """mdmd:hidden"""
+
         async def _load(provider: _Mount, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.MountGetOrCreateRequest(
                 deployment_name=label,
@@ -605,6 +607,7 @@ class _Mount(_Object, type_prefix="mo"):
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
     ) -> "_Mount":
+        """mdmd:hidden"""
         obj = _Mount.from_name(label, namespace=namespace, environment_name=environment_name)
         if client is None:
             client = await _Client.from_env()

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -105,14 +105,16 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
     ) -> "_NetworkFileSystem":
-        """Create a reference to a persisted network filesystem, optionally creating it lazily.
+        """Reference a NetworkFileSystem by its name, creating if necessary.
 
-        **Examples**
+        In contrast to `modal.NetworkFileSystem.lookup`, this is a lazy method
+        that defers hydrating the local object with metadata from Modal servers
+        until the first time it is actually used.
 
         ```python notest
-        volume = NetworkFileSystem.from_name("my-volume", create_if_missing=True)
+        nfs = NetworkFileSystem.from_name("my-nfs", create_if_missing=True)
 
-        @app.function(network_file_systems={"/vol": volume})
+        @app.function(network_file_systems={"/data": nfs})
         def f():
             pass
         ```
@@ -205,11 +207,14 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
     ) -> "_NetworkFileSystem":
-        """Lookup a network file system with a given name
+        """Lookup a named NetworkFileSystem.
+
+        In contrast to `modal.NetworkFileSystem.from_name`, this is an eager method
+        that will hydrate the local object with metadata from Modal servers.
 
         ```python
-        n = modal.NetworkFileSystem.lookup("my-nfs")
-        print(n.listdir("/"))
+        nfs = modal.NetworkFileSystem.lookup("my-nfs")
+        print(nfs.listdir("/"))
         ```
         """
         obj = _NetworkFileSystem.from_name(

--- a/modal/proxy.py
+++ b/modal/proxy.py
@@ -20,6 +20,13 @@ class _Proxy(_Object, type_prefix="pr"):
         name: str,
         environment_name: Optional[str] = None,
     ) -> "_Proxy":
+        """Reference a Proxy by its name.
+
+        In contrast to most other Modal objects, new Proxy objects must be
+        provisioned via the Dashboard and cannot be created on the fly from code.
+
+        """
+
         async def _load(self: _Proxy, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.ProxyGetRequest(
                 name=name,

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -189,11 +189,12 @@ class _Queue(_Object, type_prefix="qu"):
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
     ) -> "_Queue":
-        """Lookup a queue with a given name and tag.
+        """Lookup a named Queue.
+
+        In contrast to `modal.Queue.from_name`, this is an eager method
+        that will hydrate the local object with metadata from Modal servers.
 
         ```python
-        from modal import Queue
-
         q = modal.Queue.lookup("my-queue")
         q.put(123)
         ```

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -169,7 +169,11 @@ class _Secret(_Object, type_prefix="st"):
             str
         ] = [],  # Optionally, a list of required environment variables (will be asserted server-side)
     ) -> "_Secret":
-        """Create a reference to a persisted Secret
+        """Reference a Secret by its name.
+
+        In contrast to most other Modal objects, named Secrets must be provisioned
+        from the Dashboard. See other methods for alternate ways of creating a new
+        Secret from code.
 
         ```python
         secret = modal.Secret.from_name("my-secret")
@@ -206,13 +210,7 @@ class _Secret(_Object, type_prefix="st"):
         environment_name: Optional[str] = None,
         required_keys: List[str] = [],
     ) -> "_Secret":
-        """Lookup a secret with a given name
-
-        ```python
-        s = modal.Secret.lookup("my-secret")
-        print(s.object_id)
-        ```
-        """
+        """mdmd:hidden"""
         obj = _Secret.from_name(
             label, namespace=namespace, environment_name=environment_name, required_keys=required_keys
         )

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -157,19 +157,19 @@ class _Volume(_Object, type_prefix="vo"):
         create_if_missing: bool = False,
         version: "typing.Optional[modal_proto.api_pb2.VolumeFsVersion.ValueType]" = None,
     ) -> "_Volume":
-        """Create a reference to a persisted volume. Optionally create it lazily.
+        """Reference a Volume by name, creating if necessary.
 
-        **Example Usage**
+        In contrast to `modal.Volume.lookup`, this is a lazy method
+        that defers hydrating the local object with metadata from
+        Modal servers until the first time is is actually used.
 
         ```python
-        import modal
-
-        volume = modal.Volume.from_name("my-volume", create_if_missing=True)
+        vol = modal.Volume.from_name("my-volume", create_if_missing=True)
 
         app = modal.App()
 
         # Volume refers to the same object, even across instances of `app`.
-        @app.function(volumes={"/vol": volume})
+        @app.function(volumes={"/data": vol})
         def f():
             pass
         ```
@@ -244,11 +244,14 @@ class _Volume(_Object, type_prefix="vo"):
         create_if_missing: bool = False,
         version: "typing.Optional[modal_proto.api_pb2.VolumeFsVersion.ValueType]" = None,
     ) -> "_Volume":
-        """Lookup a volume with a given name
+        """Lookup a named Volume.
+
+        In contrast to `modal.Volume.from_name`, this is an eager method
+        that will hydrate the local object with metadata from Modal servers.
 
         ```python
-        n = modal.Volume.lookup("my-volume")
-        print(n.listdir("/"))
+        vol = modal.Volume.lookup("my-volume")
+        print(vol.listdir("/"))
         ```
         """
         obj = _Volume.from_name(


### PR DESCRIPTION
I don't think we explain the distinction between `.lookup` and `.from_name` anywhere in our docs.

We've had various conversations about how to avoid having this dichotomy (which is somewhat easier now that nearly all objects support lazy hydration) but in the meantime I think it's helpful to explain a little bit about the difference.

I don't think the explanation is _super_ helpful because I'm not certain the average user will be able to reason from the explanation that we give to the practical implications for their code. Which is why it's generally preferable to just have One Way To Do It. But hopefully the examples help a little bit in terms of guiding usage.

I also took the opportunity to modernize + standardize some of the other doctstring copy and examples, along with Jonofication of the capitalization.