### PR TITLE
volume put: upload without sha256 hash

### DIFF
--- a/modal/_utils/hash_utils.py
+++ b/modal/_utils/hash_utils.py
@@ -64,6 +64,13 @@ class UploadHashes:
         return base64.b64decode(self.sha256_base64).hex()
 
 
+DUMMY_HASH_HEX = "baadbaadbaadbaadbaadbaadbaadbaad"
+DUMMY_HASHES = UploadHashes(
+    base64.b64encode(bytes.fromhex(DUMMY_HASH_HEX)).decode("ascii"),
+    base64.b64encode(bytes.fromhex(DUMMY_HASH_HEX)).decode("ascii"),
+)
+
+
 def get_upload_hashes(
     data: Union[bytes, BinaryIO], sha256_hex: Optional[str] = None, md5_hex: Optional[str] = None
 ) -> UploadHashes:


### PR DESCRIPTION
Let the backend return the resulting sha256 hash instead of computing it up front.

Requires https://github.com/modal-labs/modal-client/pull/2722 and corresponding internal change to make sha256_hex optional in the MountPutFile handler.

## Describe your changes

- _Provide Linear issue reference (e.g. MOD-1234) if available._

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
