### PR TITLE
Add API and CLI for deleting named NetworkFileSystem objects

### DIFF
--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -221,6 +221,12 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         resp = await retry_transient_errors(client.stub.SharedVolumeGetOrCreate, request)
         return resp.shared_volume_id
 
+    @staticmethod
+    async def delete(label: str, client: Optional[_Client] = None, environment_name: Optional[str] = None):
+        obj = await _NetworkFileSystem.lookup(label, client=client, environment_name=environment_name)
+        req = api_pb2.SharedVolumeDeleteRequest(shared_volume_id=obj.object_id)
+        await retry_transient_errors(obj._client.stub.SharedVolumeDelete, req)
+
     @live_method
     async def write_file(self, remote_path: str, fp: BinaryIO, progress_cb: Optional[Callable[..., Any]] = None) -> int:
         """Write from a file object to a path on the network file system, atomically.

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -540,6 +540,14 @@ def test_nfs_get(set_env_client, servicer):
             assert f.read() == "foo bar baz"
 
 
+def test_nfs_create_delete(servicer, server_url_env, set_env_client):
+    name = "test-delete-nfs"
+    _run(["nfs", "create", name])
+    assert name in _run(["nfs", "list"]).stdout
+    _run(["nfs", "delete", "--yes", name])
+    assert name not in _run(["nfs", "list"]).stdout
+
+
 def test_volume_cli(set_env_client):
     _run(["volume", "--help"])
 


### PR DESCRIPTION
This was a feature gap exacerbated by the recent move away from "single-object apps".

Fixes CLI-283

## Changelog

- It is now possible to delete named `NetworkFileSystem` objects via the CLI (`modal nfs delete ...`) or API `(modal.NetworkFileSystem.delete(...)`)