### PR TITLE
Add runsc_runtime_version to sandbox proto

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2261,6 +2261,10 @@ message Sandbox {
   optional uint32 snapshot_version = 25;
 
   string cloud_provider_str = 26;  // Supersedes cloud_provider
+
+  // Specifies container runtime behavior for sandboxes which are restored from a snapshot.
+  // Set by the backend at snapshot creation time.
+  optional string runsc_runtime_version = 27;
 }
 
 message SandboxCreateRequest {


### PR DESCRIPTION
Necessary for sandbox snapshots - we need a way to store and refer to the runtime version used by the sandbox which was or will be snapshotted.