### PR TITLE
Add fc_trace_tag field to FunctionOutput

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1512,6 +1512,7 @@ message FunctionGetOutputsItem {
   double input_started_at = 7;
   double output_created_at = 8;
   uint32 retry_count = 9;
+  string fc_trace_tag = 10; // datadog function call trace tag
 }
 
 message FunctionGetOutputsRequest {


### PR DESCRIPTION
This PR adds a `fc_trace_tag` field to `FunctionGetOutputsItem`, needed to provide end-to-end function call traces with Datdog.

We sample a very small number of function calls, and this field is only set for function calls we _do_ sample, so this shouldn't actually impact many outputs.

This tag might also be useful for synmons, etc.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>