### PR TITLE
Pass GPU type as a string to the server

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1667,9 +1667,10 @@ message FunctionUpdateSchedulingParamsRequest {
 message FunctionUpdateSchedulingParamsResponse {}
 
 message GPUConfig {
-  GPUType type = 1;
+  GPUType type = 1;  // Deprecated, at some point
   uint32 count = 2;
   uint32 memory = 3;
+  string gpu_type = 4;
 }
 
 message GeneratorDone {  // Sent as the output when a generator finishes running.


### PR DESCRIPTION
It's been a minor annoyance of mine that we use enums for this. Strings would be nicer.

Server support is still needed for us to be able to not send enums to the server though. And we'll have to keep this enum around for backwards compatibility for a long time.