### PR TITLE
Add protos for AutoscalerSettings and request where we'll use it

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -561,6 +561,22 @@ message Asgi {
   }
 }
 
+message AutoscalerSettings {
+  // A collection of user-configurable settings for Function autoscaling
+  // These are used for static configuration and for dynamic autoscaler updates
+
+  // Minimum containers when scale-to-zero is not deisired; pka "keep_warm" or "warm_pool_size"
+  optional uint32 min_containers = 1;
+  // Limit on the number of containers that can be running for each Function; pka "concurrency_limit"
+  optional uint32 max_containers = 2;
+  // Additional container to spin up when Function is active
+  optional uint32 buffer_containers = 3;
+  // Currently unused; a placeholder in case we decide to expose scaleup control to users
+  optional uint32 scaleup_window = 4;
+  // Maximum amount of time a container can be idle before being scaled down, in seconds; pka "container_idle_timeout"
+  optional uint32 scaledown_window = 5;
+}
+
 message BaseImage {
   string image_id = 1;
   string docker_tag = 2;
@@ -1673,6 +1689,7 @@ message FunctionStats {
 message FunctionUpdateSchedulingParamsRequest {
   string function_id = 1;
   uint32 warm_pool_size_override = 2;
+  AutoscalerSettings settings = 3;
 }
 
 message FunctionUpdateSchedulingParamsResponse {}


### PR DESCRIPTION
## Describe your changes

Adding a protobuf message to bundle the "autoscaler settings" which we'll use as a unit in a few new places.

Also added a new field using it to the `FunctionUpdateSchedulerParamsRequest`. That's one of the places.

I would also like the bundle the autoscaler settings within the `Function` definition using this method. But I'll do that in a subsequent PR. I'd just like to unblock the backend PR right now.

- Part of SVC-335

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>
