### PR TITLE
Add `--write-result` flag to `modal run` to save function return values locally

### DIFF
--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -205,24 +205,24 @@ def test_run_class_hierarchy(servicer, set_env_client, test_dir):
     _run(["run", app_file.as_posix() + "::Wrapped.overridden_on_wrapped"])
 
 
-def test_run_output(servicer, set_env_client, test_dir):
+def test_run_write_result(servicer, set_env_client, test_dir):
     # Note that this test only exercises local entrypoint functions,
     # because the servicer doesn't appear to mock remote execution faithfully?
     app_file = (test_dir / "supports" / "app_run_tests" / "returns_data.py").as_posix()
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        _run(["run", "-o", output_file := f"{tmpdir}/result.txt", f"{app_file}::returns_str"])
-        with open(output_file, "rt") as f:
+        _run(["run", "--write-result", result_file := f"{tmpdir}/result.txt", f"{app_file}::returns_str"])
+        with open(result_file, "rt") as f:
             assert f.read() == "Hello!"
 
-        _run(["run", "-o", output_file := f"{tmpdir}/result.bin", f"{app_file}::returns_bytes"])
-        with open(output_file, "rb") as f:
+        _run(["run", "-w", result_file := f"{tmpdir}/result.bin", f"{app_file}::returns_bytes"])
+        with open(result_file, "rb") as f:
             assert f.read().decode("utf8") == "Hello!"
 
         _run(
-            ["run", "-o", output_file := f"{tmpdir}/result.bin", f"{app_file}::returns_int"],
+            ["run", "-w", result_file := f"{tmpdir}/result.bin", f"{app_file}::returns_int"],
             expected_exit_code=1,
-            expected_error="Function must return str or bytes when using `--output`; got int.",
+            expected_error="Function must return str or bytes when using `--write-result`; got int.",
         )
 
 

--- a/test/supports/app_run_tests/returns_data.py
+++ b/test/supports/app_run_tests/returns_data.py
@@ -1,0 +1,19 @@
+# Copyright Modal Labs 2024
+import modal
+
+app = modal.App()
+
+
+@app.local_entrypoint()
+def returns_str() -> str:
+    return "Hello!"
+
+
+@app.local_entrypoint()
+def returns_bytes() -> bytes:
+    return b"Hello!"
+
+
+@app.local_entrypoint()
+def returns_int() -> int:
+    return 42


### PR DESCRIPTION
## Changelog

- The `modal run` CLI now has a `--write-result` option. When you pass a filename, Modal will write the return value of the entrypoint function to that location on your local filesystem. The return value of the function must be either `str` or `bytes` to use this option; otherwise, an error will be raised. It can be useful for exercising a remote function that returns text, image data, etc.