### PR TITLE
Remove mount usage in tests

### DIFF
--- a/modal/_tunnel.py
+++ b/modal/_tunnel.py
@@ -145,7 +145,7 @@ async def _forward(port: int, *, unencrypted: bool = False, client: Optional[_Cl
         modal.Image.debian_slim()
         .apt_install("openssh-server")
         .run_commands("mkdir /run/sshd")
-        .copy_local_file("~/.ssh/id_rsa.pub", "/root/.ssh/authorized_keys")
+        .add_local_file("~/.ssh/id_rsa.pub", "/root/.ssh/authorized_keys", copy=True)
     )
 
 

--- a/modal/image.py
+++ b/modal/image.py
@@ -854,14 +854,17 @@ class _Image(_Object, type_prefix="im"):
         # Which follows dockerignore syntax.
         ignore: Union[Sequence[str], Callable[[Path], bool]] = [],
     ) -> "_Image":
-        """Copy a directory into the image as a part of building the image.
+        """
+        **Deprecated**: Use image.add_local_dir instead
+
+        Copy a directory into the image as a part of building the image.
 
         This works in a similar way to [`COPY`](https://docs.docker.com/engine/reference/builder/#copy)
         works in a `Dockerfile`.
 
         **Usage:**
 
-        ```python
+        ```python notest
         from pathlib import Path
         from modal import FilePatternMatcher
 

--- a/modal/image.py
+++ b/modal/image.py
@@ -662,13 +662,16 @@ class _Image(_Object, type_prefix="im"):
         return obj
 
     def copy_mount(self, mount: _Mount, remote_path: Union[str, Path] = ".") -> "_Image":
-        """Copy the entire contents of a `modal.Mount` into an image.
+        """
+        **Deprecated**: Use image.add_local_dir(..., copy=True) or similar instead.
+
+        Copy the entire contents of a `modal.Mount` into an image.
         Useful when files only available locally are required during the image
         build process.
 
         **Example**
 
-        ```python
+        ```python notest
         static_images_dir = "./static"
         # place all static images in root of mount
         mount = modal.Mount.from_local_dir(static_images_dir, remote_path="/")

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -394,11 +394,13 @@ class _Mount(_Object, type_prefix="mo"):
         recursive: bool = True,
     ) -> "_Mount":
         """
+        **Deprecated:** Use image.add_local_dir() instead
+
         Create a `Mount` from a local directory.
 
         **Usage**
 
-        ```python
+        ```python notest
         assets = modal.Mount.from_local_dir(
             "~/assets",
             condition=lambda pth: not ".venv" in pth,
@@ -449,11 +451,13 @@ class _Mount(_Object, type_prefix="mo"):
     @staticmethod
     def from_local_file(local_path: Union[str, Path], remote_path: Union[str, PurePosixPath, None] = None) -> "_Mount":
         """
+        **Deprecated**: Use image.add_local_file() instead
+
         Create a `Mount` mounting a single local file.
 
         **Usage**
 
-        ```python
+        ```python notest
         # Mount the DBT profile in user's home directory into container.
         dbt_profiles = modal.Mount.from_local_file(
             local_path="~/profiles.yml",
@@ -611,6 +615,8 @@ class _Mount(_Object, type_prefix="mo"):
         ignore: Optional[Union[Sequence[str], Callable[[Path], bool]]] = None,
     ) -> "_Mount":
         """
+        **Deprecated**: Use image.add_local_python_source instead
+
         Returns a `modal.Mount` that makes local modules listed in `module_names` available inside the container.
         This works by mounting the local path of each module's package to a directory inside the container
         that's on `PYTHONPATH`.

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -258,12 +258,15 @@ class NonLocalMountError(Exception):
 
 
 class _Mount(_Object, type_prefix="mo"):
-    """Create a mount for a local directory or file that can be attached
+    """
+    **Deprecated**: Mounts should not be used explicitly anymore, use image.add_local_* commands instead
+
+    Create a mount for a local directory or file that can be attached
     to one or more Modal functions.
 
     **Usage**
 
-    ```python
+    ```python notest
     import modal
     import os
     app = modal.App()

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -209,7 +209,7 @@ def test_init_types():
     App(
         image=Image.debian_slim().pip_install("pandas"),
         secrets=[Secret.from_dict()],
-        mounts=[Mount.from_local_file(__file__)],
+        mounts=[Mount._from_local_file(__file__)],  # TODO: remove
     )
 
 

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -561,7 +561,7 @@ def test_from_local_python_packages_inside_container(servicer):
     """`from_local_python_packages` shouldn't actually collect modules inside the container, because it's possible
     that there are modules that were present locally for the user that didn't get mounted into
     all the containers."""
-    ret = _run_container(servicer, "test.supports.package_mount", "num_mounts")
+    ret = _run_container(servicer, "test.supports.package_mount", "dummy")
     assert _unwrap_scalar(ret) == 0
 
 

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -13,7 +13,7 @@ from typing import Callable, Literal, Sequence, Union, get_args
 from unittest import mock
 
 import modal
-from modal import App, Image, Mount, Secret, build, environments, gpu, method
+from modal import App, Dict, Image, Secret, build, environments, gpu, method
 from modal._serialization import serialize
 from modal._utils.async_utils import synchronizer
 from modal.client import Client
@@ -209,7 +209,7 @@ def test_image_python_packages(builder_version, servicer, client):
             pass
 
 
-def test_image_kwargs_validation(builder_version, servicer, client):
+def test_run_commands_secrets_type_validation(builder_version, servicer, client):
     app = App()
     image = Image.debian_slim().run_commands(
         "echo hi", secrets=[Secret.from_dict({"xyz": "123"}), Secret.from_name("foo")]
@@ -221,15 +221,9 @@ def test_image_kwargs_validation(builder_version, servicer, client):
             secrets=[
                 Secret.from_dict({"xyz": "123"}),
                 Secret.from_name("foo"),
-                Mount.from_local_dir("/", remote_path="/"),  # type: ignore
+                Dict.from_name("mydict"),  # type: ignore
             ],  # Mount is not a valid Secret
         )
-
-    Image.debian_slim().copy_local_dir("/", remote_path="/dummy")
-    Image.debian_slim().copy_mount(Mount.from_name("foo"), remote_path="/dummy")
-    with pytest.raises(InvalidError):
-        # Secret is not a valid Mount
-        Image.debian_slim().copy_mount(Secret.from_dict({"xyz": "123"}), remote_path="/dummy")  # type: ignore
 
 
 def test_wrong_type(builder_version, servicer, client):

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -222,7 +222,7 @@ def test_run_commands_secrets_type_validation(builder_version, servicer, client)
                 Secret.from_dict({"xyz": "123"}),
                 Secret.from_name("foo"),
                 Dict.from_name("mydict"),  # type: ignore
-            ],  # Mount is not a valid Secret
+            ],  # Dict is not a valid Secret
         )
 
 
@@ -1738,7 +1738,7 @@ def test_image_add_local_dir_ignore_nothing(servicer, client, tmp_path_with_cont
         for file in files:
             file_paths.add(os.path.join(root, file))
 
-    expected = {f"/place/{Path(fn).relative_to(tmp_path_with_content)}" for fn in file_paths}
+    expected = {f"/place/{Path(fn).relative_to(tmp_path_with_content).as_posix()}" for fn in file_paths}
     app = App()
 
     img = Image.from_registry("unknown_image").workdir("/proj")

--- a/test/mounted_files_test.py
+++ b/test/mounted_files_test.py
@@ -393,7 +393,7 @@ def test_pdm_cache_automount_exclude(tmp_path, monkeypatch, supports_dir, servic
 
 def test_mount_directory_with_symlinked_file(path_with_symlinked_files, servicer, client):
     path, files = path_with_symlinked_files
-    mount = Mount.from_local_dir(path)
+    mount = Mount._from_local_dir(path)
     mount._deploy("mo-1", client=client)
     pkg_a_mount = servicer.mount_contents["mo-1"]
     for src_f in files:
@@ -426,12 +426,12 @@ def test_module_with_dot_prefixed_parent_can_be_mounted(tmp_path, monkeypatch, s
     (bar_package / ".hidden_mod.py").touch()  # should be excluded
 
     monkeypatch.syspath_prepend(parent_dir)
-    foo_mount = Mount.from_local_python_packages("foo")
+    foo_mount = Mount._from_local_python_packages("foo")
     foo_mount._deploy("mo-1", client=client)
     foo_mount_content = servicer.mount_contents["mo-1"]
     assert foo_mount_content.keys() == {"/root/foo.py"}
 
-    bar_mount = Mount.from_local_python_packages("bar")
+    bar_mount = Mount._from_local_python_packages("bar")
     bar_mount._deploy("mo-2", client=client)
 
     bar_mount_content = servicer.mount_contents["mo-2"]

--- a/test/mounted_files_test.py
+++ b/test/mounted_files_test.py
@@ -229,7 +229,8 @@ def foo():
     pass
 
 
-def test_mounts_are_not_traversed_on_declaration(test_dir, monkeypatch, client, server_url_env):
+def test_mounts_are_not_traversed_on_declaration(supports_dir, monkeypatch, client, server_url_env):
+    # TODO: remove once Mount is fully deprecated (replaced by test_image_mounts_are_not_traversed_on_declaration)
     return_values = []
     original = modal.mount._MountDir.get_files_to_upload
 
@@ -240,8 +241,36 @@ def test_mounts_are_not_traversed_on_declaration(test_dir, monkeypatch, client, 
 
     monkeypatch.setattr("modal.mount._MountDir.get_files_to_upload", mock_get_files_to_upload)
     app = modal.App()
-    mount_with_many_files = Mount.from_local_dir(test_dir, remote_path="/test")
+    mount_with_many_files = Mount._from_local_dir(supports_dir / "pkg_a", remote_path="/test")
     app.function(mounts=[mount_with_many_files])(foo)
+    assert len(return_values) == 0  # ensure we don't look at the files yet
+
+    with app.run(client=client):
+        pass
+
+    assert return_values  # at this point we should have gotten all the mount files
+    # flatten inspected files
+    files = set()
+    for r in return_values:
+        for fn, _ in r:
+            files.add(fn)
+    # sanity check - this test file should be included since we mounted the test dir
+    assert Path(__file__) in files  # this test file should have been included
+
+
+def test_image_mounts_are_not_traversed_on_declaration(supports_dir, monkeypatch, client, server_url_env):
+    return_values = []
+    original = modal.mount._MountDir.get_files_to_upload
+
+    def mock_get_files_to_upload(self):
+        r = list(original(self))
+        return_values.append(r)
+        return r
+
+    monkeypatch.setattr("modal.mount._MountDir.get_files_to_upload", mock_get_files_to_upload)
+    app = modal.App()
+    image_mount_with_many_files = modal.Image.debian_slim().add_local_dir(supports_dir / "pkg_a", remote_path="/test")
+    app.function(image=image_mount_with_many_files)(foo)
     assert len(return_values) == 0  # ensure we don't look at the files yet
 
     with app.run(client=client):

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -44,9 +44,21 @@ def test_sandbox(app, servicer):
 
 @skip_non_linux
 def test_sandbox_mount(app, servicer, tmpdir):
+    # TODO: remove once Mounts are fully deprecated (replaced by test_sandbox_mount_layer)
     tmpdir.join("a.py").write(b"foo")
 
-    sb = Sandbox.create("echo", "hi", mounts=[Mount.from_local_dir(Path(tmpdir), remote_path="/m")], app=app)
+    sb = Sandbox.create("echo", "hi", mounts=[Mount._from_local_dir(Path(tmpdir), remote_path="/m")], app=app)
+    sb.wait()
+
+    sha = hashlib.sha256(b"foo").hexdigest()
+    assert servicer.files_sha2data[sha]["data"] == b"foo"
+
+
+@skip_non_linux
+def test_sandbox_mount_layer(app, servicer, tmpdir):
+    tmpdir.join("a.py").write(b"foo")
+
+    sb = Sandbox.create("echo", "hi", image=Image.debian_slim().add_local_dir(Path(tmpdir), remote_path="/m"), app=app)
     sb.wait()
 
     sha = hashlib.sha256(b"foo").hexdigest()

--- a/test/supports/mount_dedupe.py
+++ b/test/supports/mount_dedupe.py
@@ -10,12 +10,15 @@ import pkg_a  # noqa
 if int(os.environ["USE_EXPLICIT"]):
     image_1 = modal.Image.debian_slim().add_local_python_source("pkg_a")  # this should be reused
     # same as above, but different instance - should be app-deduplicated:
-    image_2 = [
-        modal.Image.debian_slim().add_local_python_source("pkg_a"),  # identical to first explicit mount and auto mounts
-        modal.Image.debian_slim().add_local_python_source(
-            "pkg_a", ignore=["*.pyc"]
-        ),  # custom condition, include normally_not_included.pyc
-    ]
+    image_2 = (
+        modal.Image.debian_slim()
+        .add_local_python_source("pkg_a")  # identical to first explicit mount and auto mounts
+        .add_local_python_source(
+            # custom ignore condition, include normally_not_included.pyc (but skip __pycache__)
+            "pkg_a",
+            ignore=["**/__pycache__"],
+        )
+    )
 else:
     # only use automounting
     image_1 = modal.Image.debian_slim()

--- a/test/supports/mount_dedupe.py
+++ b/test/supports/mount_dedupe.py
@@ -2,30 +2,31 @@
 import os
 
 import modal
-from modal import Mount
 
 app = modal.App()
 import pkg_a  # noqa
 
 
 if int(os.environ["USE_EXPLICIT"]):
-    explicit_mounts1 = [Mount.from_local_python_packages("pkg_a")]  # this should be reused
+    image_1 = modal.Image.debian_slim().add_local_python_source("pkg_a")  # this should be reused
     # same as above, but different instance - should be app-deduplicated:
-    explicit_mounts2 = [
-        Mount.from_local_python_packages("pkg_a"),  # identical to first explicit mount and auto mounts
-        Mount.from_local_python_packages(
-            "pkg_a", condition=lambda fn: "__pycache__" not in fn
+    image_2 = [
+        modal.Image.debian_slim().add_local_python_source("pkg_a"),  # identical to first explicit mount and auto mounts
+        modal.Image.debian_slim().add_local_python_source(
+            "pkg_a", ignore=["*.pyc"]
         ),  # custom condition, include normally_not_included.pyc
     ]
 else:
-    explicit_mounts1 = explicit_mounts2 = []  # only use automounting
+    # only use automounting
+    image_1 = modal.Image.debian_slim()
+    image_2 = modal.Image.debian_slim()
 
 
-@app.function(mounts=explicit_mounts1)
+@app.function(image=image_1)
 def foo():
     pass
 
 
-@app.function(mounts=explicit_mounts2)
+@app.function(image=image_2)
 def bar():
     pass

--- a/test/supports/package_mount.py
+++ b/test/supports/package_mount.py
@@ -3,12 +3,10 @@ from modal import App, Image
 
 app = App()
 
-image = Image.debian_slim().add_local_python_source("module_1")
+# just make sure that non-existing package doesn't cause this to crash in containers:
+image = Image.debian_slim().add_local_python_source("non_existing_package_123154")
 
 
 @app.function(image=image, serialized=True)
-def num_mounts(_x):
-    print(image._mount_layers)
-    assert len(image._mount_layers) == 1
-    mount = image._mount_layers[0]
-    return len(mount.entries)
+def dummy(_x):
+    return 0

--- a/test/supports/package_mount.py
+++ b/test/supports/package_mount.py
@@ -1,10 +1,14 @@
 # Copyright Modal Labs 2022
-from modal import App, Mount
+from modal import App, Image
 
 app = App()
 
+image = Image.debian_slim().add_local_python_source("module_1")
 
-@app.function()
+
+@app.function(image=image, serialized=True)
 def num_mounts(_x):
-    mount = Mount.from_local_python_packages("module_1")
+    print(image._mount_layers)
+    assert len(image._mount_layers) == 1
+    mount = image._mount_layers[0]
     return len(mount.entries)

--- a/test/watcher_test.py
+++ b/test/watcher_test.py
@@ -17,9 +17,9 @@ from modal.mount import _get_client_mount, _Mount
 async def test__watch_args_from_mounts(monkeypatch, test_dir):
     paths, watch_filter = _watch_args_from_mounts(
         mounts=[
-            _Mount.from_local_file("/x/foo.py", remote_path="/foo.py"),
-            _Mount.from_local_dir("/one/two/bucklemyshoe", remote_path="/"),
-            _Mount.from_local_dir("/x/z", remote_path="/z"),
+            _Mount._from_local_file("/x/foo.py", remote_path="/foo.py"),
+            _Mount._from_local_dir("/one/two/bucklemyshoe", remote_path="/"),
+            _Mount._from_local_dir("/x/z", remote_path="/z"),
         ]
     )
 
@@ -51,9 +51,10 @@ def test_watch_mounts_requires_running_app():
 
 
 def test_watch_mounts_includes_function_mounts(client, supports_dir, monkeypatch, disable_auto_mount):
+    # TODO: remove this test once public Mount constructions are fully deprecated
     monkeypatch.syspath_prepend(supports_dir)
     app = modal.App()
-    pkg_a_mount = modal.Mount.from_local_python_packages("pkg_a")
+    pkg_a_mount = modal.Mount._from_local_python_packages("pkg_a")
 
     @app.function(mounts=[pkg_a_mount], serialized=True)
     def f():
@@ -65,9 +66,10 @@ def test_watch_mounts_includes_function_mounts(client, supports_dir, monkeypatch
 
 
 def test_watch_mounts_includes_cls_mounts(client, supports_dir, monkeypatch, disable_auto_mount):
+    # TODO: remove this test once public Mount constructions are fully deprecated
     monkeypatch.syspath_prepend(supports_dir)
     app = modal.App()
-    pkg_a_mount = modal.Mount.from_local_python_packages("pkg_a")
+    pkg_a_mount = modal.Mount._from_local_python_packages("pkg_a")
 
     @app.cls(mounts=[pkg_a_mount], serialized=True)
     class A:
@@ -81,9 +83,10 @@ def test_watch_mounts_includes_cls_mounts(client, supports_dir, monkeypatch, dis
 
 
 def test_watch_mounts_includes_image_mounts(client, supports_dir, monkeypatch, disable_auto_mount):
+    # TODO: remove this test once public Mount constructions are fully deprecated
     monkeypatch.syspath_prepend(supports_dir)
     app = modal.App()
-    pkg_a_mount = modal.Mount.from_local_python_packages("pkg_a")
+    pkg_a_mount = modal.Mount._from_local_python_packages("pkg_a")
     image = modal.Image.debian_slim().copy_mount(pkg_a_mount)
 
     @app.function(image=image, serialized=True)


### PR DESCRIPTION
Replaces `Mount.from_local` usages in tests to not trigger deprecation warnings.

Three different ways of removing:
* Some are kept around temporarily using the new private equivalents `Mount._from_local*`, to prevent regressions in the `mount=`-SDK surfaces until we fully deprecate these methods. 
* Some are replaced with Image.add_local equivalents
* Some docstring code snippets are kept as is with a deprecation note in the docstring and `notest` added to the fence

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
