### PR TITLE
Make CLI import logic consistent between listings and runnability

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -309,21 +309,8 @@ class _App:
     def __setitem__(self, tag: str, obj: _Object):
         deprecation_error((2024, 3, 25), _app_attr_error)
 
-    def __getattr__(self, tag: str):
-        # TODO(erikbern): remove this method later
-        assert isinstance(tag, str)
-        if tag.startswith("__"):
-            # Hacky way to avoid certain issues, e.g. pickle will try to look this up
-            raise AttributeError(f"App has no member {tag}")
-        if tag not in self._functions or tag not in self._classes:
-            # Primarily to make hasattr work
-            raise AttributeError(f"App has no member {tag}")
-        deprecation_error((2024, 3, 25), _app_attr_error)
-
     def __setattr__(self, tag: str, obj: _Object):
         # TODO(erikbern): remove this method later
-        # Note that only attributes defined in __annotations__ are set on the object itself,
-        # everything else is registered on the indexed_objects
         if tag in self.__annotations__:
             object.__setattr__(self, tag, obj)
         elif tag == "image":

--- a/modal/app.py
+++ b/modal/app.py
@@ -118,23 +118,6 @@ class _FunctionDecoratorType:
         ...
 
 
-_app_attr_error = """\
-App assignments of the form `app.x` or `app["x"]` are deprecated!
-
-The only use cases for these assignments is in conjunction with `.new()`, which is now
-in itself deprecated. If you are constructing objects with `.from_name(...)`, there is no
-need to assign those objects to the app. Example:
-
-```python
-d = modal.Dict.from_name("my-dict", create_if_missing=True)
-
-@app.function()
-def f(x, y):
-    d[x] = y  # Refer to d in global scope
-```
-"""
-
-
 class _App:
     """A Modal App is a group of functions and classes that are deployed together.
 
@@ -302,21 +285,6 @@ class _App:
     def _validate_blueprint_value(self, key: str, value: Any):
         if not isinstance(value, _Object):
             raise InvalidError(f"App attribute `{key}` with value {value!r} is not a valid Modal object")
-
-    def __getitem__(self, tag: str):
-        deprecation_error((2024, 3, 25), _app_attr_error)
-
-    def __setitem__(self, tag: str, obj: _Object):
-        deprecation_error((2024, 3, 25), _app_attr_error)
-
-    def __setattr__(self, tag: str, obj: _Object):
-        # TODO(erikbern): remove this method later
-        if tag in self.__annotations__:
-            object.__setattr__(self, tag, obj)
-        elif tag == "image":
-            self._image = obj
-        else:
-            deprecation_error((2024, 3, 25), _app_attr_error)
 
     @property
     def image(self) -> _Image:

--- a/modal/cli/import_refs.py
+++ b/modal/cli/import_refs.py
@@ -229,7 +229,7 @@ def import_app(app_ref: str) -> App:
         if object_path is None:
             guidance_msg = Markdown(
                 f"Expected to find an app variable named **`{DEFAULT_APP_NAME}`** (the default app name). "
-                "If your `modal.App` is named differently, "
+                "If your `modal.App` is assigned to a different variable name, "
                 "you must specify it in the app ref argument. "
                 f"For example an App variable `app_2 = modal.App()` in `{import_path}` would "
                 f"be specified as `{import_path}::app_2`."

--- a/modal/cli/import_refs.py
+++ b/modal/cli/import_refs.py
@@ -153,7 +153,6 @@ def list_cli_commands(
             all_runnables.setdefault(entity, []).insert(0, name)
 
     def _is_web_endpoint(runnable: Runnable) -> bool:
-        print("checking", runnable)
         if isinstance(runnable, Function) and runnable._is_web_endpoint():
             return True
         elif isinstance(runnable, MethodReference):
@@ -203,66 +202,6 @@ def filter_cli_commands(
         prefix_matches = [x for x in cli_command.names if x.startswith(f"{name_prefix}.")]
         if prefix_matches:
             yield (prefix_matches, cli_command)
-
-
-def _infer_function_or_help(
-    app: App, module: types.ModuleType, accept_local_entrypoint: bool, accept_webhook: bool
-) -> Union[Function, LocalEntrypoint, MethodReference]:
-    """Using only an app - automatically infer a single "runnable" for a `modal run` invocation
-
-    If a single runnable can't be determined, show CLI help indicating valid choices.
-    """
-    filtered_local_entrypoints = [
-        entrypoint
-        for entrypoint in app.registered_entrypoints.values()
-        if entrypoint.info.module_name == module.__name__
-    ]
-
-    if accept_local_entrypoint:
-        if len(filtered_local_entrypoints) == 1:
-            # If there is just a single local entrypoint in the target module, use
-            # that regardless of other functions.
-            return filtered_local_entrypoints[0]
-        elif len(app.registered_entrypoints) == 1:
-            # Otherwise, if there is just a single local entrypoint in the app as a whole,
-            # use that one.
-            return list(app.registered_entrypoints.values())[0]
-
-    # TODO: refactor registered_functions to only contain function services, not class services
-    function_choices: dict[str, Union[Function, LocalEntrypoint, MethodReference]] = {
-        name: f for name, f in app.registered_functions.items() if not name.endswith(".*")
-    }
-    for cls_name, cls in app.registered_classes.items():
-        for method_name in cls._get_method_names():
-            function_choices[f"{cls_name}.{method_name}"] = MethodReference(cls, method_name)
-
-    if not accept_webhook:
-        for web_endpoint_name in app.registered_web_endpoints:
-            function_choices.pop(web_endpoint_name, None)
-
-    if accept_local_entrypoint:
-        function_choices.update(app.registered_entrypoints)
-
-    if len(function_choices) == 1:
-        return list(function_choices.values())[0]
-
-    if len(function_choices) == 0:
-        if app.registered_web_endpoints:
-            err_msg = "Modal app has only web endpoints. Use `modal serve` instead of `modal run`."
-        else:
-            err_msg = "Modal app has no registered functions. Nothing to run."
-        raise click.UsageError(err_msg)
-
-    # there are multiple choices - we can't determine which one to use:
-    registered_functions_str = "\n".join(sorted(function_choices))
-    help_text = f"""You need to specify a Modal function or local entrypoint to run, e.g.
-
-modal run app.py::my_function [...args]
-
-Registered functions and local entrypoints on the selected app are:
-{registered_functions_str}
-"""
-    raise click.UsageError(help_text)
 
 
 def _show_no_auto_detectable_app(app_ref: ImportRef) -> None:
@@ -331,9 +270,6 @@ You would run foo as [bold green]{base_cmd} app.py::foo[/bold green]"""
     error_console.print(guidance_msg)
 
 
-# class Runnable:
-
-
 def _import_cli_commands(file_or_module: str) -> list[CLICommand]:
     module = import_file_or_module(file_or_module)
     return list_cli_commands(module)
@@ -371,14 +307,15 @@ def import_and_filter(
     filtered_commands = list(
         filter_cli_commands(cli_commands, import_ref.object_path, accept_local_entrypoint, accept_webhook)
     )
+    all_usable_commands = list(filter_cli_commands(cli_commands, "", accept_local_entrypoint, accept_webhook))
 
     if len(filtered_commands) == 1:
         _, cli_command = filtered_commands[0]
         return cli_command.runnable
 
     if len(filtered_commands) == 0:
-        all_types = list(filter_cli_commands(cli_commands, import_ref.object_path))
-        if len(all_types):
+        all_cmds_matching_names = list(filter_cli_commands(cli_commands, import_ref.object_path))
+        if len(all_cmds_matching_names):
             required_types = []
             if not accept_local_entrypoint:
                 required_types.append("non-local_entrypoint")
@@ -386,15 +323,36 @@ def import_and_filter(
                 required_types.append("non-web function")
             required_types_str = ", ".join(required_types)
             raise click.UsageError(
-                f"The `{import_ref.object_path}` function can't be used by `{base_cmd}` "
-                f"(needs to be a {required_types_str})"
+                f"`{import_ref.object_path}` can't be used by `{base_cmd}` " f"(needs to be a {required_types_str})"
             )
 
     # we are here if there is more than one matching function
     if accept_local_entrypoint:
-        local_entrypoint_cmds = [cmd for cmd in filtered_commands if isinstance(cmd.runnable, LocalEntrypoint)]
+        local_entrypoint_cmds = [cmd for _, cmd in filtered_commands if isinstance(cmd.runnable, LocalEntrypoint)]
         if len(local_entrypoint_cmds) == 1:
             return local_entrypoint_cmds[0].runnable
 
-    _show_function_ref_help(import_ref, base_cmd)
-    raise SystemExit(1)
+    # some special case errors in case there are no applicable functions to run:
+    # if len(function_choices) == 0:
+    #     if app.registered_web_endpoints:
+    #         err_msg = "Modal app has only web endpoints. Use `modal serve` instead of `modal run`."
+    #     else:
+    #         err_msg = "Modal app has no registered functions. Nothing to run."
+    #     raise click.UsageError(err_msg)
+
+    # there are multiple choices - we can't determine which one to use:
+
+    usable_command_lines = []
+    for _, cmd in all_usable_commands:
+        cmd_names = " / ".join(cmd.names)
+        usable_command_lines.append(cmd_names)
+
+    registered_functions_str = "\n".join(usable_command_lines)
+    help_text = f"""You need to specify a Modal function or local entrypoint to run, e.g.
+
+modal run app[.py]::[app_var.]my_function [...args]
+
+Registered functions and local entrypoints on the selected app are:
+{registered_functions_str}
+"""
+    raise click.UsageError(help_text)

--- a/modal/cli/import_refs.py
+++ b/modal/cli/import_refs.py
@@ -303,10 +303,14 @@ def import_and_filter(
     """
 
     import_ref = parse_import_ref(func_ref)
+    # all commands:
     cli_commands = _import_cli_commands(import_ref.file_or_module)
+
+    # all commands that satisfy local entrypoint/accept webhook limitations AND object path prefix
     filtered_commands = list(
         filter_cli_commands(cli_commands, import_ref.object_path, accept_local_entrypoint, accept_webhook)
     )
+    # all commands that satisfy local entrypoint/accept webhook limitations:
     all_usable_commands = list(filter_cli_commands(cli_commands, "", accept_local_entrypoint, accept_webhook))
 
     if len(filtered_commands) == 1:

--- a/modal/cli/import_refs.py
+++ b/modal/cli/import_refs.py
@@ -126,7 +126,7 @@ def list_cli_commands(
     """
     apps = cast(list[tuple[str, App]], inspect.getmembers(module, lambda x: isinstance(x, App)))
 
-    all_runnables = {}
+    all_runnables: dict[Runnable, list[str]] = {}
     for app_name, app in apps:
         for name, local_entrypoint in app.registered_entrypoints.items():
             all_runnables.setdefault(local_entrypoint, []).append(f"{app_name}.{name}")

--- a/modal/cli/launch.py
+++ b/modal/cli/launch.py
@@ -12,7 +12,7 @@ from ..app import LocalEntrypoint
 from ..exception import _CliUserExecutionError
 from ..output import enable_output
 from ..runner import run_app
-from .import_refs import import_and_filter
+from .import_refs import _get_runnable_app, import_and_filter
 
 launch_cli = Typer(
     name="launch",
@@ -29,10 +29,11 @@ def _launch_program(name: str, filename: str, detach: bool, args: dict[str, Any]
     os.environ["MODAL_LAUNCH_ARGS"] = json.dumps(args)
 
     program_path = str(Path(__file__).parent / "programs" / filename)
-    app, entrypoint = import_and_filter(program_path, "modal launch")
+    entrypoint = import_and_filter(program_path, "modal launch")
     if not isinstance(entrypoint, LocalEntrypoint):
         raise ValueError(f"{program_path} has no single local_entrypoint")
 
+    app = _get_runnable_app(entrypoint)
     app.set_description(f"modal launch {name}")
 
     # `launch/` scripts must have a `local_entrypoint()` with no args, for simplicity here.

--- a/modal/cli/launch.py
+++ b/modal/cli/launch.py
@@ -12,7 +12,7 @@ from ..app import LocalEntrypoint
 from ..exception import _CliUserExecutionError
 from ..output import enable_output
 from ..runner import run_app
-from .import_refs import _get_runnable_app, import_and_filter
+from .import_refs import _get_runnable_app, import_and_filter, parse_import_ref
 
 launch_cli = Typer(
     name="launch",
@@ -29,7 +29,9 @@ def _launch_program(name: str, filename: str, detach: bool, args: dict[str, Any]
     os.environ["MODAL_LAUNCH_ARGS"] = json.dumps(args)
 
     program_path = str(Path(__file__).parent / "programs" / filename)
-    entrypoint = import_and_filter(program_path, "modal launch")
+    entrypoint, _ = import_and_filter(
+        parse_import_ref(program_path), accept_local_entrypoint=True, accept_webhook=False
+    )
     if not isinstance(entrypoint, LocalEntrypoint):
         raise ValueError(f"{program_path} has no single local_entrypoint")
 

--- a/modal/cli/launch.py
+++ b/modal/cli/launch.py
@@ -12,7 +12,7 @@ from ..app import LocalEntrypoint
 from ..exception import _CliUserExecutionError
 from ..output import enable_output
 from ..runner import run_app
-from .import_refs import import_and_infer
+from .import_refs import import_and_filter
 
 launch_cli = Typer(
     name="launch",
@@ -29,7 +29,7 @@ def _launch_program(name: str, filename: str, detach: bool, args: dict[str, Any]
     os.environ["MODAL_LAUNCH_ARGS"] = json.dumps(args)
 
     program_path = str(Path(__file__).parent / "programs" / filename)
-    app, entrypoint = import_and_infer(program_path, "modal launch")
+    app, entrypoint = import_and_filter(program_path, "modal launch")
     if not isinstance(entrypoint, LocalEntrypoint):
         raise ValueError(f"{program_path} has no single local_entrypoint")
 

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -24,7 +24,7 @@ from ..output import enable_output
 from ..runner import deploy_app, interactive_shell, run_app
 from ..serving import serve_app
 from ..volume import Volume
-from .import_refs import MethodReference, import_and_infer, import_app
+from .import_refs import MethodReference, import_and_filter, import_app
 from .utils import ENV_OPTION, ENV_OPTION_HELP, is_tty, stream_app_logs
 
 
@@ -260,7 +260,7 @@ class RunGroup(click.Group):
         ctx.ensure_object(dict)
         ctx.obj["env"] = ensure_env(ctx.params["env"])
 
-        app, imported_object = import_and_infer(func_ref, accept_local_entrypoint=True, base_cmd="modal run")
+        app, imported_object = import_and_filter(func_ref, accept_local_entrypoint=True, base_cmd="modal run")
 
         if app.description is None:
             app.set_description(_get_clean_app_description(func_ref))
@@ -478,7 +478,7 @@ def shell(
             exec(container_id=container_or_function, command=shlex.split(cmd), pty=pty)
             return
 
-        original_app, function_or_method_ref = import_and_infer(
+        original_app, function_or_method_ref = import_and_filter(
             container_or_function, accept_local_entrypoint=False, accept_webhook=True, base_cmd="modal shell"
         )
         function_spec: _FunctionSpec

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -480,7 +480,7 @@ def shell(
             exec(container_id=container_or_function, command=shlex.split(cmd), pty=pty)
             return
 
-        original_app, function_or_method_ref = import_and_filter(
+        function_or_method_ref = import_and_filter(
             container_or_function, accept_local_entrypoint=False, accept_webhook=True, base_cmd="modal shell"
         )
         function_spec: _FunctionSpec

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -275,10 +275,13 @@ class RunGroup(click.Group):
             import_ref, accept_local_entrypoint=True, accept_webhook=False
         )
         if not runnable:
-            help_header = "Specify a Modal Function or local entrypoint to run."
+            help_header = (
+                "Specify a Modal Function or local entrypoint to run. E.g.\n"
+                f"> modal run {import_ref.file_or_module}::my_function [..args]"
+            )
 
             if all_usable_commands:
-                help_footer = f"'{import_ref.file_or_module}' has the following functions and local entrypoints:\n\n"
+                help_footer = f"'{import_ref.file_or_module}' has the following functions and local entrypoints:\n"
                 help_footer += _get_runnable_list(all_usable_commands)
             else:
                 help_footer = f"'{import_ref.file_or_module}' has no functions or local entrypoints."
@@ -509,13 +512,16 @@ def shell(
             import_ref, accept_local_entrypoint=False, accept_webhook=True
         )
         if not runnable:
-            help_header = "Specify a Modal function or class to start a shell session for"
+            help_header = (
+                "Specify a Modal function or class to start a shell session for. E.g.\n"
+                f"> modal shell {import_ref.file_or_module}::my_function"
+            )
 
             if all_usable_commands:
-                help_footer = f"'{import_ref.file_or_module}' has the following choices:\n\n"
+                help_footer = f"The selected module '{import_ref.file_or_module}' has the following choices:\n\n"
                 help_footer += _get_runnable_list(all_usable_commands)
             else:
-                help_footer = f"'{import_ref.file_or_module}' has no Modal functions or classes."
+                help_footer = f"The selected module '{import_ref.file_or_module}' has no Modal functions or classes."
 
             raise ClickException(f"{help_header}\n\n{help_footer}")
 

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -513,7 +513,7 @@ def shell(
         )
         if not runnable:
             help_header = (
-                "Specify a Modal function or class to start a shell session for. E.g.\n"
+                "Specify a Modal function to start a shell session for. E.g.\n"
                 f"> modal shell {import_ref.file_or_module}::my_function"
             )
 

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -72,9 +72,7 @@ def _get_class_constructor_signature(user_cls: type) -> inspect.Signature:
 
 
 def _bind_instance_method(service_function: _Function, class_bound_method: _Function):
-    """mdmd:hidden
-
-    Binds an "instance service function" to a specific method name.
+    """Binds an "instance service function" to a specific method name.
     This "dummy" _Function gets no unique object_id and isn't backend-backed at the moment, since all
     it does it forward invocations to the underlying instance_service_function with the specified method,
     and we don't support web_config for parameterized methods at the moment.
@@ -129,6 +127,7 @@ def _bind_instance_method(service_function: _Function, class_bound_method: _Func
     fun._is_method = True
     fun._app = class_bound_method._app
     fun._spec = class_bound_method._spec
+    fun._is_web_endpoint = class_bound_method._is_web_endpoint
     return fun
 
 
@@ -431,6 +430,7 @@ class _Cls(_Object, type_prefix="cs"):
                     self._method_functions[method_name]._hydrate(
                         self._class_service_function.object_id, self._client, method_handle_metadata
                     )
+
             else:
                 # We're here when the function is loaded remotely (e.g. _Cls.from_name)
                 self._method_functions = {}

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -383,7 +383,10 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
     _serve_mounts: frozenset[_Mount]  # set at load time, only by loader
     _app: Optional["modal.app._App"] = None
     _obj: Optional["modal.cls._Obj"] = None  # only set for InstanceServiceFunctions and bound instance methods
-    _web_url: Optional[str]
+
+    _webhook_config: Optional[api_pb2.WebhookConfig] = None  # this is set in definition scope, only locally
+    _web_url: Optional[str]  # this is set on hydration
+
     _function_name: Optional[str]
     _is_method: bool
     _spec: Optional[_FunctionSpec] = None
@@ -911,6 +914,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         obj._cluster_size = cluster_size
         obj._is_method = False
         obj._spec = function_spec  # needed for modal shell
+        obj._webhook_config = webhook_config  # only set locally
 
         # Used to check whether we should rebuild a modal.Image which uses `run_function`.
         gpus: list[GPU_T] = gpu if isinstance(gpu, list) else [gpu]
@@ -1136,6 +1140,10 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         """mdmd:hidden"""
         assert self._spec
         return self._spec
+
+    def _is_web_endpoint(self) -> bool:
+        # only defined in definition scope/locally, and not for class methods at the moment
+        return self._webhook_config and self._webhook_config.type != api_pb2.WEBHOOK_TYPE_UNSPECIFIED
 
     def get_build_def(self) -> str:
         """mdmd:hidden"""

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1143,7 +1143,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
 
     def _is_web_endpoint(self) -> bool:
         # only defined in definition scope/locally, and not for class methods at the moment
-        return self._webhook_config and self._webhook_config.type != api_pb2.WEBHOOK_TYPE_UNSPECIFIED
+        return bool(self._webhook_config and self._webhook_config.type != api_pb2.WEBHOOK_TYPE_UNSPECIFIED)
 
     def get_build_def(self) -> str:
         """mdmd:hidden"""

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -92,6 +92,11 @@ class _PartialFunction(typing.Generic[P, ReturnType, OriginalReturnType]):
     def _get_raw_f(self) -> Callable[P, ReturnType]:
         return self.raw_f
 
+    def _is_web_endpoint(self) -> bool:
+        if self.webhook_config is None:
+            return False
+        return self.webhook_config.type != api_pb2.WEBHOOK_TYPE_UNSPECIFIED
+
     def __get__(self, obj, objtype=None) -> _Function[P, ReturnType, OriginalReturnType]:
         k = self.raw_f.__name__
         if obj:  # accessing the method on an instance of a class, e.g. `MyClass().fun``

--- a/test/app_composition_test.py
+++ b/test/app_composition_test.py
@@ -4,7 +4,7 @@ from test.helpers import deploy_app_externally
 
 def test_app_composition_includes_all_functions(servicer, credentials, supports_dir, monkeypatch, client):
     print(deploy_app_externally(servicer, credentials, "main.py", cwd=supports_dir / "multifile_project"))
-    assert servicer.n_functions == 4
+    assert servicer.n_functions == 5
     assert {"/root/main.py", "/root/a.py", "/root/b.py", "/root/c.py"} == set(servicer.files_name2sha.keys())
     assert len(servicer.secrets) == 1  # secret from B should be included
     assert servicer.n_mounts == 4  # mounts should not be duplicated

--- a/test/app_composition_test.py
+++ b/test/app_composition_test.py
@@ -4,7 +4,7 @@ from test.helpers import deploy_app_externally
 
 def test_app_composition_includes_all_functions(servicer, credentials, supports_dir, monkeypatch, client):
     print(deploy_app_externally(servicer, credentials, "main.py", cwd=supports_dir / "multifile_project"))
-    assert servicer.n_functions == 3
+    assert servicer.n_functions == 4
     assert {"/root/main.py", "/root/a.py", "/root/b.py", "/root/c.py"} == set(servicer.files_name2sha.keys())
     assert len(servicer.secrets) == 1  # secret from B should be included
     assert servicer.n_mounts == 4  # mounts should not be duplicated

--- a/test/app_composition_test.py
+++ b/test/app_composition_test.py
@@ -3,8 +3,14 @@ from test.helpers import deploy_app_externally
 
 
 def test_app_composition_includes_all_functions(servicer, credentials, supports_dir, monkeypatch, client):
-    print(deploy_app_externally(servicer, credentials, "main.py", cwd=supports_dir / "multifile_project"))
+    print(deploy_app_externally(servicer, credentials, "multifile_project.main", cwd=supports_dir))
     assert servicer.n_functions == 5
-    assert {"/root/main.py", "/root/a.py", "/root/b.py", "/root/c.py"} == set(servicer.files_name2sha.keys())
+    assert {
+        "/root/multifile_project/__init__.py",
+        "/root/multifile_project/main.py",
+        "/root/multifile_project/a.py",
+        "/root/multifile_project/b.py",
+        "/root/multifile_project/c.py",
+    } == set(servicer.files_name2sha.keys())
     assert len(servicer.secrets) == 1  # secret from B should be included
-    assert servicer.n_mounts == 4  # mounts should not be duplicated
+    assert servicer.n_mounts == 5  # mounts should not be duplicated

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -6,7 +6,7 @@ import time
 
 from grpclib import GRPCError, Status
 
-from modal import App, Dict, Image, Mount, Secret, Stub, Volume, enable_output, web_endpoint
+from modal import App, Image, Mount, Secret, Stub, Volume, enable_output, web_endpoint
 from modal._utils.async_utils import synchronizer
 from modal.exception import DeprecationError, ExecutionError, InvalidError, NotFoundError
 from modal.partial_function import _parse_custom_domains
@@ -14,13 +14,6 @@ from modal.runner import deploy_app, deploy_stub, run_app
 from modal_proto import api_pb2
 
 from .supports import module_1, module_2
-
-
-@pytest.mark.asyncio
-async def test_attrs(servicer, client):
-    app = App()
-    with pytest.raises(DeprecationError):
-        app.d = Dict.from_name("xyz")
 
 
 def square(x):

--- a/test/cli_imports_test.py
+++ b/test/cli_imports_test.py
@@ -1,5 +1,7 @@
 # Copyright Modal Labs 2023
 import pytest
+import types
+from typing import cast
 
 from modal.app import App, LocalEntrypoint
 from modal.cli.import_refs import (
@@ -173,10 +175,8 @@ def test_invalid_source_file_exception():
 
 def test_list_cli_commands():
     class FakeModule:
-        pass
-
-    FakeModule.app = App()
-    FakeModule.other_app = App()
+        app = App()
+        other_app = App()
 
     @FakeModule.app.function(serialized=True, name="foo")
     def foo():
@@ -195,11 +195,11 @@ def test_list_cli_commands():
     def non_modal_func():
         pass
 
-    FakeModule.non_modal_func = non_modal_func
-    FakeModule.foo = foo
-    FakeModule.Cls = Cls
+    FakeModule.non_modal_func = non_modal_func  # type: ignore[attr-defined]
+    FakeModule.foo = foo  # type: ignore[attr-defined]
+    FakeModule.Cls = Cls  # type: ignore[attr-defined]
 
-    res = list_cli_commands(FakeModule)  # noqa
+    res = list_cli_commands(cast(types.ModuleType, FakeModule))
 
     assert res == [
         CLICommand(["foo", "app.foo"], foo, False),  # type: ignore

--- a/test/cli_imports_test.py
+++ b/test/cli_imports_test.py
@@ -8,9 +8,7 @@ from modal import web_endpoint
 from modal.app import App, LocalEntrypoint
 from modal.cli.import_refs import (
     MethodReference,
-    _import_object,
-    _infer_runnable,
-    get_by_object_path,
+    _import_runnables,
     import_file_or_module,
     list_runnables,
 )
@@ -109,7 +107,7 @@ dir_containing_python_package = {
 )
 def test_import_object(dir_structure, ref, expected_object_type, mock_dir):
     with mock_dir(dir_structure):
-        obj, _ = _import_object(ref, base_cmd="modal some_command")
+        obj, _ = _import_runnables(ref, base_cmd="modal some_command")
         assert isinstance(obj, expected_object_type)
 
 
@@ -222,23 +220,6 @@ def test_import_package_and_module_names(monkeypatch, supports_dir):
     mod3 = import_file_or_module("supports/assert_package.py")
     assert mod3.__package__ == ""
     assert mod3.__name__ == "assert_package"
-
-
-def test_get_by_object_path():
-    class NS(dict):
-        def __getattr__(self, n):
-            return dict.__getitem__(self, n)
-
-    # simple
-    assert get_by_object_path(NS(foo="bar"), "foo") == "bar"
-    assert get_by_object_path(NS(foo="bar"), "bar") is None
-
-    # nested simple
-    assert get_by_object_path(NS(foo=NS(bar="baz")), "foo.bar") == "baz"
-
-    # try to find item keys with periods in them (ugh).
-    # this helps resolving lifecycled functions
-    assert get_by_object_path(NS({"foo.bar": "baz"}), "foo.bar") == "baz"
 
 
 def test_invalid_source_file_exception():

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -1128,7 +1128,7 @@ def test_can_run_all_listed_functions_with_includes(supports_on_path, monkeypatc
     res = _run(["run", "multifile_project.main"], expected_exit_code=1)
     print("err", res.stderr)
     # there are no runnables directly in the target module, so references need to go via the app
-    func_listing = res.stderr.split("entrypoints:")[1]
+    func_listing = res.stderr.split("functions:")[1]
 
     listed_runnables = set(re.findall(r"\b[\w.]+\b", func_listing))
 

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -235,9 +235,11 @@ def test_deploy(servicer, set_env_client, test_dir):
 def test_run_custom_app(servicer, set_env_client, test_dir):
     app_file = test_dir / "supports" / "app_run_tests" / "custom_app.py"
     res = _run(["run", app_file.as_posix() + "::app"], expected_exit_code=2, expected_stderr=None)
-    assert "Could not find" in res.stderr
+    assert "You need to specify" in res.stderr
+    assert "foo / my_app.foo" in res.stderr
     res = _run(["run", app_file.as_posix() + "::app.foo"], expected_exit_code=2, expected_stderr=None)
-    assert "Could not find" in res.stderr
+    assert "You need to specify" in res.stderr
+    assert "foo / my_app.foo" in res.stderr
 
     _run(["run", app_file.as_posix() + "::foo"])
 
@@ -1125,7 +1127,7 @@ def test_can_run_all_listed_functions_with_includes(supports_dir, monkeypatch, s
 
     res = _run(["run", "main"], expected_exit_code=2)
     # there are no runnables directly in the target module, so references need to go via the app
-    func_listing = res.stderr.split("on the selected app are:")[1]
+    func_listing = res.stderr.split("has the following registered functions and local entrypoints:")[1]
     listed_runnables = set(re.findall(r"\b[\w.]+\b", func_listing))
 
     expected_runnables = {

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -1122,12 +1122,14 @@ def test_container_exec(servicer, set_env_client, mock_shell_pty, app):
     sb.terminate()
 
 
-def test_can_run_all_listed_functions_with_includes(supports_dir, monkeypatch, set_env_client):
-    monkeypatch.chdir(supports_dir / "multifile_project")
+def test_can_run_all_listed_functions_with_includes(supports_on_path, monkeypatch, set_env_client):
+    monkeypatch.setenv("TERM", "dumb")  # prevents looking at ansi escape sequences
 
-    res = _run(["run", "main"], expected_exit_code=1)
+    res = _run(["run", "multifile_project.main"], expected_exit_code=1)
+    print("err", res.stderr)
     # there are no runnables directly in the target module, so references need to go via the app
-    func_listing = res.stderr.split("has the following registered functions and local entrypoints:")[1]
+    func_listing = res.stderr.split("entrypoints:")[1]
+
     listed_runnables = set(re.findall(r"\b[\w.]+\b", func_listing))
 
     expected_runnables = {
@@ -1143,4 +1145,4 @@ def test_can_run_all_listed_functions_with_includes(supports_dir, monkeypatch, s
 
     for runnable in expected_runnables:
         assert runnable in res.stderr
-        _run(["run", f"main::{runnable}"], expected_exit_code=0)
+        _run(["run", f"multifile_project.main::{runnable}"], expected_exit_code=0)

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -776,7 +776,7 @@ def test_environment_noflag(test_dir, servicer, command, monkeypatch):
 def test_cls(servicer, set_env_client, test_dir):
     app_file = test_dir / "supports" / "app_run_tests" / "cls.py"
 
-    _run(["run", app_file.as_posix(), "--x", "42", "--y", "1000"])
+    print(_run(["run", app_file.as_posix(), "--x", "42", "--y", "1000"]))
     _run(["run", f"{app_file.as_posix()}::AParametrized.some_method", "--x", "42", "--y", "1000"])
 
 

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -131,7 +131,7 @@ def test_run(servicer, set_env_client, test_dir):
     _run(["run", app_file.as_posix()])
     _run(["run", app_file.as_posix() + "::app"])
     _run(["run", app_file.as_posix() + "::foo"])
-    _run(["run", app_file.as_posix() + "::bar"], expected_exit_code=1, expected_stderr=None)
+    _run(["run", app_file.as_posix() + "::bar"], expected_exit_code=2, expected_stderr=None)
     file_with_entrypoint = test_dir / "supports" / "app_run_tests" / "local_entrypoint.py"
     _run(["run", file_with_entrypoint.as_posix()])
     _run(["run", file_with_entrypoint.as_posix() + "::main"])
@@ -234,9 +234,9 @@ def test_deploy(servicer, set_env_client, test_dir):
 
 def test_run_custom_app(servicer, set_env_client, test_dir):
     app_file = test_dir / "supports" / "app_run_tests" / "custom_app.py"
-    res = _run(["run", app_file.as_posix() + "::app"], expected_exit_code=1, expected_stderr=None)
+    res = _run(["run", app_file.as_posix() + "::app"], expected_exit_code=2, expected_stderr=None)
     assert "Could not find" in res.stderr
-    res = _run(["run", app_file.as_posix() + "::app.foo"], expected_exit_code=1, expected_stderr=None)
+    res = _run(["run", app_file.as_posix() + "::app.foo"], expected_exit_code=2, expected_stderr=None)
     assert "Could not find" in res.stderr
 
     _run(["run", app_file.as_posix() + "::foo"])

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -1125,7 +1125,20 @@ def test_can_run_all_listed_functions_with_includes(supports_dir, monkeypatch, s
 
     res = _run(["run", "main"], expected_exit_code=2)
     # there are no runnables directly in the target module, so references need to go via the app
-    for runnable in ["app.a_func", "app.b_func", "app.c_func", "main_function", "other_app.other_function"]:
-        assert runnable in res.stderr
+    func_listing = res.stderr.split("on the selected app are:")[1]
+    listed_runnables = set(re.findall(r"\b[\w.]+\b", func_listing))
 
+    expected_runnables = {
+        "app.a_func",
+        "app.b_func",
+        "app.c_func",
+        "app.main_function",
+        "main_function",
+        "other_app.other_function",
+        "other_function",
+    }
+    assert listed_runnables == expected_runnables
+
+    for runnable in expected_runnables:
+        assert runnable in res.stderr
         _run(["run", f"main::{runnable}"], expected_exit_code=0)

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -1134,8 +1134,8 @@ def test_can_run_all_listed_functions_with_includes(supports_dir, monkeypatch, s
         "app.c_func",
         "app.main_function",
         "main_function",
-        "other_app.other_function",
-        "other_function",
+        "Cls.method_on_other_app_class",
+        "other_app.Cls.method_on_other_app_class",
     }
     assert listed_runnables == expected_runnables
 

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -131,7 +131,7 @@ def test_run(servicer, set_env_client, test_dir):
     _run(["run", app_file.as_posix()])
     _run(["run", app_file.as_posix() + "::app"])
     _run(["run", app_file.as_posix() + "::foo"])
-    _run(["run", app_file.as_posix() + "::bar"], expected_exit_code=2, expected_stderr=None)
+    _run(["run", app_file.as_posix() + "::bar"], expected_exit_code=1, expected_stderr=None)
     file_with_entrypoint = test_dir / "supports" / "app_run_tests" / "local_entrypoint.py"
     _run(["run", file_with_entrypoint.as_posix()])
     _run(["run", file_with_entrypoint.as_posix() + "::main"])
@@ -162,14 +162,14 @@ def test_run_generator(servicer, set_env_client, test_dir):
 
 def test_help_message_unspecified_function(servicer, set_env_client, test_dir):
     app_file = test_dir / "supports" / "app_run_tests" / "app_with_multiple_functions.py"
-    result = _run(["run", app_file.as_posix()], expected_exit_code=2, expected_stderr=None)
+    result = _run(["run", app_file.as_posix()], expected_exit_code=1, expected_stderr=None)
 
     # should suggest available functions on the app:
     assert "foo" in result.stderr
     assert "bar" in result.stderr
 
     result = _run(
-        ["run", app_file.as_posix(), "--help"], expected_exit_code=2, expected_stderr=None
+        ["run", app_file.as_posix(), "--help"], expected_exit_code=1, expected_stderr=None
     )  # TODO: help should not return non-zero
     # help should also available functions on the app:
     assert "foo" in result.stderr
@@ -234,10 +234,10 @@ def test_deploy(servicer, set_env_client, test_dir):
 
 def test_run_custom_app(servicer, set_env_client, test_dir):
     app_file = test_dir / "supports" / "app_run_tests" / "custom_app.py"
-    res = _run(["run", app_file.as_posix() + "::app"], expected_exit_code=2, expected_stderr=None)
+    res = _run(["run", app_file.as_posix() + "::app"], expected_exit_code=1, expected_stderr=None)
     assert "You need to specify" in res.stderr
     assert "foo / my_app.foo" in res.stderr
-    res = _run(["run", app_file.as_posix() + "::app.foo"], expected_exit_code=2, expected_stderr=None)
+    res = _run(["run", app_file.as_posix() + "::app.foo"], expected_exit_code=1, expected_stderr=None)
     assert "You need to specify" in res.stderr
     assert "foo / my_app.foo" in res.stderr
 
@@ -273,7 +273,7 @@ def test_run_local_entrypoint_invalid_with_app_run(servicer, set_env_client, tes
 
 def test_run_parse_args_entrypoint(servicer, set_env_client, test_dir):
     app_file = test_dir / "supports" / "app_run_tests" / "cli_args.py"
-    res = _run(["run", app_file.as_posix()], expected_exit_code=2, expected_stderr=None)
+    res = _run(["run", app_file.as_posix()], expected_exit_code=1, expected_stderr=None)
     assert "You need to specify a Modal function or local entrypoint to run" in res.stderr
 
     valid_call_args = [
@@ -318,7 +318,7 @@ def test_run_parse_args_entrypoint(servicer, set_env_client, test_dir):
 
 def test_run_parse_args_function(servicer, set_env_client, test_dir, recwarn):
     app_file = test_dir / "supports" / "app_run_tests" / "cli_args.py"
-    res = _run(["run", app_file.as_posix()], expected_exit_code=2, expected_stderr=None)
+    res = _run(["run", app_file.as_posix()], expected_exit_code=1, expected_stderr=None)
     assert "You need to specify a Modal function or local entrypoint to run" in res.stderr
 
     # HACK: all the tests use the same arg, i.
@@ -1125,7 +1125,7 @@ def test_container_exec(servicer, set_env_client, mock_shell_pty, app):
 def test_can_run_all_listed_functions_with_includes(supports_dir, monkeypatch, set_env_client):
     monkeypatch.chdir(supports_dir / "multifile_project")
 
-    res = _run(["run", "main"], expected_exit_code=2)
+    res = _run(["run", "main"], expected_exit_code=1)
     # there are no runnables directly in the target module, so references need to go via the app
     func_listing = res.stderr.split("has the following registered functions and local entrypoints:")[1]
     listed_runnables = set(re.findall(r"\b[\w.]+\b", func_listing))

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -1125,7 +1125,7 @@ def test_can_run_all_listed_functions_with_includes(supports_dir, monkeypatch, s
 
     res = _run(["run", "main"], expected_exit_code=2)
     # there are no runnables directly in the target module, so references need to go via the app
-    for runnable in ["app.a_func", "app.b_func", "app.c_func", "main_function"]:
+    for runnable in ["app.a_func", "app.b_func", "app.c_func", "main_function", "other_app.other_function"]:
         assert runnable in res.stderr
 
         _run(["run", f"main::{runnable}"], expected_exit_code=0)

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -1125,7 +1125,7 @@ def test_can_run_all_listed_functions_with_includes(supports_dir, monkeypatch, s
 
     res = _run(["run", "main"], expected_exit_code=2)
     # there are no runnables directly in the target module, so references need to go via the app
-    for runnable in ["app.a_func", "app.b_func", "app.c_func"]:
+    for runnable in ["app.a_func", "app.b_func", "app.c_func", "main_function"]:
         assert runnable in res.stderr
 
         _run(["run", f"main::{runnable}"], expected_exit_code=0)

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -1118,3 +1118,14 @@ def test_container_exec(servicer, set_env_client, mock_shell_pty, app):
     captured_out.clear()
 
     sb.terminate()
+
+
+def test_can_run_all_listed_functions_with_includes(supports_dir, monkeypatch, set_env_client):
+    monkeypatch.chdir(supports_dir / "multifile_project")
+
+    res = _run(["run", "main"], expected_exit_code=2)
+    # there are no runnables directly in the target module, so references need to go via the app
+    for runnable in ["app.a_func", "app.b_func", "app.c_func"]:
+        assert runnable in res.stderr
+
+        _run(["run", f"main::{runnable}"], expected_exit_code=0)

--- a/test/supports/app_run_tests/cls.py
+++ b/test/supports/app_run_tests/cls.py
@@ -13,6 +13,6 @@ class AParametrized:
     def some_method(self, y: int):
         ...
 
-    @modal.method()
-    def other_method(self, z: int):
+    @modal.asgi_app()
+    def other_method(self):
         ...

--- a/test/supports/app_run_tests/cls.py
+++ b/test/supports/app_run_tests/cls.py
@@ -12,3 +12,7 @@ class AParametrized:
     @modal.method()
     def some_method(self, y: int):
         ...
+
+    @modal.method()
+    def other_method(self, z: int):
+        ...

--- a/test/supports/import_and_filter_source.py
+++ b/test/supports/import_and_filter_source.py
@@ -1,0 +1,60 @@
+from modal import App, asgi_app, method, web_endpoint
+
+app_with_one_web_function = App()
+
+
+@app_with_one_web_function.function()
+@web_endpoint()
+def web1():
+    pass
+
+
+app_with_one_function_one_web_endpoint = App()
+
+
+@app_with_one_function_one_web_endpoint.function()
+def f1():
+    pass
+
+
+@app_with_one_function_one_web_endpoint.function()
+@web_endpoint()
+def web2():
+    pass
+
+
+app_with_one_web_method = App()
+
+
+@app_with_one_web_method.cls()
+class C1:
+    @asgi_app()
+    def web_3(self):
+        pass
+
+
+app_with_one_web_method_one_method = App()
+
+
+@app_with_one_web_method_one_method.cls()
+class C2:
+    @asgi_app()
+    def web_4(self):
+        pass
+
+    @method()
+    def f2(self):
+        pass
+
+
+app_with_local_entrypoint_and_function = App()
+
+
+@app_with_local_entrypoint_and_function.local_entrypoint()
+def le_1():
+    pass
+
+
+@app_with_local_entrypoint_and_function.function()
+def f3():
+    pass

--- a/test/supports/import_and_filter_source.py
+++ b/test/supports/import_and_filter_source.py
@@ -1,3 +1,4 @@
+# Copyright Modal Labs 2025
 from modal import App, asgi_app, method, web_endpoint
 
 app_with_one_web_function = App()

--- a/test/supports/multifile_project/__init__.py
+++ b/test/supports/multifile_project/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Modal Labs 2025

--- a/test/supports/multifile_project/a.py
+++ b/test/supports/multifile_project/a.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2024
-import c
-
 import modal
+
+from . import c
 
 app = modal.App()
 

--- a/test/supports/multifile_project/b.py
+++ b/test/supports/multifile_project/b.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2024
-import c
-
 import modal
+
+from . import c
 
 app = modal.App()
 

--- a/test/supports/multifile_project/main.py
+++ b/test/supports/multifile_project/main.py
@@ -1,9 +1,8 @@
 # Copyright Modal Labs 2024
-import a
-import b
-
 import modal
 from modal import method, web_endpoint
+
+from . import a, b
 
 app = modal.App()
 app.include(a.app)

--- a/test/supports/multifile_project/main.py
+++ b/test/supports/multifile_project/main.py
@@ -3,6 +3,7 @@ import a
 import b
 
 import modal
+from modal import method, web_endpoint
 
 app = modal.App()
 app.include(a.app)
@@ -14,9 +15,21 @@ def main_function():
     pass
 
 
+@app.function()
+@web_endpoint()
+def web():
+    pass
+
+
 other_app = modal.App()
 
 
-@other_app.function()
-def other_function():
-    pass
+@other_app.cls()
+class Cls:
+    @method()
+    def method_on_other_app_class(self):
+        pass
+
+    @web_endpoint()
+    def web_endpoint_on_other_app(self):
+        pass

--- a/test/supports/multifile_project/main.py
+++ b/test/supports/multifile_project/main.py
@@ -7,3 +7,16 @@ import modal
 app = modal.App()
 app.include(a.app)
 app.include(b.app)
+
+
+@app.function()
+def main_function():
+    pass
+
+
+other_app = modal.App()
+
+
+@other_app.function()
+def other_function():
+    pass

--- a/test/supports/multifile_project/main.py
+++ b/test/supports/multifile_project/main.py
@@ -1,6 +1,6 @@
 # Copyright Modal Labs 2024
 import modal
-from modal import method, web_endpoint
+from modal import enter, method, web_endpoint
 
 from . import a, b
 
@@ -25,6 +25,10 @@ other_app = modal.App()
 
 @other_app.cls()
 class Cls:
+    @enter()
+    def startup(self):
+        pass
+
     @method()
     def method_on_other_app_class(self):
         pass


### PR DESCRIPTION
Changes the CLI import logic to use an exhaustive list of commands + filters instead of `getattr()` navigation.

This ensures that the listed modal "runnables" in the CLI error output will always be runnable by the command that you've run, which wasn't previously the case.

While this was a lot of code, I think it's mostly a simplification of the previous code.
The tests are still a bit of a mess since I mostly ported the old tests, and they now overlap quite a lot, but they are quick so it doesn't matter too much.

Note that this does remove a few of the helpful commands for special cases that we had before in favor of a more general error message that always lists the runnable commands if the user passes something that can't resolve to a single "runnable" (function, entrypoint, method)

Also fixes CLI-293

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

* Fixes a CLI bug where you couldn't reference functions via a qualified app, e.g. `mymodule::{app_variable}.{function_name}`.
* The `modal run`, `modal serve` and `modal shell` commands get more consistent error messages in cases where the passed app or function reference isn't resolvable to something that the current command expects.
* Removes the deprecated `__getattr__`, `__setattr__`, `__getitem__` and `__setitem__` methods from `modal.App`

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
