### PR TITLE
Simplify input cancellation path

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -322,6 +322,16 @@ def call_function(
             user_code_event_loop.run(run_concurrent_inputs())
     else:
         for io_context in container_io_manager.run_inputs_outputs(finalized_functions, batch_max_size, batch_wait_ms):
+            # This goes to a registered signal handler for sync Modal functions, or to the
+            # `SignalHandlingEventLoop` for async functions.
+            #
+            # We only send this signal on functions that do not have concurrent inputs enabled.
+            # This allows us to do fine-grained input cancellation. On sync functions, the
+            # SIGUSR1 signal should interrupt the main thread where user code is running,
+            # raising an InputCancellation() exception. On async functions, the signal should
+            # reach a handler in SignalHandlingEventLoop, which cancels the task.
+            io_context.set_cancel_callback(lambda: os.kill(os.getpid(), signal.SIGUSR1))
+
             if io_context.finalized_function.is_async:
                 user_code_event_loop.run(run_input_async(io_context))
             else:

--- a/modal/_runtime/container_io_manager.py
+++ b/modal/_runtime/container_io_manager.py
@@ -85,11 +85,6 @@ class IOContext:
         self._is_batched = is_batched
         self._client = client
 
-    @property
-    def is_cancelled(self) -> bool:
-        """Returns whether this input has been cancelled."""
-        return self._cancel_issued
-
     @classmethod
     async def create(
         cls,


### PR DESCRIPTION
## Describe your changes

This PR simplifies the input cancellation code path to always call `io_context.cancel()`. This solves #2843 and might be helpful for #2847.