### PR TITLE
Fix sandbox proxy & add to shell

### DIFF
--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -482,6 +482,7 @@ def shell(
             volumes=function_spec.volumes,
             region=function_spec.scheduler_placement.proto.regions if function_spec.scheduler_placement else None,
             pty=pty,
+            proxy=function_spec.proxy,
         )
     else:
         modal_image = Image.from_registry(image, add_python=add_python) if image else None

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -346,6 +346,7 @@ class _FunctionSpec:
     memory: Optional[Union[int, tuple[int, int]]]
     ephemeral_disk: Optional[int]
     scheduler_placement: Optional[SchedulerPlacement]
+    proxy: Optional[_Proxy]
 
 
 P = typing_extensions.ParamSpec("P")
@@ -530,6 +531,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
             memory=memory,
             ephemeral_disk=ephemeral_disk,
             scheduler_placement=scheduler_placement,
+            proxy=proxy,
         )
 
         if info.user_cls and not is_auto_snapshot:

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -118,6 +118,8 @@ class _Sandbox(_Object, type_prefix="sb"):
             for _, cloud_bucket_mount in cloud_bucket_mounts:
                 if cloud_bucket_mount.secret:
                     deps.append(cloud_bucket_mount.secret)
+            if proxy:
+                deps.append(proxy)
             return deps
 
         async def _load(self: _Sandbox, resolver: Resolver, _existing_object_id: Optional[str]):

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -6,7 +6,7 @@ import pytest
 import time
 from pathlib import Path
 
-from modal import App, Image, Mount, NetworkFileSystem, Sandbox, Secret
+from modal import App, Image, Mount, NetworkFileSystem, Proxy, Sandbox, Secret
 from modal.exception import DeprecationError, InvalidError
 from modal.stream_type import StreamType
 from modal_proto import api_pb2
@@ -429,3 +429,10 @@ def test_sandbox_cpu_limit(app, servicer):
 
     assert servicer.sandbox_defs[0].resources.milli_cpu == 2000
     assert servicer.sandbox_defs[0].resources.milli_cpu_max == 4000
+
+
+@skip_non_linux
+def test_sandbox_proxy(app, servicer):
+    _ = Sandbox.create(proxy=Proxy.from_name("my-proxy"), app=app)
+
+    assert servicer.sandbox_defs[0].proxy_id == "pr-123"


### PR DESCRIPTION
Was propagating `proxy` info from the function spec to `modal shell`, and then realized proxies never worked with sandboxes. Fixing that here.

(edit: they worked sometimes if the `Proxy` object was resolved separately via an `app.run()`)

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
