### PR TITLE
Add Sandbox support for cpu-limit and fix types

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -347,7 +347,7 @@ class _FunctionSpec:
     volumes: dict[Union[str, PurePosixPath], Union[_Volume, _CloudBucketMount]]
     gpus: Union[GPU_T, list[GPU_T]]  # TODO(irfansharif): Somehow assert that it's the first kind, in sandboxes
     cloud: Optional[str]
-    cpu: Optional[float]
+    cpu: Optional[Union[float, tuple[float, float]]]
     memory: Optional[Union[int, tuple[int, int]]]
     ephemeral_disk: Optional[int]
     scheduler_placement: Optional[SchedulerPlacement]
@@ -448,7 +448,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         batch_max_size: Optional[int] = None,
         batch_wait_ms: Optional[int] = None,
         container_idle_timeout: Optional[int] = None,
-        cpu: Optional[float] = None,
+        cpu: Optional[Union[float, tuple[float, float]]] = None,
         keep_warm: Optional[int] = None,  # keep_warm=True is equivalent to keep_warm=1
         cloud: Optional[str] = None,
         scheduler_placement: Optional[SchedulerPlacement] = None,

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -196,7 +196,10 @@ class _Sandbox(_Object, type_prefix="sb"):
         gpu: GPU_T = None,
         cloud: Optional[str] = None,
         region: Optional[Union[str, Sequence[str]]] = None,  # Region or regions to run the sandbox on.
-        cpu: Optional[float] = None,  # How many CPU cores to request. This is a soft limit.
+        # Specify, in fractional CPU cores, how many CPU cores to request.
+        # Or, pass (request, limit) to additionally specify a hard limit in fractional CPU cores.
+        # CPU throttling will prevent a container from exceeding its specified limit.
+        cpu: Optional[Union[float, tuple[float, float]]] = None,
         # Specify, in MiB, a memory request which is the minimum memory required.
         # Or, pass (request, limit) to additionally specify a hard limit in MiB.
         memory: Optional[Union[int, tuple[int, int]]] = None,

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -412,3 +412,19 @@ def test_sandbox_snapshot_fs(app, servicer):
 
     assert image.object_id == "im-123"
     assert servicer.sandbox_defs[1].image_id == "im-123"
+
+
+@skip_non_linux
+def test_sandbox_cpu_request(app, servicer):
+    _ = Sandbox.create(cpu=2.0, app=app)
+
+    assert servicer.sandbox_defs[0].resources.milli_cpu == 2000
+    assert servicer.sandbox_defs[0].resources.milli_cpu_max == 0
+
+
+@skip_non_linux
+def test_sandbox_cpu_limit(app, servicer):
+    _ = Sandbox.create(cpu=(2, 4), app=app)
+
+    assert servicer.sandbox_defs[0].resources.milli_cpu == 2000
+    assert servicer.sandbox_defs[0].resources.milli_cpu_max == 4000


### PR DESCRIPTION
## Describe your changes

Resolves WRK-599.

This is a purely client change, as server/worker logic was already compatible with adding cpu limits to Sandboxes.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

Sandboxes now support [cpu limits](https://modal.com/docs/guide/resources#cpu-limits):
```python
cpu_request = 1.0
cpu_limit = 4.0
app = modal.App.lookup("my-app", create_if_missing=True)
modal.Sandbox.create(app=app, cpu=(cpu_request, cpu_limit))
```