### PR TITLE
Fix docs for objects defined in submodules

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -520,8 +520,10 @@ class _Sandbox(_Object, type_prefix="sb"):
         # Internal option to set terminal size and metadata
         _pty_info: Optional[api_pb2.PTYInfo] = None,
     ):
-        """Execute a command in the Sandbox and return
-        a [`ContainerProcess`](/docs/reference/modal.ContainerProcess#modalcontainer_process) handle.
+        """Execute a command in the Sandbox and return a ContainerProcess handle.
+
+        See the [`ContainerProcess`](/docs/reference/modal.container_process#modalcontainer_processcontainerprocess)
+        docs for more information.
 
         **Usage**
 
@@ -623,8 +625,9 @@ class _Sandbox(_Object, type_prefix="sb"):
         path: str,
         mode: Union["_typeshed.OpenTextMode", "_typeshed.OpenBinaryMode"] = "r",
     ):
-        """Open a file in the Sandbox and return
-        a [`FileIO`](/docs/reference/modal.FileIO#modalfile_io) handle.
+        """Open a file in the Sandbox and return a FileIO handle.
+
+        See the [`FileIO`](/docs/reference/modal.file_io#modalfile_iofileio) docs for more information.
 
         **Usage**
 

--- a/modal_docs/gen_reference_docs.py
+++ b/modal_docs/gen_reference_docs.py
@@ -77,10 +77,11 @@ def run(output_dir: str = None):
     base_title_level = "#"
     forced_module_docs = [
         ("modal.call_graph", "modal.call_graph"),
+        ("modal.container_process", "modal.container_process"),
         ("modal.gpu", "modal.gpu"),
         ("modal.runner", "modal.runner"),
         ("modal.io_streams", "modal.io_streams"),
-        ("modal.FileIO", "modal.file_io"),
+        ("modal.file_io", "modal.file_io"),
     ]
     # These aren't defined in `modal`, but should still be documented as top-level entries.
     forced_members: set[str] = set()


### PR DESCRIPTION
Follow-up to #2899; a couple of objects were documented as if they are in the top-level namespace, but they aren't.