### PR TITLE
Move _bind_instance_method out of _Function

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -72,6 +72,68 @@ def _get_class_constructor_signature(user_cls: type) -> inspect.Signature:
         return inspect.Signature(constructor_parameters)
 
 
+def _bind_instance_method(service_function: _Function, class_bound_method: _Function):
+    """mdmd:hidden
+
+    Binds an "instance service function" to a specific method.
+    This "dummy" _Function gets no unique object_id and isn't backend-backed at the moment, since all
+    it does it forward invocations to the underlying instance_service_function with the specified method,
+    and we don't support web_config for parameterized methods at the moment.
+    """
+    # TODO(elias): refactor to not use `_from_loader()` as a crutch for lazy-loading the
+    #   underlying instance_service_function. It's currently used in order to take advantage
+    #   of resolver logic and get "chained" resolution of lazy loads, even though this thin
+    #   object itself doesn't need any "loading"
+    assert service_function._obj
+    method_name = class_bound_method._use_method_name
+    full_function_name = f"{class_bound_method._function_name}[parameterized]"
+
+    def hydrate_from_instance_service_function(method_placeholder_fun):
+        method_placeholder_fun._hydrate_from_other(service_function)
+        method_placeholder_fun._obj = service_function._obj
+        method_placeholder_fun._web_url = (
+            class_bound_method._web_url
+        )  # TODO: this shouldn't be set when actual parameters are used
+        method_placeholder_fun._function_name = full_function_name
+        method_placeholder_fun._is_generator = class_bound_method._is_generator
+        method_placeholder_fun._cluster_size = class_bound_method._cluster_size
+        method_placeholder_fun._use_method_name = method_name
+        method_placeholder_fun._is_method = True
+
+    async def _load(fun: "_Function", resolver: Resolver, existing_object_id: Optional[str]):
+        # there is currently no actual loading logic executed to create each method on
+        # the *parameterized* instance of a class - it uses the parameter-bound service-function
+        # for the instance. This load method just makes sure to set all attributes after the
+        # `service_function` has been loaded (it's in the `_deps`)
+        hydrate_from_instance_service_function(fun)
+
+    def _deps():
+        if service_function.is_hydrated:
+            # without this check, the common service_function will be reloaded by all methods
+            # TODO(elias): Investigate if we can fix this multi-loader in the resolver - feels like a bug?
+            return []
+        return [service_function]
+
+    rep = f"Method({full_function_name})"
+
+    fun = _Function._from_loader(
+        _load,
+        rep,
+        deps=_deps,
+        hydrate_lazily=True,
+    )
+    if service_function.is_hydrated:
+        # Eager hydration (skip load) if the instance service function is already loaded
+        hydrate_from_instance_service_function(fun)
+
+    fun._info = class_bound_method._info
+    fun._obj = service_function._obj
+    fun._is_method = True
+    fun._app = class_bound_method._app
+    fun._spec = class_bound_method._spec
+    return fun
+
+
 class _Obj:
     """An instance of a `Cls`, i.e. `Cls("foo", 42)` returns an `Obj`.
 
@@ -108,7 +170,7 @@ class _Obj:
             # first create the singular object function used by all methods on this parameterization
             self._instance_service_function = class_service_function._bind_parameters(self, options, args, kwargs)
             for method_name, class_bound_method in classbound_methods.items():
-                method = self._instance_service_function._bind_instance_method(class_bound_method)
+                method = _bind_instance_method(self._instance_service_function, class_bound_method)
                 self._method_functions[method_name] = method
         else:
             # looked up <v0.63 classes - bind each individual method to the new parameters
@@ -271,7 +333,7 @@ class _Cls(_Object, type_prefix="cs"):
             and self._class_service_function._method_handle_metadata
             and len(self._class_service_function._method_handle_metadata)
         ):
-            # The class only has a class service service function and no method placeholders (v0.67+)
+            # The class only has a class service function and no method placeholders (v0.67+)
             if self._method_functions:
                 # We're here when the Cls is loaded locally (e.g. _Cls.from_local) so the _method_functions mapping is
                 # populated with (un-hydrated) _Function objects

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -424,68 +424,6 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         fun._is_method = True
         return fun
 
-    def _bind_instance_method(self, class_bound_method: "_Function"):
-        """mdmd:hidden
-
-        Binds an "instance service function" to a specific method.
-        This "dummy" _Function gets no unique object_id and isn't backend-backed at the moment, since all
-        it does it forward invocations to the underlying instance_service_function with the specified method,
-        and we don't support web_config for parameterized methods at the moment.
-        """
-        # TODO(elias): refactor to not use `_from_loader()` as a crutch for lazy-loading the
-        #   underlying instance_service_function. It's currently used in order to take advantage
-        #   of resolver logic and get "chained" resolution of lazy loads, even though this thin
-        #   object itself doesn't need any "loading"
-        instance_service_function = self
-        assert instance_service_function._obj
-        method_name = class_bound_method._use_method_name
-        full_function_name = f"{class_bound_method._function_name}[parameterized]"
-
-        def hydrate_from_instance_service_function(method_placeholder_fun):
-            method_placeholder_fun._hydrate_from_other(instance_service_function)
-            method_placeholder_fun._obj = instance_service_function._obj
-            method_placeholder_fun._web_url = (
-                class_bound_method._web_url
-            )  # TODO: this shouldn't be set when actual parameters are used
-            method_placeholder_fun._function_name = full_function_name
-            method_placeholder_fun._is_generator = class_bound_method._is_generator
-            method_placeholder_fun._cluster_size = class_bound_method._cluster_size
-            method_placeholder_fun._use_method_name = method_name
-            method_placeholder_fun._is_method = True
-
-        async def _load(fun: "_Function", resolver: Resolver, existing_object_id: Optional[str]):
-            # there is currently no actual loading logic executed to create each method on
-            # the *parameterized* instance of a class - it uses the parameter-bound service-function
-            # for the instance. This load method just makes sure to set all attributes after the
-            # `instance_service_function` has been loaded (it's in the `_deps`)
-            hydrate_from_instance_service_function(fun)
-
-        def _deps():
-            if instance_service_function.is_hydrated:
-                # without this check, the common instance_service_function will be reloaded by all methods
-                # TODO(elias): Investigate if we can fix this multi-loader in the resolver - feels like a bug?
-                return []
-            return [instance_service_function]
-
-        rep = f"Method({full_function_name})"
-
-        fun = _Function._from_loader(
-            _load,
-            rep,
-            deps=_deps,
-            hydrate_lazily=True,
-        )
-        if instance_service_function.is_hydrated:
-            # Eager hydration (skip load) if the instance service function is already loaded
-            hydrate_from_instance_service_function(fun)
-
-        fun._info = class_bound_method._info
-        fun._obj = instance_service_function._obj
-        fun._is_method = True
-        fun._app = class_bound_method._app
-        fun._spec = class_bound_method._spec
-        return fun
-
     @staticmethod
     def from_args(
         info: FunctionInfo,

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -982,7 +982,6 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
     def _bind_parameters(
         self,
         obj: "modal.cls._Obj",
-        from_other_workspace: bool,
         options: Optional[api_pb2.FunctionOptions],
         args: Sized,
         kwargs: dict[str, Any],
@@ -993,7 +992,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         """
 
         # In some cases, reuse the base function, i.e. not create new clones of each method or the "service function"
-        can_use_parent = len(args) + len(kwargs) == 0 and not from_other_workspace and options is None
+        can_use_parent = len(args) + len(kwargs) == 0 and options is None
         parent = self
 
         async def _load(param_bound_func: _Function, resolver: Resolver, existing_object_id: Optional[str]):


### PR DESCRIPTION
Trying to make small changes toward a simpler Cls/Obj/Function code base.

This is a first tiny step towards decoupling "Function - the interface" from "Function - the autoscaling container pool", and having methods only be an instance of the former.

This PR just moves the `_bind_instance_method` method out of `_Function` as a simple separation.

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
