### PR TITLE
Add app_id to SandboxInfo protobuf

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2338,6 +2338,7 @@ message SandboxInfo {
   string id = 1;
   double created_at = 3;
   TaskInfo task_info = 4;
+  string app_id = 5;
 
   reserved 2; // modal.client.Sandbox definition
 }


### PR DESCRIPTION
## Describe your changes

Part of PRD-694. After this change, `SandboxGet` and `SandboxList` can return the sandbox's app ID.

---

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

