### PR TITLE
Remove telemetry protos

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -152,12 +152,6 @@ enum GPUType {
   GPU_TYPE_L40S = 11;
 }
 
-enum InstrumentationType {
-  INSTRUMENTATION_TYPE_UNSPECIFIED = 0;
-  INSTRUMENTATION_TYPE_METRICS = 1;
-  INSTRUMENTATION_TYPE_TRACE = 2;
-}
-
 enum ObjectCreationType {
   OBJECT_CREATION_TYPE_UNSPECIFIED = 0;  // just lookup
   OBJECT_CREATION_TYPE_CREATE_IF_MISSING = 1;
@@ -242,13 +236,6 @@ enum TaskState {
   TASK_STATE_PREEMPTIBLE = 9;
   TASK_STATE_PREEMPTED = 10;
   TASK_STATE_LOADING_CHECKPOINT_IMAGE = 11;
-}
-
-// Encoding type used for user telemetry data.
-enum TelemetryEncodingType {
-  TELEMETRY_ENCODING_TYPE_UNSPECIFIED = 0;
-  TELEMETRY_ENCODING_TYPE_PROTOBUF = 1;
-  TELEMETRY_ENCODING_TYPE_JSON = 2;
 }
 
 enum VolumeFsVersion {
@@ -1580,12 +1567,6 @@ message FunctionPutOutputsRequest {
   double requested_at = 5; // Used for waypoints.
 }
 
-message FunctionPutUserTelemetryRequest {
-  bytes data = 1;
-  TelemetryEncodingType encoding_type = 2;
-  InstrumentationType instrumentation_type = 3;
-}
-
 message FunctionRetryInputsItem {
   string input_jwt = 1;
   FunctionInput input = 2;
@@ -2725,7 +2706,6 @@ service ModalClient {
   rpc FunctionPrecreate(FunctionPrecreateRequest) returns (FunctionPrecreateResponse);
   rpc FunctionPutInputs(FunctionPutInputsRequest) returns (FunctionPutInputsResponse);
   rpc FunctionPutOutputs(FunctionPutOutputsRequest) returns (google.protobuf.Empty);  // For containers to return result
-  rpc FunctionPutUserTelemetry(FunctionPutUserTelemetryRequest) returns (google.protobuf.Empty);
   rpc FunctionRetryInputs(FunctionRetryInputsRequest) returns (FunctionRetryInputsResponse);
   rpc FunctionStartPtyShell(google.protobuf.Empty) returns (google.protobuf.Empty);
   rpc FunctionUpdateSchedulingParams(FunctionUpdateSchedulingParamsRequest) returns (FunctionUpdateSchedulingParamsResponse);


### PR DESCRIPTION
## Describe your changes

Remove the previously added user telemetry protos, as we're no longer writing client exporters. 

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
