### PR TITLE
WRK-399 Add runtime option for sandbox creation

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -187,6 +187,7 @@ class _Sandbox(_Object, type_prefix="sb"):
                 ),
                 cloud_provider_str=cloud if cloud else None,  # Supersedes cloud_provider
                 nfs_mounts=network_file_system_mount_protos(validated_network_file_systems, False),
+                runtime=config.get("function_runtime"),
                 runtime_debug=config.get("function_runtime_debug"),
                 cloud_bucket_mounts=cloud_bucket_mounts_to_proto(cloud_bucket_mounts),
                 volume_mounts=volume_mounts,

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2289,9 +2289,6 @@ message Sandbox {
 
   // Specifies container runtime behavior for sandboxes which are restored from a snapshot.
   // Set by the backend at snapshot creation time.
-  // TODO(saltzm): This really should only be provided if the runtime
-  // is "gvisor". See if there's a back-compatible way to enforce this
-  // or whether perhaps runc also requires a version option.
   optional string runsc_runtime_version = 27;
 
   // If set, overrides the runtime used by the function, either "runc" or "gvisor".

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2290,7 +2290,7 @@ message Sandbox {
   // Specifies container runtime behavior for sandboxes which are restored from a snapshot.
   // Set by the backend at snapshot creation time.
   // TODO(saltzm): This really should only be provided if the runtime
-  // is "runsc". See if there's a back-compatible way to enforce this
+  // is "gvisor". See if there's a back-compatible way to enforce this
   // or whether perhaps runc also requires a version option.
   optional string runsc_runtime_version = 27;
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2295,7 +2295,7 @@ message Sandbox {
   optional string runsc_runtime_version = 27;
 
   // If set, overrides the runtime used by the function, either "runc" or "gvisor".
-  string runtime = 28;
+  optional string runtime = 28;
 }
 
 message SandboxCreateRequest {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2289,7 +2289,13 @@ message Sandbox {
 
   // Specifies container runtime behavior for sandboxes which are restored from a snapshot.
   // Set by the backend at snapshot creation time.
+  // TODO(saltzm): This really should only be provided if the runtime
+  // is "runsc". See if there's a back-compatible way to enforce this
+  // or whether perhaps runc also requires a version option.
   optional string runsc_runtime_version = 27;
+
+  // If set, overrides the runtime used by the function, either "runc" or "gvisor".
+  string runtime = 28;
 }
 
 message SandboxCreateRequest {


### PR DESCRIPTION
## Describe your changes

- WRK-399: Allow sandboxes to be created with the runc runtime for admin users
- This adds a field to the Sandbox protobuf definition, and checks for an environment variable or config variable to pass as the value for that field

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
