### PR TITLE
Quickfix for leaking implementation objects when using Modal objects as cls parameters

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -524,6 +524,7 @@ class _Cls(_Object, type_prefix="cs"):
         await resolver.load(obj)
         return obj
 
+    @synchronizer.no_input_translation
     def __call__(self, *args, **kwargs) -> _Obj:
         """This acts as the class constructor."""
         return _Obj(

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -1007,3 +1007,20 @@ def test_unsupported_function_decorators_on_methods():
             @app.function(serialized=True)
             def f(self):
                 pass
+
+
+def test_modal_object_param_uses_wrapped_type(servicer, set_env_client, client):
+    with servicer.intercept() as ctx:
+        with modal.Dict.ephemeral() as dct:
+            with baz_app.run():
+                # create bound instance:
+                Baz(x=dct).keep_warm(1)  # type:ignore[attribute]
+
+    req: api_pb2.FunctionBindParamsRequest = ctx.pop_request("FunctionBindParams")
+    function_def: api_pb2.Function = servicer.app_functions[req.function_id]
+    from modal._container_entrypoint import deserialize_params
+
+    _client = synchronizer._translate_in(client)  # ugly
+    container_params = deserialize_params(req.serialized_params, function_def, _client)
+    args, kwargs = container_params
+    assert type(kwargs["x"]) == type(dct)

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -1020,7 +1020,7 @@ def test_modal_object_param_uses_wrapped_type(servicer, set_env_client, client):
     function_def: api_pb2.Function = servicer.app_functions[req.function_id]
     from modal._container_entrypoint import deserialize_params
 
-    _client = synchronizer._translate_in(client)  # ugly
+    _client = typing.cast(modal.client._Client, synchronizer._translate_in(client))
     container_params = deserialize_params(req.serialized_params, function_def, _client)
     args, kwargs = container_params
     assert type(kwargs["x"]) == type(dct)

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -1014,7 +1014,7 @@ def test_modal_object_param_uses_wrapped_type(servicer, set_env_client, client):
         with modal.Dict.ephemeral() as dct:
             with baz_app.run():
                 # create bound instance:
-                Baz(x=dct).keep_warm(1)  # type:ignore[attribute]
+                typing.cast(modal.Cls, Baz(x=dct)).keep_warm(1)
 
     req: api_pb2.FunctionBindParamsRequest = ctx.pop_request("FunctionBindParams")
     function_def: api_pb2.Function = servicer.app_functions[req.function_id]


### PR DESCRIPTION
Still not something that should be encouraged, given that we'll most likely be deprecating custom constructor patterns in favor of the new structured parameterization...