### PR TITLE
Fix deployments better

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -37,6 +37,8 @@ jobs:
           private_key: ${{ secrets.GH_PRBOT_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v3
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
 
       - uses: ./.github/actions/setup-cached-python
         with:


### PR DESCRIPTION
OK I think this is what I was missing in https://github.com/modal-labs/modal-client/pull/2559

We need to use the token to check out the repo — then we can use the fact that prbot is allowed to push directly to main in the subsequent step. That is set up in the GitHub settings UI (not the config) and I am not 100% sure how the token propagates from one step to the other, but I reckon this is the solution.