### PR TITLE
Improve presentation of warnings originating from modal server

### DIFF
--- a/modal/cli/_traceback.py
+++ b/modal/cli/_traceback.py
@@ -1,5 +1,6 @@
 # Copyright Modal Labs 2024
 """Helper functions related to displaying tracebacks in the CLI."""
+
 import functools
 import re
 import warnings
@@ -11,7 +12,7 @@ from rich.syntax import Syntax
 from rich.text import Text
 from rich.traceback import PathHighlighter, Stack, Traceback, install
 
-from ..exception import DeprecationError, PendingDeprecationError
+from ..exception import DeprecationError, PendingDeprecationError, ServerWarning
 
 
 @group()
@@ -165,7 +166,7 @@ def highlight_modal_deprecation_warnings() -> None:
     base_showwarning = warnings.showwarning
 
     def showwarning(warning, category, filename, lineno, file=None, line=None):
-        if issubclass(category, (DeprecationError, PendingDeprecationError)):
+        if issubclass(category, (DeprecationError, PendingDeprecationError, ServerWarning)):
             content = str(warning)
             if re.match(r"^\d{4}-\d{2}-\d{2}", content):
                 date = content[:10]
@@ -180,10 +181,16 @@ def highlight_modal_deprecation_warnings() -> None:
             except OSError:
                 # e.g., when filename is "<unknown>"; raises FileNotFoundError on posix but OSError on windows
                 pass
+            if issubclass(category, ServerWarning):
+                title = "Modal Warning"
+            else:
+                title = "Modal Deprecation Warning"
+            if date:
+                title += f" ({date})"
             panel = Panel(
                 message,
-                style="yellow",
-                title=f"Modal Deprecation Warning ({date})" if date else "Modal Deprecation Warning",
+                border_style="yellow",
+                title=title,
                 title_align="left",
             )
             Console().print(panel)

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -13,8 +13,6 @@ from typing import Any, Callable, Optional, get_type_hints
 
 import click
 import typer
-from rich.console import Console
-from rich.panel import Panel
 from typing_extensions import TypedDict
 
 from .. import Cls
@@ -306,14 +304,7 @@ def deploy(
     if name is None:
         name = app.name
 
-    with enable_output():
-        res = deploy_app(app, name=name, environment_name=env or "", tag=tag)
-        if res.warnings:
-            console = Console()
-            for warning in res.warnings:
-                panel = Panel(warning, title="Warning", title_align="left", border_style="yellow")
-                console.print(panel, highlight=False)
-
+    res = deploy_app(app, name=name, environment_name=env or "", tag=tag)
     if stream_logs:
         stream_app_logs(app_id=res.app_id, app_logs_url=res.app_logs_url)
 

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -14,11 +14,12 @@ from modal_proto import api_pb2
 from ._resolver import Resolver
 from ._resources import convert_fn_config_to_resources_config
 from ._serialization import check_valid_cls_constructor_arg
+from ._traceback import print_server_warnings
 from ._utils.async_utils import synchronize_api, synchronizer
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.mount_utils import validate_volumes
 from .client import _Client
-from .exception import InvalidError, NotFoundError, VersionError, print_server_warnings
+from .exception import InvalidError, NotFoundError, VersionError
 from .functions import _Function, _parse_retries
 from .gpu import GPU_T
 from .object import _get_environment_name, _Object

--- a/modal/exception.py
+++ b/modal/exception.py
@@ -110,6 +110,10 @@ class PendingDeprecationError(UserWarning):
     """Soon to be deprecated feature. Only used intermittently because of multi-repo concerns."""
 
 
+class ServerWarning(UserWarning):
+    """Warning originating from the Modal server and re-issued in client code."""
+
+
 class _CliUserExecutionError(Exception):
     """mdmd:hidden
     Private wrapper for exceptions during when importing or running stubs from the CLI.

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -32,6 +32,7 @@ from ._resolver import Resolver
 from ._resources import convert_fn_config_to_resources_config
 from ._runtime.execution_context import current_input_id, is_local
 from ._serialization import serialize, serialize_proto_params
+from ._traceback import print_server_warnings
 from ._utils.async_utils import (
     TaskContext,
     async_merge,
@@ -64,7 +65,6 @@ from .exception import (
     NotFoundError,
     OutputExpiredError,
     deprecation_warning,
-    print_server_warnings,
 )
 from .gpu import GPU_T, parse_gpu_config
 from .image import _Image

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -17,7 +17,7 @@ from modal_proto import api_pb2
 from ._pty import get_pty_info
 from ._resolver import Resolver
 from ._runtime.execution_context import is_local
-from ._traceback import traceback_contains_remote_call
+from ._traceback import print_server_warnings, traceback_contains_remote_call
 from ._utils.async_utils import TaskContext, gather_cancel_on_exc, synchronize_api
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name, is_valid_tag
@@ -206,6 +206,7 @@ async def _publish_app(
             raise InvalidError(exc.message)
         raise
 
+    print_server_warnings(response.server_warnings)
     return response.url, response.server_warnings
 
 

--- a/test/lookup_test.py
+++ b/test/lookup_test.py
@@ -2,7 +2,7 @@
 import pytest
 
 from modal import App, Function, Volume, web_endpoint
-from modal.exception import DeprecationError, ExecutionError, NotFoundError
+from modal.exception import ExecutionError, NotFoundError, ServerWarning
 from modal.runner import deploy_app
 from modal_proto import api_pb2
 
@@ -83,9 +83,9 @@ def test_lookup_server_warnings(servicer, client):
             message="xyz",
         )
     ]
-    with pytest.warns(DeprecationError, match="xyz"):
+    with pytest.warns(ServerWarning, match="xyz"):
         Function.lookup("my-function", "square", client=client)
 
     servicer.function_get_server_warnings = [api_pb2.Warning(message="abc")]
-    with pytest.warns(UserWarning, match="abc"):
+    with pytest.warns(ServerWarning, match="abc"):
         Function.lookup("my-function", "square", client=client)


### PR DESCRIPTION
- Adds a `ServerWarning` class that we now also use to decide which warnings get a special Rich panel in CLI output
- Moves `print_server_warnings` into `_traceback` to suppress it from public API
- Calls `print_server_warnings` from `publish_app` so we warn about deprecated client versions for both ephemeral and deployed apps
- Removes the logic to explicitly print deployment warnings from the `deploy` CLI command, since it now happens automatically with the warnings interception in the CLI

Warnings now look like this when using the CLI:
<img width="962" alt="image" src="https://github.com/user-attachments/assets/b6f09989-db7b-4692-8de8-f98818190dae" />

When not using the CLI, they appear like regular Python warnings, but with the origin more clearly attributed to the Modal server:
<img width="960" alt="image" src="https://github.com/user-attachments/assets/37f96f0d-7d00-464a-b493-a3be7476a15c" />
