### PR TITLE
Allow Cls.with_options to lazily hydrate self and dependencies

### DIFF
--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -144,8 +144,13 @@ def test_class_with_options(client, servicer):
         assert options.retry_policy.retries == 5
 
 
-def test_class_with_options_need_hydrating(client, servicer):
-    with pytest.raises(ExecutionError, match="hydrate"):
+def test_class_with_options_needs_running_app(servicer):
+    with pytest.raises(ExecutionError, match="hydrate.+not running"):
+        Foo.with_options()  # type: ignore
+
+
+def test_class_with_options_lazy_hydration(servicer, set_env_client):
+    with app.run():
         Foo.with_options()  # type: ignore
 
 


### PR DESCRIPTION
## Describe your changes

Currently `Cls.with_options` has a couple rough edges around lazy hydration:

- The Cls itself must be hydrated, so naively migrating `Cls.lookup(...).with_options(...)` to `Cls.from_name` doesn't work
- Any Volume or Secret objects that are passed are assumed to be hydrated

This change feels slightly hacky, but it appears to make simple examples work!

Fixes CLI-37

## Changelog

- `modal.Cls.with_options` now supports lazy hydration.