### PR TITLE
Add file watching client changes

### DIFF
--- a/modal/file_io.py
+++ b/modal/file_io.py
@@ -410,49 +410,6 @@ class _FileIO(Generic[T]):
         await self._wait(resp.exec_id)
 
     @classmethod
-    async def ls(cls, path: str, client: _Client, task_id: str) -> list[str]:
-        """List the contents of the provided directory."""
-        self = cls.__new__(cls)
-        self._client = client
-        self._task_id = task_id
-        resp = await self._make_request(
-            api_pb2.ContainerFilesystemExecRequest(
-                file_ls_request=api_pb2.ContainerFileLsRequest(path=path),
-                task_id=task_id,
-            )
-        )
-        output = await self._wait(resp.exec_id)
-        return await self._parse_list_output(output)
-
-    @classmethod
-    async def mkdir(cls, path: str, client: _Client, task_id: str, parents: bool = False) -> None:
-        """Create a new directory."""
-        self = cls.__new__(cls)
-        self._client = client
-        self._task_id = task_id
-        resp = await self._make_request(
-            api_pb2.ContainerFilesystemExecRequest(
-                file_mkdir_request=api_pb2.ContainerFileMkdirRequest(path=path, make_parents=parents),
-                task_id=self._task_id,
-            )
-        )
-        await self._wait(resp.exec_id)
-
-    @classmethod
-    async def rm(cls, path: str, client: _Client, task_id: str, recursive: bool = False) -> None:
-        """Remove a file or directory in the Sandbox."""
-        self = cls.__new__(cls)
-        self._client = client
-        self._task_id = task_id
-        resp = await self._make_request(
-            api_pb2.ContainerFilesystemExecRequest(
-                file_rm_request=api_pb2.ContainerFileRmRequest(path=path, recursive=recursive),
-                task_id=self._task_id,
-            )
-        )
-        await self._wait(resp.exec_id)
-
-    @classmethod
     async def watch(
         cls, path: str, client: _Client, task_id: str, timeout: Optional[int] = None, recursive: bool = False
     ) -> AsyncIterator[FileWatchEvent]:

--- a/modal/file_io.py
+++ b/modal/file_io.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING, AsyncIterator, Generic, Optional, Sequence, Ty
 if TYPE_CHECKING:
     import _typeshed
 
+from collections.abc import AsyncGenerator
+
 from grpclib.exceptions import GRPCError, StreamTerminatedError
 
 from modal._utils.grpc_utils import retry_transient_errors
@@ -336,6 +338,71 @@ class _FileIO(Generic[T]):
             )
         )
         await self._wait(resp.exec_id)
+
+    @classmethod
+    async def ls(cls, path: str, client: _Client, task_id: str) -> list[str]:
+        """List the contents of the provided directory."""
+        self = cls.__new__(cls)
+        self._client = client
+        self._task_id = task_id
+        resp = await self._make_request(
+            api_pb2.ContainerFilesystemExecRequest(
+                file_ls_request=api_pb2.ContainerFileLsRequest(path=path),
+                task_id=task_id,
+            )
+        )
+        output = await self._wait(resp.exec_id)
+        return await self._parse_list_output(output)
+
+    @classmethod
+    async def mkdir(cls, path: str, client: _Client, task_id: str, parents: bool = False) -> None:
+        """Create a new directory."""
+        self = cls.__new__(cls)
+        self._client = client
+        self._task_id = task_id
+        resp = await self._make_request(
+            api_pb2.ContainerFilesystemExecRequest(
+                file_mkdir_request=api_pb2.ContainerFileMkdirRequest(path=path, make_parents=parents),
+                task_id=self._task_id,
+            )
+        )
+        await self._wait(resp.exec_id)
+
+    @classmethod
+    async def rm(cls, path: str, client: _Client, task_id: str, recursive: bool = False) -> None:
+        """Remove a file or directory in the Sandbox."""
+        self = cls.__new__(cls)
+        self._client = client
+        self._task_id = task_id
+        resp = await self._make_request(
+            api_pb2.ContainerFilesystemExecRequest(
+                file_rm_request=api_pb2.ContainerFileRmRequest(path=path, recursive=recursive),
+                task_id=self._task_id,
+            )
+        )
+        await self._wait(resp.exec_id)
+
+    @classmethod
+    async def watch(
+        cls, path: str, client: _Client, task_id: str, timeout: Optional[int] = None, recursive: bool = False
+    ) -> AsyncGenerator[str, None]:
+        self = cls.__new__(cls)
+        self._client = client
+        self._task_id = task_id
+        resp = await self._make_request(
+            api_pb2.ContainerFilesystemExecRequest(
+                file_watch_request=api_pb2.ContainerFileWatchRequest(
+                    path=path,
+                    recursive=recursive,
+                    timeout_secs=timeout,
+                ),
+                task_id=self._task_id,
+            )
+        )
+        print("resp", resp)
+        while True:
+            await asyncio.sleep(1.0)
+            yield "dummy event"
 
     async def _close(self) -> None:
         # Buffer is flushed by the runner on close

--- a/modal/file_io.py
+++ b/modal/file_io.py
@@ -454,8 +454,9 @@ class _FileIO(Generic[T]):
         )
         await self._wait(resp.exec_id)
 
+    @classmethod
     async def watch(
-        cls, path: str, client: _Client, task_id: str, timeout: Optional[int] = None, recursive: bool = False
+        cls, path: str, client: _Client, task_id: str, recursive: bool = False, timeout: Optional[int] = None
     ) -> AsyncIterator[FileWatchEvent]:
         self = cls.__new__(cls)
         self._client = client

--- a/modal/file_io.py
+++ b/modal/file_io.py
@@ -1,8 +1,8 @@
 # Copyright Modal Labs 2024
 import asyncio
+import enum
 import io
 from dataclasses import dataclass
-from enum import Enum
 from typing import TYPE_CHECKING, AsyncIterator, Generic, Optional, Sequence, TypeVar, Union, cast
 
 if TYPE_CHECKING:
@@ -97,7 +97,7 @@ async def _replace_bytes(file: "_FileIO", data: bytes, start: Optional[int] = No
     await file._wait(resp.exec_id)
 
 
-class WatchEvent(Enum):
+class WatchEvent(enum.Enum):
     Unknown = "Unknown"
     Access = "Access"
     Create = "Create"

--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -178,7 +178,7 @@ class _StreamReader(Generic[T]):
             return
 
         def item_handler(item: Optional[bytes]):
-            if self._stream_type == StreamType.STDOUT:
+            if self._stream_type == StreamType.STDOUT and item is not None:
                 print(item.decode("utf-8"), end="")
             elif self._stream_type == StreamType.PIPE:
                 self._container_process_buffer.append(item)

--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -14,7 +14,8 @@ from typing import (
 from grpclib import Status
 from grpclib.exceptions import GRPCError, StreamTerminatedError
 
-from modal.exception import ClientClosed, InvalidError
+from modal.exception import InvalidError
+from modal.io_streams_helper import consume_stream_with_retries
 from modal_proto import api_pb2
 
 from ._utils.async_utils import synchronize_api
@@ -176,34 +177,21 @@ class _StreamReader(Generic[T]):
         if self._stream_type == StreamType.DEVNULL:
             return
 
-        completed = False
-        retries_remaining = 10
-        while not completed:
-            try:
-                iterator = _container_process_logs_iterator(self._object_id, self._file_descriptor, self._client)
+        def item_handler(item: Optional[bytes]):
+            if self._stream_type == StreamType.STDOUT:
+                print(item.decode("utf-8"), end="")
+            elif self._stream_type == StreamType.PIPE:
+                self._container_process_buffer.append(item)
 
-                async for message in iterator:
-                    if self._stream_type == StreamType.STDOUT and message:
-                        print(message.decode("utf-8"), end="")
-                    elif self._stream_type == StreamType.PIPE:
-                        self._container_process_buffer.append(message)
-                    if message is None:
-                        completed = True
-                        break
+        def completion_check(item: Optional[bytes]):
+            return item is None
 
-            except (GRPCError, StreamTerminatedError, ClientClosed) as exc:
-                if retries_remaining > 0:
-                    retries_remaining -= 1
-                    if isinstance(exc, GRPCError):
-                        if exc.status in RETRYABLE_GRPC_STATUS_CODES:
-                            await asyncio.sleep(1.0)
-                            continue
-                    elif isinstance(exc, StreamTerminatedError):
-                        continue
-                    elif isinstance(exc, ClientClosed):
-                        # If the client was closed, the user has triggered a cleanup.
-                        break
-                raise exc
+        iterator = _container_process_logs_iterator(self._object_id, self._file_descriptor, self._client)
+        await consume_stream_with_retries(
+            iterator,
+            item_handler,
+            completion_check,
+        )
 
     async def _stream_container_process(self) -> AsyncGenerator[tuple[Optional[bytes], str], None]:
         """Streams the container process buffer to the reader."""

--- a/modal/io_streams_helper.py
+++ b/modal/io_streams_helper.py
@@ -1,0 +1,52 @@
+# Copyright Modal Labs 2024
+import asyncio
+from typing import AsyncIterator, Callable, TypeVar
+
+from grpclib.exceptions import GRPCError, StreamTerminatedError
+
+from modal.exception import ClientClosed
+
+from ._utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES
+
+T = TypeVar("T")
+
+
+async def consume_stream_with_retries(
+    stream: AsyncIterator[T],
+    item_handler: Callable[[T], None],
+    completion_check: Callable[[T], bool],
+    max_retries: int = 10,
+    retry_delay: float = 1.0,
+) -> None:
+    """Helper function to consume a stream with retry logic for transient errors.
+
+    Args:
+        stream_generator: Function that returns an AsyncIterator to consume
+        item_handler: Callback function to handle each item from the stream
+        completion_check: Callback function to check if the stream is complete
+        max_retries: Maximum number of retry attempts
+        retry_delay: Delay in seconds between retries
+    """
+    completed = False
+    retries_remaining = max_retries
+
+    while not completed:
+        try:
+            async for item in stream:
+                item_handler(item)
+                if completion_check(item):
+                    completed = True
+                    break
+
+        except (GRPCError, StreamTerminatedError, ClientClosed) as exc:
+            if retries_remaining > 0:
+                retries_remaining -= 1
+                if isinstance(exc, GRPCError):
+                    if exc.status in RETRYABLE_GRPC_STATUS_CODES:
+                        await asyncio.sleep(retry_delay)
+                        continue
+                elif isinstance(exc, StreamTerminatedError):
+                    continue
+                elif isinstance(exc, ClientClosed):
+                    break
+            raise

--- a/modal/io_streams_helper.py
+++ b/modal/io_streams_helper.py
@@ -18,7 +18,8 @@ async def consume_stream_with_retries(
     max_retries: int = 10,
     retry_delay: float = 1.0,
 ) -> None:
-    """Helper function to consume a stream with retry logic for transient errors.
+    """mdmd:hidden
+    Helper function to consume a stream with retry logic for transient errors.
 
     Args:
         stream_generator: Function that returns an AsyncIterator to consume

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -567,21 +567,6 @@ class _Sandbox(_Object, type_prefix="sb"):
         task_id = await self._get_task_id()
         return await _FileIO.create(path, mode, self._client, task_id)
 
-    async def ls(self, path: str) -> list[str]:
-        """List the contents of a directory in the Sandbox."""
-        task_id = await self._get_task_id()
-        return await _FileIO.ls(path, self._client, task_id)
-
-    async def mkdir(self, path: str, parents: bool = False) -> None:
-        """Create a new directory in the Sandbox."""
-        task_id = await self._get_task_id()
-        return await _FileIO.mkdir(path, self._client, task_id, parents)
-
-    async def rm(self, path: str, recursive: bool = False) -> None:
-        """Remove a file or directory in the Sandbox."""
-        task_id = await self._get_task_id()
-        return await _FileIO.rm(path, self._client, task_id, recursive)
-
     async def watch(
         self,
         path: str,

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -2,7 +2,7 @@
 import asyncio
 import os
 from collections.abc import AsyncGenerator, Sequence
-from typing import TYPE_CHECKING, Literal, Optional, Union, overload
+from typing import TYPE_CHECKING, AsyncIterator, Literal, Optional, Union, overload
 
 if TYPE_CHECKING:
     import _typeshed
@@ -587,9 +587,10 @@ class _Sandbox(_Object, type_prefix="sb"):
         path: str,
         recursive: Optional[bool] = None,
         timeout: Optional[int] = None,
-    ) -> None:
+    ) -> AsyncIterator[bytes]:
         task_id = await self._get_task_id()
-        await _FileIO.watch(path, self._client, task_id, recursive, timeout)
+        async for event in _FileIO.watch(path, self._client, task_id, recursive, timeout):
+            yield event
 
     @property
     def stdout(self) -> _StreamReader[str]:

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -567,6 +567,30 @@ class _Sandbox(_Object, type_prefix="sb"):
         task_id = await self._get_task_id()
         return await _FileIO.create(path, mode, self._client, task_id)
 
+    async def ls(self, path: str) -> list[str]:
+        """List the contents of a directory in the Sandbox."""
+        task_id = await self._get_task_id()
+        return await _FileIO.ls(path, self._client, task_id)
+
+    async def mkdir(self, path: str, parents: bool = False) -> None:
+        """Create a new directory in the Sandbox."""
+        task_id = await self._get_task_id()
+        return await _FileIO.mkdir(path, self._client, task_id, parents)
+
+    async def rm(self, path: str, recursive: bool = False) -> None:
+        """Remove a file or directory in the Sandbox."""
+        task_id = await self._get_task_id()
+        return await _FileIO.rm(path, self._client, task_id, recursive)
+
+    async def watch(
+        self,
+        path: str,
+        recursive: Optional[bool] = None,
+        timeout: Optional[int] = None,
+    ) -> AsyncGenerator[str, None]:
+        task_id = await self._get_task_id()
+        return await _FileIO.watch(path, self._client, task_id, recursive, timeout)
+
     @property
     def stdout(self) -> _StreamReader[str]:
         """

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -587,9 +587,9 @@ class _Sandbox(_Object, type_prefix="sb"):
         path: str,
         recursive: Optional[bool] = None,
         timeout: Optional[int] = None,
-    ) -> AsyncGenerator[str, None]:
+    ) -> None:
         task_id = await self._get_task_id()
-        return await _FileIO.watch(path, self._client, task_id, recursive, timeout)
+        await _FileIO.watch(path, self._client, task_id, recursive, timeout)
 
     @property
     def stdout(self) -> _StreamReader[str]:

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -781,6 +781,12 @@ message ContainerFileMkdirRequest {
   bool make_parents = 2;
 }
 
+message ContainerFileWatchRequest {
+  string path = 1;
+  bool recursive = 2;
+  optional uint64 timeout_secs = 3;
+}
+
 message ContainerFileOpenRequest {
   // file descriptor is hydrated when sent from server -> worker
   optional string file_descriptor = 1;
@@ -839,6 +845,7 @@ message ContainerFilesystemExecRequest {
     ContainerFileLsRequest file_ls_request = 11;
     ContainerFileMkdirRequest file_mkdir_request = 12;
     ContainerFileRmRequest file_rm_request = 13;
+    ContainerFileWatchRequest file_watch_request = 14;
   }
   string task_id = 10;
 }

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -781,12 +781,6 @@ message ContainerFileMkdirRequest {
   bool make_parents = 2;
 }
 
-message ContainerFileWatchRequest {
-  string path = 1;
-  bool recursive = 2;
-  optional uint64 timeout_secs = 3;
-}
-
 message ContainerFileOpenRequest {
   // file descriptor is hydrated when sent from server -> worker
   optional string file_descriptor = 1;


### PR DESCRIPTION
## Describe your changes

WRK-484

### Blockers
- [x] https://github.com/modal-labs/modal/pull/18215 roll out to all workers

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Sandboxes now support fsnotify-like file watching:
```python
from modal.file_io import FileWatchEventType

app = modal.App.lookup("file-watch", create_if_missing=True)
sb = modal.Sandbox.create(app=app)
events = sb.watch("/foo")
for event in events:
    if event.type == FileWatchEventType.Modify:
        print(event.paths)
```