### PR TITLE
Bump file_io write limit to 1 GiB

### DIFF
--- a/test/file_io_test.py
+++ b/test/file_io_test.py
@@ -4,7 +4,7 @@ import pytest
 from grpclib import Status
 from grpclib.exceptions import GRPCError
 
-from modal.file_io import FileIO, delete_bytes, replace_bytes
+from modal.file_io import WRITE_CHUNK_SIZE, WRITE_FILE_SIZE_LIMIT, FileIO, delete_bytes, replace_bytes  # type: ignore
 from modal_proto import api_pb2
 
 OPEN_EXEC_ID = "exec-open-123"
@@ -118,6 +118,44 @@ def test_file_write(servicer, client):
         f.write(content)
         assert f.read() == content
         f.close()
+
+
+def test_file_write_large(servicer, client):
+    """Test file write chunking logic."""
+    content = "A" * WRITE_FILE_SIZE_LIMIT
+    write_counter = 0
+
+    async def container_filesystem_exec_get_output(servicer, stream):
+        nonlocal write_counter
+        req = await stream.recv_message()
+        if req.exec_id == WRITE_EXEC_ID:
+            write_counter += 1
+        await stream.send_message(api_pb2.FilesystemRuntimeOutputBatch(eof=True))
+
+    with servicer.intercept() as ctx:
+        ctx.set_responder("ContainerFilesystemExec", container_filesystem_exec)
+        ctx.set_responder("ContainerFilesystemExecGetOutput", container_filesystem_exec_get_output)
+
+        f = FileIO.create("/test.txt", "a+", client, "task-123")
+        f.write(content)
+        assert write_counter == WRITE_FILE_SIZE_LIMIT // WRITE_CHUNK_SIZE
+        f.close()
+
+
+def test_file_write_too_large(servicer, client):
+    """Test that writing a file larger than WRITE_FILE_SIZE_LIMIT raises an error."""
+    content = "A" * (WRITE_FILE_SIZE_LIMIT + 1)
+
+    async def container_filesystem_exec_get_output(servicer, stream):
+        await stream.recv_message()
+        await stream.send_message(api_pb2.FilesystemRuntimeOutputBatch(eof=True))
+
+    with servicer.intercept() as ctx:
+        ctx.set_responder("ContainerFilesystemExec", container_filesystem_exec)
+        ctx.set_responder("ContainerFilesystemExecGetOutput", container_filesystem_exec_get_output)
+
+        with pytest.raises(ValueError):
+            FileIO.create("/test.txt", "a+", client, "task-123").write(content)
 
 
 def test_file_readline(servicer, client):


### PR DESCRIPTION
Bumps `file_io` write limit to 1 GiB by chunking for users. Context: https://modal-com.slack.com/archives/C080XT1RB54/p1735311548119669?thread_ts=1732294114.622879&cid=C080XT1RB54

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- The sandbox filesystem API now accepts write payloads of sizes up to 1 GiB.