### PR TITLE
Add `modal volume rename` and `modal.Volume.rename`

### DIFF
--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -298,6 +298,15 @@ async def delete(
 async def rename(
     old_name: str,
     new_name: str,
+    yes: bool = YES_OPTION,
     env: Optional[str] = ENV_OPTION,
 ):
+    if not yes:
+        typer.confirm(
+            f"Are you sure you want rename the modal.Volume '{old_name}'?"
+            " This may break any Apps currently using it.",
+            default=False,
+            abort=True,
+        )
+
     await _Volume.rename(old_name, new_name, environment_name=env)

--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -287,3 +287,17 @@ async def delete(
         )
 
     await _Volume.delete(volume_name, environment_name=env)
+
+
+@volume_cli.command(
+    name="rename",
+    help="Rename a modal.Volume.",
+    rich_help_panel="Management",
+)
+@synchronizer.create_blocking
+async def rename(
+    old_name: str,
+    new_name: str,
+    env: Optional[str] = ENV_OPTION,
+):
+    await _Volume.rename(old_name, new_name, environment_name=env)

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -506,6 +506,18 @@ class _Volume(_Object, type_prefix="vo"):
         req = api_pb2.VolumeDeleteRequest(volume_id=obj.object_id)
         await retry_transient_errors(obj._client.stub.VolumeDelete, req)
 
+    @staticmethod
+    async def rename(
+        old_name: str,
+        new_name: str,
+        *,
+        client: Optional[_Client] = None,
+        environment_name: Optional[str] = None,
+    ):
+        obj = await _Volume.lookup(old_name, client=client, environment_name=environment_name)
+        req = api_pb2.VolumeRenameRequest(volume_id=obj.object_id, name=new_name)
+        await retry_transient_errors(obj._client.stub.VolumeRename, req)
+
 
 class _VolumeUploadContextManager:
     """Context manager for batch-uploading files to a Volume."""

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -688,6 +688,14 @@ def test_volume_create_delete(servicer, server_url_env, set_env_client):
     assert vol_name not in _run(["volume", "list"]).stdout
 
 
+def test_volume_rename(servicer, server_url_env, set_env_client):
+    old_name, new_name = "foo-vol", "bar-vol"
+    _run(["volume", "create", old_name])
+    _run(["volume", "rename", old_name, new_name])
+    assert new_name in _run(["volume", "list"]).stdout
+    assert old_name not in _run(["volume", "list"]).stdout
+
+
 @pytest.mark.parametrize("command", [["run"], ["deploy"], ["serve", "--timeout=1"], ["shell"]])
 @pytest.mark.usefixtures("set_env_client", "mock_shell_pty")
 @skip_windows("modal shell is not supported on Windows.")

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -691,7 +691,7 @@ def test_volume_create_delete(servicer, server_url_env, set_env_client):
 def test_volume_rename(servicer, server_url_env, set_env_client):
     old_name, new_name = "foo-vol", "bar-vol"
     _run(["volume", "create", old_name])
-    _run(["volume", "rename", old_name, new_name])
+    _run(["volume", "rename", "--yes", old_name, new_name])
     assert new_name in _run(["volume", "list"]).stdout
     assert old_name not in _run(["volume", "list"]).stdout
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1740,6 +1740,14 @@ class MockClientServicer(api_grpc.ModalClientBase):
         del self.volume_files[req.volume_id][req.path]
         await stream.send_message(Empty())
 
+    async def VolumeRename(self, stream):
+        req = await stream.recv_message()
+        for key, vol_id in self.deployed_volumes.items():
+            if vol_id == req.volume_id:
+                break
+        self.deployed_volumes[(req.name, *key[1:])] = self.deployed_volumes.pop(key)
+        await stream.send_message(Empty())
+
     async def VolumeListFiles(self, stream):
         req = await stream.recv_message()
         path = req.path if req.path else "/"


### PR DESCRIPTION
Depends on #2736 and https://github.com/modal-labs/modal/pull/18674

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Modal Volumes can now be renamed via the CLI (`modal volume rename`) or SDK (`modal.Volume.rename`).