### PR TITLE
CLI-298: Add from_file support to FilePatternMatcher & Image.*_docker_* methods

### DIFF
--- a/modal/file_pattern_matcher.py
+++ b/modal/file_pattern_matcher.py
@@ -96,6 +96,13 @@ class FilePatternMatcher(_AbstractPatternMatcher):
 
     @classmethod
     def from_file(cls, file_path: Path) -> "FilePatternMatcher":
+        """Initialize a new FilePatternMatcher instance from a file.
+
+        The patterns in the file will be read lazily when the matcher is first used.
+
+        Args:
+            file_path (Path): The path to the file containing patterns.
+        """
         uninitialized = cls.__new__(cls)
 
         def _delayed_init():
@@ -112,8 +119,6 @@ class FilePatternMatcher(_AbstractPatternMatcher):
         library. The reason is that `Matches()` in the original library is
         deprecated due to buggy behavior.
         """
-        if self._delayed_init:
-            self._delayed_init()
 
         matched = False
         file_path = os.path.normpath(file_path)
@@ -164,6 +169,8 @@ class FilePatternMatcher(_AbstractPatternMatcher):
         assert matcher(Path("foo.py"))
         ```
         """
+        if self._delayed_init:
+            self._delayed_init()
         return self._matches(str(file_path))
 
 

--- a/modal/image.py
+++ b/modal/image.py
@@ -683,6 +683,7 @@ class _Image(_Object, type_prefix="im"):
         **Usage:**
 
         ```python
+        from pathlib import Path
         from modal import FilePatternMatcher
 
         image = modal.Image.debian_slim().add_local_dir(
@@ -697,17 +698,24 @@ class _Image(_Object, type_prefix="im"):
             ignore=lambda p: p.is_relative_to(".venv"),
         )
 
-        image = modal.Image.debian_slim().copy_local_dir(
+        image = modal.Image.debian_slim().add_local_dir(
             "~/assets",
             remote_path="/assets",
             ignore=FilePatternMatcher("**/*.txt"),
         )
 
         # When including files is simpler than excluding them, you can use the `~` operator to invert the matcher.
-        image = modal.Image.debian_slim().copy_local_dir(
+        image = modal.Image.debian_slim().add_local_dir(
             "~/assets",
             remote_path="/assets",
             ignore=~FilePatternMatcher("**/*.py"),
+        )
+
+        # You can also read ignore patterns from a file.
+        image = modal.Image.debian_slim().add_local_dir(
+            "~/assets",
+            remote_path="/assets",
+            ignore=FilePatternMatcher.from_file(Path("/path/to/ignorefile")),
         )
         ```
         """
@@ -792,6 +800,7 @@ class _Image(_Object, type_prefix="im"):
         **Usage:**
 
         ```python
+        from pathlib import Path
         from modal import FilePatternMatcher
 
         image = modal.Image.debian_slim().copy_local_dir(
@@ -817,6 +826,13 @@ class _Image(_Object, type_prefix="im"):
             "~/assets",
             remote_path="/assets",
             ignore=~FilePatternMatcher("**/*.py"),
+        )
+
+        # You can also read ignore patterns from a file.
+        image = modal.Image.debian_slim().copy_local_dir(
+            "~/assets",
+            remote_path="/assets",
+            ignore=FilePatternMatcher.from_file(Path("/path/to/ignorefile")),
         )
         ```
         """
@@ -1207,7 +1223,43 @@ class _Image(_Object, type_prefix="im"):
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
         ignore: Union[Sequence[str], Callable[[Path], bool]] = (),
     ) -> "_Image":
-        """Extend an image with arbitrary Dockerfile-like commands."""
+        """
+        Extend an image with arbitrary Dockerfile-like commands.
+
+        **Usage:**
+
+        ```python
+        from pathlib import Path
+        from modal import FilePatternMatcher
+
+        image = modal.Image.debian_slim().dockerfile_commands(
+            ["COPY data /data"],
+            ignore=["*.venv"],
+        )
+
+        image = modal.Image.debian_slim().dockerfile_commands(
+            ["COPY data /data"],
+            ignore=lambda p: p.is_relative_to(".venv"),
+        )
+
+        image = modal.Image.debian_slim().dockerfile_commands(
+            ["COPY data /data"],
+            ignore=FilePatternMatcher("**/*.txt"),
+        )
+
+        # When including files is simpler than excluding them, you can use the `~` operator to invert the matcher.
+        image = modal.Image.debian_slim().dockerfile_commands(
+            ["COPY data /data"],
+            ignore=~FilePatternMatcher("**/*.py"),
+        )
+
+        # You can also read ignore patterns from a file.
+        image = modal.Image.debian_slim().dockerfile_commands(
+            ["COPY data /data"],
+            ignore=FilePatternMatcher.from_file(Path("/path/to/dockerignore")),
+        )
+        ```
+        """
         cmds = _flatten_str_args("dockerfile_commands", "dockerfile_commands", dockerfile_commands)
         if not cmds:
             return self
@@ -1608,10 +1660,43 @@ class _Image(_Object, type_prefix="im"):
         If your Dockerfile does not have Python installed, you can use the `add_python` parameter
         to specify a version of Python to add to the image.
 
-        **Example**
+        **Usage:**
 
         ```python
-        image = modal.Image.from_dockerfile("./Dockerfile", add_python="3.12")
+        from pathlib import Path
+        from modal import FilePatternMatcher
+
+        image = modal.Image.from_dockerfile(
+            "./Dockerfile",
+            add_python="3.12",
+            ignore=["*.venv"],
+        )
+
+        image = modal.Image.from_dockerfile(
+            "./Dockerfile",
+            add_python="3.12",
+            ignore=lambda p: p.is_relative_to(".venv"),
+        )
+
+        image = modal.Image.from_dockerfile(
+            "./Dockerfile",
+            add_python="3.12",
+            ignore=FilePatternMatcher("**/*.txt"),
+        )
+
+        # When including files is simpler than excluding them, you can use the `~` operator to invert the matcher.
+        image = modal.Image.from_dockerfile(
+            "./Dockerfile",
+            add_python="3.12",
+            ignore=~FilePatternMatcher("**/*.py"),
+        )
+
+        # You can also read ignore patterns from a file.
+        image = modal.Image.from_dockerfile(
+            "./Dockerfile",
+            add_python="3.12",
+            ignore=FilePatternMatcher.from_file(Path("/path/to/dockerignore")),
+        )
         ```
         """
 

--- a/test/file_pattern_matcher_test.py
+++ b/test/file_pattern_matcher_test.py
@@ -175,19 +175,19 @@ def test_clean_patterns_strip_empty_patterns():
 def test_clean_patterns_exception_flag():
     patterns = ["docs", "!docs/README.md"]
     pm = FilePatternMatcher(*patterns)
-    assert pm.exclusions
+    assert any(p.exclusion for p in pm.patterns)
 
 
 def test_clean_patterns_leading_space_trimmed():
     patterns = ["docs", "  !docs/README.md"]
     pm = FilePatternMatcher(*patterns)
-    assert pm.exclusions
+    assert any(p.exclusion for p in pm.patterns)
 
 
 def test_clean_patterns_trailing_space_trimmed():
     patterns = ["docs", "!docs/README.md  "]
     pm = FilePatternMatcher(*patterns)
-    assert pm.exclusions
+    assert any(p.exclusion for p in pm.patterns)
 
 
 def test_clean_patterns_error_single_exception():
@@ -334,3 +334,15 @@ def test_invert_patterns(tmp_path_with_content):
     lff = FilePatternMatcher("!**/*.txt")
     for file_path in file_paths:
         assert not lff(file_path)
+
+
+@pytest.mark.usefixtures("tmp_cwd")
+def test_from_file():
+    rel_top_dir = Path("top")
+    rel_top_dir.mkdir()
+    ignore_file = rel_top_dir / "pattern_file"
+    ignore_file.write_text("**/*.txt")
+
+    lff = FilePatternMatcher.from_file(ignore_file)
+    assert lff(Path("top/data.txt"))
+    assert not lff(Path("top/data.py"))

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -18,6 +18,7 @@ from modal._serialization import serialize
 from modal._utils.async_utils import synchronizer
 from modal.client import Client
 from modal.exception import DeprecationError, InvalidError, VersionError
+from modal.file_pattern_matcher import FilePatternMatcher
 from modal.image import (
     SUPPORTED_PYTHON_SERIES,
     ImageBuilderVersion,
@@ -826,6 +827,43 @@ def test_image_docker_command_copy(
 
     if maybe_dockerfile:
         Path(maybe_dockerfile.name).unlink()
+
+
+@pytest.mark.parametrize("use_dockerfile", (True, False))
+@pytest.mark.usefixtures("tmp_cwd")
+def test_image_dockerfile_copy_ignore_from_file(builder_version, servicer, client, use_dockerfile):
+    rel_top_dir = Path("top")
+    rel_top_dir.mkdir()
+    (rel_top_dir / "data.txt").write_text("world")
+    (rel_top_dir / "file.py").write_text("world")
+    dockerfile = rel_top_dir / "Dockerfile"
+    dockerfile.write_text(f"COPY {rel_top_dir} /dummy\n")
+
+    # explicitly provide the .dockerignore file
+    dockerignore = rel_top_dir / "something_special.dockerignore"
+    dockerignore.write_text("**/*.py")
+
+    app = App()
+    if use_dockerfile:
+        image = Image.debian_slim().from_dockerfile(dockerfile, ignore=FilePatternMatcher.from_file(dockerignore))
+        layer = 1
+    else:
+        image = Image.debian_slim().dockerfile_commands(
+            [f"COPY {rel_top_dir} /dummy"], ignore=FilePatternMatcher.from_file(dockerignore)
+        )
+        layer = 0
+    app.function(image=image)(dummy)
+
+    with app.run(client=client):
+        layers = get_image_layers(image.object_id, servicer)
+        assert f"COPY {rel_top_dir} /dummy" in layers[layer].dockerfile_commands
+        mount_id = layers[layer].context_mount_id
+        files = set(Path(fn) for fn in servicer.mount_contents[mount_id].keys())
+        assert files == {
+            Path("/") / rel_top_dir / "Dockerfile",
+            Path("/") / rel_top_dir / "data.txt",
+            Path("/") / rel_top_dir / "something_special.dockerignore",
+        }
 
 
 @pytest.mark.parametrize("use_callable", (True, False))
@@ -1679,3 +1717,34 @@ def test_image_add_local_dir_ignore_nothing(servicer, client, tmp_path_with_cont
             assert set(Path(fn) for fn in servicer.mount_contents[mount_id].keys()) == {
                 Path(f"/place{f}") for f in expected
             }
+
+
+@pytest.mark.parametrize("copy", [True, False])
+@pytest.mark.usefixtures("tmp_cwd")
+def test_image_add_local_dir_ignore_from_file(servicer, client, tmp_path_with_content, copy):
+    rel_top_dir = Path("top")
+    rel_top_dir.mkdir()
+    ignore_file = rel_top_dir / "something_special.ignore_file"
+    ignore_file.write_text("**/*.txt")
+
+    expected = {"/data.txt"}
+    app = App()
+
+    img = Image.from_registry("unknown_image").workdir("/proj")
+    if copy:
+        app.image = img.copy_local_dir(
+            tmp_path_with_content, "/place/", ignore=~FilePatternMatcher.from_file(ignore_file)
+        )
+        app.function()(dummy)
+        with app.run(client=client):
+            assert len(img._mount_layers) == 0
+            layers = get_image_layers(app.image.object_id, servicer)
+            mount_id = layers[0].context_mount_id
+            assert set(servicer.mount_contents[mount_id].keys()) == expected
+    else:
+        img = img.add_local_dir(tmp_path_with_content, "/place/", ignore=~FilePatternMatcher.from_file(ignore_file))
+        app.function(image=img)(dummy)
+        with app.run(client=client):
+            assert len(img._mount_layers) == 1
+            mount_id = img._mount_layers[0].object_id
+            assert set(servicer.mount_contents[mount_id].keys()) == {f"/place{f}" for f in expected}


### PR DESCRIPTION
## Describe your changes

Breakout PR from https://github.com/modal-labs/modal-client/pull/2729 which adds support for reading ignore patterns from files and auto detecting dockerignore files if present. This PR only has the support for reading ignore patterns from files.


We already support auto-inferring context mounts for `Image.from_dockerfile()` and `image.dockerfile_commands()` methods and an `ignore` argument which accepts a sequence of patterns to ignore or a callable to determine which files to ignore.

This PR adds
- support for a new constructor to `FilePatternMatcher`, `from_file` which allows you to pass the `Path` to a `dockerignore`-compatible file which will be used to ignore files for the context mount instead. 

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

* `FilePatternMatcher` has a new constructor `from_file` which allows you to read file matching patterns from a file instead of having to pass them in directly, this can be used for `Image` methods accepting an `ignore` parameter in order to read ignore patterns from files.