### PR TITLE
feat: add all-extras flag to poetry install from file

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -1113,6 +1113,8 @@ class _Image(_Object, type_prefix="im"):
         without: list[str] = [],
         # Only install dependency groups specifed in this list.
         only: list[str] = [],
+        # Install all extras (See https://python-poetry.org/docs/cli/#options-2)
+        all_extras: bool = False,
         *,
         secrets: Sequence[_Secret] = [],
         gpu: GPU_T = None,
@@ -1160,6 +1162,10 @@ class _Image(_Object, type_prefix="im"):
 
             if only:
                 install_cmd += f" --only {','.join(only)}"
+
+            if all_extras:
+                install_cmd += " --all-extras"
+
             install_cmd += " --compile"  # no .pyc compilation slows down cold-start.
 
             commands += [


### PR DESCRIPTION
## Describe your changes

- _Provide Linear issue reference (e.g. MOD-1234) if available._

I was running into an issue where I wanted to install dependencies via `poetry install --all-extras`, but the poetry install from file util doesn't support it. My workaround without using the util (below) is kind of clunky:

```python
image=modal.Image.debian_slim().add_local_file("pyproject.toml", "/pyproject.toml", copy=True)
    .pip_install("poetry")
    .run_commands(["poetry config virtualenvs.create false && poetry install --all-extras"])
```

It's not so bad for me to use my workaround; I just spent quite a bit of time debugging and someone may have a similar issue. Feel free to delete this PR if it's not good to have in the codebase; no worries.

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
