### PR TITLE
Fix and test for Function.from_name in module scope preventing modal run [CLI-323]

### DIFF
--- a/modal/cli/import_refs.py
+++ b/modal/cli/import_refs.py
@@ -146,11 +146,11 @@ def list_cli_commands(
         inspect.getmembers(module, lambda x: isinstance(x, (Function, Cls, LocalEntrypoint))),
     )
     for name, entity in module_level_entities:
-        if isinstance(entity, Cls):
+        if isinstance(entity, Cls) and entity._is_local():
             for method_name in entity._get_method_names():
                 method_ref = MethodReference(entity, method_name)
                 all_runnables.setdefault(method_ref, []).insert(0, f"{name}.{method_name}")
-        else:
+        elif (isinstance(entity, Function) and entity._is_local()) or isinstance(entity, LocalEntrypoint):
             all_runnables.setdefault(entity, []).insert(0, name)
 
     def _is_web_endpoint(runnable: Runnable) -> bool:

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -712,6 +712,9 @@ class _Cls(_Object, type_prefix="cs"):
             return self._method_functions[k]
         return getattr(self._user_cls, k)
 
+    def _is_local(self) -> bool:
+        return self._user_cls is not None
+
 
 Cls = synchronize_api(_Cls)
 

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -1161,3 +1161,15 @@ def test_modal_launch_vscode(monkeypatch, set_env_client, servicer):
         _run(["launch", "vscode"])
 
     assert mock_open.call_count == 1
+
+
+def test_run_file_with_global_lookups(servicer, set_env_client, supports_dir):
+    # having module-global Function/Cls objects from .from_name constructors shouldn't
+    # cause issues, and they shouldn't be runnable via CLI (for now)
+    with servicer.intercept() as ctx:
+        _run(["run", str(supports_dir / "app_run_tests" / "file_with_global_lookups.py")])
+
+    (req,) = ctx.get_requests("FunctionCreate")
+    assert req.function.function_name == "local_f"
+    assert len(ctx.get_requests("FunctionMap")) == 1
+    assert len(ctx.get_requests("FunctionGet")) == 0

--- a/test/supports/app_run_tests/file_with_global_lookups.py
+++ b/test/supports/app_run_tests/file_with_global_lookups.py
@@ -1,3 +1,4 @@
+# Copyright Modal Labs 2025
 import modal
 
 remote_func = modal.Function.from_name("app", "some_func")

--- a/test/supports/app_run_tests/file_with_global_lookups.py
+++ b/test/supports/app_run_tests/file_with_global_lookups.py
@@ -1,0 +1,11 @@
+import modal
+
+remote_func = modal.Function.from_name("app", "some_func")
+remote_cls = modal.Cls.from_name("app", "some_class")
+
+app = modal.App()
+
+
+@app.function()
+def local_f():
+    pass


### PR DESCRIPTION
## Changelog

* Fixes bug introduced in v0.72.48 where `modal run` didn't work with files having global `Function.from_name()`/`Function.lookup()`/`Cls.from_name()`/`Cls.lookup()` calls.