### PR TITLE
Add more memory snapshotting protos

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2318,13 +2318,19 @@ message SandboxListResponse {
 }
 
 message SandboxRestoreRequest {
-  string app_id = 1 [ (modal.options.audit_target_attr) = true ];
-  string snapshot_id = 2;
-  string environment_name = 3;
+  string snapshot_id = 1;
 }
 
 message SandboxRestoreResponse {
   string sandbox_id = 1;
+}
+
+message SandboxSnapshotFromIdRequest {
+  string snapshot_id = 1;
+}
+
+message SandboxSnapshotFromIdResponse {
+  string snapshot_id = 1;
 }
 
 message SandboxSnapshotFsRequest {
@@ -2982,6 +2988,7 @@ service ModalClient {
   rpc SandboxList(SandboxListRequest) returns (SandboxListResponse);
   rpc SandboxRestore(SandboxRestoreRequest) returns (SandboxRestoreResponse);
   rpc SandboxSnapshot(SandboxSnapshotRequest) returns (SandboxSnapshotResponse);
+  rpc SandboxSnapshotFromId(SandboxSnapshotFromIdRequest) returns (SandboxSnapshotFromIdResponse);
   rpc SandboxSnapshotFs(SandboxSnapshotFsRequest) returns (SandboxSnapshotFsResponse);
   rpc SandboxSnapshotWait(SandboxSnapshotWaitRequest) returns (SandboxSnapshotWaitResponse);
   rpc SandboxStdinWrite(SandboxStdinWriteRequest) returns (SandboxStdinWriteResponse);


### PR DESCRIPTION
## Describe your changes

- Modifies `SandboxRestoreRequest` to not take in app dependency
- Add `SandboxSnapshotFromId` RPC

Nothing is in production yet so existing protos should be safe to modify.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
