### PR TITLE
Fix for nested maps freezing

### DIFF
--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -385,6 +385,10 @@ class AsyncOrSyncIterable:
         except NestedEventLoops:
             raise InvalidError(self.nested_async_message)
 
+    async def aclose(self):
+        if hasattr(self._async_iterable, "aclose"):
+            await self._async_iterable.aclose()
+
 
 _shutdown_tasks = []
 

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -86,6 +86,16 @@ def test_map(client, servicer, slow_put_inputs):
         assert len(servicer.cleared_function_calls) == 2
 
 
+def test_nested_map(client):
+    app = App()
+    dummy_modal = app.function()(dummy)
+
+    with app.run(client=client):
+        res1 = dummy_modal.map([1, 2])
+        final_results = list(dummy_modal.map(res1))
+        assert final_results == [1, 16]
+
+
 @pytest.mark.asyncio
 async def test_map_async_generator(client):
     app = App()

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -96,6 +96,22 @@ def test_nested_map(client):
         assert final_results == [1, 16]
 
 
+def test_map_with_exception_in_input_iterator(client):
+    class CustomException(Exception):
+        pass
+
+    def input_gen():
+        yield 1
+        raise CustomException()
+
+    app = App()
+    dummy_modal = app.function()(dummy)
+
+    with app.run(client=client):
+        with pytest.raises(CustomException):
+            list(dummy_modal.map(input_gen()))
+
+
 @pytest.mark.asyncio
 async def test_map_async_generator(client):
     app = App()


### PR DESCRIPTION
This fixes two bugs:
1. Function.map would previously stall indefinitely if an exception was raised in the *input iterator itself* (i.e. not in the mapper function). This is a critical bug, and it obscured the second bug:
2. `AsyncOrSyncIterable` didn't have an `.aclose()` method, but we still treated it as a generator (which has .aclose()) when wrapping it in `WarnIfGeneratorNotConsumed` so we ended up calling .aclose() on it anyways in the `Function.map` implementation, resulting in an AttributeError - triggering bug 1 above and an indefinite stall.

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

* Fixes a bug which could cause `Function.map` and sibling methods to stall indefinitely if there was an exception in the input iterator itself (i.e. not the mapper function)