### PR TITLE
Add `ignore_cache` config field

### DIFF
--- a/modal/config.py
+++ b/modal/config.py
@@ -218,7 +218,7 @@ _SETTINGS = {
     "worker_id": _Setting(),  # For internal debugging use.
     "restore_state_path": _Setting("/__modal/restore-state.json"),
     "force_build": _Setting(False, transform=_to_boolean),
-    "ignore_image_cache": _Setting(False, transform=_to_boolean),
+    "ignore_cache": _Setting(False, transform=_to_boolean),
     "traceback": _Setting(False, transform=_to_boolean),
     "image_builder_version": _Setting(),
     "strict_parameters": _Setting(False, transform=_to_boolean),  # For internal/experimental use

--- a/modal/config.py
+++ b/modal/config.py
@@ -218,6 +218,7 @@ _SETTINGS = {
     "worker_id": _Setting(),  # For internal debugging use.
     "restore_state_path": _Setting("/__modal/restore-state.json"),
     "force_build": _Setting(False, transform=_to_boolean),
+    "ignore_image_cache": _Setting(False, transform=_to_boolean),
     "traceback": _Setting(False, transform=_to_boolean),
     "image_builder_version": _Setting(),
     "strict_parameters": _Setting(False, transform=_to_boolean),  # For internal/experimental use

--- a/modal/config.py
+++ b/modal/config.py
@@ -60,6 +60,13 @@ Other possible configuration options are:
   When set, ignores the Image cache and builds all Image layers. Note that this
   will break the cache for all images based on the rebuilt layers, so other images
   may rebuild on subsequent runs / deploys even if the config is reverted.
+* `ignore_cache` (in the .toml file) / `MODAL_IGNORE_CACHE` (as an env var).
+  Defaults to False.
+  When set, ignores the Image cache and builds all Image layers. Unlike `force_build`,
+  this will not overwrite the cache for other images that have the same recipe.
+  Subsequent runs that do not use this option will pull the *previous* Image from
+  the cache, if one exists. It can be useful for testing an App's robustness to
+  Image rebuilds without clobbering Images used by other Apps.
 * `traceback` (in the .toml file) / `MODAL_TRACEBACK` (as an env var).
   Defaults to False. Enables printing full tracebacks on unexpected CLI
   errors, which can be useful for debugging client issues.

--- a/modal/image.py
+++ b/modal/image.py
@@ -622,6 +622,7 @@ class _Image(_Object, type_prefix="im"):
                 # Failsafe mechanism to prevent inadvertant updates to the global images.
                 # Only admins can publish to the global namespace, but they have to additionally request it.
                 allow_global_deployment=os.environ.get("MODAL_IMAGE_ALLOW_GLOBAL_DEPLOYMENT", "0") == "1",
+                ignore_cache=config.get("ignore_image_cache"),
             )
             resp = await retry_transient_errors(resolver.client.stub.ImageGetOrCreate, req)
             image_id = resp.image_id

--- a/modal/image.py
+++ b/modal/image.py
@@ -622,7 +622,7 @@ class _Image(_Object, type_prefix="im"):
                 # Failsafe mechanism to prevent inadvertant updates to the global images.
                 # Only admins can publish to the global namespace, but they have to additionally request it.
                 allow_global_deployment=os.environ.get("MODAL_IMAGE_ALLOW_GLOBAL_DEPLOYMENT", "0") == "1",
-                ignore_cache=config.get("ignore_image_cache"),
+                ignore_cache=config.get("ignore_cache"),
             )
             resp = await retry_transient_errors(resolver.client.stub.ImageGetOrCreate, req)
             image_id = resp.image_id


### PR DESCRIPTION
## Describe your changes

Adds a new field to the config, `ignore_cache`. This will be included in the `ImageGetOrCreateRequest`. It will effectively ignore the Image cache (in practice, it will include the App ID and version in the cache key, although the backend implementation could change). This can be useful for testing whether Apps can run when rebuilding an Image from top-to-bottom without then forcing other Apps that depend on the same base layer(s) to rebuild.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Adds a new config field, `ignore_cache` (also accessible via environment variables as `MODAL_IGNORE_CACHE=1`), which will force Images used by the App to rebuild but not clobber any existing cached Images. This can be useful for testing an App's robustness to Image rebuilds without affecting other Apps that depend on the same base Image layer(s).