### PR TITLE
Remove aiostream from library dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ packages = find:
 python_requires = >=3.9
 install_requires =
     aiohttp
-    aiostream~=0.5.2
     certifi
     click>=8.1.0
     fastapi


### PR DESCRIPTION
Closes CLI-241

We have to keep the library in the requirements files for legacy Image Builder versions but it's not part of `2024.10`. Even though it will be installed in the container with older Image Builders, up-to-date clients won't actually import it.

## Changelog

- Removed the `aiostream` package from the modal client library dependencies.