### PR TITLE
Add ContainerHello endpoint

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2675,6 +2675,7 @@ service ModalClient {
   rpc ContainerFilesystemExec(ContainerFilesystemExecRequest) returns (ContainerFilesystemExecResponse);
   rpc ContainerFilesystemExecGetOutput(ContainerFilesystemExecGetOutputRequest) returns (stream FilesystemRuntimeOutputBatch);
   rpc ContainerHeartbeat(ContainerHeartbeatRequest) returns (ContainerHeartbeatResponse);
+  rpc ContainerHello(google.protobuf.Empty) returns (google.protobuf.Empty);
   rpc ContainerLog(ContainerLogRequest) returns (google.protobuf.Empty);
   rpc ContainerStop(ContainerStopRequest) returns (ContainerStopResponse);
 


### PR DESCRIPTION
I've been working on removing the need for `ClientHello` which adds 10-100ms on every container start, as well as every local client creation. @gongy pointed out that it would be useful to have something container-side that at least hits the worker. It wouldn't be used for anything right now, but that way we have the optionality later on to add any logic we want. Since the worker would respond to this request, it would not add more than maybe a few milliseconds.

Adding it to the proto for now. Will add it on the worker at some point later. After that's rolled out, I'll wire it together so that we call this method from all containers on startup.