### PR TITLE
Don't send GPU_TYPE from client

### DIFF
--- a/modal/gpu.py
+++ b/modal/gpu.py
@@ -9,14 +9,14 @@ from .exception import InvalidError
 
 @dataclass(frozen=True)
 class _GPUConfig:
-    count: int
     gpu_type: str
+    count: int
 
     def _to_proto(self) -> api_pb2.GPUConfig:
         """Convert this GPU config to an internal protobuf representation."""
         return api_pb2.GPUConfig(
-            count=self.count,
             gpu_type=self.gpu_type,
+            count=self.count,
         )
 
 
@@ -31,7 +31,7 @@ class T4(_GPUConfig):
         self,
         count: int = 1,  # Number of GPUs per container. Defaults to 1.
     ):
-        super().__init__(count, "T4")
+        super().__init__("T4", count)
 
     def __repr__(self):
         return f"GPU(T4, count={self.count})"
@@ -49,7 +49,7 @@ class L4(_GPUConfig):
         self,
         count: int = 1,  # Number of GPUs per container. Defaults to 1.
     ):
-        super().__init__(count, "L4")
+        super().__init__("L4", count)
 
     def __repr__(self):
         return f"GPU(L4, count={self.count})"
@@ -69,9 +69,9 @@ class A100(_GPUConfig):
         size: Union[str, None] = None,  # Select GB configuration of GPU device: "40GB" or "80GB". Defaults to "40GB".
     ):
         if size == "40GB" or not size:
-            super().__init__(count, "A100-40GB")
+            super().__init__("A100-40GB", count)
         elif size == "80GB":
-            super().__init__(count, "A100-80GB")
+            super().__init__("A100-80GB", count)
         else:
             raise ValueError(f"size='{size}' is invalid. A100s can only have memory values of 40GB or 80GB.")
 
@@ -95,7 +95,7 @@ class A10G(_GPUConfig):
         # Useful if you have very large models that don't fit on a single GPU.
         count: int = 1,
     ):
-        super().__init__(count, "A10G")
+        super().__init__("A10G", count)
 
     def __repr__(self):
         return f"GPU(A10G, count={self.count})"
@@ -117,7 +117,7 @@ class H100(_GPUConfig):
         # Useful if you have very large models that don't fit on a single GPU.
         count: int = 1,
     ):
-        super().__init__(count, "H100")
+        super().__init__("H100", count)
 
     def __repr__(self):
         return f"GPU(H100, count={self.count})"
@@ -138,7 +138,7 @@ class L40S(_GPUConfig):
         # Useful if you have very large models that don't fit on a single GPU.
         count: int = 1,
     ):
-        super().__init__(count, "L40S")
+        super().__init__("L40S", count)
 
     def __repr__(self):
         return f"GPU(L40S, count={self.count})"
@@ -148,7 +148,7 @@ class Any(_GPUConfig):
     """Selects any one of the GPU classes available within Modal, according to availability."""
 
     def __init__(self, *, count: int = 1):
-        super().__init__(count, "ANY")
+        super().__init__("ANY", count)
 
     def __repr__(self):
         return f"GPU(Any, count={self.count})"

--- a/modal/gpu.py
+++ b/modal/gpu.py
@@ -9,14 +9,12 @@ from .exception import InvalidError
 
 @dataclass(frozen=True)
 class _GPUConfig:
-    type: "api_pb2.GPUType.V"  # Deprecated, at some point
     count: int
     gpu_type: str
 
     def _to_proto(self) -> api_pb2.GPUConfig:
         """Convert this GPU config to an internal protobuf representation."""
         return api_pb2.GPUConfig(
-            type=self.type,
             count=self.count,
             gpu_type=self.gpu_type,
         )
@@ -33,7 +31,7 @@ class T4(_GPUConfig):
         self,
         count: int = 1,  # Number of GPUs per container. Defaults to 1.
     ):
-        super().__init__(api_pb2.GPU_TYPE_T4, count, "T4")
+        super().__init__(count, "T4")
 
     def __repr__(self):
         return f"GPU(T4, count={self.count})"
@@ -51,7 +49,7 @@ class L4(_GPUConfig):
         self,
         count: int = 1,  # Number of GPUs per container. Defaults to 1.
     ):
-        super().__init__(api_pb2.GPU_TYPE_L4, count, "L4")
+        super().__init__(count, "L4")
 
     def __repr__(self):
         return f"GPU(L4, count={self.count})"
@@ -71,9 +69,9 @@ class A100(_GPUConfig):
         size: Union[str, None] = None,  # Select GB configuration of GPU device: "40GB" or "80GB". Defaults to "40GB".
     ):
         if size == "40GB" or not size:
-            super().__init__(api_pb2.GPU_TYPE_A100, count, "A100-40GB")
+            super().__init__(count, "A100-40GB")
         elif size == "80GB":
-            super().__init__(api_pb2.GPU_TYPE_A100_80GB, count, "A100-80GB")
+            super().__init__(count, "A100-80GB")
         else:
             raise ValueError(f"size='{size}' is invalid. A100s can only have memory values of 40GB or 80GB.")
 
@@ -97,7 +95,7 @@ class A10G(_GPUConfig):
         # Useful if you have very large models that don't fit on a single GPU.
         count: int = 1,
     ):
-        super().__init__(api_pb2.GPU_TYPE_A10G, count, "A10G")
+        super().__init__(count, "A10G")
 
     def __repr__(self):
         return f"GPU(A10G, count={self.count})"
@@ -119,7 +117,7 @@ class H100(_GPUConfig):
         # Useful if you have very large models that don't fit on a single GPU.
         count: int = 1,
     ):
-        super().__init__(api_pb2.GPU_TYPE_H100, count, "H100")
+        super().__init__(count, "H100")
 
     def __repr__(self):
         return f"GPU(H100, count={self.count})"
@@ -140,7 +138,7 @@ class L40S(_GPUConfig):
         # Useful if you have very large models that don't fit on a single GPU.
         count: int = 1,
     ):
-        super().__init__(api_pb2.GPU_TYPE_L40S, count, "L40S")
+        super().__init__(count, "L40S")
 
     def __repr__(self):
         return f"GPU(L40S, count={self.count})"
@@ -150,7 +148,7 @@ class Any(_GPUConfig):
     """Selects any one of the GPU classes available within Modal, according to availability."""
 
     def __init__(self, *, count: int = 1):
-        super().__init__(api_pb2.GPU_TYPE_ANY, count, "ANY")
+        super().__init__(count, "ANY")
 
     def __repr__(self):
         return f"GPU(Any, count={self.count})"

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -143,6 +143,8 @@ enum FunctionCallType {
 }
 
 enum GPUType {
+  // Note: this enum is no longer used by current clients - don't add new types
+  // Old clients still send it, so we use it server-side for compatibility
   GPU_TYPE_UNSPECIFIED = 0;
   GPU_TYPE_T4 = 1;
   GPU_TYPE_A100 = 2;

--- a/test/gpu_fallbacks_test.py
+++ b/test/gpu_fallbacks_test.py
@@ -27,19 +27,19 @@ def test_gpu_fallback(servicer, client):
 
         a10_1 = api_pb2.Resources(
             gpu_config=api_pb2.GPUConfig(
-                type=api_pb2.GPU_TYPE_A10G,
+                gpu_type="A10G",
                 count=1,
             )
         )
         t4_2 = api_pb2.Resources(
             gpu_config=api_pb2.GPUConfig(
-                type=api_pb2.GPU_TYPE_T4,
+                gpu_type="T4",
                 count=2,
             )
         )
         h100_2 = api_pb2.Resources(
             gpu_config=api_pb2.GPUConfig(
-                type=api_pb2.GPU_TYPE_H100,
+                gpu_type="H100",
                 count=2,
             )
         )
@@ -49,20 +49,20 @@ def test_gpu_fallback(servicer, client):
 
         fn1 = servicer.app_functions["fu-1"]  # f1
         assert len(fn1.ranked_functions) == 1
-        assert fn1.ranked_functions[0].function.resources.gpu_config.type == a10_1.gpu_config.type
+        assert fn1.ranked_functions[0].function.resources.gpu_config.gpu_type == a10_1.gpu_config.gpu_type
         assert fn1.ranked_functions[0].function.resources.gpu_config.count == a10_1.gpu_config.count
 
         fn2 = servicer.app_functions["fu-2"]  # f2
         assert len(fn2.ranked_functions) == 2
-        assert fn2.ranked_functions[0].function.resources.gpu_config.type == a10_1.gpu_config.type
+        assert fn2.ranked_functions[0].function.resources.gpu_config.gpu_type == a10_1.gpu_config.gpu_type
         assert fn2.ranked_functions[0].function.resources.gpu_config.count == a10_1.gpu_config.count
-        assert fn2.ranked_functions[1].function.resources.gpu_config.type == t4_2.gpu_config.type
+        assert fn2.ranked_functions[1].function.resources.gpu_config.gpu_type == t4_2.gpu_config.gpu_type
         assert fn2.ranked_functions[1].function.resources.gpu_config.count == t4_2.gpu_config.count
 
         fn3 = servicer.app_functions["fu-3"]  # f3
         assert len(fn3.ranked_functions) == 2
-        assert fn3.ranked_functions[0].function.resources.gpu_config.type == h100_2.gpu_config.type
+        assert fn3.ranked_functions[0].function.resources.gpu_config.gpu_type == h100_2.gpu_config.gpu_type
         assert fn3.ranked_functions[0].function.resources.gpu_config.count == h100_2.gpu_config.count
-        assert fn3.ranked_functions[1].function.resources.gpu_config.type == a100_80gb_2.gpu_config.type
+        assert fn3.ranked_functions[1].function.resources.gpu_config.gpu_type == a100_80gb_2.gpu_config.gpu_type
         assert fn3.ranked_functions[1].function.resources.gpu_config.count == a100_80gb_2.gpu_config.count
         assert fn3.ranked_functions[1].function.resources.gpu_config.gpu_type == a100_80gb_2.gpu_config.gpu_type

--- a/test/gpu_test.py
+++ b/test/gpu_test.py
@@ -20,7 +20,6 @@ def test_gpu_any_function(client, servicer):
     assert len(servicer.app_functions) == 1
     func_def = next(iter(servicer.app_functions.values()))
     assert func_def.resources.gpu_config.count == 1
-    assert func_def.resources.gpu_config.type == api_pb2.GPU_TYPE_ANY
 
 
 def test_gpu_string_config(client, servicer):
@@ -37,7 +36,6 @@ def test_gpu_string_config(client, servicer):
     assert len(servicer.app_functions) == 1
     func_def = next(iter(servicer.app_functions.values()))
     assert func_def.resources.gpu_config.count == 1
-    assert func_def.resources.gpu_config.type == api_pb2.GPU_TYPE_A100
 
 
 def test_gpu_string_count_config(client, servicer):
@@ -56,7 +54,6 @@ def test_gpu_string_count_config(client, servicer):
     assert len(servicer.app_functions) == 1
     func_def = next(iter(servicer.app_functions.values()))
     assert func_def.resources.gpu_config.count == 4
-    assert func_def.resources.gpu_config.type == api_pb2.GPU_TYPE_A10G
 
 
 def test_gpu_config_function(client, servicer):
@@ -71,7 +68,6 @@ def test_gpu_config_function(client, servicer):
     assert len(servicer.app_functions) == 1
     func_def = next(iter(servicer.app_functions.values()))
     assert func_def.resources.gpu_config.count == 1
-    assert func_def.resources.gpu_config.type == api_pb2.GPU_TYPE_A100
 
 
 def test_cloud_provider_selection(client, servicer):
@@ -89,7 +85,6 @@ def test_cloud_provider_selection(client, servicer):
     assert func_def.cloud_provider_str == "GCP"
 
     assert func_def.resources.gpu_config.count == 1
-    assert func_def.resources.gpu_config.type == api_pb2.GPU_TYPE_A100
 
     # Invalid enum value.
     with pytest.raises(InvalidError):
@@ -97,13 +92,13 @@ def test_cloud_provider_selection(client, servicer):
 
 
 @pytest.mark.parametrize(
-    "memory_arg,gpu_type,gpu_type_str",
+    "memory_arg,gpu_type",
     [
-        ("40GB", api_pb2.GPU_TYPE_A100, "A100-40GB"),
-        ("80GB", api_pb2.GPU_TYPE_A100_80GB, "A100-80GB"),
+        ("40GB", "A100-40GB"),
+        ("80GB", "A100-80GB"),
     ],
 )
-def test_memory_selection_gpu_variant(client, servicer, memory_arg, gpu_type, gpu_type_str):
+def test_memory_selection_gpu_variant(client, servicer, memory_arg, gpu_type):
     import modal
 
     app = App()
@@ -118,8 +113,7 @@ def test_memory_selection_gpu_variant(client, servicer, memory_arg, gpu_type, gp
     func_def = next(iter(servicer.app_functions.values()))
 
     assert func_def.resources.gpu_config.count == 1
-    assert func_def.resources.gpu_config.type == gpu_type
-    assert func_def.resources.gpu_config.gpu_type == gpu_type_str
+    assert func_def.resources.gpu_config.gpu_type == gpu_type
 
 
 def test_gpu_unsupported_config():
@@ -145,4 +139,3 @@ def test_gpu_type_selection_from_count(client, servicer, count):
     func_def = next(iter(servicer.app_functions.values()))
 
     assert func_def.resources.gpu_config.count == count
-    assert func_def.resources.gpu_config.type == api_pb2.GPU_TYPE_A100

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -992,19 +992,20 @@ def test_image_gpu(builder_version, servicer, client):
     app.function()(dummy)
     with app.run(client=client):
         layers = get_image_layers(app.image.object_id, servicer)
-        assert layers[0].gpu_config.type == api_pb2.GPU_TYPE_UNSPECIFIED
+        assert not layers[0].gpu_config.type
+        assert not layers[0].gpu_config.gpu_type
 
     app = App(image=Image.debian_slim().run_commands("echo 1", gpu="any"))
     app.function()(dummy)
     with app.run(client=client):
         layers = get_image_layers(app.image.object_id, servicer)
-        assert layers[0].gpu_config.type == api_pb2.GPU_TYPE_ANY
+        assert layers[0].gpu_config.gpu_type == "ANY"
 
     app = App(image=Image.debian_slim().run_commands("echo 2", gpu=gpu.A10G()))
     app.function()(dummy)
     with app.run(client=client):
         layers = get_image_layers(app.image.object_id, servicer)
-        assert layers[0].gpu_config.type == api_pb2.GPU_TYPE_A10G
+        assert layers[0].gpu_config.gpu_type == "A10G"
 
 
 def test_image_force_build(builder_version, servicer, client):


### PR DESCRIPTION
This removes the use of GPU_TYPE enum.

A later change would make it possible to pass-through strings to the server without having to go through the gpu classes defined in `modal/gpu.py`. For now we still rely on those.