### PR TITLE
Adds experimental support for GPU memory snapshots

### DIFF
--- a/modal/_runtime/container_io_manager.py
+++ b/modal/_runtime/container_io_manager.py
@@ -25,6 +25,7 @@ from grpclib import Status
 from synchronicity.async_wrap import asynccontextmanager
 
 import modal_proto.api_pb2
+from modal._runtime import gpu_memory_snapshot
 from modal._serialization import deserialize, serialize, serialize_data_format
 from modal._traceback import extract_traceback, print_exception
 from modal._utils.async_utils import TaskContext, asyncify, synchronize_api, synchronizer
@@ -877,6 +878,12 @@ class _ContainerIOManager:
             if value != "":
                 config.override_locally(key, value)
 
+        # Restore GPU memory.
+        if config.get("gpu_snapshot_enabled") and self.function_def.resources.gpu_config.gpu_type:
+            logger.debug("GPU memory snapshot enabled. Attempting to restore GPU memory.")
+            if gpu_memory_snapshot.get_state() == gpu_memory_snapshot.CudaCheckpointState.CHECKPOINTED:
+                gpu_memory_snapshot.toggle()
+
         # Restore input to default state.
         self.current_input_id = None
         self.current_inputs = {}
@@ -892,6 +899,13 @@ class _ContainerIOManager:
 
         # Pause heartbeats since they keep the client connection open which causes the snapshotter to crash
         async with self.heartbeat_condition:
+            # Snapshot GPU memory.
+            if config.get("gpu_snapshot_enabled") and self.function_def.resources.gpu_config.gpu_type:
+                logger.debug("GPU memory snapshot enabled. Attempting to snapshot GPU memory.")
+                if gpu_memory_snapshot.get_state() == gpu_memory_snapshot.CudaCheckpointState.RUNNING:
+                    gpu_memory_snapshot.toggle()
+                    gpu_memory_snapshot.wait_for_state(gpu_memory_snapshot.CudaCheckpointState.CHECKPOINTED)
+
             # Notify the heartbeat loop that the snapshot phase has begun in order to
             # prevent it from sending heartbeat RPCs
             self._waiting_for_memory_snapshot = True

--- a/modal/_runtime/container_io_manager.py
+++ b/modal/_runtime/container_io_manager.py
@@ -879,7 +879,7 @@ class _ContainerIOManager:
                 config.override_locally(key, value)
 
         # Restore GPU memory.
-        if config.get("gpu_snapshot_enabled") and self.function_def.resources.gpu_config.gpu_type:
+        if self.function_def._experimental_enable_gpu_snapshot and self.function_def.resources.gpu_config.gpu_type:
             logger.debug("GPU memory snapshot enabled. Attempting to restore GPU memory.")
             if gpu_memory_snapshot.get_state() == gpu_memory_snapshot.CudaCheckpointState.CHECKPOINTED:
                 gpu_memory_snapshot.toggle()
@@ -900,7 +900,7 @@ class _ContainerIOManager:
         # Pause heartbeats since they keep the client connection open which causes the snapshotter to crash
         async with self.heartbeat_condition:
             # Snapshot GPU memory.
-            if config.get("gpu_snapshot_enabled") and self.function_def.resources.gpu_config.gpu_type:
+            if self.function_def._experimental_enable_gpu_snapshot and self.function_def.resources.gpu_config.gpu_type:
                 logger.debug("GPU memory snapshot enabled. Attempting to snapshot GPU memory.")
                 if gpu_memory_snapshot.get_state() == gpu_memory_snapshot.CudaCheckpointState.RUNNING:
                     gpu_memory_snapshot.toggle()

--- a/modal/_runtime/gpu_memory_snapshot.py
+++ b/modal/_runtime/gpu_memory_snapshot.py
@@ -1,0 +1,107 @@
+# Copyright Modal Labs 2022
+#
+# This module provides a simple interface for creating GPU memory snapshots,
+# provising a convenient interface to `cuda-checkpoint` [1]. This is intended
+# to be used in conjunction with memory snapshots.
+#
+# [1] https://github.com/NVIDIA/cuda-checkpoint
+
+import os
+import subprocess
+import time
+from enum import Enum
+
+from modal.config import config, logger
+
+CUDA_CHECKPOINT_PATH: str = config.get("cuda_checkpoint_path")
+
+
+class CudaCheckpointState(Enum):
+    """State representation from the CUDA API: https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TYPES.html#group__CUDA__TYPES_1gc96cdda177a2b8c296144567cbea4f23"""
+
+    RUNNING = "running"
+    LOCKED = "locked"
+    CHECKPOINTED = "checkpointed"
+    FAILED = "failed"
+
+
+class CudaCheckpointException(Exception):
+    pass
+
+
+def toggle():
+    """Toggle CUDA checkpoint state for current process, moving GPU memory to the
+    CPU and back depending on the current process state when called."""
+    pid = get_own_pid()
+    logger.debug(f"Toggling CUDA checkpoint state for PID {pid}")
+
+    try:
+        cuda_checkpoint_lock_timeout_ms = 5 * 1000
+        subprocess.run(
+            [
+                CUDA_CHECKPOINT_PATH,
+                "--toggle",
+                "--pid",
+                str(pid),
+                "--timeout",
+                str(cuda_checkpoint_lock_timeout_ms),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        logger.debug("Successfully toggled CUDA checkpoint state")
+
+    except subprocess.CalledProcessError as e:
+        logger.debug(f"Failed to toggle CUDA checkpoint state: {e.stderr}")
+        raise CudaCheckpointException(e.stderr)
+
+
+def get_state() -> CudaCheckpointState:
+    """Get current CUDA checkpoint state for this process."""
+    pid = get_own_pid()
+
+    try:
+        result = subprocess.run(
+            [CUDA_CHECKPOINT_PATH, "--get-state", "--pid", str(pid)], check=True, capture_output=True, text=True
+        )
+
+        # Parse output to get state
+        state_str = result.stdout.strip().lower()
+        logger.debug(f"Raw state output: {state_str}")
+
+        try:
+            return CudaCheckpointState(state_str)
+        except ValueError:
+            logger.debug(f"Failed to parse state output: {state_str}")
+            raise CudaCheckpointException(f"Unexpected state output: {state_str}")
+
+    except subprocess.CalledProcessError as e:
+        logger.debug(f"Failed to get CUDA checkpoint state: {e.stderr}")
+        raise CudaCheckpointException(e.stderr)
+
+
+def wait_for_state(target_state: CudaCheckpointState, timeout_secs: float = 5.0) -> bool:
+    """Wait for CUDA checkpoint to reach a specific state."""
+    logger.debug(f"Waiting for CUDA checkpoint state {target_state.value}")
+    start_time = time.monotonic()
+
+    while True:
+        current_state = get_state()
+
+        if current_state == target_state:
+            logger.debug(f"Target state {target_state.value} reached")
+            return True
+
+        elapsed = time.monotonic() - start_time
+        if elapsed >= timeout_secs:
+            raise CudaCheckpointException(f"Timeout after {elapsed:.2f}s waiting for state {target_state.value}")
+
+        time.sleep(0.1)
+
+
+def get_own_pid():
+    """Returns the Process ID (PID) of the current Python process
+    using only the standard library.
+    """
+    return os.getpid()

--- a/modal/_runtime/gpu_memory_snapshot.py
+++ b/modal/_runtime/gpu_memory_snapshot.py
@@ -69,12 +69,7 @@ def get_state() -> CudaCheckpointState:
         # Parse output to get state
         state_str = result.stdout.strip().lower()
         logger.debug(f"Raw state output: {state_str}")
-
-        try:
-            return CudaCheckpointState(state_str)
-        except ValueError:
-            logger.debug(f"Failed to parse state output: {state_str}")
-            raise CudaCheckpointException(f"Unexpected state output: {state_str}")
+        return CudaCheckpointState(state_str)
 
     except subprocess.CalledProcessError as e:
         logger.debug(f"Failed to get CUDA checkpoint state: {e.stderr}")

--- a/modal/_runtime/gpu_memory_snapshot.py
+++ b/modal/_runtime/gpu_memory_snapshot.py
@@ -81,7 +81,7 @@ def get_state() -> CudaCheckpointState:
         raise CudaCheckpointException(e.stderr)
 
 
-def wait_for_state(target_state: CudaCheckpointState, timeout_secs: float = 5.0) -> bool:
+def wait_for_state(target_state: CudaCheckpointState, timeout_secs: float = 5.0):
     """Wait for CUDA checkpoint to reach a specific state."""
     logger.debug(f"Waiting for CUDA checkpoint state {target_state.value}")
     start_time = time.monotonic()
@@ -91,7 +91,9 @@ def wait_for_state(target_state: CudaCheckpointState, timeout_secs: float = 5.0)
 
         if current_state == target_state:
             logger.debug(f"Target state {target_state.value} reached")
-            return True
+
+        if current_state == CudaCheckpointState.FAILED:
+            raise CudaCheckpointException(f"CUDA process state is {current_state}")
 
         elapsed = time.monotonic() - start_time
         if elapsed >= timeout_secs:

--- a/modal/config.py
+++ b/modal/config.py
@@ -224,7 +224,6 @@ _SETTINGS = {
     "snapshot_debug": _Setting(False, transform=_to_boolean),
     "client_retries": _Setting(False, transform=_to_boolean),  # For internal testing.
     "cuda_checkpoint_path": _Setting("/__modal/.bin/cuda-checkpoint"),  # Used for snapshotting GPU memory.
-    "gpu_snapshot_enabled": _Setting(False, transform=_to_boolean),  # For internal/experimental use
 }
 
 

--- a/modal/config.py
+++ b/modal/config.py
@@ -223,6 +223,8 @@ _SETTINGS = {
     "strict_parameters": _Setting(False, transform=_to_boolean),  # For internal/experimental use
     "snapshot_debug": _Setting(False, transform=_to_boolean),
     "client_retries": _Setting(False, transform=_to_boolean),  # For internal testing.
+    "cuda_checkpoint_path": _Setting("/__modal/.bin/cuda-checkpoint"),  # Used for snapshotting GPU memory.
+    "gpu_snapshot_enabled": _Setting(False, transform=_to_boolean),  # For internal/experimental use
 }
 
 


### PR DESCRIPTION
Adds support for snapshotting GPU memory using `cuda-checkpoint`. The interface is reserved for internal/experimental use.