### PR TITLE
Draft/RFC: prep payload serialization code

### DIFF
--- a/modal/_serialization.py
+++ b/modal/_serialization.py
@@ -441,11 +441,11 @@ def serialize_proto_params(python_params: dict[str, Any], schema: typing.Sequenc
 def _python_to_proto_value(python_value: Any) -> api_pb2.ClassParameterValue:
     proto_type = PYTHON_TO_PROTO_TYPE[type(python_value)]
     proto_type_info = PROTO_TYPE_INFO[proto_type]
-    proto_dto = proto_type_info.encoder(python_value)
+    proto_scalar = proto_type_info.encoder(python_value)
     return api_pb2.ClassParameterValue(
         name="",  # this field is unused for payloads and exists for legacy reasons/code reuse with class params
         type=proto_type,
-        **{proto_type_info.proto_field: proto_dto},
+        **{proto_type_info.proto_field: proto_scalar},
     )
 
 

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Optional, TypeVar, Union
 from google.protobuf.message import Message
 from grpclib import GRPCError, Status
 
-from modal._utils.function_utils import CLASS_PARAM_TYPE_MAP, FunctionInfo
+from modal._utils.function_utils import SUPPORTED_CLASS_PARAM_TYPES, FunctionInfo
 from modal_proto import api_pb2
 
 from ._functions import _Function, _parse_retries
@@ -444,9 +444,9 @@ class _Cls(_Object, type_prefix="cs"):
 
         annotated_params = {k: t for k, t in annotations.items() if k in params}
         for k, t in annotated_params.items():
-            if t not in CLASS_PARAM_TYPE_MAP:
+            if t not in SUPPORTED_CLASS_PARAM_TYPES:
                 t_name = getattr(t, "__name__", repr(t))
-                supported = ", ".join(t.__name__ for t in CLASS_PARAM_TYPE_MAP.keys())
+                supported = ", ".join(t.__name__ for t in SUPPORTED_CLASS_PARAM_TYPES)
                 raise InvalidError(
                     f"{user_cls.__name__}.{k}: {t_name} is not a supported parameter type. Use one of: {supported}"
                 )

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -680,17 +680,28 @@ message ClassParameterInfo {
   enum ParameterSerializationFormat {
     PARAM_SERIALIZATION_FORMAT_UNSPECIFIED = 0;
     PARAM_SERIALIZATION_FORMAT_PICKLE = 1; // legacy format - pickle of (args, kwargs) tuple
-    PARAM_SERIALIZATION_FORMAT_PROTO = 2; // new format using api.FunctionParameterSet
+    PARAM_SERIALIZATION_FORMAT_PROTO = 2; // new format using api.ClassParameterSet
   }
   ParameterSerializationFormat format = 1;
   repeated ClassParameterSpec schema = 2; // only set for PARAM_SERIALIZATION_FORMAT_PROTO
+}
+
+
+message ParameterArgKwargs {
+  // do not use args for class parameters (can still be used in function calls)
+  // (pack everything in kwargs so its consistent regardless of construction syntax)
+  PayloadListValue args = 1;
+  PayloadDictValue kwargs = 2;
 }
 
 message ClassParameterSet {
   // NOTE: adding additional *fields* here can invalidate function lookups
   //  since we use the serialized message as the bound function identifier
   //  for parameter-bound classes. Modify with *caution*
-  repeated ClassParameterValue parameters = 1;
+  oneof parameters_oneof {
+    repeated ClassParameterValue parameters = 1; // legacy mode
+    ParameterArgKwargs arg_kwargs = 2;
+  }
 }
 
 message ClassParameterSpec {
@@ -704,11 +715,11 @@ message ClassParameterSpec {
   }
 }
 
-message ClassParameterValue {
+message ClassParameterValue { // TODO: rename to PayloadValue
   // NOTE: adding additional *fields* here can invalidate function lookups
   //  since we use the serialized message as the bound function identifier
   //  for parameter-bound classes. Modify with *caution*
-  string name = 1;
+  optional string name = 1;  // deprecated
   ParameterType type = 2;
   oneof value_oneof {
     string string_value = 3;
@@ -716,6 +727,20 @@ message ClassParameterValue {
     bytes pickle_value = 5;
   }
 }
+
+message PayloadListValue {
+  repeated ClassParameterValue values = 1;
+}
+
+message PayloadDictEntry {
+  string name = 1;
+  ClassParameterValue value = 2;
+}
+
+message PayloadDictValue {
+  repeated PayloadDictEntry entries = 1;
+}
+
 
 message ClientHelloResponse {
   string warning = 1;

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -686,10 +686,8 @@ message ClassParameterInfo {
   repeated ClassParameterSpec schema = 2; // only set for PARAM_SERIALIZATION_FORMAT_PROTO
 }
 
-
-message ParameterArgKwargs {
-  // do not use args for class parameters (can still be used in function calls)
-  // (pack everything in kwargs so its consistent regardless of construction syntax)
+message Payload {
+  // this can be used
   PayloadListValue args = 1;
   PayloadDictValue kwargs = 2;
 }
@@ -698,10 +696,8 @@ message ClassParameterSet {
   // NOTE: adding additional *fields* here can invalidate function lookups
   //  since we use the serialized message as the bound function identifier
   //  for parameter-bound classes. Modify with *caution*
-  oneof parameters_oneof {
-    repeated ClassParameterValue parameters = 1; // legacy mode
-    ParameterArgKwargs arg_kwargs = 2;
-  }
+  repeated ClassParameterValue parameters = 1;
+  // PayloadDictValue kwargs = 2; // could supersede parameters at some point, so we can remove ClassParameterValue.name
 }
 
 message ClassParameterSpec {
@@ -719,7 +715,7 @@ message ClassParameterValue { // TODO: rename to PayloadValue
   // NOTE: adding additional *fields* here can invalidate function lookups
   //  since we use the serialized message as the bound function identifier
   //  for parameter-bound classes. Modify with *caution*
-  optional string name = 1;  // deprecated
+  optional string name = 1; // TODO: deprecate this eventually once all classes use a PayloadDictValue instead
   ParameterType type = 2;
   oneof value_oneof {
     string string_value = 3;

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -171,6 +171,8 @@ enum ParameterType {
   PARAM_TYPE_STRING = 1;
   PARAM_TYPE_INT = 2;
   PARAM_TYPE_PICKLE = 3;
+  PARAM_TYPE_LIST = 4;
+  PARAM_TYPE_DICT = 5;
 }
 
 enum ProgressType {
@@ -721,6 +723,8 @@ message ClassParameterValue { // TODO: rename to PayloadValue
     string string_value = 3;
     int64 int_value = 4;
     bytes pickle_value = 5;
+    PayloadListValue list_value = 6;
+    PayloadDictValue dict_value = 7;
   }
 }
 


### PR DESCRIPTION
Introduces a new form of payload serialization based on a proto structure (inspired by the Modal hackathon format), which could replace the current `pickle((args, kwargs))`.

Rough goals of this:
* Incorporate some of the structural proto changes/extensions needed for "container types" like lists and dicts
* Allow for optional separation of _serialization/deserialization_ and _validation_ logic, as opposed to the current class parameter serialization which entangles these concepts (class parameters *require* strict schemas via type annotations at the moment)
* Refactor code to reuse as much as possible between the "payload" and "parameter" serialization paths. In the future, we could migrate the current class parameter serialization format to this new payload format instead, but such a migration would have some forward/backward compatibility considerations since it would be a change to the serialized bytes etc.


As this PR stands, it shouldn't have any effect on actual live apps, but if we feel this is a good approach a next step would be to add support for *decoding* of these payload types into the actual client such that any functions deployed with this would be callable using proto payloads.

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
