### PR TITLE
Allow `modal launch vscode` to run against an arbitrary dockerhub image

### DIFF
--- a/modal/cli/launch.py
+++ b/modal/cli/launch.py
@@ -77,6 +77,7 @@ def vscode(
     cpu: int = 8,
     memory: int = 32768,
     gpu: Optional[str] = None,
+    image: str = "debian:12",
     timeout: int = 3600,
     mount: Optional[str] = None,  # Create a `modal.Mount` from a local directory.
     volume: Optional[str] = None,  # Attach a persisted `modal.Volume` by name (creating if missing).
@@ -86,6 +87,7 @@ def vscode(
         "cpu": cpu,
         "memory": memory,
         "gpu": gpu,
+        "image": image,
         "timeout": timeout,
         "mount": mount,
         "volume": volume,

--- a/modal/cli/programs/vscode.py
+++ b/modal/cli/programs/vscode.py
@@ -15,9 +15,34 @@ from modal import App, Image, Mount, Queue, Secret, Volume, forward
 # Passed by `modal launch` locally via CLI, plumbed to remote runner through secrets.
 args: dict[str, Any] = json.loads(os.environ.get("MODAL_LAUNCH_ARGS", "{}"))
 
+CODE_SERVER_INSTALLER = "https://code-server.dev/install.sh"
+CODE_SERVER_ENTRYPOINT = (
+    "https://raw.githubusercontent.com/coder/code-server/refs/tags/v4.96.1/ci/release-image/entrypoint.sh"
+)
+FIXUD_INSTALLER = "https://github.com/boxboat/fixuid/releases/download/v0.6.0/fixuid-0.6.0-linux-$ARCH.tar.gz"
+
 
 app = App()
-app.image = Image.from_registry("codercom/code-server", add_python="3.11").dockerfile_commands("ENTRYPOINT []")
+app.image = (
+    Image.from_registry(args.get("image"), add_python="3.11")
+    .apt_install("curl")
+    .run_commands(
+        f"curl -fsSL {CODE_SERVER_INSTALLER} | sh",
+        f"curl -fsSL {CODE_SERVER_ENTRYPOINT}  > /code-server.sh",
+        "chmod u+x /code-server.sh",
+    )
+    .run_commands(
+        'ARCH="$(dpkg --print-architecture)"'
+        f' && curl -fsSL "{FIXUD_INSTALLER}" | tar -C /usr/local/bin -xzf - '
+        " && chown root:root /usr/local/bin/fixuid"
+        " && chmod 4755 /usr/local/bin/fixuid"
+        " && mkdir -p /etc/fixuid"
+        ' && echo "user: root" >> /etc/fixuid/config.yml'
+        ' && echo "group: root" >> /etc/fixuid/config.yml'
+    )
+    .run_commands("mkdir /home/coder")
+    .env({"ENTRYPOINTD": ""})
+)
 
 
 mount = (
@@ -71,7 +96,7 @@ def run_vscode(q: Queue):
         url = tunnel.url
         threading.Thread(target=wait_for_port, args=((url, token), q)).start()
         subprocess.run(
-            ["/usr/bin/entrypoint.sh", "--bind-addr", "0.0.0.0:8080", "."],
+            ["/code-server.sh", "--bind-addr", "0.0.0.0:8080", "."],
             env={**os.environ, "SHELL": "/bin/bash", "PASSWORD": token},
         )
     q.put("done")


### PR DESCRIPTION
Pretty much just tried to lift the business logic from the `code-server` image this originally pointed at into `modal.Image` API so it can run on top of other images. The main thing I tested it against was an nvidia cuda image since that's a common base image you'd like to develop on top of. Probably there are edge cases and we can't really promise "arbitrary" images, but I guess we'll learn what we can and can't support.

## Changelog

- You can now point `modal launch vscode` at an arbitrary Dockerhub base image:

    `modal launch vscode --image=nvidia/cuda:12.4.0-devel-ubuntu22.04`