### PR TITLE
Add `modal.FunctionCall.gather` to replace `modal.functions.gather`

### DIFF
--- a/test/function_test.py
+++ b/test/function_test.py
@@ -14,7 +14,7 @@ from modal import App, Image, NetworkFileSystem, Proxy, asgi_app, batched, web_e
 from modal._utils.async_utils import synchronize_api
 from modal._vendor import cloudpickle
 from modal.exception import DeprecationError, ExecutionError, InvalidError
-from modal.functions import Function, FunctionCall, gather
+from modal.functions import Function, FunctionCall
 from modal.runner import deploy_app
 from modal_proto import api_pb2
 from test.helpers import deploy_app_externally
@@ -431,7 +431,7 @@ def test_sync_parallelism(client, servicer):
     with app.run(client=client):
         t0 = time.time()
         # NOTE tests breaks in macOS CI if the smaller time is smaller than ~300ms
-        res = gather(slo1_modal.spawn(0.31), slo1_modal.spawn(0.3))
+        res = FunctionCall.gather(slo1_modal.spawn(0.31), slo1_modal.spawn(0.3))
         t1 = time.time()
         assert res == [0.31, 0.3]  # results should be ordered as inputs, not by completion time
         assert t1 - t0 < 0.6  # less than the combined runtime, make sure they run in parallel

--- a/test/supports/type_assertions.py
+++ b/test/supports/type_assertions.py
@@ -22,7 +22,7 @@ def other_func() -> str:
 ret = typed_func.remote(a="hello")
 assert_type(ret, float)
 
-ret2 = modal.functions.gather(typed_func.spawn("bar"), other_func.spawn())
+ret2 = modal.FunctionCall.gather(typed_func.spawn("bar"), other_func.spawn())
 # This assertion doesn't work in mypy (it infers the more generic list[object]), but does work in pyright/vscode:
 # assert_type(ret2, typing.List[typing.Union[float, str]])
 mypy_compatible_ret: typing.Sequence[object] = ret2  # mypy infers to the broader "object" type instead


### PR DESCRIPTION
## Describe your changes

Moving `gather` to be a staticmethod on `modal.FunctionCall` makes it more discoverable and clarifies its purpose. Because we now import `modal.FunctionCall` into the top-level namespace, we no longer need to recommend using names directly from `modal.functions`, which helps enforce a clearer separation between public / private API.

- Closes CLI-334

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- We've moved the `modal.functions.gather` function to be a staticmethod on `modal.FunctionCall.gather`. The former spelling has been deprecated and will be removed in a future version.