### PR TITLE
.map retry loop should not fail retryable errors

### DIFF
--- a/modal/_utils/grpc_utils.py
+++ b/modal/_utils/grpc_utils.py
@@ -73,7 +73,7 @@ RETRYABLE_GRPC_STATUS_CODES = [
 class RetryWarningMessage:
     message: str
     warning_interval: int
-    error_to_warn_for: typing.List[Status]
+    errors_to_warn_for: typing.List[Status]
 
 def create_channel(
     server_url: str,

--- a/modal/_utils/grpc_utils.py
+++ b/modal/_utils/grpc_utils.py
@@ -73,7 +73,7 @@ RETRYABLE_GRPC_STATUS_CODES = [
 class RetryWarningMessage:
     message: str
     warning_interval: int
-    error_to_warn_for: [Status]
+    error_to_warn_for: typing.List[Status]
 
 def create_channel(
     server_url: str,

--- a/modal/_utils/grpc_utils.py
+++ b/modal/_utils/grpc_utils.py
@@ -8,6 +8,7 @@ import typing
 import urllib.parse
 import uuid
 from collections.abc import AsyncIterator
+from dataclasses import dataclass
 from typing import (
     Any,
     Optional,
@@ -68,6 +69,11 @@ RETRYABLE_GRPC_STATUS_CODES = [
     Status.INTERNAL,
 ]
 
+@dataclass
+class RetryWarningMessage:
+    message: str
+    warning_interval: int
+    error_to_warn_for: [Status]
 
 def create_channel(
     server_url: str,
@@ -144,6 +150,7 @@ async def retry_transient_errors(
     attempt_timeout: Optional[float] = None,  # timeout for each attempt
     total_timeout: Optional[float] = None,  # timeout for the entire function call
     attempt_timeout_floor=2.0,  # always have at least this much timeout (only for total_timeout)
+    retry_warning_message: Optional[RetryWarningMessage] = None
 ) -> ResponseType:
     """Retry on transient gRPC failures with back-off until max_retries is reached.
     If max_retries is None, retry forever."""
@@ -207,6 +214,9 @@ async def retry_transient_errors(
             logger.debug(f"Retryable failure {repr(exc)} {n_retries=} {delay=} for {fn.name}")
 
             n_retries += 1
+
+            if retry_warning_message and n_retries % retry_warning_message.warning_interval == 0:
+                logger.warning(retry_warning_message.message)
 
             await asyncio.sleep(delay)
             delay = min(delay * delay_factor, max_delay)

--- a/modal/parallel_map.py
+++ b/modal/parallel_map.py
@@ -142,9 +142,10 @@ async def _map_invocation(
             )
             # with 8 retries we log the warning below about every 30 seconds which isn't too spammy.
             retry_warning_message = RetryWarningMessage(
-                f"Warning: map progress for function {function._function_name} is limited."
+                message=f"Warning: map progress for function {function._function_name} is limited."
                 " Common bottlenecks include slow iteration over results, or function backlogs.",
-                8, [Status.RESOURCE_EXHAUSTED])
+                warning_interval=8,
+                errors_to_warn_for=[Status.RESOURCE_EXHAUSTED])
             resp = await retry_transient_errors(
                 client.stub.FunctionPutInputs,
                 request,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -156,7 +156,8 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.done = False
         self.rate_limit_sleep_duration = None
         self.fail_get_inputs = False
-        self.fail_put_inputs = False
+        self.fail_put_inputs_with_internal_error = False
+        self.fail_put_inputs_with_stream_terminated_error = False
         self.failure_status = api_pb2.GenericResult.GENERIC_STATUS_FAILURE
         self.slow_put_inputs = False
         self.container_inputs = []
@@ -1111,8 +1112,10 @@ class MockClientServicer(api_grpc.ModalClientBase):
             self.add_function_call_input(request.function_call_id, item, input_id)
         if self.slow_put_inputs:
             await asyncio.sleep(0.001)
-        if self.fail_put_inputs:
+        if self.fail_put_inputs_with_internal_error:
             raise GRPCError(Status.INTERNAL)
+        if self.fail_put_inputs_with_stream_terminated_error:
+            await stream.cancel()
         await stream.send_message(api_pb2.FunctionPutInputsResponse(inputs=response_items))
 
     def add_function_call_input(self, function_call_id, item, input_id):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -156,6 +156,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.done = False
         self.rate_limit_sleep_duration = None
         self.fail_get_inputs = False
+        self.fail_put_inputs = False
         self.failure_status = api_pb2.GenericResult.GENERIC_STATUS_FAILURE
         self.slow_put_inputs = False
         self.container_inputs = []
@@ -1110,6 +1111,8 @@ class MockClientServicer(api_grpc.ModalClientBase):
             self.add_function_call_input(request.function_call_id, item, input_id)
         if self.slow_put_inputs:
             await asyncio.sleep(0.001)
+        if self.fail_put_inputs:
+            raise GRPCError(Status.INTERNAL)
         await stream.send_message(api_pb2.FunctionPutInputsResponse(inputs=response_items))
 
     def add_function_call_input(self, function_call_id, item, input_id):

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -1146,6 +1146,7 @@ _map_attempt_count = 0
 def _maybe_fail(i):
     global _map_attempt_count
     if _map_attempt_count > PUMP_INPUTS_MAX_RETRIES:
+        assert _map_retry_servicer
         _map_retry_servicer.fail_put_inputs = False
     _map_attempt_count += 1
     return i

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -15,7 +15,6 @@ from modal._utils.async_utils import synchronize_api
 from modal._vendor import cloudpickle
 from modal.exception import DeprecationError, ExecutionError, InvalidError
 from modal.functions import Function, FunctionCall
-from modal.parallel_map import PUMP_INPUTS_MAX_RETRIES
 from modal.runner import deploy_app
 from modal_proto import api_pb2
 from test.helpers import deploy_app_externally
@@ -1145,14 +1144,15 @@ _map_attempt_count = 0
 
 def _maybe_fail(i):
     global _map_attempt_count
-    if _map_attempt_count > PUMP_INPUTS_MAX_RETRIES:
+    if _map_attempt_count > 10:
         assert _map_retry_servicer
-        _map_retry_servicer.fail_put_inputs = False
+        _map_retry_servicer.fail_put_inputs_with_internal_error = False
+        _map_retry_servicer.fail_put_inputs_with_stream_terminated_error = False
     _map_attempt_count += 1
     return i
 
 
-def test_map_retry(client, servicer, monkeypatch):
+def test_map_retry_with_internal_error(client, servicer, monkeypatch):
     """
     .map retries forever for all status codes in PUMP_INPUTS_RETRYABLE_GRPC_STATUS_CODES, which includes INTERNAL.
     This test forces pump_inputs to fail with INTERNAL for more than PUMP_INPUTS_MAX_RETRIES times. This verifies
@@ -1164,7 +1164,24 @@ def test_map_retry(client, servicer, monkeypatch):
     _map_retry_servicer= servicer
     maybe_fail = app.function()(_maybe_fail)
     servicer.function_body(_maybe_fail)
-    servicer.fail_put_inputs = True
+    servicer.fail_put_inputs_with_internal_error = True
+    with app.run(client=client):
+        for _ in maybe_fail.map(range(1), order_outputs=False):
+            pass
+
+def test_map_retry_with_stream_terminated_error(client, servicer, monkeypatch):
+    """
+    .map retries forever for all status codes in PUMP_INPUTS_RETRYABLE_GRPC_STATUS_CODES, which includes INTERNAL.
+    This test forces pump_inputs to fail with INTERNAL for more than PUMP_INPUTS_MAX_RETRIES times. This verifies
+    that catch and retry the INTERNAL exception, and don't stop retrying until the call succeeds.
+    """
+    global _map_retry_servicer
+    monkeypatch.setattr("modal.parallel_map.PUMP_INPUTS_MAX_RETRY_DELAY", 0.0001)
+    app = App()
+    _map_retry_servicer= servicer
+    maybe_fail = app.function()(_maybe_fail)
+    servicer.function_body(_maybe_fail)
+    servicer.fail_put_inputs_with_stream_terminated_error = True
     with app.run(client=client):
         for _ in maybe_fail.map(range(1), order_outputs=False):
             pass


### PR DESCRIPTION
Fixes SVC-405. 

There was a bug in the pump_inputs retry loop logic (my mistake!). Every 8 retries we stop retrying, so we can log a warning to the user. We should then continue retrying for all retryable error codes, but instead we were retrying again only for RESOURCE_EXHAUSTED. We will now retry forever for all retryable error codes.

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
