### PR TITLE
Print server warnings in function/class lookup but not during client construction

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -18,11 +18,8 @@ from ._utils.async_utils import synchronize_api, synchronizer
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.mount_utils import validate_volumes
 from .client import _Client
-from .exception import InvalidError, NotFoundError, VersionError
-from .functions import (
-    _Function,
-    _parse_retries,
-)
+from .exception import InvalidError, NotFoundError, VersionError, print_server_warnings
+from .functions import _Function, _parse_retries
 from .gpu import GPU_T
 from .object import _get_environment_name, _Object
 from .partial_function import (
@@ -485,6 +482,8 @@ class _Cls(_Object, type_prefix="cs"):
                     raise InvalidError(exc.message)
                 else:
                     raise
+
+            print_server_warnings(response.server_warnings)
 
             class_function_tag = f"{tag}.*"  # special name of the base service function for the class
 

--- a/modal/exception.py
+++ b/modal/exception.py
@@ -5,6 +5,8 @@ import sys
 import warnings
 from datetime import date
 
+from modal_proto import api_pb2
+
 
 class Error(Exception):
     """
@@ -213,3 +215,9 @@ class ModuleNotMountable(Exception):
 
 class ClientClosed(Error):
     pass
+
+
+def print_server_warnings(server_warnings: list[api_pb2.Warning]):
+    ALARM_EMOJI = chr(0x1F6A8)
+    for warning in server_warnings:
+        warnings.warn_explicit(f"{ALARM_EMOJI} {warning} {ALARM_EMOJI}", DeprecationError, "<unknown>", 0)

--- a/modal/exception.py
+++ b/modal/exception.py
@@ -4,6 +4,7 @@ import signal
 import sys
 import warnings
 from datetime import date
+from typing import Iterable
 
 from modal_proto import api_pb2
 
@@ -217,7 +218,7 @@ class ClientClosed(Error):
     pass
 
 
-def print_server_warnings(server_warnings: list[api_pb2.Warning]):
+def print_server_warnings(server_warnings: Iterable[api_pb2.Warning]):
     ALARM_EMOJI = chr(0x1F6A8)
     for warning in server_warnings:
         warnings.warn_explicit(f"{ALARM_EMOJI} {warning} {ALARM_EMOJI}", DeprecationError, "<unknown>", 0)

--- a/modal/exception.py
+++ b/modal/exception.py
@@ -219,6 +219,9 @@ class ClientClosed(Error):
 
 
 def print_server_warnings(server_warnings: Iterable[api_pb2.Warning]):
-    ALARM_EMOJI = chr(0x1F6A8)
+    # TODO(erikbern): move this to modal._utils.deprecation
     for warning in server_warnings:
-        warnings.warn_explicit(f"{ALARM_EMOJI} {warning} {ALARM_EMOJI}", DeprecationError, "<unknown>", 0)
+        if warning.type == api_pb2.Warning.WARNING_TYPE_CLIENT_DEPRECATION:
+            warnings.warn_explicit(warning.message, DeprecationError, "<unknown>", 0)
+        else:
+            warnings.warn_explicit(warning.message, UserWarning, "<unknown>", 0)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -64,6 +64,7 @@ from .exception import (
     NotFoundError,
     OutputExpiredError,
     deprecation_warning,
+    print_server_warnings,
 )
 from .gpu import GPU_T, parse_gpu_config
 from .image import _Image
@@ -1060,6 +1061,8 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                     raise NotFoundError(exc.message)
                 else:
                     raise
+
+            print_server_warnings(response.server_warnings)
 
             self._hydrate(response.function_id, resolver.client, response.handle_metadata)
 

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -7,7 +7,6 @@ import sys
 from google.protobuf.empty_pb2 import Empty
 from grpclib import GRPCError
 
-import modal.exception
 from modal import Client
 from modal.exception import AuthError, ConnectionError, DeprecationError, InvalidError, VersionError
 from modal_proto import api_pb2
@@ -96,13 +95,6 @@ async def test_client_server_error(servicer):
 async def test_client_old_version(servicer, credentials):
     with pytest.raises(VersionError):
         async with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, credentials, version="0.0.0"):
-            pass
-
-
-@pytest.mark.asyncio
-async def test_client_deprecated(servicer, credentials):
-    with pytest.warns(modal.exception.DeprecationError):
-        async with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, credentials, version="deprecated"):
             pass
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -655,10 +655,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
     async def ClientHello(self, stream):
         request: Empty = await stream.recv_message()
         self.requests.append(request)
-        warning = ""
-        if stream.metadata["x-modal-client-version"] == "deprecated":
-            warning = "SUPER OLD"
-        resp = api_pb2.ClientHelloResponse(warning=warning)
+        resp = api_pb2.ClientHelloResponse()
         await stream.send_message(resp)
 
     # Container

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -255,6 +255,8 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.required_creds = {token_id: token_secret}  # Any of this will be accepted
         self.last_metadata = None
 
+        self.function_get_server_warnings = None
+
         @self.function_body
         def default_function_body(*args, **kwargs):
             return sum(arg**2 for arg in args) + sum(value**2 for key, value in kwargs.items())
@@ -995,7 +997,11 @@ class MockClientServicer(api_grpc.ModalClientBase):
         if object_id is None:
             raise GRPCError(Status.NOT_FOUND, f"can't find object {request.object_tag}")
         await stream.send_message(
-            api_pb2.FunctionGetResponse(function_id=object_id, handle_metadata=self.get_function_metadata(object_id))
+            api_pb2.FunctionGetResponse(
+                function_id=object_id,
+                handle_metadata=self.get_function_metadata(object_id),
+                server_warnings=self.function_get_server_warnings,
+            )
         )
 
     async def FunctionMap(self, stream):

--- a/test/lookup_test.py
+++ b/test/lookup_test.py
@@ -2,7 +2,7 @@
 import pytest
 
 from modal import App, Function, Volume, web_endpoint
-from modal.exception import ExecutionError, NotFoundError
+from modal.exception import DeprecationError, ExecutionError, NotFoundError
 from modal.runner import deploy_app
 from modal_proto import api_pb2
 
@@ -83,5 +83,9 @@ def test_lookup_server_warnings(servicer, client):
             message="xyz",
         )
     ]
-    with pytest.warns(match="xyz"):
+    with pytest.warns(DeprecationError, match="xyz"):
+        Function.lookup("my-function", "square", client=client)
+
+    servicer.function_get_server_warnings = [api_pb2.Warning(message="abc")]
+    with pytest.warns(UserWarning, match="abc"):
         Function.lookup("my-function", "square", client=client)


### PR DESCRIPTION
This removes the remaining use case for `ClientHello` which is to print client deprecation warnings. It moves that to function and class lookup instead. We already do it during app deploys in #2639.

This will let me FINALLY merge https://github.com/modal-labs/modal-client/pull/2439 (which will need to be rebased) – this removes two server round trips which adds a fair bit of latency in remote regions.