### PR TITLE
CLI-294: Add support to ASGI apps that don't support the lifespan protocol

### DIFF
--- a/modal/_runtime/asgi.py
+++ b/modal/_runtime/asgi.py
@@ -76,6 +76,10 @@ class LifespanManager:
                 self.startup.set_exception(ExecutionError("ASGI lifespan task exited startup"))
             if not self.shutdown.done():
                 self.shutdown.set_exception(ExecutionError("ASGI lifespan task exited shutdown"))
+        else:
+            logger.info("ASGI Lifespan protocol is probably not supported by this library")
+            self.startup.set_result(None)
+            self.shutdown.set_result(None)
 
     async def lifespan_startup(self):
         await self.ensure_init()


### PR DESCRIPTION
Adds support for ASGI apps that don't support the lifespan protocol, such as django apps by detecting if there are any exceptions raised before lifespan startup and if so disabling lifespan on the app.