### PR TITLE
Container user code import tests

### DIFF
--- a/test/supports/user_code_import_samples/__init__.py
+++ b/test/supports/user_code_import_samples/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Modal Labs 2024

--- a/test/supports/user_code_import_samples/cls.py
+++ b/test/supports/user_code_import_samples/cls.py
@@ -1,0 +1,18 @@
+# Copyright Modal Labs 2024
+import modal
+from modal import App
+
+app = App()
+
+
+class UndecoratedC:
+    @modal.method()
+    def f(self, arg):
+        return f"hello {arg}"
+
+    @modal.method()
+    def f2(self, arg):
+        return f"other {arg}"
+
+
+C = app.cls()(UndecoratedC)

--- a/test/supports/user_code_import_samples/func.py
+++ b/test/supports/user_code_import_samples/func.py
@@ -5,9 +5,9 @@ app = App()
 
 
 @app.function()
-def f():
-    pass
+def f(arg):
+    return f"hello {arg}"
 
 
-def undecorated_f():
-    pass
+def undecorated_f(arg):
+    return f"hello {arg}"

--- a/test/supports/user_code_import_samples/func.py
+++ b/test/supports/user_code_import_samples/func.py
@@ -1,3 +1,4 @@
+# Copyright Modal Labs 2024
 from modal import App
 
 app = App()

--- a/test/supports/user_code_import_samples/func.py
+++ b/test/supports/user_code_import_samples/func.py
@@ -1,0 +1,12 @@
+from modal import App
+
+app = App()
+
+
+@app.function()
+def f():
+    pass
+
+
+def undecorated_f():
+    pass

--- a/test/user_code_import_test.py
+++ b/test/user_code_import_test.py
@@ -1,3 +1,4 @@
+# Copyright Modal Labs 2024
 from modal.image import _Image
 from modal.runtime import user_code_imports
 from modal_proto import api_pb2

--- a/test/user_code_import_test.py
+++ b/test/user_code_import_test.py
@@ -1,0 +1,53 @@
+from modal.image import _Image
+from modal.runtime import user_code_imports
+from modal_proto import api_pb2
+
+
+def test_import_function(supports_dir, monkeypatch):
+    monkeypatch.syspath_prepend(supports_dir)
+    fun = api_pb2.Function(module_name="user_code_import_samples.func", function_name="f")
+    service = user_code_imports.import_single_function_service(
+        fun,
+        None,
+        None,
+        None,
+        None,
+    )
+    assert len(service.code_deps) == 1
+    assert type(service.code_deps[0]) is _Image
+    assert service.app
+
+
+def test_import_function_serialized():
+    # TODO: implement
+    pass
+
+
+def test_import_function_undecorated(supports_dir, monkeypatch):
+    monkeypatch.syspath_prepend(supports_dir)
+    fun = api_pb2.Function(module_name="user_code_import_samples.func", function_name="undecorated_f")
+    service = user_code_imports.import_single_function_service(
+        fun,
+        None,
+        None,
+        None,
+        None,
+    )
+    assert len(service.code_deps) == 0  # undecorated - can't get code deps
+    # can't reliably get app - this is deferred to a name based lookup later in the container entrypoint
+    assert service.app is None
+
+
+def test_import_class():
+    # TODO: implement
+    pass
+
+
+def test_import_serialized():
+    # TODO: implement
+    pass
+
+
+def test_import_class_undecorated():
+    # TODO: implement
+    pass

--- a/test/user_code_import_test.py
+++ b/test/user_code_import_test.py
@@ -1,4 +1,6 @@
 # Copyright Modal Labs 2024
+from unittest.mock import MagicMock
+
 from modal.image import _Image
 from modal.runtime import user_code_imports
 from modal_proto import api_pb2
@@ -18,10 +20,19 @@ def test_import_function(supports_dir, monkeypatch):
     assert type(service.code_deps[0]) is _Image
     assert service.app
 
+    assert service.user_cls_instance is None
 
-def test_import_function_serialized():
-    # TODO: implement
-    pass
+    # TODO (elias): shouldn't have to pass the function definition again!
+    io_manager = MagicMock()  # shouldn't actually be used except by web endpoints - indicates some need for refactoring
+    finalized_funcs = service.get_finalized_functions(fun, container_io_manager=io_manager)
+    assert len(finalized_funcs) == 1
+    finalized_func = finalized_funcs[""]
+    assert finalized_func.is_async is False
+    assert finalized_func.is_generator is False
+    assert finalized_func.data_format == api_pb2.DATA_FORMAT_PICKLE
+    assert finalized_func.lifespan_manager is None
+    container_callable = finalized_func.callable
+    assert container_callable("world") == "hello world"
 
 
 def test_import_function_undecorated(supports_dir, monkeypatch):
@@ -39,16 +50,42 @@ def test_import_function_undecorated(supports_dir, monkeypatch):
     assert service.app is None
 
 
-def test_import_class():
-    # TODO: implement
-    pass
+def test_import_class(monkeypatch, supports_dir):
+    monkeypatch.syspath_prepend(supports_dir)
+    fun = api_pb2.Function(
+        module_name="user_code_import_samples.cls",
+        function_name="C.*",
+    )
+    service = user_code_imports.import_class_service(
+        fun,
+        None,
+        (),
+        {},
+    )
+    assert len(service.code_deps) == 1
+    assert type(service.code_deps[0]) is _Image
+    # TODO (elias): Fix app not being set
+    # assert service.app
+
+    from user_code_import_samples.cls import UndecoratedC  # type: ignore
+
+    assert isinstance(service.user_cls_instance, UndecoratedC)
+
+    # TODO (elias): shouldn't have to pass the function definition again!
+    io_manager = MagicMock()  # shouldn't actually be used except by web endpoints - indicates some need for refactoring
+    finalized_funcs = service.get_finalized_functions(fun, container_io_manager=io_manager)
+    assert len(finalized_funcs) == 2
+
+    for finalized in finalized_funcs.values():
+        assert finalized.is_async is False
+        assert finalized.is_generator is False
+        assert finalized.data_format == api_pb2.DATA_FORMAT_PICKLE
+        assert finalized.lifespan_manager is None
+
+    finalized_1, finalized_2 = finalized_funcs["f"], finalized_funcs["f2"]
+    assert finalized_1.callable("world") == "hello world"
+    assert finalized_2.callable("world") == "other world"
 
 
-def test_import_serialized():
-    # TODO: implement
-    pass
-
-
-def test_import_class_undecorated():
-    # TODO: implement
-    pass
+# TODO: add test cases for serialized functions, web endpoints, explicit/implicit generators etc.
+#   with and without decorators in globals scope...

--- a/test/user_code_import_test.py
+++ b/test/user_code_import_test.py
@@ -1,8 +1,8 @@
 # Copyright Modal Labs 2024
 from unittest.mock import MagicMock
 
+from modal._runtime import user_code_imports
 from modal.image import _Image
-from modal.runtime import user_code_imports
 from modal_proto import api_pb2
 
 
@@ -45,7 +45,7 @@ def test_import_function_undecorated(supports_dir, monkeypatch):
         None,
         None,
     )
-    assert len(service.code_deps) == 0  # undecorated - can't get code deps
+    assert service.code_deps is None  # undecorated - can't get code deps
     # can't reliably get app - this is deferred to a name based lookup later in the container entrypoint
     assert service.app is None
 


### PR DESCRIPTION
Starting to add some tests for various user code import cases - there is a lot of branching here depending on how functions are defined and we don't have great test coverage of that, since our previous tests have been more complicated container tests.

This is a step towards getting better test coverage.

Note the TODO with the service.app not being defined for class imports, which is an actual bug we would have caught with better test coverage here.