### PR TITLE
Update proto so FunctionRetry returns input_jwt

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1650,8 +1650,7 @@ message FunctionRetryInputsRequest {
 }
 
 message FunctionRetryInputsResponse {
-  // TODO(ryan): Eventually this will return entry ids, which client
-  // will send back to server to check for lost inputs.
+  repeated string input_jwts = 1;
 }
 
 message FunctionRetryPolicy {


### PR DESCRIPTION
The FunctionRetry endpoint needs to return the input_jwt of the retried input. On retry, the input will get a new entry_id. We need to return an updated input_jwt to the caller with the correct entry_id, because we use the entry_id to track lost inputs.


Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
