### PR TITLE
Begin sending bundled autoscaler settings in Function definition

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -619,6 +619,13 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                 f"strictly less than its `{keep_warm=}` parameter."
             )
 
+        autoscaler_settings = api_pb2.AutoscalerSettings(
+            max_containers=concurrency_limit,
+            min_containers=keep_warm,
+            buffer_containers=_experimental_buffer_containers,
+            scaledown_window=container_idle_timeout,
+        )
+
         if _experimental_custom_scaling_factor is not None and (
             _experimental_custom_scaling_factor < 0 or _experimental_custom_scaling_factor > 1
         ):
@@ -802,6 +809,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                     class_serialized=class_serialized or b"",
                     function_type=function_type,
                     webhook_config=webhook_config,
+                    autoscaler_settings=autoscaler_settings,
                     method_definitions=method_definitions,
                     method_definitions_set=True,
                     shared_volume_mounts=network_file_system_mount_protos(

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1174,7 +1174,7 @@ message Function {
 
   FunctionRetryPolicy retry_policy = 18;
 
-  uint32 concurrency_limit = 19;
+  uint32 concurrency_limit = 19;  // To be replaced by autoscaler_settings.max_containers
 
   reserved 20; // old fields
 
@@ -1183,11 +1183,11 @@ message Function {
   PTYInfo pty_info = 22;
   bytes class_serialized = 23;
 
-  uint32 task_idle_timeout_secs = 25;
+  uint32 task_idle_timeout_secs = 25;  // To be replaced by autoscaler_settings.scaledown_period
 
   optional CloudProvider cloud_provider = 26;  // Deprecated at some point
 
-  uint32 warm_pool_size = 27;
+  uint32 warm_pool_size = 27;  // To be replaced by autoscaler_settings.min_containers
 
   string web_url = 28;
   WebUrlInfo web_url_info = 29;
@@ -1262,7 +1262,7 @@ message Function {
   // If set, the function will be run in an untrusted environment.
   bool untrusted = 68;
 
-  uint32 _experimental_buffer_containers = 69;
+  uint32 _experimental_buffer_containers = 69;  // To be replaced by autoscaler_settings.buffer_containers
 
   // _experimental_proxy_ip -> ProxyInfo
   // TODO: deprecate.
@@ -1283,6 +1283,9 @@ message Function {
   string cloud_provider_str = 77;  // Supersedes cloud_provider
 
   bool _experimental_enable_gpu_snapshot = 78; // Experimental support for GPU snapshotting
+
+  AutoscalerSettings autoscaler_settings = 79;  // Bundle of parameters related to autoscaling
+
 }
 
 message FunctionAsyncInvokeRequest {

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -792,6 +792,25 @@ def test_default_cloud_provider(client, servicer, monkeypatch):
     assert f.cloud_provider_str == "xyz"
 
 
+def test_autoscaler_settings(client, servicer):
+    app = App()
+
+    kwargs = dict(
+        keep_warm=2,
+        concurrency_limit=10,
+        container_idle_timeout=60,
+    )
+    f = app.function(**kwargs)(dummy)
+
+    with app.run(client=client):
+        defn = servicer.app_functions[f.object_id]
+        # Test both backwards and forwards compatibility
+        settings = defn.autoscaler_settings
+        assert settings.min_containers == defn.warm_pool_size == kwargs["keep_warm"]
+        assert settings.max_containers == defn.concurrency_limit == kwargs["concurrency_limit"]
+        assert settings.scaledown_window == defn.task_idle_timeout_secs == kwargs["container_idle_timeout"]
+
+
 def test_not_hydrated():
     with pytest.raises(ExecutionError):
         assert foo.remote(2, 4) == 20

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -795,7 +795,7 @@ def test_default_cloud_provider(client, servicer, monkeypatch):
 def test_autoscaler_settings(client, servicer):
     app = App()
 
-    kwargs = dict(
+    kwargs: dict[str, typing.Any] = dict(  # No idea why we need that type hint
         keep_warm=2,
         concurrency_limit=10,
         container_idle_timeout=60,


### PR DESCRIPTION
## Describe your changes

This PR adds an `autoscaler_settings` field to the `Function` definition, using the new `AutoscalerSettings` type. It also starts sending the parameter values in this message (in duplicate with the existing fields directly on the `Function` message, since we don't have backend support to read these yet).

With this change we can use a consistent data structure for both static and dynamic configuration.

Part of CLI-31 

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>
