### PR TITLE
Ensure that the sandbox has started before taking a filesystem snapshot

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -350,6 +350,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         Returns an [`Image`](https://modal.com/docs/reference/modal.Image) object which
         can be used to spawn a new Sandbox with the same filesystem.
         """
+        await self._get_task_id()  # Ensure the sandbox has started
         req = api_pb2.SandboxSnapshotFsRequest(sandbox_id=self.object_id, timeout=timeout)
         resp = await retry_transient_errors(self._client.stub.SandboxSnapshotFs, req)
 


### PR DESCRIPTION
Previously, if you tried to take a filesystem snapshot of a sandbox that hasn't been started yet, it would fail with an error:

```py
import modal

app = modal.App.lookup("my-app", create_if_missing=True)


with modal.enable_output():
    sb = modal.Sandbox.create(app=app, gpu="H100")
    sb.terminate()

    img = sb.snapshot_filesystem()
    print(img)
```

This PR fixes this issue by blocking until the sandbox has started (or at least until it has been picked up by a worker) before executing the snapshot request.