### PR TITLE
Provide the version where we added some 1.0 APIs in their docstrings

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1643,6 +1643,8 @@ class _FunctionCall(typing.Generic[ReturnType], _Object, type_prefix="fc"):
 
         result_1, result_2 = modal.FunctionCall.gather(fc1, fc2)
         ```
+
+        *Added in v0.73.69*: This method replaces the deprecated `modal.functions.gather` function.
         """
         try:
             return await TaskContext.gather(*[fc.get() for fc in function_calls])

--- a/modal/_object.py
+++ b/modal/_object.py
@@ -255,6 +255,8 @@ class _Object:
         It is rarely necessary to call this method explicitly, as most operations
         will lazily hydrate when needed. The main use case is when you need to
         access object metadata, such as its ID.
+
+        *Added in v0.72.39*: This method replaces the deprecated `.resolve()` method.
         """
         if self._is_hydrated:
             if self.client._snapshotted and not self._is_rehydrated:

--- a/modal/_partial_function.py
+++ b/modal/_partial_function.py
@@ -264,7 +264,7 @@ def _fastapi_endpoint(
     To learn how to use Modal with popular web frameworks, see the
     [guide on web endpoints](https://modal.com/docs/guide/webhooks).
 
-    This function replaces the deprecated `@web_endpoint` decorator.
+    *Added in v0.73.82*: This function replaces the deprecated `@web_endpoint` decorator.
     """
     if isinstance(_warn_parentheses_missing, str):
         # Probably passing the method string as a positional argument.

--- a/modal/app.py
+++ b/modal/app.py
@@ -613,7 +613,7 @@ class _App:
         max_inputs: Optional[int] = None,
         i6pn: Optional[bool] = None,  # Whether to enable IPv6 container networking within the region.
         # Whether the function's home package should be included in the image - defaults to True
-        include_source: Optional[bool] = None,
+        include_source: Optional[bool] = None,  # When `False`, don't automatically add the App source to the container.
         # Parameters below here are experimental. Use with caution!
         _experimental_scheduler_placement: Optional[
             SchedulerPlacement
@@ -819,7 +819,7 @@ class _App:
         # Limits the number of inputs a container handles before shutting down.
         # Use `max_inputs = 1` for single-use containers.
         max_inputs: Optional[int] = None,
-        include_source: Optional[bool] = None,
+        include_source: Optional[bool] = None,  # When `False`, don't automatically add the App source to the container.
         # Parameters below here are experimental. Use with caution!
         _experimental_scheduler_placement: Optional[
             SchedulerPlacement

--- a/modal/image.py
+++ b/modal/image.py
@@ -714,6 +714,8 @@ class _Image(_Object, type_prefix="im"):
         copy=True can slow down iteration since it requires a rebuild of the Image and any subsequent
         build steps whenever the included files change, but it is required if you want to run additional
         build steps after this one.
+
+        *Added in v0.66.40*: This method replaces the deprecated `modal.Image.copy_local_file` method.
         """
         if not PurePosixPath(remote_path).is_absolute():
             # TODO(elias): implement relative to absolute resolution using image workdir metadata
@@ -788,6 +790,8 @@ class _Image(_Object, type_prefix="im"):
             ignore=FilePatternMatcher.from_file("/path/to/ignorefile"),
         )
         ```
+
+        *Added in v0.66.40*: This method replaces the deprecated `modal.Image.copy_local_dir` method.
         """
         if not PurePosixPath(remote_path).is_absolute():
             # TODO(elias): implement relative to absolute resolution using image workdir metadata
@@ -851,6 +855,8 @@ class _Image(_Object, type_prefix="im"):
             ignore=lambda p: p.stat().st_size > 1e9
         )
         ```
+
+        *Added in v0.67.28*: This method replaces the deprecated `modal.Mount.from_local_python_packages` pattern.
         """
         mount = _Mount._from_local_python_packages(*modules, ignore=ignore)
         img = self._add_mount_layer_or_copy(mount, copy=copy)


### PR DESCRIPTION
Helps to address drift between our docs (which mostly demonstrate up-to-date patterns) and users who may have an older client installed.

This is relatively easy to do for entire functions / methods. It's harder for new parameters, because our approach to parameter documentation doesn't leave much room for exposition. That's something I'd like to fix independently...