### PR TITLE
Handle non-PTY case for `modal shell` and `modal container exec`

### DIFF
--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -1,5 +1,4 @@
 # Copyright Modal Labs 2022
-import sys
 from typing import Optional, Union
 
 import typer
@@ -8,7 +7,7 @@ from rich.text import Text
 from modal._pty import get_pty_info
 from modal._utils.async_utils import synchronizer
 from modal._utils.grpc_utils import retry_transient_errors
-from modal.cli.utils import ENV_OPTION, display_table, stream_app_logs, timestamp_to_local
+from modal.cli.utils import ENV_OPTION, display_table, is_tty, stream_app_logs, timestamp_to_local
 from modal.client import _Client
 from modal.config import config
 from modal.container_process import _ContainerProcess
@@ -67,7 +66,7 @@ async def exec(
     """Execute a command in a container."""
 
     if pty is None:
-        pty = sys.stdout.isatty()
+        pty = is_tty()
 
     client = await _Client.from_env()
 

--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -56,9 +56,13 @@ def logs(container_id: str = typer.Argument(help="Container ID")):
 @container_cli.command("exec")
 @synchronizer.create_blocking
 async def exec(
-    container_id: str = typer.Argument(help="Container ID"),
-    command: list[str] = typer.Argument(help="A command to run inside the container."),
     pty: Optional[bool] = typer.Option(default=None, help="Run the command using a PTY."),
+    container_id: str = typer.Argument(help="Container ID"),
+    command: list[str] = typer.Argument(
+        help="A command to run inside the container.\n\n"
+        "To pass command-line flags or options, add `--` before the start of your commands. "
+        "For example: `modal container exec <id> -- /bin/bash -c 'echo hi'`"
+    ),
 ):
     """Execute a command in a container."""
 

--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -14,6 +14,7 @@ from modal.config import config
 from modal.container_process import _ContainerProcess
 from modal.environments import ensure_env
 from modal.object import _get_environment_name
+from modal.stream_type import StreamType
 from modal_proto import api_pb2
 
 container_cli = typer.Typer(name="container", help="Manage and connect to running containers.", no_args_is_help=True)
@@ -71,7 +72,10 @@ async def exec(
     )
     res: api_pb2.ContainerExecResponse = await client.stub.ContainerExec(req)
 
-    await _ContainerProcess(res.exec_id, client).attach(pty=pty)
+    if pty:
+        await _ContainerProcess(res.exec_id, client).attach()
+    else:
+        await _ContainerProcess(res.exec_id, client, stdout=StreamType.STDOUT, stderr=StreamType.STDOUT).wait()
 
 
 @container_cli.command("stop")

--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -1,5 +1,5 @@
 # Copyright Modal Labs 2022
-
+import sys
 from typing import Optional, Union
 
 import typer
@@ -58,9 +58,12 @@ def logs(container_id: str = typer.Argument(help="Container ID")):
 async def exec(
     container_id: str = typer.Argument(help="Container ID"),
     command: list[str] = typer.Argument(help="A command to run inside the container."),
-    pty: bool = typer.Option(default=True, help="Run the command using a PTY."),
+    pty: Optional[bool] = typer.Option(default=None, help="Run the command using a PTY."),
 ):
     """Execute a command in a container."""
+
+    if pty is None:
+        pty = sys.stdout.isatty()
 
     client = await _Client.from_env()
 
@@ -75,6 +78,7 @@ async def exec(
     if pty:
         await _ContainerProcess(res.exec_id, client).attach()
     else:
+        # TODO: redirect stderr to its own stream?
         await _ContainerProcess(res.exec_id, client, stdout=StreamType.STDOUT, stderr=StreamType.STDOUT).wait()
 
 

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -29,7 +29,7 @@ from ..runner import deploy_app, interactive_shell, run_app
 from ..serving import serve_app
 from ..volume import Volume
 from .import_refs import import_app, import_function
-from .utils import ENV_OPTION, ENV_OPTION_HELP, stream_app_logs
+from .utils import ENV_OPTION, ENV_OPTION_HELP, is_tty, stream_app_logs
 
 
 class ParameterMetadata(TypedDict):
@@ -392,6 +392,7 @@ def shell(
             "Can be a single region or a comma-separated list to choose from (if not using REF)."
         ),
     ),
+    pty: Optional[bool] = typer.Option(default=None, help="Run the command using a PTY."),
 ):
     """Run a command or interactive shell inside a Modal container.
 
@@ -430,7 +431,8 @@ def shell(
     """
     env = ensure_env(env)
 
-    pty = sys.stdout.isatty()
+    if pty is None:
+        pty = is_tty()
 
     if platform.system() == "Windows":
         raise InvalidError("`modal shell` is currently not supported on Windows")

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -423,9 +423,7 @@ def shell(
     """
     env = ensure_env(env)
 
-    console = Console()
-    if not console.is_terminal:
-        raise click.UsageError("`modal shell` can only be run from a terminal.")
+    pty = sys.stdout.isatty()
 
     if platform.system() == "Windows":
         raise InvalidError("`modal shell` is currently not supported on Windows")
@@ -441,7 +439,7 @@ def shell(
         ):
             from .container import exec
 
-            exec(container_id=container_or_function, command=shlex.split(cmd), pty=True)
+            exec(container_id=container_or_function, command=shlex.split(cmd))
             return
 
         function = import_function(
@@ -461,6 +459,7 @@ def shell(
             memory=function_spec.memory,
             volumes=function_spec.volumes,
             region=function_spec.scheduler_placement.proto.regions if function_spec.scheduler_placement else None,
+            pty=pty,
         )
     else:
         modal_image = Image.from_registry(image, add_python=add_python) if image else None
@@ -474,6 +473,7 @@ def shell(
             cloud=cloud,
             volumes=volumes,
             region=region.split(",") if region else [],
+            pty=pty,
         )
 
     # NB: invoking under bash makes --cmd a lot more flexible.

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -393,32 +393,39 @@ def shell(
         ),
     ),
 ):
-    """Run an interactive shell inside a Modal container.
+    """Run a command or interactive shell inside a Modal container.
 
-    **Examples:**
+    \b**Examples:**
 
-    Start a shell inside the default Debian-based image:
+    \bStart an interactive shell inside the default Debian-based image:
 
-    ```
+    \b```
     modal shell
     ```
 
-    Start a bash shell using the spec for `my_function` in your App:
+    \bStart an interactive shell with the spec for `my_function` in your App
+    (uses the same image, volumes, mounts, etc.):
 
-    ```
+    \b```
     modal shell hello_world.py::my_function
     ```
 
-    Or, if you're using a [modal.Cls](/docs/reference/modal.Cls), you can refer to a `@modal.method` directly:
+    \bOr, if you're using a [modal.Cls](/docs/reference/modal.Cls), you can refer to a `@modal.method` directly:
 
-    ```
+    \b```
     modal shell hello_world.py::MyClass.my_method
     ```
 
     Start a `python` shell:
 
-    ```
+    \b```
     modal shell hello_world.py --cmd=python
+    ```
+
+    \bRun a command with your function's spec and pipe the output to a file:
+
+    \b```
+    modal shell hello_world.py -c 'uv pip list' > env.txt
     ```
     """
     env = ensure_env(env)

--- a/modal/cli/utils.py
+++ b/modal/cli/utils.py
@@ -77,6 +77,10 @@ def _plain(text: Union[Text, str]) -> str:
     return text.plain if isinstance(text, Text) else text
 
 
+def is_tty() -> bool:
+    return Console().is_terminal
+
+
 def display_table(
     columns: Sequence[Union[Column, str]],
     rows: Sequence[Sequence[Union[Text, str]]],

--- a/modal/container_process.py
+++ b/modal/container_process.py
@@ -151,7 +151,11 @@ class _ContainerProcess(Generic[T]):
                 # time out if we can't connect to the server fast enough
                 await asyncio.wait_for(on_connect.wait(), timeout=60)
 
-                async with stream_from_stdin(_handle_input, use_raw_terminal=pty):
+                if pty:
+                    async with stream_from_stdin(_handle_input, use_raw_terminal=True):
+                        await stdout_task
+                        await stderr_task
+                else:
                     await stdout_task
                     await stderr_task
 

--- a/modal/container_process.py
+++ b/modal/container_process.py
@@ -9,7 +9,7 @@ from ._utils.async_utils import TaskContext, synchronize_api
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.shell_utils import stream_from_stdin, write_to_fd
 from .client import _Client
-from .exception import InteractiveTimeoutError, InvalidError
+from .exception import InteractiveTimeoutError, InvalidError, deprecation_error
 from .io_streams import _StreamReader, _StreamWriter
 from .stream_type import StreamType
 
@@ -114,10 +114,17 @@ class _ContainerProcess(Generic[T]):
                 self._returncode = resp.exit_code
                 return self._returncode
 
-    async def attach(self):
+    async def attach(self, *, pty: Optional[bool] = None):
         if platform.system() == "Windows":
             print("interactive exec is not currently supported on Windows.")
             return
+
+        if pty is not None:
+            deprecation_error(
+                (2024, 12, 9),
+                "The `pty` argument to `modal.container_process.attach(pty=...)` is deprecated, "
+                "as only PTY mode is supported. Please remove the argument.",
+            )
 
         from rich.console import Console
 

--- a/modal/container_process.py
+++ b/modal/container_process.py
@@ -114,7 +114,7 @@ class _ContainerProcess(Generic[T]):
                 self._returncode = resp.exit_code
                 return self._returncode
 
-    async def attach(self, *, pty: bool):
+    async def attach(self):
         if platform.system() == "Windows":
             print("interactive exec is not currently supported on Windows.")
             return
@@ -151,11 +151,7 @@ class _ContainerProcess(Generic[T]):
                 # time out if we can't connect to the server fast enough
                 await asyncio.wait_for(on_connect.wait(), timeout=60)
 
-                if pty:
-                    async with stream_from_stdin(_handle_input, use_raw_terminal=True):
-                        await stdout_task
-                        await stderr_task
-                else:
+                async with stream_from_stdin(_handle_input, use_raw_terminal=True):
                     await stdout_task
                     await stderr_task
 

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -601,7 +601,7 @@ async def _interactive_shell(_app: _App, cmds: list[str], environment_name: str 
 
         container_process = await sandbox.exec(*sandbox_cmds, pty_info=get_pty_info(shell=True))
         try:
-            await container_process.attach(pty=True)
+            await container_process.attach()
         except InteractiveTimeoutError:
             # Check on status of Sandbox. It may have crashed, causing connection failure.
             req = api_pb2.SandboxWaitRequest(sandbox_id=sandbox._object_id, timeout=0)

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -38,6 +38,7 @@ from .output import _get_output_manager, enable_output
 from .running_app import RunningApp
 from .sandbox import _Sandbox
 from .secret import _Secret
+from .stream_type import StreamType
 
 if TYPE_CHECKING:
     from .app import _App
@@ -557,7 +558,9 @@ async def _deploy_app(
     )
 
 
-async def _interactive_shell(_app: _App, cmds: list[str], environment_name: str = "", **kwargs: Any) -> None:
+async def _interactive_shell(
+    _app: _App, cmds: list[str], environment_name: str = "", pty: bool = True, **kwargs: Any
+) -> None:
     """Run an interactive shell (like `bash`) within the image for this app.
 
     This is useful for online debugging and interactive exploration of the
@@ -599,9 +602,17 @@ async def _interactive_shell(_app: _App, cmds: list[str], environment_name: str 
                 **kwargs,
             )
 
-        container_process = await sandbox.exec(*sandbox_cmds, pty_info=get_pty_info(shell=True))
         try:
-            await container_process.attach()
+            if pty:
+                container_process = await sandbox.exec(
+                    *sandbox_cmds, pty_info=get_pty_info(shell=True) if pty else None
+                )
+                await container_process.attach()
+            else:
+                container_process = await sandbox.exec(
+                    *sandbox_cmds, stdout=StreamType.STDOUT, stderr=StreamType.STDOUT
+                )
+                await container_process.wait()
         except InteractiveTimeoutError:
             # Check on status of Sandbox. It may have crashed, causing connection failure.
             req = api_pb2.SandboxWaitRequest(sandbox_id=sandbox._object_id, timeout=0)

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -21,7 +21,14 @@ from ._utils.mount_utils import validate_network_file_systems, validate_volumes
 from .client import _Client
 from .config import config
 from .container_process import _ContainerProcess
-from .exception import ExecutionError, InvalidError, SandboxTerminatedError, SandboxTimeoutError, deprecation_error, deprecation_warning
+from .exception import (
+    ExecutionError,
+    InvalidError,
+    SandboxTerminatedError,
+    SandboxTimeoutError,
+    deprecation_error,
+    deprecation_warning,
+)
 from .gpu import GPU_T
 from .image import _Image
 from .io_streams import StreamReader, StreamWriter, _StreamReader, _StreamWriter

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -21,7 +21,7 @@ from ._utils.mount_utils import validate_network_file_systems, validate_volumes
 from .client import _Client
 from .config import config
 from .container_process import _ContainerProcess
-from .exception import ExecutionError, InvalidError, SandboxTerminatedError, SandboxTimeoutError, deprecation_warning
+from .exception import ExecutionError, InvalidError, SandboxTerminatedError, SandboxTimeoutError, deprecation_error, deprecation_warning
 from .gpu import GPU_T
 from .image import _Image
 from .io_streams import StreamReader, StreamWriter, _StreamReader, _StreamWriter
@@ -604,7 +604,7 @@ Sandbox = synchronize_api(_Sandbox)
 
 def __getattr__(name):
     if name == "LogsReader":
-        deprecation_warning(
+        deprecation_error(
             (2024, 8, 12),
             "`modal.sandbox.LogsReader` is deprecated. Please import `modal.io_streams.StreamReader` instead.",
         )
@@ -612,7 +612,7 @@ def __getattr__(name):
 
         return StreamReader
     elif name == "StreamWriter":
-        deprecation_warning(
+        deprecation_error(
             (2024, 8, 12),
             "`modal.sandbox.StreamWriter` is deprecated. Please import `modal.io_streams.StreamWriter` instead.",
         )

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -385,13 +385,15 @@ def mock_shell_pty(servicer):
         yield
         write_task.cancel()
 
-    with mock.patch("rich.console.Console.is_terminal", True), mock.patch(
-        "modal.cli.container.get_pty_info", mock_get_pty_info
-    ), mock.patch("modal._pty.get_pty_info", mock_get_pty_info), mock.patch(
-        "modal.runner.get_pty_info", mock_get_pty_info
-    ), mock.patch("modal._utils.shell_utils.stream_from_stdin", fake_stream_from_stdin), mock.patch(
-        "modal.container_process.stream_from_stdin", fake_stream_from_stdin
-    ), mock.patch("modal.container_process.write_to_fd", write_to_fd):
+    with (
+        mock.patch("rich.console.Console.is_terminal", True),
+        mock.patch("modal.cli.container.get_pty_info", mock_get_pty_info),
+        mock.patch("modal._pty.get_pty_info", mock_get_pty_info),
+        mock.patch("modal.runner.get_pty_info", mock_get_pty_info),
+        mock.patch("modal._utils.shell_utils.stream_from_stdin", fake_stream_from_stdin),
+        mock.patch("modal.container_process.stream_from_stdin", fake_stream_from_stdin),
+        mock.patch("modal.container_process.write_to_fd", write_to_fd),
+    ):
         yield fake_stdin, captured_out
 
 

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -18,6 +18,7 @@ import click
 import click.testing
 import toml
 
+from modal import App, Sandbox
 from modal._utils.grpc_testing import InterceptionContext
 from modal.cli.entry_point import entrypoint_cli
 from modal.exception import InvalidError
@@ -385,12 +386,12 @@ def mock_shell_pty(servicer):
         write_task.cancel()
 
     with mock.patch("rich.console.Console.is_terminal", True), mock.patch(
-        "modal._pty.get_pty_info", mock_get_pty_info
-    ), mock.patch("modal.runner.get_pty_info", mock_get_pty_info), mock.patch(
-        "modal._utils.shell_utils.stream_from_stdin", fake_stream_from_stdin
-    ), mock.patch("modal.container_process.stream_from_stdin", fake_stream_from_stdin), mock.patch(
-        "modal.container_process.write_to_fd", write_to_fd
-    ):
+        "modal.cli.container.get_pty_info", mock_get_pty_info
+    ), mock.patch("modal._pty.get_pty_info", mock_get_pty_info), mock.patch(
+        "modal.runner.get_pty_info", mock_get_pty_info
+    ), mock.patch("modal._utils.shell_utils.stream_from_stdin", fake_stream_from_stdin), mock.patch(
+        "modal.container_process.stream_from_stdin", fake_stream_from_stdin
+    ), mock.patch("modal.container_process.write_to_fd", write_to_fd):
         yield fake_stdin, captured_out
 
 
@@ -1057,3 +1058,28 @@ def test_keyboard_interrupt_during_app_run_detach(servicer, server_url_env, toke
         assert "Shutting down Modal client." in out
         assert "The detached app keeps running. You can track its progress at:" in out
         assert "Traceback" not in err
+
+
+@pytest.fixture
+def app(client):
+    app = App()
+    with app.run(client):
+        yield app
+
+
+@skip_windows("modal shell is not supported on Windows.")
+def test_container_exec(servicer, set_env_client, mock_shell_pty, app):
+    sb = Sandbox.create("bash", "-c", "sleep 10000", app=app)
+
+    fake_stdin, captured_out = mock_shell_pty
+
+    fake_stdin.clear()
+    fake_stdin.extend([b'echo "Hello World"\n', b"exit\n"])
+
+    shell_prompt = servicer.shell_prompt
+
+    _run(["container", "exec", "--pty", sb.object_id, "/bin/bash"])
+    assert captured_out == [(1, shell_prompt), (1, b"Hello World\n")]
+    captured_out.clear()
+
+    sb.terminate()


### PR DESCRIPTION
Resolves CLI-239

`modal container exec` now checks `stdout.isatty()` to determine whether to run in PTY mode or not. If not, it uses `StreamType.STDOUT` to write output directly to stdout. This means that you can now do this:

```python
modal shell -c 'uv pip list' > env.txt
```

It didn't make sense for `ContainerProcess.attach()` to support `pty=False`, so I removed that option and made it a `deprecation_error` directly. 

Added a test for `modal container exec` since none existed, but it's a bit tricky to test PTY behavior directly because of how we run this. Tested some basic cases manually:

![image](https://github.com/user-attachments/assets/a2f286aa-5bfb-4b7e-9460-4854d3dde327)

Depends on #2624.


<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog
- `modal container exec` and `modal shell` now work correctly even when a pseudoterminal (PTY) is not present. This means, for example, that you can pipe the output of these commands to a file:

    ```python
    modal shell -c 'uv pip list' > env.txt
    ```