### PR TITLE
Add Sandbox method for running a filesystem snapshot

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -21,7 +21,7 @@ from ._utils.mount_utils import validate_network_file_systems, validate_volumes
 from .client import _Client
 from .config import config
 from .container_process import _ContainerProcess
-from .exception import InvalidError, SandboxTerminatedError, SandboxTimeoutError, deprecation_warning
+from .exception import ExecutionError, InvalidError, SandboxTerminatedError, SandboxTimeoutError, deprecation_warning
 from .gpu import GPU_T
 from .image import _Image
 from .io_streams import StreamReader, StreamWriter, _StreamReader, _StreamWriter
@@ -330,6 +330,29 @@ class _Sandbox(_Object, type_prefix="sb"):
             await retry_transient_errors(client.stub.SandboxTagsSet, req)
         except GRPCError as exc:
             raise InvalidError(exc.message) if exc.status == Status.INVALID_ARGUMENT else exc
+
+    async def snapshot_filesystem(self, timeout: int = 55) -> _Image:
+        """Snapshot the filesystem of the Sandbox.
+
+        Returns an [`Image`](https://modal.com/docs/reference/modal.Image) object which
+        can be used to spawn a new Sandbox with the same filesystem.
+        """
+        req = api_pb2.SandboxSnapshotFsRequest(sandbox_id=self.object_id, timeout=timeout)
+        resp = await retry_transient_errors(self._client.stub.SandboxSnapshotFs, req)
+
+        if resp.result.status != api_pb2.GenericResult.GENERIC_STATUS_SUCCESS:
+            raise ExecutionError(resp.result.exception)
+
+        image_id = resp.image_id
+        metadata = resp.image_metadata
+
+        async def _load(self: _Image, resolver: Resolver, existing_object_id: Optional[str]):
+            self._hydrate(image_id, resolver.client, metadata)
+
+        rep = "Image()"
+        image = _Image._from_loader(_load, rep)
+
+        return image
 
     # Live handle methods
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1426,6 +1426,15 @@ class MockClientServicer(api_grpc.ModalClientBase):
             pass
         await stream.send_message(api_pb2.SandboxTerminateResponse())
 
+    async def SandboxSnapshotFs(self, stream):
+        _request: api_pb2.SandboxSnapshotFsRequest = await stream.recv_message()
+        await stream.send_message(
+            api_pb2.SandboxSnapshotFsResponse(
+                image_id="im-123",
+                result=api_pb2.GenericResult(status=api_pb2.GenericResult.GENERIC_STATUS_SUCCESS),
+            )
+        )
+
     async def SandboxGetTaskId(self, stream):
         # only used for `modal shell` / `modal container exec`
         _request: api_pb2.SandboxGetTaskIdRequest = await stream.recv_message()

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -399,3 +399,16 @@ def test_sandbox_exec_stdout(app, servicer, capsys):
 
     with pytest.raises(InvalidError):
         cp.stdout.read()
+
+
+@skip_non_linux
+def test_sandbox_snapshot_fs(app, servicer):
+    sb = Sandbox.create(app=app)
+    image = sb.snapshot_filesystem()
+    sb.terminate()
+
+    sb2 = Sandbox.create(image=image, app=app)
+    sb2.terminate()
+
+    assert image.object_id == "im-123"
+    assert servicer.sandbox_defs[1].image_id == "im-123"


### PR DESCRIPTION
## Describe your changes

This commit adds a Sandbox function to snapshot a filesystem, returning an Image that can later be used to spawn new Sandboxes.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Sandboxes now support filesystem snapshots. Run `Sandbox.snapshot_filesystem()` to get an Image which can be used to spawn new Sandboxes.
