### PR TITLE
ci:  Run docstring tests again

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -108,7 +108,7 @@ jobs:
         run: pytest -v
 
       - name: Run docstring tests
-        if: github.event.pull_request.head.repo.fork == 'false'
+        if: github.event.pull_request.head.repo.fork == false
         env:
           MODAL_ENVIRONMENT: client-doc-tests
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}


### PR DESCRIPTION
This comparison expression has always been broken.

However in #2334 it changed from `!= 'true'` to `== 'false'`. So the tests went from always running to never running.