### PR TITLE
blobs: omit md5 for multipart uploads

### DIFF
--- a/modal/_utils/blob_utils.py
+++ b/modal/_utils/blob_utils.py
@@ -422,7 +422,12 @@ def get_file_upload_spec_from_path(
     # Python appears to give files 0o666 bits on Windows (equal for user, group, and global),
     # so we mask those out to 0o755 for compatibility with POSIX-based permissions.
     mode = mode or os.stat(filename).st_mode & (0o7777 if platform.system() != "Windows" else 0o7755)
-    return _get_file_upload_spec(lambda: open(filename, "rb"), filename, mount_filename, mode)
+    return _get_file_upload_spec(
+        lambda: open(filename, "rb"),
+        filename,
+        mount_filename,
+        mode,
+    )
 
 
 def get_file_upload_spec_from_fileobj(fp: BinaryIO, mount_filename: PurePosixPath, mode: int) -> FileUploadSpec:

--- a/modal/_utils/blob_utils.py
+++ b/modal/_utils/blob_utils.py
@@ -21,7 +21,7 @@ from modal_proto.modal_api_grpc import ModalClientModal
 from ..exception import ExecutionError
 from .async_utils import TaskContext, retry
 from .grpc_utils import retry_transient_errors
-from .hash_utils import UploadHashes, get_sha256_hex, get_upload_hashes
+from .hash_utils import UploadHashes, get_upload_hashes
 from .http_utils import ClientSessionRegistry
 from .logger import logger
 
@@ -37,6 +37,11 @@ BLOB_MAX_PARALLELISM = 10
 
 # read ~16MiB chunks by default
 DEFAULT_SEGMENT_CHUNK_SIZE = 2**24
+
+# Files larger than this will be multipart uploaded. The server might request multipart upload for smaller files as
+# well, but the limit will never be raised.
+# TODO(dano): remove this once we stop requiring md5 for blobs
+MULTIPART_UPLOAD_THRESHOLD = 1024**3
 
 
 class BytesIOSegmentPayload(BytesIOPayload):
@@ -309,8 +314,9 @@ async def blob_upload_file(
     stub: ModalClientModal,
     progress_report_cb: Optional[Callable] = None,
     sha256_hex: Optional[str] = None,
+    md5_hex: Optional[str] = None,
 ) -> str:
-    upload_hashes = get_upload_hashes(file_obj, sha256_hex=sha256_hex)
+    upload_hashes = get_upload_hashes(file_obj, sha256_hex=sha256_hex, md5_hex=md5_hex)
     return await _blob_upload(upload_hashes, file_obj, stub, progress_report_cb)
 
 
@@ -369,6 +375,7 @@ class FileUploadSpec:
     use_blob: bool
     content: Optional[bytes]  # typically None if using blob, required otherwise
     sha256_hex: str
+    md5_hex: str
     mode: int  # file permission bits (last 12 bits of st_mode)
     size: int
 
@@ -378,6 +385,7 @@ def _get_file_upload_spec(
     source_description: Any,
     mount_filename: PurePosixPath,
     mode: int,
+    md5_hex: Optional[str] = None,
 ) -> FileUploadSpec:
     with source() as fp:
         # Current position is ignored - we always upload from position 0
@@ -388,11 +396,11 @@ def _get_file_upload_spec(
         if size >= LARGE_FILE_LIMIT:
             use_blob = True
             content = None
-            sha256_hex = get_sha256_hex(fp)
+            hashes = get_upload_hashes(fp, md5_hex=md5_hex)
         else:
             use_blob = False
             content = fp.read()
-            sha256_hex = get_sha256_hex(content)
+            hashes = get_upload_hashes(content, md5_hex=md5_hex)
 
     return FileUploadSpec(
         source=source,
@@ -400,7 +408,8 @@ def _get_file_upload_spec(
         mount_filename=mount_filename.as_posix(),
         use_blob=use_blob,
         content=content,
-        sha256_hex=sha256_hex,
+        sha256_hex=hashes.sha256_hex(),
+        md5_hex=hashes.md5_hex(),
         mode=mode & 0o7777,
         size=size,
     )
@@ -412,12 +421,13 @@ def get_file_upload_spec_from_path(
     # Python appears to give files 0o666 bits on Windows (equal for user, group, and global),
     # so we mask those out to 0o755 for compatibility with POSIX-based permissions.
     mode = mode or os.stat(filename).st_mode & (0o7777 if platform.system() != "Windows" else 0o7755)
-    return _get_file_upload_spec(
-        lambda: open(filename, "rb"),
-        filename,
-        mount_filename,
-        mode,
-    )
+    if os.path.getsize(filename) > MULTIPART_UPLOAD_THRESHOLD:
+        # TODO(dano): remove this once we stop requiring md5 for blobs
+        md5_hex = "d41d8cd98f00b204e9800998ecf8427e"  # empty file placeholder - will not be used by server
+    else:
+        md5_hex = None
+
+    return _get_file_upload_spec(lambda: open(filename, "rb"), filename, mount_filename, mode, md5_hex=md5_hex)
 
 
 def get_file_upload_spec_from_fileobj(fp: BinaryIO, mount_filename: PurePosixPath, mode: int) -> FileUploadSpec:

--- a/modal/_utils/blob_utils.py
+++ b/modal/_utils/blob_utils.py
@@ -423,7 +423,7 @@ def get_file_upload_spec_from_path(
     mode = mode or os.stat(filename).st_mode & (0o7777 if platform.system() != "Windows" else 0o7755)
     if os.path.getsize(filename) > MULTIPART_UPLOAD_THRESHOLD:
         # TODO(dano): remove this once we stop requiring md5 for blobs
-        md5_hex = "d41d8cd98f00b204e9800998ecf8427e"  # empty file placeholder - will not be used by server
+        md5_hex = "baadbaadbaadbaadbaadbaadbaadbaad"  # placeholder - will not be used by server
     else:
         md5_hex = None
 

--- a/modal/_utils/hash_utils.py
+++ b/modal/_utils/hash_utils.py
@@ -3,14 +3,14 @@ import base64
 import dataclasses
 import hashlib
 import time
-from typing import BinaryIO, Callable, Optional, Union
+from typing import BinaryIO, Callable, Optional, Sequence, Union
 
 from modal.config import logger
 
 HASH_CHUNK_SIZE = 65536
 
 
-def _update(hashers: list[Callable[[bytes], None]], data: Union[bytes, BinaryIO]) -> None:
+def _update(hashers: Sequence[Callable[[bytes], None]], data: Union[bytes, BinaryIO]) -> None:
     if isinstance(data, bytes):
         for hasher in hashers:
             hasher(data)
@@ -82,12 +82,12 @@ def get_upload_hashes(
         _update(updaters, data)
 
     if sha256_hex:
-        sha256_base64 = base64.b64encode(bytes.fromhex(sha256_hex))
+        sha256_base64 = base64.b64encode(bytes.fromhex(sha256_hex)).decode("ascii")
     else:
         sha256_base64 = base64.b64encode(hashers["sha256"].digest()).decode("ascii")
 
     if md5_hex:
-        md5_base64 = base64.b64encode(bytes.fromhex(md5_hex))
+        md5_base64 = base64.b64encode(bytes.fromhex(md5_hex)).decode("ascii")
     else:
         md5_base64 = base64.b64encode(hashers["md5"].digest()).decode("ascii")
 

--- a/modal/_utils/hash_utils.py
+++ b/modal/_utils/hash_utils.py
@@ -57,23 +57,44 @@ class UploadHashes:
     md5_base64: str
     sha256_base64: str
 
+    def md5_hex(self) -> str:
+        return base64.b64decode(self.md5_base64).hex()
 
-def get_upload_hashes(data: Union[bytes, BinaryIO], sha256_hex: Optional[str] = None) -> UploadHashes:
+    def sha256_hex(self) -> str:
+        return base64.b64decode(self.sha256_base64).hex()
+
+
+def get_upload_hashes(
+    data: Union[bytes, BinaryIO], sha256_hex: Optional[str] = None, md5_hex: Optional[str] = None
+) -> UploadHashes:
     t0 = time.monotonic()
-    md5 = hashlib.md5()
-    # If we already have the sha256 digest, do not compute it again
-    if sha256_hex:
-        hashes = UploadHashes(
-            md5_base64=get_md5_base64(data),
-            sha256_base64=base64.b64encode(bytes.fromhex(sha256_hex)).decode("ascii"),
-        )
-        logger.debug("get_upload_hashes took %.3fs (get_md5_base64)", time.monotonic() - t0)
-    else:
+    hashers = {}
+
+    if not sha256_hex:
         sha256 = hashlib.sha256()
-        _update([md5.update, sha256.update], data)
-        hashes = UploadHashes(
-            md5_base64=base64.b64encode(md5.digest()).decode("ascii"),
-            sha256_base64=base64.b64encode(sha256.digest()).decode("ascii"),
-        )
-        logger.debug("get_upload_hashes took %.3fs (md5 + sha256)", time.monotonic() - t0)
+        hashers["sha256"] = sha256
+    if not md5_hex:
+        md5 = hashlib.md5()
+        hashers["md5"] = md5
+
+    if hashers:
+        updaters = [h.update for h in hashers.values()]
+        _update(updaters, data)
+
+    if sha256_hex:
+        sha256_base64 = base64.b64encode(bytes.fromhex(sha256_hex))
+    else:
+        sha256_base64 = base64.b64encode(hashers["sha256"].digest()).decode("ascii")
+
+    if md5_hex:
+        md5_base64 = base64.b64encode(bytes.fromhex(md5_hex))
+    else:
+        md5_base64 = base64.b64encode(hashers["md5"].digest()).decode("ascii")
+
+    hashes = UploadHashes(
+        md5_base64=md5_base64,
+        sha256_base64=sha256_base64,
+    )
+
+    logger.debug("get_upload_hashes took %.3fs (%s)", time.monotonic() - t0, hashers.keys())
     return hashes

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -483,7 +483,9 @@ class _Mount(_Object, type_prefix="mo"):
                 logger.debug(f"Creating blob file for {file_spec.source_description} ({file_spec.size} bytes)")
                 async with blob_upload_concurrency:
                     with file_spec.source() as fp:
-                        blob_id = await blob_upload_file(fp, resolver.client.stub, sha256_hex=file_spec.sha256_hex)
+                        blob_id = await blob_upload_file(
+                            fp, resolver.client.stub, sha256_hex=file_spec.sha256_hex, md5_hex=file_spec.md5_hex
+                        )
                 logger.debug(f"Uploading blob file {file_spec.source_description} as {remote_filename}")
                 request2 = api_pb2.MountPutFileRequest(data_blob_id=blob_id, sha256_hex=file_spec.sha256_hex)
             else:

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -636,6 +636,7 @@ class _VolumeUploadContextManager:
                         self._client.stub,
                         functools.partial(self._progress_cb, progress_task_id),
                         sha256_hex=file_spec.sha256_hex,
+                        md5_hex=file_spec.md5_hex,
                     )
                 logger.debug(f"Uploading blob file {file_spec.source_description} as {remote_filename}")
                 request2 = api_pb2.MountPutFileRequest(data_blob_id=blob_id, sha256_hex=file_spec.sha256_hex)


### PR DESCRIPTION
Turns out that the server does not use the md5 of files when performing multi-part uploads. And the creation of the unused md5 digest is [very expensive](https://github.com/modal-labs/modal-client/pull/2649#issuecomment-2541013862).

This PR omits sending a real md5 for files larger than 1GiB, which we know** will always be multipart uploaded.

** We'll likely remove md5 entirely and only use the sha256 hash. Until then we'll make sure not to raise the multipart upload threshold higher. If anything we're [lowering it](https://github.com/modal-labs/modal/pull/18208). 

TODO:
- [x] Test volume put 2GiB file
- [x] Test volume put 16MiB file
- [x] Test mount 2GiB file
- [x] Test mount 16MiB file

## Benchmark

TL;DR: We save ~2s per GiB by not doing the md5 hash. For a 64GiB file that's ~2 minutes before we even start uploading. For a 256GiB file that's ~8 minutes. 

The below benchmark uploads a 16GiB file.

```
MODAL_LOGLEVEL=DEBUG modal volume put dano-test data-16g  --force >/dev/null
```

### Before
```
[ThreadPoolExecutor-0_0] 2024-12-13T15:30:34+0100 get_sha256_hex took 9.462s
[Thread-1 (thread_inner)] 2024-12-13T15:31:01+0100 get_upload_hashes took 27.037s (get_md5_base64)
```

### After
```
[ThreadPoolExecutor-0_0] 2024-12-13T15:29:25+0100 get_upload_hashes took 9.033s (dict_keys(['sha256']))
[Thread-1 (thread_inner)] 2024-12-13T15:29:25+0100 get_upload_hashes took 0.000s (dict_keys([]))
```



---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
