### PR TITLE
Deprecate spawning generator functions.

### DIFF
--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1277,7 +1277,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
     async def _call_generator_nowait(self, args, kwargs):
         deprecation_warning(
             (2024, 12, 11),
-            "Calling spawn on a generator function is deprecated and will soon be removed.",
+            "Calling spawn on a generator function is deprecated and will soon raise an exception.",
         )
         return await _Invocation.create(
             self,

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1275,6 +1275,10 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
 
     @synchronizer.no_io_translation
     async def _call_generator_nowait(self, args, kwargs):
+        deprecation_warning(
+            (2024, 12, 11),
+            "Calling spawn on a generator function is deprecated and will soon be removed.",
+        )
         return await _Invocation.create(
             self,
             args,


### PR DESCRIPTION
This is on the way to essentially reverting https://github.com/modal-labs/modal-client/pull/2155.

Relevant slack thread with discussion: https://modal-com.slack.com/archives/C056CGAANRM/p1732215878349079

If someone was using this to get a movable function call handle for generator results, they can use a https://modal.com/docs/reference/modal.Queue for the results instead. For those just using `.spawn()` to get async semantics in one context, `.remote().aio()` should be a suitable replacement - https://modal.com/docs/guide/async.

## Changelog

We're removing support for `.spawn()`ing generator functions.