### PR TITLE
Rename parameterized to parametrized everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -467,7 +467,7 @@ New minor client version `0.67.x` comes with an internal data model change for h
 
 ### 0.64.185 (2024-10-15)
 
-- Memory snapshotting can now be used with parameterized functions.
+- Memory snapshotting can now be used with parametrized functions.
 
 
 
@@ -611,7 +611,7 @@ Introduce an experimental API to allow users to set the input concurrency for a 
 
 ### 0.64.48 (2024-08-21)
 
-- Introduces new dataclass-style syntax for class parameterization (see updated [docs](https://modal.com/docs/guide/parameterized-functions))
+- Introduces new dataclass-style syntax for class parametrization (see updated [docs](https://modal.com/docs/guide/parametrized-functions))
 
     ```python
     @app.cls()
@@ -623,9 +623,9 @@ Introduce an experimental API to allow users to set the input concurrency for a 
     
 - The new syntax enforces types (`str` or `int` for now) on all parameters
 
-- *When the new syntax is used*, any web endpoints (`web_endpoint`, `asgi_app`, `wsgi_app` or `web_server`) on the app will now also support parameterization through the use of query parameters matching the parameter names, e.g. `https://myfunc.modal.run/?param_a="hello` in the above example.
+- *When the new syntax is used*, any web endpoints (`web_endpoint`, `asgi_app`, `wsgi_app` or `web_server`) on the app will now also support parametrization through the use of query parameters matching the parameter names, e.g. `https://myfunc.modal.run/?param_a="hello` in the above example.
 
-- The old explicit `__init__` constructor syntax is still allowed, but could be deprecated in the future and doesn't work with web endpoint parameterization
+- The old explicit `__init__` constructor syntax is still allowed, but could be deprecated in the future and doesn't work with web endpoint parametrization
 
 ### 0.64.38 (2024-08-16)
 

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -373,7 +373,7 @@ def call_lifecycle_functions(
     """Call function(s), can be sync or async, but any return values are ignored."""
     with container_io_manager.handle_user_exception():
         for func in funcs:
-            # We are deprecating parameterized exit methods but want to gracefully handle old code.
+            # We are deprecating parametrized exit methods but want to gracefully handle old code.
             # We can remove this once the deprecation in the actual @exit decorator is enforced.
             args = (None, None, None) if callable_has_non_self_params(func) else ()
             # in case func is non-async, it's executed here and sigint will by default

--- a/modal/_utils/function_utils.py
+++ b/modal/_utils/function_utils.py
@@ -288,8 +288,8 @@ class FunctionInfo:
         if not _use_annotation_parameters(self.user_cls):
             return api_pb2.ClassParameterInfo(format=api_pb2.ClassParameterInfo.PARAM_SERIALIZATION_FORMAT_PICKLE)
 
-        # annotation parameters trigger strictly typed parameterization
-        # which enables web endpoint for parameterized classes
+        # annotation parameters trigger strictly typed parametrization
+        # which enables web endpoint for parametrized classes
 
         modal_parameters: list[api_pb2.ClassParameterSpec] = []
         signature = _get_class_constructor_signature(self.user_cls)

--- a/modal/_vendor/cloudpickle.py
+++ b/modal/_vendor/cloudpickle.py
@@ -597,7 +597,7 @@ def _get_bases(typ):
     if "__orig_bases__" in getattr(typ, "__dict__", {}):
         # For generic types (see PEP 560)
         # Note that simply checking `hasattr(typ, '__orig_bases__')` is not
-        # correct.  Subclasses of a fully-parameterized generic class does not
+        # correct.  Subclasses of a fully-parametrized generic class does not
         # have `__orig_bases__` defined, but `hasattr(typ, '__orig_bases__')`
         # will return True because it's defined in the base class.
         bases_attr = "__orig_bases__"

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -75,7 +75,7 @@ def _bind_instance_method(service_function: _Function, class_bound_method: _Func
     """Binds an "instance service function" to a specific method name.
     This "dummy" _Function gets no unique object_id and isn't backend-backed at the moment, since all
     it does it forward invocations to the underlying instance_service_function with the specified method,
-    and we don't support web_config for parameterized methods at the moment.
+    and we don't support web_config for parametrized methods at the moment.
     """
     # TODO(elias): refactor to not use `_from_loader()` as a crutch for lazy-loading the
     #   underlying instance_service_function. It's currently used in order to take advantage
@@ -90,7 +90,7 @@ def _bind_instance_method(service_function: _Function, class_bound_method: _Func
         method_placeholder_fun._web_url = (
             class_bound_method._web_url
         )  # TODO: this shouldn't be set when actual parameters are used
-        method_placeholder_fun._function_name = f"{class_bound_method._function_name}[parameterized]"
+        method_placeholder_fun._function_name = f"{class_bound_method._function_name}[parametrized]"
         method_placeholder_fun._is_generator = class_bound_method._is_generator
         method_placeholder_fun._cluster_size = class_bound_method._cluster_size
         method_placeholder_fun._use_method_name = method_name
@@ -98,7 +98,7 @@ def _bind_instance_method(service_function: _Function, class_bound_method: _Func
 
     async def _load(fun: "_Function", resolver: Resolver, existing_object_id: Optional[str]):
         # there is currently no actual loading logic executed to create each method on
-        # the *parameterized* instance of a class - it uses the parameter-bound service-function
+        # the *parametrized* instance of a class - it uses the parameter-bound service-function
         # for the instance. This load method just makes sure to set all attributes after the
         # `service_function` has been loaded (it's in the `_deps`)
         hydrate_from_instance_service_function(fun)

--- a/modal/functions.py
+++ b/modal/functions.py
@@ -957,7 +957,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                 identity = f"{parent.info.function_name} class service function"
             except Exception:
                 # Can't always look up the function name that way, so fall back to generic message
-                identity = "class service function for a parameterized class"
+                identity = "class service function for a parametrized class"
             if not parent.is_hydrated:
                 if parent.app._running_app is None:
                     reason = ", because the App it is defined on is not running"

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -614,7 +614,7 @@ ExitHandlerType = Union[
     #       synchronicity type stubs would strip Awaitable so we use Any for now
     # Original, __exit__ style method signature (now deprecated)
     Callable[[Any, Optional[type[BaseException]], Optional[BaseException], Any], Any],
-    # Forward-looking unparameterized method
+    # Forward-looking unparametrized method
     Callable[[Any], Any],
 ]
 

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -36,7 +36,7 @@ app = App("app")
 def auto_use_set_env_client(set_env_client):
     # TODO(elias): remove set_env_client fixture here if/when possible - this is required only since
     #  Client.from_env happens to inject an unused client when loading the
-    #  parameterized function
+    #  parametrized function
     return
 
 
@@ -916,7 +916,7 @@ def test_implicit_constructor():
     # with pytest.raises(TypeError, match="missing a required argument: 'a'"):
     #     UsingAnnotationParameters()
 
-    # check that implicit constructors trigger strict parameterization
+    # check that implicit constructors trigger strict parametrization
     function_info: FunctionInfo = synchronizer._translate_in(UsingAnnotationParameters)._class_service_function._info  # type: ignore
     assert function_info.class_parameter_info().format == api_pb2.ClassParameterInfo.PARAM_SERIALIZATION_FORMAT_PROTO
 
@@ -930,30 +930,30 @@ def test_custom_constructor():
 
     d2 = UsingCustomConstructor(11)
     assert d2.get_value.local() == 11  # run constructor before running locally
-    # check that explicit constructors trigger pickle parameterization
+    # check that explicit constructors trigger pickle parametrization
     function_info: FunctionInfo = synchronizer._translate_in(UsingCustomConstructor)._class_service_function._info  # type: ignore
     assert function_info.class_parameter_info().format == api_pb2.ClassParameterInfo.PARAM_SERIALIZATION_FORMAT_PICKLE
 
 
-class ParameterizedClass1:
+class ParametrizedClass1:
     def __init__(self, a):
         pass
 
 
-class ParameterizedClass1Implicit:
+class ParametrizedClass1Implicit:
     a: int = modal.parameter()
 
 
-class ParameterizedClass2:
+class ParametrizedClass2:
     def __init__(self, a: int = 1):
         pass
 
 
-class ParameterizedClass2Implicit:
+class ParametrizedClass2Implicit:
     a: int = modal.parameter(default=1)
 
 
-class ParameterizedClass3:
+class ParametrizedClass3:
     def __init__(self):
         pass
 

--- a/test/gpu_test.py
+++ b/test/gpu_test.py
@@ -110,7 +110,7 @@ def test_memory_selection_gpu_variant(client, servicer, memory_arg, gpu_type, me
     if isinstance(memory_arg, str):
         app.function(gpu=modal.gpu.A100(size=memory_arg))(dummy)
     else:
-        raise RuntimeError(f"Unexpected test parameterization arg type {type(memory_arg)}")
+        raise RuntimeError(f"Unexpected test parametrization arg type {type(memory_arg)}")
 
     with app.run(client=client):
         pass

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -33,7 +33,7 @@ from modal_proto import api_pb2
 
 from .supports.skip import skip_windows
 
-# Avoid parameterizing tests over ImageBuilderVersion not supported by current Python
+# Avoid parametrizing tests over ImageBuilderVersion not supported by current Python
 PYTHON_MAJOR_MINOR = "{}.{}".format(*sys.version_info)
 SUPPORTED_IMAGE_BUILDER_VERSIONS = [
     v for v in get_args(ImageBuilderVersion) if PYTHON_MAJOR_MINOR in SUPPORTED_PYTHON_SERIES[v]


### PR DESCRIPTION
## Describe your changes

SVC-305

Went for parametrized without the e over paramet`e`rized since that's what `pytest` uses 🤷. Both are apparently valid and widespread.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
