### PR TITLE
Deprecate old GPU classes

### DIFF
--- a/modal/gpu.py
+++ b/modal/gpu.py
@@ -183,6 +183,16 @@ You can see a list of Modal GPU options in the
 def my_gpu_function():
     ... # This will have 4 A100-80GB with each container
 ```
+
+**Deprecation notes**
+
+An older deprecated way to configure GPU is also still supported,
+but will be removed in future versions of Modal. Examples:
+
+- `gpu=modal.gpu.H100()` will attach 1 H100 GPU to each container
+- `gpu=modal.gpu.T4(count=4)` will attach 4 T4 GPUs to each container
+- `gpu=modal.gpu.A100()` will attach 1 A100-40GB GPUs to each container
+- `gpu=modal.gpu.A100(size="80GB")` will attach 1 A100-80GB GPUs to each container
 """
 
 GPU_T = Union[None, str, _GPUConfig]

--- a/modal/gpu.py
+++ b/modal/gpu.py
@@ -218,5 +218,5 @@ def parse_gpu_config(value: GPU_T) -> api_pb2.GPUConfig:
         return api_pb2.GPUConfig()
     else:
         raise InvalidError(
-            f"Invalid GPU config: {value}. Value must be a string or `None` (or a deprecated `_GPUConfig` object)."
+            f"Invalid GPU config: {value}. Value must be a string or `None` (or a deprecated `modal.gpu` object)"
         )

--- a/modal/gpu.py
+++ b/modal/gpu.py
@@ -1,16 +1,21 @@
 # Copyright Modal Labs 2022
-from dataclasses import dataclass
 from typing import Union
 
 from modal_proto import api_pb2
 
+from ._utils.deprecation import deprecation_warning
 from .exception import InvalidError
 
 
-@dataclass(frozen=True)
 class _GPUConfig:
     gpu_type: str
     count: int
+
+    def __init__(self, gpu_type: str, count: int):
+        name = self.__class__.__name__
+        deprecation_warning((2025, 2, 7), f'`gpu={name}(...)` is deprecated. Use `gpu="{name}"` instead.')
+        self.gpu_type = gpu_type
+        self.count = count
 
     def _to_proto(self) -> api_pb2.GPUConfig:
         """Convert this GPU config to an internal protobuf representation."""

--- a/modal/gpu.py
+++ b/modal/gpu.py
@@ -13,7 +13,10 @@ class _GPUConfig:
 
     def __init__(self, gpu_type: str, count: int):
         name = self.__class__.__name__
-        deprecation_warning((2025, 2, 7), f'`gpu={name}(...)` is deprecated. Use `gpu="{name}"` instead.')
+        str_value = gpu_type
+        if count > 1:
+            str_value += f":{count}"
+        deprecation_warning((2025, 2, 7), f'`gpu={name}(...)` is deprecated. Use `gpu="{str_value}"` instead.')
         self.gpu_type = gpu_type
         self.count = count
 

--- a/modal/gpu.py
+++ b/modal/gpu.py
@@ -185,8 +185,7 @@ def my_gpu_function():
 ```
 """
 
-# bool will be deprecated in future versions.
-GPU_T = Union[None, bool, str, _GPUConfig]
+GPU_T = Union[None, str, _GPUConfig]
 
 
 def parse_gpu_config(value: GPU_T) -> api_pb2.GPUConfig:
@@ -205,7 +204,9 @@ def parse_gpu_config(value: GPU_T) -> api_pb2.GPUConfig:
             gpu_type=gpu_type,
             count=count,
         )
-    elif value is None or value is False:
+    elif value is None:
         return api_pb2.GPUConfig()
     else:
-        raise InvalidError(f"Invalid GPU config: {value}. Value must be a string, a `GPUConfig` object, or `None`.")
+        raise InvalidError(
+            f"Invalid GPU config: {value}. Value must be a string or `None` (or a deprecated `_GPUConfig` object)."
+        )

--- a/test/gpu_fallbacks_test.py
+++ b/test/gpu_fallbacks_test.py
@@ -1,5 +1,4 @@
 # Copyright Modal Labs 2024
-import modal
 from modal import App
 from modal_proto import api_pb2
 
@@ -16,7 +15,7 @@ def f2():
     pass
 
 
-@app.function(gpu=["h100:2", modal.gpu.A100(count=2, size="80GB")])
+@app.function(gpu=["h100:2", "a100-80gb:2"])
 def f3():
     pass
 

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -13,7 +13,7 @@ from typing import Callable, Literal, Sequence, Union, get_args
 from unittest import mock
 
 import modal
-from modal import App, Dict, Image, Secret, build, environments, gpu, method
+from modal import App, Dict, Image, Secret, build, environments, method
 from modal._serialization import serialize
 from modal._utils.async_utils import synchronizer
 from modal.client import Client
@@ -1001,7 +1001,7 @@ def test_image_gpu(builder_version, servicer, client):
         layers = get_image_layers(app.image.object_id, servicer)
         assert layers[0].gpu_config.gpu_type == "ANY"
 
-    app = App(image=Image.debian_slim().run_commands("echo 2", gpu=gpu.A10G()))
+    app = App(image=Image.debian_slim().run_commands("echo 2", gpu="a10g"))
     app.function()(dummy)
     with app.run(client=client):
         layers = get_image_layers(app.image.object_id, servicer)


### PR DESCRIPTION
Going forward the only sanctioned way to configure GPU is through strings. This is nice because it's a lot less code.

## Changelog

* Deprecate the GPU classes (`gpu=A100(...)` etc) in favor of just using strings (`gpu="A100"` etc)