### PR TITLE
Have client retry lost inputs

### DIFF
--- a/modal/_utils/function_utils.py
+++ b/modal/_utils/function_utils.py
@@ -17,7 +17,14 @@ from modal_proto import api_pb2
 from .._serialization import deserialize, deserialize_data_format, serialize
 from .._traceback import append_modal_tb
 from ..config import config, logger
-from ..exception import DeserializationError, ExecutionError, FunctionTimeoutError, InvalidError, RemoteError
+from ..exception import (
+    DeserializationError,
+    ExecutionError,
+    FunctionTimeoutError,
+    InternalFailure,
+    InvalidError,
+    RemoteError,
+)
 from ..mount import ROOT_DIR, _is_modal_path, _Mount
 from .blob_utils import MAX_OBJECT_SIZE_BYTES, blob_download, blob_upload
 from .grpc_utils import RETRYABLE_GRPC_STATUS_CODES
@@ -463,6 +470,8 @@ async def _process_result(result: api_pb2.GenericResult, data_format: int, stub,
 
     if result.status == api_pb2.GenericResult.GENERIC_STATUS_TIMEOUT:
         raise FunctionTimeoutError(result.exception)
+    elif result.status == api_pb2.GenericResult.GENERIC_STATUS_INTERNAL_FAILURE:
+        raise InternalFailure(result.exception)
     elif result.status != api_pb2.GenericResult.GENERIC_STATUS_SUCCESS:
         if data:
             try:

--- a/modal/exception.py
+++ b/modal/exception.py
@@ -110,9 +110,7 @@ class ServerWarning(UserWarning):
 
 class InternalFailure(Error):
     """
-    Raised when the server returns GENERIC_STATUS_INTERNAL_FAILURE. This is a retiable error which can be
-    caused by events like 1) redis crashing and the server losing track of inputs, or 2) a worker being
-    preempted, which terminates the input.
+    Retriable internal error.
     """
 
 

--- a/modal/exception.py
+++ b/modal/exception.py
@@ -108,6 +108,14 @@ class ServerWarning(UserWarning):
     """Warning originating from the Modal server and re-issued in client code."""
 
 
+class InternalFailure(Error):
+    """
+    Raised when the server returns GENERIC_STATUS_INTERNAL_FAILURE. This is a retiable error which can be
+    caused by events like 1) redis crashing and the server losing track of inputs, or 2) a worker being
+    preempted, which terminates the input.
+    """
+
+
 class _CliUserExecutionError(Exception):
     """mdmd:hidden
     Private wrapper for exceptions during when importing or running stubs from the CLI.

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -59,7 +59,14 @@ from .call_graph import InputInfo, _reconstruct_call_graph
 from .client import _Client
 from .cloud_bucket_mount import _CloudBucketMount, cloud_bucket_mounts_to_proto
 from .config import config
-from .exception import ExecutionError, FunctionTimeoutError, InvalidError, NotFoundError, OutputExpiredError
+from .exception import (
+    ExecutionError,
+    FunctionTimeoutError,
+    InternalFailure,
+    InvalidError,
+    NotFoundError,
+    OutputExpiredError,
+)
 from .gpu import GPU_T, parse_gpu_config
 from .image import _Image
 from .mount import _get_client_mount, _Mount, get_auto_mounts
@@ -174,7 +181,7 @@ class _Invocation:
         return _Invocation(client.stub, function_call_id, client, retry_context)
 
     async def pop_function_call_outputs(
-        self, timeout: Optional[float], clear_on_success: bool
+        self, timeout: Optional[float], clear_on_success: bool, expected_jwts: Optional[list[str]] = None
     ) -> api_pb2.FunctionGetOutputsResponse:
         t0 = time.time()
         if timeout is None:
@@ -190,6 +197,7 @@ class _Invocation:
                 last_entry_id="0-0",
                 clear_on_success=clear_on_success,
                 requested_at=time.time(),
+                expected_jwts=expected_jwts,
             )
             response: api_pb2.FunctionGetOutputsResponse = await retry_transient_errors(
                 self.stub.FunctionGetOutputs,
@@ -219,10 +227,14 @@ class _Invocation:
             request,
         )
 
-    async def _get_single_output(self) -> Any:
+    async def _get_single_output(self, expected_jwt: Optional[str] = None) -> Any:
         # waits indefinitely for a single result for the function, and clear the outputs buffer after
         item: api_pb2.FunctionGetOutputsItem = (
-            await self.pop_function_call_outputs(timeout=None, clear_on_success=True)
+            await self.pop_function_call_outputs(
+                timeout=None,
+                clear_on_success=True,
+                expected_jwts=[expected_jwt] if expected_jwt else None,
+            )
         ).outputs[0]
         return await _process_result(item.result, item.data_format, self.stub, self.client)
 
@@ -242,9 +254,12 @@ class _Invocation:
 
         while True:
             try:
-                return await self._get_single_output()
+                return await self._get_single_output(ctx.input_jwt)
             except (UserCodeException, FunctionTimeoutError) as exc:
                 await user_retry_manager.raise_or_sleep(exc)
+            except InternalFailure:
+                # For system failures on the server, we retry immediately.
+                pass
             await self._retry_input()
 
     async def poll_function(self, timeout: Optional[float] = None):

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -181,7 +181,7 @@ class _Invocation:
         return _Invocation(client.stub, function_call_id, client, retry_context)
 
     async def pop_function_call_outputs(
-        self, timeout: Optional[float], clear_on_success: bool, expected_jwts: Optional[list[str]] = None
+        self, timeout: Optional[float], clear_on_success: bool, input_jwts: Optional[list[str]] = None
     ) -> api_pb2.FunctionGetOutputsResponse:
         t0 = time.time()
         if timeout is None:
@@ -197,7 +197,7 @@ class _Invocation:
                 last_entry_id="0-0",
                 clear_on_success=clear_on_success,
                 requested_at=time.time(),
-                expected_jwts=expected_jwts,
+                input_jwts=input_jwts,
             )
             response: api_pb2.FunctionGetOutputsResponse = await retry_transient_errors(
                 self.stub.FunctionGetOutputs,
@@ -233,7 +233,7 @@ class _Invocation:
             await self.pop_function_call_outputs(
                 timeout=None,
                 clear_on_success=True,
-                expected_jwts=[expected_jwt] if expected_jwt else None,
+                input_jwts=[expected_jwt] if expected_jwt else None,
             )
         ).outputs[0]
         return await _process_result(item.result, item.data_format, self.stub, self.client)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -154,6 +154,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.done = False
         self.rate_limit_sleep_duration = None
         self.fail_get_inputs = False
+        self.failure_status = api_pb2.GenericResult.GENERIC_STATUS_FAILURE
         self.slow_put_inputs = False
         self.container_inputs = []
         self.container_outputs = []
@@ -1118,7 +1119,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
             except Exception as exc:
                 serialized_exc = cloudpickle.dumps(exc)
                 result = api_pb2.GenericResult(
-                    status=api_pb2.GenericResult.GENERIC_STATUS_FAILURE,
+                    status=self.failure_status,
                     data=serialized_exc,
                     exception=repr(exc),
                     traceback="".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),


### PR DESCRIPTION
Closes SVC-224

Update client to retry inputs if FunctionGetOutputs reports that an input is lost. If an input is lost, FunctionGetOutputs returns a failed output with status `GENERIC_STATUS_INTERNAL_FAILURE`. The client then retries immediately.

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [X] Client+Server: this change is compatible with old servers
- [X] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
