### PR TITLE
Add logging to reflect when a cancellation was received and processed.

### DIFF
--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -137,6 +137,7 @@ class IOContext:
             return
 
         if self._cancel_callback:
+            logger.warning(f"Received a cancellation signal while processing input {self.input_ids}")
             self._cancel_issued = True
             self._cancel_callback()
         else:
@@ -779,7 +780,6 @@ class _ContainerIOManager:
             raise
         except (InputCancellation, asyncio.CancelledError):
             # Create terminated outputs for these inputs to signal that the cancellations have been completed.
-            logger.warning(f"Received a cancellation signal while processing input {io_context.input_ids}")
             results = [
                 api_pb2.GenericResult(status=api_pb2.GenericResult.GENERIC_STATUS_TERMINATED)
                 for _ in io_context.input_ids
@@ -790,7 +790,8 @@ class _ContainerIOManager:
                 data_format=api_pb2.DATA_FORMAT_PICKLE,
                 results=results,
             )
-            await self.exit_context(started_at, io_context.input_ids)
+            self.exit_context(started_at, io_context.input_ids)
+            logger.warning(f"Successfully canceled input {io_context.input_ids}")
             return
         except BaseException as exc:
             if isinstance(exc, ImportError):
@@ -836,9 +837,9 @@ class _ContainerIOManager:
                 data_format=api_pb2.DATA_FORMAT_PICKLE,
                 results=results,
             )
-            await self.exit_context(started_at, io_context.input_ids)
+            self.exit_context(started_at, io_context.input_ids)
 
-    async def exit_context(self, started_at, input_ids: List[str]):
+    def exit_context(self, started_at, input_ids: List[str]):
         self.total_user_time += time.time() - started_at
         self.calls_completed += 1
 
@@ -872,7 +873,7 @@ class _ContainerIOManager:
             data_format=data_format,
             results=results,
         )
-        await self.exit_context(started_at, io_context.input_ids)
+        self.exit_context(started_at, io_context.input_ids)
 
     async def memory_restore(self) -> None:
         # Busy-wait for restore. `/__modal/restore-state.json` is created

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -1705,7 +1705,7 @@ def test_cancellation_aborts_current_input_on_match(
         api_pb2.ContainerHeartbeatResponse(cancel_input_event=api_pb2.CancelInputEvent(input_ids=cancelled_input_ids))
     )
     stdout, stderr = container_process.communicate()
-    assert stderr.decode().count("Received a cancellation signal") == live_cancellations
+    assert stderr.decode().count("Successfully canceled input") == live_cancellations
     assert "Traceback" not in stderr.decode()
     assert container_process.returncode == 0  # wait for container to exit
     duration = time.monotonic() - t0  # time from heartbeat to container exit


### PR DESCRIPTION
Reverts modal-labs/modal-client#2501 and fixes the tests the original PR broke.