### PR TITLE
Remove fallbacks related to container arguments

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -38,7 +38,7 @@ from modal.partial_function import (
     _find_callables_for_obj,
     _PartialFunctionFlags,
 )
-from modal.running_app import RunningApp
+from modal.running_app import RunningApp, running_app_from_layout
 from modal_proto import api_pb2
 
 from ._runtime.container_io_manager import (
@@ -465,7 +465,7 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
                 batch_wait_ms = function_def.batch_linger_ms or 0
 
         # Get ids and metadata for objects (primarily functions and classes) on the app
-        container_app: RunningApp = container_io_manager.get_app_objects(container_args.app_layout)
+        container_app: RunningApp = running_app_from_layout(container_args.app_id, container_args.app_layout)
 
         # Initialize objects on the app.
         # This is basically only functions and classes - anything else is deprecated and will be unsupported soon
@@ -581,15 +581,10 @@ if __name__ == "__main__":
     logger.debug("Container: starting")
 
     container_args = api_pb2.ContainerArguments()
-
     container_arguments_path: Optional[str] = os.environ.get("MODAL_CONTAINER_ARGUMENTS_PATH")
     if container_arguments_path is None:
-        # TODO(erikbern): this fallback is for old workers and we can remove it very soon (days)
-        import base64
-
-        container_args.ParseFromString(base64.b64decode(sys.argv[1]))
-    else:
-        container_args.ParseFromString(open(container_arguments_path, "rb").read())
+        raise RuntimeError("No path to the container arguments file provided!")
+    container_args.ParseFromString(open(container_arguments_path, "rb").read())
 
     # Note that we're creating the client in a synchronous context, but it will be running in a separate thread.
     # This is good because if the function is long running then we the client can still send heartbeats

--- a/modal/_runtime/container_io_manager.py
+++ b/modal/_runtime/container_io_manager.py
@@ -35,7 +35,6 @@ from modal._utils.package_utils import parse_major_minor_version
 from modal.client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, _Client
 from modal.config import config, logger
 from modal.exception import ClientClosed, InputCancellation, InvalidError, SerializationError
-from modal.running_app import RunningApp, running_app_from_layout
 from modal_proto import api_pb2
 
 if TYPE_CHECKING:
@@ -448,16 +447,6 @@ class _ContainerIOManager:
                 logger.debug(f"Failed to get dynamic concurrency for task {self.task_id}, {exc}")
 
             await asyncio.sleep(DYNAMIC_CONCURRENCY_INTERVAL_SECS)
-
-    async def get_app_objects(self, app_layout: api_pb2.AppLayout) -> RunningApp:
-        if len(app_layout.objects) == 0:
-            # TODO(erikbern): this should never happen! let's keep it in here for a short second
-            # until we've sanity checked that this is, in fact, dead code.
-            req = api_pb2.AppGetLayoutRequest(app_id=self.app_id)
-            resp = await retry_transient_errors(self._client.stub.AppGetLayout, req)
-            app_layout = resp.app_layout
-
-        return running_app_from_layout(self.app_id, app_layout)
 
     async def get_serialized_function(self) -> tuple[Optional[Any], Optional[Callable[..., Any]]]:
         # Fetch the serialized function definition


### PR DESCRIPTION
This removes a bunch of code that should in theory be dead.

1. Assume we can always read the container arguments from the `MODAL_CONTAINER_ARGUMENTS_PATH` file
2. Assume that the app layout is always passed to the container as a part of that

We need fallback 1 for another couple of days just waiting for all workers to roll over.

Having fallback 2 has been incredibly useful over the last few weeks because we had to revert a bunch of server changes. 

So I'm a bit nervous about merging this. Planning to let this PR sit for a few weeks and then merge it assuming things are good.