### PR TITLE
Revert "Add deprecation warning when looking up methods"

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1090,17 +1090,6 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         f = modal.Function.from_name("other-app", "function")
         ```
         """
-        if "." in name:
-            class_name, method_name = name.split(".", 1)
-            deprecation_warning(
-                (2025, 2, 6),
-                "Looking up class methods using Function.from_name will be deprecated"
-                " in a future version of Modal.\nUse modal.Cls.from_name instead, e.g.\n\n"
-                f'{class_name} = modal.Cls.from_name("{app_name}", "{class_name}")\n'
-                f"instance = {class_name}(...)\n"
-                f"instance.{method_name}.remote(...)\n",
-                pending=True,
-            )
 
         async def _load_remote(self: _Function, resolver: Resolver, existing_object_id: Optional[str]):
             assert resolver.client and resolver.client.stub


### PR DESCRIPTION
Reverts modal-labs/modal-client#2838

See #19770 in monorepo. This has borked a handful of our synmons and adopting the recommendation code update doesn't remove the deprecation. 