### PR TITLE
Display git info in the client deployment history

### DIFF
--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -227,6 +227,8 @@ async def history(
     ]
     rows = []
     deployments_with_tags = False
+    deployments_with_commit_info = False
+    deployments_with_dirty_commit = False
     for idx, app_stats in enumerate(resp.app_deployment_histories):
         style = "bold green" if idx == 0 else ""
 
@@ -241,10 +243,23 @@ async def history(
             deployments_with_tags = True
             row.append(Text(app_stats.tag, style=style))
 
+        if app_stats.commit_info.commit_hash:
+            deployments_with_commit_info = True
+            short_hash = app_stats.commit_info.commit_hash[:7]
+            if app_stats.commit_info.dirty:
+                deployments_with_dirty_commit = True
+                short_hash = f"{short_hash}*"
+            row.append(Text(short_hash, style=style))
+
         rows.append(row)
 
     if deployments_with_tags:
         columns.append("Tag")
+    if deployments_with_commit_info:
+        columns.append("Commit")
 
     rows = sorted(rows, key=lambda x: int(str(x[0])[1:]), reverse=True)
     display_table(columns, rows, json)
+
+    if deployments_with_dirty_commit and not json:
+        rich.print("* - repo had uncommitted changes")

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -900,7 +900,9 @@ def test_app_list(servicer, mock_dir, set_env_client):
     assert "my-vol" not in res.stdout
 
 
-def test_app_history(servicer, mock_dir, set_env_client):
+@mock.patch("modal._utils.git_utils.get_git_commit_info", new_callable=mock.AsyncMock)
+def test_app_history(mock_get_git_commit_info, servicer, mock_dir, set_env_client):
+    mock_get_git_commit_info.return_value = api_pb2.CommitInfo(vcs="git", branch="main", commit_hash="commit-hash")
     with mock_dir({"myapp.py": dummy_app_file, "other_module.py": dummy_other_module_file}):
         _run(["deploy", "myapp.py", "--name", "my_app_foo"])
 
@@ -918,6 +920,7 @@ def test_app_history(servicer, mock_dir, set_env_client):
     res = _run(["app", "history", "my_app_foo"])
     assert "v1" in res.stdout
     assert "v2" in res.stdout, f"{res.stdout=}"
+    assert "commit-hash" in res.stdout
 
     # can't fetch history for stopped apps
     with mock_dir({"myapp.py": dummy_app_file, "other_module.py": dummy_other_module_file}):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -555,6 +555,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
                 "deployed_by": "foo-user",
                 "tag": "latest",
                 "rollback_version": None,
+                "commit_info": request.commit_info,
             }
         )
 
@@ -581,6 +582,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
                     client_version=app_deployment_history["client_version"],
                     deployed_by=app_deployment_history["deployed_by"],
                     tag=app_deployment_history["tag"],
+                    commit_info=app_deployment_history.get("commit_info", None),
                 )
             )
 
@@ -1080,7 +1082,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
                 retry_policy=retry_policy,
                 function_call_jwt=function_call_jwt,
                 pipelined_inputs=response_inputs,
-                sync_client_retries_enabled=self.sync_client_retries_enabled
+                sync_client_retries_enabled=self.sync_client_retries_enabled,
             )
         )
 


### PR DESCRIPTION
Show git info we started collecting in #2934.

## Changelog

- Adds a new "commit info" column to the `modal app history` command. It shows the short git hash at the time of deployment, with an asterisk `*` if the repository had uncommitted changes.