### PR TITLE
Check that environment exists when setting in config

### DIFF
--- a/modal/cli/config.py
+++ b/modal/cli/config.py
@@ -3,6 +3,7 @@ import typer
 from rich.console import Console
 
 from modal.config import _profile, _store_user_config, config
+from modal.environments import Environment
 
 config_cli = typer.Typer(
     name="config",
@@ -38,6 +39,8 @@ when running a command that requires an environment.
 
 @config_cli.command(help=SET_DEFAULT_ENV_HELP)
 def set_environment(environment_name: str):
+    # Confirm that the environment exists by looking it up
+    Environment.lookup(environment_name)
     _store_user_config({"environment": environment_name})
     typer.echo(f"New default environment for profile {_profile}: {environment_name}")
 

--- a/modal/config.py
+++ b/modal/config.py
@@ -268,7 +268,7 @@ class Config:
         return repr(self.to_dict())
 
     def to_dict(self):
-        return {key: self.get(key) for key in _SETTINGS.keys()}
+        return {key: self.get(key) for key in sorted(_SETTINGS)}
 
 
 config = Config()


### PR DESCRIPTION
Super simple, fixes #2086

<img width="407" alt="image" src="https://github.com/user-attachments/assets/e9640a54-584e-4e1d-bc35-253e1345fff0">

## Changelog

- `modal config set-environment` will now raise if the requested environment does not exist.