### PR TITLE
[Notebooks] Add CLIENT_TYPE_NOTEBOOK_KERNEL

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -82,6 +82,7 @@ enum ClientType {
   CLIENT_TYPE_WORKER = 2;
   CLIENT_TYPE_CONTAINER = 3;
   CLIENT_TYPE_WEB_SERVER = 5;
+  CLIENT_TYPE_NOTEBOOK_KERNEL = 6;
 }
 
 enum CloudProvider {


### PR DESCRIPTION
Need a new client type to register the gRPC requests to publish notebook results. Technically we could reuse an existing client type, but I think it's good to err on the side of too much information / observability rather than too little.