### PR TITLE
fix: I got ARGMAX wrong

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -44,7 +44,11 @@ _default_image: _Image = _Image.debian_slim()
 # The maximum number of bytes that can be passed to an exec on Linux.
 # Though this is technically a 'server side' limit, it is unlikely to change.
 # getconf ARG_MAX will show this value on a host.
-ARG_MAX_BYTES = 2_097_152  # 2MiB
+#
+# By probing in production, the limit is 131072 bytes (2**17).
+# We need some bytes of overhead for the rest of the command line besides the args,
+# e.g. 'runsc exec ...'. So we use 2**16 as the limit.
+ARG_MAX_BYTES = 2**16
 
 if TYPE_CHECKING:
     import modal.app

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -311,15 +311,18 @@ def test_sandbox_exec_wait(app, servicer):
 
 @skip_non_subprocess
 def test_sandbox_create_and_exec_with_bad_args(app, servicer):
+    too_big = 130_000
+    single_arg_size = too_big // 10
+    too_big_args = ["a" * single_arg_size for _ in range(10)]
     with pytest.raises(InvalidError):
-        too_big = 2_097_152 + 10
-        single_arg_size = too_big // 10
-        args = ["a" * single_arg_size for _ in range(10)]
-        Sandbox.create(*args, app=app)
+        Sandbox.create(*too_big_args, app=app)
 
     sb = Sandbox.create("sleep", "infinity", app=app)
     with pytest.raises(InvalidError):
         sb.exec("echo", 1)  # type: ignore
+
+    with pytest.raises(InvalidError):
+        sb.exec(*too_big_args)
 
 
 @skip_non_subprocess


### PR DESCRIPTION
## Describe your changes

Turns out when I threw in `ARG_MAX` handling into https://github.com/modal-labs/modal-client/pull/2856 I got it wrong. 
The real limit (in prod and on my devbox) is not 2MiB. 

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>
