### PR TITLE
Move publish-client-mount step into client-versioning job to avoid release race

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -62,6 +62,15 @@ jobs:
           pull: "--rebase --autostash"
           default_author: github_actions
 
+      - name: Publish client mount
+        env:
+          MODAL_ENVIRONMENT: main
+          MODAL_LOGLEVEL: DEBUG
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        run: python -m modal_global_objects.mounts.modal_client_package
+
+
   client-test:
     name: Unit tests on ${{ matrix.python-version }} and ${{ matrix.os }} (protobuf=${{ matrix.proto-version }})
     timeout-minutes: 30
@@ -191,14 +200,6 @@ jobs:
 
       - name: Build wheel
         run: python setup.py bdist_wheel
-
-      - name: Publish client mount
-        env:
-          MODAL_ENVIRONMENT: main
-          MODAL_LOGLEVEL: DEBUG
-          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
-          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-        run: python -m modal_global_objects.mounts.modal_client_package
 
       - name: Upload to PyPI
         env:


### PR DESCRIPTION
Fixes a deployment race condition introduced in #2558

We moved the steps that update the client changelog and version to happen immediately on a push to main rather than waiting for CI to complete. This fixed a merge conflict between subsequent deploy pipelines. But it introduced a new issue where apps couldn't run against `main` during the interval where CI was running, since we didn't publish the client mount for the new version until that finished.

This PR publishes the new client mount immediately after we tag it. In theory CI could (legitimately) fail and this could lead to the mount reflecting broken code, but the risk of that affecting users is low so long as we still condition publishing the package to PyPI on CI passing.