### PR TITLE
Improve CD pipeline to avoid issues with concurrent deployments

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -17,6 +17,43 @@ env:
   PYTHONIOENCODING: utf-8
 
 jobs:
+
+  client-versioning:
+    if: github.ref == 'refs/heads/main'
+    name: Update changelog and client version
+    concurrency: client-versioning
+    runs-on: ubuntu-20.04
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    outputs:
+      client-version: ${{ steps.version.outputs.client_version }}
+
+    steps:
+
+      - uses: actions/checkout@v3
+
+      - uses: ./.github/actions/setup-cached-python
+        with:
+          version: "3.10"
+
+      - name: Bump the version number
+        run: inv update-build-number
+
+      - name: Update the changelog
+        run: inv update-changelog --sha=$GITHUB_SHA
+
+      - name: Get the current client version
+        id: version
+        run: echo "client_version=`python -m modal_version`" >> "$GITHUB_OUTPUT"
+
+      - uses: EndBug/add-and-commit@v9
+        with:
+          add: modal_version/_version_generated.py CHANGELOG.md
+          tag: v${{ steps.version.outputs.client_version }}
+          message: "[auto-commit] [skip ci] Bump the build number"
+          pull: "--rebase --autostash"
+          default_author: github_actions
+
   client-test:
     name: Unit tests on ${{ matrix.python-version }} and ${{ matrix.os }} (protobuf=${{ matrix.proto-version }})
     timeout-minutes: 30
@@ -63,8 +100,7 @@ jobs:
         run: pytest -v
 
       - name: Run docstring tests
-        # TODO(michael) disable doctests on 3.13 until workspace is updated to new Image Builder Version
-        if: github.event.pull_request.head.repo.fork == 'false' && matrix.python-version != '3.13'
+        if: github.event.pull_request.head.repo.fork == 'false'
         env:
           MODAL_ENVIRONMENT: client-doc-tests
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
@@ -161,47 +197,19 @@ jobs:
   publish-client:
     name: Publish client package
     if: github.ref == 'refs/heads/main'
-    needs: [client-test]
+    needs: [client-versioning, client-test]
     runs-on: ubuntu-20.04
     concurrency: publish-client
     timeout-minutes: 5
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Generate token for Github PR Bot
-        id: generate_token
-        uses: tibdex/github-app-token@v1
-        with:
-          app_id: ${{ secrets.GH_PRBOT_APP_ID }}
-          private_key: ${{ secrets.GH_PRBOT_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v3
         with:
-          token: ${{ steps.generate_token.outputs.token }}
-          ref: main
-          fetch-depth: 10  # Fetch multiple commits to find the right changelog entry with concurrent deployments
+          ref: v${{ needs.client-versioning.outputs.client-version}}
 
       - uses: ./.github/actions/setup-cached-python
         with:
           version: "3.10"
-
-      - name: Bump the version number
-        run: inv update-build-number
-
-      - name: Update the changelog
-        run: inv update-changelog --sha=$GITHUB_SHA
-
-      - name: Get the current client version
-        id: version
-        run: echo "client_version=`python -m modal_version`" >> "$GITHUB_OUTPUT"
-
-      - uses: EndBug/add-and-commit@v9
-        with:
-          add: modal_version/_version_generated.py CHANGELOG.md
-          tag: v${{ steps.version.outputs.client_version }}
-          message: "[auto-commit] [skip ci] Bump the build number"
-          pull: "--rebase --autostash"
-          default_author: github_actions
 
       - name: Build protobuf
         run: inv protoc
@@ -215,11 +223,9 @@ jobs:
       - name: Build wheel
         run: python setup.py bdist_wheel
 
-      - name: Set the Modal environment
-        run: modal config set-environment main
-
       - name: Publish client mount
         env:
+          MODAL_ENVIRONMENT: main
           MODAL_LOGLEVEL: DEBUG
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}


### PR DESCRIPTION
This PR makes some changes to the CI-CD workflow to better handle concurrent deployments.

It moves the steps that mutate the repository (updating the changelog and bumping the version number) first in the pipeline, so those run before we run any tests. Then the deployment job checks out the commit created when we update the version and deploys _that_.

This helps avoid an issue with the current configuration, where the deployment job checks out main after waiting for tests to run, meaning that it can includes additional commits that have subsequently been merged (but, critically, have _not_ been validated by CI in a post-merge state).