### PR TITLE
Add protos for sandbox snapshots

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2221,6 +2221,30 @@ message Sandbox {
   NetworkAccess network_access = 22;
 
   optional string proxy_id = 23;
+
+  // Enable memory snapshots.
+  bool enable_memory_snapshot = 24;
+
+  // Used to pin gVisor version for memory-snapshottable sandboxes.
+  // This field is set by the server, not the client.
+  optional uint32 snapshot_version = 25;
+}
+
+message SandboxSnapshotRequest {
+  string sandbox_id = 1;
+  float timeout = 2;
+}
+
+message SandboxSnapshotResponse {
+  string snapshot_id = 1;
+}
+
+message SandboxSnapshotWaitRequest {
+  string snapshot_id = 1;
+}
+
+message SandboxSnapshotWaitResponse {
+  GenericResult result = 1;
 }
 
 message SandboxCreateRequest {
@@ -2230,6 +2254,16 @@ message SandboxCreateRequest {
 }
 
 message SandboxCreateResponse {
+  string sandbox_id = 1;
+}
+
+message SandboxRestoreRequest {
+  string app_id = 1 [ (modal.options.audit_target_attr) = true ];
+  string snapshot_id = 2;
+  string environment_name = 3;
+}
+
+message SandboxRestoreResponse {
   string sandbox_id = 1;
 }
 
@@ -2924,6 +2958,9 @@ service ModalClient {
   rpc SandboxTagsSet(SandboxTagsSetRequest) returns (google.protobuf.Empty);
   rpc SandboxTerminate(SandboxTerminateRequest) returns (SandboxTerminateResponse);
   rpc SandboxWait(SandboxWaitRequest) returns (SandboxWaitResponse);
+  rpc SandboxSnapshot(SandboxSnapshotRequest) returns (SandboxSnapshotResponse);
+  rpc SandboxSnapshotWait(SandboxSnapshotWaitRequest) returns (SandboxSnapshotWaitResponse);
+  rpc SandboxRestore(SandboxRestoreRequest) returns (SandboxRestoreResponse);
 
   // Secrets
   rpc SecretDelete(SecretDeleteRequest) returns (google.protobuf.Empty);

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2232,7 +2232,6 @@ message Sandbox {
 
 message SandboxSnapshotRequest {
   string sandbox_id = 1;
-  float timeout = 2;
 }
 
 message SandboxSnapshotResponse {
@@ -2241,6 +2240,7 @@ message SandboxSnapshotResponse {
 
 message SandboxSnapshotWaitRequest {
   string snapshot_id = 1;
+  float timeout = 2;
 }
 
 message SandboxSnapshotWaitResponse {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2230,23 +2230,6 @@ message Sandbox {
   optional uint32 snapshot_version = 25;
 }
 
-message SandboxSnapshotRequest {
-  string sandbox_id = 1;
-}
-
-message SandboxSnapshotResponse {
-  string snapshot_id = 1;
-}
-
-message SandboxSnapshotWaitRequest {
-  string snapshot_id = 1;
-  float timeout = 2;
-}
-
-message SandboxSnapshotWaitResponse {
-  GenericResult result = 1;
-}
-
 message SandboxCreateRequest {
   string app_id = 1 [ (modal.options.audit_target_attr) = true ];
   Sandbox definition = 2;
@@ -2254,16 +2237,6 @@ message SandboxCreateRequest {
 }
 
 message SandboxCreateResponse {
-  string sandbox_id = 1;
-}
-
-message SandboxRestoreRequest {
-  string app_id = 1 [ (modal.options.audit_target_attr) = true ];
-  string snapshot_id = 2;
-  string environment_name = 3;
-}
-
-message SandboxRestoreResponse {
   string sandbox_id = 1;
 }
 
@@ -2319,6 +2292,16 @@ message SandboxListResponse {
   repeated SandboxInfo sandboxes = 1;
 }
 
+message SandboxRestoreRequest {
+  string app_id = 1 [ (modal.options.audit_target_attr) = true ];
+  string snapshot_id = 2;
+  string environment_name = 3;
+}
+
+message SandboxRestoreResponse {
+  string sandbox_id = 1;
+}
+
 message SandboxSnapshotFsRequest {
   string sandbox_id = 1;
   float timeout = 2;
@@ -2329,6 +2312,23 @@ message SandboxSnapshotFsResponse {
   GenericResult result = 2;
   // Metadata may be empty since we may skip it for performance reasons.
   ImageMetadata image_metadata = 3;
+}
+
+message SandboxSnapshotRequest {
+  string sandbox_id = 1;
+}
+
+message SandboxSnapshotResponse {
+  string snapshot_id = 1;
+}
+
+message SandboxSnapshotWaitRequest {
+  string snapshot_id = 1;
+  float timeout = 2;
+}
+
+message SandboxSnapshotWaitResponse {
+  GenericResult result = 1;
 }
 
 message SandboxStdinWriteRequest {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2953,14 +2953,14 @@ service ModalClient {
   rpc SandboxGetTaskId(SandboxGetTaskIdRequest) returns (SandboxGetTaskIdResponse); // needed for modal container exec
   rpc SandboxGetTunnels(SandboxGetTunnelsRequest) returns (SandboxGetTunnelsResponse);
   rpc SandboxList(SandboxListRequest) returns (SandboxListResponse);
+  rpc SandboxRestore(SandboxRestoreRequest) returns (SandboxRestoreResponse);
+  rpc SandboxSnapshot(SandboxSnapshotRequest) returns (SandboxSnapshotResponse);
   rpc SandboxSnapshotFs(SandboxSnapshotFsRequest) returns (SandboxSnapshotFsResponse);
+  rpc SandboxSnapshotWait(SandboxSnapshotWaitRequest) returns (SandboxSnapshotWaitResponse);
   rpc SandboxStdinWrite(SandboxStdinWriteRequest) returns (SandboxStdinWriteResponse);
   rpc SandboxTagsSet(SandboxTagsSetRequest) returns (google.protobuf.Empty);
   rpc SandboxTerminate(SandboxTerminateRequest) returns (SandboxTerminateResponse);
   rpc SandboxWait(SandboxWaitRequest) returns (SandboxWaitResponse);
-  rpc SandboxSnapshot(SandboxSnapshotRequest) returns (SandboxSnapshotResponse);
-  rpc SandboxSnapshotWait(SandboxSnapshotWaitRequest) returns (SandboxSnapshotWaitResponse);
-  rpc SandboxRestore(SandboxRestoreRequest) returns (SandboxRestoreResponse);
 
   // Secrets
   rpc SecretDelete(SecretDeleteRequest) returns (google.protobuf.Empty);


### PR DESCRIPTION
This PR adds the protobufs needed to support sandbox memory snapshots.

I kept `SandboxCreate` and `SandboxRestore` as separate RPCs just in case their implementations / parameters diverge in the future, though admittedly I don't know why they would.

Corresponding server PR: https://github.com/modal-labs/modal/pull/18923
