### PR TITLE
Retire modal-client PyPI package: Step two

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -215,13 +215,6 @@ jobs:
       - name: Build wheel
         run: python setup.py bdist_wheel
 
-      - name: Create alias package
-        run: inv create-alias-package
-
-      - name: Build alias package
-        working-directory: alias-package
-        run: python setup.py bdist_wheel
-
       - name: Set the Modal environment
         run: modal config set-environment main
 
@@ -236,11 +229,4 @@ jobs:
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: twine upload dist/* --non-interactive
-
-      - name: Upload alias package to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        working-directory: alias-package
         run: twine upload dist/* --non-interactive

--- a/tasks.py
+++ b/tasks.py
@@ -235,57 +235,6 @@ build_number = {new_build_number}  # git: {git_sha}
 
 
 @task
-def create_alias_package(ctx):
-    os.makedirs("alias-package/modal", exist_ok=True)
-    with open("alias-package/setup.py", "w") as f:
-        f.write(
-            f"""\
-{copyright_header_full}
-from setuptools import setup
-setup(version="1.0.0")
-"""
-        )
-    with open("alias-package/setup.cfg", "w") as f:
-        f.write(
-            """\
-[metadata]
-name = modal-client
-author = Modal Labs
-author_email = support@modal.com
-description = Legacy name for the Modal client
-long_description = This is a legacy compatibility package for the `modal` client library.
-            This package is no longer functional. Please install the `modal` package instead.
-long_description_content_type = text/markdown
-project_urls =
-    Homepage = https://modal.com
-
-[options]
-packages = find:
-"""
-        )
-    with open("alias-package/pyproject.toml", "w") as f:
-        f.write(
-            """\
-[build-system]
-requires = ["setuptools", "wheel"]
-build-backend = "setuptools.build_meta"
-"""
-        )
-    with open("alias-package/modal/__init__.py", "w") as f:
-        f.write(
-            """\
-error = '''
-######################################################################
-# The legacy `modal-client` PyPI package is no longer being updated. #
-# Please install the `modal` package instead (`pip install modal`).  #
-######################################################################
-'''
-raise Exception(error)
-"""
-        )
-
-
-@task
 def type_stubs(ctx):
     # We only generate type stubs for modules that contain synchronicity wrapped types
     from synchronicity.synchronizer import SYNCHRONIZER_ATTR


### PR DESCRIPTION
Followup to https://github.com/modal-labs/modal-client/pull/2556

Removes the "alias-package" stuff from our CD pipeline.

Closes CLI-258