### PR TITLE
Add base images to invoke

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -281,5 +281,5 @@ jobs:
         run: modal config set-environment main
 
       - name: Publish base images
-        run: inv publish-base-image ${{ matrix.image-name }}
+        run: inv publish-base-images ${{ matrix.image-name }}
           --builder-version ${{ matrix.image-builder-version }} --no-confirm

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -17,7 +17,6 @@ env:
   PYTHONIOENCODING: utf-8
 
 jobs:
-
   client-versioning:
     if: github.ref == 'refs/heads/main'
     name: Update changelog and client version
@@ -74,7 +73,6 @@ jobs:
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         run: python -m modal_global_objects.mounts.modal_client_package
-
 
   client-test:
     name: Unit tests on ${{ matrix.python-version }} and ${{ matrix.os }} (protobuf=${{ matrix.proto-version }})
@@ -189,7 +187,6 @@ jobs:
     concurrency: publish-client
     timeout-minutes: 5
     steps:
-
       - uses: actions/checkout@v3
         with:
           ref: v${{ needs.client-versioning.outputs.client-version}}
@@ -249,7 +246,6 @@ jobs:
       - name: Publish mounts
         run: python -m modal_global_objects.mounts.python_standalone
 
-
   publish-base-images:
     name: |
       Publish base images for ${{ matrix.image-name }} ${{ matrix.image-builder-version }}
@@ -285,8 +281,5 @@ jobs:
         run: modal config set-environment main
 
       - name: Publish base images
-        env:
-          MODAL_IMAGE_BUILDER_VERSION: ${{ matrix.image-builder-version }}
-          MODAL_IMAGE_ALLOW_GLOBAL_DEPLOYMENT: "1"
-        run: |
-          python -m modal_global_objects.images.base_images ${{ matrix.image-name }}
+        run: inv publish-base-image ${{ matrix.image-name }}
+          --builder-version ${{ matrix.image-builder-version }} --no-confirm

--- a/modal_global_objects/images/base_images.py
+++ b/modal_global_objects/images/base_images.py
@@ -3,6 +3,9 @@ import os
 import sys
 from typing import cast
 
+import rich
+from rich.table import Table
+
 import modal
 from modal.image import SUPPORTED_PYTHON_SERIES, ImageBuilderVersion
 
@@ -20,9 +23,22 @@ if __name__ == "__main__":
     python_versions = SUPPORTED_PYTHON_SERIES[cast(ImageBuilderVersion, builder_version)]
 
     app = modal.App(f"build-{name.replace('_', '-')}-image")
+    images_map: dict[str, modal.Image] = {}
     for v in python_versions:
-        app.function(image=constructor(python_version=v), name=f"{v}")(dummy)
+        image = constructor(python_version=v)
+        images_map[v] = image
+        app.function(image=image, name=f"{v}")(dummy)
 
     with modal.enable_output():
         with app.run():
             pass
+
+    table = Table(title=f"Images for {name} ({builder_version})")
+    table.add_column("Python version")
+    table.add_column("Image ID")
+
+    for v, image in images_map.items():
+        table.add_row(v, image.object_id)
+
+    rich.print()
+    rich.print(table)

--- a/tasks.py
+++ b/tasks.py
@@ -225,13 +225,15 @@ def _check_prod(no_confirm: bool):
 
 @task
 def publish_base_mounts(ctx, no_confirm: bool = False):
+    """Publish the client mount and other mounts."""
     _check_prod(no_confirm)
     for mount in ["modal_client_package", "python_standalone"]:
         ctx.run(f"{sys.executable} modal_global_objects/mounts/{mount}.py", pty=True)
 
 
 @task
-def publish_base_image(ctx, name: str, builder_version: str = "2024.10", no_confirm: bool = False) -> None:
+def publish_base_images(ctx, name: str, builder_version: str = "2024.10", no_confirm: bool = False) -> None:
+    """Publish base images. For example, `inv publish-base-images debian_slim`."""
     _check_prod(no_confirm)
     ctx.run(
         f"python -m modal_global_objects.images.base_images {name}",


### PR DESCRIPTION
Adding base images to `inv` so they can be run more easily in development, and also to add a confirmation similar to `inv publish-base-mounts` to prevent accidental pushing to prod.

Hoping to add a new base image for notebooks soon after this.