### PR TITLE
Have client CI/CD publish source distribution to PyPI as well

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -203,8 +203,9 @@ jobs:
       - name: Build type stubs
         run: inv type-stubs
 
-      - name: Build wheel
-        run: python setup.py bdist_wheel
+      - name: Build package distributions (wheel and source)
+        run: |
+          python setup.py sdist bdist_wheel
 
       - name: Upload to PyPI
         env:

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,8 @@ install_requires =
 [options.packages.find]
 exclude =
     test*
+    modal_docs/
+    modal_global_objects/
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Have client CI/CD publish source distribution to PyPI as well.

I ran `python setup.py sdist bdist_wheel` locally and installed modal from the `.tar.gz` file and ran a couple of examples and everything worked.

This is needed because conda-forge needs a source distribution from PyPI to build the package.