### PR TITLE
More docs and types for io_streams

### DIFF
--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -146,9 +146,7 @@ class _StreamReader(Generic[T]):
         return self._file_descriptor
 
     async def read(self) -> T:
-        """Fetch and return contents of the entire stream.
-
-        If EOF was received, return an empty string.
+        """Fetch the entire contents of the stream until EOF.
 
         **Usage**
 

--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -370,7 +370,7 @@ class _StreamWriter:
         else:
             raise TypeError(f"data argument must be a bytes-like object, not {type(data).__name__}")
 
-    def write_eof(self):
+    def write_eof(self) -> None:
         """Close the write end of the stream after the buffered data is drained.
 
         If the process was blocked on input, it will become unblocked after


### PR DESCRIPTION
This might seem totally random but I wanted to take another look at this before `1.0`. Didn't find anything that needed to be changed though, just some minor documentation improvements.

https://modal.com/docs/reference/modal.io_streams

A lot of what I wanted to do was already handled by @pawalt and @azliu0's recent work on making it generic on bytes | str.