### PR TITLE
make Mount._deploy implicitly Environment-scoped

### DIFF
--- a/modal/mount.py
+++ b/modal/mount.py
@@ -622,12 +622,13 @@ class _Mount(_Object, type_prefix="mo"):
         client: Optional[_Client] = None,
     ) -> None:
         check_object_name(deployment_name, "Mount")
+        environment_name = _get_environment_name(environment_name, resolver=None)
         self._deployment_name = deployment_name
         self._namespace = namespace
         self._environment_name = environment_name
         if client is None:
             client = await _Client.from_env()
-        resolver = Resolver(client=client)
+        resolver = Resolver(client=client, environment_name=environment_name)
         await resolver.load(self)
 
     def _get_metadata(self) -> api_pb2.MountHandleMetadata:


### PR DESCRIPTION
## Describe your changes

Currently we have a benchmark failure (large_mount_data) because `Mount.lookup` is implicitly Environment-scoped by `Mount._deploy` is not. In one Environment, the named Mount is deleted and so the lookup fails but the `_deploy` looks at our "main" Environment which does have the named Mount.

I expect that Modal's workspace is the only consumer of `._deploy`.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>
