### PR TITLE
Add a timeout to `_lookup_workspace`

### DIFF
--- a/modal/cli/profile.py
+++ b/modal/cli/profile.py
@@ -46,6 +46,8 @@ async def list_(json: Optional[bool] = False):
         active = profile == _profile
         if isinstance(resp, AuthError):
             workspace = "Unknown (authentication failure)"
+        elif isinstance(resp, TimeoutError):
+            workspace = "Unknown (timed out)"
         elif isinstance(resp, Exception):
             # Catch-all for other exceptions, like incorrect server url
             workspace = "Unknown (profile misconfigured)"

--- a/modal/config.py
+++ b/modal/config.py
@@ -133,7 +133,7 @@ async def _lookup_workspace(server_url: str, token_id: str, token_secret: str) -
 
     credentials = (token_id, token_secret)
     async with _Client(server_url, api_pb2.CLIENT_TYPE_CLIENT, credentials) as client:
-        return await client.stub.WorkspaceNameLookup(Empty())
+        return await client.stub.WorkspaceNameLookup(Empty(), timeout=3)
 
 
 def config_profiles():


### PR DESCRIPTION
Useful for internal development when a local server isn't running.