### PR TITLE
 Modify FunctionGetOutputs proto for client retries

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1426,6 +1426,8 @@ message FunctionGetOutputsRequest {
   string last_entry_id = 6;
   bool clear_on_success = 7; // expires *any* remaining outputs soon after this call, not just the returned ones
   double requested_at = 8; // Used for waypoints.
+  // The inputs ids the client expects the server to be processing. This is optional and used for sync inputs only.
+  repeated string expected_input_ids = 9; 
 }
 
 message FunctionGetOutputsResponse {
@@ -1433,6 +1435,9 @@ message FunctionGetOutputsResponse {
   repeated FunctionGetOutputsItem outputs = 4;
   string last_entry_id = 5;
   int32 num_unfinished_inputs = 6;
+  // A subset of expected_input_ids in the request which the server has no record of.
+  // Client should retry these inputs. Used for sync inputs only.
+  repeated string lost_input_ids = 7;
 }
 
 message FunctionGetRequest {


### PR DESCRIPTION
~This is based on https://github.com/modal-labs/modal-client/pull/2403. That should me reviewed and merged first. ~
Update: That PR has been merged, and this one has been rebased on it.

This modifies the request and response of FunctionGetOutputs so the client can retry lost inputs. This applies to sync inputs only.

The request has a new field `expected_input_ids`, so the client can optionally pass the server a list of input ids that it expects the server to be processing.

The server will check if it has a record of all these IDs. If not, it will immediately return, populating the response's new `lost_input_ids` field with the IDs that missing. The client can the resend those inputs.

Merging the proto changes first so we can implement and test this in the server.

Part of SVC-171

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
