### PR TITLE
Clean up a little bit of 3.8-only code

### DIFF
--- a/modal/cli/import_refs.py
+++ b/modal/cli/import_refs.py
@@ -54,7 +54,7 @@ def import_file_or_module(file_or_module: str):
         # when using a script path, that scripts directory should also be on the path as it is
         # with `python some/script.py`
         full_path = Path(file_or_module).resolve()
-        if "." in full_path.name[:-3]:  # use removesuffix once we drop 3.8 support
+        if "." in full_path.name.removesuffix(".py"):
             raise InvalidError(
                 f"Invalid Modal source filename: {full_path.name!r}."
                 "\n\nSource filename cannot contain additional period characters."

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -912,7 +912,8 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                     function_data.ranked_functions.extend(ranked_functions)
                     function_definition = None  # function_definition is not used in this case
                 else:
-                    assert isinstance(gpu, GPU_T)  # includes the case where gpu==None case
+                    # TODO(irfansharif): Assert on this specific type once we get rid of python 3.9.
+                    # assert isinstance(gpu, GPU_T)  # includes the case where gpu==None case
                     function_definition.resources.CopyFrom(
                         convert_fn_config_to_resources_config(
                             cpu=cpu, memory=memory, gpu=gpu, ephemeral_disk=ephemeral_disk

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -912,9 +912,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                     function_data.ranked_functions.extend(ranked_functions)
                     function_definition = None  # function_definition is not used in this case
                 else:
-                    # TODO(irfansharif): Assert on this specific type once
-                    # we get rid of python 3.8.
-                    #   assert isinstance(gpu, GPU_T)  # includes the case where gpu==None case
+                    assert isinstance(gpu, GPU_T)  # includes the case where gpu==None case
                     function_definition.resources.CopyFrom(
                         convert_fn_config_to_resources_config(
                             cpu=cpu, memory=memory, gpu=gpu, ephemeral_disk=ephemeral_disk

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -749,8 +749,7 @@ def get_auto_mounts() -> list[_Mount]:
             continue
 
         for local_path, remote_path in mount_paths:
-            # TODO: use is_relative_to once we deprecate Python 3.8
-            if any(str(local_path).startswith(str(p)) for p in SYS_PREFIXES) or _is_modal_path(remote_path):
+            if any(local_path.is_relative_to(p) for p in SYS_PREFIXES) or _is_modal_path(remote_path):
                 # skip any module that has paths in SYS_PREFIXES, or would overwrite the modal Package in the container
                 break
         else:

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -677,16 +677,11 @@ def _open_files_error_annotation(mount_path: str) -> Optional[str]:
             cmdline = " ".join([part.decode() for part in parts]).rstrip(" ")
 
         cwd = PurePosixPath(os.readlink(f"/proc/{pid}/cwd"))
-        # NOTE(staffan): Python 3.8 doesn't have is_relative_to(), so we're stuck with catching ValueError until
-        # we drop Python 3.8 support.
-        try:
-            _rel_cwd = cwd.relative_to(mount_path)
+        if cwd.is_relative_to(mount_path):
             if pid == self_pid:
                 return "cwd is inside volume"
             else:
                 return f"cwd of '{cmdline}' is inside volume"
-        except ValueError:
-            pass
 
         for fd in os.listdir(f"/proc/{pid}/fd"):
             try:

--- a/modal_global_objects/mounts/python_standalone.py
+++ b/modal_global_objects/mounts/python_standalone.py
@@ -17,7 +17,7 @@ def publish_python_standalone_mount(client, version: str) -> None:
     release, full_version = PYTHON_STANDALONE_VERSIONS[version]
 
     libc = "gnu"
-    arch = "x86_64" if version == "3.8" else "x86_64_v3"
+    arch = "x86_64_v3"
     url = (
         "https://github.com/indygreg/python-build-standalone/releases/download"
         + f"/{release}/cpython-{full_version}+{release}-{arch}-unknown-linux-gnu-install_only.tar.gz"

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -1116,10 +1116,8 @@ def test_cli(servicer, credentials):
     stderr = ret.stderr.decode()
     if ret.returncode != 0:
         raise Exception(f"Failed with {ret.returncode} stdout: {stdout} stderr: {stderr}")
-
-    if sys.version_info[:2] != (3, 8):  # Skip on Python 3.8 as we'll have PendingDeprecationError messages
-        assert stdout == ""
-        assert stderr == ""
+    assert stdout == ""
+    assert stderr == ""
 
 
 @skip_github_non_linux


### PR DESCRIPTION
Removes some code that was called out in comments as existing to support Python 3.8.

There were a couple other cases involving nuances around asyncio Queues and synchronicity that I didn't feel comfortable touching 🙈.