### PR TITLE
Remove deprecated .new methods for storage objects

### DIFF
--- a/modal/dict.py
+++ b/modal/dict.py
@@ -10,7 +10,7 @@ from modal_proto import api_pb2
 from ._resolver import Resolver
 from ._serialization import deserialize, serialize
 from ._utils.async_utils import TaskContext, synchronize_api
-from ._utils.deprecation import deprecation_error, renamed_parameter
+from ._utils.deprecation import renamed_parameter
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from .client import _Client
@@ -57,15 +57,6 @@ class _Dict(_Object, type_prefix="di"):
 
     For more examples, see the [guide](/docs/guide/dicts-and-queues#modal-dicts).
     """
-
-    @staticmethod
-    def new(data: Optional[dict] = None):
-        """mdmd:hidden"""
-        message = (
-            "`Dict.new` is deprecated."
-            " Please use `Dict.from_name` (for persisted) or `Dict.ephemeral` (for ephemeral) dicts instead."
-        )
-        deprecation_error((2024, 3, 19), message)
 
     def __init__(self, data={}):
         """mdmd:hidden"""

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -15,7 +15,7 @@ from modal_proto import api_pb2
 from ._resolver import Resolver
 from ._utils.async_utils import TaskContext, aclosing, async_map, sync_or_async_iter, synchronize_api
 from ._utils.blob_utils import LARGE_FILE_LIMIT, blob_iter, blob_upload_file
-from ._utils.deprecation import deprecation_error, renamed_parameter
+from ._utils.deprecation import renamed_parameter
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.hash_utils import get_sha256_hex
 from ._utils.name_utils import check_object_name
@@ -89,16 +89,6 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         ...
     ```
     """
-
-    @staticmethod
-    def new(cloud: Optional[str] = None):
-        """mdmd:hidden"""
-        message = (
-            "`NetworkFileSystem.new` is deprecated."
-            " Please use `NetworkFileSystem.from_name` (for persisted)"
-            " or `NetworkFileSystem.ephemeral` (for ephemeral) network filesystems instead."
-        )
-        deprecation_error((2024, 3, 20), message)
 
     @staticmethod
     @renamed_parameter((2024, 12, 18), "label", "name")

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -13,7 +13,7 @@ from modal_proto import api_pb2
 from ._resolver import Resolver
 from ._serialization import deserialize, serialize
 from ._utils.async_utils import TaskContext, synchronize_api, warn_if_generator_is_not_consumed
-from ._utils.deprecation import deprecation_error, renamed_parameter
+from ._utils.deprecation import renamed_parameter
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from .client import _Client
@@ -93,15 +93,6 @@ class _Queue(_Object, type_prefix="qu"):
 
     Partition keys must be non-empty and must not exceed 64 bytes.
     """
-
-    @staticmethod
-    def new():
-        """mdmd:hidden"""
-        message = (
-            "`Queue.new` is deprecated."
-            " Please use `Queue.from_name` (for persisted) or `Queue.ephemeral` (for ephemeral) queues instead."
-        )
-        deprecation_error((2024, 3, 19), message)
 
     def __init__(self):
         """mdmd:hidden"""

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -135,15 +135,6 @@ class _Volume(_Object, type_prefix="vo"):
         return self._lock
 
     @staticmethod
-    def new():
-        """mdmd:hidden"""
-        message = (
-            "`Volume.new` is deprecated."
-            " Please use `Volume.from_name` (for persisted) or `Volume.ephemeral` (for ephemeral) volumes instead."
-        )
-        deprecation_error((2024, 3, 20), message)
-
-    @staticmethod
     @renamed_parameter((2024, 12, 18), "label", "name")
     def from_name(
         name: str,


### PR DESCRIPTION
These were deprecated on 2024-03-19 and turned into errors on 2024-05-29 (#1854)

Seems fine to remove. Happy to wait until 0.63 is the minimum version though.