### PR TITLE
Deprecate `.lookup` methods on Modal objects

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -669,6 +669,8 @@ class _Cls(_Object, type_prefix="cs"):
     ) -> "_Cls":
         """Lookup a Cls from a deployed App by its name.
 
+        DEPRECATED: This method is deprecated in favor of `modal.Cls.from_name`.
+
         In contrast to `modal.Cls.from_name`, this is an eager method
         that will hydrate the local object with metadata from Modal servers.
 
@@ -678,6 +680,12 @@ class _Cls(_Object, type_prefix="cs"):
         model.inference(...)
         ```
         """
+        deprecation_warning(
+            (2025, 1, 27),
+            "`modal.Cls.lookup` is deprecated and will be removed in a future release."
+            " It can be replaced with `modal.Cls.from_name`."
+            "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
+        )
         obj = _Cls.from_name(
             app_name, name, namespace=namespace, environment_name=environment_name, workspace=workspace
         )

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -11,7 +11,7 @@ from ._object import EPHEMERAL_OBJECT_HEARTBEAT_SLEEP, _get_environment_name, _O
 from ._resolver import Resolver
 from ._serialization import deserialize, serialize
 from ._utils.async_utils import TaskContext, synchronize_api
-from ._utils.deprecation import renamed_parameter
+from ._utils.deprecation import deprecation_warning, renamed_parameter
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from .client import _Client
@@ -151,6 +151,8 @@ class _Dict(_Object, type_prefix="di"):
     ) -> "_Dict":
         """Lookup a named Dict.
 
+        DEPRECATED: This method is deprecated in favor of `modal.Dict.from_name`.
+
         In contrast to `modal.Dict.from_name`, this is an eager method
         that will hydrate the local object with metadata from Modal servers.
 
@@ -159,6 +161,12 @@ class _Dict(_Object, type_prefix="di"):
         d["xyz"] = 123
         ```
         """
+        deprecation_warning(
+            (2025, 1, 27),
+            "`modal.Dict.lookup` is deprecated and will be removed in a future release."
+            " It can be replaced with `modal.Dict.from_name`."
+            "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
+        )
         obj = _Dict.from_name(
             name,
             data=data,

--- a/modal/environments.py
+++ b/modal/environments.py
@@ -11,7 +11,7 @@ from modal_proto import api_pb2
 from ._object import _Object
 from ._resolver import Resolver
 from ._utils.async_utils import synchronize_api, synchronizer
-from ._utils.deprecation import renamed_parameter
+from ._utils.deprecation import deprecation_warning, renamed_parameter
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from .client import _Client
@@ -89,6 +89,12 @@ class _Environment(_Object, type_prefix="en"):
         client: Optional[_Client] = None,
         create_if_missing: bool = False,
     ):
+        deprecation_warning(
+            (2025, 1, 27),
+            "`modal.Environment.lookup` is deprecated and will be removed in a future release."
+            " It can be replaced with `modal.Environment.from_name`."
+            "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
+        )
         obj = await _Environment.from_name(name, create_if_missing=create_if_missing)
         if client is None:
             client = await _Client.from_env()

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1096,6 +1096,8 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
     ) -> "_Function":
         """Lookup a Function from a deployed App by its name.
 
+        DEPRECATED: This method is deprecated in favor of `modal.Function.from_name`.
+
         In contrast to `modal.Function.from_name`, this is an eager method
         that will hydrate the local object with metadata from Modal servers.
 
@@ -1103,6 +1105,12 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         f = modal.Function.lookup("other-app", "function")
         ```
         """
+        deprecation_warning(
+            (2025, 1, 27),
+            "`modal.Function.lookup` is deprecated and will be removed in a future release."
+            " It can be replaced with `modal.Function.from_name`."
+            "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
+        )
         obj = _Function.from_name(app_name, name, namespace=namespace, environment_name=environment_name)
         if client is None:
             client = await _Client.from_env()

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -709,6 +709,12 @@ class _Mount(_Object, type_prefix="mo"):
         environment_name: Optional[str] = None,
     ) -> "_Mount":
         """mdmd:hidden"""
+        deprecation_warning(
+            (2025, 1, 27),
+            "`modal.Mount.lookup` is deprecated and will be removed in a future release."
+            " It can be replaced with `modal.Mount.from_name`."
+            "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
+        )
         obj = _Mount.from_name(name, namespace=namespace, environment_name=environment_name)
         if client is None:
             client = await _Client.from_env()

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -22,7 +22,7 @@ from ._object import (
 from ._resolver import Resolver
 from ._utils.async_utils import TaskContext, aclosing, async_map, sync_or_async_iter, synchronize_api
 from ._utils.blob_utils import LARGE_FILE_LIMIT, blob_iter, blob_upload_file
-from ._utils.deprecation import renamed_parameter
+from ._utils.deprecation import deprecation_warning, renamed_parameter
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.hash_utils import get_sha256_hex
 from ._utils.name_utils import check_object_name
@@ -177,6 +177,8 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
     ) -> "_NetworkFileSystem":
         """Lookup a named NetworkFileSystem.
 
+        DEPRECATED: This method is deprecated in favor of `modal.NetworkFileSystem.from_name`.
+
         In contrast to `modal.NetworkFileSystem.from_name`, this is an eager method
         that will hydrate the local object with metadata from Modal servers.
 
@@ -185,6 +187,12 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         print(nfs.listdir("/"))
         ```
         """
+        deprecation_warning(
+            (2025, 1, 27),
+            "`modal.NetworkFileSystem.lookup` is deprecated and will be removed in a future release."
+            " It can be replaced with `modal.NetworkFileSystem.from_name`."
+            "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
+        )
         obj = _NetworkFileSystem.from_name(
             name, namespace=namespace, environment_name=environment_name, create_if_missing=create_if_missing
         )

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -14,7 +14,7 @@ from ._object import EPHEMERAL_OBJECT_HEARTBEAT_SLEEP, _get_environment_name, _O
 from ._resolver import Resolver
 from ._serialization import deserialize, serialize
 from ._utils.async_utils import TaskContext, synchronize_api, warn_if_generator_is_not_consumed
-from ._utils.deprecation import renamed_parameter
+from ._utils.deprecation import deprecation_warning, renamed_parameter
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from .client import _Client
@@ -188,6 +188,8 @@ class _Queue(_Object, type_prefix="qu"):
     ) -> "_Queue":
         """Lookup a named Queue.
 
+        DEPRECATED: This method is deprecated in favor of `modal.Queue.from_name`.
+
         In contrast to `modal.Queue.from_name`, this is an eager method
         that will hydrate the local object with metadata from Modal servers.
 
@@ -196,6 +198,12 @@ class _Queue(_Object, type_prefix="qu"):
         q.put(123)
         ```
         """
+        deprecation_warning(
+            (2025, 1, 27),
+            "`modal.Queue.lookup` is deprecated and will be removed in a future release."
+            " It can be replaced with `modal.Queue.from_name`."
+            "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
+        )
         obj = _Queue.from_name(
             name, namespace=namespace, environment_name=environment_name, create_if_missing=create_if_missing
         )

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -10,7 +10,7 @@ from ._object import _get_environment_name, _Object
 from ._resolver import Resolver
 from ._runtime.execution_context import is_local
 from ._utils.async_utils import synchronize_api
-from ._utils.deprecation import renamed_parameter
+from ._utils.deprecation import deprecation_warning, renamed_parameter
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from .client import _Client
@@ -214,6 +214,12 @@ class _Secret(_Object, type_prefix="st"):
         required_keys: list[str] = [],
     ) -> "_Secret":
         """mdmd:hidden"""
+        deprecation_warning(
+            (2025, 1, 27),
+            "`modal.Secret.lookup` is deprecated and will be removed in a future release."
+            " It can be replaced with `modal.Secret.from_name`."
+            "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
+        )
         obj = _Secret.from_name(
             name, namespace=namespace, environment_name=environment_name, required_keys=required_keys
         )

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -223,6 +223,8 @@ class _Volume(_Object, type_prefix="vo"):
     ) -> "_Volume":
         """Lookup a named Volume.
 
+        DEPRECATED: This method is deprecated in favor of `modal.Volume.from_name`.
+
         In contrast to `modal.Volume.from_name`, this is an eager method
         that will hydrate the local object with metadata from Modal servers.
 
@@ -231,6 +233,12 @@ class _Volume(_Object, type_prefix="vo"):
         print(vol.listdir("/"))
         ```
         """
+        deprecation_warning(
+            (2025, 1, 27),
+            "`modal.Volume.lookup` is deprecated and will be removed in a future release."
+            " It can be replaced with `modal.Volume.from_name`."
+            "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
+        )
         obj = _Volume.from_name(
             name,
             namespace=namespace,


### PR DESCRIPTION
## Describe your changes

We're deprecating `.lookup` methods on Modal objects in favor of `.from_name`. This PR adds deprecation warnings to all `.lookup` methods on `modal.Object` subclasses. The one exception is `modal.App.lookup`, which needs to be handled separately.

Part of CLI-96

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Deprecated `.lookup` methods on Modal objects. Users are encouraged to use `.from_name` instead. In most cases this will be a simple name substitution. See [the 1.0 migration guide](https://modal.com/docs/guide/modal-1-0-migration#deprecating-the-lookup-method-on-modal-objects) for more information.