### PR TITLE
Postpone volume, secret evaluation + hydration when using with_options

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1015,6 +1015,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         def _deps():
             if options:
                 return [v for _, v in options.validated_volumes] + list(options.secrets)
+            return []
 
         fun: _Function = _Function._from_loader(_load, "Function(parametrized)", hydrate_lazily=True, deps=_deps)
 

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -928,7 +928,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
     def _bind_parameters(
         self,
         obj: "modal.cls._Obj",
-        options: Optional[api_pb2.FunctionOptions],
+        options: Optional["modal.cls._ServiceOptions"],
         args: Sized,
         kwargs: dict[str, Any],
     ) -> "_Function":
@@ -979,10 +979,32 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
 
             environment_name = _get_environment_name(None, resolver)
             assert parent is not None and parent.is_hydrated
+
+            volume_mounts = [
+                api_pb2.VolumeMount(
+                    mount_path=path,
+                    volume_id=volume.object_id,
+                    allow_background_commits=True,
+                )
+                for path, volume in options.validated_volumes
+            ]
+
+            options_pb = api_pb2.FunctionOptions(
+                secret_ids=[s.object_id for s in options.secrets],
+                replace_secret_ids=bool(options.secrets),
+                resources=options.resources,
+                retry_policy=options.retry_policy,
+                concurrency_limit=options.concurrency_limit,
+                timeout_secs=options.timeout_secs,
+                task_idle_timeout_secs=options.task_idle_timeout_secs,
+                replace_volume_mounts=len(volume_mounts) > 0,
+                volume_mounts=volume_mounts,
+                target_concurrent_inputs=options.target_concurrent_inputs,
+            )
             req = api_pb2.FunctionBindParamsRequest(
                 function_id=parent.object_id,
                 serialized_params=serialized_params,
-                function_options=options,
+                function_options=options_pb,
                 environment_name=environment_name
                 or "",  # TODO: investigate shouldn't environment name always be specified here?
             )
@@ -990,7 +1012,11 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
             response = await retry_transient_errors(parent._client.stub.FunctionBindParams, req)
             param_bound_func._hydrate(response.bound_function_id, parent._client, response.handle_metadata)
 
-        fun: _Function = _Function._from_loader(_load, "Function(parametrized)", hydrate_lazily=True)
+        def _deps():
+            if options:
+                return [v for _, v in options.validated_volumes] + list(options.secrets)
+
+        fun: _Function = _Function._from_loader(_load, "Function(parametrized)", hydrate_lazily=True, deps=_deps)
 
         fun._info = self._info
         fun._obj = obj

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -76,8 +76,8 @@ def _get_class_constructor_signature(user_cls: type) -> inspect.Signature:
 @dataclasses.dataclass()
 class _ServiceOptions:
     secrets: typing.Collection[_Secret]
-    resources: api_pb2.Resources
-    retry_policy: api_pb2.FunctionRetryPolicy
+    resources: Optional[api_pb2.Resources]
+    retry_policy: Optional[api_pb2.FunctionRetryPolicy]
     concurrency_limit: Optional[int]
     timeout_secs: Optional[int]
     task_idle_timeout_secs: Optional[int]

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -1,4 +1,5 @@
 # Copyright Modal Labs 2022
+import dataclasses
 import inspect
 import os
 import typing
@@ -70,6 +71,18 @@ def _get_class_constructor_signature(user_cls: type) -> inspect.Signature:
                     constructor_parameters.append(param)
 
         return inspect.Signature(constructor_parameters)
+
+
+@dataclasses.dataclass()
+class _ServiceOptions:
+    secrets: typing.Collection[_Secret]
+    resources: api_pb2.Resources
+    retry_policy: api_pb2.FunctionRetryPolicy
+    concurrency_limit: Optional[int]
+    timeout_secs: Optional[int]
+    task_idle_timeout_secs: Optional[int]
+    validated_volumes: typing.Sequence[tuple[str, _Volume]]
+    target_concurrent_inputs: Optional[int]
 
 
 def _bind_instance_method(cls: "_Cls", service_function: _Function, method_name: str):
@@ -144,12 +157,13 @@ class _Obj:
     _kwargs: dict[str, Any]
 
     _instance_service_function: Optional[_Function] = None  # this gets set lazily
+    _options: Optional[_ServiceOptions]
 
     def __init__(
         self,
         cls: "_Cls",
         user_cls: Optional[type],  # this would be None in case of lookups
-        options: Optional[api_pb2.FunctionOptions],
+        options: Optional[_ServiceOptions],
         args,
         kwargs,
     ):
@@ -354,7 +368,7 @@ class _Cls(_Object, type_prefix="cs"):
     """
 
     _class_service_function: Optional[_Function]  # The _Function (read "service") serving *all* methods of the class
-    _options: Optional[api_pb2.FunctionOptions]
+    _options: Optional[_ServiceOptions]  # TODO: typed dict/dataclass?
 
     _app: Optional["modal.app._App"] = None  # not set for lookups
     _name: Optional[str]
@@ -587,27 +601,15 @@ class _Cls(_Object, type_prefix="cs"):
         else:
             resources = None
 
-        volume_mounts = [
-            api_pb2.VolumeMount(
-                mount_path=path,
-                volume_id=volume.object_id,
-                allow_background_commits=True,
-            )
-            for path, volume in validate_volumes(volumes)
-        ]
-        replace_volume_mounts = len(volume_mounts) > 0
-
         cls = self.clone()
-        cls._options = api_pb2.FunctionOptions(
-            replace_secret_ids=bool(secrets),
-            secret_ids=[secret.object_id for secret in secrets],
+        cls._options = _ServiceOptions(
+            secrets=secrets,
             resources=resources,
             retry_policy=retry_policy,
             concurrency_limit=concurrency_limit,
             timeout_secs=timeout,
             task_idle_timeout_secs=container_idle_timeout,
-            replace_volume_mounts=replace_volume_mounts,
-            volume_mounts=volume_mounts,
+            validated_volumes=validate_volumes(volumes),
             target_concurrent_inputs=allow_concurrent_inputs,
         )
 

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -126,7 +126,7 @@ def test_class_with_options(client, servicer):
     unhydrated_secret = modal.Secret.from_dict({"foo": "bar"})
     with app.run(client=client):
         with servicer.intercept() as ctx:
-            foo = Foo.with_options(
+            foo = Foo.with_options(  # type: ignore
                 cpu=48, retries=5, volumes={"/vol": unhydrated_volume}, secrets=[unhydrated_secret]
             )()
             assert len(ctx.calls) == 0  # no rpcs in with_options


### PR DESCRIPTION
This enables you to pass unhydrated secrets and volumes to `with_options`

This is one of the prerequisites for making with_options fully lazy (the second part is making the `cls.clone()` operation lazily, which is a bit trickier)

Fixes CLI-37

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

* `Cls.with_options()` now accept unhydated volume and secrets