### PR TITLE
pass through gpu strings to the server

### DIFF
--- a/test/gpu_test.py
+++ b/test/gpu_test.py
@@ -26,9 +26,7 @@ def test_gpu_any_function(client, servicer):
     "gpu_arg,gpu_type,count",
     [
         ("A100-40GB", "A100-40GB", 1),
-        ("A100", "A100-40GB", 1),
         ("a100-40gb", "A100-40GB", 1),
-        ("a100", "A100-40GB", 1),
         ("a10g", "A10G", 1),
         ("t4:7", "T4", 7),
         ("a100-80GB:5", "A100-80GB", 5),
@@ -55,6 +53,8 @@ def test_invalid_gpu_string_config(client, servicer, gpu_arg):
     # Invalid enum value.
     with pytest.raises(InvalidError):
         app.function(gpu=gpu_arg)(dummy)
+        with app.run(client=client):
+            pass
 
 
 def test_gpu_config_function(client, servicer):

--- a/test/supports/app_run_tests/raises_error.py
+++ b/test/supports/app_run_tests/raises_error.py
@@ -4,6 +4,6 @@ import modal
 app = modal.App()
 
 
-@app.function(gpu="NOT_A_GPU")
+@app.function(gpu="broken:gpu:string")
 def f():
     pass


### PR DESCRIPTION
This just takes the user-provided string and sends it to the server. The server may then reject it. For instance:

```
(modal) [ec2-user@ip-10-1-2-31 client]$ modal run gpu_thing.py
✓ Initialized. View run at https://modal.com/apps/modal-labs/main/ap-VpsfeFmVGfmhocnDFc4iul
Stopping app - uncaught exception raised locally: InvalidError('A100-70GB is not a valid GPU type').
╭─ Error ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ A100-70GB is not a valid GPU type                                                                                                                                                                                       │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯

```