### PR TITLE
Make Sandbox result None if SandboxWait does not return a status

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -320,7 +320,9 @@ class _Sandbox(_Object, type_prefix="sb"):
         resp = await retry_transient_errors(client.stub.SandboxWait, req)
 
         obj = _Sandbox._new_hydrated(sandbox_id, client, None)
-        obj._result = resp.result
+
+        if resp.result.status:
+            obj._result = resp.result
 
         return obj
 


### PR DESCRIPTION

## Describe your changes

Previously, we would always set self._result to resp.result on re-hydrating a Sandbox. This kept some non-None data around, making `poll` return 0 on successive invocations. This commit reuses the exit code logic from `poll` to fix this.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>
