### PR TITLE
Make container test fixture hack a bit less bad

### DIFF
--- a/test/container_test.py
+++ b/test/container_test.py
@@ -59,6 +59,12 @@ blob_upload = synchronize_api(_blob_upload)
 blob_download = synchronize_api(_blob_download)
 
 
+@pytest.fixture(autouse=True)
+def deploy_simple_app(servicer):
+    # TODO(erikbern): this is a hack that we can remove once we pass the app layout through container arguments
+    servicer.app_unindexed_objects["ap-1"] = ["im-1"]
+
+
 def _get_inputs(
     args: tuple[tuple, dict] = ((42,), {}),
     n: int = 1,


### PR DESCRIPTION
This is helpful as I'm working on replacing `AppGetObjects` with `AppGetLayout`. We'll be able to remove the autouse fixture shortly. But until then, this at least replace one hack with a more narrowly scoped hack.