### PR TITLE
Fix state for detached (disconnected) Apps in `modal app list`

### DIFF
--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -26,9 +26,10 @@ app_cli = typer.Typer(name="app", help="Manage deployed and running apps.", no_a
 APP_STATE_TO_MESSAGE = {
     api_pb2.APP_STATE_DEPLOYED: Text("deployed", style="green"),
     api_pb2.APP_STATE_DETACHED: Text("ephemeral (detached)", style="green"),
+    api_pb2.APP_STATE_DETACHED_DISCONNECTED: Text("ephemeral (detached)", style="green"),
     api_pb2.APP_STATE_DISABLED: Text("disabled", style="dim"),
     api_pb2.APP_STATE_EPHEMERAL: Text("ephemeral", style="green"),
-    api_pb2.APP_STATE_INITIALIZING: Text("initializing...", style="green"),
+    api_pb2.APP_STATE_INITIALIZING: Text("initializing...", style="yellow"),
     api_pb2.APP_STATE_STOPPED: Text("stopped", style="blue"),
     api_pb2.APP_STATE_STOPPING: Text("stopping...", style="blue"),
 }


### PR DESCRIPTION
Previously these had an "Unknown" status in the list.

I thought about distinguishing between "detachable" and "detached", but that doesn't really work with `--detach` being the flag. I guess users don't need to think about the difference.