### PR TITLE
Renable output for modal deploy

### DIFF
--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -304,7 +304,9 @@ def deploy(
     if name is None:
         name = app.name
 
-    res = deploy_app(app, name=name, environment_name=env or "", tag=tag)
+    with enable_output():
+        res = deploy_app(app, name=name, environment_name=env or "", tag=tag)
+
     if stream_logs:
         stream_app_logs(app_id=res.app_id, app_logs_url=res.app_logs_url)
 


### PR DESCRIPTION
## Changelog

- Fixed a bug introduced in v0.67.47 that suppressed console output from the `modal deploy` CLI.