### PR TITLE
Retry transient sandbox exec failures

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -504,17 +504,16 @@ class _Sandbox(_Object, type_prefix="sb"):
             await secret.resolve(client=self._client)
 
         task_id = await self._get_task_id()
-        resp = await self._client.stub.ContainerExec(
-            api_pb2.ContainerExecRequest(
-                task_id=task_id,
-                command=cmds,
-                pty_info=_pty_info or pty_info,
-                runtime_debug=config.get("function_runtime_debug"),
-                timeout_secs=timeout or 0,
-                workdir=workdir,
-                secret_ids=[secret.object_id for secret in secrets],
-            )
+        req = api_pb2.ContainerExecRequest(
+            task_id=task_id,
+            command=cmds,
+            pty_info=_pty_info or pty_info,
+            runtime_debug=config.get("function_runtime_debug"),
+            timeout_secs=timeout or 0,
+            workdir=workdir,
+            secret_ids=[secret.object_id for secret in secrets],
         )
+        resp = await retry_transient_errors(self._client.stub.ContainerExec, req)
         by_line = bufsize == 1
         return _ContainerProcess(resp.exec_id, self._client, stdout=stdout, stderr=stderr, text=text, by_line=by_line)
 


### PR DESCRIPTION
The lack of `retry_transient_errors` was an oversight.

## Describe your changes

Added transient error retry to Sandbox exec.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>
