### PR TITLE
Use parameter info to validate parameters on instance creation

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -952,8 +952,6 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         Binds a class-function to a specific instance of (init params, options) or a new workspace
         """
 
-        # In some cases, reuse the base function, i.e. not create new clones of each method or the "service function"
-        can_use_parent = len(args) + len(kwargs) == 0 and options is None
         parent = self
 
         async def _load(param_bound_func: _Function, resolver: Resolver, existing_object_id: Optional[str]):
@@ -973,11 +971,6 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
 
             assert parent._client and parent._client.stub
 
-            if can_use_parent:
-                # We can end up here if parent wasn't hydrated when class was instantiated, but has been since.
-                param_bound_func._hydrate_from_other(parent)
-                return
-
             if (
                 parent._class_parameter_info
                 and parent._class_parameter_info.format == api_pb2.ClassParameterInfo.PARAM_SERIALIZATION_FORMAT_PROTO
@@ -989,8 +982,20 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                         "Use (<parameter_name>=value) keyword arguments when constructing classes instead."
                     )
                 serialized_params = serialize_proto_params(kwargs, parent._class_parameter_info.schema)
+                try:
+                    default_values = serialize_proto_params({}, parent._class_parameter_info.schema)
+                except ValueError:
+                    default_values = None
+                can_use_parent = serialized_params == default_values
             else:
+                can_use_parent = len(args) + len(kwargs) == 0 and options is None
                 serialized_params = serialize((args, kwargs))
+
+            if can_use_parent:
+                # We can end up here if parent wasn't hydrated when class was instantiated, but has been since.
+                param_bound_func._hydrate_from_other(parent)
+                return
+
             environment_name = _get_environment_name(None, resolver)
             assert parent is not None and parent.is_hydrated
             req = api_pb2.FunctionBindParamsRequest(
@@ -1005,10 +1010,6 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
             param_bound_func._hydrate(response.bound_function_id, parent._client, response.handle_metadata)
 
         fun: _Function = _Function._from_loader(_load, "Function(parametrized)", hydrate_lazily=True)
-
-        if can_use_parent and parent.is_hydrated:
-            # skip the resolver altogether:
-            fun._hydrate_from_other(parent)
 
         fun._info = self._info
         fun._obj = obj

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -182,6 +182,7 @@ class _Obj:
     def _get_parameter_values(self) -> dict[str, Any]:
         # binds args and kwargs according to the class constructor signature
         # (implicit by parameters or explicit)
+        # can only be called where the local definition exists
         sig = _get_class_constructor_signature(self._user_cls)
         bound_vars = sig.bind(*self._args, **self._kwargs)
         bound_vars.apply_defaults()

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -902,7 +902,7 @@ class UsingCustomConstructor:
         return self._a
 
 
-def test_implicit_constructor():
+def test_implicit_constructor(client, set_env_client):
     c = UsingAnnotationParameters(a=10)
 
     assert c.a == 10
@@ -912,9 +912,9 @@ def test_implicit_constructor():
     d = UsingAnnotationParameters(a=11, b="goodbye")
     assert d.b == "goodbye"
 
-    # TODO(elias): fix "eager" constructor call validation by looking at signature
-    # with pytest.raises(TypeError, match="missing a required argument: 'a'"):
-    #     UsingAnnotationParameters()
+    with pytest.raises(ValueError, match="Missing required parameter: a"):
+        with app2.run(client=client):
+            UsingAnnotationParameters().get_value.remote()
 
     # check that implicit constructors trigger strict parametrization
     function_info: FunctionInfo = synchronizer._translate_in(UsingAnnotationParameters)._class_service_function._info  # type: ignore

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1020,6 +1020,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
                         )
                         for method_name, method_definition in function_defn.method_definitions.items()
                     },
+                    class_parameter_info=function_defn.class_parameter_info,
                 ),
             )
         )

--- a/test/serialization_test.py
+++ b/test/serialization_test.py
@@ -84,7 +84,7 @@ def test_proto_serde_failure_incomplete_params():
         parameters=[api_pb2.ClassParameterValue(name="a", type=api_pb2.PARAM_TYPE_STRING, string_value="b")]
     )
     encoded_params = incomplete_proto_params.SerializeToString(deterministic=True)
-    with pytest.raises(AttributeError):
+    with pytest.raises(AttributeError, match="Constructor arguments don't match"):
         deserialize_proto_params(encoded_params, [api_pb2.ClassParameterSpec(name="x", type=api_pb2.PARAM_TYPE_STRING)])
 
     # TODO: add test for incorrect types


### PR DESCRIPTION
This uses the parameter info from the class service function metadata to validate parameters on instance creation (when implicit/typed constructors are used).

This also fixes the incorrect assumption that the base/parent service for a class can be used whenever the calling arguments are empty, by instead checking if the arguments can be serialized and if they match the defaults

Fixes CLI-328
Fixes CLI-327

--- 

Pretty sure this can have subtle effects on weird code paths and break in unexpected ways, so I'll make sure to run integration tests before merging this (if the client tests pass...)
