### PR TITLE
Rename autoscaler parameters and add deprecation warnings

### DIFF
--- a/modal/_utils/deprecation.py
+++ b/modal/_utils/deprecation.py
@@ -87,3 +87,38 @@ def renamed_parameter(
         return wrapper
 
     return decorator
+
+
+def warn_on_renamed_autoscaler_settings(func: Callable[P, R]) -> Callable[P, R]:
+    name_map = {
+        "keep_warm": "min_containers",
+        "concurrency_limit": "max_containers",
+        "_experimental_buffer_containers": "buffer_containers",
+        "container_idle_timeout": "scaledown_window",
+    }
+
+    @functools.wraps(func)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        mut_kwargs: dict[str, Any] = locals()["kwargs"]  # Avoid referencing kwargs directly due to bug in sigtools
+
+        substitutions = []
+        old_params_used = name_map.keys() & mut_kwargs.keys()
+        for old_param, new_param in name_map.items():
+            if old_param in old_params_used:
+                new_param = name_map[old_param]
+                mut_kwargs[new_param] = mut_kwargs.pop(old_param)
+                substitutions.append(f"- {old_param} -> {new_param}")
+
+        if substitutions:
+            substitution_string = "\n".join(substitutions)
+            message = (
+                "We have renamed several parameters related to autoscaling."
+                " Please update your code to use the following new names:"
+                f"\n\n{substitution_string}"
+                "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more details."
+            )
+            deprecation_warning((2025, 2, 24), message, pending=True, show_source=True)
+
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/modal/app.py
+++ b/modal/app.py
@@ -593,8 +593,8 @@ class _App:
         memory: Optional[Union[int, tuple[int, int]]] = None,
         ephemeral_disk: Optional[int] = None,  # Specify, in MiB, the ephemeral disk size for the Function.
         min_containers: Optional[int] = None,  # Minimum number of containers to keep warm, even when Function is idle.
-        max_containers: Optional[int] = None,  # Limit on the number of containers that can be spun up for this Function
-        buffer_containers: Optional[int] = None,  # Number of additional idle containers to maintain under active load
+        max_containers: Optional[int] = None,  # Limit on the number of containers that can be concurrently running.
+        buffer_containers: Optional[int] = None,  # Number of additional idle containers to maintain under active load.
         scaledown_window: Optional[int] = None,  # Max amount of time a container can remain idle before scaling down.
         proxy: Optional[_Proxy] = None,  # Reference to a Modal Proxy to use in front of this function.
         retries: Optional[Union[int, Retries]] = None,  # Number of times to retry each input in case of failure.
@@ -805,8 +805,8 @@ class _App:
         memory: Optional[Union[int, tuple[int, int]]] = None,
         ephemeral_disk: Optional[int] = None,  # Specify, in MiB, the ephemeral disk size for the Function.
         min_containers: Optional[int] = None,  # Minimum number of containers to keep warm, even when Function is idle.
-        max_containers: Optional[int] = None,  # Limit on the number of containers that can be spun up for this Function
-        buffer_containers: Optional[int] = None,  # Number of additional idle containers to maintain under active load
+        max_containers: Optional[int] = None,  # Limit on the number of containers that can be concurrently running.
+        buffer_containers: Optional[int] = None,  # Number of additional idle containers to maintain under active load.
         scaledown_window: Optional[int] = None,  # Max amount of time a container can remain idle before scaling down.
         proxy: Optional[_Proxy] = None,  # Reference to a Modal Proxy to use in front of this function.
         retries: Optional[Union[int, Retries]] = None,  # Number of times to retry each input in case of failure.

--- a/modal/cli/programs/vscode.py
+++ b/modal/cli/programs/vscode.py
@@ -82,7 +82,7 @@ def wait_for_port(data: tuple[str, str], q: Queue):
     timeout=args.get("timeout"),
     secrets=[Secret.from_dict({"MODAL_LAUNCH_ARGS": json.dumps(args)})],
     volumes=volumes,
-    concurrency_limit=1 if volume else None,
+    max_containers=1 if volume else None,
 )
 def run_vscode(q: Queue):
     os.chdir("/home/coder")

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -18,6 +18,7 @@ from modal._partial_function import (
 )
 from modal._serialization import deserialize, deserialize_params, serialize
 from modal._utils.async_utils import synchronizer
+from modal._utils.deprecation import PendingDeprecationError
 from modal._utils.function_utils import FunctionInfo
 from modal.exception import DeprecationError, ExecutionError, InvalidError, NotFoundError, PendingDeprecationError
 from modal.partial_function import (
@@ -142,6 +143,9 @@ def test_class_with_options(client, servicer):
         options: api_pb2.FunctionOptions = list(servicer.function_options.values())[0]
         assert options.resources.milli_cpu == 48_000
         assert options.retry_policy.retries == 5
+
+        with pytest.warns(PendingDeprecationError, match="max_containers"):
+            Foo.with_options(concurrency_limit=10)()  # type: ignore
 
 
 def test_class_with_options_need_hydrating(client, servicer):

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -20,7 +20,7 @@ from modal._serialization import deserialize, deserialize_params, serialize
 from modal._utils.async_utils import synchronizer
 from modal._utils.deprecation import PendingDeprecationError
 from modal._utils.function_utils import FunctionInfo
-from modal.exception import DeprecationError, ExecutionError, InvalidError, NotFoundError, PendingDeprecationError
+from modal.exception import DeprecationError, ExecutionError, InvalidError, NotFoundError
 from modal.partial_function import (
     PartialFunction,
     asgi_app,

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -581,12 +581,12 @@ def test_unhydrated():
 app_method_args = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
-@app_method_args.cls(keep_warm=5)
+@app_method_args.cls(min_containers=5)
 class XYZ:
-    @method()  # warns - keep_warm is not supported on methods anymore
+    @method()
     def foo(self): ...
 
-    @method()  # warns - keep_warm is not supported on methods anymore
+    @method()
     def bar(self): ...
 
 
@@ -594,7 +594,7 @@ def test_method_args(servicer, client):
     with app_method_args.run(client=client):
         funcs = servicer.app_functions.values()
         assert {f.function_name for f in funcs} == {"XYZ.*"}
-        warm_pools = {f.function_name: f.warm_pool_size for f in funcs}
+        warm_pools = {f.function_name: f.autoscaler_settings.min_containers for f in funcs}
         assert warm_pools == {"XYZ.*": 5}
 
 

--- a/test/container_buffer_test.py
+++ b/test/container_buffer_test.py
@@ -5,7 +5,7 @@ app = App(include_source=True)  # TODO: remove include_source=True when automoun
 
 
 @app.function(
-    _experimental_buffer_containers=10,
+    buffer_containers=10,
 )
 def f1():
     pass
@@ -15,4 +15,5 @@ def test_fn_container_buffer(servicer, client):
     with app.run(client=client):
         assert len(servicer.app_functions) == 1
         fn1 = servicer.app_functions["fu-1"]  # f1
-        assert fn1._experimental_buffer_containers == 10
+        # Test forward / backward compatibility
+        assert fn1._experimental_buffer_containers == fn1.autoscaler_settings.buffer_containers == 10

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -2273,10 +2273,10 @@ def test_no_warn_on_remote_local_volume_mount(client, servicer, recwarn, set_env
     assert len(recwarn) == 0
 
 
-@pytest.mark.parametrize("concurrency_limit", [1, 2])
-def test_container_io_manager_concurrency_tracking(client, servicer, concurrency_limit):
+@pytest.mark.parametrize("concurrency", [1, 2])
+def test_container_io_manager_concurrency_tracking(client, servicer, concurrency):
     dummy_container_args = api_pb2.ContainerArguments(
-        function_id="fu-123", function_def=api_pb2.Function(target_concurrent_inputs=concurrency_limit)
+        function_id="fu-123", function_def=api_pb2.Function(target_concurrent_inputs=concurrency)
     )
     from modal._utils.async_utils import synchronizer
 
@@ -2305,7 +2305,7 @@ def test_container_io_manager_concurrency_tracking(client, servicer, concurrency
         active_input_ids |= set(io_context.input_ids)
         processed_inputs += len(io_context.input_ids)
 
-        while active_inputs and (len(active_inputs) == concurrency_limit or processed_inputs == total_inputs):
+        while active_inputs and (len(active_inputs) == concurrency or processed_inputs == total_inputs):
             input_to_process = active_inputs.pop(0)
             send_failure = processed_inputs % 2 == 1
             # return values for inputs

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -263,10 +263,10 @@ def test_function_disk_request(client):
     app.function(ephemeral_disk=1_000_000)(dummy)
 
 
-def test_idle_timeout_must_be_positive():
+def test_scaledown_window_must_be_positive():
     app = App()
     with pytest.raises(InvalidError, match="must be > 0"):
-        app.function(container_idle_timeout=0)(dummy)
+        app.function(scaledown_window=0)(dummy)
 
 
 def later():
@@ -796,9 +796,9 @@ def test_autoscaler_settings(client, servicer):
     app = App()
 
     kwargs: dict[str, typing.Any] = dict(  # No idea why we need that type hint
-        keep_warm=2,
-        concurrency_limit=10,
-        container_idle_timeout=60,
+        min_containers=2,
+        max_containers=10,
+        scaledown_window=60,
     )
     f = app.function(**kwargs)(dummy)
 
@@ -806,9 +806,9 @@ def test_autoscaler_settings(client, servicer):
         defn = servicer.app_functions[f.object_id]
         # Test both backwards and forwards compatibility
         settings = defn.autoscaler_settings
-        assert settings.min_containers == defn.warm_pool_size == kwargs["keep_warm"]
-        assert settings.max_containers == defn.concurrency_limit == kwargs["concurrency_limit"]
-        assert settings.scaledown_window == defn.task_idle_timeout_secs == kwargs["container_idle_timeout"]
+        assert settings.min_containers == defn.warm_pool_size == kwargs["min_containers"]
+        assert settings.max_containers == defn.concurrency_limit == kwargs["max_containers"]
+        assert settings.scaledown_window == defn.task_idle_timeout_secs == kwargs["scaledown_window"]
 
 
 def test_not_hydrated():

--- a/test/supports/functions.py
+++ b/test/supports/functions.py
@@ -243,7 +243,7 @@ def fastapi_app_with_lifespan_failing_shutdown():
 lifespan_global_asgi_app_cls: list[str] = []
 
 
-@app.cls(container_idle_timeout=300, concurrency_limit=1, allow_concurrent_inputs=100)
+@app.cls(scaledown_window=300, max_containers=1, allow_concurrent_inputs=100)
 class fastapi_class_multiple_asgi_apps_lifespans:
     def __init__(self):
         assert len(lifespan_global_asgi_app_cls) == 0
@@ -294,7 +294,7 @@ class fastapi_class_multiple_asgi_apps_lifespans:
 lifespan_global_asgi_app_cls_fail: list[str] = []
 
 
-@app.cls(container_idle_timeout=300, concurrency_limit=1, allow_concurrent_inputs=100)
+@app.cls(scaledown_window=300, max_containers=1, allow_concurrent_inputs=100)
 class fastapi_class_lifespan_shutdown_failure:
     def __init__(self):
         assert len(lifespan_global_asgi_app_cls_fail) == 0


### PR DESCRIPTION
## Describe your changes

Introduces the new autoscaler parameters and adds a deprecation warning on usage of the old names (currently `pending=True` so that we can update docs and integration tests).

- Part of CLI-31
 
## Changelog

- We're renaming several `App.function` and `App.cls` parameters that configure the behavior of Modal's autoscaler:
    - `concurrency_limit` is now `max_containers`
    - `keep_warm` is now `min_containers`
    - `container_idle_timeout` is now `scaledown_window`
- The old names will continue to work, but using them will issue a deprecation warning. The aim of the renaming is to reduce some persistent confusion about what these parameters mean. Code updates should require only a simple substitution of the new name.
- We're adding a new parameter, `buffer_containers` (previously available as `_experimental_buffer_containers`). When your Function is actively handling inputs, the autoscaler will spin up additional `buffer_containers` so that subsequent inputs will not be blocked on cold starts. When the Function is idle, it will still scale down to the value given by `min_containers`.