### PR TITLE
Truncate dict items if too long

### DIFF
--- a/modal/cli/dict.py
+++ b/modal/cli/dict.py
@@ -89,6 +89,10 @@ async def get(name: str, key: str, *, env: Optional[str] = ENV_OPTION):
     console.print(val)
 
 
+def _truncate(val: str) -> str:
+    return val[:80] + "..." if len(val) > 80 else val
+
+
 @dict_cli.command(name="items", rich_help_panel="Inspection")
 @synchronizer.create_blocking
 async def items(
@@ -118,7 +122,7 @@ async def items(
                 display_item = key, val
             else:
                 cast = repr if use_repr else str
-                display_item = cast(key), cast(val)  # type: ignore  # mypy/issue/12056
+                display_item = _truncate(cast(key)), _truncate(cast(val))  # type: ignore  # mypy/issue/12056
             items.append(display_item)
 
     display_table(["Key", "Value"], items, json)

--- a/modal/cli/dict.py
+++ b/modal/cli/dict.py
@@ -89,7 +89,8 @@ async def get(name: str, key: str, *, env: Optional[str] = ENV_OPTION):
     console.print(val)
 
 
-def _truncate(val: str) -> str:
+def _display(input: str, use_repr: bool) -> str:
+    val = repr(input) if use_repr else str(input)
     return val[:80] + "..." if len(val) > 80 else val
 
 
@@ -121,8 +122,7 @@ async def items(
             if json:
                 display_item = key, val
             else:
-                cast = repr if use_repr else str
-                display_item = _truncate(cast(key)), _truncate(cast(val))  # type: ignore  # mypy/issue/12056
+                display_item = _display(key, use_repr), _display(val, use_repr)  # type: ignore  # mypy/issue/12056
             items.append(display_item)
 
     display_table(["Key", "Value"], items, json)


### PR DESCRIPTION
Currently fails when your Dict has large values.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x\ Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
