### PR TITLE
Make sure background task for asgi lifespans is cancelled before container shuts down

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -117,7 +117,7 @@ class UserCodeEventLoop:
 
     def __enter__(self):
         self.loop = asyncio.new_event_loop()
-        self.tasks = []
+        self.tasks = set()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
@@ -131,7 +131,10 @@ class UserCodeEventLoop:
         self.loop.close()
 
     def create_task(self, coro):
-        self.tasks.append(self.loop.create_task(coro))
+        task = self.loop.create_task(coro)
+        self.tasks.add(task)
+        task.add_done_callback(self.tasks.discard)
+        return task
 
     def run(self, coro):
         task = asyncio.ensure_future(coro, loop=self.loop)
@@ -531,10 +534,13 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
         with container_io_manager.handle_user_exception():
             finalized_functions = service.get_finalized_functions(function_def, container_io_manager)
         # Execute the function.
+        lifespan_background_task = None
         try:
             for finalized_function in finalized_functions.values():
                 if finalized_function.lifespan_manager:
-                    event_loop.create_task(finalized_function.lifespan_manager.background_task())
+                    lifespan_background_task = event_loop.create_task(
+                        finalized_function.lifespan_manager.background_task()
+                    )
                     with container_io_manager.handle_user_exception():
                         event_loop.run(finalized_function.lifespan_manager.lifespan_startup())
             call_function(
@@ -558,6 +564,11 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
                         if finalized_function.lifespan_manager:
                             with container_io_manager.handle_user_exception():
                                 event_loop.run(finalized_function.lifespan_manager.lifespan_shutdown())
+
+                            # no need to keep the lifespan asgi call around - we send it no more messages
+                            if lifespan_background_task:
+                                lifespan_background_task.cancel()  # prevent dangling task
+
                 finally:
                     # Identify "exit" methods and run them.
                     # want to make sure this is called even if the lifespan manager fails

--- a/modal/_runtime/asgi.py
+++ b/modal/_runtime/asgi.py
@@ -67,8 +67,10 @@ class LifespanManager:
         except Exception as e:
             if not self._lifespan_supported:
                 logger.info(f"ASGI lifespan task exited before receiving any messages with exception:\n{e}")
-                self._startup.set_result(None)
-                self._shutdown.set_result(None)
+                if not self._startup.done():
+                    self._startup.set_result(None)
+                if not self._shutdown.done():
+                    self._shutdown.set_result(None)
                 return
 
             logger.error(f"Error in ASGI lifespan task: {e}")
@@ -78,8 +80,10 @@ class LifespanManager:
                 self._shutdown.set_exception(ExecutionError("ASGI lifespan task exited shutdown"))
         else:
             logger.info("ASGI Lifespan protocol is probably not supported by this library")
-            self._startup.set_result(None)
-            self._shutdown.set_result(None)
+            if not self._startup.done():
+                self._startup.set_result(None)
+            if not self._shutdown.done():
+                self._shutdown.set_result(None)
 
     async def lifespan_startup(self):
         await self.ensure_init()

--- a/modal/_runtime/asgi.py
+++ b/modal/_runtime/asgi.py
@@ -22,11 +22,11 @@ FIRST_MESSAGE_TIMEOUT_SECONDS = 5.0
 
 
 class LifespanManager:
-    startup: asyncio.Future
-    shutdown: asyncio.Future
-    queue: asyncio.Queue
-    has_run_init: bool = False
-    lifespan_supported: bool = False
+    _startup: asyncio.Future
+    _shutdown: asyncio.Future
+    _queue: asyncio.Queue
+    _has_run_init: bool = False
+    _lifespan_supported: bool = False
 
     def __init__(self, asgi_app, state):
         self.asgi_app = asgi_app
@@ -37,59 +37,59 @@ class LifespanManager:
         # no async code since it has to run inside
         # the event loop to tie the
         # objects to the correct loop in python 3.9
-        if not self.has_run_init:
-            self.queue = asyncio.Queue()
-            self.startup = asyncio.Future()
-            self.shutdown = asyncio.Future()
-            self.has_run_init = True
+        if not self._has_run_init:
+            self._queue = asyncio.Queue()
+            self._startup = asyncio.Future()
+            self._shutdown = asyncio.Future()
+            self._has_run_init = True
 
     async def background_task(self):
         await self.ensure_init()
 
         async def receive():
-            self.lifespan_supported = True
-            return await self.queue.get()
+            self._lifespan_supported = True
+            return await self._queue.get()
 
         async def send(message):
             if message["type"] == "lifespan.startup.complete":
-                self.startup.set_result(None)
+                self._startup.set_result(None)
             elif message["type"] == "lifespan.startup.failed":
-                self.startup.set_exception(ExecutionError("ASGI lifespan startup failed"))
+                self._startup.set_exception(ExecutionError("ASGI lifespan startup failed"))
             elif message["type"] == "lifespan.shutdown.complete":
-                self.shutdown.set_result(None)
+                self._shutdown.set_result(None)
             elif message["type"] == "lifespan.shutdown.failed":
-                self.shutdown.set_exception(ExecutionError("ASGI lifespan shutdown failed"))
+                self._shutdown.set_exception(ExecutionError("ASGI lifespan shutdown failed"))
             else:
                 raise ExecutionError(f"Unexpected message type: {message['type']}")
 
         try:
             await self.asgi_app({"type": "lifespan", "state": self.state}, receive, send)
         except Exception as e:
-            if not self.lifespan_supported:
+            if not self._lifespan_supported:
                 logger.info(f"ASGI lifespan task exited before receiving any messages with exception:\n{e}")
-                self.startup.set_result(None)
-                self.shutdown.set_result(None)
+                self._startup.set_result(None)
+                self._shutdown.set_result(None)
                 return
 
             logger.error(f"Error in ASGI lifespan task: {e}")
-            if not self.startup.done():
-                self.startup.set_exception(ExecutionError("ASGI lifespan task exited startup"))
-            if not self.shutdown.done():
-                self.shutdown.set_exception(ExecutionError("ASGI lifespan task exited shutdown"))
+            if not self._startup.done():
+                self._startup.set_exception(ExecutionError("ASGI lifespan task exited startup"))
+            if not self._shutdown.done():
+                self._shutdown.set_exception(ExecutionError("ASGI lifespan task exited shutdown"))
         else:
             logger.info("ASGI Lifespan protocol is probably not supported by this library")
-            self.startup.set_result(None)
-            self.shutdown.set_result(None)
+            self._startup.set_result(None)
+            self._shutdown.set_result(None)
 
     async def lifespan_startup(self):
         await self.ensure_init()
-        self.queue.put_nowait({"type": "lifespan.startup"})
-        await self.startup
+        self._queue.put_nowait({"type": "lifespan.startup"})
+        await self._startup
 
     async def lifespan_shutdown(self):
         await self.ensure_init()
-        self.queue.put_nowait({"type": "lifespan.shutdown"})
-        await self.shutdown
+        self._queue.put_nowait({"type": "lifespan.shutdown"})
+        await self._shutdown
 
 
 def asgi_app_wrapper(asgi_app, container_io_manager) -> tuple[Callable[..., AsyncGenerator], LifespanManager]:

--- a/test/asgi_wrapper_test.py
+++ b/test/asgi_wrapper_test.py
@@ -305,7 +305,6 @@ async def test_lifespan_supported():
             while True:
                 message = await receive()
                 if message["type"] == "lifespan.startup":
-                    print("startup complete")
                     nonlocal lifespan_startup_complete
                     lifespan_startup_complete = True
                     await send({"type": "lifespan.startup.complete"})
@@ -341,14 +340,14 @@ async def test_lifespan_supported():
 
     assert lifespan_shutdown_complete
 
-    assert lifespan_manager.lifespan_supported
+    assert lifespan_manager._lifespan_supported
 
 
 @pytest.mark.asyncio
 async def test_lifespan_unsupported():
     async def asgi_app(scope, receive, send):
         if scope["type"] == "lifespan":
-            raise
+            raise Exception("broken lifespan scope handler")
         else:
             await send({"type": "http.response.start", "status": 200})
             await send({"type": "http.response.body", "body": b'{"some_result":"foo"}'})
@@ -374,4 +373,4 @@ async def test_lifespan_unsupported():
 
     await lifespan_manager.lifespan_shutdown()
 
-    assert not lifespan_manager.lifespan_supported
+    assert not lifespan_manager._lifespan_supported

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1859,6 +1859,11 @@ def blob_server():
 
         loop.run_until_complete(async_main())
 
+        # clean up event loop
+        loop.run_until_complete(loop.shutdown_asyncgens())
+        loop.run_until_complete(loop.shutdown_default_executor())
+        loop.close()
+
     # run server on separate thread to not lock up the server event loop in case of blocking calls in tests
     thread = threading.Thread(target=run_server_other_thread)
     thread.start()

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -417,8 +417,20 @@ def _unwrap_asgi(ret: ContainerResult):
     return values
 
 
+def _get_web_inputs(path="/", method_name=""):
+    scope = {
+        "method": "GET",
+        "type": "http",
+        "path": path,
+        "headers": {},
+        "query_string": b"arg=space",
+        "http_version": "2",
+    }
+    return _get_inputs(((scope,), {}), method_name=method_name)
+
+
 @skip_github_non_linux
-def test_success(servicer, event_loop):
+def test_success(servicer):
     t0 = time.time()
     ret = _run_container(servicer, "test.supports.functions", "square")
     assert 0 <= time.time() - t0 < EXTRA_TOLERANCE_DELAY
@@ -539,18 +551,6 @@ def test_from_local_python_packages_inside_container(servicer):
     all the containers."""
     ret = _run_container(servicer, "test.supports.package_mount", "num_mounts")
     assert _unwrap_scalar(ret) == 0
-
-
-def _get_web_inputs(path="/", method_name=""):
-    scope = {
-        "method": "GET",
-        "type": "http",
-        "path": path,
-        "headers": {},
-        "query_string": b"arg=space",
-        "http_version": "2",
-    }
-    return _get_inputs(((scope,), {}), method_name=method_name)
 
 
 # needs to be synchronized so the asyncio.Queue gets used from the same event loop as the servicer

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -759,7 +759,7 @@ def test_cls_web_asgi_with_lifespan(servicer):
 
     from test.supports import functions
 
-    assert ["enter1", "enter2", "foo1", "exit1", "exit2", "exit"] == functions.lifespan_global_asgi_app_cls
+    assert functions.lifespan_global_asgi_app_cls == ["enter1", "enter2", "foo1", "exit1", "exit2", "exit"]
 
 
 @skip_github_non_linux

--- a/test/supports/functions.py
+++ b/test/supports/functions.py
@@ -313,6 +313,26 @@ class fastapi_class_lifespan_shutdown_failure:
 
 @app.function()
 @asgi_app()
+def asgi_app_with_slow_lifespan_wind_down():
+    async def _asgi_app(scope, receive, send):
+        if scope["type"] == "lifespan":
+            while True:
+                message = await receive()
+                if message["type"] == "lifespan.startup":
+                    await send({"type": "lifespan.startup.complete"})
+                elif message["type"] == "lifespan.shutdown":
+                    await send({"type": "lifespan.shutdown.complete"})
+                await asyncio.sleep(1)  # take some time to shut down - this should either be cancelled or awaited
+        else:
+            # dummy response to other requests
+            await send({"type": "http.response.start", "status": 200})
+            await send({"type": "http.response.body", "body": b'{"some_result":"foo"}'})
+
+    return _asgi_app
+
+
+@app.function()
+@asgi_app()
 def non_lifespan_asgi():
     async def app(scope, receive, send):
         if not scope["type"] == "http":


### PR DESCRIPTION
Will prevent at least one class of "Task was destroyed but is pending" errors on container shutdown


Side note: I want to refactor the modal lifecycle + asgi lifespan execution to be a part of the same context manager, preferably the same that we'll let users use with `.local()`


---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
