### PR TITLE
fix pypi release (take 3)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -205,7 +205,7 @@ jobs:
         run: inv type-stubs
 
       - name: Install build
-        run: pip install build 'setuptools<=76.0.0'
+        run: pip install build
 
       - name: Build package distributions (wheel and source)
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools<=76.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Used `pdb` to see that `build` wasn't looking in our environment because it uses build isolation. 

```
> /home/ubuntu/modal/venv/lib/python3.11/site-packages/build/__main__.py(135)_build_in_isolated_env()
-> env.install(builder.build_system_requires)
(Pdb) builder
<build._builder.ProjectBuilder object at 0x7f3af1eb94d0>
(Pdb) builder.build_system_requires
{'setuptools', 'wheel'}
(Pdb) q
```