### PR TITLE
Add `modal launch hf-download` utility

### DIFF
--- a/modal/cli/programs/hf_download.py
+++ b/modal/cli/programs/hf_download.py
@@ -1,0 +1,43 @@
+# Copyright Modal Labs 2025
+import json
+import os
+import time
+
+import modal
+
+# Passed by `modal launch` locally via CLI, plumbed to remote runner through secrets.
+args: dict = json.loads(os.environ.get("MODAL_LAUNCH_ARGS", "{}"))
+
+CACHE_DIR = "/hf-cache"
+
+image = (
+    modal.Image.debian_slim(python_version="3.12")
+    .pip_install("huggingface-hub[hf-transfer]==0.27.1")
+    .env({"HF_HUB_CACHE": CACHE_DIR, "HF_HUB_ENABLE_HF_TRANSFER": "1"})
+)
+volume = modal.Volume.from_name(str(args.get("volume")))
+secrets = [modal.Secret.from_dict({"MODAL_LAUNCH_ARGS": json.dumps(args)})]
+if user_secret := args.get("secret"):
+    secrets.append(modal.Secret.from_name(user_secret))
+app = modal.App("hf-download", image=image, secrets=secrets, volumes={CACHE_DIR: volume})
+
+
+@app.function(cpu=4, memory=1028, timeout=int(args.get("timeout", 600)))
+def run():
+    from huggingface_hub import snapshot_download
+
+    t0 = time.monotonic()
+    snapshot_download(
+        repo_id=args.get("repo_id"),
+        repo_type=args.get("type"),
+        revision=args.get("revision"),
+        ignore_patterns=args.get("ignore", []),
+        allow_patterns=args.get("allow", []),
+        cache_dir=CACHE_DIR,
+    )
+    print(f"Completed in {time.monotonic() - t0:.2f} seconds")
+
+
+@app.local_entrypoint()
+def main():
+    run.remote()


### PR DESCRIPTION
Adds a new `modal launch` utility intended to make it simple to cache an asset from the Hugging Face hub onto a modal.Volume.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Added a `modal launch hf-download` utility. This provides a simple CLI for caching an asset from the Hugging Face Hub onto a Modal Volume:

    ```
    modal launch hf-download stabilityai/stable-diffusion-xl-base-1.0 hf-hub-cache --secret=hugging-face
    ```

   To use the assets, mount the Volume to a location that corresponds to the Hugging Face cache directory, as specified by the `HF_HUB_CACHE` environment variable or passed as the `cache_dir` in relevant functions.
