### PR TITLE
Move user code import to own module

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -2,6 +2,8 @@
 # ruff: noqa: E402
 import os
 
+from modal.runtime.user_code_imports import Service, import_class_service, import_single_function_service
+
 telemetry_socket = os.environ.get("MODAL_TELEMETRY_SOCKET")
 if telemetry_socket:
     from runtime._telemetry import instrument_imports
@@ -11,17 +13,13 @@ if telemetry_socket:
 import asyncio
 import base64
 import concurrent.futures
-import importlib
 import inspect
 import queue
 import signal
 import sys
 import threading
 import time
-import typing
-from abc import ABCMeta, abstractmethod
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence
 
 from google.protobuf.message import Message
 
@@ -30,37 +28,21 @@ from modal._proxy_tunnel import proxy_tunnel
 from modal._serialization import deserialize, deserialize_proto_params
 from modal._utils.async_utils import TaskContext, synchronizer
 from modal._utils.function_utils import (
-    LocalFunctionError,
     callable_has_non_self_params,
-    is_async as get_is_async,
-    is_global_object,
 )
 from modal.app import App, _App
 from modal.client import Client, _Client
-from modal.cls import Cls, Obj
 from modal.config import logger
 from modal.exception import ExecutionError, InputCancellation, InvalidError
-from modal.functions import Function, _Function
 from modal.partial_function import (
     _find_callables_for_obj,
-    _find_partial_methods_for_user_cls,
-    _PartialFunction,
     _PartialFunctionFlags,
 )
 from modal.running_app import RunningApp
 from modal_proto import api_pb2
 
-from .runtime._asgi import (
-    asgi_app_wrapper,
-    get_ip_address,
-    wait_for_web_server,
-    web_server_proxy,
-    webhook_asgi_app,
-    wsgi_app_wrapper,
-)
 from .runtime._container_io_manager import (
     ContainerIOManager,
-    FinalizedFunction,
     IOContext,
     UserException,
     _ContainerIOManager,
@@ -70,151 +52,6 @@ from .runtime.execution_context import _set_current_context_ids
 if TYPE_CHECKING:
     import modal.object
     import modal.runtime._container_io_manager
-
-
-def construct_webhook_callable(
-    user_defined_callable: Callable,
-    webhook_config: api_pb2.WebhookConfig,
-    container_io_manager: "modal.runtime._container_io_manager.ContainerIOManager",
-):
-    # For webhooks, the user function is used to construct an asgi app:
-    if webhook_config.type == api_pb2.WEBHOOK_TYPE_ASGI_APP:
-        # Function returns an asgi_app, which we can use as a callable.
-        return asgi_app_wrapper(user_defined_callable(), container_io_manager)
-
-    elif webhook_config.type == api_pb2.WEBHOOK_TYPE_WSGI_APP:
-        # Function returns an wsgi_app, which we can use as a callable.
-        return wsgi_app_wrapper(user_defined_callable(), container_io_manager)
-
-    elif webhook_config.type == api_pb2.WEBHOOK_TYPE_FUNCTION:
-        # Function is a webhook without an ASGI app. Create one for it.
-        return asgi_app_wrapper(
-            webhook_asgi_app(user_defined_callable, webhook_config.method, webhook_config.web_endpoint_docs),
-            container_io_manager,
-        )
-
-    elif webhook_config.type == api_pb2.WEBHOOK_TYPE_WEB_SERVER:
-        # Function spawns an HTTP web server listening at a port.
-        user_defined_callable()
-
-        # We intentionally try to connect to the external interface instead of the loopback
-        # interface here so users are forced to expose the server. This allows us to potentially
-        # change the implementation to use an external bridge in the future.
-        host = get_ip_address(b"eth0")
-        port = webhook_config.web_server_port
-        startup_timeout = webhook_config.web_server_startup_timeout
-        wait_for_web_server(host, port, timeout=startup_timeout)
-        return asgi_app_wrapper(web_server_proxy(host, port), container_io_manager)
-    else:
-        raise InvalidError(f"Unrecognized web endpoint type {webhook_config.type}")
-
-
-class Service(metaclass=ABCMeta):
-    """Common interface for singular functions and class-based "services"
-
-    There are differences in the importing/finalization logic, and this
-    "protocol"/abc basically defines a common interface for the two types
-    of "Services" after the point of import.
-    """
-
-    user_cls_instance: Any
-    app: Optional[_App]
-    code_deps: Optional[List["modal.object._Object"]]
-
-    @abstractmethod
-    def get_finalized_functions(
-        self, fun_def: api_pb2.Function, container_io_manager: "modal.runtime._container_io_manager.ContainerIOManager"
-    ) -> Dict[str, "FinalizedFunction"]:
-        ...
-
-
-@dataclass
-class ImportedFunction(Service):
-    user_cls_instance: Any
-    app: Optional[_App]
-    code_deps: Optional[List["modal.object._Object"]]
-
-    _user_defined_callable: Callable[..., Any]
-
-    def get_finalized_functions(
-        self, fun_def: api_pb2.Function, container_io_manager: "modal.runtime._container_io_manager.ContainerIOManager"
-    ) -> Dict[str, "FinalizedFunction"]:
-        # Check this property before we turn it into a method (overriden by webhooks)
-        is_async = get_is_async(self._user_defined_callable)
-        # Use the function definition for whether this is a generator (overriden by webhooks)
-        is_generator = fun_def.function_type == api_pb2.Function.FUNCTION_TYPE_GENERATOR
-
-        webhook_config = fun_def.webhook_config
-        if not webhook_config.type:
-            # for non-webhooks, the runnable is straight forward:
-            return {
-                "": FinalizedFunction(
-                    callable=self._user_defined_callable,
-                    is_async=is_async,
-                    is_generator=is_generator,
-                    data_format=api_pb2.DATA_FORMAT_PICKLE,
-                )
-            }
-
-        web_callable, lifespan_manager = construct_webhook_callable(
-            self._user_defined_callable, fun_def.webhook_config, container_io_manager
-        )
-
-        return {
-            "": FinalizedFunction(
-                callable=web_callable,
-                lifespan_manager=lifespan_manager,
-                is_async=True,
-                is_generator=True,
-                data_format=api_pb2.DATA_FORMAT_ASGI,
-            )
-        }
-
-
-@dataclass
-class ImportedClass(Service):
-    user_cls_instance: Any
-    app: Optional[_App]
-    code_deps: Optional[List["modal.object._Object"]]
-
-    _partial_functions: Dict[str, _PartialFunction]
-
-    def get_finalized_functions(
-        self, fun_def: api_pb2.Function, container_io_manager: "modal.runtime._container_io_manager.ContainerIOManager"
-    ) -> Dict[str, "FinalizedFunction"]:
-        finalized_functions = {}
-        for method_name, partial in self._partial_functions.items():
-            partial = synchronizer._translate_in(partial)  # ugly
-            user_func = partial.raw_f
-            # Check this property before we turn it into a method (overriden by webhooks)
-            is_async = get_is_async(user_func)
-            # Use the function definition for whether this is a generator (overriden by webhooks)
-            is_generator = partial.is_generator
-            webhook_config = partial.webhook_config
-
-            bound_func = user_func.__get__(self.user_cls_instance)
-
-            if not webhook_config or webhook_config.type == api_pb2.WEBHOOK_TYPE_UNSPECIFIED:
-                # for non-webhooks, the runnable is straight forward:
-                finalized_function = FinalizedFunction(
-                    callable=bound_func,
-                    is_async=is_async,
-                    is_generator=is_generator,
-                    data_format=api_pb2.DATA_FORMAT_PICKLE,
-                )
-            else:
-                web_callable, lifespan_manager = construct_webhook_callable(
-                    bound_func, webhook_config, container_io_manager
-                )
-                finalized_function = FinalizedFunction(
-                    callable=web_callable,
-                    lifespan_manager=lifespan_manager,
-                    is_async=True,
-                    is_generator=True,
-                    data_format=api_pb2.DATA_FORMAT_ASGI,
-                )
-            finalized_functions[method_name] = finalized_function
-        return finalized_functions
 
 
 class DaemonizedThreadPool:
@@ -338,7 +175,7 @@ class UserCodeEventLoop:
 def call_function(
     user_code_event_loop: UserCodeEventLoop,
     container_io_manager: "modal.runtime._container_io_manager.ContainerIOManager",
-    finalized_functions: Dict[str, FinalizedFunction],
+    finalized_functions: Dict[str, "modal.runtime.user_code_imports.FinalizedFunction"],
     batch_max_size: int,
     batch_wait_ms: int,
 ):
@@ -497,180 +334,6 @@ def call_function(
                     run_input_sync(io_context)
                 finally:
                     signal.signal(signal.SIGUSR1, usr1_handler)  # reset signal handler
-
-
-def import_single_function_service(
-    function_def: api_pb2.Function,
-    ser_cls,  # used only for @build functions
-    ser_fun,
-    cls_args,  #  used only for @build functions
-    cls_kwargs,  #  used only for @build functions
-) -> Service:
-    """Imports a function dynamically, and locates the app.
-
-    This is somewhat complex because we're dealing with 3 quite different type of functions:
-    1. Functions defined in global scope and decorated in global scope (Function objects)
-    2. Functions defined in global scope but decorated elsewhere (these will be raw callables)
-    3. Serialized functions
-
-    In addition, we also need to handle
-    * Normal functions
-    * Methods on classes (in which case we need to instantiate the object)
-
-    This helper also handles web endpoints, ASGI/WSGI servers, and HTTP servers.
-
-    In order to locate the app, we try two things:
-    * If the function is a Function, we can get the app directly from it
-    * Otherwise, use the app name and look it up from a global list of apps: this
-      typically only happens in case 2 above, or in sometimes for case 3
-
-    Note that `import_function` is *not* synchronized, because we need it to run on the main
-    thread. This is so that any user code running in global scope (which executes as a part of
-    the import) runs on the right thread.
-    """
-    user_defined_callable: Callable
-    function: Optional[_Function] = None
-    code_deps: Optional[List["modal.object._Object"]] = None
-    active_app: Optional[_App] = None
-
-    if ser_fun is not None:
-        # This is a serialized function we already fetched from the server
-        cls, user_defined_callable = ser_cls, ser_fun
-    else:
-        # Load the module dynamically
-        module = importlib.import_module(function_def.module_name)
-        qual_name: str = function_def.function_name
-
-        if not is_global_object(qual_name):
-            raise LocalFunctionError("Attempted to load a function defined in a function scope")
-
-        parts = qual_name.split(".")
-        if len(parts) == 1:
-            # This is a function
-            cls = None
-            f = getattr(module, qual_name)
-            if isinstance(f, Function):
-                function = synchronizer._translate_in(f)
-                user_defined_callable = function.get_raw_f()
-                active_app = function._app
-            else:
-                user_defined_callable = f
-        elif len(parts) == 2:
-            # As of v0.63 - this path should only be triggered by @build class builder methods
-            assert not function_def.use_method_name  # new "placeholder methods" should not be invoked directly!
-            assert function_def.is_builder_function
-            cls_name, fun_name = parts
-            cls = getattr(module, cls_name)
-            if isinstance(cls, Cls):
-                # The cls decorator is in global scope
-                _cls = synchronizer._translate_in(cls)
-                user_defined_callable = _cls._callables[fun_name]
-                function = _cls._method_functions.get(fun_name)
-                active_app = _cls._app
-            else:
-                # This is a raw class
-                user_defined_callable = getattr(cls, fun_name)
-        else:
-            raise InvalidError(f"Invalid function qualname {qual_name}")
-
-    # Instantiate the class if it's defined
-    if cls:
-        # This code is only used for @build methods on classes
-        user_cls_instance = get_user_class_instance(cls, cls_args, cls_kwargs)
-        # Bind the function to the instance as self (using the descriptor protocol!)
-        user_defined_callable = user_defined_callable.__get__(user_cls_instance)
-    else:
-        user_cls_instance = None
-
-    if function:
-        code_deps = function.deps(only_explicit_mounts=True)
-
-    return ImportedFunction(
-        user_cls_instance,
-        active_app,
-        code_deps,
-        user_defined_callable,
-    )
-
-
-def import_class_service(
-    function_def: api_pb2.Function,
-    ser_cls,
-    cls_args,
-    cls_kwargs,
-) -> Service:
-    """
-    This imports a full class to be able to execute any @method or webhook decorated methods.
-
-    See import_function.
-    """
-    active_app: Optional[_App] = None
-    code_deps: Optional[List["modal.object._Object"]] = None
-    cls: typing.Union[type, Cls]
-
-    if function_def.definition_type == api_pb2.Function.DEFINITION_TYPE_SERIALIZED:
-        assert ser_cls is not None
-        cls = ser_cls
-    else:
-        # Load the module dynamically
-        module = importlib.import_module(function_def.module_name)
-        qual_name: str = function_def.function_name
-
-        if not is_global_object(qual_name):
-            raise LocalFunctionError("Attempted to load a class defined in a function scope")
-
-        parts = qual_name.split(".")
-        if not (
-            len(parts) == 2 and parts[1] == "*"
-        ):  # the "function name" of a class service "function placeholder" is expected to be "ClassName.*"
-            raise ExecutionError(
-                f"Internal error: Invalid 'service function' identifier {qual_name}. Please contact Modal support"
-            )
-
-        assert not function_def.use_method_name  # new "placeholder methods" should not be invoked directly!
-        cls_name = parts[0]
-        cls = getattr(module, cls_name)
-
-    if isinstance(cls, Cls):
-        # The cls decorator is in global scope
-        _cls = synchronizer._translate_in(cls)
-        method_partials = _cls._get_partial_functions()
-        function = _cls._class_service_function
-    else:
-        # Undecorated user class - find all methods
-        method_partials = _find_partial_methods_for_user_cls(cls, _PartialFunctionFlags.all())
-        function = None
-
-    if function:
-        code_deps = function.deps(only_explicit_mounts=True)
-
-    user_cls_instance = get_user_class_instance(cls, cls_args, cls_kwargs)
-
-    return ImportedClass(
-        user_cls_instance,
-        active_app,
-        code_deps,
-        method_partials,
-    )
-
-
-def get_user_class_instance(cls: typing.Union[type, Cls], args: Tuple, kwargs: Dict[str, Any]) -> typing.Any:
-    """Returns instance of the underlying class to be used as the `self`
-
-    The input `cls` can either be the raw Python class the user has declared ("user class"),
-    or an @app.cls-decorated version of it which is a modal.Cls-instance wrapping the user class.
-    """
-    if isinstance(cls, Cls):
-        # globally @app.cls-decorated class
-        modal_obj: Obj = cls(*args, **kwargs)
-        modal_obj.entered = True  # ugly but prevents .local() from triggering additional enter-logic
-        # TODO: unify lifecycle logic between .local() and container_entrypoint
-        user_cls_instance = modal_obj._get_user_cls_instance()
-    else:
-        # undecorated class (non-global decoration or serialized)
-        user_cls_instance = cls(*args, **kwargs)
-
-    return user_cls_instance
 
 
 def get_active_app_fallback(function_def: api_pb2.Function) -> Optional[_App]:

--- a/modal/experimental.py
+++ b/modal/experimental.py
@@ -17,7 +17,6 @@ from .runtime._container_io_manager import _ContainerIOManager
 def stop_fetching_inputs():
     """Don't fetch any more inputs from the server, after the current one.
     The container will exit gracefully after the current input is processed."""
-
     _ContainerIOManager.stop_fetching_inputs()
 
 
@@ -25,7 +24,6 @@ def get_local_input_concurrency():
     """Get the container's local input concurrency.
     If recently reduced to particular value, it can return a larger number than
     set due to in-progress inputs."""
-
     return _ContainerIOManager.get_input_concurrency()
 
 
@@ -33,7 +31,6 @@ def set_local_input_concurrency(concurrency: int):
     """Set the container's local input concurrency. Dynamic concurrency will be disabled.
     When setting to a smaller value, this method will not interrupt in-progress inputs.
     """
-
     _ContainerIOManager.set_input_concurrency(concurrency)
 
 

--- a/modal/runtime/_container_io_manager.py
+++ b/modal/runtime/_container_io_manager.py
@@ -10,7 +10,6 @@ import sys
 import time
 import traceback
 from contextlib import AsyncExitStack
-from dataclasses import dataclass
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -46,6 +45,8 @@ from modal_proto import api_pb2
 
 if TYPE_CHECKING:
     import modal.runtime._asgi
+    import modal.runtime.user_code_imports
+
 
 DYNAMIC_CONCURRENCY_INTERVAL_SECS = 3
 DYNAMIC_CONCURRENCY_TIMEOUT_SECS = 10
@@ -62,15 +63,6 @@ class Sentinel:
     """Used to get type-stubs to work with this object."""
 
 
-@dataclass
-class FinalizedFunction:
-    callable: Callable[..., Any]
-    is_async: bool
-    is_generator: bool
-    data_format: int  # api_pb2.DataFormat
-    lifespan_manager: Optional["modal.runtime._asgi.LifespanManager"] = None
-
-
 class IOContext:
     """Context object for managing input, function calls, and function executions
     in a batched or single input context.
@@ -78,7 +70,7 @@ class IOContext:
 
     input_ids: List[str]
     function_call_ids: List[str]
-    finalized_function: FinalizedFunction
+    finalized_function: "modal.runtime.user_code_imports.FinalizedFunction"
 
     _cancel_issued: bool = False
     _cancel_callback: Optional[Callable[[], None]] = None
@@ -87,7 +79,7 @@ class IOContext:
         self,
         input_ids: List[str],
         function_call_ids: List[str],
-        finalized_function: FinalizedFunction,
+        finalized_function: "modal.runtime.user_code_imports.FinalizedFunction",
         function_inputs: List[api_pb2.FunctionInput],
         is_batched: bool,
         client: _Client,
@@ -103,7 +95,7 @@ class IOContext:
     async def create(
         cls,
         client: _Client,
-        finalized_functions: Dict[str, FinalizedFunction],
+        finalized_functions: Dict[str, "modal.runtime.user_code_imports.FinalizedFunction"],
         inputs: List[Tuple[str, str, api_pb2.FunctionInput]],
         is_batched: bool,
     ) -> "IOContext":
@@ -653,7 +645,7 @@ class _ContainerIOManager:
     @synchronizer.no_io_translation
     async def run_inputs_outputs(
         self,
-        finalized_functions: Dict[str, FinalizedFunction],
+        finalized_functions: Dict[str, "modal.runtime.user_code_imports.FinalizedFunction"],
         batch_max_size: int = 0,
         batch_wait_ms: int = 0,
     ) -> AsyncIterator[IOContext]:

--- a/modal/runtime/execution_context.py
+++ b/modal/runtime/execution_context.py
@@ -5,8 +5,6 @@ from typing import Callable, List, Optional
 from modal._utils.async_utils import synchronize_api
 from modal.exception import InvalidError
 
-from ._container_io_manager import _ContainerIOManager
-
 
 def is_local() -> bool:
     """Returns if we are currently on the machine launching/deploying a Modal app
@@ -14,6 +12,8 @@ def is_local() -> bool:
     Returns `True` when executed locally on the user's machine.
     Returns `False` when executed from a Modal container in the cloud.
     """
+    from ._container_io_manager import _ContainerIOManager
+
     return not _ContainerIOManager._singleton
 
 
@@ -23,6 +23,8 @@ async def _interact() -> None:
     See the [interactivity guide](https://modal.com/docs/guide/developing-debugging#interactivity)
     for more information on how to use this function.
     """
+    from ._container_io_manager import _ContainerIOManager
+
     container_io_manager = _ContainerIOManager._singleton
     if not container_io_manager:
         raise InvalidError("Interactivity only works inside a Modal container.")

--- a/modal/runtime/user_code_imports.py
+++ b/modal/runtime/user_code_imports.py
@@ -1,0 +1,359 @@
+import importlib
+import typing
+from abc import ABCMeta, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional
+
+import modal.cls
+import modal.object
+import modal.runtime._container_io_manager
+from modal import Function
+from modal._utils.async_utils import synchronizer
+from modal._utils.function_utils import LocalFunctionError, is_async as get_is_async, is_global_object
+from modal.exception import ExecutionError, InvalidError
+from modal.functions import _Function
+from modal.partial_function import _find_partial_methods_for_user_cls, _PartialFunctionFlags
+from modal.runtime._asgi import (
+    LifespanManager,
+    asgi_app_wrapper,
+    get_ip_address,
+    wait_for_web_server,
+    web_server_proxy,
+    webhook_asgi_app,
+    wsgi_app_wrapper,
+)
+from modal_proto import api_pb2
+
+if typing.TYPE_CHECKING:
+    import modal.app
+    import modal.partial_function
+
+
+@dataclass
+class FinalizedFunction:
+    callable: Callable[..., Any]
+    is_async: bool
+    is_generator: bool
+    data_format: int  # api_pb2.DataFormat
+    lifespan_manager: Optional[LifespanManager] = None
+
+
+def construct_webhook_callable(
+    user_defined_callable: Callable,
+    webhook_config: api_pb2.WebhookConfig,
+    container_io_manager: "modal.runtime._container_io_manager.ContainerIOManager",
+):
+    # For webhooks, the user function is used to construct an asgi app:
+    if webhook_config.type == api_pb2.WEBHOOK_TYPE_ASGI_APP:
+        # Function returns an asgi_app, which we can use as a callable.
+        return asgi_app_wrapper(user_defined_callable(), container_io_manager)
+
+    elif webhook_config.type == api_pb2.WEBHOOK_TYPE_WSGI_APP:
+        # Function returns an wsgi_app, which we can use as a callable.
+        return wsgi_app_wrapper(user_defined_callable(), container_io_manager)
+
+    elif webhook_config.type == api_pb2.WEBHOOK_TYPE_FUNCTION:
+        # Function is a webhook without an ASGI app. Create one for it.
+        return asgi_app_wrapper(
+            webhook_asgi_app(user_defined_callable, webhook_config.method, webhook_config.web_endpoint_docs),
+            container_io_manager,
+        )
+
+    elif webhook_config.type == api_pb2.WEBHOOK_TYPE_WEB_SERVER:
+        # Function spawns an HTTP web server listening at a port.
+        user_defined_callable()
+
+        # We intentionally try to connect to the external interface instead of the loopback
+        # interface here so users are forced to expose the server. This allows us to potentially
+        # change the implementation to use an external bridge in the future.
+        host = get_ip_address(b"eth0")
+        port = webhook_config.web_server_port
+        startup_timeout = webhook_config.web_server_startup_timeout
+        wait_for_web_server(host, port, timeout=startup_timeout)
+        return asgi_app_wrapper(web_server_proxy(host, port), container_io_manager)
+    else:
+        raise InvalidError(f"Unrecognized web endpoint type {webhook_config.type}")
+
+
+class Service(metaclass=ABCMeta):
+    """Common interface for singular functions and class-based "services"
+
+    There are differences in the importing/finalization logic, and this
+    "protocol"/abc basically defines a common interface for the two types
+    of "Services" after the point of import.
+    """
+
+    user_cls_instance: Any
+    app: Optional["modal.app._App"]
+    code_deps: Optional[List["modal.object._Object"]]
+
+    @abstractmethod
+    def get_finalized_functions(
+        self, fun_def: api_pb2.Function, container_io_manager: "modal.runtime._container_io_manager.ContainerIOManager"
+    ) -> Dict[str, "FinalizedFunction"]:
+        ...
+
+
+@dataclass
+class ImportedFunction(Service):
+    user_cls_instance: Any
+    app: Optional["modal.app._App"]
+    code_deps: Optional[List["modal.object._Object"]]
+
+    _user_defined_callable: Callable[..., Any]
+
+    def get_finalized_functions(
+        self, fun_def: api_pb2.Function, container_io_manager: "modal.runtime._container_io_manager.ContainerIOManager"
+    ) -> Dict[str, "FinalizedFunction"]:
+        # Check this property before we turn it into a method (overriden by webhooks)
+        is_async = get_is_async(self._user_defined_callable)
+        # Use the function definition for whether this is a generator (overriden by webhooks)
+        is_generator = fun_def.function_type == api_pb2.Function.FUNCTION_TYPE_GENERATOR
+
+        webhook_config = fun_def.webhook_config
+        if not webhook_config.type:
+            # for non-webhooks, the runnable is straight forward:
+            return {
+                "": FinalizedFunction(
+                    callable=self._user_defined_callable,
+                    is_async=is_async,
+                    is_generator=is_generator,
+                    data_format=api_pb2.DATA_FORMAT_PICKLE,
+                )
+            }
+
+        web_callable, lifespan_manager = construct_webhook_callable(
+            self._user_defined_callable, fun_def.webhook_config, container_io_manager
+        )
+
+        return {
+            "": FinalizedFunction(
+                callable=web_callable,
+                lifespan_manager=lifespan_manager,
+                is_async=True,
+                is_generator=True,
+                data_format=api_pb2.DATA_FORMAT_ASGI,
+            )
+        }
+
+
+@dataclass
+class ImportedClass(Service):
+    user_cls_instance: Any
+    app: Optional["modal.app._App"]
+    code_deps: Optional[List["modal.object._Object"]]
+
+    _partial_functions: Dict[str, "modal.partial_function._PartialFunction"]
+
+    def get_finalized_functions(
+        self, fun_def: api_pb2.Function, container_io_manager: "modal.runtime._container_io_manager.ContainerIOManager"
+    ) -> Dict[str, "FinalizedFunction"]:
+        finalized_functions = {}
+        for method_name, partial in self._partial_functions.items():
+            partial = synchronizer._translate_in(partial)  # ugly
+            user_func = partial.raw_f
+            # Check this property before we turn it into a method (overriden by webhooks)
+            is_async = get_is_async(user_func)
+            # Use the function definition for whether this is a generator (overriden by webhooks)
+            is_generator = partial.is_generator
+            webhook_config = partial.webhook_config
+
+            bound_func = user_func.__get__(self.user_cls_instance)
+
+            if not webhook_config or webhook_config.type == api_pb2.WEBHOOK_TYPE_UNSPECIFIED:
+                # for non-webhooks, the runnable is straight forward:
+                finalized_function = FinalizedFunction(
+                    callable=bound_func,
+                    is_async=is_async,
+                    is_generator=is_generator,
+                    data_format=api_pb2.DATA_FORMAT_PICKLE,
+                )
+            else:
+                web_callable, lifespan_manager = construct_webhook_callable(
+                    bound_func, webhook_config, container_io_manager
+                )
+                finalized_function = FinalizedFunction(
+                    callable=web_callable,
+                    lifespan_manager=lifespan_manager,
+                    is_async=True,
+                    is_generator=True,
+                    data_format=api_pb2.DATA_FORMAT_ASGI,
+                )
+            finalized_functions[method_name] = finalized_function
+        return finalized_functions
+
+
+def import_single_function_service(
+    function_def: api_pb2.Function,
+    ser_cls,  # used only for @build functions
+    ser_fun,
+    cls_args,  #  used only for @build functions
+    cls_kwargs,  #  used only for @build functions
+) -> Service:
+    """Imports a function dynamically, and locates the app.
+
+    This is somewhat complex because we're dealing with 3 quite different type of functions:
+    1. Functions defined in global scope and decorated in global scope (Function objects)
+    2. Functions defined in global scope but decorated elsewhere (these will be raw callables)
+    3. Serialized functions
+
+    In addition, we also need to handle
+    * Normal functions
+    * Methods on classes (in which case we need to instantiate the object)
+
+    This helper also handles web endpoints, ASGI/WSGI servers, and HTTP servers.
+
+    In order to locate the app, we try two things:
+    * If the function is a Function, we can get the app directly from it
+    * Otherwise, use the app name and look it up from a global list of apps: this
+      typically only happens in case 2 above, or in sometimes for case 3
+
+    Note that `import_function` is *not* synchronized, because we need it to run on the main
+    thread. This is so that any user code running in global scope (which executes as a part of
+    the import) runs on the right thread.
+    """
+    user_defined_callable: Callable
+    function: Optional[_Function] = None
+    code_deps: Optional[List["modal.object._Object"]] = None
+    active_app: Optional[modal.app._App] = None
+
+    if ser_fun is not None:
+        # This is a serialized function we already fetched from the server
+        cls, user_defined_callable = ser_cls, ser_fun
+    else:
+        # Load the module dynamically
+        module = importlib.import_module(function_def.module_name)
+        qual_name: str = function_def.function_name
+
+        if not is_global_object(qual_name):
+            raise LocalFunctionError("Attempted to load a function defined in a function scope")
+
+        parts = qual_name.split(".")
+        if len(parts) == 1:
+            # This is a function
+            cls = None
+            f = getattr(module, qual_name)
+            if isinstance(f, Function):
+                function = synchronizer._translate_in(f)
+                user_defined_callable = function.get_raw_f()
+                active_app = function._app
+            else:
+                user_defined_callable = f
+        elif len(parts) == 2:
+            # As of v0.63 - this path should only be triggered by @build class builder methods
+            assert not function_def.use_method_name  # new "placeholder methods" should not be invoked directly!
+            assert function_def.is_builder_function
+            cls_name, fun_name = parts
+            cls = getattr(module, cls_name)
+            if isinstance(cls, modal.cls.Cls):
+                # The cls decorator is in global scope
+                _cls = synchronizer._translate_in(cls)
+                user_defined_callable = _cls._callables[fun_name]
+                function = _cls._method_functions.get(fun_name)
+                active_app = _cls._app
+            else:
+                # This is a raw class
+                user_defined_callable = getattr(cls, fun_name)
+        else:
+            raise InvalidError(f"Invalid function qualname {qual_name}")
+
+    # Instantiate the class if it's defined
+    if cls:
+        # This code is only used for @build methods on classes
+        user_cls_instance = get_user_class_instance(cls, cls_args, cls_kwargs)
+        # Bind the function to the instance as self (using the descriptor protocol!)
+        user_defined_callable = user_defined_callable.__get__(user_cls_instance)
+    else:
+        user_cls_instance = None
+
+    if function:
+        code_deps = function.deps(only_explicit_mounts=True)
+
+    return ImportedFunction(
+        user_cls_instance,
+        active_app,
+        code_deps,
+        user_defined_callable,
+    )
+
+
+def import_class_service(
+    function_def: api_pb2.Function,
+    ser_cls,
+    cls_args,
+    cls_kwargs,
+) -> Service:
+    """
+    This imports a full class to be able to execute any @method or webhook decorated methods.
+
+    See import_function.
+    """
+    active_app: Optional["modal.app._App"] = None
+    code_deps: Optional[List["modal.object._Object"]] = None
+    cls: typing.Union[type, modal.cls.Cls]
+
+    if function_def.definition_type == api_pb2.Function.DEFINITION_TYPE_SERIALIZED:
+        assert ser_cls is not None
+        cls = ser_cls
+    else:
+        # Load the module dynamically
+        module = importlib.import_module(function_def.module_name)
+        qual_name: str = function_def.function_name
+
+        if not is_global_object(qual_name):
+            raise LocalFunctionError("Attempted to load a class defined in a function scope")
+
+        parts = qual_name.split(".")
+        if not (
+            len(parts) == 2 and parts[1] == "*"
+        ):  # the "function name" of a class service "function placeholder" is expected to be "ClassName.*"
+            raise ExecutionError(
+                f"Internal error: Invalid 'service function' identifier {qual_name}. Please contact Modal support"
+            )
+
+        assert not function_def.use_method_name  # new "placeholder methods" should not be invoked directly!
+        cls_name = parts[0]
+        cls = getattr(module, cls_name)
+
+    if isinstance(cls, modal.cls.Cls):
+        # The cls decorator is in global scope
+        _cls = synchronizer._translate_in(cls)
+        method_partials = _cls._get_partial_functions()
+        function = _cls._class_service_function
+    else:
+        # Undecorated user class - find all methods
+        method_partials = _find_partial_methods_for_user_cls(cls, _PartialFunctionFlags.all())
+        function = None
+
+    if function:
+        code_deps = function.deps(only_explicit_mounts=True)
+
+    user_cls_instance = get_user_class_instance(cls, cls_args, cls_kwargs)
+
+    return ImportedClass(
+        user_cls_instance,
+        active_app,
+        code_deps,
+        method_partials,
+    )
+
+
+def get_user_class_instance(
+    cls: typing.Union[type, modal.cls.Cls], args: typing.Tuple, kwargs: Dict[str, Any]
+) -> typing.Any:
+    """Returns instance of the underlying class to be used as the `self`
+
+    The input `cls` can either be the raw Python class the user has declared ("user class"),
+    or an @app.cls-decorated version of it which is a modal.Cls-instance wrapping the user class.
+    """
+    if isinstance(cls, modal.cls.Cls):
+        # globally @app.cls-decorated class
+        modal_obj: modal.cls.Obj = cls(*args, **kwargs)
+        modal_obj.entered = True  # ugly but prevents .local() from triggering additional enter-logic
+        # TODO: unify lifecycle logic between .local() and container_entrypoint
+        user_cls_instance = modal_obj._get_user_cls_instance()
+    else:
+        # undecorated class (non-global decoration or serialized)
+        user_cls_instance = cls(*args, **kwargs)
+
+    return user_cls_instance

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -42,10 +42,10 @@ from modal.exception import InvalidError
 from modal.partial_function import enter, method
 from modal.runtime._container_io_manager import (
     ContainerIOManager,
-    FinalizedFunction,
     InputSlots,
     IOContext,
 )
+from modal.runtime.user_code_imports import FinalizedFunction
 from modal_proto import api_pb2
 
 from .helpers import deploy_app_externally
@@ -1851,6 +1851,7 @@ def test_lifecycle_full(servicer):
 
 
 @skip_github_non_linux
+@pytest.mark.timeout(10)
 def test_stop_fetching_inputs(servicer):
     ret = _run_container(
         servicer,


### PR DESCRIPTION
A pretty large section of container entrypoint deals purely with user code imports - this just moves that out into its own module for easier groking.

No "changes" apart from imports + some test timeout thing