### PR TITLE
Let FunctionGet return warnings

### DIFF
--- a/modal/client.py
+++ b/modal/client.py
@@ -27,7 +27,7 @@ from ._utils import async_utils
 from ._utils.async_utils import TaskContext, synchronize_api
 from ._utils.grpc_utils import connect_channel, create_channel, retry_transient_errors
 from .config import _check_config, _is_remote, config, logger
-from .exception import AuthError, ClientClosed, ConnectionError, DeprecationError, VersionError
+from .exception import AuthError, ClientClosed, ConnectionError, VersionError, client_version_warning
 
 HEARTBEAT_INTERVAL: float = config.get("heartbeat_interval")
 HEARTBEAT_TIMEOUT: float = HEARTBEAT_INTERVAL + 0.1
@@ -146,8 +146,7 @@ class _Client:
                 total_timeout=CLIENT_CREATE_TOTAL_TIMEOUT,
             )
             if resp.warning:
-                ALARM_EMOJI = chr(0x1F6A8)
-                warnings.warn_explicit(f"{ALARM_EMOJI} {resp.warning} {ALARM_EMOJI}", DeprecationError, "<unknown>", 0)
+                client_version_warning(resp.warning)
         except GRPCError as exc:
             if exc.status == Status.FAILED_PRECONDITION:
                 raise VersionError(

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -18,7 +18,7 @@ from ._utils.async_utils import synchronize_api, synchronizer
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.mount_utils import validate_volumes
 from .client import _Client
-from .exception import InvalidError, NotFoundError, VersionError
+from .exception import InvalidError, NotFoundError, VersionError, client_version_warning
 from .functions import (
     _Function,
     _parse_retries,
@@ -485,6 +485,9 @@ class _Cls(_Object, type_prefix="cs"):
                     raise InvalidError(exc.message)
                 else:
                     raise
+
+            if response.client_version_warning:
+                client_version_warning(response.client_version_warning)
 
             class_function_tag = f"{tag}.*"  # special name of the base service function for the class
 

--- a/modal/exception.py
+++ b/modal/exception.py
@@ -161,6 +161,11 @@ def deprecation_warning(
     warnings.warn_explicit(f"{date(*deprecated_on)}: {msg}", warning_cls, filename, lineno)
 
 
+def client_version_warning(warning_str: str):
+    ALARM_EMOJI = chr(0x1F6A8)
+    warnings.warn_explicit(f"{ALARM_EMOJI} {warning_str} {ALARM_EMOJI}", DeprecationError, "<unknown>", 0)
+
+
 def _simulate_preemption_interrupt(signum, frame):
     signal.alarm(30)  # simulate a SIGKILL after 30s
     raise KeyboardInterrupt("Simulated preemption interrupt from modal-client!")

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -63,6 +63,7 @@ from .exception import (
     InvalidError,
     NotFoundError,
     OutputExpiredError,
+    client_version_warning,
     deprecation_warning,
 )
 from .gpu import GPU_T, parse_gpu_config
@@ -1060,6 +1061,9 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                     raise NotFoundError(exc.message)
                 else:
                     raise
+
+            if response.client_version_warning:
+                client_version_warning(response.client_version_warning)
 
             self._hydrate(response.function_id, resolver.client, response.handle_metadata)
 

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -30,6 +30,7 @@ from .exception import (
     InvalidError,
     RemoteError,
     _CliUserExecutionError,
+    client_version_warning,
     deprecation_error,
 )
 from .functions import _Function
@@ -204,6 +205,9 @@ async def _publish_app(
         if exc.status == Status.INVALID_ARGUMENT or exc.status == Status.FAILED_PRECONDITION:
             raise InvalidError(exc.message)
         raise
+
+    if response.client_version_warning:
+        client_version_warning(response.client_version_warning)
 
     return response.url, response.warnings
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -401,6 +401,7 @@ message AppPublishRequest {
 message AppPublishResponse {
   string url = 1;
   repeated string warnings = 2;
+  string client_version_warning = 3;
 }
 
 message AppRollbackRequest {
@@ -619,6 +620,7 @@ message ClassGetRequest {
 message ClassGetResponse {
   string class_id = 1;
   ClassHandleMetadata handle_metadata = 2;
+  string client_version_warning = 3;
 }
 
 message ClassHandleMetadata {
@@ -1446,6 +1448,7 @@ message FunctionGetRequest {
 message FunctionGetResponse {
   string function_id = 1;
   FunctionHandleMetadata handle_metadata = 2;
+  string client_version_warning = 3;
 }
 
 message FunctionGetSerializedRequest {

--- a/test/lookup_test.py
+++ b/test/lookup_test.py
@@ -68,3 +68,14 @@ def test_create_if_missing(servicer, client):
     v1: Volume = Volume.lookup("my-volume", create_if_missing=True, client=client)
     v2: Volume = Volume.lookup("my-volume", client=client)
     assert v1.object_id == v2.object_id
+
+
+def test_lookup_with_old_client(servicer, client):
+    app = App()
+
+    app.function()(square)
+    deploy_app(app, "my-function", client=client)
+
+    servicer.function_client_version_warning = "xyz"
+    with pytest.warns(match="xyz"):
+        Function.lookup("my-function", "square", client=client)


### PR DESCRIPTION
Since we're removing `ClientHello`, @mwaskom pointed out there won't be a great way to warn that a client is deprecated. However we can move the logic to `AppPublish` and `FunctionGet` and cover most use cases. `AppPublish` already returns a list of warnings. Adding warnings support to `FunctionGet`.

Will make the server change separately.