### PR TITLE
modal run now runs a single local entrypoints/function in target module

### DIFF
--- a/modal/cli/import_refs.py
+++ b/modal/cli/import_refs.py
@@ -109,6 +109,14 @@ class CLICommand:
     names: list[str]
     runnable: Runnable
     is_web_endpoint: bool
+    priority: int
+
+
+class AutoRunPriority:
+    MODULE_LOCAL_ENTRYPOINT = 0
+    MODULE_FUNCTION = 1
+    APP_LOCAL_ENTRYPOINT = 2
+    APP_FUNCTION = 3
 
 
 def list_cli_commands(
@@ -127,17 +135,21 @@ def list_cli_commands(
     apps = cast(list[tuple[str, App]], inspect.getmembers(module, lambda x: isinstance(x, App)))
 
     all_runnables: dict[Runnable, list[str]] = defaultdict(list)
+    priorities: dict[Runnable, int] = defaultdict(lambda: AutoRunPriority.APP_FUNCTION)
     for app_name, app in apps:
         for name, local_entrypoint in app.registered_entrypoints.items():
             all_runnables[local_entrypoint].append(f"{app_name}.{name}")
+            priorities[local_entrypoint] = AutoRunPriority.APP_LOCAL_ENTRYPOINT
         for name, function in app.registered_functions.items():
             if name.endswith(".*"):
                 continue
             all_runnables[function].append(f"{app_name}.{name}")
+            priorities[function] = AutoRunPriority.APP_FUNCTION
         for cls_name, cls in app.registered_classes.items():
             for method_name in cls._get_method_names():
                 method_ref = MethodReference(cls, method_name)
                 all_runnables[method_ref].append(f"{app_name}.{cls_name}.{method_name}")
+                priorities[method_ref] = AutoRunPriority.APP_FUNCTION
 
     # If any class or function is exported as a module level object, use that
     # as the preferred name by putting it first in the list
@@ -150,8 +162,13 @@ def list_cli_commands(
             for method_name in entity._get_method_names():
                 method_ref = MethodReference(entity, method_name)
                 all_runnables.setdefault(method_ref, []).insert(0, f"{name}.{method_name}")
-        elif (isinstance(entity, Function) and entity._is_local()) or isinstance(entity, LocalEntrypoint):
+                priorities[method_ref] = AutoRunPriority.MODULE_FUNCTION
+        elif isinstance(entity, Function) and entity._is_local():
             all_runnables.setdefault(entity, []).insert(0, name)
+            priorities[entity] = AutoRunPriority.MODULE_FUNCTION
+        elif isinstance(entity, LocalEntrypoint):
+            all_runnables.setdefault(entity, []).insert(0, name)
+            priorities[entity] = AutoRunPriority.MODULE_LOCAL_ENTRYPOINT
 
     def _is_web_endpoint(runnable: Runnable) -> bool:
         if isinstance(runnable, Function) and runnable._is_web_endpoint():
@@ -164,7 +181,10 @@ def list_cli_commands(
 
         return False
 
-    return [CLICommand(names, runnable, _is_web_endpoint(runnable)) for runnable, names in all_runnables.items()]
+    return [
+        CLICommand(names, runnable, _is_web_endpoint(runnable), priority=priorities[runnable])
+        for runnable, names in all_runnables.items()
+    ]
 
 
 def filter_cli_commands(
@@ -308,17 +328,19 @@ def import_and_filter(
     filtered_commands = filter_cli_commands(
         cli_commands, import_ref.object_path, accept_local_entrypoint, accept_webhook
     )
+
     all_usable_commands = filter_cli_commands(cli_commands, "", accept_local_entrypoint, accept_webhook)
 
-    if len(filtered_commands) == 1:
-        cli_command = filtered_commands[0]
-        return cli_command.runnable, all_usable_commands
+    if filtered_commands:
+        # if there is a single command with "highest run prio" - use that
+        filtered_commands_by_prio = defaultdict(list)
+        for cmd in filtered_commands:
+            filtered_commands_by_prio[cmd.priority].append(cmd)
 
-    # we are here if there is more than one matching function
-    if accept_local_entrypoint:
-        local_entrypoint_cmds = [cmd for cmd in filtered_commands if isinstance(cmd.runnable, LocalEntrypoint)]
-        if len(local_entrypoint_cmds) == 1:
-            # if there is a single local entrypoint - use that
-            return local_entrypoint_cmds[0].runnable, all_usable_commands
+        _, highest_prio_commands = min(filtered_commands_by_prio.items())
+        if len(highest_prio_commands) == 1:
+            cli_command = highest_prio_commands[0]
+            return cli_command.runnable, all_usable_commands
 
+    # otherwise, just return the list of all commands
     return None, all_usable_commands

--- a/test/cli_imports_test.py
+++ b/test/cli_imports_test.py
@@ -5,6 +5,7 @@ from typing import cast
 
 from modal.app import App, LocalEntrypoint
 from modal.cli.import_refs import (
+    AutoRunPriority,
     CLICommand,
     ImportRef,
     MethodReference,
@@ -210,7 +211,17 @@ def test_list_cli_commands():
     res = list_cli_commands(cast(types.ModuleType, FakeModule))
 
     assert res == [
-        CLICommand(["foo", "app.foo"], foo, False),  # type: ignore
-        CLICommand(["Cls.method_1", "app.Cls.method_1"], MethodReference(Cls, "method_1"), False),  # type: ignore
-        CLICommand(["Cls.web_method", "app.Cls.web_method"], MethodReference(Cls, "web_method"), True),  # type: ignore
+        CLICommand(["foo", "app.foo"], foo, False, priority=AutoRunPriority.MODULE_FUNCTION),  # type: ignore
+        CLICommand(
+            ["Cls.method_1", "app.Cls.method_1"],
+            MethodReference(Cls, "method_1"),
+            False,
+            priority=AutoRunPriority.MODULE_FUNCTION,
+        ),  # type: ignore
+        CLICommand(
+            ["Cls.web_method", "app.Cls.web_method"],
+            MethodReference(Cls, "web_method"),
+            True,
+            priority=AutoRunPriority.MODULE_FUNCTION,
+        ),  # type: ignore
     ]

--- a/test/cli_imports_test.py
+++ b/test/cli_imports_test.py
@@ -214,14 +214,14 @@ def test_list_cli_commands():
         CLICommand(["foo", "app.foo"], foo, False, priority=AutoRunPriority.MODULE_FUNCTION),  # type: ignore
         CLICommand(
             ["Cls.method_1", "app.Cls.method_1"],
-            MethodReference(Cls, "method_1"),
+            MethodReference(Cls, "method_1"),  # type: ignore
             False,
             priority=AutoRunPriority.MODULE_FUNCTION,
-        ),  # type: ignore
+        ),
         CLICommand(
             ["Cls.web_method", "app.Cls.web_method"],
-            MethodReference(Cls, "web_method"),
+            MethodReference(Cls, "web_method"),  # type: ignore
             True,
             priority=AutoRunPriority.MODULE_FUNCTION,
-        ),  # type: ignore
+        ),
     ]

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -1173,3 +1173,9 @@ def test_run_file_with_global_lookups(servicer, set_env_client, supports_dir):
     assert req.function.function_name == "local_f"
     assert len(ctx.get_requests("FunctionMap")) == 1
     assert len(ctx.get_requests("FunctionGet")) == 0
+
+
+def test_run_auto_infer_prefer_target_module(servicer, supports_dir, set_env_client, monkeypatch):
+    monkeypatch.syspath_prepend(supports_dir / "app_run_tests")
+    res = _run(["run", "multifile.util"])
+    assert "ran util\nmain func" in res.stdout

--- a/test/supports/app_run_tests/multifile/__init__.py
+++ b/test/supports/app_run_tests/multifile/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Modal Labs 2025

--- a/test/supports/app_run_tests/multifile/main.py
+++ b/test/supports/app_run_tests/multifile/main.py
@@ -1,0 +1,13 @@
+# Copyright Modal Labs 2025
+import modal
+
+app = modal.App()
+
+
+@app.local_entrypoint()
+def some_main_entrypoint():
+    print("main entrypoint")
+
+
+def main_func():
+    print("main func")

--- a/test/supports/app_run_tests/multifile/util.py
+++ b/test/supports/app_run_tests/multifile/util.py
@@ -1,0 +1,8 @@
+# Copyright Modal Labs 2025
+from .main import app, main_func
+
+
+@app.local_entrypoint()
+def run_this():
+    print("ran util")
+    main_func()


### PR DESCRIPTION
If exactly one local entrypoint or function  exists in the target module, the user doesn't have to qualify the runnable in the modal run command, even if some of the module's referenced apps have additional ones

This makes modal run behave more similar to how it worked prior to the recent refactor, while still allowing exhaustive
listing of runnable functions when a single runnable can't be inferred.

## Describe your changes

- _Provide Linear issue reference (e.g. MOD-1234) if available._

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

* `modal run` now runs a single local entrypoints/function in the selected module. If exactly one local entrypoint or function exists in the selected module, the user doesn't have to qualify the runnable
in the modal run command, even if some of the module's referenced apps have additional local entrypoints or functions. This partially restores "auto-inferred function" functionality that was changed in v0.72.48. 
