### PR TITLE
Add helper function for indicating when parameters have been renamed

### DIFF
--- a/modal/_traceback.py
+++ b/modal/_traceback.py
@@ -74,11 +74,15 @@ def append_modal_tb(exc: BaseException, tb_dict: TBDictType, line_cache: LineCac
 
 def reduce_traceback_to_user_code(tb: Optional[TracebackType], user_source: str) -> TracebackType:
     """Return a traceback that does not contain modal entrypoint or synchronicity frames."""
-    # Step forward all the way through the traceback and drop any synchronicity frames
+
+    # Step forward all the way through the traceback and drop any "Modal support" frames
+    def skip_frame(filename: str) -> bool:
+        return "/site-packages/synchronicity/" in filename or "modal/_utils/deprecation" in filename
+
     tb_root = tb
     while tb is not None:
         while tb.tb_next is not None:
-            if "/site-packages/synchronicity/" in tb.tb_next.tb_frame.f_code.co_filename:
+            if skip_frame(tb.tb_next.tb_frame.f_code.co_filename):
                 tb.tb_next = tb.tb_next.tb_next
             else:
                 break

--- a/modal/_utils/deprecation.py
+++ b/modal/_utils/deprecation.py
@@ -3,7 +3,9 @@ import functools
 import sys
 import warnings
 from datetime import date
-from typing import Any, Callable, ParamSpec, TypeVar
+from typing import Any, Callable, TypeVar
+
+from typing_extensions import ParamSpec  # Needed for Python 3.9
 
 from ..exception import DeprecationError, PendingDeprecationError
 

--- a/modal/_utils/deprecation.py
+++ b/modal/_utils/deprecation.py
@@ -57,15 +57,15 @@ def renamed_parameter(
     old_name: str,
     new_name: str,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
-    """Decorator for semi-gracefully renaming a parameter name.
+    """Decorator for semi-gracefully changing a parameter name.
 
     Functions wrapped with this decorator can be defined using only the `new_name` of the parameter.
-    If the function is invoked with the `old_name`, the wrapper will pass the argument as a keyword
-    argument for `old_name` and issue a Modal deprecation warning about the change.
+    If the function is invoked with the `old_name`, the wrapper will pass the value as a keyword
+    argument for `new_name` and issue a Modal deprecation warning about the change.
 
     Note that this only prevents parameter renamings from breaking code at runtime.
-    Type checking code that uses `old_name` will still fail. To avoid this, the `old_name`
-    can be preserved to the function signature with an `Annotated` type hint indicating the renaming.
+    Type checking will fail when code uses `old_name`. To avoid this, the `old_name` can be
+    preserved in the function signature with an `Annotated` type hint indicating the renaming.
     """
 
     def decorator(func: Callable[P, R]) -> Callable[P, R]:

--- a/modal/_utils/deprecation.py
+++ b/modal/_utils/deprecation.py
@@ -55,6 +55,17 @@ def renamed_parameter(
     old_name: str,
     new_name: str,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    """Decorator for semi-gracefully renaming a parameter name.
+
+    Functions wrapped with this decorator can be defined using only the `new_name` of the parameter.
+    If the function is invoked with the `old_name`, the wrapper will pass the argument as a keyword
+    argument for `old_name` and issue a Modal deprecation warning about the change.
+
+    Note that this only prevents parameter renamings from breaking code at runtime.
+    Type checking code that uses `old_name` will still fail. To avoid this, the `old_name`
+    can be preserved to the function signature with an `Annotated` type hint indicating the renaming.
+    """
+
     def decorator(func: Callable[P, R]) -> Callable[P, R]:
         @functools.wraps(func)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     grpclib==0.4.7
     protobuf>=3.19,<6.0,!=4.24.0
     rich>=12.0.0
-    synchronicity~=0.9.6
+    synchronicity~=0.9.7
     toml
     typer>=0.9
     types-certifi

--- a/tasks.py
+++ b/tasks.py
@@ -385,26 +385,40 @@ def show_deprecations(ctx):
             func_name_to_level = {
                 "deprecation_warning": "[yellow]warning[/yellow]",
                 "deprecation_error": "[red]error[/red]",
+                # We may add a flag to make renamed_parameter error instead of warn
+                # in which case this would get a little bit more complicated.
+                "renamed_parameter": "[yellow]warning[/yellow]",
             }
-            if isinstance(node.func, ast.Name) and node.func.id in func_name_to_level:
+            if (
+                isinstance(node.func, ast.Name)
+                and node.func.id in func_name_to_level
+                and isinstance(node.args[0], ast.Tuple)
+            ):
+                print(node.func.id, dir(node.args[0].elts[0]))
                 depr_date = date(*(elt.n for elt in node.args[0].elts))
                 function = (
                     f"{self.current_class}.{self.current_function}" if self.current_class else self.current_function
                 )
-                message = node.args[1]
-                if isinstance(message, ast.Name):
-                    message = self.assignments.get(message.id, "")
-                if isinstance(message, ast.Attribute):
-                    message = self.assignments.get(message.attr, "")
-                if isinstance(message, ast.Constant):
-                    message = message.s
-                elif isinstance(message, ast.JoinedStr):
-                    message = "".join(v.s for v in message.values if isinstance(v, ast.Constant))
+                if node.func.id == "renamed_parameter":
+                    message = f"Renamed parameter: {node.args[1].s} -> {node.args[2].s}"
                 else:
-                    message = str(message)
-                message = message.replace("\n", " ")
-                if len(message) > (max_length := 80):
-                    message = message[:max_length] + "..."
+                    message = node.args[1]
+                    # Handle a few different ways that the message can get passed to the deprecation helper
+                    # since it's not always a literal string (e.g. it's often a functions .__doc__ attribute)
+                    if isinstance(message, ast.Name):
+                        message = self.assignments.get(message.id, "")
+                    if isinstance(message, ast.Attribute):
+                        message = self.assignments.get(message.attr, "")
+                    if isinstance(message, ast.Constant):
+                        message = message.s
+                    elif isinstance(message, ast.JoinedStr):
+                        message = "".join(v.s for v in message.values if isinstance(v, ast.Constant))
+                    else:
+                        message = str(message)
+                    message = message.replace("\n", " ")
+                    if len(message) > (max_length := 80):
+                        message = message[:max_length] + "..."
+
                 level = func_name_to_level[node.func.id]
                 self.deprecations.append((str(depr_date), level, f"{self.fname}:{node.lineno}", function, message))
 

--- a/tasks.py
+++ b/tasks.py
@@ -394,13 +394,14 @@ def show_deprecations(ctx):
                 and node.func.id in func_name_to_level
                 and isinstance(node.args[0], ast.Tuple)
             ):
-                print(node.func.id, dir(node.args[0].elts[0]))
-                depr_date = date(*(elt.n for elt in node.args[0].elts))
+                depr_date = date(*(getattr(elt, "n") for elt in node.args[0].elts))
                 function = (
                     f"{self.current_class}.{self.current_function}" if self.current_class else self.current_function
                 )
                 if node.func.id == "renamed_parameter":
-                    message = f"Renamed parameter: {node.args[1].s} -> {node.args[2].s}"
+                    old_name = getattr(node.args[1], "s")
+                    new_name = getattr(node.args[2], "s")
+                    message = f"Renamed parameter: {old_name} -> {new_name}"
                 else:
                     message = node.args[1]
                     # Handle a few different ways that the message can get passed to the deprecation helper

--- a/test/deprecation_test.py
+++ b/test/deprecation_test.py
@@ -1,6 +1,8 @@
 # Copyright Modal Labs 2022
+import inspect
 import pytest
 
+from modal._utils.deprecation import renamed_parameter
 from modal.exception import DeprecationError
 
 from .supports.functions import deprecated_function
@@ -32,3 +34,21 @@ def test_deprecation():
     from .supports import functions
 
     assert record[0].filename == functions.__file__
+
+
+@renamed_parameter((2024, 12, 1), "bar", "foo")
+def my_func(bar: int) -> int:
+    return bar**2
+
+
+def test_renamed_parameter():
+    message = "The 'foo' parameter .+ has been renamed to 'bar'"
+    with pytest.warns(DeprecationError, match=message):
+        res = my_func(foo=2)  # type: ignore
+        assert res == 4
+    assert my_func(bar=3) == 9
+    assert my_func(4) == 16
+
+    sig = inspect.signature(my_func)
+    assert "bar" in sig.parameters
+    assert "foo" not in sig.parameters

--- a/test/deprecation_test.py
+++ b/test/deprecation_test.py
@@ -36,7 +36,7 @@ def test_deprecation():
     assert record[0].filename == functions.__file__
 
 
-@renamed_parameter((2024, 12, 1), "bar", "foo")
+@renamed_parameter((2024, 12, 1), "foo", "bar")
 def my_func(bar: int) -> int:
     return bar**2
 


### PR DESCRIPTION
Revives the `renamed_parameter` decorator from #2633.

This decorator can be used to simplify the process of renaming a function parameter

```python
@renamed_parameter((2024, 12, 18), "use_ml", "use_ai")
def do_data_science(input: np.ndarray, use_ai: bool) -> float:
    ...
```

At runtime, any invocations that use the old name of the parameter will continue to work, issuing a deprecation warning with a helpful migration error.

Note that this doesn't support graceful migrations for static analysis: type checking code that uses `old_name` as a keyword will fail. In some cases this can be supported by adding the `old_name` as an additional parameter, ideally with an annotated type hint indicating the deprecation.

Note that we exclude this wrapper from tracebacks that originate from within Modal.