### PR TITLE
Add App.from_name for construction of a lazily-hydratable App

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -263,10 +263,26 @@ class _App:
         return self._description
 
     @staticmethod
-    def from_name(name: str, environment_name: Optional[str] = None, create_if_missing: bool = False) -> "_App":
-        """TK"""
+    def from_name(name: str, environment_name: str = "", create_if_missing: bool = False) -> "_App":
+        """Look up an App with a given name, creating a new App if necessary.
 
-        # TODO what are the rules on App names? Can we use check_object_name?
+        Note that Apps created through this method will be in a deployed state,
+        but they will not have any associated Functions or Classes.
+
+        This method is mainly useful for creating an App to associate with a Sandbox:
+
+        ```python
+        app = modal.App.from_name("my-app", create_if_missing=True)
+        app.hydrate()  # Pre-hydrate to accelerate Sandbox creation
+        modal.Sandbox.create("echo", "hi", app=app)
+        ```
+
+        When building an App that will be populated with Functions and Classes, you should
+        call the main `App()` constructor directly.
+        """
+
+        # TODO We need to enforce rules about App names, but we previously weren't in App.lookup
+        # So we probably need to add that gradually (i.e. as a warning first) to avoid breaking people?
         async def _load(self: _App, client: _Client):
             request = api_pb2.AppGetOrCreateRequest(
                 app_name=name,

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -479,3 +479,23 @@ def test_overriding_function_warning(caplog):
 
     app_3.include(app_4)
     assert "Overriding existing function" in caplog.messages[0]
+
+
+def test_from_name(servicer, client):
+    app = App.from_name(name := "lazy-app")
+    assert app.app_id is None
+    assert app.name == name
+    app.hydrate(client)
+    assert app.app_id
+
+
+def test_lookup(servicer, client):
+    app = App.lookup(name := "eager-app", client=client)
+    assert app.app_id
+    assert app.name == name
+
+
+def test_lazy_hydration(servicer, client):
+    app = App("unhydratable-app")
+    with pytest.raises(InvalidError, match=r"Apps must be constructed with .from_name\(\) to be lazily hydrated"):
+        app.hydrate(client)


### PR DESCRIPTION
## Describe your changes

This PR adds a new `App.from_name` method with similar lazy construction semantics to other `.from_name` methods on Object subclasses, along with an `App.hydrate` method for on-demand hydration. The intention is to make it possible to deprecate `App.lookup` when we deprecate other `Object.lookup` methods, streamlining object construction onto a single lazy path.

As `App` is _not_ a subclass of `Object` we face a decision about whether we should make it one (and leverage the existing hydration plumbing) or add some App-specific plumbing. This PR takes the latter approach, which feels more straightforward now without foreclosing on adapting the other approach later.

There's definitely some confusing things here. I've made it so that you can't call `App.hydrate` if you instantiated an App by calling its main constructor (`App(name)`). Potentially we will want to leverage lazy-hydration of the App layout when we do App redeployments (i.e. the current `_init_local_app_existing`). I think we can punt on that as there are not currently any user-facing workflows where you would want to hydrate the App and then access its layout, but we've tlaked about it, e.g. for Function discovery after looking up a deployed App.

Part of CLI-96

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Added a new `App.from_name` methods for lazily constructing an App based on a lookup and an `App.hydrate` method for hydrating it with server metadata on demand. These methods should be used instead of the eager `App.lookup` method, which will be deprecated soon (along with other `.lookup` methods). Note that `App.from_name` is primarily useful when you need an App to associate with a `modal.Sandbox`; other use-cases should continue to create Apps via the main constructor (`app = App(name)`).