### PR TITLE
Run CI on ubuntu 24.04

### DIFF
--- a/.github/actions/setup-cached-python/action.yml
+++ b/.github/actions/setup-cached-python/action.yml
@@ -14,13 +14,13 @@ runs:
       with:
         python-version: ${{ inputs.version }}
 
-    - name: Get cached python dependencies
-      uses: actions/cache@v4
-      with:
-        path: ${{ env.pythonLocation }}
-        key: |
-          ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/setup.cfg', 'requirements.dev.txt', 'pyproject.toml') }}
-        restore-keys: ${{ runner.os }}-${{ env.pythonLocation }}-
+    # - name: Get cached python dependencies
+    #   uses: actions/cache@v4
+    #   with:
+    #     path: ${{ env.pythonLocation }}
+    #     key: |
+    #       ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/setup.cfg', 'requirements.dev.txt', 'pyproject.toml') }}
+    #     restore-keys: ${{ runner.os }}-${{ env.pythonLocation }}-
 
     - name: Install Python packages
       shell: bash

--- a/.github/actions/setup-cached-python/action.yml
+++ b/.github/actions/setup-cached-python/action.yml
@@ -14,13 +14,12 @@ runs:
       with:
         python-version: ${{ inputs.version }}
 
-    # - name: Get cached python dependencies
-    #   uses: actions/cache@v4
-    #   with:
-    #     path: ${{ env.pythonLocation }}
-    #     key: |
-    #       ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/setup.cfg', 'requirements.dev.txt', 'pyproject.toml') }}
-    #     restore-keys: ${{ runner.os }}-${{ env.pythonLocation }}-
+    - name: Get cached python dependencies
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.pythonLocation }}
+        key: |
+          ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/setup.cfg', 'requirements.dev.txt', 'pyproject.toml') }}-v2
 
     - name: Install Python packages
       shell: bash

--- a/.github/actions/setup-cached-python/action.yml
+++ b/.github/actions/setup-cached-python/action.yml
@@ -15,7 +15,7 @@ runs:
         python-version: ${{ inputs.version }}
 
     - name: Get cached python dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.pythonLocation }}
         key: |

--- a/.github/actions/setup-cached-python/action.yml
+++ b/.github/actions/setup-cached-python/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: Install Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.version }}
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   link:
     name: Ruff linting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v3
@@ -29,7 +29,7 @@ jobs:
 
   type_check:
     name: Static type checks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v3
@@ -49,7 +49,7 @@ jobs:
 
   check-copyright:
     name: Check copyright
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,7 +22,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     name: Update changelog and client version
     concurrency: client-versioning
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     outputs:
@@ -84,7 +84,7 @@ jobs:
       fail-fast: false # run all variants across python versions/os to completion
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        os: ["ubuntu-20.04"]
+        os: ["ubuntu-24.04"]
         proto-version: ["latest"]
         include:
           - os: "macos-13" # x86-64
@@ -96,7 +96,7 @@ jobs:
           - os: "windows-latest"
             python-version: "3.10"
             proto-version: "latest"
-          - os: "ubuntu-20.04"
+          - os: "ubuntu-24.04"
             python-version: "3.9"
             proto-version: "3.19"
 
@@ -131,7 +131,7 @@ jobs:
 
   container-dependencies:
     name: Check minimal container dependencies for ${{ matrix.python-version }} / ${{ matrix.image-builder-version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 4
     strategy:
       matrix:
@@ -181,7 +181,7 @@ jobs:
     name: Publish client package
     if: github.ref == 'refs/heads/main'
     needs: [client-versioning, client-test]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency: publish-client
     timeout-minutes: 5
     steps:
@@ -220,7 +220,7 @@ jobs:
     name: Publish Python standalone mounts
     if: github.ref == 'refs/heads/main'
     needs: [client-versioning, client-test, publish-client]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     env:
       MODAL_LOGLEVEL: DEBUG
@@ -251,7 +251,7 @@ jobs:
       Publish base images for ${{ matrix.image-name }} ${{ matrix.image-builder-version }}
     if: github.ref == 'refs/heads/main'
     needs: [client-versioning, client-test, publish-client]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     env:
       MODAL_LOGLEVEL: DEBUG

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
   doc-test:
     name: Doc generation tests
     timeout-minutes: 5
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
We've been getting brownouts on the 20.04 platform, which is being deprecated on April 1.