### PR TITLE
Add web_server decorator container test

### DIFF
--- a/test/supports/functions.py
+++ b/test/supports/functions.py
@@ -16,6 +16,7 @@ from modal import (
     is_local,
     method,
     web_endpoint,
+    web_server,
     wsgi_app,
 )
 from modal._utils.deprecation import deprecation_warning
@@ -156,6 +157,14 @@ def fastapi_app():
         return {"hello": arg}
 
     return web_app
+
+
+@app.function()
+@web_server(8765, startup_timeout=1)
+def non_blocking_web_server():
+    import subprocess
+
+    subprocess.Popen(["python", "-m", "http.server", "-b", "0.0.0.0", "8765"])
 
 
 lifespan_global_asgi_app_func: list[str] = []


### PR DESCRIPTION
Split out the non-blocking `web_server` container test from https://github.com/modal-labs/modal-client/pull/2255 to a separate PR as it's still useful to add a test for it (we currently don't have any!) even if we don't go forward with running the user code in a background thread