### PR TITLE
Remove pending=True from 1.0 deprecations

### DIFF
--- a/modal/cli/import_refs.py
+++ b/modal/cli/import_refs.py
@@ -69,7 +69,6 @@ def import_file_or_module(import_ref: ImportRef, base_cmd: str = ""):
                 (2025, 2, 6),
                 f"Using Python module paths will require using the -m flag in a future version of Modal.\n"
                 f"Use `{base_cmd} -m {import_ref.file_or_module}` instead.",
-                pending=True,
                 show_source=False,
             )
         try:

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -706,10 +706,9 @@ class _Cls(_Object, type_prefix="cs"):
             # if not local (== k *could* be a method) or it is local and we know k is a method
             deprecation_warning(
                 (2025, 1, 13),
-                "Usage of methods directly on the class will soon be deprecated, "
-                "instantiate classes before using methods, e.g.:\n"
+                "Calling on an uninstantiated class will soon be deprecated; "
+                "update your code to instantiate the class first, i.e.:\n"
                 f"{self._name}().{k} instead of {self._name}.{k}",
-                pending=True,
             )
             return getattr(self(), k)
         # non-method attribute access on local class - arguably shouldn't be used either:

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -706,7 +706,7 @@ class _Cls(_Object, type_prefix="cs"):
             # if not local (== k *could* be a method) or it is local and we know k is a method
             deprecation_warning(
                 (2025, 1, 13),
-                "Calling on an uninstantiated class will soon be deprecated; "
+                "Calling a method on an uninstantiated class will soon be deprecated; "
                 "update your code to instantiate the class first, i.e.:\n"
                 f"{self._name}().{k} instead of {self._name}.{k}",
             )

--- a/modal/image.py
+++ b/modal/image.py
@@ -820,7 +820,8 @@ class _Image(_Object, type_prefix="im"):
         works in a `Dockerfile`.
         """
         deprecation_warning(
-            (2025, 1, 13), COPY_DEPRECATION_MESSAGE_PATTERN.format(replacement="image.add_local_file"), pending=True
+            (2025, 1, 13),
+            COPY_DEPRECATION_MESSAGE_PATTERN.format(replacement="image.add_local_file"),
         )
         basename = str(Path(local_path).name)
 
@@ -934,7 +935,8 @@ class _Image(_Object, type_prefix="im"):
         ```
         """
         deprecation_warning(
-            (2025, 1, 13), COPY_DEPRECATION_MESSAGE_PATTERN.format(replacement="image.add_local_dir"), pending=True
+            (2025, 1, 13),
+            COPY_DEPRECATION_MESSAGE_PATTERN.format(replacement="image.add_local_dir"),
         )
 
         def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:
@@ -1367,9 +1369,8 @@ class _Image(_Object, type_prefix="im"):
         if context_mount is not None:
             deprecation_warning(
                 (2025, 1, 13),
-                "`context_mount` is deprecated."
-                + " Files are now automatically added to the build context based on the commands.",
-                pending=True,
+                "The `context_mount` parameter of `Image.dockerfile_commands` is deprecated."
+                " Files are now automatically added to the build context based on the commands.",
             )
         cmds = _flatten_str_args("dockerfile_commands", "dockerfile_commands", dockerfile_commands)
         if not cmds:
@@ -1777,9 +1778,8 @@ class _Image(_Object, type_prefix="im"):
         if context_mount is not None:
             deprecation_warning(
                 (2025, 1, 13),
-                "`context_mount` is deprecated."
-                + " Files are now automatically added to the build context based on the commands in the Dockerfile.",
-                pending=True,
+                "The `context_mount` parameter of `Image.from_dockerfile` is deprecated."
+                " Files are now automatically added to the build context based on the commands in the Dockerfile.",
             )
 
         # --- Build the base dockerfile

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -410,7 +410,8 @@ class _Mount(_Object, type_prefix="mo"):
         ```
         """
         deprecation_warning(
-            (2025, 1, 8), MOUNT_DEPRECATION_MESSAGE_PATTERN.format(replacement="image.add_local_dir"), pending=True
+            (2025, 1, 8),
+            MOUNT_DEPRECATION_MESSAGE_PATTERN.format(replacement="image.add_local_dir"),
         )
         return _Mount._from_local_dir(local_path, remote_path=remote_path, condition=condition, recursive=recursive)
 
@@ -467,7 +468,8 @@ class _Mount(_Object, type_prefix="mo"):
         ```
         """
         deprecation_warning(
-            (2025, 1, 8), MOUNT_DEPRECATION_MESSAGE_PATTERN.format(replacement="image.add_local_file"), pending=True
+            (2025, 1, 8),
+            MOUNT_DEPRECATION_MESSAGE_PATTERN.format(replacement="image.add_local_file"),
         )
         return _Mount._from_local_file(local_path, remote_path)
 
@@ -640,7 +642,6 @@ class _Mount(_Object, type_prefix="mo"):
         deprecation_warning(
             (2025, 1, 8),
             MOUNT_DEPRECATION_MESSAGE_PATTERN.format(replacement="image.add_local_python_source"),
-            pending=True,
         )
         return _Mount._from_local_python_packages(
             *module_names, remote_dir=remote_dir, condition=condition, ignore=ignore

--- a/test/cli_imports_test.py
+++ b/test/cli_imports_test.py
@@ -12,7 +12,7 @@ from modal.cli.import_refs import (
     list_cli_commands,
     parse_import_ref,
 )
-from modal.exception import InvalidError, PendingDeprecationError
+from modal.exception import DeprecationError, InvalidError
 from modal.functions import Function
 from modal.partial_function import method, web_server
 
@@ -169,7 +169,7 @@ def test_import_package_and_module_names(monkeypatch, supports_dir):
     assert mod1.__name__ == "assert_package"
 
     monkeypatch.chdir(supports_dir.parent)
-    with pytest.warns(PendingDeprecationError, match=r"\s-m\s"):
+    with pytest.warns(DeprecationError, match=r"\s-m\s"):
         # TODO: this should use use_module_mode=True once we remove the deprecation warning
         mod2 = import_file_or_module(ImportRef("test.supports.assert_package", use_module_mode=False))
 

--- a/test/cli_imports_test.py
+++ b/test/cli_imports_test.py
@@ -88,29 +88,29 @@ dir_containing_python_package = {
 
 
 @pytest.mark.parametrize(
-    ["dir_structure", "ref", "returned_runnable_type", "num_error_choices"],
+    ["dir_structure", "ref", "returned_runnable_type", "num_error_choices", "use_module_mode"],
     [
         # # file syntax
-        (empty_dir_with_python_file, "mod000.py", type(None), 2),
-        (empty_dir_with_python_file, "mod000.py::app", MethodReference, 2),
-        (empty_dir_with_python_file, "mod000.py::other_app", Function, 2),
-        (dir_containing_python_package, "pack005/file006.py", Function, 1),
-        (dir_containing_python_package, "pack005/sub009/subfile011.py", Function, 1),
-        (dir_containing_python_package, "dir001/sub002/subfile004.py", Function, 1),
+        (empty_dir_with_python_file, "mod000.py", type(None), 2, False),
+        (empty_dir_with_python_file, "mod000.py::app", MethodReference, 2, False),
+        (empty_dir_with_python_file, "mod000.py::other_app", Function, 2, False),
+        (dir_containing_python_package, "pack005/file006.py", Function, 1, False),
+        (dir_containing_python_package, "pack005/sub009/subfile011.py", Function, 1, False),
+        (dir_containing_python_package, "dir001/sub002/subfile004.py", Function, 1, False),
+        (dir_containing_python_package, "pack005/local008.py::app.main", LocalEntrypoint, 1, False),
         # # python module syntax
-        (empty_dir_with_python_file, "mod000::func", Function, 2),
-        (empty_dir_with_python_file, "mod000::other_app.func", Function, 2),
-        (empty_dir_with_python_file, "mod000::app.func", type(None), 2),
-        (empty_dir_with_python_file, "mod000::Parent.meth", MethodReference, 2),
-        (empty_dir_with_python_file, "mod000::other_app", Function, 2),
-        (dir_containing_python_package, "pack005.mod007", Function, 1),
-        (dir_containing_python_package, "pack005.mod007::other_app", Function, 1),
-        (dir_containing_python_package, "pack005/local008.py::app.main", LocalEntrypoint, 1),
+        (empty_dir_with_python_file, "mod000::func", Function, 2, True),
+        (empty_dir_with_python_file, "mod000::other_app.func", Function, 2, True),
+        (empty_dir_with_python_file, "mod000::app.func", type(None), 2, True),
+        (empty_dir_with_python_file, "mod000::Parent.meth", MethodReference, 2, True),
+        (empty_dir_with_python_file, "mod000::other_app", Function, 2, True),
+        (dir_containing_python_package, "pack005.mod007", Function, 1, True),
+        (dir_containing_python_package, "pack005.mod007::other_app", Function, 1, True),
     ],
 )
-def test_import_and_filter(dir_structure, ref, mock_dir, returned_runnable_type, num_error_choices):
+def test_import_and_filter(dir_structure, ref, mock_dir, returned_runnable_type, num_error_choices, use_module_mode):
     with mock_dir(dir_structure):
-        import_ref = parse_import_ref(ref)
+        import_ref = parse_import_ref(ref, use_module_mode=use_module_mode)
         runnable, all_usable_commands = import_and_filter(
             import_ref, base_cmd="dummy", accept_local_entrypoint=True, accept_webhook=False
         )

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -71,7 +71,7 @@ def test_app_deploy_success(servicer, mock_dir, set_env_client):
         _run(["deploy", "myapp.py"])
 
         # Deploy as a module
-        _run(["deploy", "myapp"])
+        _run(["deploy", "-m", "myapp"])
 
         # Deploy as a script with an absolute path
         _run(["deploy", os.path.abspath("myapp.py")])
@@ -589,7 +589,7 @@ def test_logs(servicer, server_url_env, set_env_client, mock_dir):
 def test_app_stop(servicer, mock_dir, set_env_client):
     with mock_dir({"myapp.py": dummy_app_file, "other_module.py": dummy_other_module_file}):
         # Deploy as a module
-        _run(["deploy", "myapp"])
+        _run(["deploy", "-m", "myapp"])
 
     res = _run(["app", "list"])
     assert re.search("my_app .+ deployed", res.stdout)
@@ -1184,7 +1184,7 @@ def test_container_exec(servicer, set_env_client, mock_shell_pty, app):
 def test_can_run_all_listed_functions_with_includes(supports_on_path, monkeypatch, set_env_client, disable_auto_mount):
     monkeypatch.setenv("TERM", "dumb")  # prevents looking at ansi escape sequences
 
-    res = _run(["run", "multifile_project.main"], expected_exit_code=1)
+    res = _run(["run", "-m", "multifile_project.main"], expected_exit_code=1)
     print("err", res.stderr)
     # there are no runnables directly in the target module, so references need to go via the app
     func_listing = res.stderr.split("functions and local entrypoints:")[1]
@@ -1204,7 +1204,7 @@ def test_can_run_all_listed_functions_with_includes(supports_on_path, monkeypatc
 
     for runnable in expected_runnables:
         assert runnable in res.stderr
-        _run(["run", f"multifile_project.main::{runnable}"], expected_exit_code=0)
+        _run(["run", "-m", f"multifile_project.main::{runnable}"], expected_exit_code=0)
 
 
 def test_modal_launch_vscode(monkeypatch, set_env_client, servicer):
@@ -1232,7 +1232,7 @@ def test_run_file_with_global_lookups(servicer, set_env_client, supports_dir):
 
 def test_run_auto_infer_prefer_target_module(servicer, supports_dir, set_env_client, monkeypatch, disable_auto_mount):
     monkeypatch.syspath_prepend(supports_dir / "app_run_tests")
-    res = _run(["run", "multifile.util"])
+    res = _run(["run", "-m", "multifile.util"])
     assert "ran util\nmain func" in res.stdout
 
 

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -1117,7 +1117,7 @@ def test_using_method_on_uninstantiated_cls(recwarn, disable_auto_mount):
     # TODO: this will be an AttributeError or return a non-modal unbound function in the future:
     assert len(recwarn) == 1
     warning_string = str(recwarn[0].message)
-    assert "instantiate classes before using methods" in warning_string
+    assert "instantiate the class first" in warning_string
     assert "C().method instead of C.method" in warning_string
 
 


### PR DESCRIPTION
A little scary as these were quite noisy at one point, but I've checked recent CI logs for 

- Integration tests
- Server tests
- Client doctests

And don't see any pending deprecation warnings.

I'm not sure where to find the Guide doctest logs though 😳.