### PR TITLE
Allow lazy hydration after Mount.from_name

### DIFF
--- a/modal/mount.py
+++ b/modal/mount.py
@@ -697,7 +697,7 @@ class _Mount(_Object, type_prefix="mo"):
             response = await resolver.client.stub.MountGetOrCreate(req)
             provider._hydrate(response.mount_id, resolver.client, response.handle_metadata)
 
-        return _Mount._from_loader(_load, "Mount()")
+        return _Mount._from_loader(_load, "Mount()", hydrate_lazily=True)
 
     @classmethod
     @renamed_parameter((2024, 12, 18), "label", "name")


### PR DESCRIPTION
Fixes an issue that popped up when the deployment pipeline ran on #2812

`Mount.from_name` does not instantiate the object with `hydrate_lazily=True`, so it's not possible to chain `modal.Mount.from_name(...).hydrate()` as we need to do for strict replacement of `modal.Mount.lookup`.

I might be missing something but I don't think there's any reason we can't enable lazy hydration here. Risk should be relatively low in any case as `Mount.from_name` is not really user-facing (and `Mount` itself will soon be deprecated from public API).