### PR TITLE
Add example of persisted queue to reference

### DIFF
--- a/modal/queue.py
+++ b/modal/queue.py
@@ -27,33 +27,6 @@ class _Queue(_Object, type_prefix="qu"):
 
     By default, the `Queue` object acts as a single FIFO queue which supports puts and gets (blocking and non-blocking).
 
-    **Queue partitions (beta)**
-
-    Specifying partition keys gives access to other independent FIFO partitions within the same `Queue` object.
-    Across any two partitions, puts and gets are completely independent.
-    For example, a put in one partition does not affect a get in any other partition.
-
-    When no partition key is specified (by default), puts and gets will operate on a default partition.
-    This default partition is also isolated from all other partitions.
-    Please see the Usage section below for an example using partitions.
-
-    **Lifetime of a queue and its partitions**
-
-    By default, each partition is cleared 24 hours after the last `put` operation.
-    A lower TTL can be specified by the `partition_ttl` argument in the `put` or `put_many` methods.
-    Each partition's expiry is handled independently.
-
-    As such, `Queue`s are best used for communication between active functions and not relied on for persistent storage.
-
-    On app completion or after stopping an app any associated `Queue` objects are cleaned up.
-    All its partitions will be cleared.
-
-    **Limits**
-
-    A single `Queue` can contain up to 100,000 partitions, each with up to 5,000 items. Each item can be up to 256 KiB.
-
-    Partition keys must be non-empty and must not exceed 64 bytes.
-
     **Usage**
 
     ```python
@@ -90,6 +63,33 @@ class _Queue(_Object, type_prefix="qu"):
     ```
 
     For more examples, see the [guide](/docs/guide/dicts-and-queues#modal-queues).
+
+    **Queue partitions (beta)**
+
+    Specifying partition keys gives access to other independent FIFO partitions within the same `Queue` object.
+    Across any two partitions, puts and gets are completely independent.
+    For example, a put in one partition does not affect a get in any other partition.
+
+    When no partition key is specified (by default), puts and gets will operate on a default partition.
+    This default partition is also isolated from all other partitions.
+    Please see the Usage section below for an example using partitions.
+
+    **Lifetime of a queue and its partitions**
+
+    By default, each partition is cleared 24 hours after the last `put` operation.
+    A lower TTL can be specified by the `partition_ttl` argument in the `put` or `put_many` methods.
+    Each partition's expiry is handled independently.
+
+    As such, `Queue`s are best used for communication between active functions and not relied on for persistent storage.
+
+    On app completion or after stopping an app any associated `Queue` objects are cleaned up.
+    All its partitions will be cleared.
+
+    **Limits**
+
+    A single `Queue` can contain up to 100,000 partitions, each with up to 5,000 items. Each item can be up to 256 KiB.
+
+    Partition keys must be non-empty and must not exceed 64 bytes.
     """
 
     @staticmethod

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -32,6 +32,7 @@ class _Queue(_Object, type_prefix="qu"):
     ```python
     from modal import Queue
 
+    # Create an ephemeral queue which is anonymous and garbage collected
     with Queue.ephemeral() as my_queue:
         # Putting values
         my_queue.put("some value")

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -82,6 +82,11 @@ class _Queue(_Object, type_prefix="qu"):
         # (beta feature) Iterate through items in place (read immutably)
         my_queue.put(1)
         assert [v for v in my_queue.iterate()] == [0, 1]
+
+    # You can also create persistent queues that can be used across apps
+    queue = Queue.from_name("my-persisted-queue", create_if_missing=True)
+    queue.put(42)
+    assert queue.get() == 42
     ```
 
     For more examples, see the [guide](/docs/guide/dicts-and-queues#modal-queues).


### PR DESCRIPTION
Realized this wasn't part of the docstring.

Also put the code sample up top. The docs currently start with a bunch of stuff about partitions which seems a bit distracting for the average user.

<img width="1085" alt="image" src="https://github.com/user-attachments/assets/f0e4210f-df3f-4690-852a-eead6c347dd8">
