### PR TITLE
Fix modal.method overriding in subclass

### DIFF
--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -155,7 +155,7 @@ def _find_partial_methods_for_user_cls(user_cls: type[Any], flags: int) -> dict[
             deprecation_error((2024, 2, 21), message)
 
     partial_functions: dict[str, PartialFunction] = {}
-    for parent_cls in user_cls.mro():
+    for parent_cls in reversed(user_cls.mro()):
         if parent_cls is not object:
             for k, v in parent_cls.__dict__.items():
                 if isinstance(v, PartialFunction):

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -201,6 +201,7 @@ def test_run_quiet(servicer, set_env_client, test_dir):
 def test_run_class_hierarchy(servicer, set_env_client, test_dir):
     app_file = test_dir / "supports" / "class_hierarchy.py"
     _run(["run", app_file.as_posix() + "::Wrapped.defined_on_base"])
+    _run(["run", app_file.as_posix() + "::Wrapped.overridden_on_wrapped"])
 
 
 def test_deploy(servicer, set_env_client, test_dir):


### PR DESCRIPTION
Fixes CLI-47

Previously if you had a `@modal.method` defined on a class and on a parent of that class:

```python
class AbstractService:
    @modal.method()
    def foo(self):
        raise NotImplementedError()

@app.cls()
class Service:
    @modal.method()
    def foo():
        print("Doing a foo")
```

Then running `Service().foo.remote()` would run the method on the base class.

I think this is a simple bug: we're iterating through the `user_cls.mro()` in the wrong order, so we always use the most ancestral version of the method.

## Changelog

- Fixed a bug that executes the wrong method when a Modal Cls overrides a `@modal.method` inherited from a parent.