### PR TITLE
Add custom_domain_info field to MethodDefinition

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1754,6 +1754,7 @@ message MethodDefinition {
   WebhookConfig webhook_config = 3;
   string web_url = 4;
   WebUrlInfo web_url_info = 5;
+  repeated CustomDomainInfo custom_domain_info = 6;
 }
 
 message MountFile {


### PR DESCRIPTION
This is so we can display custom domains created in the terminal when a user does `modal deploy` on a new-style class that doesn't have method placeholders. `FunctionDefinition` already has this field.

See corresponding server side change [here](https://github.com/modal-labs/modal/pull/17571)