### PR TITLE
Make sure we don't have an event loop when the function is not async

### DIFF
--- a/test/container_test.py
+++ b/test/container_test.py
@@ -2457,3 +2457,9 @@ def test_container_app_zero_matching(servicer, event_loop):
 @skip_github_non_linux
 def test_container_app_one_matching(servicer, event_loop):
     _run_container(servicer, "test.supports.functions", "check_container_app")
+
+
+@skip_github_non_linux
+def test_no_event_loop(servicer, event_loop):
+    ret = _run_container(servicer, "test.supports.functions", "get_running_loop")
+    assert _unwrap_exception(ret) == "RuntimeError('no running event loop')"

--- a/test/supports/functions.py
+++ b/test/supports/functions.py
@@ -713,3 +713,8 @@ def set_input_concurrency(start: float):
 def check_container_app():
     # The container app should be associated with the app object
     assert App._get_container_app() == app
+
+
+@app.function()
+def get_running_loop(x):
+    return asyncio.get_running_loop()


### PR DESCRIPTION
I realized it would be easy to introduce regressions for this – we should have a test.