### PR TITLE
Add stdin_heartbeat flag to container exec

### DIFF
--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -68,6 +68,7 @@ async def exec(
         command=command,
         pty_info=get_pty_info(shell=True) if pty else None,
         runtime_debug=config.get("function_runtime_debug"),
+        stdin_heartbeat=True,
     )
     res: api_pb2.ContainerExecResponse = await client.stub.ContainerExec(req)
 

--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -68,7 +68,7 @@ async def exec(
         command=command,
         pty_info=get_pty_info(shell=True) if pty else None,
         runtime_debug=config.get("function_runtime_debug"),
-        stdin_heartbeat=True,
+        disable_stdin_heartbeat=False,
     )
     res: api_pb2.ContainerExecResponse = await client.stub.ContainerExec(req)
 

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -490,7 +490,7 @@ class _Sandbox(_Object, type_prefix="sb"):
                 timeout_secs=timeout or 0,
                 workdir=workdir,
                 secret_ids=[secret.object_id for secret in secrets],
-                stdin_heartbeat=False,
+                disable_stdin_heartbeat=True,
             )
         )
         by_line = bufsize == 1

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -490,6 +490,7 @@ class _Sandbox(_Object, type_prefix="sb"):
                 timeout_secs=timeout or 0,
                 workdir=workdir,
                 secret_ids=[secret.object_id for secret in secrets],
+                stdin_heartbeat=False,
             )
         )
         by_line = bufsize == 1

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -743,7 +743,7 @@ message ContainerExecRequest {
   // Enabled for interactive processes like container exec. Disable for long-running
   // processes that don't require stdin, like sandbox exec.
   // Clients before v0.67.20 use pty_info as a proxy for enabling the heartbeat instead.
-  bool stdin_heartbeat = 11;
+  bool disable_stdin_heartbeat = 11;
 }
 
 message ContainerExecResponse {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -739,6 +739,11 @@ message ContainerExecRequest {
   uint32 timeout_secs = 8;
   optional string workdir = 9;
   repeated string secret_ids = 10;
+  // Controls whether the process should be terminated after 40s of stdin inactivity.
+  // Enabled for interactive processes like container exec. Disable for long-running
+  // processes that don't require stdin, like sandbox exec.
+  // Clients before v0.67.20 use pty_info as a proxy for enabling the heartbeat instead.
+  bool stdin_heartbeat = 11;
 }
 
 message ContainerExecResponse {


### PR DESCRIPTION
Adds `disable_stdin_heartbeat` to `ContainerExecRequest`, giving us direct control over the `stdin` timeout behavior for `Sandbox.exec` instead of using `pty_info` as a proxy.

For backwards compatibility, the corresponding worker changes will still look at `pty_info` but will also check whether this flag is set to `True` as an override.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>