### PR TITLE
remove way to suppress show_progress deprecation warning

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -1,6 +1,5 @@
 # Copyright Modal Labs 2022
 import inspect
-import os
 import typing
 import warnings
 from pathlib import PurePosixPath
@@ -436,9 +435,7 @@ class _App:
                 "`show_progress=True` is no longer supported. Use `with modal.enable_output():` instead.",
             )
         elif show_progress is False:
-            # TODO(erikbern): remove this env check very shortly
-            if "MODAL_DISABLE_APP_RUN_OUTPUT_WARNING" not in os.environ:
-                deprecation_warning((2024, 11, 20), "`show_progress=False` is deprecated (and has no effect)")
+            deprecation_warning((2024, 11, 20), "`show_progress=False` is deprecated (and has no effect)")
 
         async with _run_app(self, client=client, detach=detach, interactive=interactive):
             yield self

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -416,11 +416,6 @@ def test_show_progress_deprecations(client, monkeypatch):
         with app.run(client=client, show_progress=False):
             pass
 
-    # This is used by integration tests for a short period
-    monkeypatch.setenv("MODAL_DISABLE_APP_RUN_OUTPUT_WARNING", "1")
-    with app.run(client=client, show_progress=False):
-        pass
-
 
 @pytest.mark.asyncio
 async def test_deploy_from_container(servicer, container_client):


### PR DESCRIPTION
The whole point of this was to not break internal integration tests for a short period but they broke anyway so I fixed it in a different way.

Either way we can remove this now.