### PR TITLE
Fix modal run on class method defined on base of wrapped class

### DIFF
--- a/modal/_utils/function_utils.py
+++ b/modal/_utils/function_utils.py
@@ -133,6 +133,9 @@ class FunctionInfo:
         elif f is None and user_cls:
             # "service function" for running all methods of a class
             self.function_name = f"{user_cls.__name__}.*"
+        elif f and user_cls:
+            # Method may be defined on superclass of the wrapped class
+            self.function_name = f"{user_cls.__name__}.{f.__name__}"
         else:
             self.function_name = f.__qualname__
 

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -199,6 +199,11 @@ def test_run_quiet(servicer, set_env_client, test_dir):
     _run(["run", "--quiet", app_file.as_posix()])
 
 
+def test_run_class_hierarchy(servicer, set_env_client, test_dir):
+    app_file = test_dir / "supports" / "class_hierarchy.py"
+    _run(["run", app_file.as_posix() + "::Wrapped.defined_on_base"])
+
+
 def test_deploy(servicer, set_env_client, test_dir):
     app_file = test_dir / "supports" / "app_run_tests" / "default_app.py"
     _run(["deploy", "--name=deployment_name", app_file.as_posix()])

--- a/test/supports/class_hierarchy.py
+++ b/test/supports/class_hierarchy.py
@@ -1,0 +1,21 @@
+# Copyright Modal Labs 2024
+import modal
+
+app = modal.App("class-hierarchy")
+
+
+class Base:
+    @modal.method()
+    def defined_on_base(self):
+        print("base")
+
+    @modal.method()
+    def overridden_on_wrapped(self):
+        raise NotImplementedError()
+
+
+@app.cls()
+class Wrapped(Base):
+    @modal.method()
+    def overridden_on_wrapped(self):
+        print("wrapped")


### PR DESCRIPTION
Fixes CLI-22

Hard to explain exactly what the issue was here: it's fairly complex code. But there was a gap in the conditionals for resolving the name of the method to execute given (1) a Python function object (i.e. an unbound method) and (2) a Python class that has been registered to an App.

We have a lot of undefined behavior and edge cases around class inheritance.

## Changelog

- Fixed a bug where pointing `modal run` at a method on a Modal Cls would fail if the method was inherited from a parent.