### PR TITLE
Adds more verbose reprs in a couple of places

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -563,7 +563,7 @@ class _Cls(_Object, type_prefix="cs"):
             await resolver.load(self._class_service_function)
             self._hydrate(response.class_id, resolver.client, response.handle_metadata)
 
-        rep = f"Ref({app_name})"
+        rep = f"Cls.from_name({app_name!r}, {name!r})"
         cls = cls._from_loader(_load_remote, rep, is_another_app=True, hydrate_lazily=True)
 
         class_service_name = f"{name}.*"  # special name of the base service function for the class

--- a/modal/image.py
+++ b/modal/image.py
@@ -941,7 +941,7 @@ class _Image(_Object, type_prefix="im"):
             resp = await retry_transient_errors(client.stub.ImageFromId, api_pb2.ImageFromIdRequest(image_id=image_id))
             self._hydrate(resp.image_id, resolver.client, resp.metadata)
 
-        rep = "Image()"
+        rep = f"Image.from_id({image_id!r})"
         obj = _Image._from_loader(_load, rep)
 
         return obj


### PR DESCRIPTION
Mini cleanup

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>
