### PR TITLE
Ignore sync_client_retries_enabled flag for now

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -245,7 +245,8 @@ class _Invocation:
             or not ctx.retry_policy
             or ctx.retry_policy.retries == 0
             or ctx.function_call_invocation_type != api_pb2.FUNCTION_CALL_INVOCATION_TYPE_SYNC
-            or not ctx.sync_client_retries_enabled
+            # TODO: Eventually we want to honor this flag. For now, we ignore it.
+            # or not ctx.sync_client_retries_enabled
         ):
             return await self._get_single_output()
 

--- a/test/function_retry_test.py
+++ b/test/function_retry_test.py
@@ -80,6 +80,8 @@ def test_no_retries_when_first_call_succeeds(client, setup_app_and_function, mon
         function_call_count = f.remote(1)
         assert function_call_count == 1
 
+
+@pytest.mark.skip(reason="Disabled until server changes rolled out")
 def test_no_retries_when_client_retries_disabled(client, setup_app_and_function, monkeypatch, servicer):
     servicer.sync_client_retries_enabled = False
     # Set MODAL_CLIENT_RETRIES to true to use SYNC, rather than SYNC_LEGACY. This tests the sync_client_retries_enabled
@@ -90,6 +92,7 @@ def test_no_retries_when_client_retries_disabled(client, setup_app_and_function,
         with pytest.raises(FunctionCallCountException) as exc_info:
             f.remote(2)
         assert exc_info.value.function_call_count == 1
+
 
 def test_retry_dealy_ms():
     with pytest.raises(ValueError):


### PR DESCRIPTION
Don't honor the sync_client_retries_enabled flag until this has been rolled out on the server.
---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
