### PR TITLE
Allow Function.web_url to return None when Function is not a web endpoint

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1258,13 +1258,10 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
     # TODO (live_method on properties is not great, since it could be blocking the event loop from async contexts)
     @property
     @live_method
-    async def web_url(self) -> str:
+    async def web_url(self) -> Optional[str]:
         """URL of a Function running as a web endpoint."""
-        if not self._web_url:
-            raise ValueError(
-                f"No web_url can be found for function {self._function_name}. web_url "
-                "can only be referenced from a running app context"
-            )
+        # TODO If we remove the @live_method above, we may want to provide better feedback when the underlying
+        # attribute is None because the object is not hydrated, rather than because it's not a web endpoint.
         return self._web_url
 
     @property


### PR DESCRIPTION
## Describe your changes

Fixes a false-positive error that made it annoying to programmatically inspect functions for web url metadata.

I thought about refining the condition to whether the object is unhydrated, but we have a `@live_method` decorator, so that shouldn't be possible?

That said I think we would like to get rid of "live properties" as they have some gotchas. So we may need to reinstate some sort of helpful error here (ideally one that doesn't get in the way when you're on the happy path). Left a comment to that effect.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- `Function.web_url` will now return None (instead of raising an error) when the Function is not a web endpoint