### PR TITLE
Container app singleton

### DIFF
--- a/modal/_runtime/container_io_manager.py
+++ b/modal/_runtime/container_io_manager.py
@@ -457,12 +457,7 @@ class _ContainerIOManager:
             resp = await retry_transient_errors(self._client.stub.AppGetLayout, req)
             app_layout = resp.app_layout
 
-        return running_app_from_layout(
-            self.app_id,
-            app_layout,
-            self._client,
-            environment_name=self._environment_name,
-        )
+        return running_app_from_layout(self.app_id, app_layout)
 
     async def get_serialized_function(self) -> tuple[Optional[Any], Optional[Callable[..., Any]]]:
         # Fetch the serialized function definition

--- a/modal/app.py
+++ b/modal/app.py
@@ -1044,6 +1044,9 @@ class _App:
 
     @classmethod
     def container_app(cls) -> Optional["_App"]:
+        """Returns the `App` running inside a container.
+
+        This will return `None` outside of a Modal container."""
         return cls._container_app
 
     @classmethod

--- a/modal/app.py
+++ b/modal/app.py
@@ -294,12 +294,7 @@ class _App:
         app = _App(name)
         app._app_id = response.app_id
         app._client = client
-        app._running_app = RunningApp(
-            response.app_id,
-            client=client,
-            environment_name=environment_name,
-            interactive=False,
-        )
+        app._running_app = RunningApp(response.app_id, interactive=False)
         return app
 
     def set_description(self, description: str):

--- a/modal/app.py
+++ b/modal/app.py
@@ -168,7 +168,7 @@ class _App:
     """
 
     _all_apps: ClassVar[dict[Optional[str], list["_App"]]] = {}
-    _container_app: ClassVar[Optional[RunningApp]] = None
+    _container_app: ClassVar[Optional["_App"]] = None
 
     _name: Optional[str]
     _description: Optional[str]
@@ -488,7 +488,7 @@ class _App:
         self._running_app = running_app
         self._client = client
 
-        _App._container_app = running_app
+        _App._container_app = self
 
         # Hydrate function objects
         for tag, object_id in running_app.function_ids.items():
@@ -1046,6 +1046,10 @@ class _App:
                 for log in log_batch.items:
                     if log.data:
                         yield log.data
+
+    @classmethod
+    def container_app(cls) -> Optional["_App"]:
+        return cls._container_app
 
     @classmethod
     def _reset_container_app(cls):

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -64,7 +64,6 @@ async def _init_local_app_existing(client: _Client, existing_app_id: str, enviro
     return running_app_from_layout(
         existing_app_id,
         obj_resp.app_layout,
-        client,
         app_page_url=app_page_url,
     )
 
@@ -89,10 +88,8 @@ async def _init_local_app_new(
     logger.debug(f"Created new app with id {app_resp.app_id}")
     return RunningApp(
         app_resp.app_id,
-        client=client,
         app_page_url=app_resp.app_page_url,
         app_logs_url=app_resp.app_logs_url,
-        environment_name=environment_name,
         interactive=interactive,
     )
 

--- a/modal/running_app.py
+++ b/modal/running_app.py
@@ -7,14 +7,10 @@ from google.protobuf.message import Message
 from modal._utils.grpc_utils import get_proto_oneof
 from modal_proto import api_pb2
 
-from .client import _Client
-
 
 @dataclass
 class RunningApp:
     app_id: str
-    client: _Client
-    environment_name: Optional[str] = None
     app_page_url: Optional[str] = None
     app_logs_url: Optional[str] = None
     function_ids: dict[str, str] = field(default_factory=dict)
@@ -26,8 +22,6 @@ class RunningApp:
 def running_app_from_layout(
     app_id: str,
     app_layout: api_pb2.AppLayout,
-    client: _Client,
-    environment_name: Optional[str] = None,
     app_page_url: Optional[str] = None,
 ) -> RunningApp:
     object_handle_metadata = {}
@@ -37,8 +31,6 @@ def running_app_from_layout(
 
     return RunningApp(
         app_id,
-        client,
-        environment_name=environment_name,
         function_ids=dict(app_layout.function_ids),
         class_ids=dict(app_layout.class_ids),
         object_handle_metadata=object_handle_metadata,

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -276,9 +276,9 @@ class _Sandbox(_Object, type_prefix="sb"):
 
             app_id = app.app_id
             app_client = app._client
-        elif _App._container_app is not None:
-            app_id = _App._container_app.app_id
-            app_client = _App._container_app.client
+        elif (container_app := _App.container_app()) is not None:
+            app_id = container_app.app_id
+            app_client = container_app._client
         else:
             arglist = ", ".join(repr(s) for s in entrypoint_args)
             deprecation_error(

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -550,7 +550,7 @@ def test_rehydrate(client, servicer, reset_container_app):
     app_id = deploy_app(app, "my-cls-app", client=client).app_id
 
     # Initialize a container
-    container_app = RunningApp(app_id, client)
+    container_app = RunningApp(app_id)
 
     # Associate app with app
     app._init_container(client, container_app)

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -46,9 +46,7 @@ async def test_container_function_lazily_imported(container_client):
     object_handle_metadata: dict[str, Message] = {
         "fu-123": api_pb2.FunctionHandleMetadata(),
     }
-    container_app = RunningApp(
-        "ap-123", container_client, function_ids=function_ids, object_handle_metadata=object_handle_metadata
-    )
+    container_app = RunningApp("ap-123", function_ids=function_ids, object_handle_metadata=object_handle_metadata)
     app = App()
 
     # This is normally done in _container_entrypoint

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -2371,3 +2371,9 @@ def test_cls_self_doesnt_call_bind(servicer, credentials, set_env_client):
         assert not ctx.get_requests("FunctionBindParams")
 
         # TODO: add test for using self.keep_warm()
+
+
+@skip_github_non_linux
+def test_function_without_app(servicer, event_loop):
+    ret = _run_container(servicer, "test.supports.function_without_app", "f")
+    assert _unwrap_scalar(ret) == 123

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -2374,6 +2374,11 @@ def test_cls_self_doesnt_call_bind(servicer, credentials, set_env_client):
 
 
 @skip_github_non_linux
-def test_function_without_app(servicer, event_loop):
+def test_container_app_zero_matching(servicer, event_loop):
     ret = _run_container(servicer, "test.supports.function_without_app", "f")
     assert _unwrap_scalar(ret) == 123
+
+
+@skip_github_non_linux
+def test_container_app_one_matching(servicer, event_loop):
+    _run_container(servicer, "test.supports.functions", "check_container_app")

--- a/test/supports/function_without_app.py
+++ b/test/supports/function_without_app.py
@@ -1,0 +1,7 @@
+# Copyright Modal Labs 2024
+from modal.app import _App
+
+
+def f(x):
+    assert _App._container_app
+    return 123

--- a/test/supports/function_without_app.py
+++ b/test/supports/function_without_app.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2024
-from modal.app import _App
+from modal.app import App
 
 
 def f(x):
-    assert _App._container_app
+    assert App.container_app()
     return 123

--- a/test/supports/functions.py
+++ b/test/supports/functions.py
@@ -678,3 +678,9 @@ def set_input_concurrency(start: float):
     set_local_input_concurrency(3)
     time.sleep(1)
     return time.time() - start
+
+
+@app.function()
+def check_container_app():
+    # The container app should be associated with the app object
+    assert App.container_app() == app

--- a/test/supports/multiapp.py
+++ b/test/supports/multiapp.py
@@ -8,6 +8,7 @@ a = modal.App()
 def a_func(i):
     assert a_func.is_hydrated
     assert not b_func.is_hydrated
+    assert modal.App.container_app() == a
 
 
 b = modal.App()
@@ -17,3 +18,4 @@ b = modal.App()
 def b_func(i):
     assert b_func.is_hydrated
     assert not a_func.is_hydrated
+    assert modal.App.container_app() == b

--- a/test/webhook_test.py
+++ b/test/webhook_test.py
@@ -36,7 +36,7 @@ async def test_webhook(servicer, client, reset_container_app):
         assert await f.local(100) == {"square": 10000}
 
         # Make sure the container gets the app id as well
-        container_app = RunningApp(app.app_id, client)
+        container_app = RunningApp(app.app_id)
         app._init_container(client, container_app)
         assert isinstance(f, Function)
         assert f.web_url


### PR DESCRIPTION
This changes `_App._container_app` to be an `_App` rather than a `RunningApp`.

It also makes sure this property is _always_ set, regardless of whether we were able to identify the correct app. If we don't identify it, we just create one from scratch.

I also added a `App.container_app()` class method which returns the current app inside a container (which is now always set, whereas previously we wouldn't necessary have an app).

The point of this is to get rid of `RunningApp`. Some properties can be moved to the `_App` class instead. Some properties can be deleted – I removed `client` and `environment_name` as an easy thing. Merging this PR will let me continue this cleanup process.