### PR TITLE
Add space in _assert_no_mount_layers error message

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -375,7 +375,7 @@ class _Image(_Object, type_prefix="im"):
                 "\n"
                 "Run `image.add_local_*` commands last in your image build to avoid rebuilding images with every local "
                 "file change. Modal will then add these files to containers on startup instead, saving build time.\n"
-                "If you need to run other build steps after adding local files, set `copy=True` to copy the files"
+                "If you need to run other build steps after adding local files, set `copy=True` to copy the files "
                 "directly into the image, at the expense of some added build time.\n"
                 "\n"
                 "Example:\n"


### PR DESCRIPTION
Adds a space to the error message in `_assert_no_mount_layers` as it currently will concat the words _files_ and _directly_ into _filesdirectly_

<img width="518" alt="Screenshot 2024-11-28 at 14 27 52" src="https://github.com/user-attachments/assets/765f5b47-fec5-4185-80bd-8d54310e5156">
