### PR TITLE
stricter type check in Image.entrypoint() and Image.shell()

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -1383,7 +1383,9 @@ class _Image(_Object, type_prefix="im"):
         entrypoint_commands: list[str],
     ) -> "_Image":
         """Set the entrypoint for the image."""
-        args_str = _flatten_str_args("entrypoint", "entrypoint_files", entrypoint_commands)
+        if not isinstance(entrypoint_commands, list) or not all(isinstance(x, str) for x in entrypoint_commands):
+            raise InvalidError("entrypoint_commands must be a list of strings.")
+        args_str = _flatten_str_args("entrypoint", "entrypoint_commands", entrypoint_commands)
         args_str = '"' + '", "'.join(args_str) + '"' if args_str else ""
         dockerfile_cmd = f"ENTRYPOINT [{args_str}]"
 
@@ -1394,6 +1396,8 @@ class _Image(_Object, type_prefix="im"):
         shell_commands: list[str],
     ) -> "_Image":
         """Overwrite default shell for the image."""
+        if not isinstance(shell_commands, list) or not all(isinstance(x, str) for x in shell_commands):
+            raise InvalidError("shell_commands must be a list of strings.")
         args_str = _flatten_str_args("shell", "shell_commands", shell_commands)
         args_str = '"' + '", "'.join(args_str) + '"' if args_str else ""
         dockerfile_cmd = f"SHELL [{args_str}]"

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -972,9 +972,9 @@ def test_image_docker_command_entrypoint_nonempty(builder_version, servicer, cli
 
 def test_image_docker_command_entrypoint_malformed():
     with pytest.raises(InvalidError, match="must be a list of strings"):
-        Image.debian_slim().entrypoint("this is not a list of strings")
+        Image.debian_slim().entrypoint("this is not a list of strings")  # type: ignore
     with pytest.raises(InvalidError, match="must be a list of strings"):
-        Image.debian_slim().entrypoint(4711)
+        Image.debian_slim().entrypoint(4711)  # type: ignore
 
 
 def test_image_docker_command_shell(builder_version, servicer, client, tmp_path_with_content):
@@ -989,9 +989,9 @@ def test_image_docker_command_shell(builder_version, servicer, client, tmp_path_
 
 def test_image_docker_command_shell_malformed():
     with pytest.raises(InvalidError, match="must be a list of strings"):
-        Image.debian_slim().shell("this is not a list of strings")
+        Image.debian_slim().shell("this is not a list of strings")  # type: ignore
     with pytest.raises(InvalidError, match="must be a list of strings"):
-        Image.debian_slim().shell(4711)
+        Image.debian_slim().shell(4711)  # type: ignore
 
 
 def test_image_env(builder_version, servicer, client):
@@ -1032,9 +1032,9 @@ def test_image_cmd_nonempty(builder_version, servicer, client, tmp_path_with_con
 
 def test_image_cmd_malformed(builder_version, servicer, client, tmp_path_with_content):
     with pytest.raises(InvalidError, match="must be a list of strings"):
-        Image.debian_slim().cmd("this is not a list of strings")
+        Image.debian_slim().cmd("this is not a list of strings")  # type: ignore
     with pytest.raises(InvalidError, match="must be a list of strings"):
-        Image.debian_slim().cmd(4711)
+        Image.debian_slim().cmd(4711)  # type: ignore
 
 
 def test_image_debian_slim_default_cmd(builder_version, servicer, client, test_dir):

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -1030,7 +1030,7 @@ def test_image_cmd_nonempty(builder_version, servicer, client, tmp_path_with_con
         assert 'CMD ["echo", "hello"]' in layers[0].dockerfile_commands
 
 
-def test_image_cmd_malformed(builder_version, servicer, client, tmp_path_with_content):
+def test_image_cmd_malformed():
     with pytest.raises(InvalidError, match="must be a list of strings"):
         Image.debian_slim().cmd("this is not a list of strings")  # type: ignore
     with pytest.raises(InvalidError, match="must be a list of strings"):

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -970,6 +970,13 @@ def test_image_docker_command_entrypoint_nonempty(builder_version, servicer, cli
         assert 'ENTRYPOINT ["/temp.sh"]' in layers[0].dockerfile_commands
 
 
+def test_image_docker_command_entrypoint_malformed():
+    with pytest.raises(InvalidError, match="must be a list of strings"):
+        Image.debian_slim().entrypoint("this is not a list of strings")
+    with pytest.raises(InvalidError, match="must be a list of strings"):
+        Image.debian_slim().entrypoint(4711)
+
+
 def test_image_docker_command_shell(builder_version, servicer, client, tmp_path_with_content):
     app = App()
     app.image = Image.debian_slim().shell(["/bin/sh", "-c"])
@@ -978,6 +985,13 @@ def test_image_docker_command_shell(builder_version, servicer, client, tmp_path_
     with app.run(client=client):
         layers = get_image_layers(app.image.object_id, servicer)
         assert 'SHELL ["/bin/sh", "-c"]' in layers[0].dockerfile_commands
+
+
+def test_image_docker_command_shell_malformed():
+    with pytest.raises(InvalidError, match="must be a list of strings"):
+        Image.debian_slim().shell("this is not a list of strings")
+    with pytest.raises(InvalidError, match="must be a list of strings"):
+        Image.debian_slim().shell(4711)
 
 
 def test_image_env(builder_version, servicer, client):
@@ -1014,6 +1028,13 @@ def test_image_cmd_nonempty(builder_version, servicer, client, tmp_path_with_con
     with app.run(client=client):
         layers = get_image_layers(app.image.object_id, servicer)
         assert 'CMD ["echo", "hello"]' in layers[0].dockerfile_commands
+
+
+def test_image_cmd_malformed(builder_version, servicer, client, tmp_path_with_content):
+    with pytest.raises(InvalidError, match="must be a list of strings"):
+        Image.debian_slim().cmd("this is not a list of strings")
+    with pytest.raises(InvalidError, match="must be a list of strings"):
+        Image.debian_slim().cmd(4711)
 
 
 def test_image_debian_slim_default_cmd(builder_version, servicer, client, test_dir):


### PR DESCRIPTION
## Describe your changes

This prevents calls to `.entrypoint()` and`.shell()` from "flattening" strings into lists of characters.
E.g., `.shell("/bin/bash")` would produce `SHELL ["/", "b", "i", "n", "/", "b", "a", "s", "h"]`

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog
