### PR TITLE
Decode messages for `StreamType.STDOUT`

### DIFF
--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -184,7 +184,7 @@ class _StreamReader(Generic[T]):
 
                 async for message in iterator:
                     if self._stream_type == StreamType.STDOUT and message:
-                        print(message, end="")
+                        print(message.decode("utf-8"), end="")
                     elif self._stream_type == StreamType.PIPE:
                         self._container_process_buffer.append(message)
                     if message is None:

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from modal import App, Image, Mount, NetworkFileSystem, Sandbox, Secret
 from modal.exception import DeprecationError, InvalidError
+from modal.stream_type import StreamType
 from modal_proto import api_pb2
 
 skip_non_linux = pytest.mark.skipif(platform.system() != "Linux", reason="sandbox mock uses subprocess")
@@ -385,3 +386,16 @@ def test_sandbox_no_entrypoint(app, servicer):
 def test_sandbox_gpu_fallbacks_support(client, servicer):
     with pytest.raises(InvalidError, match="do not support"):
         Sandbox.create(client=client, gpu=["t4", "a100"])  # type: ignore
+
+
+@skip_non_linux
+def test_sandbox_exec_stdout(app, servicer, capsys):
+    sb = Sandbox.create("sleep", "infinity", app=app)
+
+    cp = sb.exec("bash", "-c", "echo hi", stdout=StreamType.STDOUT)
+    cp.wait()
+
+    assert capsys.readouterr().out == "hi\n"
+
+    with pytest.raises(InvalidError):
+        cp.stdout.read()


### PR DESCRIPTION
## Describe your changes

#2478 started returning raw bytes from stdout/stderr stream, which broke `StreamType.STDOUT` added in #2419. There were no tests for it, adding one now.

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

