### PR TITLE
Include `modal_docs` in client installation/build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,8 @@ Documentation = "https://modal.com/docs"
 modal = "modal.__main__:main"
 
 [tool.setuptools.packages.find]
-include = ["modal", "modal.*", "modal_version", "modal_proto"]
-exclude = ["test*", "modal_docs", "modal_global_objects"]
+include = ["modal", "modal.*", "modal_docs", "modal_version", "modal_proto"]
+exclude = ["test*", "modal_global_objects"]
 
 [tool.setuptools.package-data]
 modal = ["requirements/*.md", "requirements/*.txt", "requirements/*.json", "py.typed", "*.pyi"]


### PR DESCRIPTION
Include `modal_docs` in client installation/build, since our monorepo CI/CD installs the client and uses `modal_docs` for `inv docs`