### PR TITLE
Fix 0.62 class with build method updating to 0.67

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -354,7 +354,7 @@ class _Cls(_Object, type_prefix="cs"):
                     self._method_functions[method_name] = _Function._new_hydrated(
                         self._class_service_function.object_id, self._client, method_handle_metadata
                     )
-        elif self._class_service_function:
+        elif self._class_service_function and self._class_service_function.object_id:
             # A class with a class service function and method placeholder functions
             self._method_functions = {}
             for method in metadata.methods:


### PR DESCRIPTION
Fix 0.62 class with build method updating to 0.67. This was breaking because the build function runs before the app is updated to have a class service function for the class.

When the build function was running, the `AppGetObjects` request in container entrypoint wouldn't return any class service function (as one wasn't created). But `Cls.from_local` adds a `_class_service_function` attribute to the `Cls` object that points to the un-hydrated class service function `Function` object and is expected to by hydrated with the results of `AppGetObjects`.

The fix is to have `_hydrate_metadata` of `Cls`, in the branch where it is hydrating a 0.63+ class, check if the class service function object is actually hydrated (it has an object_id set).