### PR TITLE
Add `AppGetLayout` as an client RPC method

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -321,6 +321,14 @@ message AppGetByDeploymentNameResponse {
   string app_id = 1;
 }
 
+message AppGetLayoutRequest {
+  string app_id = 1;
+}
+
+message AppGetLayoutResponse {
+  AppLayout app_layout = 1;
+}
+
 message AppGetLogsRequest {
   string app_id = 1;
   float timeout = 2;
@@ -2700,6 +2708,7 @@ service ModalClient {
   rpc AppDeploy(AppDeployRequest) returns (AppDeployResponse);
   rpc AppDeploymentHistory(AppDeploymentHistoryRequest) returns (AppDeploymentHistoryResponse);
   rpc AppGetByDeploymentName(AppGetByDeploymentNameRequest) returns (AppGetByDeploymentNameResponse);
+  rpc AppGetLayout(AppGetLayoutRequest) returns (AppGetLayoutResponse);
   rpc AppGetLogs(AppGetLogsRequest) returns (stream TaskLogsBatch);
   rpc AppGetObjects(AppGetObjectsRequest) returns (AppGetObjectsResponse);
   rpc AppGetOrCreate(AppGetOrCreateRequest) returns (AppGetOrCreateResponse);


### PR DESCRIPTION
I realized it's a bit harder to retire `AppGetObjects` than I expected – since the client calls it in two places. So we need to add it to the public grpc interface as well. Luckily we already have the logic for it written, we just need to expose it.

Will add the server code next. After that, I'll update the client to call `AppGetLayout` instead of `AppGetObjects`.

Changing things this way is probably a bit more safe anyway since it lets us introduce `AppGetLayout` independently of the change that provides the data through the container arguments.