### PR TITLE
Deprecate `@modal.build` decorator

### DIFF
--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -552,6 +552,14 @@ def _build(
     if _warn_parentheses_missing is not None:
         raise InvalidError("Positional arguments are not allowed. Did you forget parentheses? Suggestion: `@build()`.")
 
+    deprecation_warning(
+        (2025, 1, 15),
+        "The `@modal.build` decorator is deprecated and will be removed in a future release."
+        "\n\nWe now recommend storing large assets (such as model weights) using a `modal.Volume`"
+        " instead of writing them directly into the `modal.Image` filesystem."
+        "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
+    )
+
     def wrapper(f: Union[Callable[[Any], Any], _PartialFunction]) -> _PartialFunction:
         if isinstance(f, _PartialFunction):
             _disallow_wrapping_method(f, "build")

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -1080,35 +1080,36 @@ VARIABLE_5 = 1
 VARIABLE_6 = 1
 
 
-@cls_app.cls(
-    image=Image.debian_slim().pip_install("pandas"),
-    secrets=[Secret.from_dict({"xyz": "123"})],
-)
-class Foo:
-    @build()
-    def build_func(self):
-        global VARIABLE_5
+with pytest.warns(DeprecationError, match="@modal.build"):
 
-        print("foo!", VARIABLE_5)
+    @cls_app.cls(
+        image=Image.debian_slim().pip_install("pandas"),
+        secrets=[Secret.from_dict({"xyz": "123"})],
+    )
+    class Foo:
+        @build()
+        def build_func(self):
+            global VARIABLE_5
 
-    @method()
-    def f(self):
-        global VARIABLE_6
+            print("foo!", VARIABLE_5)
 
-        print("bar!", VARIABLE_6)
+        @method()
+        def f(self):
+            global VARIABLE_6
 
+            print("bar!", VARIABLE_6)
 
-class FooInstance:
-    not_used_by_build_method: str = "normal"
-    used_by_build_method: str = "normal"
+    class FooInstance:
+        not_used_by_build_method: str = "normal"
+        used_by_build_method: str = "normal"
 
-    @build()
-    def build_func(self):
-        global VARIABLE_5
+        @build()
+        def build_func(self):
+            global VARIABLE_5
 
-        print("global variable", VARIABLE_5)
-        print("static class var", FooInstance.used_by_build_method)
-        FooInstance.used_by_build_method = "normal"
+            print("global variable", VARIABLE_5)
+            print("static class var", FooInstance.used_by_build_method)
+            FooInstance.used_by_build_method = "normal"
 
 
 def test_image_cls_var_rebuild(client, servicer):

--- a/test/supports/functions.py
+++ b/test/supports/functions.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
 import asyncio
 import contextlib
+import pytest
 import threading
 import time
 
@@ -21,6 +22,7 @@ from modal import (
     wsgi_app,
 )
 from modal._utils.deprecation import deprecation_warning
+from modal.exception import DeprecationError
 from modal.experimental import get_local_input_concurrency, set_local_input_concurrency
 
 SLEEP_DELAY = 0.1
@@ -613,32 +615,34 @@ def function_calling_method(x, y, z):
     return obj.f.remote(z)
 
 
-@app.cls()
-class BuildCls:
-    def __init__(self):
-        self._k = 1
+with pytest.warns(DeprecationError, match="@modal.build"):
 
-    @enter()
-    def enter1(self):
-        self._k += 10
+    @app.cls()
+    class BuildCls:
+        def __init__(self):
+            self._k = 1
 
-    @build()
-    def build1(self):
-        self._k += 100
-        return self._k
+        @enter()
+        def enter1(self):
+            self._k += 10
 
-    @build()
-    def build2(self):
-        self._k += 1000
-        return self._k
+        @build()
+        def build1(self):
+            self._k += 100
+            return self._k
 
-    @exit()
-    def exit1(self):
-        raise Exception("exit called!")
+        @build()
+        def build2(self):
+            self._k += 1000
+            return self._k
 
-    @method()
-    def f(self, x):
-        return self._k * x
+        @exit()
+        def exit1(self):
+            raise Exception("exit called!")
+
+        @method()
+        def f(self, x):
+            return self._k * x
 
 
 @app.cls(enable_memory_snapshot=True)


### PR DESCRIPTION
## Describe your changes

We're deprecation the `@modal.build` decorator for a few reasons:

- Storing large assets using a `modal.Volume` rather than a `modal.Image` provides an overall superior developer experience
- We're consolidating container filesystem configuration on the `modal.Image` object itself
- There are some gaps in the compatibility between `@modal.build` and other `modal.Cls` features, for example build methods silently ignore class parameters

Closes CLI-305

## Changelog

- The `@modal.build` decorator is now deprecated. For storing large assets (e.g. model weights), we now recommend using a `modal.Volume` over writing data to the `modal.Image` filesystem directly.