### PR TITLE
Quick fix for accidentally *fixing* @build deps

### DIFF
--- a/modal/_runtime/user_code_imports.py
+++ b/modal/_runtime/user_code_imports.py
@@ -264,7 +264,9 @@ def import_single_function_service(
                 # The cls decorator is in global scope
                 _cls = synchronizer._translate_in(cls)
                 user_defined_callable = _cls._callables[fun_name]
-                service_deps = _cls._get_class_service_function().deps(only_explicit_mounts=True)
+                # Intentionally not including these, since @build functions don't actually
+                # forward the information from their parent class.
+                # service_deps = _cls._get_class_service_function().deps(only_explicit_mounts=True)
                 active_app = _cls._app
             else:
                 # This is non-decorated class


### PR DESCRIPTION
In version v0.73.55 we accidentally fixed one half of a bug that previously would not add dependency objects to @build methods of classes.

Fixing the other half of the bug, which is that the dependencies are not included in the app layout as provided by the workers seems a bit more involved, so for now this just makes the two dependency lists consistent (but still incorrect, causing image.imports to not work properly in @build functions)

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
