### PR TITLE
Fixes issue where `modal run` of a method on a class triggered deprecation warning [CLI-304]

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -504,7 +504,7 @@ class _App:
         return self._functions
 
     @property
-    def registered_classes(self) -> dict[str, _Function]:
+    def registered_classes(self) -> dict[str, _Cls]:
         """All modal.Cls objects registered on the app."""
         return self._classes
 

--- a/modal/cli/import_refs.py
+++ b/modal/cli/import_refs.py
@@ -132,7 +132,10 @@ def get_by_object_path(obj: Any, obj_path: str) -> Union[Function, LocalEntrypoi
 def _infer_function_or_help(
     app: App, module, accept_local_entrypoint: bool, accept_webhook: bool
 ) -> Union[Function, LocalEntrypoint, MethodReference]:
-    function_choices = set(app.registered_functions)
+    # TODO: refactor registered_functions to only contain function services, not class services
+    function_choices = set(f for f in app.registered_functions if not f.endswith(".*"))  # no class services here
+    for cls_name, cls in app.registered_classes:
+        pass
 
     if not accept_webhook:
         function_choices -= set(app.registered_web_endpoints)

--- a/modal/cli/import_refs.py
+++ b/modal/cli/import_refs.py
@@ -9,8 +9,10 @@ These functions are only called by the Modal CLI, not in tasks.
 
 import dataclasses
 import importlib
+import importlib.util
 import inspect
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional, Union
 
@@ -19,6 +21,7 @@ from rich.console import Console
 from rich.markdown import Markdown
 
 from modal.app import App, LocalEntrypoint
+from modal.cls import Cls
 from modal.exception import InvalidError, _CliUserExecutionError
 from modal.functions import Function
 
@@ -26,6 +29,12 @@ from modal.functions import Function
 @dataclasses.dataclass
 class ImportRef:
     file_or_module: str
+
+    # object_path is a .-delimited path to the object to execute, or a parent from which to infer the object
+    # e.g.
+    # function or local_entrypoint in module scope
+    # app in module scope [+ method name]
+    # app [+ function/entrypoint on that app]
     object_path: Optional[str]
 
 
@@ -79,23 +88,36 @@ def import_file_or_module(file_or_module: str):
     return module
 
 
-def get_by_object_path(obj: Any, obj_path: str) -> Optional[Any]:
+@dataclass
+class MethodReference:
+    cls: Cls
+    method_name: str
+
+
+def get_by_object_path(obj: Any, obj_path: str) -> Union[Function, LocalEntrypoint, MethodReference, None]:
     # Try to evaluate a `.`-delimited object path in a Modal context
     # With the caveat that some object names can actually have `.` in their name (lifecycled methods' tags)
 
     # Note: this is eager, so no backtracking is performed in case an
     # earlier match fails at some later point in the path expansion
     prefix = ""
-    for segment in obj_path.split("."):
+    obj_path_segments = obj_path.split(".")
+    for i, segment in enumerate(obj_path_segments):
         attr = prefix + segment
+        if isinstance(obj, App):
+            if attr in obj.registered_entrypoints:
+                # local entrypoints are not on stub blueprint
+                obj = obj.registered_entrypoints[attr]
+                continue
+        if isinstance(obj, Cls):
+            remaining_segments = obj_path_segments[i:]
+            remaining_path = ".".join(remaining_segments)
+            if len(remaining_segments) > 1:
+                raise ValueError(f"{obj._get_name()} is a class, but {remaining_path} is not a method reference")
+            # TODO: add method inference here?
+            return MethodReference(obj, remaining_path)
         try:
-            if isinstance(obj, App):
-                if attr in obj.registered_entrypoints:
-                    # local entrypoints are not on stub blueprint
-                    obj = obj.registered_entrypoints[attr]
-                    continue
             obj = getattr(obj, attr)
-
         except Exception:
             prefix = f"{prefix}{segment}."
         else:
@@ -109,15 +131,16 @@ def get_by_object_path(obj: Any, obj_path: str) -> Optional[Any]:
 
 def _infer_function_or_help(
     app: App, module, accept_local_entrypoint: bool, accept_webhook: bool
-) -> Union[Function, LocalEntrypoint]:
+) -> Union[Function, LocalEntrypoint, MethodReference]:
     function_choices = set(app.registered_functions)
+
     if not accept_webhook:
         function_choices -= set(app.registered_web_endpoints)
     if accept_local_entrypoint:
         function_choices |= set(app.registered_entrypoints.keys())
 
     sorted_function_choices = sorted(function_choices)
-    registered_functions_str = "\n".join(sorted_function_choices)
+
     filtered_local_entrypoints = [
         name
         for name, entrypoint in app.registered_entrypoints.items()
@@ -141,6 +164,7 @@ def _infer_function_or_help(
             err_msg = "Modal app has no registered functions. Nothing to run."
         raise click.UsageError(err_msg)
     else:
+        registered_functions_str = "\n".join(sorted_function_choices)
         help_text = f"""You need to specify a Modal function or local entrypoint to run, e.g.
 
 modal run app.py::my_function [...args]
@@ -223,30 +247,42 @@ You would run foo as [bold green]{base_cmd} app.py::foo[/bold green]"""
     error_console.print(guidance_msg)
 
 
-def import_function(
+def import_object(
     func_ref: str, base_cmd: str, accept_local_entrypoint=True, accept_webhook=False
-) -> Union[Function, LocalEntrypoint]:
+) -> Union[Function, LocalEntrypoint, MethodReference]:
+    """Takes a function ref string and returns something "runnable"
+
+    The function ref can leave out partial information (apart from the file name) as
+    long as the runnable is uniquely identifiable by the provided information.
+
+    When there are multiple runnables within the provided ref, the following rules should
+    be followed:
+
+    1. if there is a single local_entrypoint, that one is used
+    2. if there is a single {function, class} that one is used
+    3. if there is a single method (within a class) that one is used
+    """
     import_ref = parse_import_ref(func_ref)
 
     module = import_file_or_module(import_ref.file_or_module)
-    app_or_function = get_by_object_path(module, import_ref.object_path or DEFAULT_APP_NAME)
+    app_function_or_method_ref = get_by_object_path(module, import_ref.object_path or DEFAULT_APP_NAME)
 
-    if app_or_function is None:
+    if app_function_or_method_ref is None:
         _show_function_ref_help(import_ref, base_cmd)
         sys.exit(1)
 
-    if isinstance(app_or_function, App):
+    if isinstance(app_function_or_method_ref, App):
         # infer function or display help for how to select one
-        app = app_or_function
+        app = app_function_or_method_ref
         function_handle = _infer_function_or_help(app, module, accept_local_entrypoint, accept_webhook)
         return function_handle
-    elif isinstance(app_or_function, Function):
-        return app_or_function
-    elif isinstance(app_or_function, LocalEntrypoint):
+    elif isinstance(app_function_or_method_ref, (Function, MethodReference)):
+        return app_function_or_method_ref
+    elif isinstance(app_function_or_method_ref, LocalEntrypoint):
         if not accept_local_entrypoint:
             raise click.UsageError(
                 f"{func_ref} is not a Modal Function (a Modal local_entrypoint can't be used in this context)"
             )
-        return app_or_function
+        return app_function_or_method_ref
     else:
-        raise click.UsageError(f"{app_or_function} is not a Modal entity (should be an App or Function)")
+        raise click.UsageError(f"{app_function_or_method_ref} is not a Modal entity (should be an App or Function)")

--- a/modal/cli/launch.py
+++ b/modal/cli/launch.py
@@ -12,7 +12,7 @@ from ..app import LocalEntrypoint
 from ..exception import _CliUserExecutionError
 from ..output import enable_output
 from ..runner import run_app
-from .import_refs import import_object
+from .import_refs import import_and_infer
 
 launch_cli = Typer(
     name="launch",
@@ -29,7 +29,7 @@ def _launch_program(name: str, filename: str, detach: bool, args: dict[str, Any]
     os.environ["MODAL_LAUNCH_ARGS"] = json.dumps(args)
 
     program_path = str(Path(__file__).parent / "programs" / filename)
-    app, entrypoint = import_object(program_path, "modal launch")
+    app, entrypoint = import_and_infer(program_path, "modal launch")
     if not isinstance(entrypoint, LocalEntrypoint):
         raise ValueError(f"{program_path} has no single local_entrypoint")
 

--- a/modal/cli/launch.py
+++ b/modal/cli/launch.py
@@ -8,7 +8,7 @@ from typing import Any, Optional
 
 from typer import Typer
 
-from ..app import App, LocalEntrypoint
+from ..app import LocalEntrypoint
 from ..exception import _CliUserExecutionError
 from ..output import enable_output
 from ..runner import run_app
@@ -29,11 +29,10 @@ def _launch_program(name: str, filename: str, detach: bool, args: dict[str, Any]
     os.environ["MODAL_LAUNCH_ARGS"] = json.dumps(args)
 
     program_path = str(Path(__file__).parent / "programs" / filename)
-    entrypoint = import_object(program_path, "modal launch")
+    app, entrypoint = import_object(program_path, "modal launch")
     if not isinstance(entrypoint, LocalEntrypoint):
         raise ValueError(f"{program_path} has no single local_entrypoint")
 
-    app: App = entrypoint.app
     app.set_description(f"modal launch {name}")
 
     # `launch/` scripts must have a `local_entrypoint()` with no args, for simplicity here.

--- a/modal/cli/launch.py
+++ b/modal/cli/launch.py
@@ -8,11 +8,11 @@ from typing import Any, Optional
 
 from typer import Typer
 
-from ..app import App
+from ..app import App, LocalEntrypoint
 from ..exception import _CliUserExecutionError
 from ..output import enable_output
 from ..runner import run_app
-from .import_refs import import_function
+from .import_refs import import_object
 
 launch_cli = Typer(
     name="launch",
@@ -29,7 +29,10 @@ def _launch_program(name: str, filename: str, detach: bool, args: dict[str, Any]
     os.environ["MODAL_LAUNCH_ARGS"] = json.dumps(args)
 
     program_path = str(Path(__file__).parent / "programs" / filename)
-    entrypoint = import_function(program_path, "modal launch")
+    entrypoint = import_object(program_path, "modal launch")
+    if not isinstance(entrypoint, LocalEntrypoint):
+        raise ValueError(f"{program_path} has no single local_entrypoint")
+
     app: App = entrypoint.app
     app.set_description(f"modal launch {name}")
 

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -24,7 +24,7 @@ from ..output import enable_output
 from ..runner import deploy_app, interactive_shell, run_app
 from ..serving import serve_app
 from ..volume import Volume
-from .import_refs import MethodReference, import_app, import_object
+from .import_refs import MethodReference, import_and_infer, import_app
 from .utils import ENV_OPTION, ENV_OPTION_HELP, is_tty, stream_app_logs
 
 
@@ -260,7 +260,7 @@ class RunGroup(click.Group):
         ctx.ensure_object(dict)
         ctx.obj["env"] = ensure_env(ctx.params["env"])
 
-        app, imported_object = import_object(func_ref, accept_local_entrypoint=True, base_cmd="modal run")
+        app, imported_object = import_and_infer(func_ref, accept_local_entrypoint=True, base_cmd="modal run")
 
         if app.description is None:
             app.set_description(_get_clean_app_description(func_ref))
@@ -478,7 +478,7 @@ def shell(
             exec(container_id=container_or_function, command=shlex.split(cmd), pty=pty)
             return
 
-        original_app, function_or_method_ref = import_object(
+        original_app, function_or_method_ref = import_and_infer(
             container_or_function, accept_local_entrypoint=False, accept_webhook=True, base_cmd="modal shell"
         )
         function_spec: _FunctionSpec

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -269,7 +269,9 @@ class RunGroup(click.Group):
         elif isinstance(imported_object, MethodReference):
             app = imported_object.cls._get_app()
         else:
-            raise ValueError(f"{imported_object} is neither function, local entrypoint or class")
+            raise click.UsageError(
+                f"{imported_object} is neither function, local entrypoint or class ({type(imported_object)})"
+            )
 
         if app.description is None:
             app.set_description(_get_clean_app_description(func_ref))
@@ -490,12 +492,12 @@ def shell(
         function_or_method_ref = import_object(
             container_or_function, accept_local_entrypoint=False, accept_webhook=True, base_cmd="modal shell"
         )
-
+        function_spec: _FunctionSpec
         if isinstance(function_or_method_ref, MethodReference):
             class_service_function = function_or_method_ref.cls._get_class_service_function()
             function_spec = class_service_function.spec
         elif isinstance(function_or_method_ref, Function):
-            function_spec: _FunctionSpec = function_or_method_ref.spec
+            function_spec = function_or_method_ref.spec
         else:
             raise ValueError("Referenced entity is neither a function nor a class/method.")
 

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -7,7 +7,6 @@ import re
 import shlex
 import sys
 import time
-import typing
 from functools import partial
 from typing import Any, Callable, Optional, get_type_hints
 
@@ -15,7 +14,6 @@ import click
 import typer
 from typing_extensions import TypedDict
 
-from .. import Cls
 from ..app import App, LocalEntrypoint
 from ..config import config
 from ..environments import ensure_env
@@ -26,7 +24,7 @@ from ..output import enable_output
 from ..runner import deploy_app, interactive_shell, run_app
 from ..serving import serve_app
 from ..volume import Volume
-from .import_refs import import_app, import_function
+from .import_refs import MethodReference, import_app, import_object
 from .utils import ENV_OPTION, ENV_OPTION_HELP, is_tty, stream_app_logs
 
 
@@ -145,39 +143,7 @@ def _write_local_result(result_path: str, res: Any):
         fid.write(res)
 
 
-def _get_click_command_for_function(app: App, function_tag):
-    function = app.registered_functions.get(function_tag)
-    if not function or (isinstance(function, Function) and function.info.user_cls is not None):
-        # This is either a function_tag for a class method function (e.g MyClass.foo) or a function tag for a
-        # class service function (MyClass.*)
-        class_name, method_name = function_tag.rsplit(".", 1)
-        if not function:
-            function = app.registered_functions.get(f"{class_name}.*")
-    assert isinstance(function, Function)
-    function = typing.cast(Function, function)
-    if function.is_generator:
-        raise InvalidError("`modal run` is not supported for generator functions")
-
-    signature: dict[str, ParameterMetadata]
-    cls: Optional[Cls] = None
-    if function.info.user_cls is not None:
-        cls = typing.cast(Cls, app.registered_classes[class_name])
-        cls_signature = _get_signature(function.info.user_cls)
-        if method_name == "*":
-            method_names = list(cls._get_partial_functions().keys())
-            if len(method_names) == 1:
-                method_name = method_names[0]
-            else:
-                class_name = function.info.user_cls.__name__
-                raise click.UsageError(
-                    f"Please specify a specific method of {class_name} to run, e.g. `modal run foo.py::MyClass.bar`"  # noqa: E501
-                )
-        fun_signature = _get_signature(getattr(cls, method_name).info.raw_f, is_method=True)
-        signature = dict(**cls_signature, **fun_signature)  # Pool all arguments
-        # TODO(erikbern): assert there's no overlap?
-    else:
-        signature = _get_signature(function.info.raw_f)
-
+def _make_click_function(app, inner: Callable[[dict[str, Any]], Any]):
     @click.pass_context
     def f(ctx, **kwargs):
         show_progress: bool = ctx.obj["show_progress"]
@@ -188,21 +154,65 @@ def _get_click_command_for_function(app: App, function_tag):
                 environment_name=ctx.obj["env"],
                 interactive=ctx.obj["interactive"],
             ):
-                if cls is None:
-                    res = function.remote(**kwargs)
-                else:
-                    # unpool class and method arguments
-                    # TODO(erikbern): this code is a bit hacky
-                    cls_kwargs = {k: kwargs[k] for k in cls_signature}
-                    fun_kwargs = {k: kwargs[k] for k in fun_signature}
-
-                    instance = cls(**cls_kwargs)
-                    method: Function = getattr(instance, method_name)
-                    res = method.remote(**fun_kwargs)
+                res = inner(kwargs)
 
             if result_path := ctx.obj["result_path"]:
                 _write_local_result(result_path, res)
 
+    return f
+
+
+def _get_click_command_for_function(app: App, function: Function):
+    if function.is_generator:
+        raise InvalidError("`modal run` is not supported for generator functions")
+
+    signature: dict[str, ParameterMetadata] = _get_signature(function.info.raw_f)
+
+    def _inner(click_kwargs):
+        return function.remote(**click_kwargs)
+
+    f = _make_click_function(app, _inner)
+
+    with_click_options = _add_click_options(f, signature)
+    return click.command(with_click_options)
+
+
+def _get_click_command_for_cls(app: App, method_ref: MethodReference):
+    signature: dict[str, ParameterMetadata]
+    cls = method_ref.cls
+    method_name = method_ref.method_name
+
+    cls_signature = _get_signature(cls._get_user_cls())
+    partial_functions = cls._get_partial_functions()
+
+    if method_name in ("*", ""):
+        # auto infer method name - not sure if we have to support this...
+        method_names = list(partial_functions.keys())
+        if len(method_names) == 1:
+            method_name = method_names[0]
+        else:
+            raise click.UsageError(
+                f"Please specify a specific method of {cls._get_name()} to run, "
+                f"e.g. `modal run foo.py::MyClass.bar`"  # noqa: E501
+            )
+
+    partial_function = partial_functions[method_name]
+    fun_signature = _get_signature(partial_function._get_raw_f(), is_method=True)
+
+    # TODO(erikbern): assert there's no overlap?
+    signature = dict(**cls_signature, **fun_signature)  # Pool all arguments
+
+    def _inner(click_kwargs):
+        # unpool class and method arguments
+        # TODO(erikbern): this code is a bit hacky
+        cls_kwargs = {k: click_kwargs[k] for k in cls_signature}
+        fun_kwargs = {k: click_kwargs[k] for k in fun_signature}
+
+        instance = cls(**cls_kwargs)
+        method: Function = getattr(instance, method_name)
+        return method.remote(**fun_kwargs)
+
+    f = _make_click_function(app, _inner)
     with_click_options = _add_click_options(f, signature)
     return click.command(with_click_options)
 
@@ -249,16 +259,29 @@ class RunGroup(click.Group):
         # needs to be handled here, and not in the `run` logic below
         ctx.ensure_object(dict)
         ctx.obj["env"] = ensure_env(ctx.params["env"])
-        function_or_entrypoint = import_function(func_ref, accept_local_entrypoint=True, base_cmd="modal run")
-        app: App = function_or_entrypoint.app
+
+        imported_object = import_object(func_ref, accept_local_entrypoint=True, base_cmd="modal run")
+
+        # this is a bit janky, to set the description of ephemeral apps without names:
+        app: App
+        if isinstance(imported_object, (Function, LocalEntrypoint)):
+            app = imported_object.app
+        elif isinstance(imported_object, MethodReference):
+            app = imported_object.cls._get_app()
+        else:
+            raise ValueError(f"{imported_object} is neither function, local entrypoint or class")
+
         if app.description is None:
             app.set_description(_get_clean_app_description(func_ref))
-        if isinstance(function_or_entrypoint, LocalEntrypoint):
-            click_command = _get_click_command_for_local_entrypoint(app, function_or_entrypoint)
-        else:
-            tag = function_or_entrypoint.info.get_tag()
-            click_command = _get_click_command_for_function(app, tag)
 
+        if isinstance(imported_object, LocalEntrypoint):
+            click_command = _get_click_command_for_local_entrypoint(app, imported_object)
+        elif isinstance(imported_object, Function):
+            click_command = _get_click_command_for_function(app, imported_object)
+        elif isinstance(imported_object, MethodReference):
+            click_command = _get_click_command_for_cls(app, imported_object)
+        else:
+            raise ValueError(f"{imported_object} is neither function, local entrypoint or class/method")
         return click_command
 
 
@@ -464,11 +487,18 @@ def shell(
             exec(container_id=container_or_function, command=shlex.split(cmd), pty=pty)
             return
 
-        function = import_function(
+        function_or_method_ref = import_object(
             container_or_function, accept_local_entrypoint=False, accept_webhook=True, base_cmd="modal shell"
         )
-        assert isinstance(function, Function)
-        function_spec: _FunctionSpec = function.spec
+
+        if isinstance(function_or_method_ref, MethodReference):
+            class_service_function = function_or_method_ref.cls._get_class_service_function()
+            function_spec = class_service_function.spec
+        elif isinstance(function_or_method_ref, Function):
+            function_spec: _FunctionSpec = function_or_method_ref.spec
+        else:
+            raise ValueError("Referenced entity is neither a function nor a class/method.")
+
         start_shell = partial(
             interactive_shell,
             image=function_spec.image,

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -260,18 +260,7 @@ class RunGroup(click.Group):
         ctx.ensure_object(dict)
         ctx.obj["env"] = ensure_env(ctx.params["env"])
 
-        imported_object = import_object(func_ref, accept_local_entrypoint=True, base_cmd="modal run")
-
-        # this is a bit janky, to set the description of ephemeral apps without names:
-        app: App
-        if isinstance(imported_object, (Function, LocalEntrypoint)):
-            app = imported_object.app
-        elif isinstance(imported_object, MethodReference):
-            app = imported_object.cls._get_app()
-        else:
-            raise click.UsageError(
-                f"{imported_object} is neither function, local entrypoint or class ({type(imported_object)})"
-            )
+        app, imported_object = import_object(func_ref, accept_local_entrypoint=True, base_cmd="modal run")
 
         if app.description is None:
             app.set_description(_get_clean_app_description(func_ref))
@@ -489,7 +478,7 @@ def shell(
             exec(container_id=container_or_function, command=shlex.split(cmd), pty=pty)
             return
 
-        function_or_method_ref = import_object(
+        original_app, function_or_method_ref = import_object(
             container_or_function, accept_local_entrypoint=False, accept_webhook=True, base_cmd="modal shell"
         )
         function_spec: _FunctionSpec

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -397,6 +397,18 @@ class _Cls(_Object, type_prefix="cs"):
             raise AttributeError("You can only get the partial functions of a local Cls instance")
         return _find_partial_methods_for_user_cls(self._user_cls, _PartialFunctionFlags.all())
 
+    def _get_app(self) -> "modal.app._App":
+        return self._app
+
+    def _get_user_cls(self) -> type:
+        return self._user_cls
+
+    def _get_name(self) -> str:
+        return self._name
+
+    def _get_class_service_function(self) -> "modal.functions._Function":
+        return self._class_service_function
+
     def _hydrate_metadata(self, metadata: Message):
         assert isinstance(metadata, api_pb2.ClassHandleMetadata)
         if (

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -409,6 +409,10 @@ class _Cls(_Object, type_prefix="cs"):
     def _get_class_service_function(self) -> "modal.functions._Function":
         return self._class_service_function
 
+    def _get_method_names(self) -> Collection[str]:
+        # returns method names for a *local* class only for now (used by cli)
+        return self._method_functions.keys()
+
     def _hydrate_metadata(self, metadata: Message):
         assert isinstance(metadata, api_pb2.ClassHandleMetadata)
         if (

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -89,6 +89,9 @@ class _PartialFunction(typing.Generic[P, ReturnType, OriginalReturnType]):
         self.force_build = force_build
         self.build_timeout = build_timeout
 
+    def _get_raw_f(self) -> Callable[P, ReturnType]:
+        return self.raw_f
+
     def __get__(self, obj, objtype=None) -> _Function[P, ReturnType, OriginalReturnType]:
         k = self.raw_f.__name__
         if obj:  # accessing the method on an instance of a class, e.g. `MyClass().fun``

--- a/tasks.py
+++ b/tasks.py
@@ -153,6 +153,7 @@ def type_check(ctx):
         "modal/io_streams.py",
         "modal/image.py",
         "modal/file_io.py",
+        "modal/cli/import_refs.py",
     ]
     ctx.run(f"pyright {' '.join(pyright_allowlist)}", pty=True)
 

--- a/test/cli_imports_test.py
+++ b/test/cli_imports_test.py
@@ -1,15 +1,20 @@
 # Copyright Modal Labs 2023
 import pytest
+import sys
 
-from modal._utils.async_utils import synchronizer
-from modal.app import _App, _LocalEntrypoint
+import click
+
+from modal import web_endpoint
+from modal.app import App, LocalEntrypoint
 from modal.cli.import_refs import (
-    DEFAULT_APP_NAME,
+    MethodReference,
+    _import_object,
+    _infer_runnable,
     get_by_object_path,
     import_file_or_module,
-    parse_import_ref,
 )
 from modal.exception import InvalidError
+from modal.partial_function import asgi_app, method
 
 # Some helper vars for import_stub tests:
 local_entrypoint_src = """
@@ -86,28 +91,94 @@ dir_containing_python_package = {
     ["dir_structure", "ref", "expected_object_type"],
     [
         # # file syntax
-        (empty_dir_with_python_file, "mod.py", _App),
-        (empty_dir_with_python_file, "mod.py::app", _App),
-        (empty_dir_with_python_file, "mod.py::other_app", _App),
-        (dir_containing_python_package, "pack/file.py", _App),
-        (dir_containing_python_package, "pack/sub/subfile.py", _App),
-        (dir_containing_python_package, "dir/sub/subfile.py", _App),
+        (empty_dir_with_python_file, "mod.py", App),
+        (empty_dir_with_python_file, "mod.py::app", App),
+        (empty_dir_with_python_file, "mod.py::other_app", App),
+        (dir_containing_python_package, "pack/file.py", App),
+        (dir_containing_python_package, "pack/sub/subfile.py", App),
+        (dir_containing_python_package, "dir/sub/subfile.py", App),
         # # python module syntax
-        (empty_dir_with_python_file, "mod", _App),
-        (empty_dir_with_python_file, "mod::app", _App),
-        (empty_dir_with_python_file, "mod::other_app", _App),
-        (dir_containing_python_package, "pack.mod", _App),
-        (dir_containing_python_package, "pack.mod::other_app", _App),
-        (dir_containing_python_package, "pack/local.py::app.main", _LocalEntrypoint),
+        (empty_dir_with_python_file, "mod", App),
+        (empty_dir_with_python_file, "mod::app", App),
+        (empty_dir_with_python_file, "mod::other_app", App),
+        (dir_containing_python_package, "pack.mod", App),
+        (dir_containing_python_package, "pack.mod::other_app", App),
+        (dir_containing_python_package, "pack/local.py::app.main", LocalEntrypoint),
     ],
 )
 def test_import_object(dir_structure, ref, expected_object_type, mock_dir):
     with mock_dir(dir_structure):
-        import_ref = parse_import_ref(ref)
-        module = import_file_or_module(import_ref.file_or_module)
-        imported_object = get_by_object_path(module, import_ref.object_path or DEFAULT_APP_NAME)
-        _translated_obj = synchronizer._translate_in(imported_object)
-        assert isinstance(_translated_obj, expected_object_type)
+        obj, _ = _import_object(ref, base_cmd="modal some_command")
+        assert isinstance(obj, expected_object_type)
+
+
+app_with_one_web_function = App()
+
+
+@app_with_one_web_function.function()
+@web_endpoint()
+def web1():
+    pass
+
+
+app_with_one_function_one_web_endpoint = App()
+
+
+@app_with_one_function_one_web_endpoint.function()
+def f1():
+    pass
+
+
+@app_with_one_function_one_web_endpoint.function()
+@web_endpoint()
+def web2():
+    pass
+
+
+app_with_one_web_method = App()
+
+
+@app_with_one_web_method.cls()
+class C1:
+    @asgi_app()
+    def web_3(self):
+        pass
+
+
+app_with_one_web_method_one_method = App()
+
+
+@app_with_one_web_method_one_method.cls()
+class C2:
+    @asgi_app()
+    def web_4(self):
+        pass
+
+    @method()
+    def f2(self):
+        pass
+
+
+def test_infer_object():
+    this_module = sys.modules[__name__]
+    with pytest.raises(click.ClickException, match="web endpoint"):
+        _infer_runnable(app_with_one_web_function, this_module, accept_webhook=False)
+
+    _, runnable = _infer_runnable(app_with_one_web_function, this_module, accept_webhook=True)
+    assert runnable == web1
+
+    _, runnable = _infer_runnable(app_with_one_function_one_web_endpoint, this_module, accept_webhook=False)
+    assert runnable == f1
+
+    with pytest.raises(click.UsageError, match="(?s)You need to specify.*\nf1\nweb2\n"):
+        _, runnable = _infer_runnable(app_with_one_function_one_web_endpoint, this_module, accept_webhook=True)
+    assert runnable == f1
+
+    with pytest.raises(click.UsageError, match="web endpoint"):
+        _, runnable = _infer_runnable(app_with_one_web_method, this_module, accept_webhook=False)
+
+    _, runnable = _infer_runnable(app_with_one_web_method, this_module, accept_webhook=True)
+    assert runnable == MethodReference(C1, "web_3")  # type: ignore
 
 
 def test_import_package_and_module_names(monkeypatch, supports_dir):

--- a/test/cli_imports_test.py
+++ b/test/cli_imports_test.py
@@ -159,6 +159,19 @@ class C2:
         pass
 
 
+app_with_local_entrypoint_and_function = App()
+
+
+@app_with_local_entrypoint_and_function.local_entrypoint()
+def le_1():
+    pass
+
+
+@app_with_local_entrypoint_and_function.function()
+def f3():
+    pass
+
+
 def test_infer_object():
     this_module = sys.modules[__name__]
     with pytest.raises(click.ClickException, match="web endpoint"):
@@ -179,6 +192,12 @@ def test_infer_object():
 
     _, runnable = _infer_runnable(app_with_one_web_method, this_module, accept_webhook=True)
     assert runnable == MethodReference(C1, "web_3")  # type: ignore
+
+    _, runnable = _infer_runnable(app_with_local_entrypoint_and_function, this_module, accept_local_entrypoint=True)
+    assert runnable == le_1
+
+    _, runnable = _infer_runnable(app_with_local_entrypoint_and_function, this_module, accept_local_entrypoint=False)
+    assert runnable == f3
 
 
 def test_import_package_and_module_names(monkeypatch, supports_dir):

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -316,8 +316,8 @@ def test_run_parse_args_entrypoint(servicer, set_env_client, test_dir):
 
 def test_run_parse_args_function(servicer, set_env_client, test_dir, recwarn):
     app_file = test_dir / "supports" / "app_run_tests" / "cli_args.py"
-    # res = _run(["run", app_file.as_posix()], expected_exit_code=2, expected_stderr=None)
-    # assert "You need to specify a Modal function or local entrypoint to run" in res.stderr
+    res = _run(["run", app_file.as_posix()], expected_exit_code=2, expected_stderr=None)
+    assert "You need to specify a Modal function or local entrypoint to run" in res.stderr
 
     # HACK: all the tests use the same arg, i.
     @servicer.function_body
@@ -325,10 +325,10 @@ def test_run_parse_args_function(servicer, set_env_client, test_dir, recwarn):
         print(repr(i), type(i))
 
     valid_call_args = [
-        # (["run", f"{app_file.as_posix()}::int_arg_fn", "--i=200"], "200 <class 'int'>"),
+        (["run", f"{app_file.as_posix()}::int_arg_fn", "--i=200"], "200 <class 'int'>"),
         (["run", f"{app_file.as_posix()}::ALifecycle.some_method", "--i=hello"], "'hello' <class 'str'>"),
-        # (["run", f"{app_file.as_posix()}::ALifecycle.some_method_int", "--i=42"], "42 <class 'int'>"),
-        # (["run", f"{app_file.as_posix()}::optional_arg_fn"], "None <class 'NoneType'>"),
+        (["run", f"{app_file.as_posix()}::ALifecycle.some_method_int", "--i=42"], "42 <class 'int'>"),
+        (["run", f"{app_file.as_posix()}::optional_arg_fn"], "None <class 'NoneType'>"),
     ]
     for args, expected in valid_call_args:
         res = _run(args)

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -314,10 +314,10 @@ def test_run_parse_args_entrypoint(servicer, set_env_client, test_dir):
         assert "Unable to generate command line interface for app entrypoint." in str(res.exception)
 
 
-def test_run_parse_args_function(servicer, set_env_client, test_dir):
+def test_run_parse_args_function(servicer, set_env_client, test_dir, recwarn):
     app_file = test_dir / "supports" / "app_run_tests" / "cli_args.py"
-    res = _run(["run", app_file.as_posix()], expected_exit_code=2, expected_stderr=None)
-    assert "You need to specify a Modal function or local entrypoint to run" in res.stderr
+    # res = _run(["run", app_file.as_posix()], expected_exit_code=2, expected_stderr=None)
+    # assert "You need to specify a Modal function or local entrypoint to run" in res.stderr
 
     # HACK: all the tests use the same arg, i.
     @servicer.function_body
@@ -325,14 +325,18 @@ def test_run_parse_args_function(servicer, set_env_client, test_dir):
         print(repr(i), type(i))
 
     valid_call_args = [
-        (["run", f"{app_file.as_posix()}::int_arg_fn", "--i=200"], "200 <class 'int'>"),
+        # (["run", f"{app_file.as_posix()}::int_arg_fn", "--i=200"], "200 <class 'int'>"),
         (["run", f"{app_file.as_posix()}::ALifecycle.some_method", "--i=hello"], "'hello' <class 'str'>"),
-        (["run", f"{app_file.as_posix()}::ALifecycle.some_method_int", "--i=42"], "42 <class 'int'>"),
-        (["run", f"{app_file.as_posix()}::optional_arg_fn"], "None <class 'NoneType'>"),
+        # (["run", f"{app_file.as_posix()}::ALifecycle.some_method_int", "--i=42"], "42 <class 'int'>"),
+        # (["run", f"{app_file.as_posix()}::optional_arg_fn"], "None <class 'NoneType'>"),
     ]
     for args, expected in valid_call_args:
         res = _run(args)
         assert expected in res.stdout
+
+    if len(recwarn):
+        print("Unexpected warnings:", [str(w) for w in recwarn])
+    assert len(recwarn) == 0
 
 
 def test_run_user_script_exception(servicer, set_env_client, test_dir):


### PR DESCRIPTION
The internal code used to intermediately make use of the class-bound function rather than instantiating the class first.
 
This required some rather messy refactoring of CLI code which should preferably be simplified further in the future.


---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

* Fixes bug introduced in v0.72.9 where `modal run SomeClass.some_method` would incorrectly print a deprecation warning.