### PR TITLE
Fix the task count status text

### DIFF
--- a/modal/_output.py
+++ b/modal/_output.py
@@ -291,7 +291,9 @@ class OutputManager:
 
         # The most advanced state that's present informs the message.
         if api_pb2.TASK_STATE_ACTIVE in states_set or api_pb2.TASK_STATE_IDLE in states_set:
-            tasks_running = tasks_at_state(api_pb2.TASK_STATE_ACTIVE)
+            # Note that as of writing the server no longer uses TASK_STATE_ACTIVE, but we'll
+            # make the numerator the sum of active / idle in case that is revived at some point in the future.
+            tasks_running = tasks_at_state(api_pb2.TASK_STATE_ACTIVE) + tasks_at_state(api_pb2.TASK_STATE_IDLE)
             tasks_not_completed = len(self._task_states) - tasks_at_state(api_pb2.TASK_STATE_COMPLETED)
             message = f"Running ({tasks_running}/{tasks_not_completed} containers active)..."
         elif api_pb2.TASK_STATE_LOADING_IMAGE in states_set:


### PR DESCRIPTION
## Describe your changes

A while back a change was made server-side to stop differentiating between TASK_STATE_IDLE and TASK_STATE_ACTIVE. For arcane reasons, TASK_STATE_IDLE was chosen to represent all tasks that had finished cold starting and not yet been terminated. That broke the status message that we show for ephemeral apps, which was counting "active" tasks as the numerator. I'm changing that to show the sum of "active" and "idle" tasks. As mentioned, "active" is currently always 0, but this approach is more future-proof in case we decide to switch the server to use the more intuitive value or reinstate the distinction between active and idle in the future.

(This does change the meaning of the status message relative to the original intention of just counting the tasks that are currently handling inputs, but it's been broken for a while so I don't think that's a problem).

- Fixes SVC-204
 
<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Fixed the status message shown in terminal logs for ephemeral Apps to accurately report the number of active containers.