### PR TITLE
Proto changes to allow byte class parameters

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -171,6 +171,7 @@ enum ParameterType {
   PARAM_TYPE_STRING = 1;
   PARAM_TYPE_INT = 2;
   PARAM_TYPE_PICKLE = 3;
+  PARAM_TYPE_BYTES = 4;
 }
 
 enum ProgressType {
@@ -701,6 +702,7 @@ message ClassParameterSpec {
     string string_default = 4;
     int64 int_default = 5;
     bytes pickle_default = 6;
+    bytes bytes_default = 7;
   }
 }
 
@@ -714,6 +716,7 @@ message ClassParameterValue {
     string string_value = 3;
     int64 int_value = 4;
     bytes pickle_value = 5;
+    bytes bytes_value = 6;
   }
 }
 


### PR DESCRIPTION
Broke out proto changes from #2837 

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
