### PR TITLE
Fix automount deprecations

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -603,6 +603,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                     is_builder_function=True,
                     is_auto_snapshot=True,
                     scheduler_placement=scheduler_placement,
+                    include_source=include_source,
                 )
                 image = _Image._from_args(
                     base_images={"base": image},

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -537,7 +537,6 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                             f"image_with_source = my_image.add_local_python_source({python_stringified_modules})\n\n"
                         )
                         + "For more information, see https://modal.com/docs/guide/modal-1-0-migration",
-                        pending=True,
                     )
                 all_mounts += auto_mounts.values()
         else:

--- a/modal/cli/programs/run_jupyter.py
+++ b/modal/cli/programs/run_jupyter.py
@@ -15,7 +15,7 @@ from modal import App, Image, Queue, Secret, Volume, forward
 # Passed by `modal launch` locally via CLI, plumbed to remote runner through secrets.
 args: dict[str, Any] = json.loads(os.environ.get("MODAL_LAUNCH_ARGS", "{}"))
 
-app = App()
+app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 image = Image.from_registry(args.get("image"), add_python=args.get("add_python")).pip_install("jupyterlab")
 

--- a/modal/cli/programs/vscode.py
+++ b/modal/cli/programs/vscode.py
@@ -22,7 +22,7 @@ CODE_SERVER_ENTRYPOINT = (
 FIXUD_INSTALLER = "https://github.com/boxboat/fixuid/releases/download/v0.6.0/fixuid-0.6.0-linux-$ARCH.tar.gz"
 
 
-app = App()
+app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 image = (
     Image.from_registry(args.get("image"), add_python="3.11")
     .apt_install("curl", "dumb-init", "git", "git-lfs")

--- a/modal/image.py
+++ b/modal/image.py
@@ -1924,6 +1924,8 @@ class _Image(_Object, type_prefix="im"):
         region: Optional[Union[str, Sequence[str]]] = None,  # Region or regions to run the function on.
         args: Sequence[Any] = (),  # Positional arguments to the function.
         kwargs: dict[str, Any] = {},  # Keyword arguments to the function.
+        *,
+        include_source: Optional[bool] = None,
     ) -> "_Image":
         """Run user-defined function `raw_f` as an image build step. The function runs just like an ordinary Modal
         function, and any kwargs accepted by `@app.function` (such as `Mount`s, `NetworkFileSystem`s,
@@ -1979,6 +1981,7 @@ class _Image(_Object, type_prefix="im"):
             timeout=timeout,
             cpu=cpu,
             is_builder_function=True,
+            include_source=include_source,
         )
         if len(args) + len(kwargs) > 0:
             args_serialized = serialize((args, kwargs))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ module = [
 ]
 ignore_errors = true
 
-
 [tool.pytest.ini_options]
 timeout = 300
 addopts = "--ignore=modal/cli/programs"

--- a/test/cli_imports_test.py
+++ b/test/cli_imports_test.py
@@ -29,8 +29,8 @@ def main():
 """
 python_module_src = """
 import modal
-app = modal.App("FOO")
-other_app = modal.App("BAR")
+app = modal.App("FOO", include_source=True)  # TODO: remove include_source=True)
+other_app = modal.App("BAR", include_source=True)  # TODO: remove include_source=True)
 @other_app.function()
 def func():
     pass
@@ -45,8 +45,8 @@ assert not __package__
 
 python_package_src = """
 import modal
-app = modal.App("FOO")
-other_app = modal.App("BAR")
+app = modal.App("FOO", include_source=True)  # TODO: remove include_source=True)
+other_app = modal.App("BAR", include_source=True)  # TODO: remove include_source=True)
 @other_app.function()
 def func():
     pass
@@ -55,8 +55,8 @@ assert __package__ == "pack005"
 
 python_subpackage_src = """
 import modal
-app = modal.App("FOO")
-other_app = modal.App("BAR")
+app = modal.App("FOO", include_source=True)  # TODO: remove include_source=True)
+other_app = modal.App("BAR", include_source=True)  # TODO: remove include_source=True)
 @other_app.function()
 def func():
     pass
@@ -65,8 +65,8 @@ assert __package__ == "pack007.sub009"
 
 python_file_src = """
 import modal
-app = modal.App("FOO")
-other_app = modal.App("BAR")
+app = modal.App("FOO", include_source=True)  # TODO: remove include_source=True)
+other_app = modal.App("BAR", include_source=True)  # TODO: remove include_source=True)
 @other_app.function()
 def func():
     pass

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -35,7 +35,7 @@ import modal
 
 import other_module
 
-app = modal.App("my_app")
+app = modal.App("my_app", include_source=True)  # TODO: remove include_source=True)
 
 # Sanity check that the module is imported properly
 import sys

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -68,7 +68,7 @@ def test_run_class(client, servicer):
     assert len(servicer.precreated_functions) == 0
     assert servicer.n_functions == 0
     with app.run(client=client):
-        method_handle_object_id = Foo.bar.object_id  # method handle object id will probably go away
+        method_handle_object_id = Foo._get_class_service_function().object_id  # type: ignore
         assert isinstance(Foo, Cls)
         assert isinstance(NoParamsCls, Cls)
         class_id = Foo.object_id
@@ -334,10 +334,10 @@ def test_lookup(client, servicer):
 
     # objects are resolved
     assert cls.object_id.startswith("cs-")
-    assert cls.bar.object_id.startswith("fu-")
+    assert cls._get_class_service_function().object_id.startswith("fu-")
 
     # Check that function properties are preserved
-    assert cls.bar.is_generator is False
+    assert cls().bar.is_generator is False
 
     # Make sure we can instantiate the class
     with servicer.intercept() as ctx:
@@ -1074,4 +1074,5 @@ def test_using_method_on_uninstantiated_cls(recwarn, disable_auto_mount):
 
 
 def test_method_on_cls_access_warns():
-    print(Foo.bar)
+    with pytest.warns(match="instantiate classes before using methods"):
+        print(Foo.bar)

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -31,7 +31,7 @@ from modal_proto import api_pb2
 
 from .supports.base_class import BaseCls2
 
-app = App("app")
+app = App("app", include_source=True)
 
 
 @pytest.fixture(autouse=True)
@@ -152,7 +152,7 @@ def test_class_with_options_need_hydrating(client, servicer):
 # Reusing the app runs into an issue with stale function handles.
 # TODO (akshat): have all the client tests use separate apps, and throw
 # an exception if the user tries to reuse an app.
-app_remote = App()
+app_remote = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @app_remote.cls(cpu=42)
@@ -192,7 +192,7 @@ def test_call_cls_remote_modal_type(client):
             FooRemote(42, q)  # type: ignore
 
 
-app_2 = App()
+app_2 = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @app_2.cls(cpu=42)
@@ -234,7 +234,7 @@ def test_run_class_serialized(client, servicer):
     assert bound_bar(100) == 1000000
 
 
-app_remote_2 = App()
+app_remote_2 = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @app_remote_2.cls(cpu=42)
@@ -255,7 +255,7 @@ async def test_call_cls_remote_async(client):
         assert await bar_remote.baz.remote.aio(8) == 64  # Mock servicer just squares the argument
 
 
-app_local = App()
+app_local = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @app_local.cls(cpu=42, enable_memory_snapshot=True)
@@ -298,7 +298,7 @@ def test_can_call_remotely_from_local(client):
         assert foo.baz.remote(9) == 81
 
 
-app_remote_3 = App()
+app_remote_3 = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @app_remote_3.cls(cpu=42)
@@ -412,7 +412,7 @@ def test_lookup_lazy_spawn(client, servicer):
     assert function_call.get() == 7693
 
 
-baz_app = App()
+baz_app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @baz_app.cls()
@@ -430,7 +430,7 @@ def test_call_not_modal_method():
     assert baz.not_modal_method(7) == 35
 
 
-cls_with_enter_app = App()
+cls_with_enter_app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 def get_thread_id():
@@ -504,7 +504,7 @@ async def test_async_enter_on_local_modal_call():
     assert obj.entered
 
 
-inheritance_app = App()
+inheritance_app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 class BaseCls:
@@ -528,7 +528,7 @@ def test_derived_cls(client, servicer):
         assert DerivedCls().run.remote(3) == 9
 
 
-inheritance_app_2 = App()
+inheritance_app_2 = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @inheritance_app_2.cls()
@@ -563,7 +563,7 @@ def test_rehydrate(client, servicer, reset_container_app):
     assert obj.bar.local(7) == 343
 
 
-app_unhydrated = App()
+app_unhydrated = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @app_unhydrated.cls()
@@ -578,7 +578,7 @@ def test_unhydrated():
         foo.bar.remote(42)
 
 
-app_method_args = App()
+app_method_args = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @app_method_args.cls(keep_warm=5)
@@ -684,7 +684,7 @@ def test_handlers():
     assert list(pfs.keys()) == ["my_exit"]
 
 
-web_app_app = App()
+web_app_app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @web_app_app.cls()
@@ -705,7 +705,7 @@ def test_web_cls(client):
         assert c.asgi.web_url == "http://asgi.internal"
 
 
-handler_app = App("handler-app")
+handler_app = App("handler-app", include_source=True)
 
 
 image = Image.debian_slim().pip_install("xyz")
@@ -733,7 +733,7 @@ def test_build_image(client, servicer):
         assert servicer.force_built_images == []
 
 
-other_handler_app = App("other-handler-app")
+other_handler_app = App("other-handler-app", include_source=True)
 
 
 with pytest.warns(DeprecationError, match="@modal.build"):
@@ -758,7 +758,7 @@ def test_force_build_image(client, servicer):
         assert servicer.force_built_images == ["im-3"]
 
 
-build_timeout_handler_app = App("build-timeout-handler-app")
+build_timeout_handler_app = App("build-timeout-handler-app", include_source=True)
 
 
 with pytest.warns(DeprecationError, match="@modal.build"):
@@ -867,7 +867,7 @@ def test_cross_process_userclass_serde(supports_dir):
     assert revived_cls().method() == "a"  # this should be bound to the object
 
 
-app2 = modal.App("app2")
+app2 = App("app2", include_source=True)
 
 
 @app2.cls()
@@ -954,7 +954,7 @@ class ParametrizedClass3:
         pass
 
 
-app_batched = App()
+app_batched = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 def test_batched_method_duplicate_error(client):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2168,7 +2168,7 @@ def no_rich(monkeypatch):
     yield
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def disable_auto_mount(monkeypatch):
     monkeypatch.setenv("MODAL_AUTOMOUNT", "0")
     yield

--- a/test/container_buffer_test.py
+++ b/test/container_buffer_test.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2024
 from modal import App
 
-app = App()
+app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @app.function(

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -19,7 +19,7 @@ from modal.runner import deploy_app
 from modal_proto import api_pb2
 from test.helpers import deploy_app_externally
 
-app = App()
+app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 if os.environ.get("GITHUB_ACTIONS") == "true":
@@ -716,7 +716,7 @@ def test_from_id_iter_gen(client, servicer, is_generator):
         assert rehydrated_function_call.get() == "hello"
 
 
-lc_app = App()
+lc_app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @lc_app.function()

--- a/test/gpu_fallbacks_test.py
+++ b/test/gpu_fallbacks_test.py
@@ -2,7 +2,7 @@
 from modal import App
 from modal_proto import api_pb2
 
-app = App()
+app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @app.function(gpu=["a10g"])

--- a/test/i6pn_clustered_test.py
+++ b/test/i6pn_clustered_test.py
@@ -3,7 +3,7 @@ import modal
 import modal.experimental
 from modal import App
 
-app = App()
+app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @app.function()

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -1060,7 +1060,7 @@ def test_hydration_metadata(servicer, client):
             assert_metadata(img, dummy_metadata)
 
 
-cls_app = App()
+cls_app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 VARIABLE_5 = 1
 VARIABLE_6 = 1
@@ -1448,7 +1448,7 @@ def test_image_stability_on_2024_10(force_2024_10, servicer, client, test_dir):
     assert get_hash(img) == "78d579f243c21dcaa59e5daf97f732e2453b004bc2122de692617d4d725c6184"
 
 
-parallel_app = App()
+parallel_app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @parallel_app.function(image=Image.debian_slim().run_commands("sleep 1", "echo hi"))

--- a/test/mounted_files_test.py
+++ b/test/mounted_files_test.py
@@ -195,6 +195,7 @@ def symlinked_python_installation_venv_path(tmp_path, repo_root):
 def test_mounted_files_symlinked_python_install(
     symlinked_python_installation_venv_path, supports_dir, server_url_env, token_env, servicer
 ):
+    # TODO(elias): This test fails when run from a uv-managed virtualenv
     subprocess.check_call(
         [symlinked_python_installation_venv_path / "bin" / "modal", "run", supports_dir / "imports_ast.py"]
     )

--- a/test/schedule_test.py
+++ b/test/schedule_test.py
@@ -2,7 +2,7 @@
 from modal import App, Period
 from modal_proto import api_pb2
 
-app = App()
+app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @app.function(schedule=Period(seconds=5))

--- a/test/scheduler_placement_test.py
+++ b/test/scheduler_placement_test.py
@@ -4,7 +4,7 @@ from modal_proto import api_pb2
 
 from .supports.skip import skip_windows
 
-app = App()
+app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @app.function(

--- a/test/supports/app_run_tests/app_with_lookups.py
+++ b/test/supports/app_run_tests/app_with_lookups.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 import modal
 
-app = modal.App("my-app")
+app = modal.App("my-app", include_source=True)  # TODO: remove include_source=True)
 
 nfs = modal.NetworkFileSystem.from_name("volume_app").hydrate()
 

--- a/test/supports/app_run_tests/cli_args.py
+++ b/test/supports/app_run_tests/cli_args.py
@@ -4,7 +4,7 @@ from typing import Optional, Union
 
 from modal import App, method
 
-app = App()
+app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @app.local_entrypoint()

--- a/test/supports/app_run_tests/variadic_args.py
+++ b/test/supports/app_run_tests/variadic_args.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 from modal import App, method
 
-app = App()
+app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @app.cls()

--- a/test/supports/app_run_tests/webhook.py
+++ b/test/supports/app_run_tests/webhook.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 from modal import App, web_endpoint
 
-app = App()
+app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @app.function()

--- a/test/supports/class_hierarchy.py
+++ b/test/supports/class_hierarchy.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2024
 import modal
 
-app = modal.App("class-hierarchy")
+app = modal.App("class-hierarchy", include_source=True)  # TODO: remove include_source=True)
 
 
 class Base:

--- a/test/supports/experimental.py
+++ b/test/supports/experimental.py
@@ -8,7 +8,7 @@ from modal import (
     method,
 )
 
-app = App()
+app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @app.cls()

--- a/test/supports/functions.py
+++ b/test/supports/functions.py
@@ -27,7 +27,7 @@ from modal.experimental import get_local_input_concurrency, set_local_input_conc
 
 SLEEP_DELAY = 0.1
 
-app = App()
+app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @app.function()

--- a/test/supports/image_run_function.py
+++ b/test/supports/image_run_function.py
@@ -1,8 +1,8 @@
 # Copyright Modal Labs 2022
 import modal
 
-app = modal.App("a")
-other = modal.App("b")
+app = modal.App("a", include_source=True)  # TODO: remove include_source=True)
+other = modal.App("b", include_source=True)  # TODO: remove include_source=True)
 
 
 def builder_function():

--- a/test/supports/import_and_filter_source.py
+++ b/test/supports/import_and_filter_source.py
@@ -1,7 +1,9 @@
 # Copyright Modal Labs 2025
 from modal import App, asgi_app, method, web_endpoint
 
-app_with_one_web_function = App()
+app_with_one_web_function = App(
+    include_source=True
+)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @app_with_one_web_function.function()
@@ -10,7 +12,9 @@ def web1():
     pass
 
 
-app_with_one_function_one_web_endpoint = App()
+app_with_one_function_one_web_endpoint = App(
+    include_source=True
+)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @app_with_one_function_one_web_endpoint.function()
@@ -24,7 +28,9 @@ def web2():
     pass
 
 
-app_with_one_web_method = App()
+app_with_one_web_method = App(
+    include_source=True
+)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @app_with_one_web_method.cls()
@@ -34,7 +40,9 @@ class C1:
         pass
 
 
-app_with_one_web_method_one_method = App()
+app_with_one_web_method_one_method = App(
+    include_source=True
+)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @app_with_one_web_method_one_method.cls()
@@ -48,7 +56,9 @@ class C2:
         pass
 
 
-app_with_local_entrypoint_and_function = App()
+app_with_local_entrypoint_and_function = App(
+    include_source=True
+)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @app_with_local_entrypoint_and_function.local_entrypoint()

--- a/test/supports/imports_ast.py
+++ b/test/supports/imports_ast.py
@@ -3,7 +3,7 @@ import ast  # noqa
 
 import modal
 
-app = modal.App("imports_ast")
+app = modal.App("imports_ast", include_source=True)  # TODO: remove include_source=True)
 
 
 @app.function()

--- a/test/supports/imports_six.py
+++ b/test/supports/imports_six.py
@@ -3,7 +3,7 @@ import six  # noqa
 
 import modal
 
-app = modal.App("imports_six")
+app = modal.App("imports_six", include_source=True)  # TODO: remove include_source=True)
 
 
 @app.function()

--- a/test/supports/lazy_hydration.py
+++ b/test/supports/lazy_hydration.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2024
 from modal import App, Image, Queue, Volume
 
-app = App()
+app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 image = Image.debian_slim().pip_install("xyz")
 volume = Volume.from_name("my-vol")

--- a/test/supports/multiapp_privately_decorated_named_app.py
+++ b/test/supports/multiapp_privately_decorated_named_app.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2023
 import modal
 
-app = modal.App("dummy")
+app = modal.App("dummy", include_source=True)  # TODO: remove include_source=True)
 
 
 def foo(i):

--- a/test/supports/multiapp_same_name.py
+++ b/test/supports/multiapp_same_name.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2023
 import modal
 
-app = modal.App("dummy")
+app = modal.App("dummy", include_source=True)  # TODO: remove include_source=True)
 
 
 def foo(i):
@@ -11,7 +11,7 @@ def foo(i):
 foo_handle = app.function()(foo)
 
 
-other_app = modal.App("dummy")
+other_app = modal.App("dummy", include_source=True)  # TODO: remove include_source=True)
 
 
 @other_app.function()

--- a/test/supports/multifile_project/c.py
+++ b/test/supports/multifile_project/c.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2024
 import modal
 
-app = modal.App("c")
+app = modal.App("c", include_source=True)  # TODO: remove include_source=True)
 
 
 @app.function()

--- a/test/supports/package_mount.py
+++ b/test/supports/package_mount.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 from modal import App, Image
 
-app = App()
+app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 # just make sure that non-existing package doesn't cause this to crash in containers:
 image = Image.debian_slim().add_local_python_source("non_existing_package_123154")

--- a/test/supports/startup_failure.py
+++ b/test/supports/startup_failure.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 import modal
 
-app = modal.App("hello-world")
+app = modal.App("hello-world", include_source=True)  # TODO: remove include_source=True)
 
 if not modal.is_local():
     import nonexistent_package  # noqa

--- a/test/supports/user_code_import_samples/cls.py
+++ b/test/supports/user_code_import_samples/cls.py
@@ -2,7 +2,7 @@
 import modal
 from modal import App
 
-app = App()
+app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 class C:

--- a/test/supports/user_code_import_samples/func.py
+++ b/test/supports/user_code_import_samples/func.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2024
 from modal import App
 
-app = App()
+app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @app.function()

--- a/test/supports/volume_local.py
+++ b/test/supports/volume_local.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2024
 from modal import App, Volume
 
-app2 = App()
+app2 = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @app2.function(volumes={"/foo": Volume.from_name("my-vol")})

--- a/test/webhook_test.py
+++ b/test/webhook_test.py
@@ -13,7 +13,7 @@ from modal.functions import Function
 from modal.running_app import RunningApp
 from modal_proto import api_pb2
 
-app = App()
+app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @app.function(cpu=42)


### PR DESCRIPTION
Also fixes a couple of outstanding issues with the `include_source` option not working for:
1. Image.run_function
2. @build() methods

This also sets pending=False on the deprecation warning, so we need to fix internal integration tests before merging this as well.


---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
