### PR TITLE
Update Python in CD job that publishes base images

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -121,7 +121,7 @@ jobs:
 
   publish-base-images:
     name: |
-      Publish base images for ${{ matrix.image-name }} ${{ matrix.image-builder-version }} on ${{ matrix.python-version }}
+      Publish base images for ${{ matrix.image-name }} ${{ matrix.image-builder-version }}
     if: github.ref == 'refs/heads/main'
     needs: [client-test]
     runs-on: ubuntu-20.04
@@ -140,7 +140,7 @@ jobs:
 
       - uses: ./.github/actions/setup-cached-python
         with:
-          version: ${{ matrix.python-version }}
+          version: "3.11"
 
       - name: Build protobuf
         run: inv protoc


### PR DESCRIPTION
Due to an oversight when I refactored the "publish base image" CD job, it was running on Python 3.8 and broke in #2500.

This PR forces the job to run on Python 3.11.

Shouldn't have any effect on the actual Image recipes themselves, as we explicitly force the Python version in [the script](https://github.com/modal-labs/modal-client/blob/main/modal_global_objects/images/base_images.py).