### PR TITLE
blobs: omit redundant sha256 digest

### DIFF
--- a/modal/_utils/blob_utils.py
+++ b/modal/_utils/blob_utils.py
@@ -305,9 +305,12 @@ async def blob_upload(payload: bytes, stub: ModalClientModal) -> str:
 
 
 async def blob_upload_file(
-    file_obj: BinaryIO, stub: ModalClientModal, progress_report_cb: Optional[Callable] = None
+    file_obj: BinaryIO,
+    stub: ModalClientModal,
+    progress_report_cb: Optional[Callable] = None,
+    sha256_hex: Optional[str] = None,
 ) -> str:
-    upload_hashes = get_upload_hashes(file_obj)
+    upload_hashes = get_upload_hashes(file_obj, sha256_hex=sha256_hex)
     return await _blob_upload(upload_hashes, file_obj, stub, progress_report_cb)
 
 

--- a/modal/_utils/hash_utils.py
+++ b/modal/_utils/hash_utils.py
@@ -59,6 +59,7 @@ class UploadHashes:
 
 
 def get_upload_hashes(data: Union[bytes, BinaryIO], sha256_hex: Optional[str] = None) -> UploadHashes:
+    t0 = time.monotonic()
     md5 = hashlib.md5()
     # If we already have the sha256 digest, do not compute it again
     if sha256_hex:
@@ -66,8 +67,8 @@ def get_upload_hashes(data: Union[bytes, BinaryIO], sha256_hex: Optional[str] = 
             md5_base64=get_md5_base64(data),
             sha256_base64=base64.b64encode(bytes.fromhex(sha256_hex)).decode("ascii"),
         )
+        logger.debug("get_upload_hashes took %.3fs (get_md5_base64)", time.monotonic() - t0)
     else:
-        t0 = time.monotonic()
         sha256 = hashlib.sha256()
         _update([md5.update, sha256.update], data)
         hashes = UploadHashes(

--- a/modal/_utils/hash_utils.py
+++ b/modal/_utils/hash_utils.py
@@ -54,7 +54,7 @@ def get_upload_hashes(data: Union[bytes, BinaryIO], sha256_hex: Optional[str] = 
     # If we already have the sha256 digest, do not compute it again
     if sha256_hex:
 
-        def sha256_update():
+        def sha256_update(_data):
             ...
 
         def sha256_finalize():

--- a/modal/_utils/hash_utils.py
+++ b/modal/_utils/hash_utils.py
@@ -4,6 +4,8 @@ import dataclasses
 import hashlib
 from typing import BinaryIO, Callable, Optional, Union
 
+from _typeshed import ReadableBuffer
+
 HASH_CHUNK_SIZE = 4096
 
 
@@ -54,7 +56,7 @@ def get_upload_hashes(data: Union[bytes, BinaryIO], sha256_hex: Optional[str] = 
     # If we already have the sha256 digest, do not compute it again
     if sha256_hex:
 
-        def sha256_update(_data):
+        def sha256_update(_data: ReadableBuffer, /):
             pass
 
         def sha256_finalize():

--- a/modal/_utils/hash_utils.py
+++ b/modal/_utils/hash_utils.py
@@ -63,18 +63,20 @@ def get_upload_hashes(data: Union[bytes, BinaryIO], sha256_hex: Optional[str] = 
     md5 = hashlib.md5()
     # If we already have the sha256 digest, do not compute it again
     if sha256_hex:
-        hashers = {"md5": md5.update}
+        hashers = [md5.update]
+        hash_names = ["md5"]
 
         def sha256_digest() -> bytes:
             return bytes.fromhex(sha256_hex)
     else:
         sha256 = hashlib.sha256()
-        hashers = {"md5": md5.update, "sha256": sha256.update}
+        hashers = [md5.update, sha256.update]
+        hash_names = ["md5", "sha256"]
         sha256_digest = sha256.digest
-    _update(list(hashers.values()), data)
+    _update(hashers, data)
     hashes = UploadHashes(
         md5_base64=base64.b64encode(md5.digest()).decode("ascii"),
         sha256_base64=base64.b64encode(sha256_digest()).decode("ascii"),
     )
-    logger.debug("get_upload_hashes took %.3fs (hashes=%s)", time.monotonic() - t0, list(hashers.keys()))
+    logger.debug("get_upload_hashes took %.3fs (%s)", time.monotonic() - t0, hash_names)
     return hashes

--- a/modal/_utils/hash_utils.py
+++ b/modal/_utils/hash_utils.py
@@ -59,14 +59,14 @@ def get_upload_hashes(data: Union[bytes, BinaryIO], sha256_hex: Optional[str] = 
         def sha256_update(_data: Buffer, /):
             pass
 
-        def sha256_finalize():
-            bytes.fromhex(sha256_hex)
+        def sha256_digest() -> bytes:
+            return bytes.fromhex(sha256_hex)
     else:
         sha256 = hashlib.sha256()
         sha256_update = sha256.update
-        sha256_finalize = sha256.digest
+        sha256_digest = sha256.digest
     _update([md5.update, sha256_update], data)
     return UploadHashes(
         md5_base64=base64.b64encode(md5.digest()).decode("ascii"),
-        sha256_base64=base64.b64encode(sha256_finalize()).decode("ascii"),
+        sha256_base64=base64.b64encode(sha256_digest()).decode("ascii"),
     )

--- a/modal/_utils/hash_utils.py
+++ b/modal/_utils/hash_utils.py
@@ -4,7 +4,7 @@ import dataclasses
 import hashlib
 from typing import BinaryIO, Callable, Optional, Union
 
-from _typeshed import ReadableBuffer
+from typing_extensions import Buffer
 
 HASH_CHUNK_SIZE = 4096
 
@@ -56,7 +56,7 @@ def get_upload_hashes(data: Union[bytes, BinaryIO], sha256_hex: Optional[str] = 
     # If we already have the sha256 digest, do not compute it again
     if sha256_hex:
 
-        def sha256_update(_data: ReadableBuffer, /):
+        def sha256_update(_data: Buffer, /):
             pass
 
         def sha256_finalize():

--- a/modal/_utils/hash_utils.py
+++ b/modal/_utils/hash_utils.py
@@ -5,8 +5,6 @@ import hashlib
 import time
 from typing import BinaryIO, Callable, Optional, Union
 
-from typing_extensions import Buffer
-
 from modal.config import logger
 
 HASH_CHUNK_SIZE = 65536
@@ -65,20 +63,18 @@ def get_upload_hashes(data: Union[bytes, BinaryIO], sha256_hex: Optional[str] = 
     md5 = hashlib.md5()
     # If we already have the sha256 digest, do not compute it again
     if sha256_hex:
-
-        def sha256_update(_data: Buffer, /):
-            pass
+        hashers = {"md5": md5.update}
 
         def sha256_digest() -> bytes:
             return bytes.fromhex(sha256_hex)
     else:
         sha256 = hashlib.sha256()
-        sha256_update = sha256.update
+        hashers = {"md5": md5.update, "sha256": sha256.update}
         sha256_digest = sha256.digest
-    _update([md5.update, sha256_update], data)
+    _update(list(hashers.values()), data)
     hashes = UploadHashes(
         md5_base64=base64.b64encode(md5.digest()).decode("ascii"),
         sha256_base64=base64.b64encode(sha256_digest()).decode("ascii"),
     )
-    logger.debug("get_upload_hashes took %.3fs", time.monotonic() - t0)
+    logger.debug("get_upload_hashes took %.3fs (hashes=%s)", time.monotonic() - t0, list(hashers.keys()))
     return hashes

--- a/modal/_utils/hash_utils.py
+++ b/modal/_utils/hash_utils.py
@@ -55,7 +55,7 @@ def get_upload_hashes(data: Union[bytes, BinaryIO], sha256_hex: Optional[str] = 
     if sha256_hex:
 
         def sha256_update(_data):
-            ...
+            pass
 
         def sha256_finalize():
             bytes.fromhex(sha256_hex)

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -483,7 +483,7 @@ class _Mount(_Object, type_prefix="mo"):
                 logger.debug(f"Creating blob file for {file_spec.source_description} ({file_spec.size} bytes)")
                 async with blob_upload_concurrency:
                     with file_spec.source() as fp:
-                        blob_id = await blob_upload_file(fp, resolver.client.stub)
+                        blob_id = await blob_upload_file(fp, resolver.client.stub, sha256_hex=file_spec.sha256_hex)
                 logger.debug(f"Uploading blob file {file_spec.source_description} as {remote_filename}")
                 request2 = api_pb2.MountPutFileRequest(data_blob_id=blob_id, sha256_hex=file_spec.sha256_hex)
             else:

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -245,7 +245,10 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         if data_size > LARGE_FILE_LIMIT:
             progress_task_id = progress_cb(name=remote_path, size=data_size)
             blob_id = await blob_upload_file(
-                fp, self._client.stub, progress_report_cb=functools.partial(progress_cb, progress_task_id)
+                fp,
+                self._client.stub,
+                progress_report_cb=functools.partial(progress_cb, progress_task_id),
+                sha256_hex=sha_hash,
             )
             req = api_pb2.SharedVolumePutFileRequest(
                 shared_volume_id=self.object_id,

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -632,7 +632,10 @@ class _VolumeUploadContextManager:
                 logger.debug(f"Creating blob file for {file_spec.source_description} ({file_spec.size} bytes)")
                 with file_spec.source() as fp:
                     blob_id = await blob_upload_file(
-                        fp, self._client.stub, functools.partial(self._progress_cb, progress_task_id)
+                        fp,
+                        self._client.stub,
+                        functools.partial(self._progress_cb, progress_task_id),
+                        sha256_hex=file_spec.sha256_hex,
                     )
                 logger.debug(f"Uploading blob file {file_spec.source_description} as {remote_filename}")
                 request2 = api_pb2.MountPutFileRequest(data_blob_id=blob_id, sha256_hex=file_spec.sha256_hex)


### PR DESCRIPTION
Currently when uploading large blobs for volume put we hash the file twice:

1. First in `_get_file_upload_spec`
2. Then again in `blob_upload_file`

This PR passes in the initial digest from the file spec in to `blob_upload_file` so that it can skip the second digest. Note that `blob_upload_file` still computes an md5 digest for use in the presigned upload url. We could possibly also remove that, but that requires server side changes as well. Future work.
