### PR TITLE
Log specific deps and IDs when there's a mismatch

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -478,7 +478,9 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
             if len(service.code_deps) != len(dep_object_ids):
                 raise ExecutionError(
                     f"Function has {len(service.code_deps)} dependencies"
-                    f" but container got {len(dep_object_ids)} object ids."
+                    f" but container got {len(dep_object_ids)} object ids.\n"
+                    f"Code deps: {service.code_deps}\n"
+                    f"Object ids: {dep_object_ids}"
                 )
             for object_id, obj in zip(dep_object_ids, service.code_deps):
                 metadata: Message = container_app.object_handle_metadata[object_id]


### PR DESCRIPTION
It's painful to debug these when users run into them because we don't know what's changing, only the numbers. We can probably give a more specific warning, but quick fix for now.

Now prints:
![image](https://github.com/user-attachments/assets/37a4fa2f-9461-44b0-aae3-ab2ae5bf9eec)
