### PR TITLE
Fix bug with add_python='3.9'

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -1506,7 +1506,8 @@ class _Image(_Object, type_prefix="im"):
                 "COPY /python/. /usr/local",
                 "ENV TERMINFO_DIRS=/etc/terminfo:/lib/terminfo:/usr/share/terminfo:/usr/lib/terminfo",
             ]
-            if add_python < "3.13":
+            python_minor = add_python.split(".")[1]
+            if int(python_minor) < 13:
                 # Previous versions did not include the `python` binary, but later ones do.
                 # (The important factor is not the Python version itself, but the standalone dist version.)
                 # We insert the command in the list at the position it was previously always added

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -47,7 +47,7 @@ from modal.client import Client
 from modal.cls import _Cls
 from modal.functions import _Function
 from modal.image import ImageBuilderVersion
-from modal.mount import client_mount_name
+from modal.mount import PYTHON_STANDALONE_VERSIONS, client_mount_name, python_standalone_mount_name
 from modal_proto import api_grpc, api_pb2
 
 
@@ -233,6 +233,13 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.default_published_client_mount = "mo-123"
         self.deployed_mounts = {
             (client_mount_name(), api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL): self.default_published_client_mount,
+            **{
+                (
+                    python_standalone_mount_name(version),
+                    api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL,
+                ): f"mo-{version.replace('.', '')}"
+                for version in PYTHON_STANDALONE_VERSIONS
+            },
         }
 
         self.deployed_nfss = {}

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -237,7 +237,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
                 (
                     python_standalone_mount_name(version),
                     api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL,
-                ): f"mo-{version.replace('.', '')}"
+                ): f"mo-py{version.replace('.', '')}"
                 for version in PYTHON_STANDALONE_VERSIONS
             },
         }

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -330,7 +330,7 @@ def test_from_registry_add_python(builder_version, servicer, client):
     with app.run(client=client):
         layers = get_image_layers(app.image.object_id, servicer)
         commands = layers[0].dockerfile_commands
-        print(commands)
+        assert layers[0].context_mount_id == "mo-py39"
         assert any("COPY /python/. /usr/local" in cmd for cmd in commands)
         assert any("ln -s /usr/local/bin/python3" in cmd for cmd in commands)
 
@@ -341,7 +341,7 @@ def test_from_registry_add_python(builder_version, servicer, client):
         with app.run(client=client):
             layers = get_image_layers(app.image.object_id, servicer)
             commands = layers[0].dockerfile_commands
-            print(commands)
+            assert layers[0].context_mount_id == "mo-py313"
             assert any("COPY /python/. /usr/local" in cmd for cmd in commands)
             assert not any("ln -s /usr/local/bin/python3" in cmd for cmd in commands)
 


### PR DESCRIPTION
Fixes a dumb bug that I introduced in https://github.com/modal-labs/modal-client/pull/2743 by doing an ordinal comparison of version number strings 🤦.

Also adds a test for the base behavior of the `from_registry(..., add_python)` functionality (it was untested) and the edge case.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->

- Fixes a bug introduced in v0.72.2 when specifying `add_python="3.9"` in `Image.from_registry`.