### PR TITLE
Require syncronicity 0.9.8 to fix decorated async exception unwrapping

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     grpclib==0.4.7
     protobuf>=3.19,<6.0,!=4.24.0
     rich>=12.0.0
-    synchronicity~=0.9.7
+    synchronicity~=0.9.8
     toml
     typer>=0.9
     types-certifi


### PR DESCRIPTION
Bug was fixed in synchronicity; this just updates the required version

## Changelog

- Fixed a bug introduced in v0.68.39 that changed the exception type raise when the target object for `.from_name`/`.lookup` methods was not found.