### PR TITLE
Second attempt: deprecation warning on method lookup

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1093,13 +1093,14 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         ```
         """
         if "." in name:
+            class_name, method_name = name.split(".", 1)
             deprecation_warning(
-                (2025, 2, 5),
+                (2025, 2, 6),
                 "Looking up class methods using Function.from_name will be deprecated"
-                " in a future version of Modal. Use modal.Cls.from_name() instead, e.g.\n"
-                "\n"
-                'DeployedClass = modal.Cls.from_name("some_app", "MyClass")\n'
-                "DeployedClass().some_method.remote()",
+                " in a future version of Modal.\nUse modal.Cls.from_name instead, e.g.\n\n"
+                f'{class_name} = modal.Cls.from_name("{app_name}", "{class_name}")\n'
+                f"instance = {class_name}(...)\n"
+                f"instance.{method_name}.remote(...)\n",
                 pending=True,
             )
 

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1074,36 +1074,9 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         await retry_transient_errors(self.client.stub.FunctionUpdateSchedulingParams, request)
 
     @classmethod
-    @renamed_parameter((2024, 12, 18), "tag", "name")
-    def from_name(
-        cls: type["_Function"],
-        app_name: str,
-        name: str,
-        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
-        environment_name: Optional[str] = None,
-    ) -> "_Function":
-        """Reference a Function from a deployed App by its name.
-
-        In contrast to `modal.Function.lookup`, this is a lazy method
-        that defers hydrating the local object with metadata from
-        Modal servers until the first time it is actually used.
-
-        ```python
-        f = modal.Function.from_name("other-app", "function")
-        ```
-        """
-        if "." in name:
-            class_name, method_name = name.split(".", 1)
-            deprecation_warning(
-                (2025, 2, 6),
-                "Looking up class methods using Function.from_name will be deprecated"
-                " in a future version of Modal.\nUse modal.Cls.from_name instead, e.g.\n\n"
-                f'{class_name} = modal.Cls.from_name("{app_name}", "{class_name}")\n'
-                f"instance = {class_name}(...)\n"
-                f"instance.{method_name}.remote(...)\n",
-                pending=True,
-            )
-
+    def _from_name(cls, app_name: str, name: str, namespace, environment_name: Optional[str]):
+        # internal function lookup implementation that allows lookup of class "service functions"
+        # in addition to non-class functions
         async def _load_remote(self: _Function, resolver: Resolver, existing_object_id: Optional[str]):
             assert resolver.client and resolver.client.stub
             request = api_pb2.FunctionGetRequest(
@@ -1126,6 +1099,38 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
 
         rep = f"Function.from_name({app_name}, {name})"
         return cls._from_loader(_load_remote, rep, is_another_app=True, hydrate_lazily=True)
+
+    @classmethod
+    @renamed_parameter((2024, 12, 18), "tag", "name")
+    def from_name(
+        cls: type["_Function"],
+        app_name: str,
+        name: str,
+        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        environment_name: Optional[str] = None,
+    ) -> "_Function":
+        """Reference a Function from a deployed App by its name.
+
+        In contrast to `modal.Function.lookup`, this is a lazy method
+        that defers hydrating the local object with metadata from
+        Modal servers until the first time it is actually used.
+
+        ```python
+        f = modal.Function.from_name("other-app", "function")
+        ```
+        """
+        if "." in name:
+            class_name, method_name = name.split(".", 1)
+            deprecation_warning(
+                (2025, 2, 11),
+                "Looking up class methods using Function.from_name will be deprecated"
+                " in a future version of Modal.\nUse modal.Cls.from_name instead, e.g.\n\n"
+                f'{class_name} = modal.Cls.from_name("{app_name}", "{class_name}")\n'
+                f"instance = {class_name}(...)\n"
+                f"instance.{method_name}.remote(...)\n",
+            )
+
+        return cls._from_name(app_name, name, namespace, environment_name)
 
     @staticmethod
     @renamed_parameter((2024, 12, 18), "tag", "name")

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1092,6 +1092,16 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         f = modal.Function.from_name("other-app", "function")
         ```
         """
+        if "." in name:
+            deprecation_warning(
+                (2025, 2, 5),
+                "Looking up class methods using Function.from_name will be deprecated"
+                " in a future version of Modal. Use modal.Cls.from_name() instead, e.g.\n"
+                "\n"
+                'DeployedClass = modal.Cls.from_name("some_app", "MyClass")\n'
+                "DeployedClass().some_method.remote()",
+                pending=True,
+            )
 
         async def _load_remote(self: _Function, resolver: Resolver, existing_object_id: Optional[str]):
             assert resolver.client and resolver.client.stub

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -557,9 +557,10 @@ class _Cls(_Object, type_prefix="cs"):
         cls = cls._from_loader(_load_remote, rep, is_another_app=True, hydrate_lazily=True)
 
         class_service_name = f"{name}.*"  # special name of the base service function for the class
-        cls._class_service_function = _Function.from_name(
+        cls._class_service_function = _Function._from_name(
             app_name,
             class_service_name,
+            namespace=namespace,
             environment_name=_environment_name,
         )
         cls._name = name


### PR DESCRIPTION
* Makes the deprecation warning non-pending which would fail any tests that triggers it.
* Moves most of the Function.from_name logic into an iternal dito that doesn't do validation and use that when looking up service functions in Cls.from_name, as to not trigger the deprecation warning for that

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
