### PR TITLE
Avoid sending empty messages on process start

### DIFF
--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -227,7 +227,7 @@ class _StreamReader(Generic[T]):
 
             entry_id += 1
 
-    async def _get_logs(self) -> AsyncGenerator[Optional[bytes], None]:
+    async def _get_logs(self, skip_empty_messages: bool = True) -> AsyncGenerator[Optional[bytes], None]:
         """Streams sandbox or process logs from the server to the reader.
 
         Logs returned by this method may contain partial or multiple lines at a time.
@@ -256,6 +256,11 @@ class _StreamReader(Generic[T]):
 
                 async for message, entry_id in iterator:
                     self._last_entry_id = entry_id
+                    # Empty messages are sent when the process boots up. Don't yield them unless
+                    # we're using the empty message to signal process liveness.
+                    if skip_empty_messages and message == b"":
+                        continue
+
                     yield message
                     if message is None:
                         completed = True


### PR DESCRIPTION
## Describe your changes

Previously, we added an empty message on container start so that the client could tell the process had booted. This turned out to be a breaking change since clients would now receive an extra message on initialization. This commit refactors output consumption to only return the empty message in `modal shell` usage.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>


