### PR TITLE
Replace `RunningApp.tag_to_object_id` with `function_ids` and `class_ids`

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -463,8 +463,8 @@ class _App:
         if self._running_app:
             # If this is inside a container, then objects can be defined after app initialization.
             # So we may have to initialize objects once they get bound to the app.
-            if function.tag in self._running_app.tag_to_object_id:
-                object_id: str = self._running_app.tag_to_object_id[function.tag]
+            if function.tag in self._running_app.function_ids:
+                object_id: str = self._running_app.function_ids[function.tag]
                 metadata: Message = self._running_app.object_handle_metadata[object_id]
                 function._hydrate(object_id, self._client, metadata)
 
@@ -476,8 +476,8 @@ class _App:
         if self._running_app:
             # If this is inside a container, then objects can be defined after app initialization.
             # So we may have to initialize objects once they get bound to the app.
-            if tag in self._running_app.tag_to_object_id:
-                object_id: str = self._running_app.tag_to_object_id[tag]
+            if tag in self._running_app.class_ids:
+                object_id: str = self._running_app.class_ids[tag]
                 metadata: Message = self._running_app.object_handle_metadata[object_id]
                 cls._hydrate(object_id, self._client, metadata)
 
@@ -490,19 +490,19 @@ class _App:
 
         _App._container_app = running_app
 
-        # Hydrate objects on app -- hydrating functions first so that when a class is being hydrated its
-        # corresponding class service function is already hydrated.
-        def hydrate_objects(objects_dict):
-            for tag, object_id in running_app.tag_to_object_id.items():
-                if tag in objects_dict:
-                    obj = objects_dict[tag]
-                    handle_metadata = running_app.object_handle_metadata[object_id]
-                    obj._hydrate(object_id, client, handle_metadata)
-
         # Hydrate function objects
-        hydrate_objects(self._functions)
+        for tag, object_id in running_app.function_ids.items():
+            if tag in self._functions:
+                obj = self._functions[tag]
+                handle_metadata = running_app.object_handle_metadata[object_id]
+                obj._hydrate(object_id, client, handle_metadata)
+
         # Hydrate class objects
-        hydrate_objects(self._classes)
+        for tag, object_id in running_app.class_ids.items():
+            if tag in self._classes:
+                obj = self._classes[tag]
+                handle_metadata = running_app.object_handle_metadata[object_id]
+                obj._hydrate(object_id, client, handle_metadata)
 
     @property
     def registered_functions(self) -> dict[str, _Function]:

--- a/modal/running_app.py
+++ b/modal/running_app.py
@@ -17,7 +17,8 @@ class RunningApp:
     environment_name: Optional[str] = None
     app_page_url: Optional[str] = None
     app_logs_url: Optional[str] = None
-    tag_to_object_id: dict[str, str] = field(default_factory=dict)
+    function_ids: dict[str, str] = field(default_factory=dict)
+    class_ids: dict[str, str] = field(default_factory=dict)
     object_handle_metadata: dict[str, Optional[Message]] = field(default_factory=dict)
     interactive: bool = False
 
@@ -29,7 +30,6 @@ def running_app_from_layout(
     environment_name: Optional[str] = None,
     app_page_url: Optional[str] = None,
 ) -> RunningApp:
-    tag_to_object_id = dict(**app_layout.function_ids, **app_layout.class_ids)
     object_handle_metadata = {}
     for obj in app_layout.objects:
         handle_metadata: Optional[Message] = get_proto_oneof(obj, "handle_metadata_oneof")
@@ -39,7 +39,8 @@ def running_app_from_layout(
         app_id,
         client,
         environment_name=environment_name,
-        tag_to_object_id=tag_to_object_id,
+        function_ids=dict(app_layout.function_ids),
+        class_ids=dict(app_layout.class_ids),
         object_handle_metadata=object_handle_metadata,
         app_page_url=app_page_url,
     )

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -40,15 +40,14 @@ def temp_restore_path(tmpdir):
 
 @pytest.mark.asyncio
 async def test_container_function_lazily_imported(container_client):
-    tag_to_object_id: dict[str, str] = {
+    function_ids: dict[str, str] = {
         "my_f_1": "fu-123",
-        "my_d": "di-123",
     }
     object_handle_metadata: dict[str, Message] = {
         "fu-123": api_pb2.FunctionHandleMetadata(),
     }
     container_app = RunningApp(
-        "ap-123", container_client, tag_to_object_id=tag_to_object_id, object_handle_metadata=object_handle_metadata
+        "ap-123", container_client, function_ids=function_ids, object_handle_metadata=object_handle_metadata
     )
     app = App()
 


### PR DESCRIPTION
Slowly peeling apart all the old `indexed_objects` and `tag_to_object_id` nonsense