### PR TITLE
Check out the upstream release tag to publish base images

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -230,6 +230,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: v${{ needs.client-versioning.outputs.client-version}}
 
       - uses: ./.github/actions/setup-cached-python
         with:


### PR DESCRIPTION
Fixes the `publish-base-images` CD step after #2679, although I don't think that PR broke this, rather it revealed that it was already broken.

This step was checking out the "wrong" commit (i.e. the commit that kicked off the CD pipeline, not the commit made in upstream job to increment the version). That meant we were always publishing the base images for one version behind what we intended to.

It emerged as an issue because #2679 had a few issues that needed followup PRs and we had a couple deployments where we incremented the version but failed to publish the mount.

This stuff is all hard to reason about and impossible to really test so hopefully this is correct now!