### PR TITLE
Fixes issue where Volume.from_name eagerly assigns event loop

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -1714,7 +1714,7 @@ class _Image(_Object, type_prefix="im"):
         """
 
         def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:
-            commands = ["FROM base", f"WORKDIR {shlex.quote(path)}"]
+            commands = ["FROM base", f"WORKDIR {shlex.quote(str(path))}"]
             return DockerfileSpec(commands=commands, context_files={})
 
         return _Image._from_args(

--- a/modal/object.py
+++ b/modal/object.py
@@ -17,7 +17,7 @@ O = TypeVar("O", bound="_Object")
 
 _BLOCKING_O = synchronize_api(O)
 
-EPHEMERAL_OBJECT_HEARTBEAT_SLEEP = 300
+EPHEMERAL_OBJECT_HEARTBEAT_SLEEP: int = 300
 
 
 def _get_environment_name(environment_name: Optional[str] = None, resolver: Optional[Resolver] = None) -> Optional[str]:


### PR DESCRIPTION
Lock was created in sync function as part of client-side object creation, causing it to bind the lock to the main thread event loop instead of the synchronizer loop on Python 3.9.

This surfaced in some tests where the event loop was un-set by some prior test and then triggered an error when a subsequent test called `Volume.from_name()` in global scope.

I *think* in most cases the locks still function across event loops on Python 3.9, as long as both the awaiter and holder run on the same loop, so this probably created no issue in practice (unless users unset the main thread event loop before initializing a volume)