### PR TITLE
Add flag to enable/disable client retries

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -99,6 +99,7 @@ class _RetryContext:
     input_jwt: str
     input_id: str
     item: api_pb2.FunctionPutInputsItem
+    sync_client_retries_enabled: bool
 
 
 class _Invocation:
@@ -151,6 +152,7 @@ class _Invocation:
                 input_jwt=input.input_jwt,
                 input_id=input.input_id,
                 item=item,
+                sync_client_retries_enabled=response.sync_client_retries_enabled,
             )
             return _Invocation(client.stub, function_call_id, client, retry_context)
 
@@ -172,6 +174,7 @@ class _Invocation:
             input_jwt=input.input_jwt,
             input_id=input.input_id,
             item=item,
+            sync_client_retries_enabled=response.sync_client_retries_enabled
         )
         return _Invocation(client.stub, function_call_id, client, retry_context)
 
@@ -242,6 +245,7 @@ class _Invocation:
             or not ctx.retry_policy
             or ctx.retry_policy.retries == 0
             or ctx.function_call_invocation_type != api_pb2.FUNCTION_CALL_INVOCATION_TYPE_SYNC
+            or not ctx.sync_client_retries_enabled
         ):
             return await self._get_single_output()
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1598,6 +1598,7 @@ message FunctionMapResponse {
   repeated FunctionPutInputsResponseItem pipelined_inputs = 2;
   FunctionRetryPolicy retry_policy = 3;
   string function_call_jwt = 4;
+  bool sync_client_retries_enabled = 5;
 }
 
 message FunctionOptions {

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -196,6 +196,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.files_sha2data = {}
         self.function_id_for_function_call = {}
         self.client_calls = {}
+        self.sync_client_retries_enabled = False
         self.function_is_running = False
         self.n_functions = 0
         self.n_schedules = 0
@@ -1079,6 +1080,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
                 retry_policy=retry_policy,
                 function_call_jwt=function_call_jwt,
                 pipelined_inputs=response_inputs,
+                sync_client_retries_enabled=self.sync_client_retries_enabled
             )
         )
 

--- a/test/function_retry_test.py
+++ b/test/function_retry_test.py
@@ -51,7 +51,8 @@ def setup_app_and_function(servicer):
     return app, f
 
 
-def test_all_retries_fail_raises_error(client, setup_app_and_function, monkeypatch):
+def test_all_retries_fail_raises_error(client, setup_app_and_function, monkeypatch, servicer):
+    servicer.sync_client_retries_enabled = True
     monkeypatch.setenv("MODAL_CLIENT_RETRIES", "true")
     app, f = setup_app_and_function
     with app.run(client=client):
@@ -62,7 +63,8 @@ def test_all_retries_fail_raises_error(client, setup_app_and_function, monkeypat
         assert exc_info.value.function_call_count == 4
 
 
-def test_failures_followed_by_success(client, setup_app_and_function, monkeypatch):
+def test_failures_followed_by_success(client, setup_app_and_function, monkeypatch, servicer):
+    servicer.sync_client_retries_enabled = True
     monkeypatch.setenv("MODAL_CLIENT_RETRIES", "true")
     app, f = setup_app_and_function
     with app.run(client=client):
@@ -70,13 +72,24 @@ def test_failures_followed_by_success(client, setup_app_and_function, monkeypatc
         assert function_call_count == 3
 
 
-def test_no_retries_when_first_call_succeeds(client, setup_app_and_function, monkeypatch):
+def test_no_retries_when_first_call_succeeds(client, setup_app_and_function, monkeypatch, servicer):
+    servicer.sync_client_retries_enabled = True
     monkeypatch.setenv("MODAL_CLIENT_RETRIES", "true")
     app, f = setup_app_and_function
     with app.run(client=client):
         function_call_count = f.remote(1)
         assert function_call_count == 1
 
+def test_no_retries_when_client_retries_disabled(client, setup_app_and_function, monkeypatch, servicer):
+    servicer.sync_client_retries_enabled = False
+    # Set MODAL_CLIENT_RETRIES to true to use SYNC, rather than SYNC_LEGACY. This tests the sync_client_retries_enabled
+    # flag is honored even when using SYNC.
+    monkeypatch.setenv("MODAL_CLIENT_RETRIES", "true")
+    app, f = setup_app_and_function
+    with app.run(client=client):
+        with pytest.raises(FunctionCallCountException) as exc_info:
+            f.remote(2)
+        assert exc_info.value.function_call_count == 1
 
 def test_retry_dealy_ms():
     with pytest.raises(ValueError):
@@ -90,6 +103,7 @@ def test_retry_dealy_ms():
 
 
 def test_lost_inputs_retried(client, setup_app_and_function, monkeypatch, servicer):
+    servicer.sync_client_retries_enabled = True
     monkeypatch.setenv("MODAL_CLIENT_RETRIES", "true")
     app, f = setup_app_and_function
     # The client should retry if it receives a internal failure status.


### PR DESCRIPTION
Part of SVC-387

* Adds `sync_client_retries_enabled` to `FunctionMapResponse`
* Updates client to retry only if the flag is true

For now I've left the MODAL_CLIENT_RETRIES flag. This determines if we use SYNC or SYNC_LEGACY. Will be removed in follow up PRs.

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
