### PR TITLE
Increase fetch depth in deployment workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -179,6 +179,7 @@ jobs:
         with:
           token: ${{ steps.generate_token.outputs.token }}
           ref: main
+          fetch-depth: 10  # Fetch multiple commits to find the right changelog entry with concurrent deployments
 
       - uses: ./.github/actions/setup-cached-python
         with:


### PR DESCRIPTION
I think this is the answer to why the changelog step fails when we have concurrent deployments: the default behavior for the checkout action is to fetch the most recent commit. That's why we crash when we try to get the log for the commit that triggered the build: if there's been a subsequent merge to main while CI ran on our commit, that's the commit we fetch, and we otherwise have no record of the commit that `$GIT_SHA` points at.