### PR TITLE
Apply object name rules in App.lookup

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -33,6 +33,7 @@ from ._utils.deprecation import deprecation_error, deprecation_warning, renamed_
 from ._utils.function_utils import FunctionInfo, is_global_object, is_method_fn
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.mount_utils import validate_volumes
+from ._utils.name_utils import check_object_name
 from .client import _Client
 from .cloud_bucket_mount import _CloudBucketMount
 from .cls import _Cls, parameter
@@ -263,6 +264,8 @@ class _App:
         modal.Sandbox.create("echo", "hi", app=app)
         ```
         """
+        check_object_name(name, "App")
+
         if client is None:
             client = await _Client.from_env()
 

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -471,3 +471,9 @@ def test_overriding_function_warning(caplog):
 
     app_3.include(app_4)
     assert "Overriding existing function" in caplog.messages[0]
+
+
+@pytest.mark.parametrize("name", ["", " ", "no way", "my-app!", "a" * 65])
+def test_lookup_invalid_name(name):
+    with pytest.raises(InvalidError, match="Invalid App name"):
+        App.lookup(name)


### PR DESCRIPTION
## Describe your changes

- Client side of CLI-331

## Changelog

- Passing `App.lookup` an invalid name now raises an error. App names may contain only alphanumeric characters, dashes, periods, and underscores, must be shorter than 64 characters, and cannot conflict with App ID strings.