### PR TITLE
fix: raise InvalidError on invalid Sandbox CMDs

### DIFF
--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -310,6 +310,19 @@ def test_sandbox_exec_wait(app, servicer):
 
 
 @skip_non_subprocess
+def test_sandbox_create_and_exec_with_bad_args(app, servicer):
+    with pytest.raises(InvalidError):
+        too_big = 2_097_152 + 10
+        single_arg_size = too_big // 10
+        args = ["a" * single_arg_size for _ in range(10)]
+        Sandbox.create(*args, app=app)
+
+    sb = Sandbox.create("sleep", "infinity", app=app)
+    with pytest.raises(InvalidError):
+        sb.exec("echo", 1)
+
+
+@skip_non_subprocess
 def test_sandbox_on_app_lookup(client, servicer):
     app = App.lookup("my-app", create_if_missing=True, client=client)
     sb = Sandbox.create("echo", "hi", app=app)

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -319,7 +319,7 @@ def test_sandbox_create_and_exec_with_bad_args(app, servicer):
 
     sb = Sandbox.create("sleep", "infinity", app=app)
     with pytest.raises(InvalidError):
-        sb.exec("echo", 1)
+        sb.exec("echo", 1)  # type: ignore
 
 
 @skip_non_subprocess


### PR DESCRIPTION
> I'm getting an occasional exception `TypeError: bad argument type for built-in operation` when calling modal_sandbox.exec(). Is this a known issue with any other async packages I may have installed? Something else? Relatively new to the async ecosystem, so
Partial traceback: ...

https://modal-com.slack.com/archives/C069RAH7X4M/p1739219264588429

The additional `ARG_MAX` thing is something I threw in when thinking of other ways users could pass us bad data 🙂. 

## Describe your changes

- _Provide Linear issue reference (e.g. MOD-1234) if available._

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
    - Doesn't involve interaction with servers.
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
    -  If we ever increase `ARG_MAX` then users will need to upgrade clients to be allow to send more than 2MiB in args.

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>