### PR TITLE
Image.from_id

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -832,6 +832,24 @@ class _Image(_Object, type_prefix="im"):
             ),
         )
 
+    @staticmethod
+    async def from_id(image_id: str, client: Optional[_Client] = None) -> "_Image":
+        """Construct an Image from an id and look up the Image result.
+
+        The ID of an Image object can be accessed using `.object_id`.
+        """
+        if client is None:
+            client = await _Client.from_env()
+
+        async def _load(self: _Image, resolver: Resolver, existing_object_id: Optional[str]):
+            resp = await retry_transient_errors(client.stub.ImageFromId, api_pb2.ImageFromIdRequest(image_id=image_id))
+            self._hydrate(resp.image_id, resolver.client, resp.metadata)
+
+        rep = "Image()"
+        obj = _Image._from_loader(_load, rep)
+
+        return obj
+
     def pip_install(
         self,
         *packages: Union[str, list[str]],  # A list of Python packages, eg. ["numpy", "matplotlib>=3.5.0"]


### PR DESCRIPTION
## Describe your changes

WRK-629 and https://modal-com.slack.com/archives/C07JNJMJPQC/p1736275888178649?thread_ts=1736200259.187379&cid=C07JNJMJPQC

Blocks on server changes: https://github.com/modal-labs/modal/pull/18627

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog
- Adds `Image.from_id`, which returns an `Image` object from an existing image id.
