### PR TITLE
Add `_method_handle_metadata` attr to `_Function`

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -329,6 +329,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
     _parent: Optional["_Function"] = None
 
     _class_parameter_info: Optional["api_pb2.ClassParameterInfo"] = None
+    _method_handle_metadata: Optional[Dict[str, "api_pb2.FunctionHandleMetadata"]] = None
     _method_functions: Optional[Dict[str, "_Function"]] = None  # Placeholder _Functions for each method
 
     def _bind_method(
@@ -1261,6 +1262,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         self._use_function_id = metadata.use_function_id
         self._use_method_name = metadata.use_method_name
         self._class_parameter_info = metadata.class_parameter_info
+        self._method_handle_metadata = dict(metadata.method_handle_metadata)
         self._definition_id = metadata.definition_id
 
     def _invocation_function_id(self) -> str:
@@ -1278,20 +1280,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
             is_method=self._is_method,
             class_parameter_info=self._class_parameter_info,
             definition_id=self._definition_id,
-            method_handle_metadata={
-                method_name: api_pb2.FunctionHandleMetadata(
-                    function_name=method_function._function_name,
-                    function_type=get_function_type(method_function._is_generator),
-                    web_url=method_function._web_url or "",
-                    is_method=method_function._is_method,
-                    definition_id=method_function._definition_id,
-                    use_method_name=method_function._use_method_name,
-                )
-                for method_name, method_function in self._method_functions.items()
-                if method_function._function_name
-            }
-            if self._method_functions
-            else None,
+            method_handle_metadata=self._method_handle_metadata,
         )
 
     def _check_no_web_url(self, fn_name: str):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -341,6 +341,16 @@ class MockClientServicer(api_grpc.ModalClientBase):
             is_method=definition.is_method,
             use_method_name=definition.use_method_name,
             use_function_id=definition.use_function_id,
+            method_handle_metadata={
+                method_name: api_pb2.FunctionHandleMetadata(
+                    function_name=method_definition.function_name,
+                    function_type=method_definition.function_type,
+                    web_url=method_definition.web_url,
+                    is_method=True,
+                    use_method_name=method_name,
+                )
+                for method_name, method_definition in definition.method_definitions.items()
+            },
         )
 
     def get_class_metadata(self, object_id: str) -> api_pb2.ClassHandleMetadata:
@@ -938,30 +948,28 @@ class MockClientServicer(api_grpc.ModalClientBase):
         else:
             self.n_functions += 1
             function_id = f"fu-{self.n_functions}"
-
         function: Optional[api_pb2.Function] = None
         function_data: Optional[api_pb2.FunctionData] = None
-
         if len(request.function_data.ranked_functions) > 0:
             function_data = api_pb2.FunctionData()
             function_data.CopyFrom(request.function_data)
-            if function_data.webhook_config.type:
-                function_data.web_url = "http://xyz.internal"
         else:
             assert request.function
             function = api_pb2.Function()
             function.CopyFrom(request.function)
-            if function.webhook_config.type:
-                function.web_url = "http://xyz.internal"
 
         assert (function is None) != (function_data is None)
         function_defn = function or function_data
         assert function_defn
+        if function_defn.webhook_config.type:
+            function_defn.web_url = "http://xyz.internal"
+        for method_name, method_definition in function_defn.method_definitions.items():
+            if method_definition.webhook_config.type:
+                method_definition.web_url = f"http://{method_name}.internal"
         self.app_functions[function_id] = function_defn
 
         if function_defn.schedule:
             self.function2schedule[function_id] = function_defn.schedule
-
         await stream.send_message(
             api_pb2.FunctionCreateResponse(
                 function_id=function_id,
@@ -973,6 +981,16 @@ class MockClientServicer(api_grpc.ModalClientBase):
                     use_function_id=function_defn.use_function_id or function_id,
                     use_method_name=function_defn.use_method_name,
                     definition_id=f"de-{self.n_functions}",
+                    method_handle_metadata={
+                        method_name: api_pb2.FunctionHandleMetadata(
+                            function_name=method_definition.function_name,
+                            function_type=method_definition.function_type,
+                            web_url=method_definition.web_url,
+                            is_method=True,
+                            use_method_name=method_name,
+                        )
+                        for method_name, method_definition in function_defn.method_definitions.items()
+                    },
                 ),
             )
         )


### PR DESCRIPTION
This is so that the `Cls` object can use `class_service_function._method_handle_metadata` to hydrate its `method_functions` mapping