### PR TITLE
Fix formatting on `modal shell` docs

### DIFF
--- a/modal/cli/launch.py
+++ b/modal/cli/launch.py
@@ -19,6 +19,8 @@ launch_cli = Typer(
     no_args_is_help=True,
     help="""
     Open a serverless app instance on Modal.
+
+    This command is in preview and may change in the future.
     """,
 )
 

--- a/modal/cli/launch.py
+++ b/modal/cli/launch.py
@@ -18,9 +18,7 @@ launch_cli = Typer(
     name="launch",
     no_args_is_help=True,
     help="""
-    [Preview] Open a serverless app instance on Modal.
-
-    This command is in preview and may change in the future.
+    Open a serverless app instance on Modal.
     """,
 )
 

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -411,7 +411,7 @@ def shell(
 
     \b**Examples:**
 
-    \bStart an interactive shell inside the default Debian-based image:
+    \bStart an ren interactive shell inside the default Debian-based image:
 
     \b```
     modal shell

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -411,7 +411,7 @@ def shell(
 
     \b**Examples:**
 
-    \bStart an ren interactive shell inside the default Debian-based image:
+    \bStart an ren ren ren interactive shell inside the default Debian-based image:
 
     \b```
     modal shell

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -407,38 +407,38 @@ def shell(
     ),
     pty: Optional[bool] = typer.Option(default=None, help="Run the command using a PTY."),
 ):
-    """Run a SPOT ME command or interactive shell inside a Modal container.
+    """Run a command or interactive shell inside a Modal container.
 
-    \b**Examples:**
+    **Examples:**
 
-    \bStart an ren ren ren interactive shell inside the default Debian-based image:
+    Start an interactive shell inside the default Debian-based image:
 
-    \b```
+    ```
     modal shell
     ```
 
-    \bStart an interactive shell with the spec for `my_function` in your App
+    Start an interactive shell with the spec for `my_function` in your App
     (uses the same image, volumes, mounts, etc.):
 
-    \b```
+    ```
     modal shell hello_world.py::my_function
     ```
 
-    \bOr, if you're using a [modal.Cls](/docs/reference/modal.Cls), you can refer to a `@modal.method` directly:
+    Or, if you're using a [modal.Cls](/docs/reference/modal.Cls), you can refer to a `@modal.method` directly:
 
-    \b```
+    ```
     modal shell hello_world.py::MyClass.my_method
     ```
 
     Start a `python` shell:
 
-    \b```
+    ```
     modal shell hello_world.py --cmd=python
     ```
 
-    \bRun a command with your function's spec and pipe the output to a file:
+    Run a command with your function's spec and pipe the output to a file:
 
-    \b```
+    ```
     modal shell hello_world.py -c 'uv pip list' > env.txt
     ```
     """

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -407,7 +407,7 @@ def shell(
     ),
     pty: Optional[bool] = typer.Option(default=None, help="Run the command using a PTY."),
 ):
-    """Run a command or interactive shell inside a Modal container.
+    """Run a SPOT ME command or interactive shell inside a Modal container.
 
     \b**Examples:**
 


### PR DESCRIPTION
Remove `\b` characters that were messing up the formatting on the reference docs page for `modal shell`
