### PR TITLE
Add root_function_id to TaskLogsBatch

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1650,7 +1650,7 @@ message FunctionRetryInputsRequest {
 }
 
 message FunctionRetryInputsResponse {
-    repeated string input_jwts = 1;
+  repeated string input_jwts = 1;
 }
 
 message FunctionRetryPolicy {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1650,8 +1650,7 @@ message FunctionRetryInputsRequest {
 }
 
 message FunctionRetryInputsResponse {
-  // TODO(ryan): Eventually this will return entry ids, which client
-  // will send back to server to check for lost inputs.
+    repeated string input_jwts = 1;
 }
 
 message FunctionRetryPolicy {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1650,7 +1650,8 @@ message FunctionRetryInputsRequest {
 }
 
 message FunctionRetryInputsResponse {
-  repeated string input_jwts = 1;
+  // TODO(ryan): Eventually this will return entry ids, which client
+  // will send back to server to check for lost inputs.
 }
 
 message FunctionRetryPolicy {
@@ -2628,6 +2629,7 @@ message TaskLogsBatch {
   string image_id = 13;  // Used for image logs
   bool eof = 14;
   string pty_exec_id = 15;  // Used for interactive functions
+  string root_function_id = 16;
 }
 
 message TaskProgress {


### PR DESCRIPTION
https://linear.app/modal-labs/issue/PRD-555/migrate-logs-table-primary-key-from-app-id-timestamp-task-id-to-app-id

Need to add a new field to `TaskLogsBatch` so that we can push the `root_function_id` to our new ClickHouse table (once that's up)