### PR TITLE
Remove deprecation errors for legacy lifecycle methods

### DIFF
--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -138,29 +138,6 @@ PartialFunction = synchronize_api(_PartialFunction)
 def _find_partial_methods_for_user_cls(user_cls: type[Any], flags: int) -> dict[str, _PartialFunction]:
     """Grabs all method on a user class, and returns partials. Includes legacy methods."""
 
-    # Build up a list of legacy attributes to check
-    check_attrs: list[str] = []
-    if flags & _PartialFunctionFlags.BUILD:
-        check_attrs += ["__build__", "__abuild__"]
-    if flags & _PartialFunctionFlags.ENTER_POST_SNAPSHOT:
-        check_attrs += ["__enter__", "__aenter__"]
-    if flags & _PartialFunctionFlags.EXIT:
-        check_attrs += ["__exit__", "__aexit__"]
-
-    # Grab legacy lifecycle methods
-    for attr in check_attrs:
-        if hasattr(user_cls, attr):
-            suggested = attr.strip("_")
-            if is_async := suggested.startswith("a"):
-                suggested = suggested[1:]
-            async_suggestion = " (on an async method)" if is_async else ""
-            message = (
-                f"Using `{attr}` methods for class lifecycle management is deprecated."
-                f" Please try using the `modal.{suggested}` decorator{async_suggestion} instead."
-                " See https://modal.com/docs/guide/lifecycle-functions for more information."
-            )
-            deprecation_error((2024, 2, 21), message)
-
     partial_functions: dict[str, _PartialFunction] = {}
     for parent_cls in reversed(user_cls.mro()):
         if parent_cls is not object:

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -14,10 +14,9 @@ from modal import App, Cls, Function, Image, Queue, build, enter, exit, method
 from modal._serialization import deserialize, serialize
 from modal._utils.async_utils import synchronizer
 from modal._utils.function_utils import FunctionInfo
-from modal.exception import DeprecationError, ExecutionError, InvalidError, NotFoundError, PendingDeprecationError
+from modal.exception import ExecutionError, InvalidError, NotFoundError, PendingDeprecationError
 from modal.partial_function import (
     PartialFunction,
-    _find_callables_for_obj,
     _find_partial_methods_for_user_cls,
     _PartialFunction,
     _PartialFunctionFlags,
@@ -793,63 +792,6 @@ def test_disallow_lifecycle_decorators_with_method(decorator):
             @method()
             def f(self):
                 pass
-
-
-def test_deprecated_sync_methods():
-    class ClsWithDeprecatedSyncMethods:
-        def __enter__(self):
-            ...
-
-        @enter()
-        def my_enter(self):
-            ...
-
-        def __exit__(self, exc_type, exc, tb):
-            ...
-
-    obj = ClsWithDeprecatedSyncMethods()
-
-    with pytest.raises(DeprecationError, match="Using `__enter__`.+`modal.enter` decorator"):
-        _find_callables_for_obj(obj, _PartialFunctionFlags.ENTER_POST_SNAPSHOT)
-
-    with pytest.raises(DeprecationError, match="Using `__exit__`.+`modal.exit` decorator"):
-        _find_callables_for_obj(obj, _PartialFunctionFlags.EXIT)
-
-    with pytest.raises(DeprecationError, match="Support for decorating parameterized methods with `@exit`"):
-
-        class ClsWithDeprecatedSyncExitMethod:
-            @exit()
-            def my_exit(self, exc_type, exc, tb):
-                ...
-
-
-@pytest.mark.asyncio
-async def test_deprecated_async_methods():
-    class ClsWithDeprecatedAsyncMethods:
-        async def __aenter__(self):
-            return 42
-
-        @enter()
-        async def my_enter(self):
-            return 43
-
-        async def __aexit__(self, exc_type, exc, tb):
-            return 44
-
-    obj = ClsWithDeprecatedAsyncMethods()
-
-    with pytest.raises(DeprecationError, match=r"Using `__aenter__`.+`modal.enter` decorator \(on an async method\)"):
-        _find_callables_for_obj(obj, _PartialFunctionFlags.ENTER_POST_SNAPSHOT)
-
-    with pytest.raises(DeprecationError, match=r"Using `__aexit__`.+`modal.exit` decorator \(on an async method\)"):
-        _find_callables_for_obj(obj, _PartialFunctionFlags.EXIT)
-
-    with pytest.raises(DeprecationError, match="Support for decorating parameterized methods with `@exit`"):
-
-        class ClsWithDeprecatedAsyncExitMethod:
-            @exit()  # type: ignore  # TODO: fix type for the exit decorator to support async exit handlers
-            async def my_exit(self, exc_type, exc, tb):
-                ...
 
 
 class HasSnapMethod:


### PR DESCRIPTION
These were deprecated on 2024-02-21 and turned into errors on 2024-06-03 (#1872). Our minimum client version 0.62 was released in late March. So this is already a deprecation for 100% of users, and it's an error for something like 99.99% of users. Seems fine to clean up.