### PR TITLE
Add function_call_id to AppGetLogsRequest

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -340,6 +340,7 @@ message AppGetLogsRequest {
   string function_id = 5;
   string input_id = 6;
   string task_id = 7;
+  string function_call_id = 9;
   FileDescriptor file_descriptor = 8;
 }
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2599,7 +2599,6 @@ message TaskLogsBatch {
   string image_id = 13;  // Used for image logs
   bool eof = 14;
   string pty_exec_id = 15;  // Used for interactive functions
-  string function_call_id = 16;
 }
 
 message TaskProgress {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2599,6 +2599,7 @@ message TaskLogsBatch {
   string image_id = 13;  // Used for image logs
   bool eof = 14;
   string pty_exec_id = 15;  // Used for interactive functions
+  string function_call_id = 16;
 }
 
 message TaskProgress {


### PR DESCRIPTION
Required to update `/logs-stream` RPC [here](https://github.com/modal-labs/modal/pull/19138)

@mwaskom we are adding the ability to filter logs by `functionCallId` to need this as a new filter on this RPC. The protobuf types live in the client, so wanted to run by you first. LMK if you have ?'s. 