### PR TITLE
Remove `single_object_id` from `AppSetObjectsRequest`

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -427,7 +427,7 @@ message AppSetObjectsRequest {
   string client_id = 3;
   repeated string unindexed_object_ids = 4;
   AppState new_app_state = 5; // promotes an app from initializing to this new state
-  string single_object_id = 6;
+  reserved 6;
 }
 
 message AppStopRequest {

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -152,7 +152,6 @@ class MockClientServicer(api_grpc.ModalClientBase):
             }
         ]
         self.app_objects = {}
-        self.app_single_objects = {}
         self.app_unindexed_objects = {
             "ap-1": ["im-1", "vo-1"],
         }
@@ -485,8 +484,6 @@ class MockClientServicer(api_grpc.ModalClientBase):
         request: api_pb2.AppSetObjectsRequest = await stream.recv_message()
         self.app_objects[request.app_id] = dict(request.indexed_object_ids)
         self.app_unindexed_objects[request.app_id] = list(request.unindexed_object_ids)
-        if request.single_object_id:
-            self.app_single_objects[request.app_id] = request.single_object_id
         self.app_set_objects_count += 1
         if request.new_app_state:
             self.app_state_history[request.app_id].append(request.new_app_state)


### PR DESCRIPTION
Hasn't been used for a long time