### PR TITLE
Rename 'label' and 'tag' to 'name' in from_name/lookup/delete methods

### DIFF
--- a/modal/_utils/deprecation.py
+++ b/modal/_utils/deprecation.py
@@ -56,6 +56,7 @@ def renamed_parameter(
     date: tuple[int, int, int],
     old_name: str,
     new_name: str,
+    show_source: bool = True,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """Decorator for semi-gracefully changing a parameter name.
 
@@ -79,7 +80,7 @@ def renamed_parameter(
                     f"The '{old_name}' parameter of `{func_name}` has been renamed to '{new_name}'."
                     "\nUsing the old name will become an error in a future release. Please update your code."
                 )
-                deprecation_warning(date, message, show_source=False)
+                deprecation_warning(date, message, show_source=show_source)
 
             return func(*args, **kwargs)
 

--- a/modal/app.py
+++ b/modal/app.py
@@ -22,7 +22,7 @@ from modal_proto import api_pb2
 
 from ._ipython import is_notebook
 from ._utils.async_utils import synchronize_api
-from ._utils.deprecation import deprecation_error, deprecation_warning
+from ._utils.deprecation import deprecation_error, deprecation_warning, renamed_parameter
 from ._utils.function_utils import FunctionInfo, is_global_object, is_method_fn
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.mount_utils import validate_volumes
@@ -260,8 +260,9 @@ class _App:
         return self._description
 
     @staticmethod
+    @renamed_parameter((2024, 12, 18), "label", "name")
     async def lookup(
-        label: str,
+        name: str,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
@@ -283,14 +284,14 @@ class _App:
         environment_name = _get_environment_name(environment_name)
 
         request = api_pb2.AppGetOrCreateRequest(
-            app_name=label,
+            app_name=name,
             environment_name=environment_name,
             object_creation_type=(api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING if create_if_missing else None),
         )
 
         response = await retry_transient_errors(client.stub.AppGetOrCreate, request)
 
-        app = _App(label)
+        app = _App(name)
         app._app_id = response.app_id
         app._client = client
         app._running_app = RunningApp(

--- a/modal/cli/network_file_system.py
+++ b/modal/cli/network_file_system.py
@@ -237,4 +237,4 @@ async def delete(
             abort=True,
         )
 
-    await _NetworkFileSystem.delete(label=nfs_name, environment_name=env)
+    await _NetworkFileSystem.delete(nfs_name, environment_name=env)

--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -286,4 +286,4 @@ async def delete(
             abort=True,
         )
 
-    await _Volume.delete(label=volume_name, environment_name=env)
+    await _Volume.delete(volume_name, environment_name=env)

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -10,7 +10,7 @@ from modal_proto import api_pb2
 from ._resolver import Resolver
 from ._serialization import deserialize, serialize
 from ._utils.async_utils import TaskContext, synchronize_api
-from ._utils.deprecation import deprecation_error
+from ._utils.deprecation import deprecation_error, renamed_parameter
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from .client import _Client
@@ -112,8 +112,9 @@ class _Dict(_Object, type_prefix="di"):
             yield cls._new_hydrated(response.dict_id, client, None, is_another_app=True)
 
     @staticmethod
+    @renamed_parameter((2024, 12, 18), "label", "name")
     def from_name(
-        label: str,
+        name: str,
         data: Optional[dict] = None,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
@@ -130,12 +131,12 @@ class _Dict(_Object, type_prefix="di"):
         d[123] = 456
         ```
         """
-        check_object_name(label, "Dict")
+        check_object_name(name, "Dict")
 
         async def _load(self: _Dict, resolver: Resolver, existing_object_id: Optional[str]):
             serialized = _serialize_dict(data if data is not None else {})
             req = api_pb2.DictGetOrCreateRequest(
-                deployment_name=label,
+                deployment_name=name,
                 namespace=namespace,
                 environment_name=_get_environment_name(environment_name, resolver),
                 object_creation_type=(api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING if create_if_missing else None),
@@ -148,8 +149,9 @@ class _Dict(_Object, type_prefix="di"):
         return _Dict._from_loader(_load, "Dict()", is_another_app=True, hydrate_lazily=True)
 
     @staticmethod
+    @renamed_parameter((2024, 12, 18), "label", "name")
     async def lookup(
-        label: str,
+        name: str,
         data: Optional[dict] = None,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         client: Optional[_Client] = None,
@@ -167,7 +169,7 @@ class _Dict(_Object, type_prefix="di"):
         ```
         """
         obj = _Dict.from_name(
-            label,
+            name,
             data=data,
             namespace=namespace,
             environment_name=environment_name,
@@ -180,13 +182,14 @@ class _Dict(_Object, type_prefix="di"):
         return obj
 
     @staticmethod
+    @renamed_parameter((2024, 12, 18), "label", "name")
     async def delete(
-        label: str,
+        name: str,
         *,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
     ):
-        obj = await _Dict.lookup(label, client=client, environment_name=environment_name)
+        obj = await _Dict.lookup(name, client=client, environment_name=environment_name)
         req = api_pb2.DictDeleteRequest(dict_id=obj.object_id)
         await retry_transient_errors(obj._client.stub.DictDelete, req)
 

--- a/modal/environments.py
+++ b/modal/environments.py
@@ -10,6 +10,7 @@ from modal_proto import api_pb2
 
 from ._resolver import Resolver
 from ._utils.async_utils import synchronize_api, synchronizer
+from ._utils.deprecation import renamed_parameter
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from .client import _Client
@@ -52,21 +53,22 @@ class _Environment(_Object, type_prefix="en"):
         )
 
     @staticmethod
+    @renamed_parameter((2024, 12, 18), "label", "name")
     async def from_name(
-        label: str,
+        name: str,
         create_if_missing: bool = False,
     ):
-        if label:
-            # Allow null labels for the case where we want to look up the "default" environment,
+        if name:
+            # Allow null names for the case where we want to look up the "default" environment,
             # which is defined by the server. It feels messy to have "from_name" without a name, though?
             # We're adding this mostly for internal use right now. We could consider an environment-only
             # alternate constructor, like `Environment.get_default`, rather than exposing "unnamed"
             # environments as part of public API when we make this class more useful.
-            check_object_name(label, "Environment")
+            check_object_name(name, "Environment")
 
         async def _load(self: _Environment, resolver: Resolver, existing_object_id: Optional[str]):
             request = api_pb2.EnvironmentGetOrCreateRequest(
-                deployment_name=label,
+                deployment_name=name,
                 object_creation_type=(
                     api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING
                     if create_if_missing
@@ -81,12 +83,13 @@ class _Environment(_Object, type_prefix="en"):
         return _Environment._from_loader(_load, "Environment()", is_another_app=True, hydrate_lazily=True)
 
     @staticmethod
+    @renamed_parameter((2024, 12, 18), "label", "name")
     async def lookup(
-        label: str,
+        name: str,
         client: Optional[_Client] = None,
         create_if_missing: bool = False,
     ):
-        obj = await _Environment.from_name(label, create_if_missing=create_if_missing)
+        obj = await _Environment.from_name(name, create_if_missing=create_if_missing)
         if client is None:
             client = await _Client.from_env()
         resolver = Resolver(client=client)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -22,7 +22,6 @@ from grpclib import GRPCError, Status
 from synchronicity.combined_types import MethodWithAio
 from synchronicity.exceptions import UserCodeException
 
-from modal._utils.async_utils import aclosing
 from modal_proto import api_pb2
 from modal_proto.modal_api_grpc import ModalClientModal
 
@@ -35,13 +34,14 @@ from ._serialization import serialize, serialize_proto_params
 from ._traceback import print_server_warnings
 from ._utils.async_utils import (
     TaskContext,
+    aclosing,
     async_merge,
     callable_to_agen,
     synchronize_api,
     synchronizer,
     warn_if_generator_is_not_consumed,
 )
-from ._utils.deprecation import deprecation_warning
+from ._utils.deprecation import deprecation_warning, renamed_parameter
 from ._utils.function_utils import (
     ATTEMPT_TIMEOUT_GRACE_PERIOD,
     OUTPUTS_TIMEOUT,
@@ -1024,10 +1024,11 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         await retry_transient_errors(self._client.stub.FunctionUpdateSchedulingParams, request)
 
     @classmethod
+    @renamed_parameter((2024, 12, 18), "tag", "name")
     def from_name(
         cls: type["_Function"],
         app_name: str,
-        tag: str,
+        name: str,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
     ) -> "_Function":
@@ -1046,7 +1047,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
             assert resolver.client and resolver.client.stub
             request = api_pb2.FunctionGetRequest(
                 app_name=app_name,
-                object_tag=tag,
+                object_tag=name,
                 namespace=namespace,
                 environment_name=_get_environment_name(environment_name, resolver) or "",
             )
@@ -1066,9 +1067,10 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         return cls._from_loader(_load_remote, rep, is_another_app=True, hydrate_lazily=True)
 
     @staticmethod
+    @renamed_parameter((2024, 12, 18), "tag", "name")
     async def lookup(
         app_name: str,
-        tag: str,
+        name: str,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
@@ -1082,7 +1084,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         f = modal.Function.lookup("other-app", "function")
         ```
         """
-        obj = _Function.from_name(app_name, tag, namespace=namespace, environment_name=environment_name)
+        obj = _Function.from_name(app_name, name, namespace=namespace, environment_name=environment_name)
         if client is None:
             client = await _Client.from_env()
         resolver = Resolver(client=client)

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -22,6 +22,7 @@ from modal_version import __version__
 from ._resolver import Resolver
 from ._utils.async_utils import aclosing, async_map, synchronize_api
 from ._utils.blob_utils import FileUploadSpec, blob_upload_file, get_file_upload_spec_from_path
+from ._utils.deprecation import renamed_parameter
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from ._utils.package_utils import get_module_mount_info
@@ -623,8 +624,9 @@ class _Mount(_Object, type_prefix="mo"):
         return mount
 
     @staticmethod
+    @renamed_parameter((2024, 12, 18), "label", "name")
     def from_name(
-        label: str,
+        name: str,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
     ) -> "_Mount":
@@ -632,7 +634,7 @@ class _Mount(_Object, type_prefix="mo"):
 
         async def _load(provider: _Mount, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.MountGetOrCreateRequest(
-                deployment_name=label,
+                deployment_name=name,
                 namespace=namespace,
                 environment_name=_get_environment_name(environment_name, resolver),
             )
@@ -642,15 +644,16 @@ class _Mount(_Object, type_prefix="mo"):
         return _Mount._from_loader(_load, "Mount()")
 
     @classmethod
+    @renamed_parameter((2024, 12, 18), "label", "name")
     async def lookup(
         cls: type["_Mount"],
-        label: str,
+        name: str,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
     ) -> "_Mount":
         """mdmd:hidden"""
-        obj = _Mount.from_name(label, namespace=namespace, environment_name=environment_name)
+        obj = _Mount.from_name(name, namespace=namespace, environment_name=environment_name)
         if client is None:
             client = await _Client.from_env()
         resolver = Resolver(client=client)

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -15,7 +15,7 @@ from modal_proto import api_pb2
 from ._resolver import Resolver
 from ._utils.async_utils import TaskContext, aclosing, async_map, sync_or_async_iter, synchronize_api
 from ._utils.blob_utils import LARGE_FILE_LIMIT, blob_iter, blob_upload_file
-from ._utils.deprecation import deprecation_error
+from ._utils.deprecation import deprecation_error, renamed_parameter
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.hash_utils import get_sha256_hex
 from ._utils.name_utils import check_object_name
@@ -101,8 +101,9 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         deprecation_error((2024, 3, 20), message)
 
     @staticmethod
+    @renamed_parameter((2024, 12, 18), "label", "name")
     def from_name(
-        label: str,
+        name: str,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
@@ -121,11 +122,11 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
             pass
         ```
         """
-        check_object_name(label, "NetworkFileSystem")
+        check_object_name(name, "NetworkFileSystem")
 
         async def _load(self: _NetworkFileSystem, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.SharedVolumeGetOrCreateRequest(
-                deployment_name=label,
+                deployment_name=name,
                 namespace=namespace,
                 environment_name=_get_environment_name(environment_name, resolver),
                 object_creation_type=(api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING if create_if_missing else None),
@@ -136,7 +137,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
             except GRPCError as exc:
                 if exc.status == Status.NOT_FOUND and exc.message == "App has wrong entity vo":
                     raise InvalidError(
-                        f"Attempted to mount: `{label}` as a NetworkFileSystem " + "which already exists as a Volume"
+                        f"Attempted to mount: `{name}` as a NetworkFileSystem " + "which already exists as a Volume"
                     )
                 raise
 
@@ -176,8 +177,9 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
             yield cls._new_hydrated(response.shared_volume_id, client, None, is_another_app=True)
 
     @staticmethod
+    @renamed_parameter((2024, 12, 18), "label", "name")
     async def lookup(
-        label: str,
+        name: str,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
@@ -194,7 +196,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         ```
         """
         obj = _NetworkFileSystem.from_name(
-            label, namespace=namespace, environment_name=environment_name, create_if_missing=create_if_missing
+            name, namespace=namespace, environment_name=environment_name, create_if_missing=create_if_missing
         )
         if client is None:
             client = await _Client.from_env()
@@ -223,8 +225,9 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         return resp.shared_volume_id
 
     @staticmethod
-    async def delete(label: str, client: Optional[_Client] = None, environment_name: Optional[str] = None):
-        obj = await _NetworkFileSystem.lookup(label, client=client, environment_name=environment_name)
+    @renamed_parameter((2024, 12, 18), "label", "name")
+    async def delete(name: str, client: Optional[_Client] = None, environment_name: Optional[str] = None):
+        obj = await _NetworkFileSystem.lookup(name, client=client, environment_name=environment_name)
         req = api_pb2.SharedVolumeDeleteRequest(shared_volume_id=obj.object_id)
         await retry_transient_errors(obj._client.stub.SharedVolumeDelete, req)
 

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -13,7 +13,7 @@ from modal_proto import api_pb2
 from ._resolver import Resolver
 from ._serialization import deserialize, serialize
 from ._utils.async_utils import TaskContext, synchronize_api, warn_if_generator_is_not_consumed
-from ._utils.deprecation import deprecation_error
+from ._utils.deprecation import deprecation_error, renamed_parameter
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from .client import _Client
@@ -154,8 +154,9 @@ class _Queue(_Object, type_prefix="qu"):
             yield cls._new_hydrated(response.queue_id, client, None, is_another_app=True)
 
     @staticmethod
+    @renamed_parameter((2024, 12, 18), "label", "name")
     def from_name(
-        label: str,
+        name: str,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
@@ -171,11 +172,11 @@ class _Queue(_Object, type_prefix="qu"):
         q.put(123)
         ```
         """
-        check_object_name(label, "Queue")
+        check_object_name(name, "Queue")
 
         async def _load(self: _Queue, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.QueueGetOrCreateRequest(
-                deployment_name=label,
+                deployment_name=name,
                 namespace=namespace,
                 environment_name=_get_environment_name(environment_name, resolver),
                 object_creation_type=(api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING if create_if_missing else None),
@@ -186,8 +187,9 @@ class _Queue(_Object, type_prefix="qu"):
         return _Queue._from_loader(_load, "Queue()", is_another_app=True, hydrate_lazily=True)
 
     @staticmethod
+    @renamed_parameter((2024, 12, 18), "label", "name")
     async def lookup(
-        label: str,
+        name: str,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
@@ -204,7 +206,7 @@ class _Queue(_Object, type_prefix="qu"):
         ```
         """
         obj = _Queue.from_name(
-            label, namespace=namespace, environment_name=environment_name, create_if_missing=create_if_missing
+            name, namespace=namespace, environment_name=environment_name, create_if_missing=create_if_missing
         )
         if client is None:
             client = await _Client.from_env()
@@ -213,8 +215,9 @@ class _Queue(_Object, type_prefix="qu"):
         return obj
 
     @staticmethod
-    async def delete(label: str, *, client: Optional[_Client] = None, environment_name: Optional[str] = None):
-        obj = await _Queue.lookup(label, client=client, environment_name=environment_name)
+    @renamed_parameter((2024, 12, 18), "label", "name")
+    async def delete(name: str, *, client: Optional[_Client] = None, environment_name: Optional[str] = None):
+        obj = await _Queue.lookup(name, client=client, environment_name=environment_name)
         req = api_pb2.QueueDeleteRequest(queue_id=obj.object_id)
         await retry_transient_errors(obj._client.stub.QueueDelete, req)
 

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -9,6 +9,7 @@ from modal_proto import api_pb2
 from ._resolver import Resolver
 from ._runtime.execution_context import is_local
 from ._utils.async_utils import synchronize_api
+from ._utils.deprecation import renamed_parameter
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from .client import _Client
@@ -161,8 +162,9 @@ class _Secret(_Object, type_prefix="st"):
         return _Secret._from_loader(_load, "Secret.from_dotenv()", hydrate_lazily=True)
 
     @staticmethod
+    @renamed_parameter((2024, 12, 18), "label", "name")
     def from_name(
-        label: str,  # Some global identifier, such as "aws-secret"
+        name: str,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
         required_keys: list[
@@ -186,7 +188,7 @@ class _Secret(_Object, type_prefix="st"):
 
         async def _load(self: _Secret, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.SecretGetOrCreateRequest(
-                deployment_name=label,
+                deployment_name=name,
                 namespace=namespace,
                 environment_name=_get_environment_name(environment_name, resolver),
                 required_keys=required_keys,
@@ -203,8 +205,9 @@ class _Secret(_Object, type_prefix="st"):
         return _Secret._from_loader(_load, "Secret()", hydrate_lazily=True)
 
     @staticmethod
+    @renamed_parameter((2024, 12, 18), "label", "name")
     async def lookup(
-        label: str,
+        name: str,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
@@ -212,7 +215,7 @@ class _Secret(_Object, type_prefix="st"):
     ) -> "_Secret":
         """mdmd:hidden"""
         obj = _Secret.from_name(
-            label, namespace=namespace, environment_name=environment_name, required_keys=required_keys
+            name, namespace=namespace, environment_name=environment_name, required_keys=required_keys
         )
         if client is None:
             client = await _Client.from_env()

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -36,7 +36,7 @@ from ._utils.blob_utils import (
     get_file_upload_spec_from_fileobj,
     get_file_upload_spec_from_path,
 )
-from ._utils.deprecation import deprecation_error, deprecation_warning
+from ._utils.deprecation import deprecation_error, deprecation_warning, renamed_parameter
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from .client import _Client
@@ -144,8 +144,9 @@ class _Volume(_Object, type_prefix="vo"):
         deprecation_error((2024, 3, 20), message)
 
     @staticmethod
+    @renamed_parameter((2024, 12, 18), "label", "name")
     def from_name(
-        label: str,
+        name: str,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
@@ -168,11 +169,11 @@ class _Volume(_Object, type_prefix="vo"):
             pass
         ```
         """
-        check_object_name(label, "Volume")
+        check_object_name(name, "Volume")
 
         async def _load(self: _Volume, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.VolumeGetOrCreateRequest(
-                deployment_name=label,
+                deployment_name=name,
                 namespace=namespace,
                 environment_name=_get_environment_name(environment_name, resolver),
                 object_creation_type=(api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING if create_if_missing else None),
@@ -220,8 +221,9 @@ class _Volume(_Object, type_prefix="vo"):
             yield cls._new_hydrated(response.volume_id, client, None, is_another_app=True)
 
     @staticmethod
+    @renamed_parameter((2024, 12, 18), "label", "name")
     async def lookup(
-        label: str,
+        name: str,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
@@ -239,7 +241,7 @@ class _Volume(_Object, type_prefix="vo"):
         ```
         """
         obj = _Volume.from_name(
-            label,
+            name,
             namespace=namespace,
             environment_name=environment_name,
             create_if_missing=create_if_missing,
@@ -507,8 +509,9 @@ class _Volume(_Object, type_prefix="vo"):
         )
 
     @staticmethod
-    async def delete(label: str, client: Optional[_Client] = None, environment_name: Optional[str] = None):
-        obj = await _Volume.lookup(label, client=client, environment_name=environment_name)
+    @renamed_parameter((2024, 12, 18), "label", "name")
+    async def delete(name: str, client: Optional[_Client] = None, environment_name: Optional[str] = None):
+        obj = await _Volume.lookup(name, client=client, environment_name=environment_name)
         req = api_pb2.VolumeDeleteRequest(volume_id=obj.object_id)
         await retry_transient_errors(obj._client.stub.VolumeDelete, req)
 


### PR DESCRIPTION
Closes CLI-284

The external interface uses some mixed terminology for the "name of things":

- The `.from_name`/`.lookup`/`.name` methods on most Modal objects uses "label"
- These methods on `Function` and `Cls` use "app_name" and "tag"

It's confusing to have so many synonyms, and in the case of "tag" it's conflicted with the deployment tag concept (this has led a few users astray).

This PR standardizes everything on "name", aligning with the `.from_name` terminology.

I expect that nearly all user code will invoke these parameters with positional argument syntax. I've used the new `renamed_parameter` to issue runtime deprecation warnings in case anyone was using keyword arguments but don't expect we need anything more than that.

## Changelog

- Standardized terminology in `.from_name`/`.lookup`/`.delete` methods to use `name` consistently where `label` and `tag` were used interchangeably before. Code that invokes these methods using `label=` as an explicit keyword argument will issue a deprecation warning and will break in a future release.