### PR TITLE
Proto prep for deprecating AppGetObjects

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -360,6 +360,12 @@ message AppHeartbeatRequest {
   string app_id = 1;
 }
 
+message AppLayout {
+  repeated Object object = 1;
+  map<string, string> function_ids = 2;  // tag -> function id
+  map<string, string> class_ids = 3;  // tag -> class id
+}
+
 message AppListRequest {
   string environment_name = 1;
 }
@@ -710,6 +716,7 @@ message ContainerArguments {  // This is used to pass data from the worker to th
   string runtime = 11;
   string environment_name = 13;
   optional string checkpoint_id = 14;
+  AppLayout app_layout = 15;
 }
 
 message ContainerCheckpointRequest {


### PR DESCRIPTION
I'm planning to get rid of the need to call `AppGetObjects` by having the worker pass the data to the container through `ContainerArguments`.

This removes a server round trip which should cut down 10-200ms cold start latency (200ms+ will be for remote regions). It also reduces complexity.

As a part of this change, I'm using a slightly different message structure. We currently have

```protobuf
message AppGetObjectsResponse {
  repeated AppGetObjectsItem items = 2;
}

message AppGetObjectsItem {
  string tag = 1;
  Object object = 6;
}
```

But only functions and classes have tags since a long time so we can make it a bit more direct. So we do this instead:


```protobuf
message AppLayout {
  repeated Object object = 1;
  map<string, string> function_ids = 2;  // tag -> function id
  map<string, string> class_ids = 3;  // tag -> class id
}
```

Note that the `object_id` is a part of the `Object` definition.