### PR TITLE
Adds ignore= argument to Image.add_local_python_source

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -747,10 +747,10 @@ class _Image(_Object, type_prefix="im"):
 
         ```py
         # includes everything except data.json
-        Image.debian_slim().add_local_python_source("mymodule", ignore=["data.json"])
+        modal.Image.debian_slim().add_local_python_source("mymodule", ignore=["data.json"])
 
         # exclude large files
-        Image.debian_slim().add_local_python_source(
+        modal.Image.debian_slim().add_local_python_source(
             "mymodule",
             ignore=lambda p: p.stat().st_size > 1e9
         )

--- a/modal/image.py
+++ b/modal/image.py
@@ -38,7 +38,7 @@ from .cloud_bucket_mount import _CloudBucketMount
 from .config import config, logger, user_config_path
 from .environments import _get_environment_cached
 from .exception import InvalidError, NotFoundError, RemoteError, VersionError
-from .file_pattern_matcher import FilePatternMatcher
+from .file_pattern_matcher import NON_PYTHON_FILES
 from .gpu import GPU_T, parse_gpu_config
 from .mount import _Mount, python_standalone_mount_name
 from .network_file_system import _NetworkFileSystem
@@ -721,7 +721,9 @@ class _Image(_Object, type_prefix="im"):
             context_mount=mount,
         )
 
-    def add_local_python_source(self, *modules: str, copy: bool = False) -> "_Image":
+    def add_local_python_source(
+        self, *modules: str, copy: bool = False, ignore: Union[Sequence[str], Callable[[Path], bool]] = NON_PYTHON_FILES
+    ) -> "_Image":
         """Adds locally available Python packages/modules to containers
 
         Adds all files from the specified Python package or module to containers running the Image.
@@ -739,9 +741,22 @@ class _Image(_Object, type_prefix="im"):
         **Note:** This excludes all dot-prefixed subdirectories or files and all `.pyc`/`__pycache__` files.
         To add full directories with finer control, use `.add_local_dir()` instead and specify `/root` as
         the destination directory.
-        """
 
-        mount = _Mount.from_local_python_packages(*modules, ignore=~FilePatternMatcher("**/*.py"))
+        By default only includes `.py`-files in the source modules. Set the `ignore` argument to a list of patterns
+        or a callable to override this behavior, e.g.:
+
+        ```py
+        # includes everything except data.json
+        Image.debian_slim().add_local_python_source("mymodule", ignore=["data.json"])
+
+        # exclude large files
+        Image.debian_slim().add_local_python_source(
+            "mymodule",
+            ignore=lambda p: p.stat().st_size > 1e9
+        )
+        ```
+        """
+        mount = _Mount.from_local_python_packages(*modules, ignore=ignore)
         return self._add_mount_layer_or_copy(mount, copy=copy)
 
     def copy_local_dir(


### PR DESCRIPTION
Minor missing thing to completely be able to replace Mount.from_local_python_packages

Also refactors pattern matchers a bit to allow custom reprs on patterns, allowing them to be used as default arguments to functions

## Describe your changes

- _Provide Linear issue reference (e.g. MOD-1234) if available._

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
