### PR TITLE
hydrate functions then classes in container entrypoint

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -493,12 +493,17 @@ class _App:
         _App._container_app = running_app
 
         # Hydrate objects on app
-        indexed_objects = dict(**self._functions, **self._classes)
-        for tag, object_id in running_app.tag_to_object_id.items():
-            if tag in indexed_objects:
-                obj = indexed_objects[tag]
-                handle_metadata = running_app.object_handle_metadata[object_id]
-                obj._hydrate(object_id, client, handle_metadata)
+        def hydrate_objects(objects_dict):
+            for tag, object_id in running_app.tag_to_object_id.items():
+                if tag in objects_dict:
+                    obj = objects_dict[tag]
+                    handle_metadata = running_app.object_handle_metadata[object_id]
+                    obj._hydrate(object_id, client, handle_metadata)
+
+        # Hydrate function objects
+        hydrate_objects(self._functions)
+        # Hydrate class objects
+        hydrate_objects(self._classes)
 
     @property
     def registered_functions(self) -> Dict[str, _Function]:

--- a/modal/app.py
+++ b/modal/app.py
@@ -492,7 +492,8 @@ class _App:
 
         _App._container_app = running_app
 
-        # Hydrate objects on app
+        # Hydrate objects on app -- hydrating functions first so that when a class is being hydrated its
+        # corresponding class service function is already hydrated.
         def hydrate_objects(objects_dict):
             for tag, object_id in running_app.tag_to_object_id.items():
                 if tag in objects_dict:


### PR DESCRIPTION
## Describe your changes

https://github.com/modal-labs/modal-client/pull/2364 introduced a subtle requirement that hydrating a class requires that the class service function for the class is hydrated first.

in `_run_app` we make sure to `resolver.load` an object's `deps` before loading the object itself, but in container entrypoint we are hydrating a class before we hydrate the class service function, so the `_method_functions` of the `Cls` was empty because the class service function was unhydrated (its `method_handle_metadata` attribute was not populated).

this PR changes the entrypoint to load the app's functions, then its classes