### PR TITLE
Add server_warnings to ClientHello

### DIFF
--- a/modal/client.py
+++ b/modal/client.py
@@ -132,10 +132,10 @@ class _Client:
         # Remove cached client.
         self.set_env_client(None)
 
-    async def hello(self, total_timeout: Optional[float] = None):
+    async def hello(self):
         """Connect to server and retrieve version information; raise appropriate error for various failures."""
         logger.debug(f"Client ({id(self)}): Starting")
-        resp = await retry_transient_errors(self.stub.ClientHello, empty_pb2.Empty(), total_timeout=total_timeout)
+        resp = await retry_transient_errors(self.stub.ClientHello, empty_pb2.Empty())
         print_server_warnings(resp.server_warnings)
 
     async def __aenter__(self):

--- a/modal/client.py
+++ b/modal/client.py
@@ -16,7 +16,6 @@ from typing import (
 import grpclib.client
 from google.protobuf import empty_pb2
 from google.protobuf.message import Message
-from grpclib import GRPCError, Status
 from synchronicity.async_wrap import asynccontextmanager
 
 from modal._utils.async_utils import synchronizer
@@ -28,12 +27,10 @@ from ._utils import async_utils
 from ._utils.async_utils import TaskContext, synchronize_api
 from ._utils.grpc_utils import connect_channel, create_channel, retry_transient_errors
 from .config import _check_config, _is_remote, config, logger
-from .exception import AuthError, ClientClosed, ConnectionError, VersionError
+from .exception import AuthError, ClientClosed, ConnectionError
 
 HEARTBEAT_INTERVAL: float = config.get("heartbeat_interval")
 HEARTBEAT_TIMEOUT: float = HEARTBEAT_INTERVAL + 0.1
-CLIENT_CREATE_ATTEMPT_TIMEOUT: float = 4.0
-CLIENT_CREATE_TOTAL_TIMEOUT: float = 15.0
 
 
 def _get_metadata(client_type: int, credentials: Optional[tuple[str, str]], version: str) -> dict[str, str]:
@@ -138,22 +135,7 @@ class _Client:
     async def hello(self):
         """Connect to server and retrieve version information; raise appropriate error for various failures."""
         logger.debug(f"Client ({id(self)}): Starting")
-        try:
-            req = empty_pb2.Empty()
-            resp = await retry_transient_errors(
-                self.stub.ClientHello,
-                req,
-                attempt_timeout=CLIENT_CREATE_ATTEMPT_TIMEOUT,
-                total_timeout=CLIENT_CREATE_TOTAL_TIMEOUT,
-            )
-        except GRPCError as exc:
-            if exc.status == Status.FAILED_PRECONDITION:
-                raise VersionError(
-                    f"The client version ({self.version}) is too old. Please update (pip install --upgrade modal)."
-                )
-            else:
-                raise exc
-
+        resp = await retry_transient_errors(self.stub.ClientHello, empty_pb2.Empty())
         print_server_warnings(resp.server_warnings)
 
     async def __aenter__(self):

--- a/modal/client.py
+++ b/modal/client.py
@@ -23,6 +23,7 @@ from modal._utils.async_utils import synchronizer
 from modal_proto import api_grpc, api_pb2, modal_api_grpc
 from modal_version import __version__
 
+from ._traceback import print_server_warnings
 from ._utils import async_utils
 from ._utils.async_utils import TaskContext, synchronize_api
 from ._utils.grpc_utils import connect_channel, create_channel, retry_transient_errors
@@ -139,7 +140,7 @@ class _Client:
         logger.debug(f"Client ({id(self)}): Starting")
         try:
             req = empty_pb2.Empty()
-            await retry_transient_errors(
+            resp = await retry_transient_errors(
                 self.stub.ClientHello,
                 req,
                 attempt_timeout=CLIENT_CREATE_ATTEMPT_TIMEOUT,
@@ -152,6 +153,8 @@ class _Client:
                 )
             else:
                 raise exc
+
+        print_server_warnings(resp.server_warnings)
 
     async def __aenter__(self):
         await self._open()

--- a/modal/client.py
+++ b/modal/client.py
@@ -132,10 +132,10 @@ class _Client:
         # Remove cached client.
         self.set_env_client(None)
 
-    async def hello(self):
+    async def hello(self, total_timeout: Optional[float] = None):
         """Connect to server and retrieve version information; raise appropriate error for various failures."""
         logger.debug(f"Client ({id(self)}): Starting")
-        resp = await retry_transient_errors(self.stub.ClientHello, empty_pb2.Empty())
+        resp = await retry_transient_errors(self.stub.ClientHello, empty_pb2.Empty(), total_timeout=total_timeout)
         print_server_warnings(resp.server_warnings)
 
     async def __aenter__(self):

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -678,6 +678,7 @@ message ClassParameterValue {
 message ClientHelloResponse {
   string warning = 1;
   string image_builder_version = 2;  // Deprecated, no longer used in client
+  repeated Warning server_warnings = 4;
 }
 
 message CloudBucketMount {

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -75,24 +75,6 @@ async def test_client_connection_failure_unix_socket():
 
 
 @pytest.mark.asyncio
-@pytest.mark.timeout(TEST_TIMEOUT)
-async def test_client_connection_timeout(servicer, monkeypatch):
-    async with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CONTAINER, None, version="timeout") as client:
-        with pytest.raises(ConnectionError) as excinfo:
-            await client.hello.aio(total_timeout=1.0)
-
-    assert "deadline" in str(excinfo.value).lower()
-
-
-@pytest.mark.asyncio
-@pytest.mark.timeout(TEST_TIMEOUT)
-async def test_client_server_error(servicer):
-    async with Client("https://modal.com", api_pb2.CLIENT_TYPE_CLIENT, None) as client:
-        with pytest.raises(GRPCError):
-            await client.hello.aio()
-
-
-@pytest.mark.asyncio
 async def test_client_old_version(servicer, credentials):
     async with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, credentials, version="0.0.0") as client:
         with pytest.raises(GRPCError) as excinfo:

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -77,13 +77,10 @@ async def test_client_connection_failure_unix_socket():
 @pytest.mark.asyncio
 @pytest.mark.timeout(TEST_TIMEOUT)
 async def test_client_connection_timeout(servicer, monkeypatch):
-    monkeypatch.setattr("modal.client.CLIENT_CREATE_ATTEMPT_TIMEOUT", 1.0)
-    monkeypatch.setattr("modal.client.CLIENT_CREATE_TOTAL_TIMEOUT", 3.0)
     async with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CONTAINER, None, version="timeout") as client:
         with pytest.raises(ConnectionError) as excinfo:
-            await client.hello.aio()
+            await client.hello.aio(total_timeout=1.0)
 
-    # The HTTP lookup will return 400 because the GRPC server rejects the http request
     assert "deadline" in str(excinfo.value).lower()
 
 

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -8,7 +8,7 @@ from google.protobuf.empty_pb2 import Empty
 from grpclib import GRPCError
 
 from modal import Client
-from modal.exception import AuthError, ConnectionError, DeprecationError, InvalidError, VersionError
+from modal.exception import AuthError, ConnectionError, DeprecationError, InvalidError, ServerWarning, VersionError
 from modal_proto import api_pb2
 
 from .supports.skip import skip_windows, skip_windows_unix_socket
@@ -99,6 +99,13 @@ async def test_client_server_error(servicer):
 async def test_client_old_version(servicer, credentials):
     async with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, credentials, version="0.0.0") as client:
         with pytest.raises(VersionError):
+            await client.hello.aio()
+
+
+@pytest.mark.asyncio
+async def test_client_deprecated(servicer, credentials):
+    async with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, credentials, version="deprecated") as client:
+        with pytest.warns(ServerWarning):
             await client.hello.aio()
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -655,7 +655,16 @@ class MockClientServicer(api_grpc.ModalClientBase):
     async def ClientHello(self, stream):
         request: Empty = await stream.recv_message()
         self.requests.append(request)
-        resp = api_pb2.ClientHelloResponse()
+        if stream.metadata["x-modal-client-version"] == "deprecated":
+            warnings = [
+                api_pb2.Warning(
+                    type=api_pb2.Warning.WARNING_TYPE_CLIENT_DEPRECATION,
+                    message="SUPER OLD",
+                )
+            ]
+        else:
+            warnings = []
+        resp = api_pb2.ClientHelloResponse(server_warnings=warnings)
         await stream.send_message(resp)
 
     # Container


### PR DESCRIPTION
Thinking more about it, I think it's actually useful to keep the `ClientHello` method indefinitely, but in a way where it's mostly used for tests and some other fringe things (the token flow uses it to verify credentials).

It simplifies testing a bit to have the same behavior with `ClientHello` as with `AppPublish` etc and return structured server warnings, so let's add this and populate it server-side. This will let me bring back this test and some other stuff: https://github.com/modal-labs/modal-client/pull/2640/files#diff-c3f9238c73a319c67ee49a92bcd534772c62b66a7a3c3b61da1ad630d178488bL102