### PR TITLE
Accelerate 4 years into the future

### DIFF
--- a/.github/actions/setup-cached-python/action.yml
+++ b/.github/actions/setup-cached-python/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: Which Python version to install
     required: true
-    default: "3.9"
+    default: "3.11"
 
 runs:
   using: composite

--- a/.github/actions/setup-cached-python/action.yml
+++ b/.github/actions/setup-cached-python/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: Install Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.version }}
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   link:
     name: Ruff linting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v3
@@ -29,7 +29,7 @@ jobs:
 
   type_check:
     name: Static type checks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v3
@@ -40,7 +40,7 @@ jobs:
 
       - run: inv protoc
 
-      - run: pip install -e .  # gets all dependencies and the package itself into python env
+      - run: pip install -e . # gets all dependencies and the package itself into python env
 
       - name: Build type stubs
         run: inv type-stubs
@@ -49,7 +49,7 @@ jobs:
 
   check-copyright:
     name: Check copyright
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -17,12 +17,11 @@ env:
   PYTHONIOENCODING: utf-8
 
 jobs:
-
   client-versioning:
     if: github.ref == 'refs/heads/main'
     name: Update changelog and client version
     concurrency: client-versioning
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     outputs:
@@ -75,7 +74,6 @@ jobs:
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         run: python -m modal_global_objects.mounts.modal_client_package
 
-
   client-test:
     name: Unit tests on ${{ matrix.python-version }} and ${{ matrix.os }} (protobuf=${{ matrix.proto-version }})
     timeout-minutes: 30
@@ -84,7 +82,7 @@ jobs:
       fail-fast: false # run all variants across python versions/os to completion
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        os: ["ubuntu-20.04"]
+        os: ["ubuntu-24.04"]
         proto-version: ["latest"]
         include:
           - os: "macos-13" # x86-64
@@ -96,7 +94,7 @@ jobs:
           - os: "windows-latest"
             python-version: "3.10"
             proto-version: "latest"
-          - os: "ubuntu-20.04"
+          - os: "ubuntu-24.04"
             python-version: "3.9"
             proto-version: "3.19"
 
@@ -131,7 +129,7 @@ jobs:
 
   container-dependencies:
     name: Check minimal container dependencies for ${{ matrix.python-version }} / ${{ matrix.image-builder-version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 4
     strategy:
       matrix:
@@ -181,11 +179,10 @@ jobs:
     name: Publish client package
     if: github.ref == 'refs/heads/main'
     needs: [client-versioning, client-test]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency: publish-client
     timeout-minutes: 5
     steps:
-
       - uses: actions/checkout@v3
         with:
           ref: v${{ needs.client-versioning.outputs.client-version}}
@@ -217,7 +214,7 @@ jobs:
       Publish base images for ${{ matrix.image-name }} ${{ matrix.image-builder-version }}
     if: github.ref == 'refs/heads/main'
     needs: [client-versioning, client-test, publish-client]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     env:
       MODAL_LOGLEVEL: DEBUG

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
   doc-test:
     name: Doc generation tests
     timeout-minutes: 5
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
 
@@ -25,7 +25,7 @@ jobs:
         run: inv protoc
 
       - name: Install package + deps
-        run: pip install -e .  # Makes sure doc generation doesn't break on client imports etc.
+        run: pip install -e . # Makes sure doc generation doesn't break on client imports etc.
 
       - name: Generate reference docs
         run: python -m modal_docs.gen_reference_docs reference_docs_output


### PR DESCRIPTION
This updates all CI to use Ubuntu 24.04. Previously, it was using 20.04.

The main thing to watch out for when upgrading OS version is that the glibc version will change. If there's a binary built in CI, it will be dynamically linked to a newer version of glibc and won't be compatible with older operating systems.

I checked and don't think anything in client CI is building binaries that link to glibc versions, they're manylinux wheels, so this should work!