### PR TITLE
Pass `pty` correctly in `modal shell <task-id>`

### DIFF
--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -461,7 +461,7 @@ def shell(
         ):
             from .container import exec
 
-            exec(container_id=container_or_function, command=shlex.split(cmd))
+            exec(container_id=container_or_function, command=shlex.split(cmd), pty=pty)
             return
 
         function = import_function(


### PR DESCRIPTION
Since `exec` is decorated with `@click.command` and we're calling it directly here, `pty` was getting a weird default value (`typer.OptionInfo`).

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
