### PR TITLE
Add `_is_web_endpoint` attr to `_Function`

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -492,7 +492,7 @@ class _App:
 
         return [m for m in all_mounts if m.is_local()]
 
-    def _add_function(self, function: _Function, is_web_endpoint: bool):
+    def _add_function(self, function: _Function):
         if function.tag in self._indexed_objects:
             old_function = self._indexed_objects[function.tag]
             if isinstance(old_function, _Function):
@@ -507,8 +507,12 @@ class _App:
                 logger.warning(f"Warning: tag {function.tag} exists but is overridden by function")
 
         self._add_object(function.tag, function)
-        if is_web_endpoint:
+        if function._is_web_endpoint:
             self._web_endpoints.append(function.tag)
+        if function._method_functions:
+            for method_function in function._method_functions.values():
+                if method_function._is_web_endpoint:
+                    self._web_endpoints.append(method_function.tag)
 
     def _init_container(self, client: _Client, running_app: RunningApp):
         self._app_id = running_app.app_id
@@ -815,7 +819,7 @@ class _App:
                 cluster_size=cluster_size,  # Experimental: Clustered functions
             )
 
-            self._add_function(function, webhook_config is not None)
+            self._add_function(function)
 
             return function
 
@@ -944,7 +948,7 @@ class _App:
                 _experimental_custom_scaling_factor=_experimental_custom_scaling_factor,
             )
 
-            self._add_function(cls_func, is_web_endpoint=False)
+            self._add_function(cls_func)
 
             cls: _Cls = _Cls.from_local(user_cls, self, cls_func)
 

--- a/modal/app.py
+++ b/modal/app.py
@@ -509,10 +509,6 @@ class _App:
         self._add_object(function.tag, function)
         if function._is_web_endpoint:
             self._web_endpoints.append(function.tag)
-        if function._method_functions:
-            for method_function in function._method_functions.values():
-                if method_function._is_web_endpoint:
-                    self._web_endpoints.append(method_function.tag)
 
     def _init_container(self, client: _Client, running_app: RunningApp):
         self._app_id = running_app.app_id

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -327,7 +327,7 @@ class _Cls(_Object, type_prefix="cs"):
 
         for method_name, partial_function in partial_functions.items():
             method_function = class_service_function._bind_method_old(user_cls, method_name, partial_function)
-            app._add_function(method_function, is_web_endpoint=partial_function.webhook_config is not None)
+            app._add_function(method_function)
             partial_function.wrapped = True
             functions[method_name] = method_function
 


### PR DESCRIPTION
## Describe your changes

Add `_is_web_endpoint` attr to `_Function`. The point of `_is_web_endpoint` is to be able to determine if a `_Function` is a web function when it is un-hydrated and `._web_url` is not populated.

The motivation for this change is that PR [2364](https://github.com/modal-labs/modal-client/pull/2364) also modifies `_add_function` to properly populate `_App.web_endpoints` when called on a new-style class service function that has `_method_functions` populated. This is necessary because for these new-style classes without method placeholder functions there won't be any invocations of `_add_function` for the class methods.

