### PR TITLE
Add Python standalone mount deployment back to CD pipeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -212,6 +212,36 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: twine upload dist/* --non-interactive
 
+  publish-python-standalone:
+    name: Publish Python standalone mounts
+    if: github.ref == 'refs/heads/main'
+    needs: [client-versioning, client-test, publish-client]
+    runs-on: ubuntu-20.04
+    timeout-minutes: 5
+    env:
+      MODAL_LOGLEVEL: DEBUG
+      MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+      MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: v${{ needs.client-versioning.outputs.client-version}}
+
+      - uses: ./.github/actions/setup-cached-python
+        with:
+          version: "3.11"
+
+      - name: Build protobuf
+        run: inv protoc
+
+      - name: Build client package (installs all dependencies)
+        run: pip install -e .
+
+      - name: Publish mounts
+        run: python -m modal_global_objects.mounts.python_standalone
+
+
   publish-base-images:
     name: |
       Publish base images for ${{ matrix.image-name }} ${{ matrix.image-builder-version }}


### PR DESCRIPTION
Whoops, [this PR](https://github.com/modal-labs/modal-client/pull/1487) from back in March 2024 refactored the "global mounts" and inadvertently (I think?) dropped the "Python standalone" mount from the CD workflow. That didn't actually cause any problems until we added support for Python 3.13, so it went unnoticed for a while. This should re-enable it. (Like all main-only-CD-PRs, this might require an iteration or two to address unforeseen issues).