### PR TITLE
Remove dead protos AppDeploySingleObject

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -305,17 +305,6 @@ message AppDeployResponse {
   string url = 1;
 }
 
-message AppDeploySingleObjectRequest {
-  string name = 1;
-  DeploymentNamespace namespace = 2;
-  string environment_name = 3;
-  string object_id = 4;
-}
-
-message AppDeploySingleObjectResponse {
-  string app_id = 1;
-}
-
 message AppDeploymentHistory {
   string app_id = 1;
   uint32 version = 2;
@@ -2660,7 +2649,6 @@ service ModalClient {
   rpc AppClientDisconnect(AppClientDisconnectRequest) returns (google.protobuf.Empty);
   rpc AppCreate(AppCreateRequest) returns (AppCreateResponse);
   rpc AppDeploy(AppDeployRequest) returns (AppDeployResponse);
-  rpc AppDeploySingleObject(AppDeploySingleObjectRequest) returns (AppDeploySingleObjectResponse);
   rpc AppDeploymentHistory(AppDeploymentHistoryRequest) returns (AppDeploymentHistoryResponse);
   rpc AppGetByDeploymentName(AppGetByDeploymentNameRequest) returns (AppGetByDeploymentNameResponse);
   rpc AppGetLogs(AppGetLogsRequest) returns (stream TaskLogsBatch);


### PR DESCRIPTION
While tearing down "dummy apps" I randomly noticed this dead RPC which isn't used anywhere.

It was added in #1009 but I'm not sure why.