### PR TITLE
disable test_pdm_cache_automount_exclude due to ci failure

### DIFF
--- a/test/mounted_files_test.py
+++ b/test/mounted_files_test.py
@@ -12,7 +12,7 @@ from modal import Mount
 from modal.mount import get_auto_mounts
 
 from . import helpers
-from .supports.skip import skip_old_py, skip_windows
+from .supports.skip import skip_windows
 
 
 @pytest.fixture
@@ -319,8 +319,9 @@ def test_mount_dedupe_explicit(servicer, credentials, test_dir, server_url_env):
     assert len(mount_with_pyc) == len(remaining_mount) + 1
 
 
-@skip_windows("pip-installed pdm seems somewhat broken on windows")
-@skip_old_py("some weird issues w/ pdm and Python 3.9", min_version=(3, 10, 0))
+# @skip_windows("pip-installed pdm seems somewhat broken on windows")
+# @skip_old_py("some weird issues w/ pdm and Python 3.9", min_version=(3, 10, 0))
+@pytest.mark.skip(reason="currently broken on ubuntu github actions")
 def test_pdm_cache_automount_exclude(tmp_path, monkeypatch, supports_dir, servicer, server_url_env, token_env):
     # check that `pdm`'s cached packages are not included in automounts
     project_dir = Path(__file__).parent.parent


### PR DESCRIPTION
`test_pdm_cache_automount_exclude` currently fails on ubuntu-20 `python3.13` probably due to some unpinned underlying library, disabling for not to unblock publishing new client versions