### PR TITLE
Fix `COPY --from=` in Dockerfiles

### DIFF
--- a/modal/_utils/docker_utils.py
+++ b/modal/_utils/docker_utils.py
@@ -37,6 +37,12 @@ def extract_copy_command_patterns(dockerfile_lines: Sequence[str]) -> list[str]:
                 args = match.group(1)
                 parts = shlex.split(args)
 
+                # COPY --from=... commands reference external sources and do not need a context mount.
+                # https://docs.docker.com/reference/dockerfile/#copy---from
+                if parts[0].startswith("--from="):
+                    current_command = ""
+                    continue
+
                 if len(parts) >= 2:
                     # Last part is destination, everything else is a mount source
                     sources = parts[:-1]

--- a/test/docker_utils_test.py
+++ b/test/docker_utils_test.py
@@ -26,6 +26,7 @@ from modal._utils.docker_utils import extract_copy_command_patterns
         ),
         (
             [
+                "copy --from=a b",
                 "copy ./smth \\",
                 "./foo.py \\",
                 "# this is a comment",
@@ -33,6 +34,12 @@ from modal._utils.docker_utils import extract_copy_command_patterns
                 "/x",
             ],
             {"./smth", "./foo.py", "./bar.py"},
+        ),
+        (
+            [
+                "COPY --from=a b",
+            ],
+            set(),
         ),
     ],
 )


### PR DESCRIPTION
Noticed we accidentally broke support for `COPY --from=` with the automatic context mount changes.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
