### PR TITLE
Add log when receiving cancellation signal for a single input.

### DIFF
--- a/modal/_container_io_manager.py
+++ b/modal/_container_io_manager.py
@@ -407,6 +407,7 @@ class _ContainerIOManager:
                     # SIGUSR1 signal should interrupt the main thread where user code is running,
                     # raising an InputCancellation() exception. On async functions, the signal should
                     # reach a handler in SignalHandlingEventLoop, which cancels the task.
+                    logger.warning(f"Received a cancellation signal while processing input {self.current_input_id}")
                     os.kill(os.getpid(), signal.SIGUSR1)
             return True
         return False


### PR DESCRIPTION
Missed this case when adding the log in the IOContext cancel() call. For single inputs, we just issue a SIGUSR1 and the signal handler then does the task cancellation. Everything works as intended, just missing the log.