### PR TITLE
Add `wait_until_ready=True` to sandbox snapshot task id retrieval

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -581,7 +581,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         )
         sandbox = await _Sandbox.from_id(restore_resp.sandbox_id, client)
 
-        task_id_req = api_pb2.SandboxGetTaskIdRequest(sandbox_id=restore_resp.sandbox_id)
+        task_id_req = api_pb2.SandboxGetTaskIdRequest(sandbox_id=restore_resp.sandbox_id, wait_until_ready=True)
         resp = await retry_transient_errors(client.stub.SandboxGetTaskId, task_id_req)
         if resp.task_result.status not in [
             api_pb2.GenericResult.GENERIC_STATUS_UNSPECIFIED,


### PR DESCRIPTION
## Describe your changes

I was playing around with trying to break snapshots ([see here](https://github.com/modal-labs/modal/pull/19338)) and realized I forgot to include this earlier.

For context, this flag will more gracefully propagate snapshot failures to the client. Without this flag, it may be possible to `exec` something on the broken snapshot and receive a `container exited` failure instead.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---