### PR TITLE
fix sync_or_async_iter: check if async iterable has `aclose` before aclosing it

### DIFF
--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -6,7 +6,7 @@ import inspect
 import itertools
 import time
 import typing
-from collections.abc import AsyncGenerator, Awaitable, Iterable, Iterator
+from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Iterable, Iterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import (
@@ -484,14 +484,17 @@ class aclosing(typing.Generic[T]):  # noqa
         await self.agen.aclose()
 
 
-async def sync_or_async_iter(iter: Union[Iterable[T], AsyncGenerator[T, None]]) -> AsyncGenerator[T, None]:
+async def sync_or_async_iter(iter: Union[Iterable[T], AsyncIterator[T, None]]) -> AsyncGenerator[T, None]:
     if hasattr(iter, "__aiter__"):
         agen = typing.cast(AsyncGenerator[T, None], iter)
         try:
             async for item in agen:
                 yield item
         finally:
-            await agen.aclose()
+            if hasattr(agen, "aclose"):
+                # All AsyncGenerators have an aclose method
+                # but some AsyncIterators don't necessarily
+                await agen.aclose()
     else:
         assert hasattr(iter, "__iter__"), "sync_or_async_iter requires an Iterable or AsyncGenerator"
         # This intentionally could block the event loop for the duration of calling __iter__ and __next__,

--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -484,7 +484,7 @@ class aclosing(typing.Generic[T]):  # noqa
         await self.agen.aclose()
 
 
-async def sync_or_async_iter(iter: Union[Iterable[T], AsyncIterator[T, None]]) -> AsyncGenerator[T, None]:
+async def sync_or_async_iter(iter: Union[Iterable[T], AsyncIterator[T]]) -> AsyncGenerator[T, None]:
     if hasattr(iter, "__aiter__"):
         agen = typing.cast(AsyncGenerator[T, None], iter)
         try:

--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -6,7 +6,7 @@ import inspect
 import itertools
 import time
 import typing
-from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Iterable, Iterator
+from collections.abc import AsyncGenerator, AsyncIterable, Awaitable, Iterable, Iterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import (
@@ -484,7 +484,7 @@ class aclosing(typing.Generic[T]):  # noqa
         await self.agen.aclose()
 
 
-async def sync_or_async_iter(iter: Union[Iterable[T], AsyncIterator[T]]) -> AsyncGenerator[T, None]:
+async def sync_or_async_iter(iter: Union[Iterable[T], AsyncIterable[T]]) -> AsyncGenerator[T, None]:
     if hasattr(iter, "__aiter__"):
         agen = typing.cast(AsyncGenerator[T, None], iter)
         try:
@@ -492,8 +492,8 @@ async def sync_or_async_iter(iter: Union[Iterable[T], AsyncIterator[T]]) -> Asyn
                 yield item
         finally:
             if hasattr(agen, "aclose"):
-                # All AsyncGenerators have an aclose method
-                # but some AsyncIterators don't necessarily
+                # All AsyncGenerator's have an aclose method
+                # but some AsyncIterable's don't necessarily
                 await agen.aclose()
     else:
         assert hasattr(iter, "__iter__"), "sync_or_async_iter requires an Iterable or AsyncGenerator"


### PR DESCRIPTION
Changing `sync_or_async_iter` to accept the more generic `AsyncIterable` instead of `AsyncGenerator` and also then checking if the object has an `aclose` method (which doesn't necessarily exist on `AsyncIteratable`s ) before calling it