### PR TITLE
Remove num_active_tasks

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1661,7 +1661,6 @@ message FunctionRetryPolicy {
 
 message FunctionStats {
   uint32 backlog = 1;
-  uint32 num_active_tasks = 2;
   uint32 num_total_tasks = 3;
 }
 


### PR DESCRIPTION
We don't return this from the server or reference it in the client.
