### PR TITLE
Write all data in `write_to_fd`

### DIFF
--- a/modal/_utils/shell_utils.py
+++ b/modal/_utils/shell_utils.py
@@ -19,14 +19,20 @@ def write_to_fd(fd: int, data: bytes):
     future = loop.create_future()
 
     def try_write():
+        nonlocal data
         try:
             nbytes = os.write(fd, data)
-            loop.remove_writer(fd)
-            future.set_result(nbytes)
+            data = data[nbytes:]
+            if not data:
+                loop.remove_writer(fd)
+                future.set_result(None)
         except OSError as e:
-            if e.errno != errno.EAGAIN:
-                future.set_exception(e)
-                raise
+            if e.errno == errno.EAGAIN:
+                # Wait for the next write notification
+                return
+            # Fail if it's not EAGAIN
+            loop.remove_writer(fd)
+            future.set_exception(e)
 
     loop.add_writer(fd, try_write)
     return future


### PR DESCRIPTION
Originally from a user report that `top` in `modal shell` was behaving weirdly sometimes. Was coming from our `write_to_fd` function just giving up after a partial write to the buffer (originally from #1188, @thecodingwizard any idea if this is for a reason?). 

After the fix:

https://github.com/user-attachments/assets/d5721bb4-2108-4382-b9d0-300dc5f5a6e4



<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
