### PR TITLE
Fix flakey test

### DIFF
--- a/test/container_test.py
+++ b/test/container_test.py
@@ -1622,7 +1622,7 @@ def test_function_io_doesnt_inspect_args_or_return_values(monkeypatch, servicer)
     for call in translate_out_spy.call_args_list:
         out_translations += list(call.args)
 
-    assert len(in_translations) < 1000  # typically 136 or something
+    assert len(in_translations) < 2000  # typically ~400 or something
     assert len(out_translations) < 2000
 
 

--- a/test/shutdown_test.py
+++ b/test/shutdown_test.py
@@ -92,5 +92,5 @@ async def test_client_close_cancellation_context_only_used_in_correct_event_loop
             await asyncio.sleep(0.1)
     with pytest.raises(grpclib.exceptions.StreamTerminatedError):
         await t
-    assert len(caplog.records) == 1
-    assert "QueueGet made outside of task context" in caplog.records[0].message
+    expected_warnings = [msg for msg in caplog.messages if "QueueGet made outside of task context" in msg]
+    assert len(expected_warnings) == 1


### PR DESCRIPTION
Flaked sometimes since it could emit a heartbeat loop warning too depending on timing