### PR TITLE
Adds experimental GPU snapshotting flag to Sanboxes

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -237,7 +237,7 @@ class _Sandbox(_Object, type_prefix="sb"):
             SchedulerPlacement
         ] = None,  # Experimental controls over fine-grained scheduling (alpha).
         client: Optional[_Client] = None,
-        _experimental_enable_gpu_snapshot: bool = False,  # Experimental support for GPU snapshots.
+        _experimental_enable_gpu_snapshot: bool = False,  # Experimentally enable GPU memory snapshots.
     ) -> "_Sandbox":
         from .app import _App
 

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -60,7 +60,6 @@ class _Sandbox(_Object, type_prefix="sb"):
     _task_id: Optional[str] = None
     _tunnels: Optional[dict[int, Tunnel]] = None
     _enable_snapshot: bool = False
-    _experimental_enable_gpu_snapshot: bool = False
 
     @staticmethod
     def _new(
@@ -275,7 +274,6 @@ class _Sandbox(_Object, type_prefix="sb"):
             _experimental_enable_gpu_snapshot=_experimental_enable_gpu_snapshot,
         )
         obj._enable_snapshot = _experimental_enable_snapshot
-        obj._experimental_enable_gpu_snapshot = _experimental_enable_gpu_snapshot
 
         app_id: Optional[str] = None
         app_client: Optional[_Client] = None

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -60,7 +60,7 @@ class _Sandbox(_Object, type_prefix="sb"):
     _task_id: Optional[str] = None
     _tunnels: Optional[dict[int, Tunnel]] = None
     _enable_snapshot: bool = False
-    _experimental_gpu_snapshot: bool = False
+    _experimental_enable_gpu_snapshot: bool = False
 
     @staticmethod
     def _new(
@@ -85,7 +85,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         proxy: Optional[_Proxy] = None,
         _experimental_scheduler_placement: Optional[SchedulerPlacement] = None,
         enable_snapshot: bool = False,
-        _experimental_gpu_snapshot: bool = False,
+        _experimental_enable_gpu_snapshot: bool = False,
     ) -> "_Sandbox":
         """mdmd:hidden"""
 
@@ -183,7 +183,7 @@ class _Sandbox(_Object, type_prefix="sb"):
                 network_access=network_access,
                 proxy_id=(proxy.object_id if proxy else None),
                 enable_snapshot=enable_snapshot,
-                _experimental_gpu_snapshot=_experimental_gpu_snapshot,
+                _experimental_enable_gpu_snapshot=_experimental_enable_gpu_snapshot,
             )
 
             # Note - `resolver.app_id` will be `None` for app-less sandboxes
@@ -237,7 +237,7 @@ class _Sandbox(_Object, type_prefix="sb"):
             SchedulerPlacement
         ] = None,  # Experimental controls over fine-grained scheduling (alpha).
         client: Optional[_Client] = None,
-        _experimental_gpu_snapshot: bool = False,  # Experimental support for GPU snapshots.
+        _experimental_enable_gpu_snapshot: bool = False,  # Experimental support for GPU snapshots.
     ) -> "_Sandbox":
         from .app import _App
 
@@ -272,10 +272,10 @@ class _Sandbox(_Object, type_prefix="sb"):
             proxy=proxy,
             _experimental_scheduler_placement=_experimental_scheduler_placement,
             enable_snapshot=_experimental_enable_snapshot,
-            _experimental_gpu_snapshot=_experimental_gpu_snapshot,
+            _experimental_enable_gpu_snapshot=_experimental_enable_gpu_snapshot,
         )
         obj._enable_snapshot = _experimental_enable_snapshot
-        obj._experimental_gpu_snapshot = _experimental_gpu_snapshot
+        obj._experimental_enable_gpu_snapshot = _experimental_enable_gpu_snapshot
 
         app_id: Optional[str] = None
         app_client: Optional[_Client] = None

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -60,6 +60,7 @@ class _Sandbox(_Object, type_prefix="sb"):
     _task_id: Optional[str] = None
     _tunnels: Optional[dict[int, Tunnel]] = None
     _enable_snapshot: bool = False
+    _experimental_gpu_snapshot: bool = False
 
     @staticmethod
     def _new(
@@ -84,6 +85,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         proxy: Optional[_Proxy] = None,
         _experimental_scheduler_placement: Optional[SchedulerPlacement] = None,
         enable_snapshot: bool = False,
+        _experimental_gpu_snapshot: bool = False,
     ) -> "_Sandbox":
         """mdmd:hidden"""
 
@@ -181,6 +183,7 @@ class _Sandbox(_Object, type_prefix="sb"):
                 network_access=network_access,
                 proxy_id=(proxy.object_id if proxy else None),
                 enable_snapshot=enable_snapshot,
+                _experimental_gpu_snapshot=_experimental_gpu_snapshot,
             )
 
             # Note - `resolver.app_id` will be `None` for app-less sandboxes
@@ -234,6 +237,7 @@ class _Sandbox(_Object, type_prefix="sb"):
             SchedulerPlacement
         ] = None,  # Experimental controls over fine-grained scheduling (alpha).
         client: Optional[_Client] = None,
+        _experimental_gpu_snapshot: bool = False,  # Experimental support for GPU snapshots.
     ) -> "_Sandbox":
         from .app import _App
 
@@ -268,8 +272,10 @@ class _Sandbox(_Object, type_prefix="sb"):
             proxy=proxy,
             _experimental_scheduler_placement=_experimental_scheduler_placement,
             enable_snapshot=_experimental_enable_snapshot,
+            _experimental_gpu_snapshot=_experimental_gpu_snapshot,
         )
         obj._enable_snapshot = _experimental_enable_snapshot
+        obj._experimental_gpu_snapshot = _experimental_gpu_snapshot
 
         app_id: Optional[str] = None
         app_client: Optional[_Client] = None

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2262,6 +2262,8 @@ message Sandbox {
   optional uint32 snapshot_version = 25;
 
   string cloud_provider_str = 26;  // Supersedes cloud_provider
+
+  bool _experimental_gpu_snapshot = 27; // Enables GPU snapshotting.
 }
 
 message SandboxCreateRequest {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2263,7 +2263,7 @@ message Sandbox {
 
   string cloud_provider_str = 26;  // Supersedes cloud_provider
 
-  bool _experimental_gpu_snapshot = 27; // Enables GPU snapshotting.
+  bool _experimental_enable_gpu_snapshot = 27; // Enables GPU snapshotting.
 }
 
 message SandboxCreateRequest {


### PR DESCRIPTION
Adds interface for experimental GPU support for memory snapshots, similar to https://github.com/modal-labs/modal-client/pull/2830