### PR TITLE
Remove defer_updates from FunctionCreateRequest

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -872,7 +872,6 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                     function=function_definition,
                     function_data=function_data,
                     existing_function_id=existing_object_id or "",
-                    defer_updates=True,
                 )
                 try:
                     response: api_pb2.FunctionCreateResponse = await retry_transient_errors(

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1361,10 +1361,7 @@ message FunctionCreateRequest {
   string app_id = 2  [ (modal.options.audit_target_attr) = true ];
   Schedule schedule = 6 [deprecated=true]; // Deprecated: now passed in the Function definition
   string existing_function_id = 7;
-  // This flag tells the server to avoid doing updates in FunctionCreate that should now
-  // be done in AppPublish. Provides a smoother migration onto atomic deployments with 0.64,
-  // and can be deprecated once we no longer support ealier versions.
-  bool defer_updates = 8;
+  reserved 8;  // defer_updates
   FunctionData function_data = 9;  // supersedes 'function' field above
 }
 


### PR DESCRIPTION
Now that we no longer need backwards compatibility for <0.64 clients in the server, this field is no longer used.

Closes SVC-402