### PR TITLE
More tests for concurrency info

### DIFF
--- a/test/container_test.py
+++ b/test/container_test.py
@@ -2463,3 +2463,15 @@ def test_container_app_one_matching(servicer, event_loop):
 def test_no_event_loop(servicer, event_loop):
     ret = _run_container(servicer, "test.supports.functions", "get_running_loop")
     assert _unwrap_exception(ret) == "RuntimeError('no running event loop')"
+
+
+@skip_github_non_linux
+def test_is_main_thread_sync(servicer, event_loop):
+    ret = _run_container(servicer, "test.supports.functions", "is_main_thread_async")
+    assert _unwrap_scalar(ret) is True
+
+
+@skip_github_non_linux
+def test_is_main_thread_async(servicer, event_loop):
+    ret = _run_container(servicer, "test.supports.functions", "is_main_thread_sync")
+    assert _unwrap_scalar(ret) is True

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -2467,11 +2467,17 @@ def test_no_event_loop(servicer, event_loop):
 
 @skip_github_non_linux
 def test_is_main_thread_sync(servicer, event_loop):
-    ret = _run_container(servicer, "test.supports.functions", "is_main_thread_async")
+    ret = _run_container(servicer, "test.supports.functions", "is_main_thread_sync")
     assert _unwrap_scalar(ret) is True
 
 
 @skip_github_non_linux
 def test_is_main_thread_async(servicer, event_loop):
-    ret = _run_container(servicer, "test.supports.functions", "is_main_thread_sync")
+    ret = _run_container(servicer, "test.supports.functions", "is_main_thread_async")
+    assert _unwrap_scalar(ret) is True
+
+
+@skip_github_non_linux
+def test_import_thread_is_main_thread(servicer, event_loop):
+    ret = _run_container(servicer, "test.supports.functions", "import_thread_is_main_thread")
     assert _unwrap_scalar(ret) is True

--- a/test/supports/functions.py
+++ b/test/supports/functions.py
@@ -729,3 +729,11 @@ def is_main_thread_sync(x):
 @app.function()
 async def is_main_thread_async(x):
     return threading.main_thread() == threading.current_thread()
+
+
+_import_thread_is_main_thread = threading.main_thread() == threading.current_thread()
+
+
+@app.function()
+def import_thread_is_main_thread(x):
+    return _import_thread_is_main_thread

--- a/test/supports/functions.py
+++ b/test/supports/functions.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
 import asyncio
 import contextlib
+import threading
 import time
 
 from modal import (
@@ -718,3 +719,13 @@ def check_container_app():
 @app.function()
 def get_running_loop(x):
     return asyncio.get_running_loop()
+
+
+@app.function()
+def is_main_thread_sync(x):
+    return threading.main_thread() == threading.current_thread()
+
+
+@app.function()
+async def is_main_thread_async(x):
+    return threading.main_thread() == threading.current_thread()


### PR DESCRIPTION
Following up on #2745. I realized we actually have integration tests for this in the proprietary repo! But those are slow and are much better as isolated tests like this. So I quickly ported them over to the client instead.