### PR TITLE
[SVC-331] Gracefully handle user-thrown asyncio.CancelledErrors

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -324,7 +324,7 @@ def call_function(
 
             user_code_event_loop.run(
                 run_concurrent_inputs(),
-                # on_sigint=lambda: container_io_manager.mark_all_inputs_as_cancelled(),
+                on_sigint=lambda: container_io_manager.mark_all_inputs_as_cancelled(),
             )
     else:
         for io_context in container_io_manager.run_inputs_outputs(finalized_functions, batch_max_size, batch_wait_ms):

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -494,6 +494,24 @@ def test_failure(servicer, capsys):
 
 
 @skip_github_non_linux
+def test_raises_asyncio_cancellederror(servicer, capsys):
+    ret = _run_container(servicer, "test.supports.functions", "raises_asyncio_cancellederror")
+    exc = _unwrap_exception(ret)
+    assert isinstance(exc, asyncio.CancelledError)
+    assert repr(exc) == "CancelledError()"
+    assert "raise asyncio.CancelledError()" in capsys.readouterr().err  # traceback
+
+
+@skip_github_non_linux
+def test_raises_asyncio_cancellederror_async(servicer, capsys):
+    ret = _run_container(servicer, "test.supports.functions", "raises_asyncio_cancellederror_async")
+    exc = _unwrap_exception(ret)
+    assert isinstance(exc, asyncio.CancelledError)
+    assert repr(exc) == "CancelledError()"
+    assert "raise asyncio.CancelledError()" in capsys.readouterr().err  # traceback
+
+
+@skip_github_non_linux
 def test_raises_base_exception(servicer, capsys):
     ret = _run_container(servicer, "test.supports.functions", "raises_sysexit")
     exc = _unwrap_exception(ret)

--- a/test/supports/functions.py
+++ b/test/supports/functions.py
@@ -72,6 +72,16 @@ def raises(x):
 
 
 @app.function()
+def raises_asyncio_cancellederror(x):
+    raise asyncio.CancelledError()
+
+
+@app.function()
+async def raises_asyncio_cancellederror_async(x):
+    raise asyncio.CancelledError()
+
+
+@app.function()
 def raises_sysexit(x):
     raise SystemExit(1)
 


### PR DESCRIPTION
This PR gracefully handles user-thrown `asyncio.CancelledError`s, correctly propagating these exceptions back to the server and marking the input as failed _unless_ we received a cancellation request for this input.

Depends on #2850

There is an additional complication: What do we do when we get a `SIGINT` signal?

This PR preserves existing behavior, sending a TERMINATED result for async inputs and suppressing cancellation traceback and doing nothing for sync inputs. 