### PR TITLE
PoC: get rid of hydrate_lazily concept

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -114,12 +114,7 @@ def _bind_instance_method(service_function: _Function, class_bound_method: _Func
 
     rep = f"Method({method_name})"
 
-    fun = _Function._from_loader(
-        _load,
-        rep,
-        deps=_deps,
-        hydrate_lazily=True,
-    )
+    fun = _Function._from_loader(_load, rep, deps=_deps)
     if service_function.is_hydrated:
         # Eager hydration (skip load) if the instance service function is already loaded
         hydrate_from_instance_service_function(fun)
@@ -350,7 +345,6 @@ class _Obj:
             method_loader,
             repr,
             deps=lambda: [],  # TODO: use cls as dep instead of loading inside method_loader?
-            hydrate_lazily=True,
         )
 
 
@@ -594,7 +588,7 @@ class _Cls(_Object, type_prefix="cs"):
             obj._hydrate(response.class_id, resolver.client, response.handle_metadata)
 
         rep = f"Ref({app_name})"
-        cls = cls._from_loader(_load_remote, rep, is_another_app=True, hydrate_lazily=True)
+        cls = cls._from_loader(_load_remote, rep, is_another_app=True)
         # TODO: when pre 0.63 is phased out, we can set class_service_function here instead
         cls._name = name
         return cls

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -137,7 +137,7 @@ class _Dict(_Object, type_prefix="di"):
             logger.debug(f"Created dict with id {response.dict_id}")
             self._hydrate(response.dict_id, resolver.client, None)
 
-        return _Dict._from_loader(_load, "Dict()", is_another_app=True, hydrate_lazily=True)
+        return _Dict._from_loader(_load, "Dict()", is_another_app=True)
 
     @staticmethod
     @renamed_parameter((2024, 12, 18), "label", "name")

--- a/modal/environments.py
+++ b/modal/environments.py
@@ -80,7 +80,7 @@ class _Environment(_Object, type_prefix="en"):
             self._hydrate(response.environment_id, resolver.client, response.metadata)
 
         # TODO environment name (and id?) in the repr? (We should make reprs consistently more useful)
-        return _Environment._from_loader(_load, "Environment()", is_another_app=True, hydrate_lazily=True)
+        return _Environment._from_loader(_load, "Environment()", is_another_app=True)
 
     @staticmethod
     @renamed_parameter((2024, 12, 18), "label", "name")

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -995,7 +995,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
             response = await retry_transient_errors(parent._client.stub.FunctionBindParams, req)
             param_bound_func._hydrate(response.bound_function_id, parent._client, response.handle_metadata)
 
-        fun: _Function = _Function._from_loader(_load, "Function(parametrized)", hydrate_lazily=True)
+        fun: _Function = _Function._from_loader(_load, "Function(parametrized)")
 
         if can_use_parent and parent.is_hydrated:
             # skip the resolver altogether:
@@ -1079,7 +1079,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
             self._hydrate(response.function_id, resolver.client, response.handle_metadata)
 
         rep = f"Ref({app_name})"
-        return cls._from_loader(_load_remote, rep, is_another_app=True, hydrate_lazily=True)
+        return cls._from_loader(_load_remote, rep, is_another_app=True)
 
     @staticmethod
     @renamed_parameter((2024, 12, 18), "tag", "name")

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -131,7 +131,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
                     )
                 raise
 
-        return _NetworkFileSystem._from_loader(_load, "NetworkFileSystem()", hydrate_lazily=True)
+        return _NetworkFileSystem._from_loader(_load, "NetworkFileSystem()")
 
     @classmethod
     @asynccontextmanager

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -175,7 +175,7 @@ class _Queue(_Object, type_prefix="qu"):
             response = await resolver.client.stub.QueueGetOrCreate(req)
             self._hydrate(response.queue_id, resolver.client, None)
 
-        return _Queue._from_loader(_load, "Queue()", is_another_app=True, hydrate_lazily=True)
+        return _Queue._from_loader(_load, "Queue()", is_another_app=True)
 
     @staticmethod
     @renamed_parameter((2024, 12, 18), "label", "name")

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -76,7 +76,7 @@ class _Secret(_Object, type_prefix="st"):
             self._hydrate(resp.secret_id, resolver.client, None)
 
         rep = f"Secret.from_dict([{', '.join(env_dict.keys())}])"
-        return _Secret._from_loader(_load, rep, hydrate_lazily=True)
+        return _Secret._from_loader(_load, rep)
 
     @staticmethod
     def from_local_environ(
@@ -159,7 +159,7 @@ class _Secret(_Object, type_prefix="st"):
 
             self._hydrate(resp.secret_id, resolver.client, None)
 
-        return _Secret._from_loader(_load, "Secret.from_dotenv()", hydrate_lazily=True)
+        return _Secret._from_loader(_load, "Secret.from_dotenv()")
 
     @staticmethod
     @renamed_parameter((2024, 12, 18), "label", "name")
@@ -202,7 +202,7 @@ class _Secret(_Object, type_prefix="st"):
                     raise
             self._hydrate(response.secret_id, resolver.client, None)
 
-        return _Secret._from_loader(_load, "Secret()", hydrate_lazily=True)
+        return _Secret._from_loader(_load, "Secret()")
 
     @staticmethod
     @renamed_parameter((2024, 12, 18), "label", "name")

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -173,7 +173,7 @@ class _Volume(_Object, type_prefix="vo"):
             response = await resolver.client.stub.VolumeGetOrCreate(req)
             self._hydrate(response.volume_id, resolver.client, None)
 
-        return _Volume._from_loader(_load, "Volume()", hydrate_lazily=True)
+        return _Volume._from_loader(_load, "Volume()")
 
     @classmethod
     @asynccontextmanager


### PR DESCRIPTION
In theory, all Modal objects now support lazy / just-in-time hydration. So we can simplify the codebase a bit by getting rid of the `hydrate_lazily` parameter in the Object initialization process, along with some validation logic.

It looks like were weren't passing `hydrate_lazily=True` _everywhere_ we could, but I can't follow the logic to understand whether that's because those routes truly don't support lazy hydration.

As a good empiricist, my first step is just to delete it and see if the tests pass.