### PR TITLE
Make @app.cls decorator produce a Cls instead of a user type for static typing

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -36,7 +36,7 @@ from ._utils.mount_utils import validate_volumes
 from ._utils.name_utils import check_object_name
 from .client import _Client
 from .cloud_bucket_mount import _CloudBucketMount
-from .cls import _Cls, parameter
+from .cls import _Cls
 from .config import logger
 from .exception import ExecutionError, InvalidError
 from .functions import Function
@@ -773,7 +773,6 @@ class _App:
 
         return wrapped
 
-    @typing_extensions.dataclass_transform(field_specifiers=(parameter,), kw_only_default=True)
     def cls(
         self,
         _warn_parentheses_missing: Optional[bool] = None,

--- a/modal/app.py
+++ b/modal/app.py
@@ -55,6 +55,9 @@ from .volume import _Volume
 
 _default_image: _Image = _Image.debian_slim()
 
+if typing.TYPE_CHECKING:
+    import modal.cls
+
 
 class _LocalEntrypoint:
     _info: FunctionInfo
@@ -91,7 +94,7 @@ def check_sequence(items: typing.Sequence[typing.Any], item_type: type[typing.An
         raise InvalidError(error_msg)
 
 
-CLS_T = typing.TypeVar("CLS_T", bound=type[Any])
+CLS_T = typing.TypeVar("CLS_T")
 
 
 P = typing_extensions.ParamSpec("P")
@@ -820,7 +823,7 @@ class _App:
         _experimental_proxy_ip: Optional[str] = None,  # IP address of proxy
         _experimental_custom_scaling_factor: Optional[float] = None,  # Custom scaling factor
         _experimental_enable_gpu_snapshot: bool = False,  # Experimentally enable GPU memory snapshots.
-    ) -> Callable[[CLS_T], CLS_T]:
+    ) -> Callable[[typing.Type[CLS_T]], "modal.cls._Cls[CLS_T]"]:
         """
         Decorator to register a new Modal [Cls](/docs/reference/modal.Cls) with this App.
         """

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -343,8 +343,10 @@ class _Obj:
 
 Obj = synchronize_api(_Obj)
 
+UserCls = typing.TypeVar("UserCls")
 
-class _Cls(_Object, type_prefix="cs"):
+
+class _Cls(typing.Generic[UserCls], _Object, type_prefix="cs"):
     """
     Cls adds method pooling and [lifecycle hook](/docs/guide/lifecycle-functions) behavior
     to [modal.Function](/docs/reference/modal.Function).
@@ -452,7 +454,9 @@ class _Cls(_Object, type_prefix="cs"):
                 )
 
     @staticmethod
-    def from_local(user_cls, app: "modal.app._App", class_service_function: _Function) -> "_Cls":
+    def from_local(
+        user_cls: typing.Type[UserCls], app: "modal.app._App", class_service_function: _Function
+    ) -> "_Cls[UserCls]":
         """mdmd:hidden"""
         # validate signature
         _Cls.validate_construction_mechanism(user_cls)
@@ -652,7 +656,7 @@ class _Cls(_Object, type_prefix="cs"):
         return obj
 
     @synchronizer.no_input_translation
-    def __call__(self, *args, **kwargs) -> _Obj:
+    def __call__(self, *args, **kwargs) -> UserCls:
         """This acts as the class constructor."""
         return _Obj(
             self,

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -503,13 +503,13 @@ class _Cls(typing.Generic[UserCls], _Object, type_prefix="cs"):
     @classmethod
     @renamed_parameter((2024, 12, 18), "tag", "name")
     def from_name(
-        cls: type["_Cls"],
+        cls,
         app_name: str,
         name: str,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
         workspace: Optional[str] = None,
-    ) -> "_Cls":
+    ) -> "_Cls[Any]":
         """Reference a Cls from a deployed App by its name.
 
         In contrast to `modal.Cls.lookup`, this is a lazy method
@@ -560,7 +560,7 @@ class _Cls(typing.Generic[UserCls], _Object, type_prefix="cs"):
         return cls
 
     def with_options(
-        self: "_Cls",
+        self,
         cpu: Optional[Union[float, tuple[float, float]]] = None,
         memory: Optional[Union[int, tuple[int, int]]] = None,
         gpu: GPU_T = None,
@@ -571,7 +571,7 @@ class _Cls(typing.Generic[UserCls], _Object, type_prefix="cs"):
         concurrency_limit: Optional[int] = None,
         allow_concurrent_inputs: Optional[int] = None,
         container_idle_timeout: Optional[int] = None,
-    ) -> "_Cls":
+    ) -> "_Cls[UserCls]":
         """
         **Beta:** Allows for the runtime modification of a modal.Cls's configuration.
 
@@ -626,7 +626,7 @@ class _Cls(typing.Generic[UserCls], _Object, type_prefix="cs"):
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         workspace: Optional[str] = None,
-    ) -> "_Cls":
+    ) -> "_Cls[Any]":
         """Lookup a Cls from a deployed App by its name.
 
         DEPRECATED: This method is deprecated in favor of `modal.Cls.from_name`.

--- a/test/supports/type_assertions.py
+++ b/test/supports/type_assertions.py
@@ -37,14 +37,13 @@ async def async_typed_func(b: bool) -> str:
     return ""
 
 
-async_typed_func
-
 should_be_str = async_typed_func.remote(False)  # should be blocking without aio
 assert_type(should_be_str, str)
 
 
-@app.cls()
-class Cls:
+class OriginalCls:
+    p: int = modal.parameter()
+
     @method()
     def foo(self, a: str) -> int:
         return 1
@@ -54,7 +53,12 @@ class Cls:
         return 1
 
 
-instance = Cls()
+MyCls = app.cls()(OriginalCls)  # simulate decorator
+
+MyCls.with_options()
+
+instance = MyCls(p=10)
+
 should_be_int = instance.foo.remote("foo")
 assert_type(should_be_int, int)
 

--- a/test/supports/user_code_import_samples/cls.py
+++ b/test/supports/user_code_import_samples/cls.py
@@ -21,4 +21,4 @@ class C:
 
 UndecoratedC = C  # keep a reference to original class before overwriting
 
-C = app.cls()(C)  # type: ignore[misc]   # "decorator" of C
+C = app.cls()(C)  # type: ignore[misc,assignment]   # Cls[C] gets replaced by user type type[C]


### PR DESCRIPTION
`@app.cls()` now produces a `modal.Cls[USER_TYPE]` instead of the user's type.
When the Cls is then "instantiated" (called) it produces an instance of the user's type

Basically this will make:

`MyClass.my_method` - invalid!
`MyClass().my_method` - still valid!
`MyClass.with_options()` - used to be unknown, now valid!

This only modifies static types, so functionality should be unchanged.

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
