### PR TITLE
Add some utilities back to vscode image

### DIFF
--- a/modal/cli/programs/vscode.py
+++ b/modal/cli/programs/vscode.py
@@ -25,7 +25,7 @@ FIXUD_INSTALLER = "https://github.com/boxboat/fixuid/releases/download/v0.6.0/fi
 app = App()
 app.image = (
     Image.from_registry(args.get("image"), add_python="3.11")
-    .apt_install("curl")
+    .apt_install("curl", "dumb-init", "git", "git-lfs")
     .run_commands(
         f"curl -fsSL {CODE_SERVER_INSTALLER} | sh",
         f"curl -fsSL {CODE_SERVER_ENTRYPOINT}  > /code-server.sh",


### PR DESCRIPTION
Wrapping up a loose end I forgot to include with #2704; apt-installing a few utilities that were included in the old image and might be useful in the context of development (especially `git`). I'm being more selective than the true `code-server` because I'd like to minimize the risk of issues with esoteric images, and not all of the utilities included in the `code-server` image seemed relevant (e.g. it also installed `vim` and `nano` which seems unnecessary if the whole point is to provide `vscode`).