### PR TITLE
Don't print warning if adding the same Function object again

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -445,11 +445,13 @@ class _App:
         return [m for m in all_mounts if m.is_local()]
 
     def _add_function(self, function: _Function, is_web_endpoint: bool):
-        if function.tag in self._functions:
+        if old_function := self._functions.get(function.tag, None):
+            if old_function is function:
+                return  # already added the same exact instance, ignore
+
             if not is_notebook():
-                old_function: _Function = self._functions[function.tag]
                 logger.warning(
-                    f"Warning: Tag '{function.tag}' collision!"
+                    f"Warning: function name '{function.tag}' collision!"
                     " Overriding existing function "
                     f"[{old_function._info.module_name}].{old_function._info.function_name}"
                     f" with new function [{function._info.module_name}].{function._info.function_name}"
@@ -998,13 +1000,6 @@ class _App:
         ```
         """
         for tag, function in other_app._functions.items():
-            existing_function = self._functions.get(tag)
-            if existing_function and existing_function != function:
-                logger.warning(
-                    f"Named app function {tag} with existing value {existing_function} is being "
-                    f"overwritten by a different function {function}"
-                )
-
             self._add_function(function, False)  # TODO(erikbern): webhook config?
 
         for tag, cls in other_app._classes.items():

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -437,3 +437,36 @@ def test_app_create_bad_environment_name_error(client):
             pass
 
     assert len(asyncio.all_tasks(synchronizer._loop)) == 1  # no trailing tasks, except the `loop_inner` ever-task
+
+
+def test_overriding_function_warning(caplog):
+    app = App()
+
+    @app.function(serialized=True)
+    def func():  # type: ignore
+        return 1
+
+    assert len(caplog.messages) == 0
+
+    app_2 = App()
+    app_2.include(app)
+
+    assert len(caplog.messages) == 0
+
+    app_3 = App()
+
+    app_3.include(app)
+    app_3.include(app_2)
+
+    assert len(caplog.messages) == 0
+
+    app_4 = App()
+
+    @app_4.function(serialized=True)
+    def func():  # noqa: F811
+        return 2
+
+    assert len(caplog.messages) == 0
+
+    app_3.include(app_4)
+    assert "Overriding existing function" in caplog.messages[0]


### PR DESCRIPTION
This can happen if you use app.include on an app that has a function which is already included by means of including 

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

* No longer prints a warning if app.include re-includes an already included function

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
