### PR TITLE
Don't import ipykernel if it's not already in sys.modules

### DIFF
--- a/modal/_ipython.py
+++ b/modal/_ipython.py
@@ -1,21 +1,11 @@
 # Copyright Modal Labs 2022
 import sys
-import warnings
-
-ipy_outstream = None
-try:
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        import ipykernel.iostream
-
-    ipy_outstream = ipykernel.iostream.OutStream
-except ImportError:
-    pass
 
 
 def is_notebook(stdout=None):
-    if ipy_outstream is None:
+    ipykernel_iostream = sys.modules.get("ipykernel.iostream")
+    if ipykernel_iostream is None:
         return False
     if stdout is None:
         stdout = sys.stdout
-    return isinstance(stdout, ipy_outstream)
+    return isinstance(stdout, ipykernel_iostream.OutStream)

--- a/test/notebook_test.py
+++ b/test/notebook_test.py
@@ -3,7 +3,9 @@ import pytest
 import warnings
 from pathlib import Path
 
-import jupytext
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    import jupytext
 
 try:
     from nbclient.exceptions import CellExecutionError


### PR DESCRIPTION
I was looking at import times using `python -X importtime -c 'import modal' 2>&1 | sort -n -k 5` and I noticed we waste like 25ms (on my laptop, probably more in other environments) importing ipykernel. This seems kind of wasteful. Optimized the check a bit by
1. Using `sys.modules` to see if the `ipython.iostream` is even present (if not, then it can't be inside a notebook)
2. Do the import in local scope

Actually reduces total import times on my laptop fairly consistently from ~240ms to ~200ms which seems good! The import modal benchmark has gotten significantly slower in the last month or two so I hope this plus a few other quick hacks could make a meaningful difference.

![image](https://github.com/user-attachments/assets/cec963b4-25aa-4e67-9aef-e57baf941168)
