### PR TITLE
Accept variable-length arguments for custom argument parsing

### DIFF
--- a/modal/cli/__init__.py
+++ b/modal/cli/__init__.py
@@ -1,1 +1,5 @@
 # Copyright Modal Labs 2022
+
+from .run import get_extra_args
+
+__all__ = ["get_extra_args"]

--- a/modal/cli/__init__.py
+++ b/modal/cli/__init__.py
@@ -1,5 +1,1 @@
 # Copyright Modal Labs 2022
-
-from .run import get_extra_args
-
-__all__ = ["get_extra_args"]

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -94,7 +94,7 @@ def _get_signature(f: Callable[..., Any], is_method: bool = False) -> FnSignatur
             }
 
     if has_variadic_args and len(signature) > 0:
-        raise InvalidError("Functions with variadic positional parameters cannot accept other parameters")
+        raise InvalidError("Functions with variable-length positional arguments (*args) cannot have other parameters.")
 
     return FnSignature(signature, has_variadic_args)
 
@@ -219,7 +219,7 @@ def _get_click_command_for_cls(app: App, method_ref: MethodReference):
     cls_signature = _get_signature(cls._get_user_cls())
 
     if cls_signature.has_variadic_args:
-        raise InvalidError("Modal classes with variadic positional parameters cannot be run from the CLI")
+        raise InvalidError("Modal classes cannot have variable-length positional arguments (*args).")
 
     partial_functions = cls._get_partial_functions()
 
@@ -248,7 +248,7 @@ def _get_click_command_for_cls(app: App, method_ref: MethodReference):
 
         instance = cls(**cls_kwargs)
         method: Function = getattr(instance, method_name)
-        return method.remote(**fun_kwargs)
+        return method.remote(*args, **fun_kwargs)
 
     f = _make_click_function(app, fun_signature, _inner)
     with_click_options = _add_click_options(f, parameters)

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -36,7 +36,7 @@ class ParameterMetadata(TypedDict):
     default: Any
     annotation: Any
     type_hint: Any
-    kind: inspect.Parameter
+    kind: Any
 
 
 class AnyParamType(click.ParamType):

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -145,6 +145,10 @@ def _write_local_result(result_path: str, res: Any):
         fid.write(res)
 
 
+def get_extra_args():
+    return click.get_current_context().args
+
+
 def _make_click_function(app, inner: Callable[[dict[str, Any]], Any]):
     @click.pass_context
     def f(ctx, **kwargs):
@@ -251,7 +255,9 @@ def _get_click_command_for_local_entrypoint(app: App, entrypoint: LocalEntrypoin
                 _write_local_result(result_path, res)
 
     with_click_options = _add_click_options(f, _get_signature(func))
-    return click.command(with_click_options)
+    return click.command(context_settings={"ignore_unknown_options": True, "allow_extra_args": True})(
+        with_click_options
+    )
 
 
 def _get_runnable_list(all_usable_commands: list[CLICommand]) -> str:

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -158,10 +158,6 @@ def _write_local_result(result_path: str, res: Any):
         fid.write(res)
 
 
-def get_extra_args():
-    return click.get_current_context().args
-
-
 def _make_click_function(app, extra_args_param: Optional[str], inner: Callable[[dict[str, Any]], Any]):
     @click.pass_context
     def f(ctx, **kwargs):

--- a/test/supports/app_run_tests/variadic_args.py
+++ b/test/supports/app_run_tests/variadic_args.py
@@ -1,0 +1,33 @@
+# Copyright Modal Labs 2022
+from modal import App, method
+
+app = App()
+
+@app.cls()
+class VaClass:
+    @method()
+    def va_method(self, *args):
+        pass # Set via @servicer.function_body
+
+    @method()
+    def va_method_invalid(self, x: int, *args):
+        pass # Set via @servicer.function_body
+
+@app.function()
+def va_function(*args):
+    pass # Set via @servicer.function_body
+
+
+@app.function()
+def va_function_invalid(x: int, *args):
+    pass # Set via @servicer.function_body
+
+
+@app.local_entrypoint()
+def va_entrypoint(*args):
+    print(f"args: {args}")
+
+
+@app.local_entrypoint()
+def va_entrypoint_invalid(x: int, *args):
+    print(f"args: {args}")


### PR DESCRIPTION
Adds support for accepting variable-length arguments to entrypoints. See changelog for more.

## Describe your changes

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

* Modal functions, methods and entrypoints can now accept variable-length arguments to skip Modal's default CLI parsing. This is useful if you want to use Modal with custom argument parsing via `argparse` or `HfArgumentParser`. For example, the following function can be invoked with `modal run my_file.py --foo=42 --bar="baz"`:

    ```python
    import argparse

    @app.function()
    def train(*arglist):
        parser = argparse.ArgumentParser()
        parser.add_argument("--foo", type=int)
        parser.add_argument("--bar", type=str)
        args = parser.parse_args(args = arglist)
```