### PR TITLE
Only check if returned object ID is different from existing_object_id for functions

### DIFF
--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -130,9 +130,14 @@ class Resolver:
                         raise NotFoundError(exc.message)
                     raise
 
-                # Check that the id of functions and classes didn't change
+                # Check that the id of functions didn't change
                 # Persisted refs are ignored because their life cycle is managed independently.
-                if not obj._is_another_app and existing_object_id is not None and obj.object_id != existing_object_id:
+                if (
+                    not obj._is_another_app
+                    and existing_object_id is not None
+                    and existing_object_id.startswith("fu-")
+                    and obj.object_id != existing_object_id
+                ):
                     raise Exception(
                         f"Tried creating an object using existing id {existing_object_id}"
                         f" but it has id {obj.object_id}"


### PR DESCRIPTION
Only check if returned object ID is different from existing_object_id for functions.

Currently only functions and classes use `existing_object_id` in function/class creation RPCs. 

After the server-side fix [here](https://github.com/modal-labs/modal/pull/17677), ID of an existing class might change if the set of methods of the class change.

existing function IDs should not change because the way we modify functions is by assigning them a new definition id