### PR TITLE
Add deprecation warning for `@modal.web_endpoint()`

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -12,7 +12,7 @@ def pytest_markdown_docs_globals():
         "app": modal.App.lookup("my-app", create_if_missing=True),
         "math": math,
         "__name__": "runtest",
-        "web_endpoint": modal.web_endpoint,
+        "fastapi_endpoint": modal.fastapi_endpoint,
         "asgi_app": modal.asgi_app,
         "wsgi_app": modal.wsgi_app,
         "__file__": "xyz.py",

--- a/modal/_partial_function.py
+++ b/modal/_partial_function.py
@@ -312,6 +312,8 @@ def _web_endpoint(
 ) -> Callable[[Callable[P, ReturnType]], _PartialFunction[P, ReturnType, ReturnType]]:
     """Register a basic web endpoint with this application.
 
+    DEPRECATED: This decorator has been renamed to `@modal.fastapi_endpoint`.
+
     This is the simple way to create a web endpoint on Modal. The function
     behaves as a [FastAPI](https://fastapi.tiangolo.com/) handler and should
     return a response object to the caller.
@@ -331,6 +333,10 @@ def _web_endpoint(
         raise InvalidError(
             "Positional arguments are not allowed. Did you forget parentheses? Suggestion: `@web_endpoint()`."
         )
+
+    deprecation_warning(
+        (2025, 3, 5), "The `@modal.web_endpoint` decorator has been renamed to `@modal.fastapi_endpoint`."
+    )
 
     def wrapper(raw_f: Callable[..., Any]) -> _PartialFunction:
         if isinstance(raw_f, _Function):

--- a/modal/_runtime/asgi.py
+++ b/modal/_runtime/asgi.py
@@ -236,14 +236,14 @@ def wsgi_app_wrapper(wsgi_app, container_io_manager):
     return asgi_app_wrapper(asgi_app, container_io_manager)
 
 
-def webhook_asgi_app(fn: Callable[..., Any], method: str, docs: bool):
+def magic_fastapi_app(fn: Callable[..., Any], method: str, docs: bool):
     """Return a FastAPI app wrapping a function handler."""
     try:
         from fastapi import FastAPI
         from fastapi.middleware.cors import CORSMiddleware
     except ImportError as exc:
         message = (
-            "Modal web_endpoint functions require FastAPI to be installed in the modal.Image."
+            "Modal functions decorated with `fastapi_endpoint` require FastAPI to be installed in the modal.Image."
             ' Please update your Image definition code, e.g. with `.pip_install("fastapi[standard]")`.'
         )
         raise InvalidError(message) from exc

--- a/modal/_runtime/user_code_imports.py
+++ b/modal/_runtime/user_code_imports.py
@@ -69,7 +69,7 @@ def construct_webhook_callable(
     elif webhook_config.type == api_pb2.WEBHOOK_TYPE_FUNCTION:
         # Function is a webhook without an ASGI app. Create one for it.
         return asgi.asgi_app_wrapper(
-            asgi.webhook_asgi_app(user_defined_callable, webhook_config.method, webhook_config.web_endpoint_docs),
+            asgi.magic_fastapi_app(user_defined_callable, webhook_config.method, webhook_config.web_endpoint_docs),
             container_io_manager,
         )
 

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -23,7 +23,7 @@ from modal.exception import DeprecationError, ExecutionError, InvalidError, NotF
 from modal.partial_function import (
     PartialFunction,
     asgi_app,
-    web_endpoint,
+    fastapi_endpoint,
 )
 from modal.runner import deploy_app
 from modal.running_app import RunningApp
@@ -719,7 +719,7 @@ web_app_app = App(include_source=True)  # TODO: remove include_source=True when 
 
 @web_app_app.cls()
 class WebCls:
-    @web_endpoint()
+    @fastapi_endpoint()
     def endpoint(self):
         pass
 
@@ -857,7 +857,7 @@ def test_partial_function_descriptors(client):
         def bar(self):
             return "a"
 
-        @modal.web_endpoint()
+        @modal.fastapi_endpoint()
         def web(self):
             pass
 
@@ -1048,7 +1048,7 @@ def test_unsupported_function_decorators_on_methods():
         @app.cls(serialized=True)
         class M:
             @app.function(serialized=True)
-            @modal.web_endpoint()
+            @modal.fastapi_endpoint()
             def f(self):
                 pass
 

--- a/test/decorator_test.py
+++ b/test/decorator_test.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2023
 import pytest
 
-from modal import App, asgi_app, batched, fastapi_endpoint, method, web_endpoint, wsgi_app
+from modal import App, asgi_app, batched, fastapi_endpoint, method, wsgi_app
 from modal.exception import InvalidError
 
 
@@ -50,10 +50,10 @@ def test_method_forgot_parentheses():
 def test_invalid_web_decorator_usage():
     app = App()
 
-    with pytest.raises(InvalidError, match="web_endpoint()"):
+    with pytest.raises(InvalidError, match="fastapi_endpoint()"):
 
         @app.function()  # type: ignore
-        @web_endpoint  # type: ignore
+        @fastapi_endpoint  # type: ignore
         def my_handle():
             pass
 
@@ -72,7 +72,7 @@ def test_invalid_web_decorator_usage():
             pass
 
 
-def test_web_endpoint_method():
+def test_fastapi_endpoint_method():
     app = App()
 
     with pytest.raises(InvalidError, match="remove the `@method`"):

--- a/test/supports/serialize_class.py
+++ b/test/supports/serialize_class.py
@@ -16,7 +16,7 @@ class UserCls:
         return "a"
 
     @fastapi_endpoint()
-    def web_endpoint(self):
+    def fastapi_endpoint(self):
         pass
 
 


### PR DESCRIPTION
## Describe your changes

This PR adds a deprecation warning for `@modal.web_endpoint`, which is being replaced with `@modal.fastapi_endpoint` (added in https://github.com/modal-labs/modal-client/pull/2917). Closes CLI-339

## Changelog

- The `@modal.web_endpoint` decorator is now deprecated. We are replacing it with `@modal.fastapi_endpoint`. This can be a simple name substitution in your code; the two decorators have identical semantics.