### PR TITLE
Adds field for using OIDC authentication to mount S3 buckets

### DIFF
--- a/modal/cloud_bucket_mount.py
+++ b/modal/cloud_bucket_mount.py
@@ -112,6 +112,9 @@ class _CloudBucketMount:
     # If the bucket is publicly accessible, the secret is unnecessary and can be omitted.
     secret: Optional[_Secret] = None
 
+    # Role ARN used for using OIDC authentication to access a cloud bucket.
+    oidc_auth_role_arn: Optional[str] = None
+
     read_only: bool = False
     requester_pays: bool = False
 
@@ -155,6 +158,7 @@ def cloud_bucket_mounts_to_proto(mounts: list[tuple[str, _CloudBucketMount]]) ->
             bucket_type=bucket_type,
             requester_pays=mount.requester_pays,
             key_prefix=key_prefix,
+            oidc_auth_role_arn=mount.oidc_auth_role_arn,
         )
         cloud_bucket_mounts.append(cloud_bucket_mount)
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -714,6 +714,7 @@ message CloudBucketMount {
   bool requester_pays = 6;
   optional string bucket_endpoint_url = 7;
   optional string key_prefix = 8;
+  optional string oidc_auth_role_arn = 9;
 }
 
 message ContainerArguments {  // This is used to pass data from the worker to the container


### PR DESCRIPTION
## Describe your changes

- _Provide Linear issue reference (e.g. MOD-1234) if available._

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog
* Adds a new `oidc_auth_role_arn` field to `CloudBucketMount` for using OIDC authentication to create the mountpoint.
<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
