### PR TITLE
Remove check for snapshot enabled locally

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -562,11 +562,6 @@ class _Sandbox(_Object, type_prefix="sb"):
         return _ContainerProcess(resp.exec_id, self._client, stdout=stdout, stderr=stderr, text=text, by_line=by_line)
 
     async def _experimental_snapshot(self) -> _SandboxSnapshot:
-        if not self._enable_snapshot:
-            raise ValueError(
-                "Memory snapshots are not supported for this sandbox. To enable memory snapshots, "
-                "set `_experimental_enable_snapshot=True` when creating the sandbox."
-            )
         await self._get_task_id()
         snap_req = api_pb2.SandboxSnapshotRequest(sandbox_id=self.object_id)
         snap_resp = await retry_transient_errors(self._client.stub.SandboxSnapshot, snap_req)

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -426,11 +426,6 @@ def test_sandbox_exec_stdout(app, servicer, capsys):
 
 @skip_non_subprocess
 def test_sandbox_snapshot(app, client, servicer):
-    invalid_sb = Sandbox.create(app=app)
-    with pytest.raises(ValueError):
-        # cannot snapshot a sandbox without memory snapshotting enabled
-        sandbox_snapshot = invalid_sb._experimental_snapshot()
-
     sb = Sandbox.create(app=app, _experimental_enable_snapshot=True)
     sandbox_snapshot = sb._experimental_snapshot()
     snapshot_id = sandbox_snapshot.object_id


### PR DESCRIPTION
Removes a local check in `Sandbox._experimental_snapshot` that verifies snapshots are enabled for the sandbox before snapshotting. We don't correctly hydrate the field we're checking correctly, and we also verify on the server.

This fixes the issue quickly, for now. I've created a ticket to add back the local check (and add a test) once I figure out hydration.

## Changelog

- Fixes a bug where sandboxes returned from `Sandbox.list()` were not snapshottable even if they were created with `_experimental_enable_snapshot`.