### PR TITLE
Add protos for sandbox file-watching api

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -808,6 +808,12 @@ message ContainerFileSeekRequest {
   SeekWhence whence = 3;
 }
 
+message ContainerFileWatchRequest {
+  string path = 1;
+  bool recursive = 2;
+  optional uint64 timeout_secs = 3;
+}
+
 message ContainerFileWriteReplaceBytesRequest {
   string file_descriptor = 1;
   bytes data = 2;
@@ -839,6 +845,7 @@ message ContainerFilesystemExecRequest {
     ContainerFileLsRequest file_ls_request = 11;
     ContainerFileMkdirRequest file_mkdir_request = 12;
     ContainerFileRmRequest file_rm_request = 13;
+    ContainerFileWatchRequest file_watch_request = 14;
   }
   string task_id = 10;
 }


### PR DESCRIPTION
## Describe your changes

Adds protos for WRK-484.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `ContainerFileWatchRequest` to `api.proto` and integrate it into `ContainerFilesystemExecRequest`.
> 
>   - **Protobuf Messages**:
>     - Add `ContainerFileWatchRequest` with fields `path`, `recursive`, and `timeout_secs` to `api.proto`.
>   - **Request Integration**:
>     - Integrate `ContainerFileWatchRequest` into `ContainerFilesystemExecRequest` as a new option.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=modal-labs%2Fmodal-client&utm_source=github&utm_medium=referral)<sup> for f8b8c8adc45b13237e08183b42ac89268dbe94fb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->