### PR TITLE
include sha256_hex in MountPutFile response

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1847,6 +1847,7 @@ message MountPutFileRequest {
 
 message MountPutFileResponse {
   bool exists = 2;
+  string sha256_hex = 3;
 }
 
 message MultiPartUpload {


### PR DESCRIPTION
Prepare for making it optional to pass in the sha256_hex in the request.

## Describe your changes

- _Provide Linear issue reference (e.g. MOD-1234) if available._

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
