### PR TITLE
Add environment_name to 'App.run'

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -365,6 +365,7 @@ class _App:
         show_progress: Optional[bool] = None,
         detach: bool = False,
         interactive: bool = False,
+        environment_name: Optional[str] = None,
     ) -> AsyncGenerator["_App", None]:
         """Context manager that runs an app on Modal.
 
@@ -420,7 +421,9 @@ class _App:
         elif show_progress is False:
             deprecation_warning((2024, 11, 20), "`show_progress=False` is deprecated (and has no effect)")
 
-        async with _run_app(self, client=client, detach=detach, interactive=interactive):
+        async with _run_app(
+            self, client=client, detach=detach, interactive=interactive, environment_name=environment_name
+        ):
             yield self
 
     def _get_default_image(self):


### PR DESCRIPTION
## Describe your changes

`App.run` is just a thin wrapper around `modal.runner.run_app`. The latter allowed you to specify the `environment_name` at runtime, but the former did not.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Added an `environment_name` parameter to the `App.run` context manager.