### PR TITLE
Replace `AppGetObjects` with `AppGetLayout`

### DIFF
--- a/modal/_runtime/container_io_manager.py
+++ b/modal/_runtime/container_io_manager.py
@@ -21,7 +21,6 @@ from typing import (
 )
 
 from google.protobuf.empty_pb2 import Empty
-from google.protobuf.message import Message
 from grpclib import Status
 from synchronicity.async_wrap import asynccontextmanager
 
@@ -31,12 +30,12 @@ from modal._traceback import extract_traceback, print_exception
 from modal._utils.async_utils import TaskContext, asyncify, synchronize_api, synchronizer
 from modal._utils.blob_utils import MAX_OBJECT_SIZE_BYTES, blob_download, blob_upload
 from modal._utils.function_utils import _stream_function_call_data
-from modal._utils.grpc_utils import get_proto_oneof, retry_transient_errors
+from modal._utils.grpc_utils import retry_transient_errors
 from modal._utils.package_utils import parse_major_minor_version
 from modal.client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, _Client
 from modal.config import config, logger
 from modal.exception import ClientClosed, InputCancellation, InvalidError, SerializationError
-from modal.running_app import RunningApp
+from modal.running_app import RunningApp, running_app_from_layout
 from modal_proto import api_pb2
 
 if TYPE_CHECKING:
@@ -451,24 +450,15 @@ class _ContainerIOManager:
             await asyncio.sleep(DYNAMIC_CONCURRENCY_INTERVAL_SECS)
 
     async def get_app_objects(self) -> RunningApp:
-        req = api_pb2.AppGetObjectsRequest(app_id=self.app_id, include_unindexed=True, only_class_function=True)
-        resp = await retry_transient_errors(self._client.stub.AppGetObjects, req)
-        logger.debug(f"AppGetObjects received {len(resp.items)} objects for app {self.app_id}")
+        req = api_pb2.AppGetLayoutRequest(app_id=self.app_id)
+        resp = await retry_transient_errors(self._client.stub.AppGetLayout, req)
+        logger.debug(f"AppGetLayout received {len(resp.app_layout.objects)} objects for app {self.app_id}")
 
-        tag_to_object_id = {}
-        object_handle_metadata = {}
-        for item in resp.items:
-            handle_metadata: Optional[Message] = get_proto_oneof(item.object, "handle_metadata_oneof")
-            object_handle_metadata[item.object.object_id] = handle_metadata
-            if item.tag:
-                tag_to_object_id[item.tag] = item.object.object_id
-
-        return RunningApp(
+        return running_app_from_layout(
             self.app_id,
+            resp.app_layout,
+            self._client,
             environment_name=self._environment_name,
-            tag_to_object_id=tag_to_object_id,
-            object_handle_metadata=object_handle_metadata,
-            client=self._client,
         )
 
     async def get_serialized_function(self) -> tuple[Optional[Any], Optional[Callable[..., Any]]]:

--- a/modal/running_app.py
+++ b/modal/running_app.py
@@ -4,16 +4,42 @@ from typing import Optional
 
 from google.protobuf.message import Message
 
+from modal._utils.grpc_utils import get_proto_oneof
+from modal_proto import api_pb2
+
 from .client import _Client
 
 
 @dataclass
 class RunningApp:
     app_id: str
+    client: _Client
     environment_name: Optional[str] = None
     app_page_url: Optional[str] = None
     app_logs_url: Optional[str] = None
     tag_to_object_id: dict[str, str] = field(default_factory=dict)
     object_handle_metadata: dict[str, Optional[Message]] = field(default_factory=dict)
     interactive: bool = False
-    client: Optional[_Client] = None
+
+
+def running_app_from_layout(
+    app_id: str,
+    app_layout: api_pb2.AppLayout,
+    client: _Client,
+    environment_name: Optional[str] = None,
+    app_page_url: Optional[str] = None,
+) -> RunningApp:
+    tag_to_object_id = dict(**app_layout.function_ids, **app_layout.class_ids)
+    object_handle_metadata = {}
+    for obj in app_layout.objects:
+        handle_metadata: Optional[Message] = get_proto_oneof(obj, "handle_metadata_oneof")
+        object_handle_metadata[obj.object_id] = handle_metadata
+
+    return RunningApp(
+        app_id,
+        client,
+        environment_name=environment_name,
+        tag_to_object_id=tag_to_object_id,
+        object_handle_metadata=object_handle_metadata,
+        app_page_url=app_page_url,
+    )

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -550,7 +550,7 @@ def test_rehydrate(client, servicer, reset_container_app):
     app_id = deploy_app(app, "my-cls-app", client=client).app_id
 
     # Initialize a container
-    container_app = RunningApp(app_id=app_id)
+    container_app = RunningApp(app_id, client)
 
     # Associate app with app
     app._init_container(client, container_app)

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -48,7 +48,7 @@ async def test_container_function_lazily_imported(container_client):
         "fu-123": api_pb2.FunctionHandleMetadata(),
     }
     container_app = RunningApp(
-        app_id="ap-123", tag_to_object_id=tag_to_object_id, object_handle_metadata=object_handle_metadata
+        "ap-123", container_client, tag_to_object_id=tag_to_object_id, object_handle_metadata=object_handle_metadata
     )
     app = App()
 

--- a/test/webhook_test.py
+++ b/test/webhook_test.py
@@ -36,7 +36,7 @@ async def test_webhook(servicer, client, reset_container_app):
         assert await f.local(100) == {"square": 10000}
 
         # Make sure the container gets the app id as well
-        container_app = RunningApp(app_id=app.app_id)
+        container_app = RunningApp(app.app_id, client)
         app._init_container(client, container_app)
         assert isinstance(f, Function)
         assert f.web_url


### PR DESCRIPTION
This uses the new `AppGetLayout` endpoint instead of `AppGetObjects` endpoint.

Note that it's used in two places:
1. containers on cold start
2. runner.py when redeploying to an existing app

We will be able to provide the app layout through the container argument soon, obviating the need for 1.