### PR TITLE
Instal the client before publishing the client mount

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -62,6 +62,9 @@ jobs:
           pull: "--rebase --autostash"
           default_author: github_actions
 
+      - name: Install the client
+        run: pip install .
+
       - name: Publish client mount
         env:
           MODAL_ENVIRONMENT: main


### PR DESCRIPTION
Follow-up to #2678

We need to install the client to run the mount publishing steps.