### PR TITLE
Only print warning for RESOURCE_EXHAUSTED

### DIFF
--- a/modal/_utils/grpc_utils.py
+++ b/modal/_utils/grpc_utils.py
@@ -219,7 +219,12 @@ async def retry_transient_errors(
 
             n_retries += 1
 
-            if retry_warning_message and n_retries % retry_warning_message.warning_interval == 0:
+            if (
+                retry_warning_message
+                and n_retries % retry_warning_message.warning_interval == 0
+                and isinstance(exc, GRPCError)
+                and exc.status in retry_warning_message.errors_to_warn_for
+            ):
                 logger.warning(retry_warning_message.message)
 
             await asyncio.sleep(delay)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -156,8 +156,9 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.done = False
         self.rate_limit_sleep_duration = None
         self.fail_get_inputs = False
-        self.fail_put_inputs_with_internal_error = False
+        self.fail_put_inputs_with_grpc_error: None | GRPCError = None
         self.fail_put_inputs_with_stream_terminated_error = False
+        self.fail_put_inputs_with_resource_exhausted = False
         self.failure_status = api_pb2.GenericResult.GENERIC_STATUS_FAILURE
         self.slow_put_inputs = False
         self.container_inputs = []
@@ -1112,8 +1113,8 @@ class MockClientServicer(api_grpc.ModalClientBase):
             self.add_function_call_input(request.function_call_id, item, input_id)
         if self.slow_put_inputs:
             await asyncio.sleep(0.001)
-        if self.fail_put_inputs_with_internal_error:
-            raise GRPCError(Status.INTERNAL)
+        if self.fail_put_inputs_with_grpc_error:
+            raise GRPCError(self.fail_put_inputs_with_grpc_error)
         if self.fail_put_inputs_with_stream_terminated_error:
             await stream.cancel()
         await stream.send_message(api_pb2.FunctionPutInputsResponse(inputs=response_items))

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -156,7 +156,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.done = False
         self.rate_limit_sleep_duration = None
         self.fail_get_inputs = False
-        self.fail_put_inputs_with_grpc_error: None | GRPCError = None
+        self.fail_put_inputs_with_grpc_error: None | Status = None
         self.fail_put_inputs_with_stream_terminated_error = False
         self.fail_put_inputs_with_resource_exhausted = False
         self.failure_status = api_pb2.GenericResult.GENERIC_STATUS_FAILURE

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -1,12 +1,14 @@
 # Copyright Modal Labs 2022
 import asyncio
 import inspect
+import logging
 import os
 import pytest
 import time
 import typing
 from contextlib import contextmanager
 
+from grpclib import Status
 from synchronicity.exceptions import UserCodeException
 
 import modal
@@ -1170,44 +1172,73 @@ _map_attempt_count = 0
 
 def _maybe_fail(i):
     global _map_attempt_count
-    if _map_attempt_count > 10:
+    if _map_attempt_count >= 10:
         assert _map_retry_servicer
-        _map_retry_servicer.fail_put_inputs_with_internal_error = False
+        _map_retry_servicer.fail_put_inputs_with_grpc_error = None
         _map_retry_servicer.fail_put_inputs_with_stream_terminated_error = False
     _map_attempt_count += 1
     return i
 
 
-def test_map_retry_with_internal_error(client, servicer, monkeypatch):
+def test_map_retry_with_internal_error(client, servicer, monkeypatch, caplog):
     """
-    .map retries forever for all status codes in PUMP_INPUTS_RETRYABLE_GRPC_STATUS_CODES, which includes INTERNAL.
-    This test forces pump_inputs to fail with INTERNAL for more than PUMP_INPUTS_MAX_RETRIES times. This verifies
-    that catch and retry the INTERNAL exception, and don't stop retrying until the call succeeds.
+    This test forces pump_inputs to fail with INTERNAL for 10 times, and then succeed. This tests that the error
+    is caught and retried error, and does not propagate up.
     """
-    global _map_retry_servicer
+    global _map_retry_servicer, _map_attempt_count
     monkeypatch.setattr("modal.parallel_map.PUMP_INPUTS_MAX_RETRY_DELAY", 0.0001)
     app = App()
     _map_retry_servicer= servicer
+    # reset count from any previous tests
+    _map_attempt_count = 0
     maybe_fail = app.function()(_maybe_fail)
     servicer.function_body(_maybe_fail)
-    servicer.fail_put_inputs_with_internal_error = True
+    servicer.fail_put_inputs_with_grpc_error = Status.INTERNAL
+    with caplog.at_level(logging.WARNING):
+        with app.run(client=client):
+            for _ in maybe_fail.map(range(1), order_outputs=False):
+                pass
+    # Verify we don't log the warning that is intended for RESOURCE_EXHAUSTED only
+    assert "Warning: map progress for function" not in caplog.text
+
+def test_map_retry_with_resource_exhausted(client, servicer, monkeypatch, caplog):
+    """
+    This test forces pump_inputs to fail with RESOURCE_EXHAUSTED for 10 times, and then succeed. This tests that
+    the error is caught and retried error, and does not propagate up.
+    """
+    global _map_retry_servicer, _map_attempt_count
+    monkeypatch.setattr("modal.parallel_map.PUMP_INPUTS_MAX_RETRY_DELAY", 0.0001)
+    app = App()
+    _map_retry_servicer= servicer
+    # reset count from any previous tests
+    _map_attempt_count = 0
+    maybe_fail = app.function()(_maybe_fail)
+    servicer.function_body(_maybe_fail)
+    servicer.fail_put_inputs_with_grpc_error = Status.RESOURCE_EXHAUSTED
+    # with caplog.at_level(logging.WARNING):
     with app.run(client=client):
         for _ in maybe_fail.map(range(1), order_outputs=False):
             pass
+    # Verify we log the warning for RESOURCE_EXHAUSTED
+    assert "Warning: map progress for function" in caplog.text
 
-def test_map_retry_with_stream_terminated_error(client, servicer, monkeypatch):
+def test_map_retry_with_stream_terminated_error(client, servicer, monkeypatch, caplog):
     """
-    .map retries forever for all status codes in PUMP_INPUTS_RETRYABLE_GRPC_STATUS_CODES, which includes INTERNAL.
-    This test forces pump_inputs to fail with INTERNAL for more than PUMP_INPUTS_MAX_RETRIES times. This verifies
-    that catch and retry the INTERNAL exception, and don't stop retrying until the call succeeds.
+    This test forces pump_inputs to fail with StreamTerminatedError for 10 times, and then succeed. This tests that
+    the error is caught and retried error, and does not propagate up.
     """
-    global _map_retry_servicer
+    global _map_retry_servicer, _map_attempt_count
     monkeypatch.setattr("modal.parallel_map.PUMP_INPUTS_MAX_RETRY_DELAY", 0.0001)
     app = App()
     _map_retry_servicer= servicer
+    # reset count from any previous tests
+    _map_attempt_count = 0
     maybe_fail = app.function()(_maybe_fail)
     servicer.function_body(_maybe_fail)
     servicer.fail_put_inputs_with_stream_terminated_error = True
-    with app.run(client=client):
-        for _ in maybe_fail.map(range(1), order_outputs=False):
-            pass
+    with caplog.at_level(logging.WARNING):
+        with app.run(client=client):
+            for _ in maybe_fail.map(range(1), order_outputs=False):
+                pass
+    # Verify we don't log the warning that is intended for RESOURCE_EXHAUSTED only
+    assert "Warning: map progress for function" not in caplog.text

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -1194,12 +1194,11 @@ def test_map_retry_with_internal_error(client, servicer, monkeypatch, caplog):
     maybe_fail = app.function()(_maybe_fail)
     servicer.function_body(_maybe_fail)
     servicer.fail_put_inputs_with_grpc_error = Status.INTERNAL
-    with caplog.at_level(logging.WARNING):
-        with app.run(client=client):
-            for _ in maybe_fail.map(range(1), order_outputs=False):
-                pass
+    with app.run(client=client):
+        for _ in maybe_fail.map(range(1), order_outputs=False):
+            pass
     # Verify we don't log the warning that is intended for RESOURCE_EXHAUSTED only
-    assert "Warning: map progress for function" not in caplog.text
+    assert not [r for r in caplog.records if r.levelno == logging.WARNING]
 
 def test_map_retry_with_resource_exhausted(client, servicer, monkeypatch, caplog):
     """
@@ -1215,12 +1214,12 @@ def test_map_retry_with_resource_exhausted(client, servicer, monkeypatch, caplog
     maybe_fail = app.function()(_maybe_fail)
     servicer.function_body(_maybe_fail)
     servicer.fail_put_inputs_with_grpc_error = Status.RESOURCE_EXHAUSTED
-    # with caplog.at_level(logging.WARNING):
     with app.run(client=client):
         for _ in maybe_fail.map(range(1), order_outputs=False):
             pass
     # Verify we log the warning for RESOURCE_EXHAUSTED
-    assert "Warning: map progress for function" in caplog.text
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
 
 def test_map_retry_with_stream_terminated_error(client, servicer, monkeypatch, caplog):
     """
@@ -1236,9 +1235,8 @@ def test_map_retry_with_stream_terminated_error(client, servicer, monkeypatch, c
     maybe_fail = app.function()(_maybe_fail)
     servicer.function_body(_maybe_fail)
     servicer.fail_put_inputs_with_stream_terminated_error = True
-    with caplog.at_level(logging.WARNING):
-        with app.run(client=client):
-            for _ in maybe_fail.map(range(1), order_outputs=False):
-                pass
+    with app.run(client=client):
+        for _ in maybe_fail.map(range(1), order_outputs=False):
+            pass
     # Verify we don't log the warning that is intended for RESOURCE_EXHAUSTED only
-    assert "Warning: map progress for function" not in caplog.text
+    assert not [r for r in caplog.records if r.levelno == logging.WARNING]


### PR DESCRIPTION
Closes SVC-405

Fixes a bug in previous PR where we were not checking status codes in `errors_to_warn_for`. Also adds test which would have caught this.
