### PR TITLE
Fix Python 3.13 standalone mount steps

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -1504,9 +1504,14 @@ class _Image(_Object, type_prefix="im"):
             _validate_python_version(add_python, builder_version, allow_micro_granularity=False)
             add_python_commands = [
                 "COPY /python/. /usr/local",
-                "RUN ln -s /usr/local/bin/python3 /usr/local/bin/python",
                 "ENV TERMINFO_DIRS=/etc/terminfo:/lib/terminfo:/usr/share/terminfo:/usr/lib/terminfo",
             ]
+            if add_python < "3.13":
+                # Previous versions did not include the `python` binary, but later ones do.
+                # (The important factor is not the Python version itself, but the standalone dist version.)
+                # We insert the command in the list at the position it was previously always added
+                # for backwards compatibility with existing images.
+                add_python_commands.insert(1, "RUN ln -s /usr/local/bin/python3 /usr/local/bin/python")
 
         # Note: this change is because we install dependencies with uv in 2024.10+
         requirements_prefix = "python -m " if builder_version < "2024.10" else ""


### PR DESCRIPTION
Older versions of the standalone Python distribution included only a `python3` binary, so our Image recipe when using `add_python` added a softlink from `python3` to `python` (which Modal otherwise expects to exist).

With newer versions of the standalone Python distribution, which we start picking up with Python 3.13, `python` is included so the build recipe would fail

```python
=> Step 2: RUN ln -s /usr/local/bin/python3 /usr/local/bin/python
ln: failed to create symbolic link '/usr/local/bin/python': File exists
```

This PR skips the linking step based on a Python version check. (Technically it's the standalone mount version, not the Python version that matters, but the result is equivalent and the latter is easier to check in the relevant context).