### PR TITLE
Add runsc_runtime_version to CheckpointInfo proto

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -628,8 +628,8 @@ message CheckpointInfo {
   int64 size = 5;
   bool checksum_is_file_index = 6;
   string original_task_id = 7;
-  // snapshot version used to take the checkpoint
-  uint32 snapshot_version = 8;
+  reserved 8;
+  string runsc_runtime_version = 9;
 }
 
 message ClassCreateRequest {


### PR DESCRIPTION
Required for migrating Function memory snapshots to use the new runtime versioning system.