### PR TITLE
Ensure PartialFunction has a final is_generator value

### DIFF
--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -73,9 +73,8 @@ class _PartialFunction(typing.Generic[P, ReturnType, OriginalReturnType]):
         self.raw_f = raw_f
         self.flags = flags
         self.webhook_config = webhook_config
-        if webhook_config:
-            final_is_generator = True
-        elif is_generator is None:
+        if is_generator is None:
+            # auto detect - doesn't work if the function *returns* a generator
             final_is_generator = inspect.isgeneratorfunction(raw_f) or inspect.isasyncgenfunction(raw_f)
         else:
             final_is_generator = is_generator

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -31,5 +31,7 @@ nbclient==0.6.8
 notebook==6.5.1
 jupytext==1.14.1
 pyright==1.1.351
+python-json-logger==2.0.7  # unpinned transitive dependency of jupytext breaking on later versions
 pdm==2.12.4  # used for testing pdm cache behavior w/ automounts
 console-ctrl==0.1.0
+


### PR DESCRIPTION
Annoyingly breaks some type-checking assumptions in other files otherwise

Also some other minor type stuff that hasn't been caught by mypy due to the `pyi` shadowing implementation. 
(pyright fails on this file for other reasons so can't add it to the allow list without more work...)