### PR TITLE
Revert "Add runsc_runtime_version to CheckpointInfo proto (#2915)"

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -628,8 +628,8 @@ message CheckpointInfo {
   int64 size = 5;
   bool checksum_is_file_index = 6;
   string original_task_id = 7;
-  reserved 8;
-  string runsc_runtime_version = 9;
+  // snapshot version used to take the checkpoint
+  uint32 snapshot_version = 8;
 }
 
 message ClassCreateRequest {


### PR DESCRIPTION
This reverts commit ba0bed26ca079581eda177e8206724e29d046463.

Didn't end up needing this. Field is unused so it's safe to revert.