### PR TITLE
Add more debug logging to `retry_transient_errors`

### DIFF
--- a/modal/_utils/grpc_utils.py
+++ b/modal/_utils/grpc_utils.py
@@ -191,6 +191,10 @@ async def retry_transient_errors(
                 final_attempt = False
 
             if final_attempt:
+                logger.debug(
+                    f"Final attempt failed with {repr(exc)} {n_retries=} {delay=} "
+                    f"{total_deadline=} for {fn.name} ({idempotency_key[:8]})"
+                )
                 if isinstance(exc, OSError):
                     raise ConnectionError(str(exc))
                 elif isinstance(exc, asyncio.TimeoutError):
@@ -204,7 +208,7 @@ async def retry_transient_errors(
                 # TODO: update to newer version (>=0.4.8) once stable
                 raise exc
 
-            logger.debug(f"Retryable failure {repr(exc)} {n_retries=} {delay=} for {fn.name}")
+            logger.debug(f"Retryable failure {repr(exc)} {n_retries=} {delay=} for {fn.name} ({idempotency_key[:8]})")
 
             n_retries += 1
 


### PR DESCRIPTION
Trying to figure out this failure within `retry_transient_errors` that we don't have a repro for.

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>