### PR TITLE
Container calling ContainerHello

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -415,6 +415,9 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
 
     _client: _Client = synchronizer._translate_in(client)  # TODO(erikbern): ugly
 
+    # Call ContainerHello - currently a noop but might be used later for things
+    container_io_manager.hello()
+
     with container_io_manager.heartbeats(is_snapshotting_function), UserCodeEventLoop() as event_loop:
         # If this is a serialized function, fetch the definition from the server
         if function_def.definition_type == api_pb2.Function.DEFINITION_TYPE_SERIALIZED:

--- a/modal/_runtime/container_io_manager.py
+++ b/modal/_runtime/container_io_manager.py
@@ -335,6 +335,9 @@ class _ContainerIOManager:
         """Only used for tests."""
         cls._singleton = None
 
+    async def hello(self):
+        await self._client.stub.ContainerHello(Empty())
+
     async def _run_heartbeat_loop(self):
         while 1:
             t0 = time.monotonic()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -729,6 +729,10 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
         await stream.send_message(api_pb2.RuntimeOutputBatch(exit_code=0))
 
+    async def ContainerHello(self, stream):
+        await stream.recv_message()
+        await stream.send_message(Empty())
+
     ### Dict
 
     async def DictGetOrCreate(self, stream):


### PR DESCRIPTION
This causes containers to call the new `ContainerHello` grpc method. It gets intercepted on the worker so it should be very fast. This helps us remove `ClientHello` since we have the optionality to put logic in `ContainerHello` instead.

I timed this and every request was in the 1-2ms range.

This isn't ready to be merged yet – we can't merge this PR until the worker change has been fully rolled out. Wed morning would give us some buffer.