### PR TITLE
Remove ClientHello (attempt 2)

### DIFF
--- a/modal/client.py
+++ b/modal/client.py
@@ -155,11 +155,6 @@ class _Client:
 
     async def __aenter__(self):
         await self._open()
-        try:
-            await self.hello()
-        except BaseException:
-            await self._close()
-            raise
         return self
 
     async def __aexit__(self, exc_type, exc, tb):
@@ -175,7 +170,6 @@ class _Client:
         client = cls(server_url, api_pb2.CLIENT_TYPE_CLIENT, credentials=None)
         try:
             await client._open()
-            # Skip client.hello
             yield client
         finally:
             await client._close()
@@ -226,7 +220,6 @@ class _Client:
             client = _Client(server_url, client_type, credentials)
             await client._open()
             async_utils.on_shutdown(client._close())
-            await client.hello()
             cls._client_from_env = client
             return client
 
@@ -249,11 +242,6 @@ class _Client:
         credentials = (token_id, token_secret)
         client = _Client(server_url, client_type, credentials)
         await client._open()
-        try:
-            await client.hello()
-        except BaseException:
-            await client._close()
-            raise
         async_utils.on_shutdown(client._close())
         return client
 
@@ -262,8 +250,8 @@ class _Client:
         """mdmd:hidden
         Check whether can the client can connect to this server with these credentials; raise if not.
         """
-        async with cls(server_url, api_pb2.CLIENT_TYPE_CLIENT, credentials):
-            pass  # Will call ClientHello RPC and possibly raise AuthError or ConnectionError
+        async with cls(server_url, api_pb2.CLIENT_TYPE_CLIENT, credentials) as client:
+            client.hello()  # Will call ClientHello RPC and possibly raise AuthError or ConnectionError
 
     @classmethod
     def set_env_client(cls, client: Optional["_Client"]):
@@ -313,7 +301,6 @@ class _Client:
             self.set_env_client(None)
             # TODO(elias): reset _cancellation_context in case ?
             await self._open()
-            # intentionally not doing self.hello since we should already be authenticated etc.
 
     async def _get_grpclib_method(self, method_name: str) -> Any:
         # safely get grcplib method that is bound to a valid channel

--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -7,7 +7,7 @@ from ._version_generated import build_number
 major_number = 0
 
 # Bump this manually on breaking changes, then reset the number in _version_generated.py
-minor_number = 67
+minor_number = 68
 
 # Right now, automatically increment the patch number in CI
 __version__ = f"{major_number}.{minor_number}.{max(build_number, 0)}"

--- a/modal_version/_version_generated.py
+++ b/modal_version/_version_generated.py
@@ -1,4 +1,4 @@
 # Copyright Modal Labs 2024
 
 # Note: Reset this value to -1 whenever you make a minor `0.X` release of the client.
-build_number = 47  # git: a3d399f
+build_number = -1  # git: a3d399f

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -4,7 +4,6 @@ import logging
 import pytest
 import time
 
-from google.protobuf.empty_pb2 import Empty
 from grpclib import GRPCError, Status
 
 from modal import App, Dict, Image, Mount, Secret, Stub, Volume, enable_output, web_endpoint
@@ -167,11 +166,10 @@ async def test_grpc_protocol(client, servicer):
     app = App()
     async with app.run(client=client):
         await asyncio.sleep(0.01)  # wait for heartbeat
-    assert len(servicer.requests) == 4
-    assert isinstance(servicer.requests[0], Empty)  # ClientHello
-    assert isinstance(servicer.requests[1], api_pb2.AppCreateRequest)
-    assert isinstance(servicer.requests[2], api_pb2.AppHeartbeatRequest)
-    assert isinstance(servicer.requests[3], api_pb2.AppClientDisconnectRequest)
+    assert len(servicer.requests) == 3
+    assert isinstance(servicer.requests[0], api_pb2.AppCreateRequest)
+    assert isinstance(servicer.requests[1], api_pb2.AppHeartbeatRequest)
+    assert isinstance(servicer.requests[2], api_pb2.AppClientDisconnectRequest)
 
 
 async def web1(x):

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -17,12 +17,15 @@ TEST_TIMEOUT = 4.0  # align this with the container client timeout in client.py
 
 
 def test_client_type(servicer, client):
+    assert len(servicer.requests) == 0
+    client.hello()
     assert len(servicer.requests) == 1
     assert isinstance(servicer.requests[0], Empty)
     assert servicer.last_metadata["x-modal-client-type"] == str(api_pb2.CLIENT_TYPE_CLIENT)
 
 
 def test_client_platform_string(servicer, client):
+    client.hello()
     platform_str = servicer.last_metadata["x-modal-platform"]
     system, release, machine = platform_str.split("-")
     if platform.system() == "Darwin":
@@ -36,7 +39,8 @@ def test_client_platform_string(servicer, client):
 
 @pytest.mark.asyncio
 async def test_container_client_type(servicer, container_client):
-    assert len(servicer.requests) == 1  # no heartbeat, just ClientHello
+    await container_client.hello.aio()
+    assert len(servicer.requests) == 1
     assert isinstance(servicer.requests[0], Empty)
     assert servicer.last_metadata["x-modal-client-type"] == str(api_pb2.CLIENT_TYPE_CONTAINER)
 
@@ -44,9 +48,9 @@ async def test_container_client_type(servicer, container_client):
 @pytest.mark.asyncio
 @pytest.mark.timeout(TEST_TIMEOUT)
 async def test_client_dns_failure():
-    with pytest.raises(ConnectionError) as excinfo:
-        async with Client("https://xyz.invalid", api_pb2.CLIENT_TYPE_CONTAINER, None):
-            pass
+    async with Client("https://xyz.invalid", api_pb2.CLIENT_TYPE_CONTAINER, None) as client:
+        with pytest.raises(ConnectionError) as excinfo:
+            await client.hello.aio()
     assert excinfo.value
 
 
@@ -54,9 +58,9 @@ async def test_client_dns_failure():
 @pytest.mark.timeout(TEST_TIMEOUT)
 @skip_windows("Windows test crashes on connection failure")
 async def test_client_connection_failure():
-    with pytest.raises(ConnectionError) as excinfo:
-        async with Client("https://localhost:443", api_pb2.CLIENT_TYPE_CONTAINER, None):
-            pass
+    async with Client("https://localhost:443", api_pb2.CLIENT_TYPE_CONTAINER, None) as client:
+        with pytest.raises(ConnectionError) as excinfo:
+            await client.hello.aio()
     assert excinfo.value
 
 
@@ -64,9 +68,9 @@ async def test_client_connection_failure():
 @pytest.mark.timeout(TEST_TIMEOUT)
 @skip_windows_unix_socket
 async def test_client_connection_failure_unix_socket():
-    with pytest.raises(ConnectionError) as excinfo:
-        async with Client("unix:/tmp/xyz.txt", api_pb2.CLIENT_TYPE_CONTAINER, None):
-            pass
+    async with Client("unix:/tmp/xyz.txt", api_pb2.CLIENT_TYPE_CONTAINER, None) as client:
+        with pytest.raises(ConnectionError) as excinfo:
+            await client.hello.aio()
     assert excinfo.value
 
 
@@ -75,9 +79,9 @@ async def test_client_connection_failure_unix_socket():
 async def test_client_connection_timeout(servicer, monkeypatch):
     monkeypatch.setattr("modal.client.CLIENT_CREATE_ATTEMPT_TIMEOUT", 1.0)
     monkeypatch.setattr("modal.client.CLIENT_CREATE_TOTAL_TIMEOUT", 3.0)
-    with pytest.raises(ConnectionError) as excinfo:
-        async with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CONTAINER, None, version="timeout"):
-            pass
+    async with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CONTAINER, None, version="timeout") as client:
+        with pytest.raises(ConnectionError) as excinfo:
+            await client.hello.aio()
 
     # The HTTP lookup will return 400 because the GRPC server rejects the http request
     assert "deadline" in str(excinfo.value).lower()
@@ -86,23 +90,23 @@ async def test_client_connection_timeout(servicer, monkeypatch):
 @pytest.mark.asyncio
 @pytest.mark.timeout(TEST_TIMEOUT)
 async def test_client_server_error(servicer):
-    with pytest.raises(GRPCError):
-        async with Client("https://modal.com", api_pb2.CLIENT_TYPE_CLIENT, None):
-            pass
+    async with Client("https://modal.com", api_pb2.CLIENT_TYPE_CLIENT, None) as client:
+        with pytest.raises(GRPCError):
+            await client.hello.aio()
 
 
 @pytest.mark.asyncio
 async def test_client_old_version(servicer, credentials):
-    with pytest.raises(VersionError):
-        async with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, credentials, version="0.0.0"):
-            pass
+    async with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, credentials, version="0.0.0") as client:
+        with pytest.raises(VersionError):
+            await client.hello.aio()
 
 
 @pytest.mark.asyncio
 async def test_client_unauthenticated(servicer):
     with pytest.raises(AuthError):
-        async with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, None, version="unauthenticated"):
-            pass
+        async with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, None, version="unauthenticated") as client:
+            await client.hello.aio()
 
 
 def client_from_env(client_addr, credentials):
@@ -114,7 +118,9 @@ def client_from_env(client_addr, credentials):
         "task_id": None,
         "task_secret": None,
     }
-    return Client.from_env(_override_config=_override_config)
+    client = Client.from_env(_override_config=_override_config)
+    client.hello()
+    return client
 
 
 def test_client_from_env_client(servicer, credentials):
@@ -200,8 +206,8 @@ def test_import_modal_from_thread(supports_dir):
 
 def test_from_env_container(servicer, container_env):
     servicer.required_creds = {}  # Disallow default client creds
-    Client.from_env()
-    # TODO(erikbern): once we no longer run ClientHello by default, add a ping here
+    client = Client.from_env()
+    client.hello()
     assert servicer.last_metadata["x-modal-client-type"] == str(api_pb2.CLIENT_TYPE_CONTAINER)
 
 
@@ -209,8 +215,8 @@ def test_from_env_container_with_tokens(servicer, container_env, token_env):
     # Even if MODAL_TOKEN_ID and MODAL_TOKEN_SECRET are set, if we're in a containers, ignore those
     servicer.required_creds = {}  # Disallow default client creds
     with pytest.warns(match="token"):
-        Client.from_env()
-    # TODO(erikbern): once we no longer run ClientHello by default, add a ping here
+        client = Client.from_env()
+    client.hello()
     assert servicer.last_metadata["x-modal-client-type"] == str(api_pb2.CLIENT_TYPE_CONTAINER)
 
 
@@ -219,8 +225,8 @@ def test_from_credentials_client(servicer, set_env_client, server_url_env, token
     token_id = "ak-foo-1"
     token_secret = "as-bar"
     servicer.required_creds = {token_id: token_secret}
-    Client.from_credentials(token_id, token_secret)
-    # TODO(erikbern): once we no longer run ClientHello by default, add a ping here
+    client = Client.from_credentials(token_id, token_secret)
+    client.hello()
     assert servicer.last_metadata["x-modal-client-type"] == str(api_pb2.CLIENT_TYPE_CLIENT)
 
 
@@ -228,6 +234,6 @@ def test_from_credentials_container(servicer, container_env):
     token_id = "ak-foo-2"
     token_secret = "as-bar"
     servicer.required_creds = {token_id: token_secret}
-    Client.from_credentials(token_id, token_secret)
-    # TODO(erikbern): once we no longer run ClientHello by default, add a ping here
+    client = Client.from_credentials(token_id, token_secret)
+    client.hello()
     assert servicer.last_metadata["x-modal-client-type"] == str(api_pb2.CLIENT_TYPE_CLIENT)

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -48,9 +48,9 @@ async def test_container_client_type(servicer, container_client):
 @pytest.mark.asyncio
 @pytest.mark.timeout(TEST_TIMEOUT)
 async def test_client_dns_failure():
-    async with Client("https://xyz.invalid", api_pb2.CLIENT_TYPE_CONTAINER, None) as client:
-        with pytest.raises(ConnectionError) as excinfo:
-            await client.hello.aio()
+    with pytest.raises(ConnectionError) as excinfo:
+        async with Client("https://xyz.invalid", api_pb2.CLIENT_TYPE_CONTAINER, None):
+            pass
     assert excinfo.value
 
 
@@ -58,9 +58,9 @@ async def test_client_dns_failure():
 @pytest.mark.timeout(TEST_TIMEOUT)
 @skip_windows("Windows test crashes on connection failure")
 async def test_client_connection_failure():
-    async with Client("https://localhost:443", api_pb2.CLIENT_TYPE_CONTAINER, None) as client:
-        with pytest.raises(ConnectionError) as excinfo:
-            await client.hello.aio()
+    with pytest.raises(ConnectionError) as excinfo:
+        async with Client("https://localhost:443", api_pb2.CLIENT_TYPE_CONTAINER, None):
+            pass
     assert excinfo.value
 
 
@@ -68,9 +68,9 @@ async def test_client_connection_failure():
 @pytest.mark.timeout(TEST_TIMEOUT)
 @skip_windows_unix_socket
 async def test_client_connection_failure_unix_socket():
-    async with Client("unix:/tmp/xyz.txt", api_pb2.CLIENT_TYPE_CONTAINER, None) as client:
-        with pytest.raises(ConnectionError) as excinfo:
-            await client.hello.aio()
+    with pytest.raises(ConnectionError) as excinfo:
+        async with Client("unix:/tmp/xyz.txt", api_pb2.CLIENT_TYPE_CONTAINER, None):
+            pass
     assert excinfo.value
 
 


### PR DESCRIPTION
Not sure what happened but I did something weird with Git and Github decided to close https://github.com/modal-labs/modal-client/pull/2439 – I'm not able to reopen it for whatever reason so I'm just creating a new PR instead. This is rebased on latest main as well! Otherwise no changes.

Anyway, this PR removes `ClientHello` finally. The point of this is to eliminate a server roundtrip for every container startup, which can be 100-300ms in remote regions. It eliminates two server roundtrips for ephemeral apps since one is happening locally as well. There are still other server roundtrips (`AppGetObjects`) that we should remove separately.

Bumped the minor version to 0.68 so that there's a clear deprecation point for `ClientHello` support in the server.

Note that we still have `client.hello()` as a dummy method to verify connections though – we mostly use it in some tests, and we use it to verify the credentials during the token flow. But we can remove all logic later so it's a pure dummy method.
