### PR TITLE
Retire modal-client PyPI package: Step one

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -236,35 +236,31 @@ build_number = {new_build_number}  # git: {git_sha}
 
 @task
 def create_alias_package(ctx):
-    from modal_version import __version__
-
-    os.makedirs("alias-package", exist_ok=True)
+    os.makedirs("alias-package/modal", exist_ok=True)
     with open("alias-package/setup.py", "w") as f:
         f.write(
             f"""\
 {copyright_header_full}
 from setuptools import setup
-setup(version="{__version__}")
+setup(version="1.0.0")
 """
         )
     with open("alias-package/setup.cfg", "w") as f:
         f.write(
-            f"""\
+            """\
 [metadata]
 name = modal-client
 author = Modal Labs
 author_email = support@modal.com
 description = Legacy name for the Modal client
-long_description = This is a legacy compatibility package that just requires the `modal` client library.
-            In versions before 0.51, the official name of the client library was called `modal-client`.
-            We have renamed it to `modal`, but this library is kept updated for compatibility.
+long_description = This is a legacy compatibility package for the `modal` client library.
+            This package is no longer functional. Please install the `modal` package instead.
 long_description_content_type = text/markdown
 project_urls =
     Homepage = https://modal.com
 
 [options]
-install_requires =
-    modal=={__version__}
+packages = find:
 """
         )
     with open("alias-package/pyproject.toml", "w") as f:
@@ -273,6 +269,18 @@ install_requires =
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+"""
+        )
+    with open("alias-package/modal/__init__.py", "w") as f:
+        f.write(
+            """\
+error = '''
+######################################################################
+# The legacy `modal-client` PyPI package is no longer being updated. #
+# Please install the `modal` package instead (`pip install modal`).  #
+######################################################################
+'''
+raise Exception(error)
 """
         )
 


### PR DESCRIPTION
Step one of retiring the `modal-client` alias package. This does one final release (version 1.0!!) with a module that just raises an exception on import directing users to the `modal` PyPI package.

I'll follow up with a subsequent PR to stop publishing the alias package.