### PR TITLE
Adds pending deprecations for Mount.from_* methods

### DIFF
--- a/modal/_utils/function_utils.py
+++ b/modal/_utils/function_utils.py
@@ -311,7 +311,7 @@ class FunctionInfo:
         # make sure the function's own entrypoint is included:
         if self._type == FunctionInfoType.PACKAGE:
             if config.get("automount"):
-                return [_Mount.from_local_python_packages(self.module_name)]
+                return [_Mount._from_local_python_packages(self.module_name)]
             elif self.definition_type == api_pb2.Function.DEFINITION_TYPE_FILE:
                 # mount only relevant file and __init__.py:s
                 return [

--- a/modal/app.py
+++ b/modal/app.py
@@ -200,10 +200,9 @@ class _App:
 
         ```python notest
         image = modal.Image.debian_slim().pip_install(...)
-        mount = modal.Mount.from_local_dir("./config")
         secret = modal.Secret.from_name("my-secret")
         volume = modal.Volume.from_name("my-data")
-        app = modal.App(image=image, mounts=[mount], secrets=[secret], volumes={"/mnt/data": volume})
+        app = modal.App(image=image, secrets=[secret], volumes={"/mnt/data": volume})
         ```
         """
         if name is not None and not isinstance(name, str):

--- a/modal/image.py
+++ b/modal/image.py
@@ -741,7 +741,7 @@ class _Image(_Object, type_prefix="im"):
         the destination directory.
         """
 
-        mount = _Mount.from_local_python_packages(*modules, ignore=~FilePatternMatcher("**/*.py"))
+        mount = _Mount._from_local_python_packages(*modules, ignore=~FilePatternMatcher("**/*.py"))
         return self._add_mount_layer_or_copy(mount, copy=copy)
 
     def copy_local_dir(


### PR DESCRIPTION
Will nudge users toward new replacements ahead of real deprecation with client 1.0

## Describe your changes

- _Provide Linear issue reference (e.g. MOD-1234) if available._

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
