### PR TITLE
Hash 64KiB chunks

### DIFF
--- a/modal/_utils/hash_utils.py
+++ b/modal/_utils/hash_utils.py
@@ -7,7 +7,7 @@ from typing import BinaryIO, Callable, Union
 
 from modal.config import logger
 
-HASH_CHUNK_SIZE = 4096
+HASH_CHUNK_SIZE = 65536
 
 
 def _update(hashers: list[Callable[[bytes], None]], data: Union[bytes, BinaryIO]) -> None:

--- a/modal/_utils/hash_utils.py
+++ b/modal/_utils/hash_utils.py
@@ -2,7 +2,10 @@
 import base64
 import dataclasses
 import hashlib
+import time
 from typing import BinaryIO, Callable, Union
+
+from modal.config import logger
 
 HASH_CHUNK_SIZE = 4096
 
@@ -26,20 +29,26 @@ def _update(hashers: list[Callable[[bytes], None]], data: Union[bytes, BinaryIO]
 
 
 def get_sha256_hex(data: Union[bytes, BinaryIO]) -> str:
+    t0 = time.monotonic()
     hasher = hashlib.sha256()
     _update([hasher.update], data)
+    logger.debug("get_sha256_hex took %.3fs", time.monotonic() - t0)
     return hasher.hexdigest()
 
 
 def get_sha256_base64(data: Union[bytes, BinaryIO]) -> str:
+    t0 = time.monotonic()
     hasher = hashlib.sha256()
     _update([hasher.update], data)
+    logger.debug("get_sha256_base64 took %.3fs", time.monotonic() - t0)
     return base64.b64encode(hasher.digest()).decode("ascii")
 
 
 def get_md5_base64(data: Union[bytes, BinaryIO]) -> str:
+    t0 = time.monotonic()
     hasher = hashlib.md5()
     _update([hasher.update], data)
+    logger.debug("get_md5_base64 took %.3fs", time.monotonic() - t0)
     return base64.b64encode(hasher.digest()).decode("utf-8")
 
 
@@ -50,10 +59,13 @@ class UploadHashes:
 
 
 def get_upload_hashes(data: Union[bytes, BinaryIO]) -> UploadHashes:
+    t0 = time.monotonic()
     md5 = hashlib.md5()
     sha256 = hashlib.sha256()
     _update([md5.update, sha256.update], data)
-    return UploadHashes(
+    hashes = UploadHashes(
         md5_base64=base64.b64encode(md5.digest()).decode("ascii"),
         sha256_base64=base64.b64encode(sha256.digest()).decode("ascii"),
     )
+    logger.debug("get_upload_hashes took %.3fs", time.monotonic() - t0)
+    return hashes


### PR DESCRIPTION
* Add debug log statements for hash latencies - also makes it easier to see how many hashes are being performed
* Bump read buffer size to 64KiB to speed up hashing

### 4KiB chunks
```
$ MODAL_LOGLEVEL=DEBUG modal volume put dano-test data-4g >/dev/null
...
[ThreadPoolExecutor-0_0] 2024-12-13T10:05:16+0100 get_sha256_hex took 2.664s
...
[Thread-1 (thread_inner)] 2024-12-13T10:05:25+0100 get_md5_base64 took 8.623s
```

### 64KiB chunks
```
$ MODAL_LOGLEVEL=DEBUG modal volume put dano-test data-4g >/dev/null
...
[ThreadPoolExecutor-0_0] 2024-12-13T10:04:17+0100 get_sha256_hex took 1.964s
...
[Thread-1 (thread_inner)] 2024-12-13T10:04:25+0100 get_md5_base64 took 7.986s
```

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
