### PR TITLE
Upgrades pytest-markdown-docs to version with better code traversal

### DIFF
--- a/modal/_tunnel.py
+++ b/modal/_tunnel.py
@@ -61,7 +61,7 @@ async def _forward(port: int, *, unencrypted: bool = False, client: Optional[_Cl
 
     **Usage:**
 
-    ```python
+    ```python notest
     import modal
     from flask import Flask
 

--- a/modal/app.py
+++ b/modal/app.py
@@ -401,14 +401,14 @@ class _App:
 
         **Example**
 
-        ```python
+        ```python notest
         with app.run():
             some_modal_function.remote()
         ```
 
         To enable output printing, use `modal.enable_output()`:
 
-        ```python
+        ```python notest
         with modal.enable_output():
             with app.run():
                 some_modal_function.remote()

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -154,7 +154,7 @@ class _Obj:
         Note that all Modal methods and web endpoints of a class share the same set
         of containers and the warm_pool_size affects that common container pool.
 
-        ```python
+        ```python notest
         # Usage on a parametrized function.
         Model = modal.Cls.lookup("my-app", "Model")
         Model("fine-tuned-model").keep_warm(2)
@@ -524,7 +524,7 @@ class _Cls(_Object, type_prefix="cs"):
         In contrast to `modal.Cls.from_name`, this is an eager method
         that will hydrate the local object with metadata from Modal servers.
 
-        ```python
+        ```python notest
         Class = modal.Cls.lookup("other-app", "Class")
         obj = Class()
         ```

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -88,7 +88,9 @@ class _Dict(_Object, type_prefix="di"):
 
         with Dict.ephemeral() as d:
             d["foo"] = "bar"
+        ```
 
+        ```python notest
         async with Dict.ephemeral() as d:
             await d.put.aio("foo", "bar")
         ```

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -997,7 +997,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         Please exercise care when using this advanced feature!
         Setting and forgetting a warm pool on functions can lead to increased costs.
 
-        ```python
+        ```python notest
         # Usage on a regular function.
         f = modal.Function.lookup("my-app", "function")
         f.keep_warm(2)
@@ -1076,7 +1076,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         In contrast to `modal.Function.from_name`, this is an eager method
         that will hydrate the local object with metadata from Modal servers.
 
-        ```python
+        ```python notest
         f = modal.Function.lookup("other-app", "function")
         ```
         """

--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -385,13 +385,14 @@ class _StreamWriter:
 
         **Usage**
 
-        ```python
-        # Synchronous
+        ```python notest
         writer.write(data)
         writer.drain()
+        ```
 
-        # Async
-        writer.write(data)
+        Async usage:
+        ```python notest
+        writer.write(data)  # not a blocking operation
         await writer.drain.aio()
         ```
         """

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -152,11 +152,13 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
 
         Usage:
         ```python
-        with NetworkFileSystem.ephemeral() as nfs:
-            assert nfs.listdir() == []
+        with modal.NetworkFileSystem.ephemeral() as nfs:
+            assert nfs.listdir("/") == []
+        ```
 
-        async with NetworkFileSystem.ephemeral() as nfs:
-            assert await nfs.listdir() == []
+        ```python notest
+        async with modal.NetworkFileSystem.ephemeral() as nfs:
+            assert await nfs.listdir("/") == []
         ```
         """
         if client is None:
@@ -184,7 +186,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         In contrast to `modal.NetworkFileSystem.from_name`, this is an eager method
         that will hydrate the local object with metadata from Modal servers.
 
-        ```python
+        ```python notest
         nfs = modal.NetworkFileSystem.lookup("my-nfs")
         print(nfs.listdir("/"))
         ```

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -126,7 +126,9 @@ class _Queue(_Object, type_prefix="qu"):
 
         with Queue.ephemeral() as q:
             q.put(123)
+        ```
 
+        ```python notest
         async with Queue.ephemeral() as q:
             await q.put.aio(123)
         ```

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -200,11 +200,14 @@ class _Volume(_Object, type_prefix="vo"):
 
         Usage:
         ```python
-        with Volume.ephemeral() as vol:
-            assert vol.listdir() == []
+        import modal
+        with modal.Volume.ephemeral() as vol:
+            assert vol.listdir("/") == []
+        ```
 
-        async with Volume.ephemeral() as vol:
-            assert await vol.listdir() == []
+        ```python notest
+        async with modal.Volume.ephemeral() as vol:
+            assert await vol.listdir("/") == []
         ```
         """
         if client is None:
@@ -234,7 +237,7 @@ class _Volume(_Object, type_prefix="vo"):
         In contrast to `modal.Volume.from_name`, this is an eager method
         that will hydrate the local object with metadata from Modal servers.
 
-        ```python
+        ```python notest
         vol = modal.Volume.lookup("my-volume")
         print(vol.listdir("/"))
         ```

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -14,7 +14,7 @@ pre-commit>=2.21,<4
 pytest~=8.0.0
 pytest-asyncio @ git+https://github.com/modal-labs/pytest-asyncio.git@b535db05f6e43019700483c442ab6686f132a415
 pytest-env~=0.6.2
-pytest-markdown-docs==0.6.0
+pytest-markdown-docs==0.7.1
 pytest-timeout~=2.1.0
 python-dotenv~=1.0.0;python_version>='3.8'
 requests~=2.31.0


### PR DESCRIPTION
All tests weren't previously detected, since the code traversal only looked at the docstrings that were transferred by synchronicity to the wrapper objects/functions. Now we use the implementation classes/functions instead as the test objects, which finds a bunch more tests (many of which were failing)

* Disables and splits up a bunch of tests that got detected and failed
* Fixes a bunch of docstring tests that had missing args etc.

**Note** Would be nice to find a way to test async code and inject async fixtures like our MockServicer into the markdown tests (some kind of pytest-asyncio compatibility). Until then, we'll have to disable a bunch of tests that assume prior existence of resources or event loop usage.