### PR TITLE
Have .remote() use SYNC instead of SYNC_LEGACY

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -245,8 +245,7 @@ class _Invocation:
             or not ctx.retry_policy
             or ctx.retry_policy.retries == 0
             or ctx.function_call_invocation_type != api_pb2.FUNCTION_CALL_INVOCATION_TYPE_SYNC
-            # TODO: Eventually we want to honor this flag. For now, we ignore it.
-            # or not ctx.sync_client_retries_enabled
+            or not ctx.sync_client_retries_enabled
         ):
             return await self._get_single_output()
 
@@ -1311,16 +1310,12 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                 yield item
 
     async def _call_function(self, args, kwargs) -> ReturnType:
-        if config.get("client_retries"):
-            function_call_invocation_type = api_pb2.FUNCTION_CALL_INVOCATION_TYPE_SYNC
-        else:
-            function_call_invocation_type = api_pb2.FUNCTION_CALL_INVOCATION_TYPE_SYNC_LEGACY
         invocation = await _Invocation.create(
             self,
             args,
             kwargs,
             client=self.client,
-            function_call_invocation_type=function_call_invocation_type,
+            function_call_invocation_type=api_pb2.FUNCTION_CALL_INVOCATION_TYPE_SYNC,
         )
 
         return await invocation.run_function()

--- a/modal/config.py
+++ b/modal/config.py
@@ -230,7 +230,6 @@ _SETTINGS = {
     "image_builder_version": _Setting(),
     "strict_parameters": _Setting(False, transform=_to_boolean),  # For internal/experimental use
     "snapshot_debug": _Setting(False, transform=_to_boolean),
-    "client_retries": _Setting(False, transform=_to_boolean),  # For internal testing.
     "cuda_checkpoint_path": _Setting("/__modal/.bin/cuda-checkpoint"),  # Used for snapshotting GPU memory.
 }
 

--- a/test/function_retry_test.py
+++ b/test/function_retry_test.py
@@ -53,7 +53,6 @@ def setup_app_and_function(servicer):
 
 def test_all_retries_fail_raises_error(client, setup_app_and_function, monkeypatch, servicer):
     servicer.sync_client_retries_enabled = True
-    monkeypatch.setenv("MODAL_CLIENT_RETRIES", "true")
     app, f = setup_app_and_function
     with app.run(client=client):
         with pytest.raises(FunctionCallCountException) as exc_info:
@@ -65,7 +64,6 @@ def test_all_retries_fail_raises_error(client, setup_app_and_function, monkeypat
 
 def test_failures_followed_by_success(client, setup_app_and_function, monkeypatch, servicer):
     servicer.sync_client_retries_enabled = True
-    monkeypatch.setenv("MODAL_CLIENT_RETRIES", "true")
     app, f = setup_app_and_function
     with app.run(client=client):
         function_call_count = f.remote(3)
@@ -74,19 +72,14 @@ def test_failures_followed_by_success(client, setup_app_and_function, monkeypatc
 
 def test_no_retries_when_first_call_succeeds(client, setup_app_and_function, monkeypatch, servicer):
     servicer.sync_client_retries_enabled = True
-    monkeypatch.setenv("MODAL_CLIENT_RETRIES", "true")
     app, f = setup_app_and_function
     with app.run(client=client):
         function_call_count = f.remote(1)
         assert function_call_count == 1
 
 
-@pytest.mark.skip(reason="Disabled until server changes rolled out")
 def test_no_retries_when_client_retries_disabled(client, setup_app_and_function, monkeypatch, servicer):
     servicer.sync_client_retries_enabled = False
-    # Set MODAL_CLIENT_RETRIES to true to use SYNC, rather than SYNC_LEGACY. This tests the sync_client_retries_enabled
-    # flag is honored even when using SYNC.
-    monkeypatch.setenv("MODAL_CLIENT_RETRIES", "true")
     app, f = setup_app_and_function
     with app.run(client=client):
         with pytest.raises(FunctionCallCountException) as exc_info:
@@ -107,7 +100,6 @@ def test_retry_dealy_ms():
 
 def test_lost_inputs_retried(client, setup_app_and_function, monkeypatch, servicer):
     servicer.sync_client_retries_enabled = True
-    monkeypatch.setenv("MODAL_CLIENT_RETRIES", "true")
     app, f = setup_app_and_function
     # The client should retry if it receives a internal failure status.
     servicer.failure_status = api_pb2.GenericResult.GENERIC_STATUS_INTERNAL_FAILURE


### PR DESCRIPTION
Previously MODAL_CLIENT_RETRIES controlled whether you used SYNC or SYNC_LEGACY. Now we always use SYNC, and MODAL_CLIENT_RETRIES has been removed. The ability to enable/disable client-side retries is now on the server.

Do not merge until all server changes have been deployed.

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
