### PR TITLE
Update sandbox get task id protos

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2242,7 +2242,7 @@ message SandboxGetLogsRequest {
 
 message SandboxGetTaskIdRequest {
   string sandbox_id = 1;
-  float timeout = 2;
+  optional float timeout = 2; // Legacy clients do not provide a timeout. New clients must always provide a timeout.
   bool wait_until_ready = 3; // If true, waits until the container's postStart hook has been run before returning. Useful for detecting init failures.
 }
 


### PR DESCRIPTION
We need to differentiate between old clients and new clients on the server. One way to do this is to make timeout optional and force new clients to always specify this field explicitly.