### PR TITLE
Add attempt number input item proto

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1457,7 +1457,7 @@ message FunctionGetInputsItem {
   reserved 4; // previously used
   string function_call_id = 5;
   FunctionCallInvocationType function_call_invocation_type = 6;
-  uint32 attempt_number = 7;
+  uint32 retry_count = 7;
 }
 
 message FunctionGetInputsRequest {
@@ -1484,7 +1484,6 @@ message FunctionGetOutputsItem {
   string task_id = 6;
   double input_started_at = 7;
   double output_created_at = 8;
-  uint32 attempt_number = 9;
 }
 
 message FunctionGetOutputsRequest {
@@ -1631,7 +1630,7 @@ message FunctionPutOutputsItem {
   double input_started_at = 3;
   double output_created_at = 4;
   DataFormat data_format = 7; // for result.data_oneof
-  uint32 attempt_number = 8;
+  uint32 retry_count = 8;
 }
 
 message FunctionPutOutputsRequest {
@@ -1642,7 +1641,7 @@ message FunctionPutOutputsRequest {
 message FunctionRetryInputsItem {
   string input_jwt = 1;
   FunctionInput input = 2;
-  uint32 attempt_number = 3;
+  uint32 retry_count = 3;
 }
 
 message FunctionRetryInputsRequest {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1457,6 +1457,7 @@ message FunctionGetInputsItem {
   reserved 4; // previously used
   string function_call_id = 5;
   FunctionCallInvocationType function_call_invocation_type = 6;
+  uint32 attempt_number = 7;
 }
 
 message FunctionGetInputsRequest {
@@ -1483,6 +1484,7 @@ message FunctionGetOutputsItem {
   string task_id = 6;
   double input_started_at = 7;
   double output_created_at = 8;
+  uint32 attempt_number = 9;
 }
 
 message FunctionGetOutputsRequest {
@@ -1629,6 +1631,7 @@ message FunctionPutOutputsItem {
   double input_started_at = 3;
   double output_created_at = 4;
   DataFormat data_format = 7; // for result.data_oneof
+  uint32 attempt_number = 8;
 }
 
 message FunctionPutOutputsRequest {
@@ -1639,6 +1642,7 @@ message FunctionPutOutputsRequest {
 message FunctionRetryInputsItem {
   string input_jwt = 1;
   FunctionInput input = 2;
+  uint32 attempt_number = 3;
 }
 
 message FunctionRetryInputsRequest {


### PR DESCRIPTION
Part of SVC-180.

This adds attempt number to the input item proto. Adding just the proto definitions so it can be used by the server ([see this PR](https://github.com/modal-labs/modal/pull/19299). Will make follow up PRs to actually use this field in the client.


Check these boxes or delete any item (or this section) if not relevant for this PR.

- [X] Client+Server: this change is compatible with old servers
- [X] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
