### PR TITLE
Handle resizing in pty-shell

### DIFF
--- a/modal/_utils/shell_utils.py
+++ b/modal/_utils/shell_utils.py
@@ -114,9 +114,6 @@ class WindowSizeHandler:
         """Context manager that processes window resize events from the queue.
         Can be run from any thread. If the window manager was initialized from a thread that is not the main thread,
         e.g. in tests, this context manager is a no-op.
-
-        Args:
-            handler: Callback function to handle window resize events
         """
         if not self._is_main_thread:
             yield

--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -8,6 +8,7 @@ from modal._object import _get_environment_name
 from modal._pty import get_pty_info
 from modal._utils.async_utils import synchronizer
 from modal._utils.grpc_utils import retry_transient_errors
+from modal._utils.shell_utils import WindowSizeHandler
 from modal.cli.utils import ENV_OPTION, display_table, is_tty, stream_app_logs, timestamp_to_local
 from modal.client import _Client
 from modal.config import config
@@ -79,7 +80,8 @@ async def exec(
     res: api_pb2.ContainerExecResponse = await client.stub.ContainerExec(req)
 
     if pty:
-        await _ContainerProcess(res.exec_id, client).attach()
+        window_size_handler = WindowSizeHandler()
+        await _ContainerProcess(res.exec_id, client).attach(window_size_handler=window_size_handler)
     else:
         # TODO: redirect stderr to its own stream?
         await _ContainerProcess(res.exec_id, client, stdout=StreamType.STDOUT, stderr=StreamType.STDOUT).wait()

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -14,6 +14,7 @@ import click
 import typer
 from typing_extensions import TypedDict
 
+from .._utils.shell_utils import WindowSizeHandler
 from ..app import App, LocalEntrypoint
 from ..config import config
 from ..environments import ensure_env
@@ -461,6 +462,8 @@ def shell(
     if pty is None:
         pty = is_tty()
 
+    window_size_handler = WindowSizeHandler()
+
     if platform.system() == "Windows":
         raise InvalidError("`modal shell` is currently not supported on Windows")
 
@@ -503,6 +506,7 @@ def shell(
             volumes=function_spec.volumes,
             region=function_spec.scheduler_placement.proto.regions if function_spec.scheduler_placement else None,
             pty=pty,
+            window_size_handler=window_size_handler,
             proxy=function_spec.proxy,
         )
     else:
@@ -518,6 +522,7 @@ def shell(
             volumes=volumes,
             region=region.split(",") if region else [],
             pty=pty,
+            window_size_handler=window_size_handler,
         )
 
     # NB: invoking under bash makes --cmd a lot more flexible.

--- a/modal/container_process.py
+++ b/modal/container_process.py
@@ -153,15 +153,12 @@ class _ContainerProcess(Generic[T]):
             await self.stdin.drain()
 
         async def _send_window_resize(rows: int, cols: int):
-            # create resize sequence:
-            # - magic byte 0xC1 to identify the resize sequence
+            # resize sequence:
             # - 2 bytes for the number of rows (big-endian)
             # - 2 bytes for the number of columns (big-endian)
-            magic = bytes([0xC1])
             dims = struct.pack(">HH", rows, cols)
-            resize_data = magic + dims
-            self.stdin.write(resize_data)
-            await self.stdin.drain()
+            self.stdin.write(dims)
+            await self.stdin.drain(_is_resize=True)
 
         async with TaskContext() as tc:
             stdout_task = tc.create_task(_write_to_fd_loop(self.stdout))

--- a/modal/container_process.py
+++ b/modal/container_process.py
@@ -158,7 +158,7 @@ class _ContainerProcess(Generic[T]):
             # - 2 bytes for the number of columns (big-endian)
             dims = struct.pack(">HH", rows, cols)
             self.stdin.write(dims)
-            await self.stdin.drain(_is_resize=True)
+            await self.stdin.drain(_terminal_size=(rows, cols))
 
         async with TaskContext() as tc:
             stdout_task = tc.create_task(_write_to_fd_loop(self.stdout))

--- a/modal/container_process.py
+++ b/modal/container_process.py
@@ -151,7 +151,7 @@ class _ContainerProcess(Generic[T]):
             self.stdin.write(data)
             await self.stdin.drain()
 
-        async def _send_window_resize(rows: int, cols: int):
+        async def _send_window_resize(cols: int, rows: int):
             await self.stdin.drain(_terminal_size=(rows, cols))
 
         async with TaskContext() as tc:

--- a/modal/container_process.py
+++ b/modal/container_process.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2024
 import asyncio
 import platform
-import struct
 from typing import Generic, Optional, TypeVar
 
 from modal_proto import api_pb2
@@ -153,11 +152,6 @@ class _ContainerProcess(Generic[T]):
             await self.stdin.drain()
 
         async def _send_window_resize(rows: int, cols: int):
-            # resize sequence:
-            # - 2 bytes for the number of rows (big-endian)
-            # - 2 bytes for the number of columns (big-endian)
-            dims = struct.pack(">HH", rows, cols)
-            self.stdin.write(dims)
             await self.stdin.drain(_terminal_size=(rows, cols))
 
         async with TaskContext() as tc:

--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -386,7 +386,8 @@ class _StreamWriter:
 
     async def drain(
         self,
-        _terminal_size: Optional[tuple[int, int]] = None,  # internal option to send terminal window resize events
+        # internal option to send terminal resize events to container exec
+        _terminal_size: Optional[tuple[int, int]] = None,
     ) -> None:
         """Flush the write buffer and send data to the running process.
 

--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -386,7 +386,7 @@ class _StreamWriter:
 
     async def drain(
         self,
-        _is_resize: bool = False,  # internal option to send terminal window resize events
+        _terminal_size: Optional[tuple[int, int]] = None,  # internal option to send terminal window resize events
     ) -> None:
         """Flush the write buffer and send data to the running process.
 
@@ -407,9 +407,6 @@ class _StreamWriter:
         ```
         """
         data = bytes(self._buffer)
-        if _is_resize:
-            assert len(data) == 4, "unexpected buffer size for resize event"  # rrww
-            assert self._object_type == "container_process", "resize event can only be sent for container processes"
 
         self._buffer.clear()
         index = self._get_next_index()
@@ -431,7 +428,8 @@ class _StreamWriter:
                             message=data,
                             message_index=index,
                             eof=self._is_closed,
-                            is_resize=_is_resize,
+                            window_rows=_terminal_size[0] if _terminal_size else None,
+                            window_cols=_terminal_size[1] if _terminal_size else None,
                         ),
                     ),
                 )


### PR DESCRIPTION
## Describe your changes

Very minor QoL improvement: support resizing the terminal window in `pty-shell`.

## Implementation detail

It'd be cleaner to create the `WindowSizeHandler` inside of the `ContainerProcess` handle, but signal modifications must happen in the main thread / event loop. Synchronicity forces all apis wrapped in `synchronize_api` to execute in a different thread, hence the need to create `WindowSizeHandler` externally and pass it in as an arg to `attach`.

## Server pr

- [ ] Pairs with server changes https://github.com/modal-labs/modal/pull/19216

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
