### PR TITLE
Chore: Split functions into separate modules for implementation and wrapper

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -580,7 +580,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                 )
                 image = _Image._from_args(
                     base_images={"base": image},
-                    build_function=snapshot_function,  # type: ignore   # TODO: separate functions.py and _functions.py
+                    build_function=snapshot_function,
                     force_build=image.force_build or pf.force_build,
                 )
 

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1265,7 +1265,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
 
         async with aclosing(
             _map_invocation(
-                self,  # type: ignore
+                self,
                 input_queue,
                 self.client,
                 order_outputs,
@@ -1354,7 +1354,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
             raise InvalidError(
                 "A non-generator function cannot be called with `.remote_gen(...)`. Use `.remote(...)` instead."
             )
-        async for item in self._call_generator(args, kwargs):  # type: ignore
+        async for item in self._call_generator(args, kwargs):
             yield item
 
     def _is_local(self):

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -877,7 +877,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                     function_definition.resources.CopyFrom(
                         convert_fn_config_to_resources_config(
                             cpu=cpu, memory=memory, gpu=gpu, ephemeral_disk=ephemeral_disk
-                        ),  # type: ignore
+                        ),
                     )
 
                 assert resolver.app_id

--- a/modal/_runtime/user_code_imports.py
+++ b/modal/_runtime/user_code_imports.py
@@ -9,10 +9,10 @@ import modal._object
 import modal._runtime.container_io_manager
 import modal.cls
 from modal import Function
+from modal._functions import _Function
 from modal._utils.async_utils import synchronizer
 from modal._utils.function_utils import LocalFunctionError, is_async as get_is_async, is_global_object
 from modal.exception import ExecutionError, InvalidError
-from modal.functions import _Function
 from modal.partial_function import _find_partial_methods_for_user_cls, _PartialFunctionFlags
 from modal_proto import api_pb2
 

--- a/modal/_utils/mount_utils.py
+++ b/modal/_utils/mount_utils.py
@@ -65,7 +65,7 @@ def validate_volumes(
     volume_to_paths: dict[_Volume, list[str]] = {}
     for path, volume in validated_volumes:
         if not isinstance(volume, (_Volume, _CloudBucketMount)):
-            raise InvalidError(f"Object of type {type(volume)} mounted at '{path}' is not useable as a volume.")
+            raise InvalidError(f"Object of type {type(volume)} mounted at '{path}' is not usable as a volume.")
         elif isinstance(volume, (_Volume)):
             volume_to_paths.setdefault(volume, []).append(path)
     for paths in volume_to_paths.values():

--- a/modal/app.py
+++ b/modal/app.py
@@ -20,6 +20,7 @@ from synchronicity.async_wrap import asynccontextmanager
 
 from modal_proto import api_pb2
 
+from ._functions import _Function
 from ._ipython import is_notebook
 from ._object import _get_environment_name, _Object
 from ._utils.async_utils import synchronize_api
@@ -32,7 +33,7 @@ from .cloud_bucket_mount import _CloudBucketMount
 from .cls import _Cls, parameter
 from .config import logger
 from .exception import ExecutionError, InvalidError
-from .functions import Function, _Function
+from .functions import Function
 from .gpu import GPU_T
 from .image import _Image
 from .mount import _Mount

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -15,11 +15,12 @@ import typer
 from click import ClickException
 from typing_extensions import TypedDict
 
+from .._functions import _FunctionSpec
 from ..app import App, LocalEntrypoint
 from ..config import config
 from ..environments import ensure_env
 from ..exception import ExecutionError, InvalidError, _CliUserExecutionError
-from ..functions import Function, _FunctionSpec
+from ..functions import Function
 from ..image import Image
 from ..output import enable_output
 from ..runner import deploy_app, interactive_shell, run_app

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -11,6 +11,7 @@ from grpclib import GRPCError, Status
 from modal._utils.function_utils import CLASS_PARAM_TYPE_MAP
 from modal_proto import api_pb2
 
+from ._functions import _Function, _parse_retries
 from ._object import _get_environment_name, _Object
 from ._resolver import Resolver
 from ._resources import convert_fn_config_to_resources_config
@@ -22,7 +23,6 @@ from ._utils.grpc_utils import retry_transient_errors
 from ._utils.mount_utils import validate_volumes
 from .client import _Client
 from .exception import ExecutionError, InvalidError, NotFoundError, VersionError
-from .functions import _Function, _parse_retries
 from .gpu import GPU_T
 from .partial_function import (
     _find_callables_for_obj,

--- a/modal/experimental.py
+++ b/modal/experimental.py
@@ -5,12 +5,12 @@ from typing import Any, Callable, Optional
 from modal_proto import api_pb2
 
 from ._clustered_functions import ClusterInfo, get_cluster_info as _get_cluster_info
+from ._functions import _Function
 from ._object import _get_environment_name
 from ._runtime.container_io_manager import _ContainerIOManager
 from ._utils.async_utils import synchronizer
 from .client import _Client
 from .exception import InvalidError
-from .functions import _Function
 from .partial_function import _PartialFunction, _PartialFunctionFlags
 
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1,3 +1,4 @@
+# Copyright Modal Labs 2025
 from ._functions import _Function, _FunctionCall, _gather
 from ._utils.async_utils import synchronize_api
 

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -1,0 +1,6 @@
+from ._functions import _Function, _FunctionCall, _gather
+from ._utils.async_utils import synchronize_api
+
+Function = synchronize_api(_Function, target_module=__name__)
+FunctionCall = synchronize_api(_FunctionCall, target_module=__name__)
+gather = synchronize_api(_gather, target_module=__name__)

--- a/modal/image.py
+++ b/modal/image.py
@@ -53,7 +53,7 @@ from .secret import _Secret
 from .volume import _Volume
 
 if typing.TYPE_CHECKING:
-    import modal.functions
+    import modal._functions
 
 # This is used for both type checking and runtime validation
 ImageBuilderVersion = Literal["2023.12", "2024.04", "2024.10"]
@@ -481,7 +481,7 @@ class _Image(_Object, type_prefix="im"):
         dockerfile_function: Optional[Callable[[ImageBuilderVersion], DockerfileSpec]] = None,
         secrets: Optional[Sequence[_Secret]] = None,
         gpu_config: Optional[api_pb2.GPUConfig] = None,
-        build_function: Optional["modal.functions._Function"] = None,
+        build_function: Optional["modal._functions._Function"] = None,
         build_function_input: Optional[api_pb2.FunctionInput] = None,
         image_registry_config: Optional[_ImageRegistryConfig] = None,
         context_mount_function: Optional[Callable[[], Optional[_Mount]]] = None,
@@ -1942,7 +1942,7 @@ class _Image(_Object, type_prefix="im"):
         )
         ```
         """
-        from .functions import _Function
+        from ._functions import _Function
 
         if not callable(raw_f):
             raise InvalidError(f"Argument to Image.run_function must be a function, not {type(raw_f).__name__}.")

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -14,12 +14,12 @@ import typing_extensions
 
 from modal_proto import api_pb2
 
+from ._functions import _Function
 from ._utils.async_utils import synchronize_api, synchronizer
 from ._utils.deprecation import deprecation_error, deprecation_warning
 from ._utils.function_utils import callable_has_non_self_non_default_params, callable_has_non_self_params
 from .config import logger
 from .exception import InvalidError
-from .functions import _Function
 
 MAX_MAX_BATCH_SIZE = 1000
 MAX_BATCH_WAIT_MS = 10 * 60 * 1000  # 10 minutes

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -15,6 +15,7 @@ from synchronicity.async_wrap import asynccontextmanager
 import modal_proto.api_pb2
 from modal_proto import api_pb2
 
+from ._functions import _Function
 from ._object import _get_environment_name, _Object
 from ._pty import get_pty_info
 from ._resolver import Resolver
@@ -29,7 +30,6 @@ from .cls import _Cls
 from .config import config, logger
 from .environments import _get_environment_cached
 from .exception import InteractiveTimeoutError, InvalidError, RemoteError, _CliUserExecutionError
-from .functions import _Function
 from .output import _get_output_manager, enable_output
 from .running_app import RunningApp, running_app_from_layout
 from .sandbox import _Sandbox

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     grpclib==0.4.7
     protobuf>=3.19,<6.0,!=4.24.0
     rich>=12.0.0
-    synchronicity~=0.9.9
+    synchronicity~=0.9.10
     toml
     typer>=0.9
     types-certifi

--- a/tasks.py
+++ b/tasks.py
@@ -135,7 +135,7 @@ def type_check(ctx):
 
     # use pyright for checking implementation of those files
     pyright_allowlist = [
-        "modal/functions.py",
+        "modal/_functions.py",
         "modal/_runtime/asgi.py",
         "modal/_utils/__init__.py",
         "modal/_utils/async_utils.py",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -35,6 +35,7 @@ from grpclib.events import RecvRequest, listen
 
 import modal._serialization
 from modal import __version__, config
+from modal._functions import _Function
 from modal._runtime.container_io_manager import _ContainerIOManager
 from modal._serialization import serialize_data_format
 from modal._utils.async_utils import asyncify, synchronize_api
@@ -45,7 +46,6 @@ from modal._vendor import cloudpickle
 from modal.app import _App
 from modal.client import Client
 from modal.cls import _Cls
-from modal.functions import _Function
 from modal.image import ImageBuilderVersion
 from modal.mount import PYTHON_STANDALONE_VERSIONS, client_mount_name, python_standalone_mount_name
 from modal_proto import api_grpc, api_pb2


### PR DESCRIPTION
Similar to what we did for modal.object recently.

It surfaced a few minor typing issues. Mostly just cleans up the type stub by not having to emit all of already typed private implementation details. This also allows mypy to type check implementation since it's no longer "shadowed" by a type stub
