### PR TITLE
Include modal_docs subpackages in client installation/build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ Documentation = "https://modal.com/docs"
 modal = "modal.__main__:main"
 
 [tool.setuptools.packages.find]
-include = ["modal", "modal.*", "modal_docs", "modal_version", "modal_proto"]
+include = ["modal", "modal.*", "modal_docs", "modal_docs.*", "modal_version", "modal_proto"]
 exclude = ["test*", "modal_global_objects"]
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
Include `modal_docs` subpackages in client installation/build. https://github.com/modal-labs/modal-client/pull/2871 was unfortunately not sufficient