### PR TITLE
Handle conflicts on changelog update; print debugging info

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -322,7 +322,7 @@ def type_stubs(ctx):
 def update_changelog(ctx, sha: str = ""):
     # Parse a commit message for a GitHub PR number, defaulting to most recent commit
     res = ctx.run(f"git log --pretty=format:%s -n 1 {sha}", hide="stdout", warn=True)
-    if not res.exited:
+    if res.exited:
         print("Failed to extract changelog update!")
         print("Last 5 commits:")
         res = ctx.run(f"git log --pretty=oneline -n 5 {sha}")

--- a/tasks.py
+++ b/tasks.py
@@ -321,7 +321,12 @@ def type_stubs(ctx):
 @task
 def update_changelog(ctx, sha: str = ""):
     # Parse a commit message for a GitHub PR number, defaulting to most recent commit
-    res = ctx.run(f"git log --pretty=format:%s -n 1 {sha}", hide="stdout")
+    res = ctx.run(f"git log --pretty=format:%s -n 1 {sha}", hide="stdout", warn=True)
+    if not res.exited:
+        print("Failed to extract changelog update!")
+        print("Last 5 commits:")
+        res = ctx.run(f"git log --pretty=oneline -n 5 {sha}")
+        return
     m = re.search(r"\(#(\d+)\)$", res.stdout)
     if m:
         pull_number = m.group(1)

--- a/tasks.py
+++ b/tasks.py
@@ -325,7 +325,7 @@ def update_changelog(ctx, sha: str = ""):
     if res.exited:
         print("Failed to extract changelog update!")
         print("Last 5 commits:")
-        res = ctx.run(f"git log --pretty=oneline -n 5 {sha}")
+        res = ctx.run("git log --pretty=oneline -n 5")
         return
     m = re.search(r"\(#(\d+)\)$", res.stdout)
     if m:


### PR DESCRIPTION
Concurrent runs of the CD pipeline against main cause a conflict when we try to parse the changelog update. I'm not sure why. This fails more gracefully (we should still do the deployment, but the changelog won't get updated) and prints some debugging information that might be useful.