### PR TITLE
Move deprecation utilities to private namespace

### DIFF
--- a/modal/_utils/deprecation.py
+++ b/modal/_utils/deprecation.py
@@ -1,0 +1,44 @@
+# Copyright Modal Labs 2024
+import sys
+import warnings
+from datetime import date
+
+from ..exception import DeprecationError, PendingDeprecationError
+
+_INTERNAL_MODULES = ["modal", "synchronicity"]
+
+
+def _is_internal_frame(frame):
+    module = frame.f_globals["__name__"].split(".")[0]
+    return module in _INTERNAL_MODULES
+
+
+def deprecation_error(deprecated_on: tuple[int, int, int], msg: str):
+    raise DeprecationError(f"Deprecated on {date(*deprecated_on)}: {msg}")
+
+
+def deprecation_warning(
+    deprecated_on: tuple[int, int, int], msg: str, *, pending: bool = False, show_source: bool = True
+) -> None:
+    """Issue a Modal deprecation warning with source optionally attributed to user code.
+
+    See the implementation of the built-in [warnings.warn](https://docs.python.org/3/library/warnings.html#available-functions).
+    """
+    filename, lineno = "<unknown>", 0
+    if show_source:
+        # Find the last non-Modal line that triggered the warning
+        try:
+            frame = sys._getframe()
+            while frame is not None and _is_internal_frame(frame):
+                frame = frame.f_back
+            if frame is not None:
+                filename = frame.f_code.co_filename
+                lineno = frame.f_lineno
+        except ValueError:
+            # Use the defaults from above
+            pass
+
+    warning_cls = PendingDeprecationError if pending else DeprecationError
+
+    # This is a lower-level function that warnings.warn uses
+    warnings.warn_explicit(f"{date(*deprecated_on)}: {msg}", warning_cls, filename, lineno)

--- a/modal/app.py
+++ b/modal/app.py
@@ -22,6 +22,7 @@ from modal_proto import api_pb2
 
 from ._ipython import is_notebook
 from ._utils.async_utils import synchronize_api
+from ._utils.deprecation import deprecation_error, deprecation_warning
 from ._utils.function_utils import FunctionInfo, is_global_object, is_method_fn
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.mount_utils import validate_volumes
@@ -29,7 +30,7 @@ from .client import _Client
 from .cloud_bucket_mount import _CloudBucketMount
 from .cls import _Cls, parameter
 from .config import logger
-from .exception import ExecutionError, InvalidError, deprecation_error, deprecation_warning
+from .exception import ExecutionError, InvalidError
 from .functions import Function, _Function
 from .gpu import GPU_T
 from .image import _Image

--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -10,9 +10,9 @@ from rich.text import Text
 from typer import Argument
 
 from modal._utils.async_utils import synchronizer
+from modal._utils.deprecation import deprecation_warning
 from modal.client import _Client
 from modal.environments import ensure_env
-from modal.exception import deprecation_warning
 from modal.object import _get_environment_name
 from modal_proto import api_pb2
 

--- a/modal/config.py
+++ b/modal/config.py
@@ -86,8 +86,9 @@ from google.protobuf.empty_pb2 import Empty
 
 from modal_proto import api_pb2
 
+from ._utils.deprecation import deprecation_error
 from ._utils.logger import configure_logger
-from .exception import InvalidError, deprecation_error
+from .exception import InvalidError
 
 # Locate config file and read it
 

--- a/modal/container_process.py
+++ b/modal/container_process.py
@@ -6,10 +6,11 @@ from typing import Generic, Optional, TypeVar
 from modal_proto import api_pb2
 
 from ._utils.async_utils import TaskContext, synchronize_api
+from ._utils.deprecation import deprecation_error
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.shell_utils import stream_from_stdin, write_to_fd
 from .client import _Client
-from .exception import InteractiveTimeoutError, InvalidError, deprecation_error
+from .exception import InteractiveTimeoutError, InvalidError
 from .io_streams import _StreamReader, _StreamWriter
 from .stream_type import StreamType
 

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -10,11 +10,12 @@ from modal_proto import api_pb2
 from ._resolver import Resolver
 from ._serialization import deserialize, serialize
 from ._utils.async_utils import TaskContext, synchronize_api
+from ._utils.deprecation import deprecation_error
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from .client import _Client
 from .config import logger
-from .exception import RequestSizeError, deprecation_error
+from .exception import RequestSizeError
 from .object import EPHEMERAL_OBJECT_HEARTBEAT_SLEEP, _get_environment_name, _Object, live_method, live_method_gen
 
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -41,6 +41,7 @@ from ._utils.async_utils import (
     synchronizer,
     warn_if_generator_is_not_consumed,
 )
+from ._utils.deprecation import deprecation_warning
 from ._utils.function_utils import (
     ATTEMPT_TIMEOUT_GRACE_PERIOD,
     OUTPUTS_TIMEOUT,
@@ -58,14 +59,7 @@ from .call_graph import InputInfo, _reconstruct_call_graph
 from .client import _Client
 from .cloud_bucket_mount import _CloudBucketMount, cloud_bucket_mounts_to_proto
 from .config import config
-from .exception import (
-    ExecutionError,
-    FunctionTimeoutError,
-    InvalidError,
-    NotFoundError,
-    OutputExpiredError,
-    deprecation_warning,
-)
+from .exception import ExecutionError, FunctionTimeoutError, InvalidError, NotFoundError, OutputExpiredError
 from .gpu import GPU_T, parse_gpu_config
 from .image import _Image
 from .mount import _get_client_mount, _Mount, get_auto_mounts

--- a/modal/image.py
+++ b/modal/image.py
@@ -30,13 +30,14 @@ from ._resolver import Resolver
 from ._serialization import serialize
 from ._utils.async_utils import synchronize_api
 from ._utils.blob_utils import MAX_OBJECT_SIZE_BYTES
+from ._utils.deprecation import deprecation_error, deprecation_warning
 from ._utils.function_utils import FunctionInfo
 from ._utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES, retry_transient_errors
 from .client import _Client
 from .cloud_bucket_mount import _CloudBucketMount
 from .config import config, logger, user_config_path
 from .environments import _get_environment_cached
-from .exception import InvalidError, NotFoundError, RemoteError, VersionError, deprecation_error, deprecation_warning
+from .exception import InvalidError, NotFoundError, RemoteError, VersionError
 from .file_pattern_matcher import FilePatternMatcher
 from .gpu import GPU_T, parse_gpu_config
 from .mount import _Mount, python_standalone_mount_name

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -15,11 +15,12 @@ from modal_proto import api_pb2
 from ._resolver import Resolver
 from ._utils.async_utils import TaskContext, aclosing, async_map, sync_or_async_iter, synchronize_api
 from ._utils.blob_utils import LARGE_FILE_LIMIT, blob_iter, blob_upload_file
+from ._utils.deprecation import deprecation_error
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.hash_utils import get_sha256_hex
 from ._utils.name_utils import check_object_name
 from .client import _Client
-from .exception import InvalidError, deprecation_error
+from .exception import InvalidError
 from .object import (
     EPHEMERAL_OBJECT_HEARTBEAT_SLEEP,
     _get_environment_name,

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -15,9 +15,10 @@ import typing_extensions
 from modal_proto import api_pb2
 
 from ._utils.async_utils import synchronize_api, synchronizer
+from ._utils.deprecation import deprecation_error, deprecation_warning
 from ._utils.function_utils import callable_has_non_self_non_default_params, callable_has_non_self_params
 from .config import logger
-from .exception import InvalidError, deprecation_error, deprecation_warning
+from .exception import InvalidError
 from .functions import _Function
 
 MAX_MAX_BATCH_SIZE = 1000

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -13,10 +13,11 @@ from modal_proto import api_pb2
 from ._resolver import Resolver
 from ._serialization import deserialize, serialize
 from ._utils.async_utils import TaskContext, synchronize_api, warn_if_generator_is_not_consumed
+from ._utils.deprecation import deprecation_error
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from .client import _Client
-from .exception import InvalidError, RequestSizeError, deprecation_error
+from .exception import InvalidError, RequestSizeError
 from .object import EPHEMERAL_OBJECT_HEARTBEAT_SLEEP, _get_environment_name, _Object, live_method, live_method_gen
 
 

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -19,19 +19,14 @@ from ._resolver import Resolver
 from ._runtime.execution_context import is_local
 from ._traceback import print_server_warnings, traceback_contains_remote_call
 from ._utils.async_utils import TaskContext, gather_cancel_on_exc, synchronize_api
+from ._utils.deprecation import deprecation_error
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name, is_valid_tag
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, _Client
 from .cls import _Cls
 from .config import config, logger
 from .environments import _get_environment_cached
-from .exception import (
-    InteractiveTimeoutError,
-    InvalidError,
-    RemoteError,
-    _CliUserExecutionError,
-    deprecation_error,
-)
+from .exception import InteractiveTimeoutError, InvalidError, RemoteError, _CliUserExecutionError
 from .functions import _Function
 from .object import _get_environment_name, _Object
 from .output import _get_output_manager, enable_output

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -19,18 +19,13 @@ from ._location import parse_cloud_provider
 from ._resolver import Resolver
 from ._resources import convert_fn_config_to_resources_config
 from ._utils.async_utils import synchronize_api
+from ._utils.deprecation import deprecation_error
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.mount_utils import validate_network_file_systems, validate_volumes
 from .client import _Client
 from .config import config
 from .container_process import _ContainerProcess
-from .exception import (
-    ExecutionError,
-    InvalidError,
-    SandboxTerminatedError,
-    SandboxTimeoutError,
-    deprecation_error,
-)
+from .exception import ExecutionError, InvalidError, SandboxTerminatedError, SandboxTimeoutError
 from .file_io import _FileIO
 from .gpu import GPU_T
 from .image import _Image

--- a/modal/serving.py
+++ b/modal/serving.py
@@ -11,12 +11,12 @@ from synchronicity.async_wrap import asynccontextmanager
 from modal._output import OutputManager
 
 from ._utils.async_utils import TaskContext, asyncify, synchronize_api, synchronizer
+from ._utils.deprecation import deprecation_error
 from ._utils.logger import logger
 from ._watcher import watch
 from .cli.import_refs import import_app
 from .client import _Client
 from .config import config
-from .exception import deprecation_error
 from .output import _get_output_manager, enable_output
 from .runner import _run_app, serve_update
 

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -24,7 +24,7 @@ from grpclib import GRPCError, Status
 from synchronicity.async_wrap import asynccontextmanager
 
 import modal_proto.api_pb2
-from modal.exception import VolumeUploadTimeoutError, deprecation_error, deprecation_warning
+from modal.exception import VolumeUploadTimeoutError
 from modal_proto import api_pb2
 
 from ._resolver import Resolver
@@ -36,6 +36,7 @@ from ._utils.blob_utils import (
     get_file_upload_spec_from_fileobj,
     get_file_upload_spec_from_path,
 )
+from ._utils.deprecation import deprecation_error, deprecation_warning
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from .client import _Client

--- a/test/supports/functions.py
+++ b/test/supports/functions.py
@@ -18,7 +18,7 @@ from modal import (
     web_endpoint,
     wsgi_app,
 )
-from modal.exception import deprecation_warning
+from modal._utils.deprecation import deprecation_warning
 from modal.experimental import get_local_input_concurrency, set_local_input_concurrency
 
 SLEEP_DELAY = 0.1


### PR DESCRIPTION
Splitting this off from https://github.com/modal-labs/modal-client/pull/2633. We're not very clear about whether functions in nested public modules: we should clean that up.

In particular the exception classes in `modal.exception` _are_ public, but it makes sense not to pull them up into the the top-level namespace, since there's a bunch and referencing them is niche. So it seems particularly important to keep this namespace clean. That said, can't imagine any users are calling these utilities directly.

## Changelog

- The internal `deprecation_error` and `deprecation_warning` utilities have been moved to a private namespace