### PR TITLE
Run pyupgrade for Py3.9+

### DIFF
--- a/modal/_clustered_functions.py
+++ b/modal/_clustered_functions.py
@@ -2,7 +2,7 @@
 import os
 import socket
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Optional
 
 from modal._utils.async_utils import synchronize_api
 from modal._utils.grpc_utils import retry_transient_errors
@@ -14,7 +14,7 @@ from modal_proto import api_pb2
 @dataclass
 class ClusterInfo:
     rank: int
-    container_ips: List[str]
+    container_ips: list[str]
 
 
 cluster_info: Optional[ClusterInfo] = None

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -19,7 +19,8 @@ import signal
 import sys
 import threading
 import time
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from google.protobuf.message import Message
 
@@ -175,7 +176,7 @@ class UserCodeEventLoop:
 def call_function(
     user_code_event_loop: UserCodeEventLoop,
     container_io_manager: "modal._runtime.container_io_manager.ContainerIOManager",
-    finalized_functions: Dict[str, "modal._runtime.user_code_imports.FinalizedFunction"],
+    finalized_functions: dict[str, "modal._runtime.user_code_imports.FinalizedFunction"],
     batch_max_size: int,
     batch_wait_ms: int,
 ):
@@ -473,7 +474,7 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
         # 1. Enable lazy hydration for all objects
         # 2. Fully deprecate .new() objects
         if service.code_deps is not None:  # this is not set for serialized or non-global scope functions
-            dep_object_ids: List[str] = [dep.object_id for dep in function_def.object_dependencies]
+            dep_object_ids: list[str] = [dep.object_id for dep in function_def.object_dependencies]
             if len(service.code_deps) != len(dep_object_ids):
                 raise ExecutionError(
                     f"Function has {len(service.code_deps)} dependencies"
@@ -595,7 +596,7 @@ if __name__ == "__main__":
     # from shutting down. The sleep(0) here is needed for finished ThreadPoolExecutor resources to
     # shut down without triggering this warning (e.g., `@wsgi_app()`).
     time.sleep(0)
-    lingering_threads: List[threading.Thread] = []
+    lingering_threads: list[threading.Thread] = []
     for thread in threading.enumerate():
         current_thread = threading.get_ident()
         if thread.ident is not None and thread.ident != current_thread and not thread.daemon and thread.is_alive():

--- a/modal/_pty.py
+++ b/modal/_pty.py
@@ -2,12 +2,12 @@
 import contextlib
 import os
 import sys
-from typing import Optional, Tuple
+from typing import Optional
 
 from modal_proto import api_pb2
 
 
-def get_winsz(fd) -> Tuple[Optional[int], Optional[int]]:
+def get_winsz(fd) -> tuple[Optional[int], Optional[int]]:
     try:
         import fcntl
         import struct

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -3,7 +3,8 @@ import asyncio
 import contextlib
 import typing
 from asyncio import Future
-from typing import TYPE_CHECKING, Dict, Hashable, List, Optional
+from collections.abc import Hashable
+from typing import TYPE_CHECKING, Optional
 
 from grpclib import GRPCError, Status
 
@@ -40,10 +41,10 @@ class StatusRow:
 
 
 class Resolver:
-    _local_uuid_to_future: Dict[str, Future]
+    _local_uuid_to_future: dict[str, Future]
     _environment_name: Optional[str]
     _app_id: Optional[str]
-    _deduplication_cache: Dict[Hashable, Future]
+    _deduplication_cache: dict[Hashable, Future]
     _client: _Client
 
     def __init__(
@@ -153,8 +154,8 @@ class Resolver:
         # TODO(elias): print original exception/trace rather than the Resolver-internal trace
         return await cached_future
 
-    def objects(self) -> List["_Object"]:
-        unique_objects: Dict[str, "_Object"] = {}
+    def objects(self) -> list["_Object"]:
+        unique_objects: dict[str, "_Object"] = {}
         for fut in self._local_uuid_to_future.values():
             if not fut.done():
                 # this will raise an exception if not all loads have been awaited, but that *should* never happen

--- a/modal/_resources.py
+++ b/modal/_resources.py
@@ -1,5 +1,5 @@
 # Copyright Modal Labs 2024
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 
 from modal_proto import api_pb2
 
@@ -9,8 +9,8 @@ from .gpu import GPU_T, parse_gpu_config
 
 def convert_fn_config_to_resources_config(
     *,
-    cpu: Optional[Union[float, Tuple[float, float]]],
-    memory: Optional[Union[int, Tuple[int, int]]],
+    cpu: Optional[Union[float, tuple[float, float]]],
+    memory: Optional[Union[int, tuple[int, int]]],
     gpu: GPU_T,
     ephemeral_disk: Optional[int],
 ) -> api_pb2.Resources:

--- a/modal/_runtime/asgi.py
+++ b/modal/_runtime/asgi.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
 import asyncio
-from typing import Any, AsyncGenerator, Callable, Dict, NoReturn, Optional, Tuple, cast
+from collections.abc import AsyncGenerator
+from typing import Any, Callable, NoReturn, Optional, cast
 
 import aiohttp
 
@@ -80,8 +81,8 @@ class LifespanManager:
         await self.shutdown
 
 
-def asgi_app_wrapper(asgi_app, container_io_manager) -> Tuple[Callable[..., AsyncGenerator], LifespanManager]:
-    state: Dict[str, Any] = {}  # used for lifespan state
+def asgi_app_wrapper(asgi_app, container_io_manager) -> tuple[Callable[..., AsyncGenerator], LifespanManager]:
+    state: dict[str, Any] = {}  # used for lifespan state
 
     async def fn(scope):
         if "state" in scope:
@@ -92,8 +93,8 @@ def asgi_app_wrapper(asgi_app, container_io_manager) -> Tuple[Callable[..., Asyn
         function_call_id = current_function_call_id()
         assert function_call_id, "internal error: function_call_id not set in asgi_app() scope"
 
-        messages_from_app: asyncio.Queue[Dict[str, Any]] = asyncio.Queue(1)
-        messages_to_app: asyncio.Queue[Dict[str, Any]] = asyncio.Queue(1)
+        messages_from_app: asyncio.Queue[dict[str, Any]] = asyncio.Queue(1)
+        messages_to_app: asyncio.Queue[dict[str, Any]] = asyncio.Queue(1)
 
         async def disconnect_app():
             if scope["type"] == "http":
@@ -415,7 +416,7 @@ async def _proxy_websocket_request(session: aiohttp.ClientSession, scope, receiv
                     raise ExecutionError(f"Unexpected message type: {client_message['type']}")
 
         async def upstream_to_client():
-            msg: Dict[str, Any] = {
+            msg: dict[str, Any] = {
                 "type": "websocket.accept",
                 "subprotocol": upstream_ws.protocol,
             }

--- a/modal/_runtime/execution_context.py
+++ b/modal/_runtime/execution_context.py
@@ -1,6 +1,6 @@
 # Copyright Modal Labs 2024
 from contextvars import ContextVar
-from typing import Callable, List, Optional
+from typing import Callable, Optional
 
 from modal._utils.async_utils import synchronize_api
 from modal.exception import InvalidError
@@ -71,7 +71,7 @@ def current_function_call_id() -> Optional[str]:
         return None
 
 
-def _set_current_context_ids(input_ids: List[str], function_call_ids: List[str]) -> Callable[[], None]:
+def _set_current_context_ids(input_ids: list[str], function_call_ids: list[str]) -> Callable[[], None]:
     assert len(input_ids) == len(function_call_ids) and len(input_ids) > 0
     input_id = input_ids[0]
     function_call_id = function_call_ids[0]

--- a/modal/_runtime/telemetry.py
+++ b/modal/_runtime/telemetry.py
@@ -7,7 +7,6 @@ import socket
 import sys
 import threading
 import time
-import typing
 import uuid
 from importlib.util import find_spec, module_from_spec
 from struct import pack
@@ -65,7 +64,7 @@ class InterceptedModuleLoader(importlib.abc.Loader):
 
 
 class ImportInterceptor(importlib.abc.MetaPathFinder):
-    loading: typing.Dict[str, typing.Tuple[str, float]]
+    loading: dict[str, tuple[str, float]]
     tracing_socket: socket.socket
     events: queue.Queue
 

--- a/modal/_runtime/user_code_imports.py
+++ b/modal/_runtime/user_code_imports.py
@@ -3,7 +3,7 @@ import importlib
 import typing
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Optional
 
 import modal._runtime.container_io_manager
 import modal.cls
@@ -49,12 +49,12 @@ class Service(metaclass=ABCMeta):
 
     user_cls_instance: Any
     app: Optional["modal.app._App"]
-    code_deps: Optional[List["modal.object._Object"]]
+    code_deps: Optional[list["modal.object._Object"]]
 
     @abstractmethod
     def get_finalized_functions(
         self, fun_def: api_pb2.Function, container_io_manager: "modal._runtime.container_io_manager.ContainerIOManager"
-    ) -> Dict[str, "FinalizedFunction"]:
+    ) -> dict[str, "FinalizedFunction"]:
         ...
 
 
@@ -99,13 +99,13 @@ def construct_webhook_callable(
 class ImportedFunction(Service):
     user_cls_instance: Any
     app: Optional["modal.app._App"]
-    code_deps: Optional[List["modal.object._Object"]]
+    code_deps: Optional[list["modal.object._Object"]]
 
     _user_defined_callable: Callable[..., Any]
 
     def get_finalized_functions(
         self, fun_def: api_pb2.Function, container_io_manager: "modal._runtime.container_io_manager.ContainerIOManager"
-    ) -> Dict[str, "FinalizedFunction"]:
+    ) -> dict[str, "FinalizedFunction"]:
         # Check this property before we turn it into a method (overriden by webhooks)
         is_async = get_is_async(self._user_defined_callable)
         # Use the function definition for whether this is a generator (overriden by webhooks)
@@ -142,13 +142,13 @@ class ImportedFunction(Service):
 class ImportedClass(Service):
     user_cls_instance: Any
     app: Optional["modal.app._App"]
-    code_deps: Optional[List["modal.object._Object"]]
+    code_deps: Optional[list["modal.object._Object"]]
 
-    _partial_functions: Dict[str, "modal.partial_function._PartialFunction"]
+    _partial_functions: dict[str, "modal.partial_function._PartialFunction"]
 
     def get_finalized_functions(
         self, fun_def: api_pb2.Function, container_io_manager: "modal._runtime.container_io_manager.ContainerIOManager"
-    ) -> Dict[str, "FinalizedFunction"]:
+    ) -> dict[str, "FinalizedFunction"]:
         finalized_functions = {}
         for method_name, partial in self._partial_functions.items():
             partial = synchronizer._translate_in(partial)  # ugly
@@ -184,9 +184,7 @@ class ImportedClass(Service):
         return finalized_functions
 
 
-def get_user_class_instance(
-    cls: typing.Union[type, modal.cls.Cls], args: typing.Tuple, kwargs: Dict[str, Any]
-) -> typing.Any:
+def get_user_class_instance(cls: typing.Union[type, modal.cls.Cls], args: tuple, kwargs: dict[str, Any]) -> typing.Any:
     """Returns instance of the underlying class to be used as the `self`
 
     The input `cls` can either be the raw Python class the user has declared ("user class"),
@@ -236,7 +234,7 @@ def import_single_function_service(
     """
     user_defined_callable: Callable
     function: Optional[_Function] = None
-    code_deps: Optional[List["modal.object._Object"]] = None
+    code_deps: Optional[list["modal.object._Object"]] = None
     active_app: Optional[modal.app._App] = None
 
     if ser_fun is not None:
@@ -311,7 +309,7 @@ def import_class_service(
     See import_function.
     """
     active_app: Optional["modal.app._App"]
-    code_deps: Optional[List["modal.object._Object"]]
+    code_deps: Optional[list["modal.object._Object"]]
     cls: typing.Union[type, modal.cls.Cls]
 
     if function_def.definition_type == api_pb2.Function.DEFINITION_TYPE_SERIALIZED:

--- a/modal/_serialization.py
+++ b/modal/_serialization.py
@@ -398,10 +398,8 @@ PARAM_TYPE_MAPPING = {
 }
 
 
-def serialize_proto_params(
-    python_params: typing.Dict[str, Any], schema: typing.Sequence[api_pb2.ClassParameterSpec]
-) -> bytes:
-    proto_params: typing.List[api_pb2.ClassParameterValue] = []
+def serialize_proto_params(python_params: dict[str, Any], schema: typing.Sequence[api_pb2.ClassParameterSpec]) -> bytes:
+    proto_params: list[api_pb2.ClassParameterValue] = []
     for schema_param in schema:
         type_info = PARAM_TYPE_MAPPING.get(schema_param.type)
         if not type_info:
@@ -426,9 +424,7 @@ def serialize_proto_params(
     return proto_bytes
 
 
-def deserialize_proto_params(
-    serialized_params: bytes, schema: typing.List[api_pb2.ClassParameterSpec]
-) -> typing.Dict[str, Any]:
+def deserialize_proto_params(serialized_params: bytes, schema: list[api_pb2.ClassParameterSpec]) -> dict[str, Any]:
     proto_struct = api_pb2.ClassParameterSet()
     proto_struct.ParseFromString(serialized_params)
     value_by_name = {p.name: p for p in proto_struct.parameters}

--- a/modal/_traceback.py
+++ b/modal/_traceback.py
@@ -8,15 +8,15 @@ import re
 import sys
 import traceback
 from types import TracebackType
-from typing import Any, Dict, Optional, Tuple, Type
+from typing import Any, Optional
 
 from ._vendor.tblib import Traceback as TBLibTraceback
 
-TBDictType = Dict[str, Any]
-LineCacheType = Dict[Tuple[str, str], str]
+TBDictType = dict[str, Any]
+LineCacheType = dict[tuple[str, str], str]
 
 
-def extract_traceback(exc: BaseException, task_id: str) -> Tuple[TBDictType, LineCacheType]:
+def extract_traceback(exc: BaseException, task_id: str) -> tuple[TBDictType, LineCacheType]:
     """Given an exception, extract a serializable traceback (with task ID markers included),
     and a line cache that maps (filename, lineno) to line contents. The latter is used to show
     a helpful traceback to the user, even if they don't have packages installed locally that
@@ -103,7 +103,7 @@ def traceback_contains_remote_call(tb: Optional[TracebackType]) -> bool:
     return False
 
 
-def print_exception(exc: Optional[Type[BaseException]], value: Optional[BaseException], tb: Optional[TracebackType]):
+def print_exception(exc: Optional[type[BaseException]], value: Optional[BaseException], tb: Optional[TracebackType]):
     """Add backwards compatibility for printing exceptions with "notes" for Python<3.11."""
     traceback.print_exception(exc, value, tb)
     if sys.version_info < (3, 11) and value is not None:

--- a/modal/_tunnel.py
+++ b/modal/_tunnel.py
@@ -1,8 +1,9 @@
 # Copyright Modal Labs 2023
 """Client for Modal relay servers, allowing users to expose TLS."""
 
+from collections.abc import AsyncIterator
 from dataclasses import dataclass
-from typing import AsyncIterator, Optional, Tuple
+from typing import Optional
 
 from grpclib import GRPCError, Status
 from synchronicity.async_wrap import asynccontextmanager
@@ -35,12 +36,12 @@ class Tunnel:
         return value
 
     @property
-    def tls_socket(self) -> Tuple[str, int]:
+    def tls_socket(self) -> tuple[str, int]:
         """Get the public TLS socket as a (host, port) tuple."""
         return (self.host, self.port)
 
     @property
-    def tcp_socket(self) -> Tuple[str, int]:
+    def tcp_socket(self) -> tuple[str, int]:
         """Get the public TCP socket as a (host, port) tuple."""
         if not self.unencrypted_host:
             raise InvalidError(

--- a/modal/_utils/blob_utils.py
+++ b/modal/_utils/blob_utils.py
@@ -5,9 +5,10 @@ import hashlib
 import io
 import os
 import platform
+from collections.abc import AsyncIterator
 from contextlib import AbstractContextManager, contextmanager
 from pathlib import Path, PurePosixPath
-from typing import Any, AsyncIterator, BinaryIO, Callable, List, Optional, Union
+from typing import Any, BinaryIO, Callable, Optional, Union
 from urllib.parse import urlparse
 
 from aiohttp import BytesIOPayload
@@ -173,7 +174,7 @@ async def perform_multipart_upload(
     *,
     content_length: int,
     max_part_size: int,
-    part_urls: List[str],
+    part_urls: list[str],
     completion_url: str,
     upload_chunk_size: int = DEFAULT_SEGMENT_CHUNK_SIZE,
     progress_report_cb: Optional[Callable] = None,
@@ -184,7 +185,7 @@ async def perform_multipart_upload(
 
     # Give each part its own IO reader object to avoid needing to
     # lock access to the reader's position pointer.
-    data_file_readers: List[BinaryIO]
+    data_file_readers: list[BinaryIO]
     if isinstance(data_file, io.BytesIO):
         view = data_file.getbuffer()  # does not copy data
         data_file_readers = [io.BytesIO(view) for _ in range(len(part_urls))]

--- a/modal/_utils/function_utils.py
+++ b/modal/_utils/function_utils.py
@@ -2,9 +2,10 @@
 import asyncio
 import inspect
 import os
+from collections.abc import AsyncGenerator
 from enum import Enum
 from pathlib import Path, PurePosixPath
-from typing import Any, AsyncGenerator, Callable, Dict, List, Literal, Optional, Tuple, Type
+from typing import Any, Callable, Literal, Optional
 
 from grpclib import GRPCError
 from grpclib.exceptions import StreamTerminatedError
@@ -30,7 +31,7 @@ class FunctionInfoType(Enum):
 
 
 # TODO(elias): Add support for quoted/str annotations
-CLASS_PARAM_TYPE_MAP: Dict[Type, Tuple["api_pb2.ParameterType.ValueType", str]] = {
+CLASS_PARAM_TYPE_MAP: dict[type, tuple["api_pb2.ParameterType.ValueType", str]] = {
     str: (api_pb2.PARAM_TYPE_STRING, "string_default"),
     int: (api_pb2.PARAM_TYPE_INT, "int_default"),
 }
@@ -102,7 +103,7 @@ class FunctionInfo:
 
     raw_f: Optional[Callable[..., Any]]  # if None - this is a "class service function"
     function_name: str
-    user_cls: Optional[Type[Any]]
+    user_cls: Optional[type[Any]]
     definition_type: "modal_proto.api_pb2.Function.DefinitionType.ValueType"
     module_name: Optional[str]
 
@@ -123,7 +124,7 @@ class FunctionInfo:
         f: Optional[Callable[..., Any]],
         serialized=False,
         name_override: Optional[str] = None,
-        user_cls: Optional[Type] = None,
+        user_cls: Optional[type] = None,
     ):
         self.raw_f = f
         self.user_cls = user_cls
@@ -150,7 +151,7 @@ class FunctionInfo:
             # Get the package path
             # Note: __import__ always returns the top-level package.
             self._file = os.path.abspath(module.__file__)
-            package_paths = set([os.path.abspath(p) for p in __import__(module.__package__).__path__])
+            package_paths = {os.path.abspath(p) for p in __import__(module.__package__).__path__}
             # There might be multiple package paths in some weird cases
             base_dirs = [
                 base_dir for base_dir in package_paths if os.path.commonpath((base_dir, self._file)) == base_dir
@@ -213,7 +214,7 @@ class FunctionInfo:
             logger.debug(f"Serializing function for class service function {self.user_cls.__qualname__} as empty")
             return b""
 
-    def get_cls_vars(self) -> Dict[str, Any]:
+    def get_cls_vars(self) -> dict[str, Any]:
         if self.user_cls is not None:
             cls_vars = {
                 attr: getattr(self.user_cls, attr)
@@ -223,7 +224,7 @@ class FunctionInfo:
             return cls_vars
         return {}
 
-    def get_cls_var_attrs(self) -> Dict[str, Any]:
+    def get_cls_var_attrs(self) -> dict[str, Any]:
         import dis
 
         import opcode
@@ -244,7 +245,7 @@ class FunctionInfo:
         f_attrs = {k: cls_vars[k] for k in cls_vars if k in f_attr_ops}
         return f_attrs
 
-    def get_globals(self) -> Dict[str, Any]:
+    def get_globals(self) -> dict[str, Any]:
         from .._vendor.cloudpickle import _extract_code_globals
 
         func = self.raw_f
@@ -265,7 +266,7 @@ class FunctionInfo:
         # annotation parameters trigger strictly typed parameterization
         # which enables web endpoint for parameterized classes
 
-        modal_parameters: List[api_pb2.ClassParameterSpec] = []
+        modal_parameters: list[api_pb2.ClassParameterSpec] = []
         signature = _get_class_constructor_signature(self.user_cls)
         for param in signature.parameters.values():
             has_default = param.default is not param.empty
@@ -281,7 +282,7 @@ class FunctionInfo:
             format=api_pb2.ClassParameterInfo.PARAM_SERIALIZATION_FORMAT_PROTO, schema=modal_parameters
         )
 
-    def get_entrypoint_mount(self) -> List[_Mount]:
+    def get_entrypoint_mount(self) -> list[_Mount]:
         """
         Includes:
         * Implicit mount of the function itself (the module or package that the function is part of)

--- a/modal/_utils/grpc_testing.py
+++ b/modal/_utils/grpc_testing.py
@@ -4,7 +4,8 @@ import inspect
 import logging
 import typing
 from collections import Counter, defaultdict
-from typing import Any, Awaitable, Callable, Dict, List, Tuple
+from collections.abc import Awaitable
+from typing import Any, Callable
 
 import grpclib.server
 from grpclib import GRPCError, Status
@@ -93,7 +94,7 @@ def patch_mock_servicer(cls):
 
 
 class ResponseNotConsumed(Exception):
-    def __init__(self, unconsumed_requests: List[str]):
+    def __init__(self, unconsumed_requests: list[str]):
         self.unconsumed_requests = unconsumed_requests
         request_count = Counter(unconsumed_requests)
         super().__init__(f"Expected but did not receive the following requests: {request_count}")
@@ -101,9 +102,9 @@ class ResponseNotConsumed(Exception):
 
 class InterceptionContext:
     def __init__(self):
-        self.calls: List[Tuple[str, Any]] = []  # List[Tuple[method_name, message]]
-        self.custom_responses: Dict[str, List[Tuple[Callable[[Any], bool], List[Any]]]] = defaultdict(list)
-        self.custom_defaults: Dict[str, Callable[["MockClientServicer", grpclib.server.Stream], Awaitable[None]]] = {}
+        self.calls: list[tuple[str, Any]] = []  # List[Tuple[method_name, message]]
+        self.custom_responses: dict[str, list[tuple[Callable[[Any], bool], list[Any]]]] = defaultdict(list)
+        self.custom_defaults: dict[str, Callable[["MockClientServicer", grpclib.server.Stream], Awaitable[None]]] = {}
 
     def add_response(
         self, method_name: str, first_payload, *, request_filter: Callable[[Any], bool] = lambda req: True
@@ -147,7 +148,7 @@ class InterceptionContext:
 
         raise KeyError(f"No message of that type in call list: {self.calls}")
 
-    def get_requests(self, method_name: str) -> List[Any]:
+    def get_requests(self, method_name: str) -> list[Any]:
         return [msg for _method_name, msg in self.calls if _method_name == method_name]
 
     def _add_recv(self, method_name: str, msg):

--- a/modal/_utils/grpc_utils.py
+++ b/modal/_utils/grpc_utils.py
@@ -7,10 +7,9 @@ import time
 import typing
 import urllib.parse
 import uuid
+from collections.abc import AsyncIterator
 from typing import (
     Any,
-    AsyncIterator,
-    Dict,
     Optional,
     TypeVar,
 )
@@ -72,7 +71,7 @@ RETRYABLE_GRPC_STATUS_CODES = [
 
 def create_channel(
     server_url: str,
-    metadata: Dict[str, str] = {},
+    metadata: dict[str, str] = {},
 ) -> grpclib.client.Channel:
     """Creates a grpclib.Channel.
 

--- a/modal/_utils/hash_utils.py
+++ b/modal/_utils/hash_utils.py
@@ -2,12 +2,12 @@
 import base64
 import dataclasses
 import hashlib
-from typing import BinaryIO, Callable, List, Union
+from typing import BinaryIO, Callable, Union
 
 HASH_CHUNK_SIZE = 4096
 
 
-def _update(hashers: List[Callable[[bytes], None]], data: Union[bytes, BinaryIO]) -> None:
+def _update(hashers: list[Callable[[bytes], None]], data: Union[bytes, BinaryIO]) -> None:
     if isinstance(data, bytes):
         for hasher in hashers:
             hasher(data)

--- a/modal/_utils/mount_utils.py
+++ b/modal/_utils/mount_utils.py
@@ -1,8 +1,9 @@
 # Copyright Modal Labs 2022
 import posixpath
 import typing
+from collections.abc import Mapping, Sequence
 from pathlib import PurePath, PurePosixPath
-from typing import Dict, List, Mapping, Sequence, Tuple, Union
+from typing import Union
 
 from ..cloud_bucket_mount import _CloudBucketMount
 from ..exception import InvalidError
@@ -15,7 +16,7 @@ T = typing.TypeVar("T", bound=Union[_Volume, _NetworkFileSystem, _CloudBucketMou
 def validate_mount_points(
     display_name: str,
     volume_likes: Mapping[Union[str, PurePosixPath], T],
-) -> List[Tuple[str, T]]:
+) -> list[tuple[str, T]]:
     """Mount point path validation for volumes and network file systems."""
 
     if not isinstance(volume_likes, dict):
@@ -57,11 +58,11 @@ def validate_network_file_systems(
 
 def validate_volumes(
     volumes: Mapping[Union[str, PurePosixPath], Union[_Volume, _CloudBucketMount]],
-) -> Sequence[Tuple[str, Union[_Volume, _CloudBucketMount]]]:
+) -> Sequence[tuple[str, Union[_Volume, _CloudBucketMount]]]:
     validated_volumes = validate_mount_points("Volume", volumes)
     # We don't support mounting a modal.Volume in more than one location,
     # but the same CloudBucketMount object can be used in more than one location.
-    volume_to_paths: Dict[_Volume, List[str]] = {}
+    volume_to_paths: dict[_Volume, list[str]] = {}
     for path, volume in validated_volumes:
         if not isinstance(volume, (_Volume, _CloudBucketMount)):
             raise InvalidError(f"Object of type {type(volume)} mounted at '{path}' is not useable as a volume.")

--- a/modal/_utils/package_utils.py
+++ b/modal/_utils/package_utils.py
@@ -4,7 +4,6 @@ import importlib.util
 import typing
 from importlib.metadata import PackageNotFoundError, files
 from pathlib import Path
-from typing import Tuple
 
 from ..exception import ModuleNotMountable
 
@@ -24,7 +23,7 @@ def get_file_formats(module):
 BINARY_FORMATS = ["so", "S", "s", "asm"]  # TODO
 
 
-def get_module_mount_info(module_name: str) -> typing.Sequence[typing.Tuple[bool, Path]]:
+def get_module_mount_info(module_name: str) -> typing.Sequence[tuple[bool, Path]]:
     """Returns a list of tuples [(is_dir, path)] describing how to mount a given module."""
     file_formats = get_file_formats(module_name)
     if set(BINARY_FORMATS) & set(file_formats):
@@ -49,7 +48,7 @@ def get_module_mount_info(module_name: str) -> typing.Sequence[typing.Tuple[bool
     return entries
 
 
-def parse_major_minor_version(version_string: str) -> Tuple[int, int]:
+def parse_major_minor_version(version_string: str) -> tuple[int, int]:
     parts = version_string.split(".")
     if len(parts) < 2:
         raise ValueError("version_string must have at least an 'X.Y' format")

--- a/modal/_utils/pattern_matcher.py
+++ b/modal/_utils/pattern_matcher.py
@@ -12,7 +12,7 @@ then asking it whether file paths match any of its patterns.
 import enum
 import os
 import re
-from typing import List, Optional, TextIO
+from typing import Optional, TextIO
 
 escape_chars = frozenset(".+()|{}$")
 
@@ -32,7 +32,7 @@ class Pattern:
         """Initialize a new Pattern instance."""
         self.match_type = MatchType.UNKNOWN
         self.cleaned_pattern = ""
-        self.dirs: List[str] = []
+        self.dirs: list[str] = []
         self.regexp: Optional[re.Pattern] = None
         self.exclusion = False
 
@@ -151,7 +151,7 @@ class Pattern:
 class PatternMatcher:
     """Allows checking paths against a list of patterns."""
 
-    def __init__(self, patterns: List[str]) -> None:
+    def __init__(self, patterns: list[str]) -> None:
         """Initialize a new PatternMatcher instance.
 
         Args:
@@ -160,7 +160,7 @@ class PatternMatcher:
         Raises:
             ValueError: If an illegal exclusion pattern is provided.
         """
-        self.patterns: List[Pattern] = []
+        self.patterns: list[Pattern] = []
         self.exclusions = False
         for pattern in patterns:
             pattern = pattern.strip()
@@ -217,7 +217,7 @@ class PatternMatcher:
         return matched
 
 
-def read_ignorefile(reader: TextIO) -> List[str]:
+def read_ignorefile(reader: TextIO) -> list[str]:
     """Read an ignore file from a reader and return the list of file patterns to
     ignore, applying the following rules:
 
@@ -241,7 +241,7 @@ def read_ignorefile(reader: TextIO) -> List[str]:
     if reader is None:
         return []
 
-    excludes: List[str] = []
+    excludes: list[str] = []
 
     for line in reader:
         pattern = line.rstrip("\n\r")

--- a/modal/_utils/rand_pb_testing.py
+++ b/modal/_utils/rand_pb_testing.py
@@ -7,13 +7,13 @@ Modal, with random seeds, and it supports oneofs, and Protobuf v4.
 
 import string
 from random import Random
-from typing import Any, Callable, Dict, Optional, Type, TypeVar
+from typing import Any, Callable, Optional, TypeVar
 
 from google.protobuf.descriptor import Descriptor, FieldDescriptor
 
 T = TypeVar("T")
 
-_FIELD_RANDOM_GENERATOR: Dict[int, Callable[[Random], Any]] = {
+_FIELD_RANDOM_GENERATOR: dict[int, Callable[[Random], Any]] = {
     FieldDescriptor.TYPE_DOUBLE: lambda rand: rand.normalvariate(0, 1),
     FieldDescriptor.TYPE_FLOAT: lambda rand: rand.normalvariate(0, 1),
     FieldDescriptor.TYPE_INT32: lambda rand: int.from_bytes(rand.randbytes(4), "little", signed=True),
@@ -71,7 +71,7 @@ def _fill(msg, desc: Descriptor, rand: Random) -> None:
                 setattr(msg, field.name, generator(rand))
 
 
-def rand_pb(proto: Type[T], rand: Optional[Random] = None) -> T:
+def rand_pb(proto: type[T], rand: Optional[Random] = None) -> T:
     """Generate a pseudorandom protobuf message.
 
     ```python notest

--- a/modal/_utils/shell_utils.py
+++ b/modal/_utils/shell_utils.py
@@ -6,7 +6,8 @@ import errno
 import os
 import select
 import sys
-from typing import Callable, Coroutine, Optional
+from collections.abc import Coroutine
+from typing import Callable, Optional
 
 from modal._pty import raw_terminal, set_nonblocking
 

--- a/modal/_vendor/a2wsgi_wsgi.py
+++ b/modal/_vendor/a2wsgi_wsgi.py
@@ -35,10 +35,8 @@ from concurrent.futures import ThreadPoolExecutor
 from types import TracebackType
 from typing import (
     Any,
-    Awaitable,
     Callable,
     Dict,
-    Iterable,
     List,
     Literal,
     Optional,
@@ -48,6 +46,7 @@ from typing import (
     TypedDict,
     Union,
 )
+from collections.abc import Awaitable, Iterable
 
 
 ## BEGIN a2wsgi/asgi_typing.py
@@ -73,11 +72,11 @@ class HTTPScope(TypedDict):
     raw_path: NotRequired[bytes]
     query_string: bytes
     root_path: str
-    headers: Iterable[Tuple[bytes, bytes]]
-    client: NotRequired[Tuple[str, int]]
-    server: NotRequired[Tuple[str, Optional[int]]]
-    state: NotRequired[Dict[str, Any]]
-    extensions: NotRequired[Dict[str, Dict[object, object]]]
+    headers: Iterable[tuple[bytes, bytes]]
+    client: NotRequired[tuple[str, int]]
+    server: NotRequired[tuple[str, Optional[int]]]
+    state: NotRequired[dict[str, Any]]
+    extensions: NotRequired[dict[str, dict[object, object]]]
 
 
 class WebSocketScope(TypedDict):
@@ -89,18 +88,18 @@ class WebSocketScope(TypedDict):
     raw_path: bytes
     query_string: bytes
     root_path: str
-    headers: Iterable[Tuple[bytes, bytes]]
-    client: NotRequired[Tuple[str, int]]
-    server: NotRequired[Tuple[str, Optional[int]]]
+    headers: Iterable[tuple[bytes, bytes]]
+    client: NotRequired[tuple[str, int]]
+    server: NotRequired[tuple[str, Optional[int]]]
     subprotocols: Iterable[str]
-    state: NotRequired[Dict[str, Any]]
-    extensions: NotRequired[Dict[str, Dict[object, object]]]
+    state: NotRequired[dict[str, Any]]
+    extensions: NotRequired[dict[str, dict[object, object]]]
 
 
 class LifespanScope(TypedDict):
     type: Literal["lifespan"]
     asgi: ASGIVersions
-    state: NotRequired[Dict[str, Any]]
+    state: NotRequired[dict[str, Any]]
 
 
 WWWScope = Union[HTTPScope, WebSocketScope]
@@ -116,7 +115,7 @@ class HTTPRequestEvent(TypedDict):
 class HTTPResponseStartEvent(TypedDict):
     type: Literal["http.response.start"]
     status: int
-    headers: NotRequired[Iterable[Tuple[bytes, bytes]]]
+    headers: NotRequired[Iterable[tuple[bytes, bytes]]]
     trailers: NotRequired[bool]
 
 
@@ -137,7 +136,7 @@ class WebSocketConnectEvent(TypedDict):
 class WebSocketAcceptEvent(TypedDict):
     type: Literal["websocket.accept"]
     subprotocol: NotRequired[str]
-    headers: NotRequired[Iterable[Tuple[bytes, bytes]]]
+    headers: NotRequired[Iterable[tuple[bytes, bytes]]]
 
 
 class WebSocketReceiveEvent(TypedDict):
@@ -223,56 +222,47 @@ ASGIApp = Callable[[Scope, Receive, Send], Awaitable[None]]
 
 ## BEGIN a2wsgi/wsgi_typing.py
 
-CGIRequiredDefined = TypedDict(
-    "CGIRequiredDefined",
-    {
-        # The HTTP request method, such as GET or POST. This cannot ever be an
-        # empty string, and so is always required.
-        "REQUEST_METHOD": str,
-        # When HTTP_HOST is not set, these variables can be combined to determine
-        # a default.
-        # SERVER_NAME and SERVER_PORT are required strings and must never be empty.
-        "SERVER_NAME": str,
-        "SERVER_PORT": str,
-        # The version of the protocol the client used to send the request.
-        # Typically this will be something like "HTTP/1.0" or "HTTP/1.1" and
-        # may be used by the application to determine how to treat any HTTP
-        # request headers. (This variable should probably be called REQUEST_PROTOCOL,
-        # since it denotes the protocol used in the request, and is not necessarily
-        # the protocol that will be used in the server's response. However, for
-        # compatibility with CGI we have to keep the existing name.)
-        "SERVER_PROTOCOL": str,
-    },
-)
+class CGIRequiredDefined(TypedDict):
+    # The HTTP request method, such as GET or POST. This cannot ever be an
+    # empty string, and so is always required.
+    REQUEST_METHOD: str
+    # When HTTP_HOST is not set, these variables can be combined to determine
+    # a default.
+    # SERVER_NAME and SERVER_PORT are required strings and must never be empty.
+    SERVER_NAME: str
+    SERVER_PORT: str
+    # The version of the protocol the client used to send the request.
+    # Typically this will be something like "HTTP/1.0" or "HTTP/1.1" and
+    # may be used by the application to determine how to treat any HTTP
+    # request headers. (This variable should probably be called REQUEST_PROTOCOL,
+    # since it denotes the protocol used in the request, and is not necessarily
+    # the protocol that will be used in the server's response. However, for
+    # compatibility with CGI we have to keep the existing name.)
+    SERVER_PROTOCOL: str
 
-CGIOptionalDefined = TypedDict(
-    "CGIOptionalDefined",
-    {
-        "REQUEST_URI": str,
-        "REMOTE_ADDR": str,
-        "REMOTE_PORT": str,
-        # The initial portion of the request URL’s “path” that corresponds to the
-        # application object, so that the application knows its virtual “location”.
-        # This may be an empty string, if the application corresponds to the “root”
-        # of the server.
-        "SCRIPT_NAME": str,
-        # The remainder of the request URL’s “path”, designating the virtual
-        # “location” of the request’s target within the application. This may be an
-        # empty string, if the request URL targets the application root and does
-        # not have a trailing slash.
-        "PATH_INFO": str,
-        # The portion of the request URL that follows the “?”, if any. May be empty
-        # or absent.
-        "QUERY_STRING": str,
-        # The contents of any Content-Type fields in the HTTP request. May be empty
-        # or absent.
-        "CONTENT_TYPE": str,
-        # The contents of any Content-Length fields in the HTTP request. May be empty
-        # or absent.
-        "CONTENT_LENGTH": str,
-    },
-    total=False,
-)
+class CGIOptionalDefined(TypedDict, total=False):
+    REQUEST_URI: str
+    REMOTE_ADDR: str
+    REMOTE_PORT: str
+    # The initial portion of the request URL’s “path” that corresponds to the
+    # application object, so that the application knows its virtual “location”.
+    # This may be an empty string, if the application corresponds to the “root”
+    # of the server.
+    SCRIPT_NAME: str
+    # The remainder of the request URL’s “path”, designating the virtual
+    # “location” of the request’s target within the application. This may be an
+    # empty string, if the request URL targets the application root and does
+    # not have a trailing slash.
+    PATH_INFO: str
+    # The portion of the request URL that follows the “?”, if any. May be empty
+    # or absent.
+    QUERY_STRING: str
+    # The contents of any Content-Type fields in the HTTP request. May be empty
+    # or absent.
+    CONTENT_TYPE: str
+    # The contents of any Content-Length fields in the HTTP request. May be empty
+    # or absent.
+    CONTENT_LENGTH: str
 
 
 class InputStream(Protocol):
@@ -308,7 +298,7 @@ class InputStream(Protocol):
         """
         raise NotImplementedError
 
-    def readlines(self, hint: int = -1, /) -> List[bytes]:
+    def readlines(self, hint: int = -1, /) -> list[bytes]:
         """
         Note that the hint argument to readlines() is optional for both caller and
         implementer. The application is free not to supply it, and the server or gateway
@@ -349,14 +339,14 @@ class ErrorStream(Protocol):
     def write(self, s: str, /) -> Any:
         raise NotImplementedError
 
-    def writelines(self, seq: List[str], /) -> Any:
+    def writelines(self, seq: list[str], /) -> Any:
         raise NotImplementedError
 
 
 WSGIDefined = TypedDict(
     "WSGIDefined",
     {
-        "wsgi.version": Tuple[int, int],  # e.g. (1, 0)
+        "wsgi.version": tuple[int, int],  # e.g. (1, 0)
         "wsgi.url_scheme": str,  # e.g. "http" or "https"
         "wsgi.input": InputStream,
         "wsgi.errors": ErrorStream,
@@ -381,7 +371,7 @@ class Environ(CGIRequiredDefined, CGIOptionalDefined, WSGIDefined):
     """
 
 
-ExceptionInfo = Tuple[Type[BaseException], BaseException, Optional[TracebackType]]
+ExceptionInfo = tuple[type[BaseException], BaseException, Optional[TracebackType]]
 
 # https://peps.python.org/pep-3333/#the-write-callable
 WriteCallable = Callable[[bytes], None]
@@ -391,7 +381,7 @@ class StartResponse(Protocol):
     def __call__(
         self,
         status: str,
-        response_headers: List[Tuple[str, str]],
+        response_headers: list[tuple[str, str]],
         exc_info: Optional[ExceptionInfo] = None,
         /,
     ) -> WriteCallable:
@@ -460,7 +450,7 @@ class Body:
         self.buffer.clear()
         return result
 
-    def readlines(self, hint: int = -1) -> typing.List[bytes]:
+    def readlines(self, hint: int = -1) -> list[bytes]:
         if not self.has_more:
             return []
         if hint == -1:
@@ -626,7 +616,7 @@ class WSGIResponder:
     def start_response(
         self,
         status: str,
-        response_headers: typing.List[typing.Tuple[str, str]],
+        response_headers: list[tuple[str, str]],
         exc_info: typing.Optional[ExceptionInfo] = None,
     ) -> WriteCallable:
         self.exc_info = exc_info

--- a/modal/_vendor/cloudpickle.py
+++ b/modal/_vendor/cloudpickle.py
@@ -256,7 +256,7 @@ def _should_pickle_by_reference(obj, name=None):
             return False
         return obj.__name__ in sys.modules
     else:
-        raise TypeError("cannot check importability of {} instances".format(type(obj).__name__))
+        raise TypeError(f"cannot check importability of {type(obj).__name__} instances")
 
 
 def _lookup_module_and_qualname(obj, name=None):

--- a/modal/_watcher.py
+++ b/modal/_watcher.py
@@ -1,7 +1,8 @@
 # Copyright Modal Labs 2022
 from collections import defaultdict
+from collections.abc import AsyncGenerator
 from pathlib import Path
-from typing import AsyncGenerator, Dict, List, Optional, Set, Tuple
+from typing import Optional
 
 from rich.tree import Tree
 from watchfiles import Change, DefaultFilter, awatch
@@ -21,7 +22,7 @@ class AppFilesFilter(DefaultFilter):
         # Watching specific files is discouraged on Linux, so to watch a file we watch its
         # containing directory and then filter that directory's changes for relevant files.
         # https://github.com/notify-rs/notify/issues/394
-        dir_filters: Dict[Path, Optional[Set[Path]]],
+        dir_filters: dict[Path, Optional[set[Path]]],
     ) -> None:
         self.dir_filters = dir_filters
         super().__init__()
@@ -54,7 +55,7 @@ class AppFilesFilter(DefaultFilter):
         return super().__call__(change, path)
 
 
-async def _watch_paths(paths: Set[Path], watch_filter: AppFilesFilter) -> AsyncGenerator[Set[str], None]:
+async def _watch_paths(paths: set[Path], watch_filter: AppFilesFilter) -> AsyncGenerator[set[str], None]:
     try:
         async for changes in awatch(*paths, step=500, watch_filter=watch_filter):
             changed_paths = {stringpath for _, stringpath in changes}
@@ -64,7 +65,7 @@ async def _watch_paths(paths: Set[Path], watch_filter: AppFilesFilter) -> AsyncG
         pass
 
 
-def _print_watched_paths(paths: Set[Path]):
+def _print_watched_paths(paths: set[Path]):
     msg = "️️⚡️ Serving... hit Ctrl-C to stop!"
 
     output_tree = Tree(msg, guide_style="gray50")
@@ -76,9 +77,9 @@ def _print_watched_paths(paths: Set[Path]):
         output_mgr.print(output_tree)
 
 
-def _watch_args_from_mounts(mounts: List[_Mount]) -> Tuple[Set[Path], AppFilesFilter]:
+def _watch_args_from_mounts(mounts: list[_Mount]) -> tuple[set[Path], AppFilesFilter]:
     paths = set()
-    dir_filters: Dict[Path, Optional[Set[Path]]] = defaultdict(set)
+    dir_filters: dict[Path, Optional[set[Path]]] = defaultdict(set)
     for mount in mounts:
         # TODO(elias): Make this part of the mount class instead, since it uses so much internals
         for entry in mount._entries:
@@ -94,7 +95,7 @@ def _watch_args_from_mounts(mounts: List[_Mount]) -> Tuple[Set[Path], AppFilesFi
     return paths, watch_filter
 
 
-async def watch(mounts: List[_Mount]) -> AsyncGenerator[Set[str], None]:
+async def watch(mounts: list[_Mount]) -> AsyncGenerator[set[str], None]:
     paths, watch_filter = _watch_args_from_mounts(mounts)
 
     _print_watched_paths(paths)

--- a/modal/app.py
+++ b/modal/app.py
@@ -2,19 +2,14 @@
 import inspect
 import typing
 import warnings
+from collections.abc import AsyncGenerator, Coroutine, Sequence
 from pathlib import PurePosixPath
 from textwrap import dedent
 from typing import (
     Any,
-    AsyncGenerator,
     Callable,
     ClassVar,
-    Coroutine,
-    Dict,
-    List,
     Optional,
-    Sequence,
-    Tuple,
     Union,
     overload,
 )
@@ -87,14 +82,14 @@ class _LocalEntrypoint:
 LocalEntrypoint = synchronize_api(_LocalEntrypoint)
 
 
-def check_sequence(items: typing.Sequence[typing.Any], item_type: typing.Type[typing.Any], error_msg: str) -> None:
+def check_sequence(items: typing.Sequence[typing.Any], item_type: type[typing.Any], error_msg: str) -> None:
     if not isinstance(items, (list, tuple)):
         raise InvalidError(error_msg)
     if not all(isinstance(v, item_type) for v in items):
         raise InvalidError(error_msg)
 
 
-CLS_T = typing.TypeVar("CLS_T", bound=typing.Type[Any])
+CLS_T = typing.TypeVar("CLS_T", bound=type[Any])
 
 
 P = typing_extensions.ParamSpec("P")
@@ -172,20 +167,20 @@ class _App:
     In this example, the secret and schedule are registered with the app.
     """
 
-    _all_apps: ClassVar[Dict[Optional[str], List["_App"]]] = {}
+    _all_apps: ClassVar[dict[Optional[str], list["_App"]]] = {}
     _container_app: ClassVar[Optional[RunningApp]] = None
 
     _name: Optional[str]
     _description: Optional[str]
-    _functions: Dict[str, _Function]
-    _classes: Dict[str, _Cls]
+    _functions: dict[str, _Function]
+    _classes: dict[str, _Cls]
 
     _image: Optional[_Image]
     _mounts: Sequence[_Mount]
     _secrets: Sequence[_Secret]
-    _volumes: Dict[Union[str, PurePosixPath], _Volume]
-    _web_endpoints: List[str]  # Used by the CLI
-    _local_entrypoints: Dict[str, _LocalEntrypoint]
+    _volumes: dict[Union[str, PurePosixPath], _Volume]
+    _web_endpoints: list[str]  # Used by the CLI
+    _local_entrypoints: dict[str, _LocalEntrypoint]
 
     # Running apps only (container apps or running local)
     _app_id: Optional[str]  # Kept after app finishes
@@ -199,7 +194,7 @@ class _App:
         image: Optional[_Image] = None,  # default image for all functions (default is `modal.Image.debian_slim()`)
         mounts: Sequence[_Mount] = [],  # default mounts for all functions
         secrets: Sequence[_Secret] = [],  # default secrets for all functions
-        volumes: Dict[Union[str, PurePosixPath], _Volume] = {},  # default volumes for all functions
+        volumes: dict[Union[str, PurePosixPath], _Volume] = {},  # default volumes for all functions
     ) -> None:
         """Construct a new app, optionally with default image, mounts, secrets, or volumes.
 
@@ -509,22 +504,22 @@ class _App:
         hydrate_objects(self._classes)
 
     @property
-    def registered_functions(self) -> Dict[str, _Function]:
+    def registered_functions(self) -> dict[str, _Function]:
         """All modal.Function objects registered on the app."""
         return self._functions
 
     @property
-    def registered_classes(self) -> Dict[str, _Function]:
+    def registered_classes(self) -> dict[str, _Function]:
         """All modal.Cls objects registered on the app."""
         return self._classes
 
     @property
-    def registered_entrypoints(self) -> Dict[str, _LocalEntrypoint]:
+    def registered_entrypoints(self) -> dict[str, _LocalEntrypoint]:
         """All local CLI entrypoints registered on the app."""
         return self._local_entrypoints
 
     @property
-    def indexed_objects(self) -> Dict[str, _Object]:
+    def indexed_objects(self) -> dict[str, _Object]:
         deprecation_warning(
             (2024, 11, 25),
             "`app.indexed_objects` is deprecated! Use `app.registered_functions` or `app.registered_classes` instead.",
@@ -532,7 +527,7 @@ class _App:
         return dict(**self._functions, **self._classes)
 
     @property
-    def registered_web_endpoints(self) -> List[str]:
+    def registered_web_endpoints(self) -> list[str]:
         """Names of web endpoint (ie. webhook) functions registered on the app."""
         return self._web_endpoints
 
@@ -611,24 +606,24 @@ class _App:
         schedule: Optional[Schedule] = None,  # An optional Modal Schedule for the function
         secrets: Sequence[_Secret] = (),  # Optional Modal Secret objects with environment variables for the container
         gpu: Union[
-            GPU_T, List[GPU_T]
+            GPU_T, list[GPU_T]
         ] = None,  # GPU request as string ("any", "T4", ...), object (`modal.GPU.A100()`, ...), or a list of either
         serialized: bool = False,  # Whether to send the function over using cloudpickle.
         mounts: Sequence[_Mount] = (),  # Modal Mounts added to the container
-        network_file_systems: Dict[
+        network_file_systems: dict[
             Union[str, PurePosixPath], _NetworkFileSystem
         ] = {},  # Mountpoints for Modal NetworkFileSystems
-        volumes: Dict[
+        volumes: dict[
             Union[str, PurePosixPath], Union[_Volume, _CloudBucketMount]
         ] = {},  # Mount points for Modal Volumes & CloudBucketMounts
         allow_cross_region_volumes: bool = False,  # Whether using network file systems from other regions is allowed.
         # Specify, in fractional CPU cores, how many CPU cores to request.
         # Or, pass (request, limit) to additionally specify a hard limit in fractional CPU cores.
         # CPU throttling will prevent a container from exceeding its specified limit.
-        cpu: Optional[Union[float, Tuple[float, float]]] = None,
+        cpu: Optional[Union[float, tuple[float, float]]] = None,
         # Specify, in MiB, a memory request which is the minimum memory required.
         # Or, pass (request, limit) to additionally specify a hard limit in MiB.
-        memory: Optional[Union[int, Tuple[int, int]]] = None,
+        memory: Optional[Union[int, tuple[int, int]]] = None,
         ephemeral_disk: Optional[int] = None,  # Specify, in MiB, the ephemeral disk size for the Function.
         proxy: Optional[_Proxy] = None,  # Reference to a Modal Proxy to use in front of this function.
         retries: Optional[Union[int, Retries]] = None,  # Number of times to retry each input in case of failure.
@@ -817,24 +812,24 @@ class _App:
         image: Optional[_Image] = None,  # The image to run as the container for the function
         secrets: Sequence[_Secret] = (),  # Optional Modal Secret objects with environment variables for the container
         gpu: Union[
-            GPU_T, List[GPU_T]
+            GPU_T, list[GPU_T]
         ] = None,  # GPU request as string ("any", "T4", ...), object (`modal.GPU.A100()`, ...), or a list of either
         serialized: bool = False,  # Whether to send the function over using cloudpickle.
         mounts: Sequence[_Mount] = (),
-        network_file_systems: Dict[
+        network_file_systems: dict[
             Union[str, PurePosixPath], _NetworkFileSystem
         ] = {},  # Mountpoints for Modal NetworkFileSystems
-        volumes: Dict[
+        volumes: dict[
             Union[str, PurePosixPath], Union[_Volume, _CloudBucketMount]
         ] = {},  # Mount points for Modal Volumes & CloudBucketMounts
         allow_cross_region_volumes: bool = False,  # Whether using network file systems from other regions is allowed.
         # Specify, in fractional CPU cores, how many CPU cores to request.
         # Or, pass (request, limit) to additionally specify a hard limit in fractional CPU cores.
         # CPU throttling will prevent a container from exceeding its specified limit.
-        cpu: Optional[Union[float, Tuple[float, float]]] = None,
+        cpu: Optional[Union[float, tuple[float, float]]] = None,
         # Specify, in MiB, a memory request which is the minimum memory required.
         # Or, pass (request, limit) to additionally specify a hard limit in MiB.
-        memory: Optional[Union[int, Tuple[int, int]]] = None,
+        memory: Optional[Union[int, tuple[int, int]]] = None,
         ephemeral_disk: Optional[int] = None,  # Specify, in MiB, the ephemeral disk size for the Function.
         proxy: Optional[_Proxy] = None,  # Reference to a Modal Proxy to use in front of this function.
         retries: Optional[Union[int, Retries]] = None,  # Number of times to retry each input in case of failure.
@@ -948,7 +943,7 @@ class _App:
         image: Optional[_Image] = None,  # The image to run as the container for the sandbox.
         mounts: Sequence[_Mount] = (),  # Mounts to attach to the sandbox.
         secrets: Sequence[_Secret] = (),  # Environment variables to inject into the sandbox.
-        network_file_systems: Dict[Union[str, PurePosixPath], _NetworkFileSystem] = {},
+        network_file_systems: dict[Union[str, PurePosixPath], _NetworkFileSystem] = {},
         timeout: Optional[int] = None,  # Maximum execution time of the sandbox in seconds.
         workdir: Optional[str] = None,  # Working directory of the sandbox.
         gpu: GPU_T = None,
@@ -957,12 +952,12 @@ class _App:
         # Specify, in fractional CPU cores, how many CPU cores to request.
         # Or, pass (request, limit) to additionally specify a hard limit in fractional CPU cores.
         # CPU throttling will prevent a container from exceeding its specified limit.
-        cpu: Optional[Union[float, Tuple[float, float]]] = None,
+        cpu: Optional[Union[float, tuple[float, float]]] = None,
         # Specify, in MiB, a memory request which is the minimum memory required.
         # Or, pass (request, limit) to additionally specify a hard limit in MiB.
-        memory: Optional[Union[int, Tuple[int, int]]] = None,
+        memory: Optional[Union[int, tuple[int, int]]] = None,
         block_network: bool = False,  # Whether to block network access
-        volumes: Dict[
+        volumes: dict[
             Union[str, PurePosixPath], Union[_Volume, _CloudBucketMount]
         ] = {},  # Mount points for Modal Volumes and CloudBucketMounts
         pty_info: Optional[api_pb2.PTYInfo] = None,

--- a/modal/call_graph.py
+++ b/modal/call_graph.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Dict, List, Optional
+from typing import Optional
 
 from modal_proto import api_pb2
 
@@ -31,12 +31,12 @@ class InputInfo:
     status: InputStatus
     function_name: str
     module_name: str
-    children: List["InputInfo"]
+    children: list["InputInfo"]
 
 
-def _reconstruct_call_graph(ser_graph: api_pb2.FunctionGetCallGraphResponse) -> List[InputInfo]:
-    function_calls_by_id: Dict[str, api_pb2.FunctionCallCallGraphInfo] = {}
-    inputs_by_id: Dict[str, api_pb2.InputCallGraphInfo] = {}
+def _reconstruct_call_graph(ser_graph: api_pb2.FunctionGetCallGraphResponse) -> list[InputInfo]:
+    function_calls_by_id: dict[str, api_pb2.FunctionCallCallGraphInfo] = {}
+    inputs_by_id: dict[str, api_pb2.InputCallGraphInfo] = {}
 
     for function_call in ser_graph.function_calls:
         function_calls_by_id[function_call.function_call_id] = function_call
@@ -44,7 +44,7 @@ def _reconstruct_call_graph(ser_graph: api_pb2.FunctionGetCallGraphResponse) -> 
     for input in ser_graph.inputs:
         inputs_by_id[input.input_id] = input
 
-    input_info_by_id: Dict[str, InputInfo] = {}
+    input_info_by_id: dict[str, InputInfo] = {}
     result = []
 
     def _reconstruct(input_id: str) -> Optional[InputInfo]:

--- a/modal/cli/_download.py
+++ b/modal/cli/_download.py
@@ -3,8 +3,9 @@ import asyncio
 import os
 import shutil
 import sys
+from collections.abc import AsyncIterator
 from pathlib import Path, PurePosixPath
-from typing import AsyncIterator, Callable, Optional, Tuple, Union
+from typing import Callable, Optional, Union
 
 from click import UsageError
 
@@ -25,7 +26,7 @@ async def _volume_download(
 ):
     is_pipe = local_destination == PIPE_PATH
 
-    q: asyncio.Queue[Tuple[Optional[Path], Optional[FileEntry]]] = asyncio.Queue()
+    q: asyncio.Queue[tuple[Optional[Path], Optional[FileEntry]]] = asyncio.Queue()
     num_consumers = 1 if is_pipe else 10  # concurrency limit for downloading files
 
     async def producer():

--- a/modal/cli/_traceback.py
+++ b/modal/cli/_traceback.py
@@ -2,7 +2,7 @@
 """Helper functions related to displaying tracebacks in the CLI."""
 import functools
 import warnings
-from typing import Dict, Optional
+from typing import Optional
 
 from rich.console import Console, RenderResult, group
 from rich.panel import Panel
@@ -20,14 +20,14 @@ def _render_stack(self, stack: Stack) -> RenderResult:
 
     path_highlighter = PathHighlighter()
     theme = self.theme
-    code_cache: Dict[str, str] = {}
+    code_cache: dict[str, str] = {}
     line_cache = getattr(stack, "line_cache", {})
     task_id = None
 
     def read_code(filename: str) -> str:
         code = code_cache.get(filename)
         if code is None:
-            with open(filename, "rt", encoding="utf-8", errors="replace") as code_file:
+            with open(filename, encoding="utf-8", errors="replace") as code_file:
                 code = code_file.read()
             code_cache[filename] = code
         return code
@@ -169,7 +169,7 @@ def highlight_modal_deprecation_warnings() -> None:
             date = content[:10]
             message = content[11:].strip()
             try:
-                with open(filename, "rt", encoding="utf-8", errors="replace") as code_file:
+                with open(filename, encoding="utf-8", errors="replace") as code_file:
                     source = code_file.readlines()[lineno - 1].strip()
                 message = f"{message}\n\nSource: {filename}:{lineno}\n  {source}"
             except OSError:

--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -1,6 +1,6 @@
 # Copyright Modal Labs 2022
 import re
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import rich
 import typer
@@ -65,7 +65,7 @@ async def list(env: Optional[str] = ENV_OPTION, json: bool = False):
         api_pb2.AppListRequest(environment_name=_get_environment_name(env))
     )
 
-    columns: List[Union[Column, str]] = [
+    columns: list[Union[Column, str]] = [
         Column("App ID", min_width=25),  # Ensure that App ID is not truncated in slim terminals
         "Description",
         "State",
@@ -73,7 +73,7 @@ async def list(env: Optional[str] = ENV_OPTION, json: bool = False):
         "Created at",
         "Stopped at",
     ]
-    rows: List[List[Union[Text, str]]] = []
+    rows: list[list[Union[Text, str]]] = []
     for app_stats in resp.apps:
         state = APP_STATE_TO_MESSAGE.get(app_stats.state, Text("unknown", style="gray"))
         rows.append(

--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -56,7 +56,7 @@ def warn_on_name_option(command: str, app_identifier: str, name: str) -> str:
 
 @app_cli.command("list")
 @synchronizer.create_blocking
-async def list(env: Optional[str] = ENV_OPTION, json: bool = False):
+async def list_(env: Optional[str] = ENV_OPTION, json: bool = False):
     """List Modal apps that are currently deployed/running or recently stopped."""
     env = ensure_env(env)
     client = await _Client.from_env()

--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -1,6 +1,6 @@
 # Copyright Modal Labs 2022
 
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import typer
 from rich.text import Text
@@ -31,7 +31,7 @@ async def list(env: Optional[str] = ENV_OPTION, json: bool = False):
     )
 
     column_names = ["Container ID", "App ID", "App Name", "Start Time"]
-    rows: List[List[Union[Text, str]]] = []
+    rows: list[list[Union[Text, str]]] = []
     res.tasks.sort(key=lambda task: task.started_at, reverse=True)
     for task_stats in res.tasks:
         rows.append(
@@ -56,7 +56,7 @@ def logs(container_id: str = typer.Argument(help="Container ID")):
 @synchronizer.create_blocking
 async def exec(
     container_id: str = typer.Argument(help="Container ID"),
-    command: List[str] = typer.Argument(help="A command to run inside the container."),
+    command: list[str] = typer.Argument(help="A command to run inside the container."),
     pty: bool = typer.Option(default=True, help="Run the command using a PTY."),
 ):
     """Execute a command in a container."""

--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -21,7 +21,7 @@ container_cli = typer.Typer(name="container", help="Manage and connect to runnin
 
 @container_cli.command("list")
 @synchronizer.create_blocking
-async def list(env: Optional[str] = ENV_OPTION, json: bool = False):
+async def list_(env: Optional[str] = ENV_OPTION, json: bool = False):
     """List all containers that are currently running."""
     env = ensure_env(env)
     client = await _Client.from_env()

--- a/modal/cli/dict.py
+++ b/modal/cli/dict.py
@@ -36,7 +36,7 @@ async def create(name: str, *, env: Optional[str] = ENV_OPTION):
 
 @dict_cli.command(name="list", rich_help_panel="Management")
 @synchronizer.create_blocking
-async def list(*, json: bool = False, env: Optional[str] = ENV_OPTION):
+async def list_(*, json: bool = False, env: Optional[str] = ENV_OPTION):
     """List all named Dicts."""
     env = ensure_env(env)
     client = await _Client.from_env()

--- a/modal/cli/environment.py
+++ b/modal/cli/environment.py
@@ -1,11 +1,10 @@
 # Copyright Modal Labs 2023
-from typing import Optional, Union
+from typing import Annotated, Optional, Union
 
 import typer
 from click import UsageError
 from grpclib import GRPCError, Status
 from rich.text import Text
-from typing_extensions import Annotated
 
 from modal import environments
 from modal._utils.name_utils import check_environment_name

--- a/modal/cli/environment.py
+++ b/modal/cli/environment.py
@@ -36,7 +36,7 @@ class RenderableBool(Text):
 
 
 @environment_cli.command(name="list", help="List all environments in the current workspace")
-def list(json: Optional[bool] = False):
+def list_(json: Optional[bool] = False):
     envs = environments.list_environments()
 
     # determine which environment is currently active, prioritizing the local default

--- a/modal/cli/launch.py
+++ b/modal/cli/launch.py
@@ -4,7 +4,7 @@ import inspect
 import json
 import os
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from typer import Typer
 
@@ -25,7 +25,7 @@ launch_cli = Typer(
 )
 
 
-def _launch_program(name: str, filename: str, detach: bool, args: Dict[str, Any]) -> None:
+def _launch_program(name: str, filename: str, detach: bool, args: dict[str, Any]) -> None:
     os.environ["MODAL_LAUNCH_ARGS"] = json.dumps(args)
 
     program_path = str(Path(__file__).parent / "programs" / filename)

--- a/modal/cli/network_file_system.py
+++ b/modal/cli/network_file_system.py
@@ -29,7 +29,7 @@ nfs_cli = Typer(name="nfs", help="Read and edit `modal.NetworkFileSystem` file s
 
 @nfs_cli.command(name="list", help="List the names of all network file systems.", rich_help_panel="Management")
 @synchronizer.create_blocking
-async def list(env: Optional[str] = ENV_OPTION, json: Optional[bool] = False):
+async def list_(env: Optional[str] = ENV_OPTION, json: Optional[bool] = False):
     env = ensure_env(env)
 
     client = await _Client.from_env()

--- a/modal/cli/profile.py
+++ b/modal/cli/profile.py
@@ -28,7 +28,7 @@ def current():
 
 @profile_cli.command(name="list", help="Show all Modal profiles and highlight the active one.")
 @synchronizer.create_blocking
-async def list(json: Optional[bool] = False):
+async def list_(json: Optional[bool] = False):
     config = Config()
     profiles = config_profiles()
     lookup_coros = [

--- a/modal/cli/programs/run_jupyter.py
+++ b/modal/cli/programs/run_jupyter.py
@@ -8,12 +8,12 @@ import subprocess
 import threading
 import time
 import webbrowser
-from typing import Any, Dict
+from typing import Any
 
 from modal import App, Image, Mount, Queue, Secret, Volume, forward
 
 # Passed by `modal launch` locally via CLI, plumbed to remote runner through secrets.
-args: Dict[str, Any] = json.loads(os.environ.get("MODAL_LAUNCH_ARGS", "{}"))
+args: dict[str, Any] = json.loads(os.environ.get("MODAL_LAUNCH_ARGS", "{}"))
 
 
 app = App()

--- a/modal/cli/programs/vscode.py
+++ b/modal/cli/programs/vscode.py
@@ -8,12 +8,12 @@ import subprocess
 import threading
 import time
 import webbrowser
-from typing import Any, Dict, Tuple
+from typing import Any
 
 from modal import App, Image, Mount, Queue, Secret, Volume, forward
 
 # Passed by `modal launch` locally via CLI, plumbed to remote runner through secrets.
-args: Dict[str, Any] = json.loads(os.environ.get("MODAL_LAUNCH_ARGS", "{}"))
+args: dict[str, Any] = json.loads(os.environ.get("MODAL_LAUNCH_ARGS", "{}"))
 
 
 app = App()
@@ -41,7 +41,7 @@ volume = (
 volumes = {"/home/coder/volume": volume} if volume else {}
 
 
-def wait_for_port(data: Tuple[str, str], q: Queue):
+def wait_for_port(data: tuple[str, str], q: Queue):
     start_time = time.monotonic()
     while True:
         try:

--- a/modal/cli/queues.py
+++ b/modal/cli/queues.py
@@ -58,7 +58,7 @@ async def delete(name: str, *, yes: bool = YES_OPTION, env: Optional[str] = ENV_
 
 @queue_cli.command(name="list", rich_help_panel="Management")
 @synchronizer.create_blocking
-async def list(*, json: bool = False, env: Optional[str] = ENV_OPTION):
+async def list_(*, json: bool = False, env: Optional[str] = ENV_OPTION):
     """List all named Queues."""
     env = ensure_env(env)
 

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -9,7 +9,7 @@ import sys
 import time
 import typing
 from functools import partial
-from typing import Any, Callable, Dict, Optional, get_type_hints
+from typing import Any, Callable, Optional, get_type_hints
 
 import click
 import typer
@@ -60,7 +60,7 @@ class NoParserAvailable(InvalidError):
     pass
 
 
-def _get_signature(f: Callable[..., Any], is_method: bool = False) -> Dict[str, ParameterMetadata]:
+def _get_signature(f: Callable[..., Any], is_method: bool = False) -> dict[str, ParameterMetadata]:
     try:
         type_hints = get_type_hints(f)
     except Exception as exc:
@@ -71,7 +71,7 @@ def _get_signature(f: Callable[..., Any], is_method: bool = False) -> Dict[str, 
     if is_method:
         self = None  # Dummy, doesn't matter
         f = functools.partial(f, self)
-    signature: Dict[str, ParameterMetadata] = {}
+    signature: dict[str, ParameterMetadata] = {}
     for param in inspect.signature(f).parameters.values():
         signature[param.name] = {
             "name": param.name,
@@ -98,7 +98,7 @@ def _get_param_type_as_str(annot: Any) -> str:
     return annot_str
 
 
-def _add_click_options(func, signature: Dict[str, ParameterMetadata]):
+def _add_click_options(func, signature: dict[str, ParameterMetadata]):
     """Adds @click.option based on function signature
 
     Kind of like typer, but using options instead of positional arguments
@@ -148,7 +148,7 @@ def _get_click_command_for_function(app: App, function_tag):
     if function.is_generator:
         raise InvalidError("`modal run` is not supported for generator functions")
 
-    signature: Dict[str, ParameterMetadata]
+    signature: dict[str, ParameterMetadata]
     cls: Optional[Cls] = None
     if function.info.user_cls is not None:
         cls = typing.cast(Cls, app.registered_classes[class_name])
@@ -364,7 +364,7 @@ def shell(
         default=None, help="Container image tag for inside the shell (if not using REF)."
     ),
     add_python: Optional[str] = typer.Option(default=None, help="Add Python to the image (if not using REF)."),
-    volume: Optional[typing.List[str]] = typer.Option(
+    volume: Optional[list[str]] = typer.Option(
         default=None,
         help=(
             "Name of a `modal.Volume` to mount inside the shell at `/mnt/{name}` (if not using REF)."

--- a/modal/cli/secret.py
+++ b/modal/cli/secret.py
@@ -23,7 +23,7 @@ secret_cli = typer.Typer(name="secret", help="Manage secrets.", no_args_is_help=
 
 @secret_cli.command("list", help="List your published secrets.")
 @synchronizer.create_blocking
-async def list(env: Optional[str] = ENV_OPTION, json: Optional[bool] = False):
+async def list_(env: Optional[str] = ENV_OPTION, json: Optional[bool] = False):
     env = ensure_env(env)
     client = await _Client.from_env()
     response = await retry_transient_errors(client.stub.SecretList, api_pb2.SecretListRequest(environment_name=env))

--- a/modal/cli/secret.py
+++ b/modal/cli/secret.py
@@ -3,7 +3,7 @@ import os
 import platform
 import subprocess
 from tempfile import NamedTemporaryFile
-from typing import List, Optional
+from typing import Optional
 
 import click
 import typer
@@ -47,7 +47,7 @@ async def list(env: Optional[str] = ENV_OPTION, json: Optional[bool] = False):
 @synchronizer.create_blocking
 async def create(
     secret_name,
-    keyvalues: List[str] = typer.Argument(..., help="Space-separated KEY=VALUE items"),
+    keyvalues: list[str] = typer.Argument(..., help="Space-separated KEY=VALUE items"),
     env: Optional[str] = ENV_OPTION,
     force: bool = typer.Option(False, "--force", help="Overwrite the secret if it already exists."),
 ):

--- a/modal/cli/utils.py
+++ b/modal/cli/utils.py
@@ -1,8 +1,9 @@
 # Copyright Modal Labs 2022
 import asyncio
+from collections.abc import Sequence
 from datetime import datetime
 from json import dumps
-from typing import Optional, Sequence, Union
+from typing import Optional, Union
 
 import typer
 from click import UsageError

--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -108,7 +108,7 @@ async def get(
     rich_help_panel="Management",
 )
 @synchronizer.create_blocking
-async def list(env: Optional[str] = ENV_OPTION, json: Optional[bool] = False):
+async def list_(env: Optional[str] = ENV_OPTION, json: Optional[bool] = False):
     env = ensure_env(env)
     client = await _Client.from_env()
     response = await retry_transient_errors(client.stub.VolumeList, api_pb2.VolumeListRequest(environment_name=env))

--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -2,7 +2,7 @@
 import os
 import sys
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 import typer
 from click import UsageError
@@ -257,7 +257,7 @@ async def rm(
 @synchronizer.create_blocking
 async def cp(
     volume_name: str,
-    paths: List[str],  # accepts multiple paths, last path is treated as destination path
+    paths: list[str],  # accepts multiple paths, last path is treated as destination path
     env: Optional[str] = ENV_OPTION,
 ):
     ensure_env(env)

--- a/modal/client.py
+++ b/modal/client.py
@@ -3,17 +3,12 @@ import asyncio
 import os
 import platform
 import warnings
+from collections.abc import AsyncGenerator, AsyncIterator, Collection, Mapping
 from typing import (
     Any,
-    AsyncGenerator,
-    AsyncIterator,
     ClassVar,
-    Collection,
-    Dict,
     Generic,
-    Mapping,
     Optional,
-    Tuple,
     TypeVar,
     Union,
 )
@@ -40,7 +35,7 @@ CLIENT_CREATE_ATTEMPT_TIMEOUT: float = 4.0
 CLIENT_CREATE_TOTAL_TIMEOUT: float = 15.0
 
 
-def _get_metadata(client_type: int, credentials: Optional[Tuple[str, str]], version: str) -> Dict[str, str]:
+def _get_metadata(client_type: int, credentials: Optional[tuple[str, str]], version: str) -> dict[str, str]:
     # This implements a simplified version of platform.platform() that's still machine-readable
     uname: platform.uname_result = platform.uname()
     if uname.system == "Darwin":
@@ -69,7 +64,7 @@ def _get_metadata(client_type: int, credentials: Optional[Tuple[str, str]], vers
 
 ReturnType = TypeVar("ReturnType")
 _Value = Union[str, bytes]
-_MetadataLike = Union[Mapping[str, _Value], Collection[Tuple[str, _Value]]]
+_MetadataLike = Union[Mapping[str, _Value], Collection[tuple[str, _Value]]]
 RequestType = TypeVar("RequestType", bound=Message)
 ResponseType = TypeVar("ResponseType", bound=Message)
 
@@ -85,7 +80,7 @@ class _Client:
         self,
         server_url: str,
         client_type: int,
-        credentials: Optional[Tuple[str, str]],
+        credentials: Optional[tuple[str, str]],
         version: str = __version__,
     ):
         """mdmd:hidden
@@ -201,7 +196,7 @@ class _Client:
         else:
             c = config
 
-        credentials: Optional[Tuple[str, str]]
+        credentials: Optional[tuple[str, str]]
 
         if cls._client_from_env_lock is None:
             cls._client_from_env_lock = asyncio.Lock()
@@ -266,7 +261,7 @@ class _Client:
         return client
 
     @classmethod
-    async def verify(cls, server_url: str, credentials: Tuple[str, str]) -> None:
+    async def verify(cls, server_url: str, credentials: tuple[str, str]) -> None:
         """mdmd:hidden
         Check whether can the client can connect to this server with these credentials; raise if not.
         """

--- a/modal/cloud_bucket_mount.py
+++ b/modal/cloud_bucket_mount.py
@@ -1,6 +1,6 @@
 # Copyright Modal Labs 2022
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
+from typing import Optional
 from urllib.parse import urlparse
 
 from modal_proto import api_pb2
@@ -116,9 +116,9 @@ class _CloudBucketMount:
     requester_pays: bool = False
 
 
-def cloud_bucket_mounts_to_proto(mounts: List[Tuple[str, _CloudBucketMount]]) -> List[api_pb2.CloudBucketMount]:
+def cloud_bucket_mounts_to_proto(mounts: list[tuple[str, _CloudBucketMount]]) -> list[api_pb2.CloudBucketMount]:
     """Helper function to convert `CloudBucketMount` to a list of protobufs that can be passed to the server."""
-    cloud_bucket_mounts: List[api_pb2.CloudBucketMount] = []
+    cloud_bucket_mounts: list[api_pb2.CloudBucketMount] = []
 
     for path, mount in mounts:
         # crude mapping from mount arguments to type.

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -2,7 +2,8 @@
 import inspect
 import os
 import typing
-from typing import Any, Callable, Collection, Dict, List, Optional, Tuple, Type, TypeVar, Union
+from collections.abc import Collection
+from typing import Any, Callable, Optional, TypeVar, Union
 
 from google.protobuf.message import Message
 from grpclib import GRPCError, Status
@@ -76,10 +77,10 @@ class _Obj:
 
     All this class does is to return `Function` objects."""
 
-    _functions: Dict[str, _Function]
+    _functions: dict[str, _Function]
     _entered: bool
     _user_cls_instance: Optional[Any] = None
-    _construction_args: Tuple[tuple, Dict[str, Any]]
+    _construction_args: tuple[tuple, dict[str, Any]]
 
     _instance_service_function: Optional[_Function]
 
@@ -91,7 +92,7 @@ class _Obj:
         self,
         user_cls: type,
         class_service_function: Optional[_Function],  # only None for <v0.63 classes
-        classbound_methods: Dict[str, _Function],
+        classbound_methods: dict[str, _Function],
         from_other_workspace: bool,
         options: Optional[api_pb2.FunctionOptions],
         args,
@@ -244,9 +245,9 @@ class _Cls(_Object, type_prefix="cs"):
     _class_service_function: Optional[
         _Function
     ]  # The _Function serving *all* methods of the class, used for version >=v0.63
-    _method_functions: Optional[Dict[str, _Function]] = None  # Placeholder _Functions for each method
+    _method_functions: Optional[dict[str, _Function]] = None  # Placeholder _Functions for each method
     _options: Optional[api_pb2.FunctionOptions]
-    _callables: Dict[str, Callable[..., Any]]
+    _callables: dict[str, Callable[..., Any]]
     _from_other_workspace: Optional[bool]  # Functions require FunctionBindParams before invocation.
     _app: Optional["modal.app._App"] = None  # not set for lookups
 
@@ -265,7 +266,7 @@ class _Cls(_Object, type_prefix="cs"):
         self._callables = other._callables
         self._from_other_workspace = other._from_other_workspace
 
-    def _get_partial_functions(self) -> Dict[str, _PartialFunction]:
+    def _get_partial_functions(self) -> dict[str, _PartialFunction]:
         if not self._user_cls:
             raise AttributeError("You can only get the partial functions of a local Cls instance")
         return _find_partial_methods_for_user_cls(self._user_cls, _PartialFunctionFlags.all())
@@ -344,8 +345,8 @@ class _Cls(_Object, type_prefix="cs"):
         # validate signature
         _Cls.validate_construction_mechanism(user_cls)
 
-        method_functions: Dict[str, _Function] = {}
-        partial_functions: Dict[str, _PartialFunction] = _find_partial_methods_for_user_cls(
+        method_functions: dict[str, _Function] = {}
+        partial_functions: dict[str, _PartialFunction] = _find_partial_methods_for_user_cls(
             user_cls, _PartialFunctionFlags.FUNCTION
         )
 
@@ -361,11 +362,11 @@ class _Cls(_Object, type_prefix="cs"):
             partial_function.wrapped = True
 
         # Get all callables
-        callables: Dict[str, Callable] = {
+        callables: dict[str, Callable] = {
             k: pf.raw_f for k, pf in _find_partial_methods_for_user_cls(user_cls, _PartialFunctionFlags.all()).items()
         }
 
-        def _deps() -> List[_Function]:
+        def _deps() -> list[_Function]:
             return [class_service_function]
 
         async def _load(self: "_Cls", resolver: Resolver, existing_object_id: Optional[str]):
@@ -392,7 +393,7 @@ class _Cls(_Object, type_prefix="cs"):
 
     @classmethod
     def from_name(
-        cls: Type["_Cls"],
+        cls: type["_Cls"],
         app_name: str,
         tag: str,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
@@ -454,11 +455,11 @@ class _Cls(_Object, type_prefix="cs"):
 
     def with_options(
         self: "_Cls",
-        cpu: Optional[Union[float, Tuple[float, float]]] = None,
-        memory: Optional[Union[int, Tuple[int, int]]] = None,
+        cpu: Optional[Union[float, tuple[float, float]]] = None,
+        memory: Optional[Union[int, tuple[int, int]]] = None,
         gpu: GPU_T = None,
         secrets: Collection[_Secret] = (),
-        volumes: Dict[Union[str, os.PathLike], _Volume] = {},
+        volumes: dict[Union[str, os.PathLike], _Volume] = {},
         retries: Optional[Union[int, Retries]] = None,
         timeout: Optional[int] = None,
         concurrency_limit: Optional[int] = None,

--- a/modal/config.py
+++ b/modal/config.py
@@ -80,7 +80,7 @@ import os
 import typing
 import warnings
 from textwrap import dedent
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from google.protobuf.empty_pb2 import Empty
 
@@ -282,7 +282,7 @@ configure_logger(logger, config["loglevel"], config["log_format"])
 
 
 def _store_user_config(
-    new_settings: Dict[str, Any], profile: Optional[str] = None, active_profile: Optional[str] = None
+    new_settings: dict[str, Any], profile: Optional[str] = None, active_profile: Optional[str] = None
 ):
     """Internal method, used by the CLI to set tokens."""
     if profile is None:

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -1,5 +1,6 @@
 # Copyright Modal Labs 2022
-from typing import Any, AsyncIterator, Optional, Tuple, Type
+from collections.abc import AsyncIterator
+from typing import Any, Optional
 
 from grpclib import GRPCError
 from synchronicity.async_wrap import asynccontextmanager
@@ -74,7 +75,7 @@ class _Dict(_Object, type_prefix="di"):
     @classmethod
     @asynccontextmanager
     async def ephemeral(
-        cls: Type["_Dict"],
+        cls: type["_Dict"],
         data: Optional[dict] = None,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
@@ -316,7 +317,7 @@ class _Dict(_Object, type_prefix="di"):
             yield deserialize(resp.value, self._client)
 
     @live_method_gen
-    async def items(self) -> AsyncIterator[Tuple[Any, Any]]:
+    async def items(self) -> AsyncIterator[tuple[Any, Any]]:
         """Return an iterator over the (key, value) tuples in this dictionary.
 
         Note that (unlike with Python dicts) the return value is a simple iterator,

--- a/modal/environments.py
+++ b/modal/environments.py
@@ -1,6 +1,6 @@
 # Copyright Modal Labs 2023
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from typing import Optional
 
 from google.protobuf.empty_pb2 import Empty
 from google.protobuf.message import Message
@@ -98,7 +98,7 @@ Environment = synchronize_api(_Environment)
 
 
 # Needs to be after definition; synchronicity interferes with forward references?
-ENVIRONMENT_CACHE: Dict[str, _Environment] = {}
+ENVIRONMENT_CACHE: dict[str, _Environment] = {}
 
 
 async def _get_environment_cached(name: str, client: _Client) -> _Environment:
@@ -151,7 +151,7 @@ async def create_environment(name: str, client: Optional[_Client] = None):
 
 
 @synchronizer.create_blocking
-async def list_environments(client: Optional[_Client] = None) -> List[api_pb2.EnvironmentListItem]:
+async def list_environments(client: Optional[_Client] = None) -> list[api_pb2.EnvironmentListItem]:
     if client is None:
         client = await _Client.from_env()
     resp = await client.stub.EnvironmentList(Empty())

--- a/modal/exception.py
+++ b/modal/exception.py
@@ -4,7 +4,6 @@ import signal
 import sys
 import warnings
 from datetime import date
-from typing import Tuple
 
 
 class Error(Exception):
@@ -132,12 +131,12 @@ def _is_internal_frame(frame):
     return module in _INTERNAL_MODULES
 
 
-def deprecation_error(deprecated_on: Tuple[int, int, int], msg: str):
+def deprecation_error(deprecated_on: tuple[int, int, int], msg: str):
     raise DeprecationError(f"Deprecated on {date(*deprecated_on)}: {msg}")
 
 
 def deprecation_warning(
-    deprecated_on: Tuple[int, int, int], msg: str, *, pending: bool = False, show_source: bool = True
+    deprecated_on: tuple[int, int, int], msg: str, *, pending: bool = False, show_source: bool = True
 ) -> None:
     """Utility for getting the proper stack entry.
 

--- a/modal/image.py
+++ b/modal/image.py
@@ -7,18 +7,15 @@ import shlex
 import sys
 import typing
 import warnings
+from collections.abc import Sequence
 from dataclasses import dataclass
 from inspect import isfunction
 from pathlib import Path, PurePosixPath
 from typing import (
     Any,
     Callable,
-    Dict,
-    List,
     Literal,
     Optional,
-    Sequence,
-    Set,
     Union,
     cast,
     get_args,
@@ -59,7 +56,7 @@ ImageBuilderVersion = Literal["2023.12", "2024.04", "2024.10"]
 # so that we fail fast / clearly in unsupported containers. Additionally, we enumerate the supported
 # Python versions in mount.py where we specify the "standalone Python versions" we create mounts for.
 # Consider consolidating these multiple sources of truth?
-SUPPORTED_PYTHON_SERIES: Dict[ImageBuilderVersion, List[str]] = {
+SUPPORTED_PYTHON_SERIES: dict[ImageBuilderVersion, list[str]] = {
     "2024.10": ["3.9", "3.10", "3.11", "3.12", "3.13"],
     "2024.04": ["3.9", "3.10", "3.11", "3.12"],
     "2023.12": ["3.9", "3.10", "3.11", "3.12"],
@@ -74,7 +71,7 @@ def _validate_python_version(
 ) -> str:
     if python_version is None:
         # If Python version is unspecified, match the local version, up to the minor component
-        python_version = series_version = "{0}.{1}".format(*sys.version_info)
+        python_version = series_version = "{}.{}".format(*sys.version_info)
     elif not isinstance(python_version, str):
         raise InvalidError(f"Python version must be specified as a string, not {type(python_version).__name__}")
     elif not re.match(r"^3(?:\.\d{1,2}){1,2}(rc\d*)?$", python_version):
@@ -86,7 +83,7 @@ def _validate_python_version(
                 "Python version must be specified as 'major.minor' for this interface;"
                 f" micro-level specification ({python_version!r}) is not valid."
             )
-        series_version = "{0}.{1}".format(*components)
+        series_version = "{}.{}".format(*components)
 
     supported_series = SUPPORTED_PYTHON_SERIES[builder_version]
     if series_version not in supported_series:
@@ -111,13 +108,13 @@ def _dockerhub_python_version(builder_version: ImageBuilderVersion, python_versi
     # This allows us to publish one pre-built debian-slim image per Python series.
     python_versions = _base_image_config("python", builder_version)
     series_to_micro_version = dict(tuple(v.rsplit(".", 1)) for v in python_versions)
-    python_series_requested = "{0}.{1}".format(*version_components)
+    python_series_requested = "{}.{}".format(*version_components)
     micro_version = series_to_micro_version[python_series_requested]
     return f"{python_series_requested}.{micro_version}"
 
 
 def _base_image_config(group: str, builder_version: ImageBuilderVersion) -> Any:
-    with open(LOCAL_REQUIREMENTS_DIR / "base-images.json", "r") as f:
+    with open(LOCAL_REQUIREMENTS_DIR / "base-images.json") as f:
         data = json.load(f)
     return data[group][builder_version]
 
@@ -146,7 +143,7 @@ def _get_modal_requirements_command(version: ImageBuilderVersion) -> str:
     return f"{prefix} -r {CONTAINER_REQUIREMENTS_PATH}"
 
 
-def _flatten_str_args(function_name: str, arg_name: str, args: Sequence[Union[str, List[str]]]) -> List[str]:
+def _flatten_str_args(function_name: str, arg_name: str, args: Sequence[Union[str, list[str]]]) -> list[str]:
     """Takes a sequence of strings, or string lists, and flattens it.
 
     Raises an error if any of the elements are not strings or string lists.
@@ -155,7 +152,7 @@ def _flatten_str_args(function_name: str, arg_name: str, args: Sequence[Union[st
     def is_str_list(x):
         return isinstance(x, list) and all(isinstance(y, str) for y in x)
 
-    ret: List[str] = []
+    ret: list[str] = []
     for x in args:
         if isinstance(x, str):
             ret.append(x)
@@ -166,7 +163,7 @@ def _flatten_str_args(function_name: str, arg_name: str, args: Sequence[Union[st
     return ret
 
 
-def _validate_packages(packages: List[str]) -> bool:
+def _validate_packages(packages: list[str]) -> bool:
     """Validates that a list of packages does not contain any command-line options."""
     return not any(pkg.startswith("-") for pkg in packages)
 
@@ -219,7 +216,7 @@ def _get_image_builder_version(server_version: ImageBuilderVersion) -> ImageBuil
         version_source = ""
         version = server_version
 
-    supported_versions: Set[ImageBuilderVersion] = set(get_args(ImageBuilderVersion))
+    supported_versions: set[ImageBuilderVersion] = set(get_args(ImageBuilderVersion))
     if version not in supported_versions:
         if local_config_version is not None:
             update_suggestion = "or remove your local configuration"
@@ -259,8 +256,8 @@ class _ImageRegistryConfig:
 @dataclass
 class DockerfileSpec:
     # Ideally we would use field() with default_factory=, but doesn't work with synchronicity type-stub gen
-    commands: List[str]
-    context_files: Dict[str, str]
+    commands: list[str]
+    context_files: dict[str, str]
 
 
 async def _image_await_build_result(image_id: str, client: _Client) -> api_pb2.ImageJoinStreamingResponse:
@@ -310,8 +307,8 @@ class _Image(_Object, type_prefix="im"):
     """
 
     force_build: bool
-    inside_exceptions: List[Exception]
-    _serve_mounts: typing.FrozenSet[_Mount]  # used for mounts watching in `modal serve`
+    inside_exceptions: list[Exception]
+    _serve_mounts: frozenset[_Mount]  # used for mounts watching in `modal serve`
     _deferred_mounts: Sequence[
         _Mount
     ]  # added as mounts on any container referencing the Image, see `def _mount_layers`
@@ -390,7 +387,7 @@ class _Image(_Object, type_prefix="im"):
     @staticmethod
     def _from_args(
         *,
-        base_images: Optional[Dict[str, "_Image"]] = None,
+        base_images: Optional[dict[str, "_Image"]] = None,
         dockerfile_function: Optional[Callable[[ImageBuilderVersion], DockerfileSpec]] = None,
         secrets: Optional[Sequence[_Secret]] = None,
         gpu_config: Optional[api_pb2.GPUConfig] = None,
@@ -720,7 +717,7 @@ class _Image(_Object, type_prefix="im"):
 
     def pip_install(
         self,
-        *packages: Union[str, List[str]],  # A list of Python packages, eg. ["numpy", "matplotlib>=3.5.0"]
+        *packages: Union[str, list[str]],  # A list of Python packages, eg. ["numpy", "matplotlib>=3.5.0"]
         find_links: Optional[str] = None,  # Passes -f (--find-links) pip install
         index_url: Optional[str] = None,  # Passes -i (--index-url) to pip install
         extra_index_url: Optional[str] = None,  # Passes --extra-index-url to pip install
@@ -762,7 +759,7 @@ class _Image(_Object, type_prefix="im"):
             return self
 
         def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:
-            package_args = " ".join(shlex.quote(pkg) for pkg in sorted(pkgs))
+            package_args = shlex.join(sorted(pkgs))
             extra_args = _make_pip_install_args(find_links, index_url, extra_index_url, pre, extra_options)
             commands = ["FROM base", f"RUN python -m pip install {package_args} {extra_args}"]
             if not _validate_packages(pkgs):
@@ -924,7 +921,7 @@ class _Image(_Object, type_prefix="im"):
     def pip_install_from_pyproject(
         self,
         pyproject_toml: str,
-        optional_dependencies: List[str] = [],
+        optional_dependencies: list[str] = [],
         *,
         find_links: Optional[str] = None,  # Passes -f (--find-links) pip install
         index_url: Optional[str] = None,  # Passes -i (--index-url) to pip install
@@ -968,7 +965,7 @@ class _Image(_Object, type_prefix="im"):
                         dependencies.extend(optionals[dep_group_name])
 
             extra_args = _make_pip_install_args(find_links, index_url, extra_index_url, pre, extra_options)
-            package_args = " ".join(shlex.quote(pkg) for pkg in sorted(dependencies))
+            package_args = shlex.join(sorted(dependencies))
             commands = ["FROM base", f"RUN python -m pip install {package_args} {extra_args}"]
             if version > "2023.12":  # Back-compat for legacy trailing space
                 commands = [cmd.strip() for cmd in commands]
@@ -994,11 +991,11 @@ class _Image(_Object, type_prefix="im"):
         old_installer: bool = False,
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
         # Selected optional dependency groups to install (See https://python-poetry.org/docs/cli/#install)
-        with_: List[str] = [],
+        with_: list[str] = [],
         # Selected optional dependency groups to exclude (See https://python-poetry.org/docs/cli/#install)
-        without: List[str] = [],
+        without: list[str] = [],
         # Only install dependency groups specifed in this list.
-        only: List[str] = [],
+        only: list[str] = [],
         *,
         secrets: Sequence[_Secret] = [],
         gpu: GPU_T = None,
@@ -1066,8 +1063,8 @@ class _Image(_Object, type_prefix="im"):
 
     def dockerfile_commands(
         self,
-        *dockerfile_commands: Union[str, List[str]],
-        context_files: Dict[str, str] = {},
+        *dockerfile_commands: Union[str, list[str]],
+        context_files: dict[str, str] = {},
         secrets: Sequence[_Secret] = [],
         gpu: GPU_T = None,
         # modal.Mount with local files to supply as build context for COPY commands
@@ -1093,7 +1090,7 @@ class _Image(_Object, type_prefix="im"):
 
     def entrypoint(
         self,
-        entrypoint_commands: List[str],
+        entrypoint_commands: list[str],
     ) -> "_Image":
         """Set the entrypoint for the image."""
         args_str = _flatten_str_args("entrypoint", "entrypoint_files", entrypoint_commands)
@@ -1104,7 +1101,7 @@ class _Image(_Object, type_prefix="im"):
 
     def shell(
         self,
-        shell_commands: List[str],
+        shell_commands: list[str],
     ) -> "_Image":
         """Overwrite default shell for the image."""
         args_str = _flatten_str_args("shell", "shell_commands", shell_commands)
@@ -1115,7 +1112,7 @@ class _Image(_Object, type_prefix="im"):
 
     def run_commands(
         self,
-        *commands: Union[str, List[str]],
+        *commands: Union[str, list[str]],
         secrets: Sequence[_Secret] = [],
         gpu: GPU_T = None,
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
@@ -1147,8 +1144,8 @@ class _Image(_Object, type_prefix="im"):
 
     def conda_install(
         self,
-        *packages: Union[str, List[str]],  # A list of Python packages, eg. ["numpy", "matplotlib>=3.5.0"]
-        channels: List[str] = [],  # A list of Conda channels, eg. ["conda-forge", "nvidia"]
+        *packages: Union[str, list[str]],  # A list of Python packages, eg. ["numpy", "matplotlib>=3.5.0"]
+        channels: list[str] = [],  # A list of Conda channels, eg. ["conda-forge", "nvidia"]
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
         secrets: Sequence[_Secret] = [],
         gpu: GPU_T = None,
@@ -1208,11 +1205,11 @@ class _Image(_Object, type_prefix="im"):
     def micromamba_install(
         self,
         # A list of Python packages, eg. ["numpy", "matplotlib>=3.5.0"]
-        *packages: Union[str, List[str]],
+        *packages: Union[str, list[str]],
         # A local path to a file containing package specifications
         spec_file: Optional[str] = None,
         # A list of Conda channels, eg. ["conda-forge", "nvidia"].
-        channels: List[str] = [],
+        channels: list[str] = [],
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
         secrets: Sequence[_Secret] = [],
         gpu: GPU_T = None,
@@ -1223,7 +1220,7 @@ class _Image(_Object, type_prefix="im"):
             return self
 
         def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:
-            package_args = " ".join(shlex.quote(pkg) for pkg in pkgs)
+            package_args = shlex.join(pkgs)
             channel_args = "".join(f" -c {channel}" for channel in channels)
 
             space = " " if package_args else ""
@@ -1251,10 +1248,10 @@ class _Image(_Object, type_prefix="im"):
     def _registry_setup_commands(
         tag: str,
         builder_version: ImageBuilderVersion,
-        setup_commands: List[str],
+        setup_commands: list[str],
         add_python: Optional[str] = None,
-    ) -> List[str]:
-        add_python_commands: List[str] = []
+    ) -> list[str]:
+        add_python_commands: list[str] = []
         if add_python:
             _validate_python_version(add_python, builder_version, allow_micro_granularity=False)
             add_python_commands = [
@@ -1285,7 +1282,7 @@ class _Image(_Object, type_prefix="im"):
         tag: str,
         *,
         secret: Optional[_Secret] = None,
-        setup_dockerfile_commands: List[str] = [],
+        setup_dockerfile_commands: list[str] = [],
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
         add_python: Optional[str] = None,
         **kwargs,
@@ -1344,7 +1341,7 @@ class _Image(_Object, type_prefix="im"):
         tag: str,
         secret: Optional[_Secret] = None,
         *,
-        setup_dockerfile_commands: List[str] = [],
+        setup_dockerfile_commands: list[str] = [],
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
         add_python: Optional[str] = None,
         **kwargs,
@@ -1395,7 +1392,7 @@ class _Image(_Object, type_prefix="im"):
         tag: str,
         secret: Optional[_Secret] = None,
         *,
-        setup_dockerfile_commands: List[str] = [],
+        setup_dockerfile_commands: list[str] = [],
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
         add_python: Optional[str] = None,
         **kwargs,
@@ -1550,7 +1547,7 @@ class _Image(_Object, type_prefix="im"):
 
     def apt_install(
         self,
-        *packages: Union[str, List[str]],  # A list of packages, e.g. ["ssh", "libpq-dev"]
+        *packages: Union[str, list[str]],  # A list of packages, e.g. ["ssh", "libpq-dev"]
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
         secrets: Sequence[_Secret] = [],
         gpu: GPU_T = None,
@@ -1567,7 +1564,7 @@ class _Image(_Object, type_prefix="im"):
         if not pkgs:
             return self
 
-        package_args = " ".join(shlex.quote(pkg) for pkg in pkgs)
+        package_args = shlex.join(pkgs)
 
         def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:
             commands = [
@@ -1590,11 +1587,11 @@ class _Image(_Object, type_prefix="im"):
         raw_f: Callable[..., Any],
         secrets: Sequence[_Secret] = (),  # Optional Modal Secret objects with environment variables for the container
         gpu: Union[
-            GPU_T, List[GPU_T]
+            GPU_T, list[GPU_T]
         ] = None,  # GPU request as string ("any", "T4", ...), object (`modal.GPU.A100()`, ...), or a list of either
         mounts: Sequence[_Mount] = (),  # Mounts attached to the function
-        volumes: Dict[Union[str, PurePosixPath], Union[_Volume, _CloudBucketMount]] = {},  # Volume mount paths
-        network_file_systems: Dict[Union[str, PurePosixPath], _NetworkFileSystem] = {},  # NFS mount paths
+        volumes: dict[Union[str, PurePosixPath], Union[_Volume, _CloudBucketMount]] = {},  # Volume mount paths
+        network_file_systems: dict[Union[str, PurePosixPath], _NetworkFileSystem] = {},  # NFS mount paths
         cpu: Optional[float] = None,  # How many CPU cores to request. This is a soft limit.
         memory: Optional[int] = None,  # How much memory to request, in MiB. This is a soft limit.
         timeout: Optional[int] = 60 * 60,  # Maximum execution time of the function in seconds.
@@ -1602,7 +1599,7 @@ class _Image(_Object, type_prefix="im"):
         cloud: Optional[str] = None,  # Cloud provider to run the function on. Possible values are aws, gcp, oci, auto.
         region: Optional[Union[str, Sequence[str]]] = None,  # Region or regions to run the function on.
         args: Sequence[Any] = (),  # Positional arguments to the function.
-        kwargs: Dict[str, Any] = {},  # Keyword arguments to the function.
+        kwargs: dict[str, Any] = {},  # Keyword arguments to the function.
     ) -> "_Image":
         """Run user-defined function `raw_f` as an image build step. The function runs just like an ordinary Modal
         function, and any kwargs accepted by `@app.function` (such as `Mount`s, `NetworkFileSystem`s,
@@ -1676,7 +1673,7 @@ class _Image(_Object, type_prefix="im"):
             force_build=self.force_build or force_build,
         )
 
-    def env(self, vars: Dict[str, str]) -> "_Image":
+    def env(self, vars: dict[str, str]) -> "_Image":
         """Sets the environment variables in an Image.
 
         **Example**

--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -1,14 +1,11 @@
 # Copyright Modal Labs 2022
 import asyncio
+from collections.abc import AsyncGenerator, AsyncIterator
 from typing import (
     TYPE_CHECKING,
-    AsyncGenerator,
-    AsyncIterator,
     Generic,
-    List,
     Literal,
     Optional,
-    Tuple,
     TypeVar,
     Union,
     cast,
@@ -31,7 +28,7 @@ if TYPE_CHECKING:
 
 async def _sandbox_logs_iterator(
     sandbox_id: str, file_descriptor: "api_pb2.FileDescriptor.ValueType", last_entry_id: str, client: _Client
-) -> AsyncGenerator[Tuple[Optional[bytes], str], None]:
+) -> AsyncGenerator[tuple[Optional[bytes], str], None]:
     req = api_pb2.SandboxGetLogsRequest(
         sandbox_id=sandbox_id,
         file_descriptor=file_descriptor,
@@ -137,7 +134,7 @@ class _StreamReader(Generic[T]):
             # Container process streams need to be consumed as they are produced,
             # otherwise the process will block. Use a buffer to store the stream
             # until the client consumes it.
-            self._container_process_buffer: List[Optional[bytes]] = []
+            self._container_process_buffer: list[Optional[bytes]] = []
             self._consume_container_process_task = asyncio.create_task(self._consume_container_process_stream())
 
     @property
@@ -208,7 +205,7 @@ class _StreamReader(Generic[T]):
                         break
                 raise exc
 
-    async def _stream_container_process(self) -> AsyncGenerator[Tuple[Optional[bytes], str], None]:
+    async def _stream_container_process(self) -> AsyncGenerator[tuple[Optional[bytes], str], None]:
         """Streams the container process buffer to the reader."""
         entry_id = 0
         if self._last_entry_id:

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -9,8 +9,9 @@ import sys
 import sysconfig
 import time
 import typing
+from collections.abc import AsyncGenerator
 from pathlib import Path, PurePosixPath
-from typing import AsyncGenerator, Callable, List, Optional, Tuple, Type, Union
+from typing import Callable, Optional, Union
 
 from google.protobuf.message import Message
 
@@ -36,7 +37,7 @@ MOUNT_PUT_FILE_CLIENT_TIMEOUT = 10 * 60  # 10 min max for transferring files
 #
 # These can be updated safely, but changes will trigger a rebuild for all images
 # that rely on `add_python()` in their constructor.
-PYTHON_STANDALONE_VERSIONS: typing.Dict[str, typing.Tuple[str, str]] = {
+PYTHON_STANDALONE_VERSIONS: dict[str, tuple[str, str]] = {
     "3.9": ("20230826", "3.9.18"),
     "3.10": ("20230826", "3.10.13"),
     "3.11": ("20230826", "3.11.5"),
@@ -73,21 +74,21 @@ class _MountEntry(metaclass=abc.ABCMeta):
         ...
 
     @abc.abstractmethod
-    def get_files_to_upload(self) -> typing.Iterator[Tuple[Path, str]]:
+    def get_files_to_upload(self) -> typing.Iterator[tuple[Path, str]]:
         ...
 
     @abc.abstractmethod
-    def watch_entry(self) -> Tuple[Path, Path]:
+    def watch_entry(self) -> tuple[Path, Path]:
         ...
 
     @abc.abstractmethod
-    def top_level_paths(self) -> List[Tuple[Path, PurePosixPath]]:
+    def top_level_paths(self) -> list[tuple[Path, PurePosixPath]]:
         ...
 
 
-def _select_files(entries: List[_MountEntry]) -> List[Tuple[Path, PurePosixPath]]:
+def _select_files(entries: list[_MountEntry]) -> list[tuple[Path, PurePosixPath]]:
     # TODO: make this async
-    all_files: typing.Set[Tuple[Path, PurePosixPath]] = set()
+    all_files: set[tuple[Path, PurePosixPath]] = set()
     for entry in entries:
         all_files |= set(entry.get_files_to_upload())
     return list(all_files)
@@ -113,7 +114,7 @@ class _MountFile(_MountEntry):
         safe_path = self.local_file.expanduser().absolute()
         return safe_path.parent, safe_path
 
-    def top_level_paths(self) -> List[Tuple[Path, PurePosixPath]]:
+    def top_level_paths(self) -> list[tuple[Path, PurePosixPath]]:
         return [(self.local_file, self.remote_path)]
 
 
@@ -150,7 +151,7 @@ class _MountDir(_MountEntry):
     def watch_entry(self):
         return self.local_dir.resolve().expanduser(), None
 
-    def top_level_paths(self) -> List[Tuple[Path, PurePosixPath]]:
+    def top_level_paths(self) -> list[tuple[Path, PurePosixPath]]:
         return [(self.local_dir, self.remote_path)]
 
 
@@ -194,7 +195,7 @@ class _MountedPythonModule(_MountEntry):
     def description(self) -> str:
         return f"PythonPackage:{self.module_name}"
 
-    def _proxy_entries(self) -> List[_MountEntry]:
+    def _proxy_entries(self) -> list[_MountEntry]:
         mount_infos = get_module_mount_info(self.module_name)
         entries = []
         for mount_info in mount_infos:
@@ -220,16 +221,16 @@ class _MountedPythonModule(_MountEntry):
                 )
         return entries
 
-    def get_files_to_upload(self) -> typing.Iterator[Tuple[Path, str]]:
+    def get_files_to_upload(self) -> typing.Iterator[tuple[Path, str]]:
         for entry in self._proxy_entries():
             yield from entry.get_files_to_upload()
 
-    def watch_entry(self) -> Tuple[Path, Path]:
+    def watch_entry(self) -> tuple[Path, Path]:
         for entry in self._proxy_entries():
             # TODO: fix watch for mounts of multi-path packages
             return entry.watch_entry()
 
-    def top_level_paths(self) -> List[Tuple[Path, PurePosixPath]]:
+    def top_level_paths(self) -> list[tuple[Path, PurePosixPath]]:
         paths = []
         for sub in self._proxy_entries():
             paths.extend(sub.top_level_paths())
@@ -262,14 +263,14 @@ class _Mount(_Object, type_prefix="mo"):
     the file's contents to skip uploading files that have been uploaded before.
     """
 
-    _entries: Optional[List[_MountEntry]] = None
+    _entries: Optional[list[_MountEntry]] = None
     _deployment_name: Optional[str] = None
     _namespace: Optional[int] = None
     _environment_name: Optional[str] = None
     _content_checksum_sha256_hex: Optional[str] = None
 
     @staticmethod
-    def _new(entries: List[_MountEntry] = []) -> "_Mount":
+    def _new(entries: list[_MountEntry] = []) -> "_Mount":
         rep = f"Mount({entries})"
 
         async def mount_content_deduplication_key():
@@ -298,10 +299,10 @@ class _Mount(_Object, type_prefix="mo"):
         assert isinstance(handle_metadata, api_pb2.MountHandleMetadata)
         self._content_checksum_sha256_hex = handle_metadata.content_checksum_sha256_hex
 
-    def _top_level_paths(self) -> List[Tuple[Path, PurePosixPath]]:
+    def _top_level_paths(self) -> list[tuple[Path, PurePosixPath]]:
         # Returns [(local_absolute_path, remote_path), ...] for all top level entries in the Mount
         # Used to determine if a package mount is installed in a sys directory or not
-        res: List[Tuple[Path, PurePosixPath]] = []
+        res: list[tuple[Path, PurePosixPath]] = []
         for entry in self.entries:
             res.extend(entry.top_level_paths())
         return res
@@ -413,12 +414,12 @@ class _Mount(_Object, type_prefix="mo"):
         return _Mount._new().add_local_file(local_path, remote_path=remote_path)
 
     @staticmethod
-    def _description(entries: List[_MountEntry]) -> str:
+    def _description(entries: list[_MountEntry]) -> str:
         local_contents = [e.description() for e in entries]
         return ", ".join(local_contents)
 
     @staticmethod
-    async def _get_files(entries: List[_MountEntry]) -> AsyncGenerator[FileUploadSpec, None]:
+    async def _get_files(entries: list[_MountEntry]) -> AsyncGenerator[FileUploadSpec, None]:
         loop = asyncio.get_event_loop()
         with concurrent.futures.ThreadPoolExecutor() as exe:
             all_files = await loop.run_in_executor(exe, _select_files, entries)
@@ -502,7 +503,7 @@ class _Mount(_Object, type_prefix="mo"):
 
         # Upload files, or check if they already exist.
         n_concurrent_uploads = 512
-        files: List[api_pb2.MountFile] = []
+        files: list[api_pb2.MountFile] = []
         async with aclosing(
             async_map(_Mount._get_files(self._entries), _put_file, concurrency=n_concurrent_uploads)
         ) as stream:
@@ -602,7 +603,7 @@ class _Mount(_Object, type_prefix="mo"):
 
     @classmethod
     async def lookup(
-        cls: Type["_Mount"],
+        cls: type["_Mount"],
         label: str,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         client: Optional[_Client] = None,
@@ -715,7 +716,7 @@ def _is_modal_path(remote_path: PurePosixPath):
     return False
 
 
-def get_auto_mounts() -> typing.List[_Mount]:
+def get_auto_mounts() -> list[_Mount]:
     """mdmd:hidden
 
     Auto-mount local modules that have been imported in global scope.

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -2,8 +2,9 @@
 import functools
 import os
 import time
+from collections.abc import AsyncIterator
 from pathlib import Path, PurePosixPath
-from typing import Any, AsyncIterator, BinaryIO, Callable, List, Optional, Tuple, Type, Union
+from typing import Any, BinaryIO, Callable, Optional, Union
 
 from grpclib import GRPCError, Status
 from synchronicity.async_wrap import asynccontextmanager
@@ -34,9 +35,9 @@ NETWORK_FILE_SYSTEM_PUT_FILE_CLIENT_TIMEOUT = (
 
 
 def network_file_system_mount_protos(
-    validated_network_file_systems: List[Tuple[str, "_NetworkFileSystem"]],
+    validated_network_file_systems: list[tuple[str, "_NetworkFileSystem"]],
     allow_cross_region_volumes: bool,
-) -> List[api_pb2.SharedVolumeMount]:
+) -> list[api_pb2.SharedVolumeMount]:
     network_file_system_mounts = []
     # Relies on dicts being ordered (true as of Python 3.6).
     for path, volume in validated_network_file_systems:
@@ -143,7 +144,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
     @classmethod
     @asynccontextmanager
     async def ephemeral(
-        cls: Type["_NetworkFileSystem"],
+        cls: type["_NetworkFileSystem"],
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         _heartbeat_sleep: float = EPHEMERAL_OBJECT_HEARTBEAT_SLEEP,
@@ -329,7 +330,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
                 relpath_str = subpath.relative_to(_local_path).as_posix()
                 yield subpath, PurePosixPath(remote_path, relpath_str)
 
-        async def _add_local_file(paths: Tuple[Path, PurePosixPath]) -> int:
+        async def _add_local_file(paths: tuple[Path, PurePosixPath]) -> int:
             return await self.add_local_file(paths[0], paths[1], progress_cb)
 
         async with aclosing(async_map(sync_or_async_iter(gen_transfers()), _add_local_file, concurrency=20)) as stream:
@@ -337,7 +338,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
                 pass
 
     @live_method
-    async def listdir(self, path: str) -> List[FileEntry]:
+    async def listdir(self, path: str) -> list[FileEntry]:
         """List all files in a directory in the network file system.
 
         * Passing a directory path lists all files in the directory (names are relative to the directory)

--- a/modal/object.py
+++ b/modal/object.py
@@ -1,7 +1,8 @@
 # Copyright Modal Labs 2022
 import uuid
+from collections.abc import Awaitable, Hashable, Sequence
 from functools import wraps
-from typing import Awaitable, Callable, ClassVar, Dict, Hashable, List, Optional, Sequence, Type, TypeVar
+from typing import Callable, ClassVar, Optional, TypeVar
 
 from google.protobuf.message import Message
 
@@ -31,7 +32,7 @@ def _get_environment_name(environment_name: Optional[str] = None, resolver: Opti
 
 class _Object:
     _type_prefix: ClassVar[Optional[str]] = None
-    _prefix_to_type: ClassVar[Dict[str, type]] = {}
+    _prefix_to_type: ClassVar[dict[str, type]] = {}
 
     # For constructors
     _load: Optional[Callable[[O, Resolver, Optional[str]], Awaitable[None]]]
@@ -39,7 +40,7 @@ class _Object:
     _rep: str
     _is_another_app: bool
     _hydrate_lazily: bool
-    _deps: Optional[Callable[..., List["_Object"]]]
+    _deps: Optional[Callable[..., list["_Object"]]]
     _deduplication_key: Optional[Callable[[], Awaitable[Hashable]]] = None
 
     # For hydrated objects
@@ -65,7 +66,7 @@ class _Object:
         is_another_app: bool = False,
         preload: Optional[Callable[[O, Resolver, Optional[str]], Awaitable[None]]] = None,
         hydrate_lazily: bool = False,
-        deps: Optional[Callable[..., List["_Object"]]] = None,
+        deps: Optional[Callable[..., list["_Object"]]] = None,
         deduplication_key: Optional[Callable[[], Awaitable[Hashable]]] = None,
     ):
         self._local_uuid = str(uuid.uuid4())
@@ -159,7 +160,7 @@ class _Object:
         return obj
 
     @classmethod
-    def _get_type_from_id(cls: Type[O], object_id: str) -> Type[O]:
+    def _get_type_from_id(cls: type[O], object_id: str) -> type[O]:
         parts = object_id.split("-")
         if len(parts) != 2:
             raise InvalidError(f"Object id {object_id} has no dash in it")
@@ -169,12 +170,12 @@ class _Object:
         return cls._prefix_to_type[prefix]
 
     @classmethod
-    def _is_id_type(cls: Type[O], object_id) -> bool:
+    def _is_id_type(cls: type[O], object_id) -> bool:
         return cls._get_type_from_id(object_id) == cls
 
     @classmethod
     def _new_hydrated(
-        cls: Type[O], object_id: str, client: _Client, handle_metadata: Optional[Message], is_another_app: bool = False
+        cls: type[O], object_id: str, client: _Client, handle_metadata: Optional[Message], is_another_app: bool = False
     ) -> O:
         if cls._type_prefix is not None:
             # This is called directly on a subclass, e.g. Secret.from_id
@@ -215,7 +216,7 @@ class _Object:
         return self._is_hydrated
 
     @property
-    def deps(self) -> Callable[..., List["_Object"]]:
+    def deps(self) -> Callable[..., list["_Object"]]:
         """mdmd:hidden"""
         return self._deps if self._deps is not None else lambda: []
 

--- a/modal/output.py
+++ b/modal/output.py
@@ -7,7 +7,8 @@ us to avoid importing Rich for client code that runs in the container environmen
 
 """
 import contextlib
-from typing import TYPE_CHECKING, Generator, Optional
+from collections.abc import Generator
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from ._output import OutputManager

--- a/modal/parallel_map.py
+++ b/modal/parallel_map.py
@@ -3,7 +3,7 @@ import asyncio
 import time
 import typing
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Optional, Set, Tuple
+from typing import Any, Callable, Optional
 
 from grpclib import GRPCError, Status
 
@@ -95,8 +95,8 @@ async def _map_invocation(
         if count_update_callback is not None:
             count_update_callback(num_outputs, num_inputs)
 
-    pending_outputs: Dict[str, int] = {}  # Map input_id -> next expected gen_index value
-    completed_outputs: Set[str] = set()  # Set of input_ids whose outputs are complete (expecting no more values)
+    pending_outputs: dict[str, int] = {}  # Map input_id -> next expected gen_index value
+    completed_outputs: set[str] = set()  # Set of input_ids whose outputs are complete (expecting no more values)
 
     input_queue: asyncio.Queue = asyncio.Queue()
 
@@ -216,7 +216,7 @@ async def _map_invocation(
             )
             await retry_transient_errors(client.stub.FunctionGetOutputs, request)
 
-    async def fetch_output(item: api_pb2.FunctionGetOutputsItem) -> Tuple[int, Any]:
+    async def fetch_output(item: api_pb2.FunctionGetOutputsItem) -> tuple[int, Any]:
         try:
             output = await _process_result(item.result, item.data_format, client.stub, client)
         except Exception as e:

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -2,15 +2,11 @@
 import enum
 import inspect
 import typing
+from collections.abc import Coroutine, Iterable
 from typing import (
     Any,
     Callable,
-    Coroutine,
-    Dict,
-    Iterable,
-    List,
     Optional,
-    Type,
     Union,
 )
 
@@ -132,11 +128,11 @@ class _PartialFunction(typing.Generic[P, ReturnType, OriginalReturnType]):
 PartialFunction = synchronize_api(_PartialFunction)
 
 
-def _find_partial_methods_for_user_cls(user_cls: Type[Any], flags: int) -> Dict[str, _PartialFunction]:
+def _find_partial_methods_for_user_cls(user_cls: type[Any], flags: int) -> dict[str, _PartialFunction]:
     """Grabs all method on a user class, and returns partials. Includes legacy methods."""
 
     # Build up a list of legacy attributes to check
-    check_attrs: List[str] = []
+    check_attrs: list[str] = []
     if flags & _PartialFunctionFlags.BUILD:
         check_attrs += ["__build__", "__abuild__"]
     if flags & _PartialFunctionFlags.ENTER_POST_SNAPSHOT:
@@ -158,7 +154,7 @@ def _find_partial_methods_for_user_cls(user_cls: Type[Any], flags: int) -> Dict[
             )
             deprecation_error((2024, 2, 21), message)
 
-    partial_functions: Dict[str, PartialFunction] = {}
+    partial_functions: dict[str, PartialFunction] = {}
     for parent_cls in user_cls.mro():
         if parent_cls is not object:
             for k, v in parent_cls.__dict__.items():
@@ -170,9 +166,9 @@ def _find_partial_methods_for_user_cls(user_cls: Type[Any], flags: int) -> Dict[
     return partial_functions
 
 
-def _find_callables_for_obj(user_obj: Any, flags: int) -> Dict[str, Callable[..., Any]]:
+def _find_callables_for_obj(user_obj: Any, flags: int) -> dict[str, Callable[..., Any]]:
     """Grabs all methods for an object, and binds them to the class"""
-    user_cls: Type = type(user_obj)
+    user_cls: type = type(user_obj)
     return {k: pf.raw_f.__get__(user_obj) for k, pf in _find_partial_methods_for_user_cls(user_cls, flags).items()}
 
 
@@ -256,9 +252,9 @@ def _method(
     return wrapper
 
 
-def _parse_custom_domains(custom_domains: Optional[Iterable[str]] = None) -> List[api_pb2.CustomDomainConfig]:
+def _parse_custom_domains(custom_domains: Optional[Iterable[str]] = None) -> list[api_pb2.CustomDomainConfig]:
     assert not isinstance(custom_domains, str), "custom_domains must be `Iterable[str]` but is `str` instead."
-    _custom_domains: List[api_pb2.CustomDomainConfig] = []
+    _custom_domains: list[api_pb2.CustomDomainConfig] = []
     if custom_domains is not None:
         for custom_domain in custom_domains:
             _custom_domains.append(api_pb2.CustomDomainConfig(name=custom_domain))
@@ -608,7 +604,7 @@ ExitHandlerType = Union[
     # NOTE: return types of these callables should be `Union[None, Awaitable[None]]` but
     #       synchronicity type stubs would strip Awaitable so we use Any for now
     # Original, __exit__ style method signature (now deprecated)
-    Callable[[Any, Optional[Type[BaseException]], Optional[BaseException], Any], Any],
+    Callable[[Any, Optional[type[BaseException]], Optional[BaseException], Any], Any],
     # Forward-looking unparameterized method
     Callable[[Any], Any],
 ]

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -2,7 +2,8 @@
 import queue  # The system library
 import time
 import warnings
-from typing import Any, AsyncGenerator, AsyncIterator, List, Optional, Type
+from collections.abc import AsyncGenerator, AsyncIterator
+from typing import Any, Optional
 
 from grpclib import GRPCError, Status
 from synchronicity.async_wrap import asynccontextmanager
@@ -113,7 +114,7 @@ class _Queue(_Object, type_prefix="qu"):
     @classmethod
     @asynccontextmanager
     async def ephemeral(
-        cls: Type["_Queue"],
+        cls: type["_Queue"],
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         _heartbeat_sleep: float = EPHEMERAL_OBJECT_HEARTBEAT_SLEEP,
@@ -210,7 +211,7 @@ class _Queue(_Object, type_prefix="qu"):
         req = api_pb2.QueueDeleteRequest(queue_id=obj.object_id)
         await retry_transient_errors(obj._client.stub.QueueDelete, req)
 
-    async def _get_nonblocking(self, partition: Optional[str], n_values: int) -> List[Any]:
+    async def _get_nonblocking(self, partition: Optional[str], n_values: int) -> list[Any]:
         request = api_pb2.QueueGetRequest(
             queue_id=self.object_id,
             partition_key=self.validate_partition_key(partition),
@@ -224,7 +225,7 @@ class _Queue(_Object, type_prefix="qu"):
         else:
             return []
 
-    async def _get_blocking(self, partition: Optional[str], timeout: Optional[float], n_values: int) -> List[Any]:
+    async def _get_blocking(self, partition: Optional[str], timeout: Optional[float], n_values: int) -> list[Any]:
         if timeout is not None:
             deadline = time.time() + timeout
         else:
@@ -294,7 +295,7 @@ class _Queue(_Object, type_prefix="qu"):
     @live_method
     async def get_many(
         self, n_values: int, block: bool = True, timeout: Optional[float] = None, *, partition: Optional[str] = None
-    ) -> List[Any]:
+    ) -> list[Any]:
         """Remove and return up to `n_values` objects from the queue.
 
         If there are fewer than `n_values` items in the queue, return all of them.
@@ -337,7 +338,7 @@ class _Queue(_Object, type_prefix="qu"):
     @live_method
     async def put_many(
         self,
-        vs: List[Any],
+        vs: list[Any],
         block: bool = True,
         timeout: Optional[float] = None,
         *,
@@ -361,7 +362,7 @@ class _Queue(_Object, type_prefix="qu"):
             await self._put_many_nonblocking(partition, partition_ttl, vs)
 
     async def _put_many_blocking(
-        self, partition: Optional[str], partition_ttl: int, vs: List[Any], timeout: Optional[float] = None
+        self, partition: Optional[str], partition_ttl: int, vs: list[Any], timeout: Optional[float] = None
     ):
         vs_encoded = [serialize(v) for v in vs]
 
@@ -390,7 +391,7 @@ class _Queue(_Object, type_prefix="qu"):
             else:
                 raise exc
 
-    async def _put_many_nonblocking(self, partition: Optional[str], partition_ttl: int, vs: List[Any]):
+    async def _put_many_nonblocking(self, partition: Optional[str], partition_ttl: int, vs: list[Any]):
         vs_encoded = [serialize(v) for v in vs]
         request = api_pb2.QueuePutRequest(
             queue_id=self.object_id,

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -4,8 +4,9 @@ import dataclasses
 import os
 import time
 import typing
+from collections.abc import AsyncGenerator
 from multiprocessing.synchronize import Event
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Dict, List, Optional, Tuple, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar
 
 from grpclib import GRPCError, Status
 from synchronicity.async_wrap import asynccontextmanager
@@ -123,7 +124,7 @@ async def _init_local_app_from_name(
 async def _create_all_objects(
     client: _Client,
     running_app: RunningApp,
-    indexed_objects: Dict[str, _Object],
+    indexed_objects: dict[str, _Object],
     environment_name: str,
 ) -> None:
     """Create objects that have been defined but not created on the server."""
@@ -171,15 +172,15 @@ async def _publish_app(
     client: _Client,
     running_app: RunningApp,
     app_state: int,  # api_pb2.AppState.value
-    indexed_objects: Dict[str, _Object],
+    indexed_objects: dict[str, _Object],
     name: str = "",  # Only relevant for deployments
     tag: str = "",  # Only relevant for deployments
-) -> Tuple[str, List[str]]:
+) -> tuple[str, list[str]]:
     """Wrapper for AppPublish RPC."""
 
     # Could simplify this function some changing the internal representation to use
     # function_ids / class_ids rather than the current tag_to_object_id (i.e. "indexed_objects")
-    def filter_values(full_dict: Dict[str, V], condition: Callable[[V], bool]) -> Dict[str, V]:
+    def filter_values(full_dict: dict[str, V], condition: Callable[[V], bool]) -> dict[str, V]:
         return {k: v for k, v in full_dict.items() if condition(v)}
 
     function_ids = filter_values(running_app.tag_to_object_id, _Function._is_id_type)
@@ -453,7 +454,7 @@ class DeployResult:
     app_id: str
     app_page_url: str
     app_logs_url: str
-    warnings: List[str]
+    warnings: list[str]
 
 
 async def _deploy_app(
@@ -556,7 +557,7 @@ async def _deploy_app(
     )
 
 
-async def _interactive_shell(_app: _App, cmds: List[str], environment_name: str = "", **kwargs: Any) -> None:
+async def _interactive_shell(_app: _App, cmds: list[str], environment_name: str = "", **kwargs: Any) -> None:
     """Run an interactive shell (like `bash`) within the image for this app.
 
     This is useful for online debugging and interactive exploration of the

--- a/modal/running_app.py
+++ b/modal/running_app.py
@@ -1,6 +1,6 @@
 # Copyright Modal Labs 2024
 from dataclasses import dataclass, field
-from typing import Dict, Optional
+from typing import Optional
 
 from google.protobuf.message import Message
 
@@ -13,7 +13,7 @@ class RunningApp:
     environment_name: Optional[str] = None
     app_page_url: Optional[str] = None
     app_logs_url: Optional[str] = None
-    tag_to_object_id: Dict[str, str] = field(default_factory=dict)
-    object_handle_metadata: Dict[str, Optional[Message]] = field(default_factory=dict)
+    tag_to_object_id: dict[str, str] = field(default_factory=dict)
+    object_handle_metadata: dict[str, Optional[Message]] = field(default_factory=dict)
     interactive: bool = False
     client: Optional[_Client] = None

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -1,7 +1,8 @@
 # Copyright Modal Labs 2022
 import asyncio
 import os
-from typing import TYPE_CHECKING, AsyncGenerator, Dict, List, Literal, Optional, Sequence, Tuple, Union, overload
+from collections.abc import AsyncGenerator, Sequence
+from typing import TYPE_CHECKING, Literal, Optional, Union, overload
 
 from google.protobuf.message import Message
 from grpclib import GRPCError, Status
@@ -50,7 +51,7 @@ class _Sandbox(_Object, type_prefix="sb"):
     _stderr: _StreamReader[str]
     _stdin: _StreamWriter
     _task_id: Optional[str] = None
-    _tunnels: Optional[Dict[int, Tunnel]] = None
+    _tunnels: Optional[dict[int, Tunnel]] = None
 
     @staticmethod
     def _new(
@@ -64,11 +65,11 @@ class _Sandbox(_Object, type_prefix="sb"):
         cloud: Optional[str] = None,
         region: Optional[Union[str, Sequence[str]]] = None,
         cpu: Optional[float] = None,
-        memory: Optional[Union[int, Tuple[int, int]]] = None,
-        network_file_systems: Dict[Union[str, os.PathLike], _NetworkFileSystem] = {},
+        memory: Optional[Union[int, tuple[int, int]]] = None,
+        network_file_systems: dict[Union[str, os.PathLike], _NetworkFileSystem] = {},
         block_network: bool = False,
         cidr_allowlist: Optional[Sequence[str]] = None,
-        volumes: Dict[Union[str, os.PathLike], Union[_Volume, _CloudBucketMount]] = {},
+        volumes: dict[Union[str, os.PathLike], Union[_Volume, _CloudBucketMount]] = {},
         pty_info: Optional[api_pb2.PTYInfo] = None,
         encrypted_ports: Sequence[int] = [],
         unencrypted_ports: Sequence[int] = [],
@@ -101,8 +102,8 @@ class _Sandbox(_Object, type_prefix="sb"):
         cloud_bucket_mounts = [(k, v) for k, v in validated_volumes if isinstance(v, _CloudBucketMount)]
         validated_volumes = [(k, v) for k, v in validated_volumes if isinstance(v, _Volume)]
 
-        def _deps() -> List[_Object]:
-            deps: List[_Object] = [image] + list(mounts) + list(secrets)
+        def _deps() -> list[_Object]:
+            deps: list[_Object] = [image] + list(mounts) + list(secrets)
             for _, vol in validated_network_file_systems:
                 deps.append(vol)
             for _, vol in validated_volumes:
@@ -186,7 +187,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         image: Optional[_Image] = None,  # The image to run as the container for the sandbox.
         mounts: Sequence[_Mount] = (),  # Mounts to attach to the sandbox.
         secrets: Sequence[_Secret] = (),  # Environment variables to inject into the sandbox.
-        network_file_systems: Dict[Union[str, os.PathLike], _NetworkFileSystem] = {},
+        network_file_systems: dict[Union[str, os.PathLike], _NetworkFileSystem] = {},
         timeout: Optional[int] = None,  # Maximum execution time of the sandbox in seconds.
         workdir: Optional[str] = None,  # Working directory of the sandbox.
         gpu: GPU_T = None,
@@ -195,11 +196,11 @@ class _Sandbox(_Object, type_prefix="sb"):
         cpu: Optional[float] = None,  # How many CPU cores to request. This is a soft limit.
         # Specify, in MiB, a memory request which is the minimum memory required.
         # Or, pass (request, limit) to additionally specify a hard limit in MiB.
-        memory: Optional[Union[int, Tuple[int, int]]] = None,
+        memory: Optional[Union[int, tuple[int, int]]] = None,
         block_network: bool = False,  # Whether to block network access
         # List of CIDRs the sandbox is allowed to access. If None, all CIDRs are allowed.
         cidr_allowlist: Optional[Sequence[str]] = None,
-        volumes: Dict[
+        volumes: dict[
             Union[str, os.PathLike], Union[_Volume, _CloudBucketMount]
         ] = {},  # Mount points for Modal Volumes and CloudBucketMounts
         pty_info: Optional[api_pb2.PTYInfo] = None,
@@ -306,7 +307,7 @@ class _Sandbox(_Object, type_prefix="sb"):
 
         return obj
 
-    async def set_tags(self, tags: Dict[str, str], *, client: Optional[_Client] = None):
+    async def set_tags(self, tags: dict[str, str], *, client: Optional[_Client] = None):
         """Set tags (key-value pairs) on the Sandbox. Tags can be used to filter results in `Sandbox.list`."""
         environment_name = _get_environment_name()
         if client is None:
@@ -341,7 +342,7 @@ class _Sandbox(_Object, type_prefix="sb"):
                     raise SandboxTerminatedError()
                 break
 
-    async def tunnels(self, timeout: int = 50) -> Dict[int, Tunnel]:
+    async def tunnels(self, timeout: int = 50) -> dict[int, Tunnel]:
         """Get tunnel metadata for the sandbox.
 
         Raises `SandboxTimeoutError` if the tunnels are not available after the timeout.
@@ -531,7 +532,7 @@ class _Sandbox(_Object, type_prefix="sb"):
 
     @staticmethod
     async def list(
-        *, app_id: Optional[str] = None, tags: Optional[Dict[str, str]] = None, client: Optional[_Client] = None
+        *, app_id: Optional[str] = None, tags: Optional[dict[str, str]] = None, client: Optional[_Client] = None
     ) -> AsyncGenerator["_Sandbox", None]:
         """List all sandboxes for the current environment or app ID (if specified). If tags are specified, only
         sandboxes that have at least those tags are returned. Returns an iterator over `Sandbox` objects."""

--- a/modal/scheduler_placement.py
+++ b/modal/scheduler_placement.py
@@ -1,5 +1,6 @@
 # Copyright Modal Labs 2024
-from typing import Optional, Sequence, Union
+from collections.abc import Sequence
+from typing import Optional, Union
 
 from modal_proto import api_pb2
 

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -1,6 +1,6 @@
 # Copyright Modal Labs 2022
 import os
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union
 
 from grpclib import GRPCError, Status
 
@@ -30,7 +30,7 @@ class _Secret(_Object, type_prefix="st"):
 
     @staticmethod
     def from_dict(
-        env_dict: Dict[
+        env_dict: dict[
             str, Union[str, None]
         ] = {},  # dict of entries to be inserted as environment variables in functions using the secret
     ):
@@ -46,7 +46,7 @@ class _Secret(_Object, type_prefix="st"):
         if not isinstance(env_dict, dict):
             raise InvalidError(ENV_DICT_WRONG_TYPE_ERR)
 
-        env_dict_filtered: Dict[str, str] = {k: v for k, v in env_dict.items() if v is not None}
+        env_dict_filtered: dict[str, str] = {k: v for k, v in env_dict.items() if v is not None}
         if not all(isinstance(k, str) for k in env_dict_filtered.keys()):
             raise InvalidError(ENV_DICT_WRONG_TYPE_ERR)
         if not all(isinstance(v, str) for v in env_dict_filtered.values()):
@@ -79,7 +79,7 @@ class _Secret(_Object, type_prefix="st"):
 
     @staticmethod
     def from_local_environ(
-        env_keys: List[str],  # list of local env vars to be included for remote execution
+        env_keys: list[str],  # list of local env vars to be included for remote execution
     ):
         """Create secrets from local environment variables automatically."""
 
@@ -165,7 +165,7 @@ class _Secret(_Object, type_prefix="st"):
         label: str,  # Some global identifier, such as "aws-secret"
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
-        required_keys: List[
+        required_keys: list[
             str
         ] = [],  # Optionally, a list of required environment variables (will be asserted server-side)
     ) -> "_Secret":
@@ -208,7 +208,7 @@ class _Secret(_Object, type_prefix="st"):
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
-        required_keys: List[str] = [],
+        required_keys: list[str] = [],
     ) -> "_Secret":
         """mdmd:hidden"""
         obj = _Secret.from_name(
@@ -223,7 +223,7 @@ class _Secret(_Object, type_prefix="st"):
     @staticmethod
     async def create_deployed(
         deployment_name: str,
-        env_dict: Dict[str, str],
+        env_dict: dict[str, str],
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,

--- a/modal/serving.py
+++ b/modal/serving.py
@@ -1,9 +1,10 @@
 # Copyright Modal Labs 2023
 import multiprocessing
 import platform
+from collections.abc import AsyncGenerator
 from multiprocessing.context import SpawnProcess
 from multiprocessing.synchronize import Event
-from typing import TYPE_CHECKING, AsyncGenerator, Optional, Set, TypeVar
+from typing import TYPE_CHECKING, Optional, TypeVar
 
 from synchronicity.async_wrap import asynccontextmanager
 
@@ -69,7 +70,7 @@ async def _terminate(proc: Optional[SpawnProcess], timeout: float = 5.0):
 async def _run_watch_loop(
     app_ref: str,
     app_id: str,
-    watcher: AsyncGenerator[Set[str], None],
+    watcher: AsyncGenerator[set[str], None],
     environment_name: str,
 ):
     unsupported_msg = None
@@ -96,7 +97,7 @@ async def _run_watch_loop(
 async def _serve_app(
     app: "_App",
     app_ref: str,
-    _watcher: Optional[AsyncGenerator[Set[str], None]] = None,  # for testing
+    _watcher: Optional[AsyncGenerator[set[str], None]] = None,  # for testing
     environment_name: Optional[str] = None,
 ) -> AsyncGenerator["_App", None]:
     if environment_name is None:

--- a/modal/token_flow.py
+++ b/modal/token_flow.py
@@ -2,7 +2,8 @@
 import itertools
 import os
 import webbrowser
-from typing import AsyncGenerator, Optional, Tuple
+from collections.abc import AsyncGenerator
+from typing import Optional
 
 import aiohttp.web
 from rich.console import Console
@@ -24,7 +25,7 @@ class _TokenFlow:
     @asynccontextmanager
     async def start(
         self, utm_source: Optional[str] = None, next_url: Optional[str] = None
-    ) -> AsyncGenerator[Tuple[str, str, str], None]:
+    ) -> AsyncGenerator[tuple[str, str, str], None]:
         """mdmd:hidden"""
         # Run a temporary http server returning the token id on /
         # This helps us add direct validation later

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -8,20 +8,15 @@ import platform
 import re
 import time
 import typing
+from collections.abc import AsyncGenerator, AsyncIterator, Generator, Sequence
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import (
     IO,
     Any,
-    AsyncGenerator,
-    AsyncIterator,
     BinaryIO,
     Callable,
-    Generator,
-    List,
     Optional,
-    Sequence,
-    Type,
     Union,
 )
 
@@ -190,7 +185,7 @@ class _Volume(_Object, type_prefix="vo"):
     @classmethod
     @asynccontextmanager
     async def ephemeral(
-        cls: Type["_Volume"],
+        cls: type["_Volume"],
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         version: "typing.Optional[modal_proto.api_pb2.VolumeFsVersion.ValueType]" = None,
@@ -364,7 +359,7 @@ class _Volume(_Object, type_prefix="vo"):
                 yield FileEntry._from_proto(entry)
 
     @live_method
-    async def listdir(self, path: str, *, recursive: bool = False) -> List[FileEntry]:
+    async def listdir(self, path: str, *, recursive: bool = False) -> list[FileEntry]:
         """List all files under a path prefix in the modal.Volume.
 
         Passing a directory path lists all files in the directory. For a file path, return only that
@@ -421,7 +416,7 @@ class _Volume(_Object, type_prefix="vo"):
 
         n = fileobj.write(response.data)
         if n != len(response.data):
-            raise IOError(f"failed to write {len(response.data)} bytes to output. Wrote {n}.")
+            raise OSError(f"failed to write {len(response.data)} bytes to output. Wrote {n}.")
         elif n == response.size:
             return response.size
         elif n > response.size:
@@ -442,7 +437,7 @@ class _Volume(_Object, type_prefix="vo"):
 
             n = fileobj.write(response.data)
             if n != len(response.data):
-                raise IOError(f"failed to write {len(response.data)} bytes to output. Wrote {n}.")
+                raise OSError(f"failed to write {len(response.data)} bytes to output. Wrote {n}.")
             written += n
             if written == file_size:
                 break
@@ -524,7 +519,7 @@ class _VolumeUploadContextManager:
     _client: _Client
     _force: bool
     progress_cb: Callable[..., Any]
-    _upload_generators: List[Generator[Callable[[], FileUploadSpec], None, None]]
+    _upload_generators: list[Generator[Callable[[], FileUploadSpec], None, None]]
 
     def __init__(
         self, volume_id: str, client: _Client, progress_cb: Optional[Callable[..., Any]] = None, force: bool = False
@@ -556,7 +551,7 @@ class _VolumeUploadContextManager:
                         yield await fut
 
             # Compute checksums & Upload files
-            files: List[api_pb2.MountFile] = []
+            files: list[api_pb2.MountFile] = []
             async with aclosing(async_map(gen_file_upload_specs(), self._upload_file, concurrency=20)) as stream:
                 async for item in stream:
                     files.append(item)

--- a/modal_docs/mdmd/signatures.py
+++ b/modal_docs/mdmd/signatures.py
@@ -4,12 +4,11 @@ import inspect
 import re
 import textwrap
 import warnings
-from typing import Tuple
 
 from synchronicity.synchronizer import FunctionWithAio
 
 
-def _signature_from_ast(func) -> Tuple[str, str]:
+def _signature_from_ast(func) -> tuple[str, str]:
     """Get function signature, including decorators and comments, from source code
 
     Traverses functools.wraps-wrappings to get source of underlying function.

--- a/protoc_plugin/plugin.py
+++ b/protoc_plugin/plugin.py
@@ -5,9 +5,10 @@
 import os
 import sys
 from collections import deque
+from collections.abc import Collection, Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Collection, Deque, Dict, Iterator, List, NamedTuple, Optional, Tuple
+from typing import Any, Deque, NamedTuple, Optional
 
 from google.protobuf.compiler.plugin_pb2 import CodeGeneratorRequest, CodeGeneratorResponse
 from google.protobuf.descriptor_pb2 import DescriptorProto, FileDescriptorProto
@@ -30,12 +31,12 @@ class Method(NamedTuple):
 
 class Service(NamedTuple):
     name: str
-    methods: List[Method]
+    methods: list[Method]
 
 
 class Buffer:
     def __init__(self) -> None:
-        self._lines: List[str] = []
+        self._lines: list[str] = []
         self._indent = 0
 
     def add(self, string: str, *args: Any, **kwargs: Any) -> None:
@@ -139,7 +140,7 @@ def _type_names(
     proto_file: FileDescriptorProto,
     message_type: DescriptorProto,
     parents: Optional[Deque[str]] = None,
-) -> Iterator[Tuple[str, str]]:
+) -> Iterator[tuple[str, str]]:
     if parents is None:
         parents = deque()
 
@@ -165,7 +166,7 @@ def main() -> None:
     with os.fdopen(sys.stdin.fileno(), "rb") as inp:
         request = CodeGeneratorRequest.FromString(inp.read())
 
-    types_map: Dict[str, str] = {}
+    types_map: dict[str, str] = {}
     for pf in request.proto_file:
         for mt in pf.message_type:
             types_map.update(_type_names(pf, mt))

--- a/tasks.py
+++ b/tasks.py
@@ -9,11 +9,12 @@ import pkgutil
 import re
 import subprocess
 import sys
+from collections.abc import Generator
 from contextlib import contextmanager
 from datetime import date
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Generator, List, Optional
+from typing import Optional
 
 import requests
 from invoke import task
@@ -260,7 +261,7 @@ def type_stubs(ctx):
                 modules.append(full_name)
         return modules
 
-    def get_wrapped_types(module_name: str) -> List[str]:
+    def get_wrapped_types(module_name: str) -> list[str]:
         module = importlib.import_module(module_name)
         return [
             name
@@ -318,7 +319,7 @@ def update_changelog(ctx, sha: str = ""):
         return
 
     # Read the existing changelog and split after the header so we can prepend new content
-    with open("CHANGELOG.md", "r") as fid:
+    with open("CHANGELOG.md") as fid:
         content = fid.read()
     token_pattern = "<!-- NEW CONTENT GENERATED BELOW. PLEASE PRESERVE THIS COMMENT. -->"
     m = re.search(token_pattern, content)

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -232,7 +232,7 @@ def test_redeploy_delete_objects(servicer, client):
     res = deploy_app(app, "xyz", client=client)
 
     # Check objects
-    assert set(servicer.app_objects[res.app_id].keys()) == set(["d1", "d2"])
+    assert set(servicer.app_objects[res.app_id].keys()) == {"d1", "d2"}
 
     # Deploy an app with objects d2 and d3
     app = App()
@@ -241,7 +241,7 @@ def test_redeploy_delete_objects(servicer, client):
     res = deploy_app(app, "xyz", client=client)
 
     # Make sure d1 is deleted
-    assert set(servicer.app_objects[res.app_id].keys()) == set(["d2", "d3"])
+    assert set(servicer.app_objects[res.app_id].keys()) == {"d2", "d3"}
 
 
 @pytest.mark.asyncio

--- a/test/async_utils_test.py
+++ b/test/async_utils_test.py
@@ -896,8 +896,7 @@ async def test_async_map_output_exception_async_func(in_order):
     def gen():
         states.append("enter")
         try:
-            for i in range(5):
-                yield i
+            yield from range(5)
         finally:
             states.append("exit")
 

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -12,7 +12,6 @@ import tempfile
 import threading
 import traceback
 from pickle import dumps
-from typing import List
 from unittest import mock
 
 import click
@@ -43,7 +42,7 @@ assert mod.app == app
 dummy_other_module_file = "x = 42"
 
 
-def _run(args: List[str], expected_exit_code: int = 0, expected_stderr: str = "", expected_error: str = ""):
+def _run(args: list[str], expected_exit_code: int = 0, expected_stderr: str = "", expected_error: str = ""):
     runner = click.testing.CliRunner(mix_stderr=False)
     # DEBUGGING TIP: this runs the CLI in a separate subprocess, and output from it is not echoed by default,
     # including from the mock fixtures. Print res.stdout and res.stderr for debugging tests.
@@ -536,7 +535,7 @@ def test_nfs_get(set_env_client, servicer):
         _run(["nfs", "put", nfs_name, upload_path, "test.txt"])
 
         _run(["nfs", "get", nfs_name, "test.txt", tmpdir])
-        with open(os.path.join(tmpdir, "test.txt"), "r") as f:
+        with open(os.path.join(tmpdir, "test.txt")) as f:
             assert f.read() == "foo bar baz"
 
 
@@ -981,7 +980,7 @@ def test_call_update_environment_suffix(servicer, set_env_client):
     _run(["environment", "update", "main", "--set-web-suffix", "_"])
 
 
-def _run_subprocess(cli_cmd: List[str]) -> helpers.PopenWithCtrlC:
+def _run_subprocess(cli_cmd: list[str]) -> helpers.PopenWithCtrlC:
     p = helpers.PopenWithCtrlC(
         [sys.executable, "-m", "modal"] + cli_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf8"
     )

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 import threading
 import typing
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING
 
 from typing_extensions import assert_type
 
@@ -87,7 +87,7 @@ def test_call_class_sync(client, servicer):
     assert (
         len(ctx.get_requests("FunctionBindParams")) == 0
     )  # shouldn't need to bind in case there are no instance args etc.
-    function_creates_requests: typing.List[api_pb2.FunctionCreateRequest] = ctx.get_requests("FunctionCreate")
+    function_creates_requests: list[api_pb2.FunctionCreateRequest] = ctx.get_requests("FunctionCreate")
     assert len(function_creates_requests) == 1
     (class_create,) = ctx.get_requests("ClassCreate")
     function_creates = {fc.function.function_name: fc for fc in function_creates_requests}
@@ -589,7 +589,7 @@ class ClsWithHandlers:
 
 
 def test_handlers():
-    pfs: Dict[str, _PartialFunction]
+    pfs: dict[str, _PartialFunction]
 
     pfs = _find_partial_methods_for_user_cls(ClsWithHandlers, _PartialFunctionFlags.BUILD)
     assert list(pfs.keys()) == ["my_build", "my_build_and_enter"]

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -26,7 +26,7 @@ def _cli(args, env={}):
         # For windows
         "PYTHONUTF8": "1",
     }
-    ret = subprocess.run(args, cwd=lib_dir, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    ret = subprocess.run(args, cwd=lib_dir, env=env, capture_output=True)
     stdout = ret.stdout.decode()
     stderr = ret.stderr.decode()
     if ret.returncode != 0:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -19,9 +19,10 @@ import threading
 import traceback
 import uuid
 from collections import defaultdict
+from collections.abc import Iterator
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Dict, Iterator, List, Optional, Tuple, get_args
+from typing import Any, get_args
 
 import aiohttp.web
 import aiohttp.web_runner
@@ -70,8 +71,8 @@ def ignore_local_config():
 
 class FunctionsRegistry:
     def __init__(self):
-        self._functions: Dict[str, api_pb2.Function] = {}
-        self._functions_data: Dict[str, api_pb2.FunctionData] = {}
+        self._functions: dict[str, api_pb2.Function] = {}
+        self._functions_data: dict[str, api_pb2.FunctionData] = {}
 
     def __getitem__(self, key):
         if key in self._functions:
@@ -116,7 +117,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         )  # set to non-1 to get lock-step of input releases within a test
 
         self.app_state_history = defaultdict(list)
-        self.app_heartbeats: Dict[str, int] = defaultdict(int)
+        self.app_heartbeats: dict[str, int] = defaultdict(int)
         self.container_snapshot_requests = 0
         self.n_blobs = 0
         self.blob_host = blob_host
@@ -131,11 +132,11 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.fail_get_data_out = []
         self.fc_data_in = defaultdict(lambda: asyncio.Queue())  # unbounded
         self.fc_data_out = defaultdict(lambda: asyncio.Queue())  # unbounded
-        self.queue: Dict[bytes, List[bytes]] = {b"": []}
+        self.queue: dict[bytes, list[bytes]] = {b"": []}
         self.deployed_apps = {
             client_mount_name(): "ap-x",
         }
-        self.app_deployment_history: defaultdict[str, List[Dict[str, Any]]] = defaultdict(list)
+        self.app_deployment_history: defaultdict[str, list[dict[str, Any]]] = defaultdict(list)
         self.app_deployment_history["ap-x"] = [
             {
                 "app_id": "ap-x",
@@ -167,7 +168,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.n_functions = 0
         self.n_schedules = 0
         self.function2schedule = {}
-        self.function_create_error: Optional[BaseException] = None
+        self.function_create_error: BaseException | None = None
         self.heartbeat_status_code = None
         self.n_apps = 0
         self.classes = []
@@ -175,8 +176,8 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
         self.task_result = None
 
-        self.nfs_files: Dict[str, Dict[str, api_pb2.SharedVolumePutFileRequest]] = defaultdict(dict)
-        self.volume_files: Dict[str, Dict[str, VolumeFile]] = defaultdict(dict)
+        self.nfs_files: dict[str, dict[str, api_pb2.SharedVolumePutFileRequest]] = defaultdict(dict)
+        self.volume_files: dict[str, dict[str, VolumeFile]] = defaultdict(dict)
         self.images = {}
         self.image_build_function_ids = {}
         self.image_builder_versions = {}
@@ -188,9 +189,9 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.precreated_functions = set()
 
         self.app_functions: FunctionsRegistry = FunctionsRegistry()
-        self.bound_functions: Dict[Tuple[str, bytes], str] = {}
-        self.function_params: Dict[str, Tuple[Tuple, Dict[str, Any]]] = {}
-        self.function_options: Dict[str, api_pb2.FunctionOptions] = {}
+        self.bound_functions: dict[tuple[str, bytes], str] = {}
+        self.function_params: dict[str, tuple[tuple, dict[str, Any]]] = {}
+        self.function_options: dict[str, api_pb2.FunctionOptions] = {}
         self.fcidx = 0
 
         self.function_serialized = None
@@ -221,17 +222,17 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
         self.volume_counter = 0
         # Volume-id -> commit/reload count
-        self.volume_commits: Dict[str, int] = defaultdict(lambda: 0)
-        self.volume_reloads: Dict[str, int] = defaultdict(lambda: 0)
+        self.volume_commits: dict[str, int] = defaultdict(int)
+        self.volume_reloads: dict[str, int] = defaultdict(int)
 
         self.sandbox_defs = []
         self.sandbox_app_id = None
         self.sandbox: asyncio.subprocess.Process = None
-        self.sandbox_result: Optional[api_pb2.GenericResult] = None
+        self.sandbox_result: api_pb2.GenericResult | None = None
 
         self.shell_prompt = None
         self.container_exec: asyncio.subprocess.Process = None
-        self.container_exec_result: Optional[api_pb2.GenericResult] = None
+        self.container_exec_result: api_pb2.GenericResult | None = None
 
         self.token_flow_localhost_port = None
         self.queue_max_len = 100
@@ -303,7 +304,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self._function_body = func
         return func
 
-    def function_by_name(self, name: str, params: Optional[Tuple[Tuple, Dict[str, Any]]] = None) -> api_pb2.Function:
+    def function_by_name(self, name: str, params: tuple[tuple, dict[str, Any]] | None = None) -> api_pb2.Function:
         matches = []
         all_names = []
         for function_id, fun in self.app_functions.items():
@@ -926,8 +927,8 @@ class MockClientServicer(api_grpc.ModalClientBase):
         else:
             self.n_functions += 1
             function_id = f"fu-{self.n_functions}"
-        function: Optional[api_pb2.Function] = None
-        function_data: Optional[api_pb2.FunctionData] = None
+        function: api_pb2.Function | None = None
+        function_data: api_pb2.FunctionData | None = None
         if len(request.function_data.ranked_functions) > 0:
             function_data = api_pb2.FunctionData()
             function_data.CopyFrom(request.function_data)
@@ -1504,9 +1505,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     ### Task
 
-    async def TaskCurrentInputs(
-        self, stream: "grpclib.server.Stream[Empty, api_pb2.TaskCurrentInputsResponse]"
-    ) -> None:
+    async def TaskCurrentInputs(self, stream: grpclib.server.Stream[Empty, api_pb2.TaskCurrentInputsResponse]) -> None:
         await stream.send_message(api_pb2.TaskCurrentInputsResponse(input_ids=[]))  # dummy implementation
 
     async def TaskResult(self, stream):
@@ -1695,7 +1694,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
 @pytest.fixture
 def blob_server():
     blobs = {}
-    blob_parts: Dict[str, Dict[int, bytes]] = defaultdict(dict)
+    blob_parts: dict[str, dict[int, bytes]] = defaultdict(dict)
 
     async def upload(request):
         blob_id = request.query["blob_id"]

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -155,10 +155,12 @@ async def test_container_debug_snapshot(container_client, tmpdir, servicer):
 
 @pytest.mark.asyncio
 async def test_rpc_wrapping_restores(container_client, servicer, tmpdir):
+    import modal
+
     io_manager = ContainerIOManager(api_pb2.ContainerArguments(), container_client)
     restore_path = temp_restore_path(tmpdir)
 
-    d = dict.lookup("my-amazing-dict", {"xyz": 123}, create_if_missing=True, client=container_client)
+    d = modal.Dict.lookup("my-amazing-dict", {"xyz": 123}, create_if_missing=True, client=container_client)
     d["abc"] = 42
 
     with set_env_vars(restore_path, servicer.container_addr):

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -4,7 +4,6 @@ import os
 import pytest
 import time
 from contextlib import contextmanager
-from typing import Dict
 from unittest import mock
 
 from google.protobuf.empty_pb2 import Empty
@@ -41,11 +40,11 @@ def temp_restore_path(tmpdir):
 
 @pytest.mark.asyncio
 async def test_container_function_lazily_imported(container_client):
-    tag_to_object_id: Dict[str, str] = {
+    tag_to_object_id: dict[str, str] = {
         "my_f_1": "fu-123",
         "my_d": "di-123",
     }
-    object_handle_metadata: Dict[str, Message] = {
+    object_handle_metadata: dict[str, Message] = {
         "fu-123": api_pb2.FunctionHandleMetadata(),
     }
     container_app = RunningApp(
@@ -156,12 +155,10 @@ async def test_container_debug_snapshot(container_client, tmpdir, servicer):
 
 @pytest.mark.asyncio
 async def test_rpc_wrapping_restores(container_client, servicer, tmpdir):
-    from modal import Dict
-
     io_manager = ContainerIOManager(api_pb2.ContainerArguments(), container_client)
     restore_path = temp_restore_path(tmpdir)
 
-    d = Dict.lookup("my-amazing-dict", {"xyz": 123}, create_if_missing=True, client=container_client)
+    d = dict.lookup("my-amazing-dict", {"xyz": 123}, create_if_missing=True, client=container_client)
     d["abc"] = 42
 
     with set_env_vars(restore_path, servicer.container_addr):

--- a/test/e2e_test.py
+++ b/test/e2e_test.py
@@ -3,10 +3,9 @@ import os
 import pathlib
 import subprocess
 import sys
-from typing import Tuple
 
 
-def _cli(args, server_url, credentials, extra_env={}, check=True) -> Tuple[int, str, str]:
+def _cli(args, server_url, credentials, extra_env={}, check=True) -> tuple[int, str, str]:
     lib_dir = pathlib.Path(__file__).parent.parent
     args = [sys.executable] + args
     token_id, token_secret = credentials
@@ -18,7 +17,7 @@ def _cli(args, server_url, credentials, extra_env={}, check=True) -> Tuple[int, 
         "PYTHONUTF8": "1",  # For windows
         **extra_env,
     }
-    ret = subprocess.run(args, cwd=lib_dir, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    ret = subprocess.run(args, cwd=lib_dir, env=env, capture_output=True)
 
     stdout = ret.stdout.decode()
     stderr = ret.stderr.decode()

--- a/test/fork_test.py
+++ b/test/fork_test.py
@@ -8,5 +8,5 @@ from test.supports.skip import skip_windows
 def test_process_fork(supports_dir, server_url_env, token_env):
     output = subprocess.check_output([sys.executable, supports_dir / "forking.py"], timeout=2, encoding="utf8")
 
-    success_pids = set(int(x) for x in output.split())
+    success_pids = {int(x) for x in output.split()}
     assert len(success_pids) == 2

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -831,8 +831,8 @@ def test_deps_explicit(client, servicer):
         object_id: str = app.registered_functions["dummy"].object_id
         f = servicer.app_functions[object_id]
 
-    dep_object_ids = set(d.object_id for d in f.object_dependencies)
-    assert dep_object_ids == set([image.object_id, nfs_1.object_id, nfs_2.object_id])
+    dep_object_ids = {d.object_id for d in f.object_dependencies}
+    assert dep_object_ids == {image.object_id, nfs_1.object_id, nfs_2.object_id}
 
 
 def assert_is_wrapped_dict(some_arg):

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -4,12 +4,12 @@ import pathlib
 import signal
 import subprocess
 import sys
-from typing import Optional, Tuple
+from typing import Optional
 
 
 def deploy_app_externally(
     servicer,
-    credentials: Tuple[str, str],
+    credentials: tuple[str, str],
     file_or_module: str,
     app_variable: Optional[str] = None,
     deployment_name="Deployment",

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -7,7 +7,7 @@ import sys
 import threading
 from hashlib import sha256
 from tempfile import NamedTemporaryFile
-from typing import List, Literal, get_args
+from typing import Literal, get_args
 from unittest import mock
 
 import modal
@@ -31,7 +31,7 @@ from modal_proto import api_pb2
 from .supports.skip import skip_windows
 
 # Avoid parameterizing tests over ImageBuilderVersion not supported by current Python
-PYTHON_MAJOR_MINOR = "{0}.{1}".format(*sys.version_info)
+PYTHON_MAJOR_MINOR = "{}.{}".format(*sys.version_info)
 SUPPORTED_IMAGE_BUILDER_VERSIONS = [
     v for v in get_args(ImageBuilderVersion) if PYTHON_MAJOR_MINOR in SUPPORTED_PYTHON_SERIES[v]
 ]
@@ -54,7 +54,7 @@ def test_supported_python_series():
         assert SUPPORTED_PYTHON_SERIES[builder_version] <= list(PYTHON_STANDALONE_VERSIONS)
 
 
-def get_image_layers(image_id: str, servicer) -> List[api_pb2.Image]:
+def get_image_layers(image_id: str, servicer) -> list[api_pb2.Image]:
     """Follow pointers to the previous image recursively in the servicer's list of images,
     and return a list of image layers from top to bottom."""
 
@@ -96,7 +96,7 @@ def clear_environment_cache():
 
 
 def test_python_version_validation(builder_version):
-    assert _validate_python_version(None, builder_version) == "{0}.{1}".format(*sys.version_info)
+    assert _validate_python_version(None, builder_version) == "{}.{}".format(*sys.version_info)
     assert _validate_python_version("3.12", builder_version) == "3.12"
     assert _validate_python_version("3.12.0", builder_version) == "3.12.0"
 
@@ -155,7 +155,7 @@ def test_image_base(builder_version, servicer, client, test_dir):
 
 @pytest.mark.parametrize("python_version", [None, "3.10", "3.11.4"])
 def test_python_version(builder_version, servicer, client, python_version):
-    local_python = "{0}.{1}".format(*sys.version_info)
+    local_python = "{}.{}".format(*sys.version_info)
     expected_python = local_python if python_version is None else python_version
 
     app = App()

--- a/test/mounted_files_test.py
+++ b/test/mounted_files_test.py
@@ -298,7 +298,7 @@ def test_mount_dedupe_explicit(servicer, credentials, test_dir, server_url_env):
     assert servicer.n_mounts == 3
 
     # mounts are loaded in parallel, but there
-    mounted_files_sets = set(frozenset(m.keys()) for m in servicer.mount_contents.values() if m)
+    mounted_files_sets = {frozenset(m.keys()) for m in servicer.mount_contents.values() if m}
     assert {"/root/mount_dedupe.py"} in mounted_files_sets
     mounted_files_sets.remove(frozenset({"/root/mount_dedupe.py"}))
 

--- a/test/supports/functions.py
+++ b/test/supports/functions.py
@@ -2,7 +2,6 @@
 import asyncio
 import contextlib
 import time
-from typing import List, Tuple
 
 from modal import (
     App,
@@ -159,7 +158,7 @@ def fastapi_app():
     return web_app
 
 
-lifespan_global_asgi_app_func: List[str] = []
+lifespan_global_asgi_app_func: list[str] = []
 
 
 @app.function()
@@ -229,7 +228,7 @@ def fastapi_app_with_lifespan_failing_shutdown():
     return web_app
 
 
-lifespan_global_asgi_app_cls: List[str] = []
+lifespan_global_asgi_app_cls: list[str] = []
 
 
 @app.cls(container_idle_timeout=300, concurrency_limit=1, allow_concurrent_inputs=100)
@@ -280,7 +279,7 @@ class fastapi_class_multiple_asgi_apps_lifespans:
         lifespan_global_asgi_app_cls.append("exit")
 
 
-lifespan_global_asgi_app_cls_fail: List[str] = []
+lifespan_global_asgi_app_cls_fail: list[str] = []
 
 
 @app.cls(container_idle_timeout=300, concurrency_limit=1, allow_concurrent_inputs=100)
@@ -415,7 +414,7 @@ class LifecycleCls:
         sync_exit_duration=0,
         async_exit_duration=0,
     ):
-        self.events: List[str] = []
+        self.events: list[str] = []
         self.sync_enter_duration = sync_enter_duration
         self.async_enter_duration = async_enter_duration
         self.sync_exit_duration = sync_exit_duration
@@ -521,7 +520,7 @@ async def sleep_700_async(x):
 
 @app.function()
 @batched(max_batch_size=4, wait_ms=500)
-def batch_function_sync(x: Tuple[int], y: Tuple[int]):
+def batch_function_sync(x: tuple[int], y: tuple[int]):
     outputs = []
     for x_i, y_i in zip(x, y):
         outputs.append(x_i / y_i)
@@ -530,19 +529,19 @@ def batch_function_sync(x: Tuple[int], y: Tuple[int]):
 
 @app.function()
 @batched(max_batch_size=4, wait_ms=500)
-def batch_function_outputs_not_list(x: Tuple[int], y: Tuple[int]):
+def batch_function_outputs_not_list(x: tuple[int], y: tuple[int]):
     return str(x)
 
 
 @app.function()
 @batched(max_batch_size=4, wait_ms=500)
-def batch_function_outputs_wrong_len(x: Tuple[int], y: Tuple[int]):
+def batch_function_outputs_wrong_len(x: tuple[int], y: tuple[int]):
     return list(x) + [0]
 
 
 @app.function()
 @batched(max_batch_size=4, wait_ms=500)
-async def batch_function_async(x: Tuple[int], y: Tuple[int]):
+async def batch_function_async(x: tuple[int], y: tuple[int]):
     outputs = []
     for x_i, y_i in zip(x, y):
         outputs.append(x_i / y_i)

--- a/test/telemetry_test.py
+++ b/test/telemetry_test.py
@@ -27,7 +27,7 @@ from modal._runtime.telemetry import (
 class TelemetryConsumer:
     socket_filename: Path
     server: socket.socket
-    connections: typing.Set[socket.socket]
+    connections: set[socket.socket]
     events: queue.Queue
     tmp: tempfile.TemporaryDirectory
 
@@ -101,7 +101,7 @@ def test_import_tracing(monkeypatch):
     with TelemetryConsumer() as consumer, ImportInterceptor.connect(consumer.socket_filename.absolute().as_posix()):
         from .telemetry import tracing_module_1  # noqa
 
-        expected_messages: list[typing.Dict[str, typing.Any]] = [
+        expected_messages: list[dict[str, typing.Any]] = [
             {"event": "module_load_start", "attributes": {"name": "test.telemetry.tracing_module_1"}},
             {"event": "module_load_start", "attributes": {"name": "test.telemetry.tracing_module_2"}},
             {"event": "module_load_end", "attributes": {"name": "test.telemetry.tracing_module_2"}},

--- a/test/traceback_test.py
+++ b/test/traceback_test.py
@@ -2,7 +2,6 @@
 import pytest
 from pathlib import Path
 from traceback import extract_tb
-from typing import Dict, List, Tuple
 
 from modal._traceback import (
     append_modal_tb,
@@ -82,7 +81,7 @@ def test_append_modal_tb():
     assert frames == ["test_append_modal_tb", "call_raise_error", "raise_error"]
 
 
-def make_tb_stack(frames: List[Tuple[str, str]]) -> List[Dict]:
+def make_tb_stack(frames: list[tuple[str, str]]) -> list[dict]:
     """Given a minimal specification of (code filename, code name), return dict formatted for tblib."""
     tb_frames = []
     for lineno, (filename, name) in enumerate(frames):
@@ -100,7 +99,7 @@ def make_tb_stack(frames: List[Tuple[str, str]]) -> List[Dict]:
     return tb_frames
 
 
-def tb_dict_from_stack_dicts(stack: List[Dict]) -> Dict:
+def tb_dict_from_stack_dicts(stack: list[dict]) -> dict:
     tb_root = tb = stack.pop(0)
     while stack:
         tb["tb_next"] = stack.pop(0)

--- a/test/web_server_proxy_test.py
+++ b/test/web_server_proxy_test.py
@@ -4,7 +4,7 @@ import contextlib
 import pytest
 import socket
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any
 
 import pytest_asyncio
 from aiohttp.web import Application
@@ -20,7 +20,7 @@ class DummyHttpServer:
     host: str
     port: int
     event: asyncio.Event
-    assertion_log: List[str]
+    assertion_log: list[str]
 
 
 @contextlib.asynccontextmanager
@@ -63,14 +63,14 @@ async def http_dummy_server():
         return web.Response(text="Hello, world")
 
     app = web.Application()
-    app.add_routes(([web.post("/", hello)]))
+    app.add_routes([web.post("/", hello)])
     async with run_temporary_http_server(app) as (host, port):
         yield DummyHttpServer(host=host, port=port, event=event, assertion_log=assertion_log)
 
 
 @contextlib.asynccontextmanager
 async def lifespan_ctx_manager(asgi_app):
-    state: Dict[str, Any] = {}
+    state: dict[str, Any] = {}
 
     lm = modal._runtime.asgi.LifespanManager(asgi_app, state)
     t = asyncio.create_task(lm.background_task())


### PR DESCRIPTION
We dropped support for Python 3.8 on 15 November and haven't heard of that causing any problems, so I'd say we can start taking advantage to remove vestigial code.

This is a ~fully~ mostly automated PR, resulting from 

```
pyupgrade --py39-plus `find . -name "*.py"`
```

and then some manual fixes for a couple edge cases:

- Change a `from modal import Dict` import to `import modal; modal.Dict`, as pyupgrade overzealously turned the first one into `dict`
- Rename CLI `list` functions to `list_` to avoid shadowing the builtin type (no external effect as we provide a command name in the typer decorator)