### PR TITLE
Add `@modal.fastapi_endpoint` to replace `@modal.web_endpoint`

### DIFF
--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -23,7 +23,18 @@ try:
     from .mount import Mount
     from .network_file_system import NetworkFileSystem
     from .output import enable_output
-    from .partial_function import asgi_app, batched, build, enter, exit, method, web_endpoint, web_server, wsgi_app
+    from .partial_function import (
+        asgi_app,
+        batched,
+        build,
+        enter,
+        exit,
+        fastapi_endpoint,
+        method,
+        web_endpoint,
+        web_server,
+        wsgi_app,
+    )
     from .proxy import Proxy
     from .queue import Queue
     from .retries import Retries
@@ -76,6 +87,7 @@ __all__ = [
     "enable_output",
     "enter",
     "exit",
+    "fastapi_endpoint",
     "forward",
     "is_local",
     "interact",

--- a/modal/app.py
+++ b/modal/app.py
@@ -658,13 +658,13 @@ class _App:
                 if is_method_fn(f.raw_f.__qualname__):
                     raise InvalidError(
                         "The `@app.function` decorator cannot be used on class methods. "
-                        "Swap with `@modal.method` or `@modal.web_endpoint`, or drop the `@app.function` decorator. "
+                        "Swap with `@modal.method` or one of the web endpoint decorators. "
                         "Example: "
                         "\n\n"
                         "```python\n"
                         "@app.cls()\n"
                         "class MyClass:\n"
-                        "    @modal.web_endpoint()\n"
+                        "    @modal.method()\n"
                         "    def f(self, x):\n"
                         "        ...\n"
                         "```\n"

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -7,6 +7,7 @@ from ._partial_function import (
     _build,
     _enter,
     _exit,
+    _fastapi_endpoint,
     _method,
     _PartialFunction,
     _web_endpoint,
@@ -19,6 +20,7 @@ from ._partial_function import (
 PartialFunction = synchronize_api(_PartialFunction, target_module=__name__)
 method = synchronize_api(_method, target_module=__name__)
 web_endpoint = synchronize_api(_web_endpoint, target_module=__name__)
+fastapi_endpoint = synchronize_api(_fastapi_endpoint, target_module=__name__)
 asgi_app = synchronize_api(_asgi_app, target_module=__name__)
 wsgi_app = synchronize_api(_wsgi_app, target_module=__name__)
 web_server = synchronize_api(_web_server, target_module=__name__)

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -6,7 +6,7 @@ import time
 
 from grpclib import GRPCError, Status
 
-from modal import App, Image, Mount, Secret, Stub, Volume, enable_output, web_endpoint
+from modal import App, Image, Mount, Secret, Stub, Volume, enable_output, fastapi_endpoint, web_endpoint
 from modal._partial_function import _parse_custom_domains
 from modal._utils.async_utils import synchronizer
 from modal.exception import DeprecationError, ExecutionError, InvalidError, NotFoundError
@@ -173,15 +173,16 @@ async def web2(x):
     return {"cube": x**3}
 
 
-def test_registered_web_endpoints(client, servicer):
+@pytest.mark.parametrize("decorator", [web_endpoint, fastapi_endpoint])
+def test_registered_web_endpoints(client, servicer, decorator):
     app = App()
     app.function()(square)
-    app.function()(web_endpoint()(web1))
-    app.function()(web_endpoint()(web2))
+    app.function()(decorator()(web1))
+    app.function()(decorator()(web2))
 
     @app.cls(serialized=True)
     class Cls:
-        @web_endpoint()
+        @decorator()
         def cls_web_endpoint(self):
             pass
 

--- a/test/decorator_test.py
+++ b/test/decorator_test.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2023
 import pytest
 
-from modal import App, asgi_app, batched, method, web_endpoint, wsgi_app
+from modal import App, asgi_app, batched, fastapi_endpoint, method, web_endpoint, wsgi_app
 from modal.exception import InvalidError
 
 
@@ -80,7 +80,7 @@ def test_web_endpoint_method():
         @app.cls()
         class Container:
             @method()  # type: ignore
-            @web_endpoint()
+            @fastapi_endpoint()
             def generate(self):
                 pass
 

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -10,7 +10,7 @@ from contextlib import contextmanager
 from synchronicity.exceptions import UserCodeException
 
 import modal
-from modal import App, Image, NetworkFileSystem, Proxy, asgi_app, batched, web_endpoint
+from modal import App, Image, NetworkFileSystem, Proxy, asgi_app, batched, fastapi_endpoint
 from modal._utils.async_utils import synchronize_api
 from modal._vendor import cloudpickle
 from modal.exception import DeprecationError, ExecutionError, InvalidError
@@ -591,7 +591,7 @@ def test_local_execution_on_web_endpoint(client, servicer):
     app = App()
 
     @app.function(serialized=True)
-    @web_endpoint()
+    @fastapi_endpoint()
     def foo(x: str):
         return f"{x}!"
 
@@ -638,7 +638,7 @@ def test_invalid_remote_executor_on_web_endpoint(client, servicer, remote_execut
     app = App()
 
     @app.function(serialized=True)
-    @web_endpoint()
+    @fastapi_endpoint()
     def foo():
         pass
 
@@ -746,7 +746,7 @@ def test_allow_cross_region_volumes_webhook(client, servicer):
     vol2 = NetworkFileSystem.from_name("xyz-2", create_if_missing=True)
     # Should pass flag for all the function's NetworkFileSystemMounts
     app.function(network_file_systems={"/sv-1": vol1, "/sv-2": vol2}, allow_cross_region_volumes=True)(
-        web_endpoint()(dummy)
+        fastapi_endpoint()(dummy)
     )
 
     with app.run(client=client):
@@ -763,7 +763,7 @@ def test_serialize_deserialize_function_handle(servicer, client):
     app = App()
 
     @app.function(serialized=True)
-    @web_endpoint()
+    @fastapi_endpoint()
     def my_handle():
         pass
 

--- a/test/function_utils_test.py
+++ b/test/function_utils_test.py
@@ -5,7 +5,7 @@ import time
 
 from grpclib import Status
 
-from modal import method, web_endpoint
+from modal import fastapi_endpoint, method
 from modal._serialization import serialize_data_format
 from modal._utils import async_utils
 from modal._utils.function_utils import (
@@ -100,7 +100,7 @@ class Foo:
     def bar(self):
         return "hello"
 
-    @web_endpoint()
+    @fastapi_endpoint()
     def web(self):
         pass
 

--- a/test/lookup_test.py
+++ b/test/lookup_test.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2023
 import pytest
 
-from modal import App, Function, Volume, web_endpoint
+from modal import App, Function, Volume, fastapi_endpoint, web_endpoint
 from modal.exception import ExecutionError, NotFoundError, ServerWarning
 from modal.runner import deploy_app
 from modal_proto import api_pb2
@@ -46,9 +46,10 @@ def test_lookup_function(servicer, client):
         assert f.local(2, 4) == 20
 
 
-def test_webhook_lookup(servicer, client):
+@pytest.mark.parametrize("decorator", [web_endpoint, fastapi_endpoint])
+def test_webhook_lookup(servicer, client, decorator):
     app = App()
-    app.function()(web_endpoint(method="POST")(square))
+    app.function()(decorator(method="POST")(square))
     deploy_app(app, "my-webhook", client=client)
 
     f = Function.from_name("my-webhook", "square").hydrate(client)

--- a/test/supports/app_run_tests/webhook.py
+++ b/test/supports/app_run_tests/webhook.py
@@ -1,10 +1,10 @@
 # Copyright Modal Labs 2022
-from modal import App, web_endpoint
+from modal import App, fastapi_endpoint
 
 app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 
 @app.function()
-@web_endpoint()
+@fastapi_endpoint()
 def foo():
     return {"bar": "baz"}

--- a/test/supports/functions.py
+++ b/test/supports/functions.py
@@ -15,9 +15,9 @@ from modal import (
     current_input_id,
     enter,
     exit,
+    fastapi_endpoint,
     is_local,
     method,
-    web_endpoint,
     web_server,
     wsgi_app,
 )
@@ -101,7 +101,7 @@ def deprecated_function(x):
 
 
 @app.function()
-@web_endpoint()
+@fastapi_endpoint()
 def webhook(arg="world"):
     return {"hello": arg}
 
@@ -113,7 +113,7 @@ def stream():
 
 
 @app.function()
-@web_endpoint()
+@fastapi_endpoint()
 def webhook_streaming():
     from fastapi.responses import StreamingResponse
 
@@ -127,7 +127,7 @@ async def stream_async():
 
 
 @app.function()
-@web_endpoint()
+@fastapi_endpoint()
 async def webhook_streaming_async():
     from fastapi.responses import StreamingResponse
 

--- a/test/supports/import_and_filter_source.py
+++ b/test/supports/import_and_filter_source.py
@@ -1,5 +1,5 @@
 # Copyright Modal Labs 2025
-from modal import App, asgi_app, method, web_endpoint
+from modal import App, asgi_app, fastapi_endpoint, method
 
 app_with_one_web_function = App(
     include_source=True
@@ -7,7 +7,7 @@ app_with_one_web_function = App(
 
 
 @app_with_one_web_function.function()
-@web_endpoint()
+@fastapi_endpoint()
 def web1():
     pass
 
@@ -23,7 +23,7 @@ def f1():
 
 
 @app_with_one_function_one_web_endpoint.function()
-@web_endpoint()
+@fastapi_endpoint()
 def web2():
     pass
 

--- a/test/supports/multifile_project/main.py
+++ b/test/supports/multifile_project/main.py
@@ -1,6 +1,6 @@
 # Copyright Modal Labs 2024
 import modal
-from modal import enter, method, web_endpoint
+from modal import enter, fastapi_endpoint, method
 
 from . import a, b
 
@@ -15,7 +15,7 @@ def main_function():
 
 
 @app.function()
-@web_endpoint()
+@fastapi_endpoint()
 def web():
     pass
 
@@ -33,6 +33,6 @@ class Cls:
     def method_on_other_app_class(self):
         pass
 
-    @web_endpoint()
+    @fastapi_endpoint()
     def web_endpoint_on_other_app(self):
         pass

--- a/test/supports/serialize_class.py
+++ b/test/supports/serialize_class.py
@@ -2,7 +2,7 @@
 import sys
 
 import modal
-from modal import enter, method, web_endpoint
+from modal import enter, fastapi_endpoint, method
 from modal._serialization import serialize
 
 
@@ -15,7 +15,7 @@ class UserCls:
     def method(self):
         return "a"
 
-    @web_endpoint()
+    @fastapi_endpoint()
     def web_endpoint(self):
         pass
 

--- a/test/supports/sibling_hydration_app.py
+++ b/test/supports/sibling_hydration_app.py
@@ -1,6 +1,6 @@
 # Copyright Modal Labs 2025
 import modal
-from modal import asgi_app, enter, method, web_endpoint
+from modal import asgi_app, enter, fastapi_endpoint, method
 
 app = modal.App()
 
@@ -61,7 +61,7 @@ class NonParamCls:
     def f(self, x):
         return self._k * x
 
-    @web_endpoint()
+    @fastapi_endpoint()
     def web(self, arg):
         return {"ret": arg * self._k}
 

--- a/test/supports/webhook_forgot_function.py
+++ b/test/supports/webhook_forgot_function.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2023
-from modal import web_endpoint
+from modal import fastapi_endpoint
 
 
-@web_endpoint()
+@fastapi_endpoint()
 async def absent_minded_function(x):
     pass


### PR DESCRIPTION
## Describe your changes

Adds `modal.fastapi_endpoint` as an alias for `modal.web_endpoint`. (Actually I just duplicated the code; there was enough fussiness in the error messages that it was simpler to do it that way).

I migrated most tests to use `fastapi_endpoint`, while leaving a few parameterized across both spellings.

These can coexist for a little while as we update the docs etc., before `@modal.web_endpoint` begins issuing deprecation warnings.

We're doing the renaming to make it more obvious that the feature depends on `fastapi` (which must be explicitly installed in the Image as of image builder version 2024.10) and to free up the `web_endpoint` name so that we can potentially introduce a lightweight / dependency-free version of the functionality in the future.

- Part of CLI-339
 
<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Adds `modal.fastapi_endpoint` as an alias for `modal.web_endpoint`. We will be deprecating the `modal.web_endpoint`  _name_ (but not the functionality) as part of the Modal 1.0 release.