### PR TITLE
Export modal.FunctionCall at the top level for FunctionCall.from_id()

### DIFF
--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -18,7 +18,7 @@ try:
     from .dict import Dict
     from .exception import Error
     from .file_pattern_matcher import FilePatternMatcher
-    from .functions import Function
+    from .functions import Function, FunctionCall
     from .image import Image
     from .mount import Mount
     from .network_file_system import NetworkFileSystem
@@ -52,6 +52,7 @@ __all__ = [
     "Error",
     "FilePatternMatcher",
     "Function",
+    "FunctionCall",
     "Image",
     "Mount",
     "NetworkFileSystem",

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1474,7 +1474,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
 
         This experimental version of the spawn method allows up to 1 million inputs to be spawned.
 
-        Returns a `modal.functions.FunctionCall` object, that can later be polled or
+        Returns a `modal.FunctionCall` object, that can later be polled or
         waited for using `.get(timeout=...)`.
         Conceptually similar to `multiprocessing.pool.apply_async`, or a Future/Promise in other contexts.
         """
@@ -1497,7 +1497,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
     async def spawn(self, *args: P.args, **kwargs: P.kwargs) -> "_FunctionCall[ReturnType]":
         """Calls the function with the given arguments, without waiting for the results.
 
-        Returns a `modal.functions.FunctionCall` object, that can later be polled or
+        Returns a `modal.FunctionCall` object, that can later be polled or
         waited for using `.get(timeout=...)`.
         Conceptually similar to `multiprocessing.pool.apply_async`, or a Future/Promise in other contexts.
         """


### PR DESCRIPTION
Noticed this was missing in the package level exports, but feels like it should be there since we have some public uses of this API in our examples

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->

- `modal.FunctionCall` is now available in the top-level `modal` namespace. We recommend referencing the class this way instead of using the the fully-qualified `modal.functions.FunctionCall` name.