### PR TITLE
Add protos for directory level sandbox api

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -811,6 +811,20 @@ message ContainerFilesystemExecGetOutputRequest {
   float timeout = 2;
 }
 
+message ContainerFileLsRequest {
+  string path = 1;
+}
+
+message ContainerFileMkdirRequest {
+  string path = 1;
+  bool parents = 2;
+}
+
+message ContainerFileRmRequest {
+  string path = 1;
+  bool recursive = 2;
+}
+
 message ContainerFilesystemExecRequest {
   oneof file_exec_request_oneof {
     ContainerFileOpenRequest file_open_request = 1;
@@ -822,6 +836,9 @@ message ContainerFilesystemExecRequest {
     ContainerFileDeleteBytesRequest file_delete_bytes_request = 7;
     ContainerFileWriteReplaceBytesRequest file_write_replace_bytes_request = 8;
     ContainerFileCloseRequest file_close_request = 9;
+    ContainerFileLsRequest file_ls_request = 11;
+    ContainerFileMkdirRequest file_mkdir_request = 12;
+    ContainerFileRmRequest file_rm_request = 13;
   }
   string task_id = 10;
 }

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -778,7 +778,7 @@ message ContainerFileLsRequest {
 
 message ContainerFileMkdirRequest {
   string path = 1;
-  bool parents = 2;
+  bool make_parents = 2;
 }
 
 message ContainerFileOpenRequest {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -772,6 +772,15 @@ message ContainerFileFlushRequest {
   string file_descriptor = 1;
 }
 
+message ContainerFileLsRequest {
+  string path = 1;
+}
+
+message ContainerFileMkdirRequest {
+  string path = 1;
+  bool parents = 2;
+}
+
 message ContainerFileOpenRequest {
   // file descriptor is hydrated when sent from server -> worker
   optional string file_descriptor = 1;
@@ -786,6 +795,11 @@ message ContainerFileReadLineRequest {
 message ContainerFileReadRequest {
   string file_descriptor = 1;
   optional uint32 n = 2;
+}
+
+message ContainerFileRmRequest {
+  string path = 1;
+  bool recursive = 2;
 }
 
 message ContainerFileSeekRequest {
@@ -809,20 +823,6 @@ message ContainerFileWriteRequest {
 message ContainerFilesystemExecGetOutputRequest {
   string exec_id = 1;
   float timeout = 2;
-}
-
-message ContainerFileLsRequest {
-  string path = 1;
-}
-
-message ContainerFileMkdirRequest {
-  string path = 1;
-  bool parents = 2;
-}
-
-message ContainerFileRmRequest {
-  string path = 1;
-  bool recursive = 2;
 }
 
 message ContainerFilesystemExecRequest {


### PR DESCRIPTION
## Describe your changes

This pr adds protos for the directory-level api in WRK-521.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>