### PR TITLE
Dumb typo: `AppLayout.objects` not `object`

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -361,7 +361,7 @@ message AppHeartbeatRequest {
 }
 
 message AppLayout {
-  repeated Object object = 1;
+  repeated Object objects = 1;
   map<string, string> function_ids = 2;  // tag -> function id
   map<string, string> class_ids = 3;  // tag -> class id
 }


### PR DESCRIPTION
This message isn't used anywhere, but realized this mistake while implementing the server code