### PR TITLE
Remove pending from autoscaler parameter deprecation

### DIFF
--- a/modal/_utils/deprecation.py
+++ b/modal/_utils/deprecation.py
@@ -117,7 +117,7 @@ def warn_on_renamed_autoscaler_settings(func: Callable[P, R]) -> Callable[P, R]:
                 f"\n\n{substitution_string}"
                 "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more details."
             )
-            deprecation_warning((2025, 2, 24), message, pending=True, show_source=True)
+            deprecation_warning((2025, 2, 24), message, show_source=True)
 
         return func(*args, **kwargs)
 

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -154,7 +154,7 @@ def test_class_with_options(client, servicer):
         assert options.resources.milli_cpu == 48_000
         assert options.retry_policy.retries == 5
 
-        with pytest.warns(PendingDeprecationError, match="max_containers"):
+        with pytest.warns(DeprecationError, match="max_containers"):
             Foo.with_options(concurrency_limit=10)()  # type: ignore
 
 

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -18,7 +18,6 @@ from modal._partial_function import (
 )
 from modal._serialization import deserialize, deserialize_params, serialize
 from modal._utils.async_utils import synchronizer
-from modal._utils.deprecation import PendingDeprecationError
 from modal._utils.function_utils import FunctionInfo
 from modal.exception import DeprecationError, ExecutionError, InvalidError, NotFoundError
 from modal.partial_function import (

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -811,6 +811,21 @@ def test_autoscaler_settings(client, servicer):
         assert settings.scaledown_window == defn.task_idle_timeout_secs == kwargs["scaledown_window"]
 
 
+@pytest.mark.parametrize(
+    "new,old",
+    [
+        ("min_containers", "keep_warm"),
+        ("max_containers", "concurrency_limit"),
+        ("scaledown_window", "container_idle_timeout"),
+    ],
+)
+def test_autoscaler_settings_deprecations(new, old):
+    app = App()
+
+    with pytest.warns(DeprecationError, match=f"{old} -> {new}"):
+        app.function(**{old: 10})(dummy)  # type: ignore
+
+
 def test_not_hydrated():
     with pytest.raises(ExecutionError):
         assert foo.remote(2, 4) == 20


### PR DESCRIPTION
## Describe your changes

We've now updated docs and internal usage.

Closes CLI-31

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>
