### PR TITLE
Rename proto: enable_memory_snapshot -> enable_snapshot

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2228,8 +2228,9 @@ message Sandbox {
 
   optional string proxy_id = 23;
 
-  // Enable memory snapshots.
-  bool enable_memory_snapshot = 24;
+  // Enable snapshotting the sandbox (both memory and filesystem).
+  // This doesn't need to be enabled to save the filesystem as an image (i.e. a filesystem-only snapshot).
+  bool enable_snapshot = 24;
 
   // Used to pin gVisor version for memory-snapshottable sandboxes.
   // This field is set by the server, not the client.


### PR DESCRIPTION
follow-up to #2774. this isn't used by anyone yet.