### PR TITLE
Eliminate some unnecessary nesting in the reference docs

### DIFF
--- a/modal_docs/gen_reference_docs.py
+++ b/modal_docs/gen_reference_docs.py
@@ -76,20 +76,14 @@ def run(output_dir: str = None):
 
     base_title_level = "#"
     forced_module_docs = [
-        ("modal.Function", "modal.functions"),
-        ("modal.Secret", "modal.secret"),
-        ("modal.Dict", "modal.dict"),
-        ("modal.Queue", "modal.queue"),
         ("modal.call_graph", "modal.call_graph"),
         ("modal.gpu", "modal.gpu"),
         ("modal.runner", "modal.runner"),
-        ("modal.Sandbox", "modal.sandbox"),
-        ("modal.ContainerProcess", "modal.container_process"),
         ("modal.io_streams", "modal.io_streams"),
         ("modal.FileIO", "modal.file_io"),
     ]
     # These aren't defined in `modal`, but should still be documented as top-level entries.
-    forced_members = {"web_endpoint", "asgi_app", "method", "wsgi_app", "forward"}
+    forced_members: set[str] = set()
     # These are excluded from the sidebar, typically to 'soft release' some documentation.
     sidebar_excluded: set[str] = set()
 


### PR DESCRIPTION
Now that we're pulling `FunctionCall` up to the top-level namespace, we should also include it in the sidebar of the reference docs rather than hiding it on the page that you get to if you click `modal.Function`.

While looking into this, I noticed that a few other objects were the only public object defined in their module, but we were for some reason configuring their reference to represent the module. This doesn't seem necessary; I removed it so that the references docs are more consistently formatted across types.

e.g., before:

<img width="1078" alt="image" src="https://github.com/user-attachments/assets/6aa23a2d-662c-4cc6-afda-534913b881ff" />

and after:

<img width="1082" alt="image" src="https://github.com/user-attachments/assets/d92186a4-d122-4d41-b613-c54c7c28cfe2" />

Also, hey buddy 👋 

<img width="313" alt="image" src="https://github.com/user-attachments/assets/3ff7d5f9-2d7e-415a-abfb-1f0f4ffe907c" />
