### PR TITLE
Add autoscaler_settings to FunctionData as well

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -862,6 +862,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                         warm_pool_size=function_definition.warm_pool_size,
                         concurrency_limit=function_definition.concurrency_limit,
                         task_idle_timeout_secs=function_definition.task_idle_timeout_secs,
+                        autoscaler_settings=function_definition.autoscaler_settings,
                         worker_id=function_definition.worker_id,
                         timeout_secs=function_definition.timeout_secs,
                         web_url=function_definition.web_url,

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1435,6 +1435,9 @@ message FunctionData {
   bool untrusted = 27; // If set, the function will be run in an untrusted environment.
   bool snapshot_debug = 28; // For internal debugging use only.
   bool runtime_perf_record = 29; // For internal debugging use only.
+
+  AutoscalerSettings autoscaler_settings = 31;  // Bundle of parameters related to autoscaling
+
 }
 
 message FunctionExtended {


### PR DESCRIPTION
Forgot to do this in #2861 (still don't have my head quite wrapped around `Function`/`FunctionData`).


<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>
