### PR TITLE
Brings mock servicer to rpc parity for Function.remote()

### DIFF
--- a/test/function_test.py
+++ b/test/function_test.py
@@ -49,6 +49,16 @@ def test_run_function(client, servicer):
         assert len(servicer.cleared_function_calls) == 1
 
 
+def test_single_input_function_call_uses_single_rpc(client, servicer):
+    with app.run(client=client):
+        with servicer.intercept() as ctx:
+            assert foo.remote(2, 4) == 20
+        assert len(ctx.calls) == 2
+        (msg1_type, msg1), (msg2_type, msg2) = ctx.calls
+        assert msg1_type == "FunctionMap"
+        assert msg2_type == "FunctionGetOutputs"
+
+
 @pytest.mark.asyncio
 async def test_call_function_locally(client, servicer):
     assert foo.local(22, 44) == 77  # call it locally


### PR DESCRIPTION
Unit tests would previously always send FunctionMap + FunctionPutInputs, whereas the production server prevents the latter by accepting and responding with pipelined_inputs in the first request. This brings that functionality to the mock servicer too, to get the client behaving more similar to production in our unit tests.

I needed this to make proper rpc assertions in another PR

This PR has no changes outside of tests
