### PR TITLE
add CMD primitives to Image

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -2039,6 +2039,9 @@ class _Image(_Object, type_prefix="im"):
         ```
         """
 
+        if not isinstance(cmd, list) or not all(isinstance(x, str) for x in cmd):
+            raise InvalidError("Image CMD must be a list of strings.")
+
         cmd_str = _flatten_str_args("cmd", "cmd", cmd)
         cmd_str = '"' + '", "'.join(cmd_str) + '"' if cmd_str else ""
         dockerfile_cmd = f"CMD [{cmd_str}]"


### PR DESCRIPTION
## Describe your changes

Adds `Image.cmd()` for setting image `CMD`. Also, as of a future builder version, default `CMD` of `sleep 48h` is added to `Image.debian_slim()` and `Image.micromamba()`. This provides ease-of-use in conjunction with `Sandbox`, as a future version will run `CMD` when no `entrypoint_args` are given.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Added `Image.cmd()` for setting image default entrypoint args (a.k.a. `CMD`).