### PR TITLE
[Alternative Implementation] Gracefully handle user-thrown asyncio.CancelledErrors 

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -324,7 +324,7 @@ def call_function(
 
             user_code_event_loop.run(
                 run_concurrent_inputs(),
-                # on_sigint=lambda: container_io_manager.mark_all_inputs_as_cancelled(),
+                on_sigint=lambda: container_io_manager.mark_all_inputs_as_cancelled(),
             )
     else:
         for io_context in container_io_manager.run_inputs_outputs(finalized_functions, batch_max_size, batch_wait_ms):

--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -135,7 +135,7 @@ class UserCodeEventLoop:
         task.add_done_callback(self.tasks.discard)
         return task
 
-    def run(self, coro, on_sigint: Optional[Callable[[], None]] = None):
+    def run(self, coro):
         task = asyncio.ensure_future(coro, loop=self.loop)
         self._sigints = 0
 
@@ -143,9 +143,6 @@ class UserCodeEventLoop:
             # cancel the task in order to have run_until_complete return soon and
             # prevent a bunch of unwanted tracebacks when shutting down the
             # event loop.
-
-            if on_sigint is not None:
-                on_sigint()
 
             # this basically replicates the sigint handler installed by asyncio.run()
             self._sigints += 1
@@ -322,10 +319,7 @@ def call_function(
                             thread_pool.submit(run_input_sync, io_context)
                             io_context.set_cancel_callback(cancel_callback_sync)
 
-            user_code_event_loop.run(
-                run_concurrent_inputs(),
-                on_sigint=lambda: container_io_manager.mark_all_inputs_as_cancelled(),
-            )
+            user_code_event_loop.run(run_concurrent_inputs())
     else:
         for io_context in container_io_manager.run_inputs_outputs(finalized_functions, batch_max_size, batch_wait_ms):
             # This goes to a registered signal handler for sync Modal functions, or to the
@@ -339,10 +333,7 @@ def call_function(
             io_context.set_cancel_callback(lambda: os.kill(os.getpid(), signal.SIGUSR1))
 
             if io_context.finalized_function.is_async:
-                user_code_event_loop.run(
-                    run_input_async(io_context),
-                    on_sigint=lambda: container_io_manager.mark_all_inputs_as_cancelled(),
-                )
+                user_code_event_loop.run(run_input_async(io_context))
             else:
                 # Set up a custom signal handler for `SIGUSR1`, which gets translated to an InputCancellation
                 # during function execution. This is sent to cancel inputs from the user

--- a/modal/_runtime/container_io_manager.py
+++ b/modal/_runtime/container_io_manager.py
@@ -120,13 +120,9 @@ class IOContext:
     def set_cancel_callback(self, cb: Callable[[], None]):
         self._cancel_callback = cb
 
-    def cancel(self, skip_callback: bool = False):
+    def cancel(self):
         # Ensure we only issue the cancellation once.
         if self._cancel_issued:
-            return
-
-        if skip_callback:
-            self._cancel_issued = True
             return
 
         if self._cancel_callback:
@@ -981,10 +977,6 @@ class _ContainerIOManager:
         except Exception as e:
             logger.error("Failed to start PTY shell.")
             raise e
-
-    def mark_all_inputs_as_cancelled(self):
-        for io_context in self.current_inputs.values():
-            io_context.cancel(skip_callback=True)
 
     @property
     def target_concurrency(self) -> int:

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -494,6 +494,24 @@ def test_failure(servicer, capsys):
 
 
 @skip_github_non_linux
+def test_raises_asyncio_cancellederror(servicer, capsys):
+    ret = _run_container(servicer, "test.supports.functions", "raises_asyncio_cancellederror")
+    exc = _unwrap_exception(ret)
+    assert isinstance(exc, asyncio.CancelledError)
+    assert repr(exc) == "CancelledError()"
+    assert "raise asyncio.CancelledError()" in capsys.readouterr().err  # traceback
+
+
+@skip_github_non_linux
+def test_raises_asyncio_cancellederror_async(servicer, capsys):
+    ret = _run_container(servicer, "test.supports.functions", "raises_asyncio_cancellederror_async")
+    exc = _unwrap_exception(ret)
+    assert isinstance(exc, asyncio.CancelledError)
+    assert repr(exc) == "CancelledError()"
+    assert "raise asyncio.CancelledError()" in capsys.readouterr().err  # traceback
+
+
+@skip_github_non_linux
 def test_raises_base_exception(servicer, capsys):
     ret = _run_container(servicer, "test.supports.functions", "raises_sysexit")
     exc = _unwrap_exception(ret)

--- a/test/supports/functions.py
+++ b/test/supports/functions.py
@@ -72,6 +72,16 @@ def raises(x):
 
 
 @app.function()
+def raises_asyncio_cancellederror(x):
+    raise asyncio.CancelledError()
+
+
+@app.function()
+async def raises_asyncio_cancellederror_async(x):
+    raise asyncio.CancelledError()
+
+
+@app.function()
 def raises_sysexit(x):
     raise SystemExit(1)
 


### PR DESCRIPTION
This PR gracefully handles user-thrown `asyncio.CancelledError`s, correctly propagating these exceptions back to the server and marking the input as failed _unless_ we received a cancellation request for this input.

Depends on #2850

There is an additional complication: What do we do when we get a `SIGINT` signal?

This PR sends a FAILURE result for async input and does _not_ suppress cancellation traceback. It also does nothing for sync inputs.

Alternatively, #2847 preserves existing behavior, sending a TERMINATED result for async inputs and suppressing cancellation traceback and doing nothing for sync inputs.