### PR TITLE
Deprecate workspace from Cls.from_name and Cls.lookup

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -504,7 +504,7 @@ class _Cls(_Object, type_prefix="cs"):
         name: str,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
-        workspace: Optional[str] = None,
+        workspace: Optional[str] = None,  # Deprecated and unused
     ) -> "_Cls":
         """Reference a Cls from a deployed App by its name.
 
@@ -518,6 +518,11 @@ class _Cls(_Object, type_prefix="cs"):
         """
         _environment_name = environment_name or config.get("environment")
 
+        if workspace is not None:
+            deprecation_warning(
+                (2025, 1, 27), "The `workspace` argument is no longer used and will be removed in a future release."
+            )
+
         async def _load_remote(self: _Cls, resolver: Resolver, existing_object_id: Optional[str]):
             request = api_pb2.ClassGetRequest(
                 app_name=app_name,
@@ -525,7 +530,6 @@ class _Cls(_Object, type_prefix="cs"):
                 namespace=namespace,
                 environment_name=_environment_name,
                 lookup_published=workspace is not None,
-                workspace_name=workspace,
                 only_class_function=True,
             )
             try:
@@ -621,7 +625,7 @@ class _Cls(_Object, type_prefix="cs"):
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
-        workspace: Optional[str] = None,
+        workspace: Optional[str] = None,  # Deprecated and unused
     ) -> "_Cls":
         """Lookup a Cls from a deployed App by its name.
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -652,7 +652,7 @@ message ClassGetRequest {
   string environment_name = 4;
 
   bool lookup_published = 8; // Lookup class on app published by another workspace
-  string workspace_name = 9;
+  reserved 9; // workspace_name
   bool only_class_function = 10; // True starting with 0.67.x clients, which don't create method placeholder functions
 }
 


### PR DESCRIPTION
## Describe your changes

This parameter is leftover from when you used to be able deploy / lookup classes to the global namepsace. The field on the proto is no longer read in the server.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Adds a deprecation warning to the `workspace` parameter in `modal.Cls` lookup methods. This argument is unused and will be removed in the future.