### PR TITLE
Include method definitions in FunctionData message

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -886,6 +886,8 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                         is_method=function_definition.is_method,
                         use_function_id=function_definition.use_function_id,
                         use_method_name=function_definition.use_method_name,
+                        method_definitions=function_definition.method_definitions,
+                        method_definitions_set=function_definition.method_definitions_set,
                         _experimental_group_size=function_definition._experimental_group_size,
                         _experimental_buffer_containers=function_definition._experimental_buffer_containers,
                         _experimental_custom_scaling=function_definition._experimental_custom_scaling,


### PR DESCRIPTION
Fixes CLI-275.

I'm not really sure how to write a unit test for this -- open to suggestions. See the ticket for a simple repro.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Fixed a bug introduced in v0.67.0 where it was impossible to call `modal.Cls` methods when passing a list of requested GPUs.