### PR TITLE
[CLI-290] Fix relative mount dedupe

### DIFF
--- a/modal/mount.py
+++ b/modal/mount.py
@@ -131,6 +131,8 @@ class _MountDir(_MountEntry):
         return str(self.local_dir.expanduser().absolute())
 
     def get_files_to_upload(self):
+        # we can't use .resolve() eagerly here since that could end up "renaming" symlinked files
+        # see test_mount_directory_with_symlinked_file
         local_dir = self.local_dir.expanduser().absolute()
 
         if not local_dir.exists():

--- a/test/mounted_files_test.py
+++ b/test/mounted_files_test.py
@@ -254,7 +254,7 @@ def test_mounts_are_not_traversed_on_declaration(test_dir, monkeypatch, client, 
         for fn, _ in r:
             files.add(fn)
     # sanity check - this test file should be included since we mounted the test dir
-    assert __file__ in files  # this test file should have been included
+    assert Path(__file__) in files  # this test file should have been included
 
 
 def test_mount_dedupe(servicer, credentials, test_dir, server_url_env):


### PR DESCRIPTION
Ensure deduplication of mounts when using modal run on a relative parent directory (having `..` in path segments)

Mostly a superficial change as this didn't have real world effects previously, but this will help preventing false positives in warnings when we disable auto mounting.


---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
