### PR TITLE
add some runtime type-checking in Image.env

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -2011,13 +2011,12 @@ class _Image(_Object, type_prefix="im"):
         )
         ```
         """
+        non_str_keys = [key for key, val in vars.items() if not isinstance(val, str)]
+        if non_str_keys:
+            raise InvalidError(f"Image ENV variables must be strings. Invalid keys: {non_str_keys}")
 
         def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:
-            try:
-                env_commands = [f"ENV {key}={shlex.quote(val)}" for (key, val) in vars.items()]
-            except TypeError:
-                non_str_keys = [key for key, val in vars.items() if not isinstance(val, str)]
-                raise InvalidError(f"Environment variables must be strings. Invalid keys: {non_str_keys}")
+            env_commands = [f"ENV {key}={shlex.quote(val)}" for (key, val) in vars.items()]
             return DockerfileSpec(commands=["FROM base"] + env_commands, context_files={})
 
         return _Image._from_args(

--- a/modal/image.py
+++ b/modal/image.py
@@ -2013,8 +2013,12 @@ class _Image(_Object, type_prefix="im"):
         """
 
         def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:
-            commands = ["FROM base"] + [f"ENV {key}={shlex.quote(val)}" for (key, val) in vars.items()]
-            return DockerfileSpec(commands=commands, context_files={})
+            try:
+                env_commands = [f"ENV {key}={shlex.quote(val)}" for (key, val) in vars.items()]
+            except TypeError:
+                non_str_keys = [key for key, val in vars.items() if not isinstance(val, str)]
+                raise InvalidError(f"Environment variables must be strings. Invalid keys: {non_str_keys}")
+            return DockerfileSpec(commands=["FROM base"] + env_commands, context_files={})
 
         return _Image._from_args(
             base_images={"base": self},

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -988,7 +988,7 @@ def test_image_env(builder_version, servicer, client):
 
     # unhappy path, reject invalid input
     with pytest.raises(InvalidError, match="Image ENV variables must be strings."):
-        app = App(image=Image.debian_slim().env({"HELLO": 123}))
+        app = App(image=Image.debian_slim().env({"HELLO": 123}))  # type: ignore
         app.function()(dummy)
         with app.run(client=client):
             pass

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -986,6 +986,13 @@ def test_image_env(builder_version, servicer, client):
         layers = get_image_layers(app.image.object_id, servicer)
         assert any("ENV HELLO=" in cmd and "world!" in cmd for cmd in layers[0].dockerfile_commands)
 
+    # unhappy path, reject invalid input
+    with pytest.raises(InvalidError, match="Image ENV variables must be strings."):
+        app = App(image=Image.debian_slim().env({"HELLO": 123}))
+        app.function()(dummy)
+        with app.run(client=client):
+            pass
+
 
 def test_image_gpu(builder_version, servicer, client):
     app = App(image=Image.debian_slim().run_commands("echo 0"))


### PR DESCRIPTION
## Describe your changes

Action taken in response to user report: https://modal-com.slack.com/archives/C069RAH7X4M/p1739956895311459

But if feels a bit piecemeal? Don't really want to spread lots of runtime type-checking across the code just for the purposes of nicer error messages. Alternatively I've put up a docs change on the other repo (#20024)

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>
