### PR TITLE
Hydrate Image from Sandbox.snapshot_filesystem eagerly

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -361,10 +361,12 @@ class _Sandbox(_Object, type_prefix="sb"):
         metadata = resp.image_metadata
 
         async def _load(self: _Image, resolver: Resolver, existing_object_id: Optional[str]):
-            self._hydrate(image_id, resolver.client, metadata)
+            # no need to hydrate again since we do it eagerly below
+            pass
 
         rep = "Image()"
-        image = _Image._from_loader(_load, rep)
+        image = _Image._from_loader(_load, rep, hydrate_lazily=True)
+        image._hydrate(image_id, self._client, metadata)  # hydrating eagerly since we have all of the data
 
         return image
 


### PR DESCRIPTION
## Describe your changes

Hydrate the `Image` from `Sandbox.snapshot_filesystem()` eagerly since we have all the necessary data.

Allows the following pattern for reusing sandbox images using IDs:

```py
import modal

app = modal.App()


@app.function()
def hello():
    sb = modal.Sandbox.create(app=app)
    p = sb.exec("bash", "-c", "echo 'test' > /models/test")
    p.wait()
    assert p.returncode == 0, "failed to write to file"

    sb2 = modal.Sandbox.create(image=modal.Image.from_id(image.object_id), app=app)
    p2 = sb2.exec("bash", "-c", "ls /models")
    p2.wait()
    assert p2.returncode == 0, "failed to list files"
    sb2.terminate()
```

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

* The Image returned by `Sandbox.snapshot_filesystem` now has `object_id` and other metadata pre-assigned rather than require loading by subsequent calls to sandboxes or similar to set this data.

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
