### PR TITLE
Update FunctionData proto with recently added Function fields

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -861,6 +861,11 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                         use_function_id=function_definition.use_function_id,
                         use_method_name=function_definition.use_method_name,
                         _experimental_group_size=function_definition._experimental_group_size,
+                        _experimental_buffer_containers=function_definition._experimental_buffer_containers,
+                        _experimental_custom_scaling=function_definition._experimental_custom_scaling,
+                        _experimental_proxy_ip=function_definition._experimental_proxy_ip,
+                        snapshot_debug=function_definition.snapshot_debug,
+                        runtime_perf_record=function_definition.runtime_perf_record,
                     )
 
                     ranked_functions = []

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1328,6 +1328,11 @@ message FunctionData {
   uint32 warm_pool_size = 4;
   uint32 concurrency_limit = 5;
   uint32 task_idle_timeout_secs = 6;
+  // When the function is a "grouped" one, this records the # of tasks we want
+  // to schedule in tandem.
+  uint32 _experimental_group_size = 19;
+  uint32 _experimental_buffer_containers = 22;
+  bool _experimental_custom_scaling = 23;
   string worker_id = 7; // for internal debugging use only
 
   uint32 timeout_secs = 8;
@@ -1336,6 +1341,12 @@ message FunctionData {
   WebUrlInfo web_url_info = 10;
   WebhookConfig webhook_config = 11;
   repeated CustomDomainInfo custom_domain_info = 12;
+  // _experimental_proxy_ip -> ProxyInfo
+  // TODO: deprecate.
+  optional string _experimental_proxy_ip = 24;
+  // Mapping of method names to method definitions, only non-empty for class service functions
+  map<string, MethodDefinition> method_definitions = 25;
+  bool method_definitions_set = 26;
 
   bool is_class = 13;  // if "Function" is actually a class grouping multiple methods - applies across all underlying tasks
   ClassParameterInfo class_parameter_info = 14;
@@ -1350,13 +1361,13 @@ message FunctionData {
   }
   repeated RankedFunction ranked_functions = 18;
 
-  // When the function is a "grouped" one, this records the # of tasks we want
-  // to schedule in tandem.
-  uint32 _experimental_group_size = 19;
-
   Schedule schedule = 20;
 
   reserved 21;
+
+  bool untrusted = 27; // If set, the function will be run in an untrusted environment.
+  bool snapshot_debug = 28; // For internal debugging use only.
+  bool runtime_perf_record = 29; // For internal debugging use only.
 }
 
 message FunctionExtended {


### PR DESCRIPTION
Picking up the Function -> FunctionData migration work again. Catching up to some recent fields we added to the former, fields that will get "moved up" to the latter.