### PR TITLE
Exit with a non-zero exit code if we have unrecoverable errors

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -593,12 +593,14 @@ if __name__ == "__main__":
     # The only caveat is a bunch of calls will now cross threads, which adds a bit of overhead?
     client = Client.from_env()
 
+    exited_successfully = True
     try:
         with proxy_tunnel(container_args.proxy_info):
             try:
                 main(container_args, client)
             except UserException:
                 logger.info("User exception caught, exiting")
+                exited_successfully = False
     except KeyboardInterrupt:
         logger.debug("Container: interrupted")
 
@@ -619,3 +621,9 @@ if __name__ == "__main__":
         )
 
     logger.debug("Container: done")
+
+    # At this point, we've already logged that the container hit an error,
+    # but we need to exit with a non-zero exit code so the worker knows about
+    # the failure.
+    if not exited_successfully:
+        exit(1)


### PR DESCRIPTION

## Describe your changes

This commit propagates non-zero exit codes upwards so the runner of this code knows that the container did not exit successfully.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>
