### PR TITLE
Experimental spawn now uses FunctionAsyncInvoke

### DIFF
--- a/modal/_utils/function_utils.py
+++ b/modal/_utils/function_utils.py
@@ -495,7 +495,13 @@ async def _process_result(result: api_pb2.GenericResult, data_format: int, stub,
 
 
 async def _create_input(
-    args, kwargs, client, *, idx: Optional[int] = None, method_name: Optional[str] = None
+    args,
+    kwargs,
+    client,
+    *,
+    idx: Optional[int] = None,
+    method_name: Optional[str] = None,
+    force_blob_upload: bool = False,
 ) -> api_pb2.FunctionPutInputsItem:
     """Serialize function arguments and create a FunctionInput protobuf,
     uploading to blob storage if needed.
@@ -507,7 +513,7 @@ async def _create_input(
 
     args_serialized = serialize((args, kwargs))
 
-    if len(args_serialized) > MAX_OBJECT_SIZE_BYTES:
+    if len(args_serialized) > MAX_OBJECT_SIZE_BYTES or force_blob_upload:
         args_blob_id = await blob_upload(args_serialized, client.stub)
 
         return api_pb2.FunctionPutInputsItem(

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1391,7 +1391,6 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         """
         self._check_no_web_url("_experimental_spawn")
         if self._is_generator:
-            # TODO(dshaar): Deprecate this.
             invocation = await self._call_generator_nowait(args, kwargs)
             fc = _FunctionCall._new_hydrated(invocation.function_call_id, invocation.client, None)
             fc._is_generator = True

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1239,7 +1239,6 @@ message FunctionAsyncInvokeRequest {
 message FunctionAsyncInvokeResponse {
   bool retry_with_blob_upload = 1;
   string function_call_id = 2;
-  string input_id = 3;
 }
 
 message FunctionBindParamsRequest {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1239,6 +1239,7 @@ message FunctionAsyncInvokeRequest {
 message FunctionAsyncInvokeResponse {
   bool retry_with_blob_upload = 1;
   string function_call_id = 2;
+  string input_id = 3;
 }
 
 message FunctionBindParamsRequest {

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -828,6 +828,13 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     ### Function
 
+    async def FunctionAsyncInvoke(self, stream):
+        self.fcidx += 1
+        request: api_pb2.FunctionAsyncInvokeRequest = await stream.recv_message()
+        function_call_id = f"fc-{self.fcidx}"
+        self.function_id_for_function_call[function_call_id] = request.function_id
+        await stream.send_message(api_pb2.FunctionAsyncInvokeResponse(function_call_id=function_call_id))
+
     async def FunctionBindParams(self, stream):
         from modal._serialization import deserialize
 

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -11,6 +11,7 @@ from synchronicity.exceptions import UserCodeException
 
 import modal
 from modal import App, Image, Mount, NetworkFileSystem, Proxy, asgi_app, batched, web_endpoint
+from modal._serialization import deserialize
 from modal._utils.async_utils import synchronize_api
 from modal._vendor import cloudpickle
 from modal.exception import DeprecationError, ExecutionError, InvalidError
@@ -1009,9 +1010,9 @@ def test_experimental_spawn(client, servicer):
         with app.run(client=client):
             dummy_modal._experimental_spawn(1, 2)
 
-    # Verify the correct invocation type is set
-    function_map = ctx.pop_request("FunctionMap")
-    assert function_map.function_call_invocation_type == api_pb2.FUNCTION_CALL_INVOCATION_TYPE_ASYNC
+    # Verify the correct input was passed to the function.
+    request = ctx.pop_request("FunctionAsyncInvoke")
+    assert deserialize(request.input.args, client) == ((1, 2), {})
 
 
 def test_from_name_web_url(servicer, set_env_client):


### PR DESCRIPTION
## Describe your changes

SVC-220

Context in the linear ticket's linked notion doc.

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
  - **This is NOT compatible with servers that don't implement the new RPC!**

---
