### PR TITLE
Add minor version headers to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@ We appreciate your patience while we speedily work towards a stable release of t
 
 ### 0.67.0 (2024-11-27)
 
-New minor client version `0.67.x` comes with an internal data model change for how Modal creates functions for Modal classes. There are no breaking or backwards-incompatible changes with this new minor version. All forward lookup scenarios (`.lookup()` of a `0.67` class from a pre `0.67` client) as well as backwards lookup scenarios (`.lookup()` of a pre `0.67` class from a `0.67` client) work, except for a `0.62` client looking up a `0.67` class (this maintains our current restriction of not being able to lookup a `0.63+` class from a `0.62` client).
+New minor client version `0.67.x` comes with an internal data model change for how Modal creates functions for Modal classes. There are no breaking or backwards-incompatible changes with this release. All forward lookup scenarios (`.lookup()` of a `0.67` class from a pre `0.67` client) as well as backwards lookup scenarios (`.lookup()` of a pre `0.67` class from a `0.67` client) work, except for a `0.62` client looking up a `0.67` class (this maintains our current restriction of not being able to lookup a `0.63+` class from a `0.62` client).
+
+
+## 0.66
 
 
 
@@ -61,6 +64,10 @@ New minor client version `0.67.x` comes with an internal data model change for h
 ### 0.66.0 (2024-11-15)
 
 - Modal no longer supports Python 3.8, which has reached its [official EoL](https://devguide.python.org/versions/).
+
+
+
+## 0.65
 
 
 


### PR DESCRIPTION
Annoying that we need to do this manually, but I can never quite get over threshold to automate it.