### PR TITLE
Add proto changes for pty-shell resizing

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2180,6 +2180,9 @@ message RuntimeInputMessage {
   bytes message = 1;
   uint64 message_index = 2;
   bool eof = 3;
+  // only used to handle `container exec` terminal resize events
+  optional uint32 window_rows = 4;
+  optional uint32 window_cols = 5;
 }
 
 message RuntimeOutputBatch {


### PR DESCRIPTION
## Describe your changes

Adds proto changes for handling resize in `pty-shell`.
- Full client changes: https://github.com/modal-labs/modal-client/pull/2803
- Worker changes: https://github.com/modal-labs/modal/pull/19216

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
