### PR TITLE
Validate that local_python_source is passed as a string

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -862,7 +862,7 @@ class _Image(_Object, type_prefix="im"):
         *Added in v0.67.28*: This method replaces the deprecated `modal.Mount.from_local_python_packages` pattern.
         """
         if not all(isinstance(module, str) for module in modules):
-            raise TypeError("Local Python modules must be specified as strings.")
+            raise InvalidError("Local Python modules must be specified as strings.")
         mount = _Mount._from_local_python_packages(*modules, ignore=ignore)
         img = self._add_mount_layer_or_copy(mount, copy=copy)
         img._added_python_source_set |= set(modules)

--- a/modal/image.py
+++ b/modal/image.py
@@ -861,6 +861,8 @@ class _Image(_Object, type_prefix="im"):
 
         *Added in v0.67.28*: This method replaces the deprecated `modal.Mount.from_local_python_packages` pattern.
         """
+        if not all(isinstance(module, str) for module in modules):
+            raise TypeError("Local Python modules must be specified as strings.")
         mount = _Mount._from_local_python_packages(*modules, ignore=ignore)
         img = self._add_mount_layer_or_copy(mount, copy=copy)
         img._added_python_source_set |= set(modules)

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -1607,6 +1607,11 @@ def test_from_local_python_packages_missing_module(servicer, client, test_dir, s
             pass
 
 
+def test_from_local_python_packages_wrong_type():
+    with pytest.raises(TypeError, match="specified as strings"):
+        Image.debian_slim().add_local_python_source(os, sys)  # type: ignore
+
+
 @skip_windows("servicer sandbox implementation not working on windows")
 def test_add_locals_are_attached_to_sandboxes(servicer, client, supports_on_path):
     deb_slim = Image.debian_slim()

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -1608,7 +1608,7 @@ def test_from_local_python_packages_missing_module(servicer, client, test_dir, s
 
 
 def test_from_local_python_packages_wrong_type():
-    with pytest.raises(TypeError, match="specified as strings"):
+    with pytest.raises(InvalidError, match="specified as strings"):
         Image.debian_slim().add_local_python_source(os, sys)  # type: ignore
 
 


### PR DESCRIPTION
Feels like it's relatively easy to accidentally pass a module type here. While that does raise a relevant error currently, it happens inside the resolver, so the context / traceback are suppressed and it's harder to understand what the actual problem is.