### PR TITLE
Update twine to support metadata 2.4

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -205,7 +205,7 @@ jobs:
         run: inv type-stubs
 
       - name: Install build
-        run: pip install build setuptools<=76.0.0
+        run: pip install build twine==6.1.0
 
       - name: Build package distributions (wheel and source)
         run: |

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -205,7 +205,7 @@ jobs:
         run: inv type-stubs
 
       - name: Install build
-        run: pip install build twine==6.1.0
+        run: pip install build
 
       - name: Build package distributions (wheel and source)
         run: |

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -25,7 +25,7 @@ types-requests~=2.31.0
 types-setuptools~=57.4.11
 types-six==1.16.21
 types-toml~=0.10.4
-twine~=5.1.1
+twine~=6.1.0
 wheel~=0.37.1
 nbclient==0.6.8
 notebook==6.5.1

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -10,6 +10,7 @@ httpx~=0.23.0
 invoke~=2.2
 mypy~=1.11.2
 mypy-protobuf~=3.3.0  # TODO: can't use mypy-protobuf>=3.4 because of protobuf==3.19 support
+packaging==24.2
 pre-commit>=2.21,<4
 pytest~=8.0.0
 pytest-asyncio @ git+https://github.com/modal-labs/pytest-asyncio.git@b535db05f6e43019700483c442ab6686f132a415


### PR DESCRIPTION
## Describe your changes

The metadata [CI error](https://github.com/modal-labs/modal-client/actions/runs/14040452854/job/39310227411) is because the older version of twine does not support Metadata 2.4. From the [twine docs](https://twine.readthedocs.io/en/stable/changelog.html) updating to 6.1.0 should fix the upload.

The alternative is to pin setuptools in `pyproject.toml` (which is used by `python -m build`).

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
