### PR TITLE
Add `.update_autoscaler` methods and deprecate `.keep_warm`

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1097,7 +1097,15 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
             """
                 )
             )
-        # TODO deprecation warn
+
+        deprecation_warning(
+            (2025, 2, 24),
+            "The .keep_warm() method has been deprecated in favor of the more general "
+            ".update_autoscaler(min_containers=...) method.",
+            pending=True,
+            show_source=True,
+        )
+
         await self.update_autoscaler(min_containers=warm_pool_size)
 
     @classmethod

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -231,6 +231,7 @@ class _Obj:
 
     async def update_autoscaler(
         self,
+        *,
         min_containers: Optional[int] = None,
         max_containers: Optional[int] = None,
         scaledown_window: Optional[int] = None,

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -229,6 +229,41 @@ class _Obj:
         user_cls_instance._modal_functions = instance_methods
         return user_cls_instance
 
+    async def update_autoscaler(
+        self,
+        min_containers: Optional[int] = None,
+        max_containers: Optional[int] = None,
+        scaledown_window: Optional[int] = None,
+        buffer_containers: Optional[int] = None,
+    ) -> None:
+        """Override the current autoscaler behavior for this Cls instance.
+
+        Unspecified parameters will retain their current value, i.e. either the static value
+        from the function decorator, or an override value from a previous call to this method.
+
+        Subsequent deployments of the App containing this Cls will reset the autoscaler back to
+        its static configuration.
+
+        Examples:
+
+        ```python notest
+        Model = modal.Cls.from_name("my-app", "Model")
+        model = Model()  # This method is called on an *instance* of the class
+
+        # Always have at least 2 containers running, with an extra buffer when the Function is active
+        model.update_autoscaler(min_containers=2, buffer_containers=1)
+
+        # Limit this Function to avoid consuming all of your workspace's resources
+        model.update_autoscaler(max_containers=5)
+        ```
+        """
+        return await self._cached_service_function().update_autoscaler(
+            min_containers=min_containers,
+            max_containers=max_containers,
+            scaledown_window=scaledown_window,
+            buffer_containers=buffer_containers,
+        )
+
     async def keep_warm(self, warm_pool_size: int) -> None:
         """Set the warm pool size for the class containers
 
@@ -244,7 +279,7 @@ class _Obj:
         Model("fine-tuned-model").keep_warm(2)
         ```
         """
-        await self._cached_service_function().keep_warm(warm_pool_size)
+        await self._cached_service_function().update_autoscaler(min_containers=warm_pool_size)
 
     def _cached_user_cls_instance(self):
         """Get or construct the local object


### PR DESCRIPTION
## Describe your changes

- Follow-on to #2885 
- Part of CLI-31

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

