### PR TITLE
Include original task ID in checkpoint info response

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -589,6 +589,7 @@ message CheckpointInfo {
   string runtime_fingerprint = 4;
   int64 size = 5;
   bool checksum_is_file_index = 6;
+  string original_task_id = 7;
 }
 
 message ClassCreateRequest {


### PR DESCRIPTION
## Describe your changes

This commit adds the task ID which creategd the checkpoint to CheckpointInfo. This allows us to restore a container with the exact same arguments which were used to create it.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

