### PR TITLE
Format modal client deprecation warning better

### DIFF
--- a/modal/cli/_traceback.py
+++ b/modal/cli/_traceback.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2024
 """Helper functions related to displaying tracebacks in the CLI."""
 import functools
+import re
 import warnings
 from typing import Optional
 
@@ -166,8 +167,12 @@ def highlight_modal_deprecation_warnings() -> None:
     def showwarning(warning, category, filename, lineno, file=None, line=None):
         if issubclass(category, (DeprecationError, PendingDeprecationError)):
             content = str(warning)
-            date = content[:10]
-            message = content[11:].strip()
+            if re.match(r"^\d{4}-\d{2}-\d{2}", content):
+                date = content[:10]
+                message = content[11:].strip()
+            else:
+                date = ""
+                message = content
             try:
                 with open(filename, encoding="utf-8", errors="replace") as code_file:
                     source = code_file.readlines()[lineno - 1].strip()
@@ -178,7 +183,7 @@ def highlight_modal_deprecation_warnings() -> None:
             panel = Panel(
                 message,
                 style="yellow",
-                title=f"Modal Deprecation Warning ({date})",
+                title=f"Modal Deprecation Warning ({date})" if date else "Modal Deprecation Warning",
                 title_align="left",
             )
             Console().print(panel)

--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -115,7 +115,7 @@ def logs(
     ```
 
     """
-    app_identifier = warn_on_name_option("stop", app_identifier, name)
+    app_identifier = warn_on_name_option("logs", app_identifier, name)
     app_id = get_app_id(app_identifier, env)
     stream_app_logs(app_id)
 

--- a/modal/client.py
+++ b/modal/client.py
@@ -147,7 +147,7 @@ class _Client:
             )
             if resp.warning:
                 ALARM_EMOJI = chr(0x1F6A8)
-                warnings.warn(f"{ALARM_EMOJI} {resp.warning} {ALARM_EMOJI}", DeprecationError)
+                warnings.warn_explicit(f"{ALARM_EMOJI} {resp.warning} {ALARM_EMOJI}", DeprecationError, "<unknown>", 0)
         except GRPCError as exc:
             if exc.status == Status.FAILED_PRECONDITION:
                 raise VersionError(


### PR DESCRIPTION
We have some code that does rich formatting of deprecation warnings that was malfunctioning for client deprecations:

<img width="852" alt="image" src="https://github.com/user-attachments/assets/23c61eb2-0ad9-4d60-aca6-5e9be165b376">

The main problem is that we assume the `modal.exception.DeprecationError` warnings are issued from `modal.exception.deprecation_warning`, which prefixes the message with the date of deprecation. But when we issue the client deprecation warning we don't include a date.

We also have a flag in `deprecation_warning` to suppress the source of the error in cases where the surrounding context is not relevant for the warning; I copied that approach here to clean up the message. Result:

<img width="856" alt="image" src="https://github.com/user-attachments/assets/3d7a6771-66ea-4623-9190-d754969de689">

I don't love how the alarm emoji look here, but they're helpful in the app logs. Could maybe omit them when `modal.is_local`.