### PR TITLE
Add _experimental_fs_api

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2083,6 +2083,10 @@ message Sandbox {
 
   // Network access configuration beyond simple allow/block.
   NetworkAccess network_access = 22;
+
+  // Note: This enables gVisor's "-host-uds=all" flag which may have stability issues
+  // pending resolution of https://github.com/google/gvisor/issues/11202
+  bool _experimental_fs_api = 23;
 }
 
 message SandboxCreateRequest {


### PR DESCRIPTION
## Describe your changes

This pr adds a flag enabling testing of modal-daemon (i.e., filesystem api) in production.

This flag is necessary as enabling the daemon requires enabling `-host-uds=all` in gVisor, which is currently unstable (see [here](https://github.com/google/gvisor/issues/11202)). Adding the flag here temporarily unblocks us from merging and testing the daemon changes.