### PR TITLE
Add proto changes for lost inputs

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1480,7 +1480,7 @@ message FunctionGetOutputsRequest {
   bool clear_on_success = 7; // expires *any* remaining outputs soon after this call, not just the returned ones
   double requested_at = 8; // Used for waypoints.
   // The jwts the client expects the server to be processing. This is optional and used for sync inputs only.
-  repeated string expected_jwts = 9;
+  repeated string input_jwts = 9;
 }
 
 message FunctionGetOutputsResponse {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1479,6 +1479,8 @@ message FunctionGetOutputsRequest {
   string last_entry_id = 6;
   bool clear_on_success = 7; // expires *any* remaining outputs soon after this call, not just the returned ones
   double requested_at = 8; // Used for waypoints.
+  // The jwts the client expects the server to be processing. This is optional and used for sync inputs only.
+  repeated string expected_jwts = 9;
 }
 
 message FunctionGetOutputsResponse {
@@ -1678,6 +1680,7 @@ message GenericResult {  // Used for both tasks and function outputs
     // Used when the user's function fails to initialize (ex. S3 mount failed due to invalid credentials).
     // Terminates the function and all remaining inputs.
     GENERIC_STATUS_INIT_FAILURE = 5;
+    GENERIC_STATUS_INTERNAL_FAILURE = 6;
   }
 
   GenericStatus status = 1; // Status of the task or function output.


### PR DESCRIPTION
Part of SVC-224

These are the API changes needed to track lost inputs during client side retries. These are used by #2600. Opening as a separate PR so the server can start using this before we merge the client changes.

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
