### PR TITLE
Add retry_count to get output response item

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1505,6 +1505,7 @@ message FunctionGetOutputsItem {
   string task_id = 6;
   double input_started_at = 7;
   double output_created_at = 8;
+  uint32 retry_count = 9;
 }
 
 message FunctionGetOutputsRequest {


### PR DESCRIPTION
We will use the retry_count field to distinguish between outputs resulting from different attempts. This will allow us to 
1)  ignore duplicate outputs
2) ignore outputs from old attempts which arrived after newer attempts. 

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
