### PR TITLE
Implement aclose for StreamReader

### DIFF
--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -311,6 +311,11 @@ class _StreamReader(Generic[T]):
         else:
             return cast(T, value)
 
+    async def aclose(self):
+        """mdmd:hidden"""
+        if self._stream:
+            await self._stream.aclose()
+
 
 MAX_BUFFER_SIZE = 2 * 1024 * 1024
 

--- a/test/io_streams_test.py
+++ b/test/io_streams_test.py
@@ -2,6 +2,7 @@
 import pytest
 
 from modal import enable_output
+from modal._utils.async_utils import aclosing, sync_or_async_iter
 from modal.io_streams import StreamReader
 from modal_proto import api_pb2
 
@@ -191,3 +192,47 @@ def test_stream_reader_line_buffered_bytes(servicer, client):
             by_line=True,
             text=False,
         )
+
+
+@pytest.mark.asyncio
+async def test_stream_reader_async_iter(servicer, client):
+    """Test that StreamReader behaves as a proper async iterator."""
+
+    async def sandbox_get_logs(servicer, stream):
+        await stream.recv_message()
+
+        log1 = api_pb2.TaskLogs(
+            data="foo",
+            file_descriptor=api_pb2.FILE_DESCRIPTOR_STDOUT,
+        )
+        await stream.send_message(api_pb2.TaskLogsBatch(entry_id="0", items=[log1]))
+
+        log2 = api_pb2.TaskLogs(
+            data="bar",
+            file_descriptor=api_pb2.FILE_DESCRIPTOR_STDOUT,
+        )
+        await stream.send_message(api_pb2.TaskLogsBatch(entry_id="1", items=[log2]))
+
+        # send EOF
+        await stream.send_message(api_pb2.TaskLogsBatch(eof=True))
+
+    with servicer.intercept() as ctx:
+        ctx.set_responder("SandboxGetLogs", sandbox_get_logs)
+
+        expected = "foobar"
+
+        with enable_output():
+            stdout: StreamReader[str] = StreamReader(
+                file_descriptor=api_pb2.FILE_DESCRIPTOR_STDOUT,
+                object_id="sb-123",
+                object_type="sandbox",
+                client=client,
+                by_line=True,
+            )
+
+            out = ""
+            async with aclosing(sync_or_async_iter(stdout)) as stream:
+                async for line in stream:
+                    out += line
+
+            assert out == expected


### PR DESCRIPTION
Resolves [PRD-496](https://linear.app/modal-labs/issue/PRD-496/run-button-becomes-unresponsive-after-first-invocation-in-playground).

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>
