### PR TITLE
Don't import aiohttp in global scope

### DIFF
--- a/modal/_runtime/asgi.py
+++ b/modal/_runtime/asgi.py
@@ -1,4 +1,8 @@
 # Copyright Modal Labs 2022
+
+# Note: this module isn't imported unless it's needed.
+# This is because aiohttp is a pretty big dependency that adds significant latency when imported
+
 import asyncio
 from collections.abc import AsyncGenerator
 from typing import Any, Callable, NoReturn, Optional, cast

--- a/modal/_runtime/user_code_imports.py
+++ b/modal/_runtime/user_code_imports.py
@@ -9,15 +9,6 @@ import modal._runtime.container_io_manager
 import modal.cls
 import modal.object
 from modal import Function
-from modal._runtime.asgi import (
-    LifespanManager,
-    asgi_app_wrapper,
-    get_ip_address,
-    wait_for_web_server,
-    web_server_proxy,
-    webhook_asgi_app,
-    wsgi_app_wrapper,
-)
 from modal._utils.async_utils import synchronizer
 from modal._utils.function_utils import LocalFunctionError, is_async as get_is_async, is_global_object
 from modal.exception import ExecutionError, InvalidError
@@ -28,6 +19,7 @@ from modal_proto import api_pb2
 if typing.TYPE_CHECKING:
     import modal.app
     import modal.partial_function
+    from modal._runtime.asgi import LifespanManager
 
 
 @dataclass
@@ -36,7 +28,7 @@ class FinalizedFunction:
     is_async: bool
     is_generator: bool
     data_format: int  # api_pb2.DataFormat
-    lifespan_manager: Optional[LifespanManager] = None
+    lifespan_manager: Optional["LifespanManager"] = None
 
 
 class Service(metaclass=ABCMeta):
@@ -66,20 +58,28 @@ def construct_webhook_callable(
     # For webhooks, the user function is used to construct an asgi app:
     if webhook_config.type == api_pb2.WEBHOOK_TYPE_ASGI_APP:
         # Function returns an asgi_app, which we can use as a callable.
+        from modal._runtime.asgi import asgi_app_wrapper
+
         return asgi_app_wrapper(user_defined_callable(), container_io_manager)
 
     elif webhook_config.type == api_pb2.WEBHOOK_TYPE_WSGI_APP:
-        # Function returns an wsgi_app, which we can use as a callable.
+        # Function returns an wsgi_app, which we can use as a callable
+        from modal._runtime.asgi import wsgi_app_wrapper
+
         return wsgi_app_wrapper(user_defined_callable(), container_io_manager)
 
     elif webhook_config.type == api_pb2.WEBHOOK_TYPE_FUNCTION:
         # Function is a webhook without an ASGI app. Create one for it.
+        from modal._runtime.asgi import asgi_app_wrapper, webhook_asgi_app
+
         return asgi_app_wrapper(
             webhook_asgi_app(user_defined_callable, webhook_config.method, webhook_config.web_endpoint_docs),
             container_io_manager,
         )
 
     elif webhook_config.type == api_pb2.WEBHOOK_TYPE_WEB_SERVER:
+        from modal._runtime.asgi import asgi_app_wrapper, get_ip_address, wait_for_web_server, web_server_proxy
+
         # Function spawns an HTTP web server listening at a port.
         user_defined_callable()
 

--- a/modal/_utils/blob_utils.py
+++ b/modal/_utils/blob_utils.py
@@ -9,11 +9,13 @@ import time
 from collections.abc import AsyncIterator
 from contextlib import AbstractContextManager, contextmanager
 from pathlib import Path, PurePosixPath
-from typing import Any, BinaryIO, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, BinaryIO, Callable, Optional, Union
 from urllib.parse import urlparse
 
 from aiohttp import BytesIOPayload
-from aiohttp.abc import AbstractStreamWriter
+
+if TYPE_CHECKING:
+    from aiohttp.abc import AbstractStreamWriter
 
 from modal_proto import api_pb2
 from modal_proto.modal_api_grpc import ModalClientModal
@@ -95,7 +97,7 @@ class BytesIOSegmentPayload(BytesIOPayload):
     def md5_checksum(self):
         return self._md5_checksum
 
-    async def write(self, writer: AbstractStreamWriter):
+    async def write(self, writer: "AbstractStreamWriter"):
         loop = asyncio.get_event_loop()
 
         async def safe_read():

--- a/modal/_utils/blob_utils.py
+++ b/modal/_utils/blob_utils.py
@@ -12,11 +12,6 @@ from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any, BinaryIO, Callable, Optional, Union
 from urllib.parse import urlparse
 
-from aiohttp import BytesIOPayload
-
-if TYPE_CHECKING:
-    from aiohttp.abc import AbstractStreamWriter
-
 from modal_proto import api_pb2
 from modal_proto.modal_api_grpc import ModalClientModal
 
@@ -26,6 +21,9 @@ from .grpc_utils import retry_transient_errors
 from .hash_utils import UploadHashes, get_sha256_hex, get_upload_hashes
 from .http_utils import ClientSessionRegistry
 from .logger import logger
+
+if TYPE_CHECKING:
+    from .bytes_io_segment_payload import BytesIOSegmentPayload
 
 # Max size for function inputs and outputs.
 MAX_OBJECT_SIZE_BYTES = 2 * 1024 * 1024  # 2 MiB
@@ -41,92 +39,10 @@ BLOB_MAX_PARALLELISM = 10
 DEFAULT_SEGMENT_CHUNK_SIZE = 2**24
 
 
-class BytesIOSegmentPayload(BytesIOPayload):
-    """Modified bytes payload for concurrent sends of chunks from the same file.
-
-    Adds:
-    * read limit using remaining_bytes, in order to split files across streams
-    * larger read chunk (to prevent excessive read contention between parts)
-    * calculates an md5 for the segment
-
-    Feels like this should be in some standard lib...
-    """
-
-    def __init__(
-        self,
-        bytes_io: BinaryIO,  # should *not* be shared as IO position modification is not locked
-        segment_start: int,
-        segment_length: int,
-        chunk_size: int = DEFAULT_SEGMENT_CHUNK_SIZE,
-        progress_report_cb: Optional[Callable] = None,
-    ):
-        # not thread safe constructor!
-        super().__init__(bytes_io)
-        self.initial_seek_pos = bytes_io.tell()
-        self.segment_start = segment_start
-        self.segment_length = segment_length
-        # seek to start of file segment we are interested in, in order to make .size() evaluate correctly
-        self._value.seek(self.initial_seek_pos + segment_start)
-        assert self.segment_length <= super().size
-        self.chunk_size = chunk_size
-        self.progress_report_cb = progress_report_cb or (lambda *_, **__: None)
-        self.reset_state()
-
-    def reset_state(self):
-        self._md5_checksum = hashlib.md5()
-        self.num_bytes_read = 0
-        self._value.seek(self.initial_seek_pos)
-
-    @contextmanager
-    def reset_on_error(self):
-        try:
-            yield
-        except Exception as exc:
-            try:
-                self.progress_report_cb(reset=True)
-            except Exception as cb_exc:
-                raise cb_exc from exc
-            raise exc
-        finally:
-            self.reset_state()
-
-    @property
-    def size(self) -> int:
-        return self.segment_length
-
-    def md5_checksum(self):
-        return self._md5_checksum
-
-    async def write(self, writer: "AbstractStreamWriter"):
-        loop = asyncio.get_event_loop()
-
-        async def safe_read():
-            read_start = self.initial_seek_pos + self.segment_start + self.num_bytes_read
-            self._value.seek(read_start)
-            num_bytes = min(self.chunk_size, self.remaining_bytes())
-            chunk = await loop.run_in_executor(None, self._value.read, num_bytes)
-
-            await loop.run_in_executor(None, self._md5_checksum.update, chunk)
-            self.num_bytes_read += len(chunk)
-            return chunk
-
-        chunk = await safe_read()
-        while chunk and self.remaining_bytes() > 0:
-            await writer.write(chunk)
-            self.progress_report_cb(advance=len(chunk))
-            chunk = await safe_read()
-        if chunk:
-            await writer.write(chunk)
-            self.progress_report_cb(advance=len(chunk))
-
-    def remaining_bytes(self):
-        return self.segment_length - self.num_bytes_read
-
-
 @retry(n_attempts=5, base_delay=0.5, timeout=None)
 async def _upload_to_s3_url(
     upload_url,
-    payload: BytesIOSegmentPayload,
+    payload: "BytesIOSegmentPayload",
     content_md5_b64: Optional[str] = None,
     content_type: Optional[str] = "application/octet-stream",  # set to None to force omission of ContentType header
 ) -> str:
@@ -182,6 +98,8 @@ async def perform_multipart_upload(
     upload_chunk_size: int = DEFAULT_SEGMENT_CHUNK_SIZE,
     progress_report_cb: Optional[Callable] = None,
 ) -> None:
+    from .bytes_io_segment_payload import BytesIOSegmentPayload
+
     upload_coros = []
     file_offset = 0
     num_bytes_left = content_length
@@ -275,6 +193,8 @@ async def _blob_upload(
             progress_report_cb=progress_report_cb,
         )
     else:
+        from .bytes_io_segment_payload import BytesIOSegmentPayload
+
         payload = BytesIOSegmentPayload(
             data, segment_start=0, segment_length=content_length, progress_report_cb=progress_report_cb
         )

--- a/modal/_utils/bytes_io_segment_payload.py
+++ b/modal/_utils/bytes_io_segment_payload.py
@@ -1,4 +1,4 @@
-# Copyright Modal Labs 2022
+# Copyright Modal Labs 2024
 
 import asyncio
 import hashlib

--- a/modal/_utils/bytes_io_segment_payload.py
+++ b/modal/_utils/bytes_io_segment_payload.py
@@ -1,0 +1,97 @@
+# Copyright Modal Labs 2022
+
+import asyncio
+import hashlib
+from contextlib import contextmanager
+from typing import BinaryIO, Callable, Optional
+
+# Note: this module needs to import aiohttp in global scope
+# This takes about 50ms and isn't needed in many cases for Modal execution
+# To avoid this, we import it in local scope when needed (blob_utils.py)
+from aiohttp import BytesIOPayload
+from aiohttp.abc import AbstractStreamWriter
+
+# read ~16MiB chunks by default
+DEFAULT_SEGMENT_CHUNK_SIZE = 2**24
+
+
+class BytesIOSegmentPayload(BytesIOPayload):
+    """Modified bytes payload for concurrent sends of chunks from the same file.
+
+    Adds:
+    * read limit using remaining_bytes, in order to split files across streams
+    * larger read chunk (to prevent excessive read contention between parts)
+    * calculates an md5 for the segment
+
+    Feels like this should be in some standard lib...
+    """
+
+    def __init__(
+        self,
+        bytes_io: BinaryIO,  # should *not* be shared as IO position modification is not locked
+        segment_start: int,
+        segment_length: int,
+        chunk_size: int = DEFAULT_SEGMENT_CHUNK_SIZE,
+        progress_report_cb: Optional[Callable] = None,
+    ):
+        # not thread safe constructor!
+        super().__init__(bytes_io)
+        self.initial_seek_pos = bytes_io.tell()
+        self.segment_start = segment_start
+        self.segment_length = segment_length
+        # seek to start of file segment we are interested in, in order to make .size() evaluate correctly
+        self._value.seek(self.initial_seek_pos + segment_start)
+        assert self.segment_length <= super().size
+        self.chunk_size = chunk_size
+        self.progress_report_cb = progress_report_cb or (lambda *_, **__: None)
+        self.reset_state()
+
+    def reset_state(self):
+        self._md5_checksum = hashlib.md5()
+        self.num_bytes_read = 0
+        self._value.seek(self.initial_seek_pos)
+
+    @contextmanager
+    def reset_on_error(self):
+        try:
+            yield
+        except Exception as exc:
+            try:
+                self.progress_report_cb(reset=True)
+            except Exception as cb_exc:
+                raise cb_exc from exc
+            raise exc
+        finally:
+            self.reset_state()
+
+    @property
+    def size(self) -> int:
+        return self.segment_length
+
+    def md5_checksum(self):
+        return self._md5_checksum
+
+    async def write(self, writer: "AbstractStreamWriter"):
+        loop = asyncio.get_event_loop()
+
+        async def safe_read():
+            read_start = self.initial_seek_pos + self.segment_start + self.num_bytes_read
+            self._value.seek(read_start)
+            num_bytes = min(self.chunk_size, self.remaining_bytes())
+            chunk = await loop.run_in_executor(None, self._value.read, num_bytes)
+
+            await loop.run_in_executor(None, self._md5_checksum.update, chunk)
+            self.num_bytes_read += len(chunk)
+            return chunk
+
+        chunk = await safe_read()
+        while chunk and self.remaining_bytes() > 0:
+            await writer.write(chunk)
+            self.progress_report_cb(advance=len(chunk))
+            chunk = await safe_read()
+        if chunk:
+            await writer.write(chunk)
+            self.progress_report_cb(advance=len(chunk))
+
+    def remaining_bytes(self):
+        return self.segment_length - self.num_bytes_read

--- a/modal/_utils/http_utils.py
+++ b/modal/_utils/http_utils.py
@@ -1,18 +1,18 @@
 # Copyright Modal Labs 2022
 import contextlib
-import socket
-import ssl
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-import certifi
-from aiohttp import ClientSession, ClientTimeout, TCPConnector
-from aiohttp.web import Application
-from aiohttp.web_runner import AppRunner, SockSite
+# Note: importing aiohttp seems to take about 100ms, and it's not really necessarily,
+# unless we need to work with blobs. So that's why we import it lazily instead.
+
+if TYPE_CHECKING:
+    from aiohttp import ClientSession
+    from aiohttp.web import Application
 
 from .async_utils import on_shutdown
 
 
-def _http_client_with_tls(timeout: Optional[float]) -> ClientSession:
+def _http_client_with_tls(timeout: Optional[float]) -> "ClientSession":
     """Create a new HTTP client session with standard, bundled TLS certificates.
 
     This is necessary to prevent client issues on some system where Python does
@@ -22,13 +22,18 @@ def _http_client_with_tls(timeout: Optional[float]) -> ClientSession:
     Specifically: the error "unable to get local issuer certificate" when making
     an aiohttp request.
     """
+    import ssl
+
+    import certifi
+    from aiohttp import ClientSession, ClientTimeout, TCPConnector
+
     ssl_context = ssl.create_default_context(cafile=certifi.where())
     connector = TCPConnector(ssl=ssl_context)
     return ClientSession(connector=connector, timeout=ClientTimeout(total=timeout))
 
 
 class ClientSessionRegistry:
-    _client_session: ClientSession
+    _client_session: "ClientSession"
     _client_session_active: bool = False
 
     @staticmethod
@@ -47,9 +52,13 @@ class ClientSessionRegistry:
 
 
 @contextlib.asynccontextmanager
-async def run_temporary_http_server(app: Application):
+async def run_temporary_http_server(app: "Application"):
     # Allocates a random port, runs a server in a context manager
     # This is used in various tests
+    import socket
+
+    from aiohttp.web_runner import AppRunner, SockSite
+
     sock = socket.socket()
     sock.bind(("", 0))
     port = sock.getsockname()[1]

--- a/test/slow_dependencies_test.py
+++ b/test/slow_dependencies_test.py
@@ -1,0 +1,13 @@
+# Copyright Modal Labs 2024
+import subprocess
+import sys
+
+
+def test_slow_dependencies_local(supports_dir):
+    # Make sure that "import modal" doesn't load some big dependencies like aiohttp
+    subprocess.check_output([sys.executable, supports_dir / "slow_dependencies_local.py"])
+
+
+def test_slow_dependencies_container(supports_dir):
+    # Make sure that "import modal._container_entrypoint" doesn't load some big dependencies like aiohttp
+    subprocess.check_output([sys.executable, supports_dir / "slow_dependencies_container.py"])

--- a/test/supports/slow_dependencies_container.py
+++ b/test/supports/slow_dependencies_container.py
@@ -1,0 +1,10 @@
+# Copyright Modal Labs 2024
+import sys
+
+import modal._container_entrypoint  # noqa
+
+assert "modal" in sys.modules
+
+# This is a very heavy dependency that takes about 70-80ms to import
+# Let's make sure it doesn't get imported in global scope
+assert "aiohttp" not in sys.modules

--- a/test/supports/slow_dependencies_local.py
+++ b/test/supports/slow_dependencies_local.py
@@ -1,0 +1,10 @@
+# Copyright Modal Labs 2024
+import sys
+
+import modal  # noqa
+
+assert "modal" in sys.modules
+
+# This is a very heavy dependency that takes about 70-80ms to import
+# Let's make sure it doesn't get imported in global scope
+assert "aiohttp" not in sys.modules

--- a/test/utils_test.py
+++ b/test/utils_test.py
@@ -4,7 +4,7 @@ import hashlib
 import io
 import pytest
 
-from modal._utils.blob_utils import BytesIOSegmentPayload
+from modal._utils.bytes_io_segment_payload import BytesIOSegmentPayload
 from modal._utils.name_utils import (
     check_object_name,
     is_valid_environment_name,


### PR DESCRIPTION
This cuts down the time it takes to run `import modal` from about 205ms to about 135ms on my devbox, i.e. a 70ms improvement. Pretty good!

Actually it might even be more. With `python -X importtime -c 'import modal'` I see a speed up of about 70ms. When I run `time python -c 'import modal'`, I see a speedup of about 80-90ms.

Note that the impact might be 2x in many cases since it removes it both locally and in the container.

I don't _love_ this code though, it's a bit janky. The reason it's complex is that we were subclassing an `aiohttp` internal class in global scope so we had to break it out into a submodule that's optionally imported. Maybe there's a more elegant way to do it?

Note that we couldn't have done this without #2656 since `ipykernel` actually imports `aiohttp` too (among other things).