### PR TITLE
Hydrate secrets in parallel during Sandbox.exec

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -19,7 +19,7 @@ from ._location import parse_cloud_provider
 from ._object import _get_environment_name, _Object
 from ._resolver import Resolver
 from ._resources import convert_fn_config_to_resources_config
-from ._utils.async_utils import synchronize_api
+from ._utils.async_utils import TaskContext, synchronize_api
 from ._utils.deprecation import deprecation_error
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.mount_utils import validate_network_file_systems, validate_volumes
@@ -517,9 +517,8 @@ class _Sandbox(_Object, type_prefix="sb"):
             raise InvalidError(f"workdir must be an absolute path, got: {workdir}")
 
         # Force secret resolution so we can pass the secret IDs to the backend.
-        # TODO should we parallelize this?
-        for secret in secrets:
-            await secret.hydrate(client=self._client)
+        secret_coros = [secret.hydrate(client=self._client) for secret in secrets]
+        await TaskContext.gather(*secret_coros)
 
         task_id = await self._get_task_id()
         req = api_pb2.ContainerExecRequest(


### PR DESCRIPTION
## Describe your changes

Noticed this while migrating `.resolve` -> `.hydrate`.

If passing a large number of secrets, this could potentially reduce the latency of `Sandbox.exec`.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>
