### PR TITLE
Swap precedence of concurrency parameters in container entrypoint

### DIFF
--- a/modal/_runtime/container_io_manager.py
+++ b/modal/_runtime/container_io_manager.py
@@ -299,8 +299,8 @@ class _ContainerIOManager:
             target_concurrency = 1
             max_concurrency = 1
         else:
-            target_concurrency = container_args.function_def.target_concurrent_inputs or 1
-            max_concurrency = container_args.function_def.max_concurrent_inputs or target_concurrency
+            max_concurrency = container_args.function_def.max_concurrent_inputs or 1
+            target_concurrency = container_args.function_def.target_concurrent_inputs or max_concurrency
 
         self._target_concurrency = target_concurrency
         self._max_concurrency = max_concurrency

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -180,8 +180,8 @@ def _container_args(
     definition_type=api_pb2.Function.DEFINITION_TYPE_FILE,
     app_name: str = "",
     is_builder_function: bool = False,
-    allow_concurrent_inputs: Optional[int] = None,
     max_concurrent_inputs: Optional[int] = None,
+    target_concurrent_inputs: Optional[int] = None,
     batch_max_size: Optional[int] = None,
     batch_wait_ms: Optional[int] = None,
     serialized_params: Optional[bytes] = None,
@@ -219,7 +219,7 @@ def _container_args(
         app_name=app_name or "",
         is_builder_function=is_builder_function,
         is_auto_snapshot=is_auto_snapshot,
-        target_concurrent_inputs=allow_concurrent_inputs,
+        target_concurrent_inputs=target_concurrent_inputs,
         max_concurrent_inputs=max_concurrent_inputs,
         batch_max_size=batch_max_size,
         batch_linger_ms=batch_wait_ms,
@@ -259,8 +259,8 @@ def _run_container(
     definition_type=api_pb2.Function.DEFINITION_TYPE_FILE,
     app_name: str = "",
     is_builder_function: bool = False,
-    allow_concurrent_inputs: Optional[int] = None,
     max_concurrent_inputs: Optional[int] = None,
+    target_concurrent_inputs: Optional[int] = None,
     batch_max_size: int = 0,
     batch_wait_ms: int = 0,
     serialized_params: Optional[bytes] = None,
@@ -278,23 +278,23 @@ def _run_container(
     web_server_startup_timeout: Optional[float] = None,
 ) -> ContainerResult:
     container_args = _container_args(
-        module_name,
-        function_name,
-        function_type,
-        webhook_type,
-        definition_type,
-        app_name,
-        is_builder_function,
-        allow_concurrent_inputs,
-        max_concurrent_inputs,
-        batch_max_size,
-        batch_wait_ms,
-        serialized_params,
-        is_checkpointing_function,
-        deps,
-        volume_mounts,
-        is_auto_snapshot,
-        max_inputs,
+        module_name=module_name,
+        function_name=function_name,
+        function_type=function_type,
+        webhook_type=webhook_type,
+        definition_type=definition_type,
+        app_name=app_name,
+        is_builder_function=is_builder_function,
+        max_concurrent_inputs=max_concurrent_inputs,
+        target_concurrent_inputs=target_concurrent_inputs,
+        batch_max_size=batch_max_size,
+        batch_wait_ms=batch_wait_ms,
+        serialized_params=serialized_params,
+        is_checkpointing_function=is_checkpointing_function,
+        deps=deps,
+        volume_mounts=volume_mounts,
+        is_auto_snapshot=is_auto_snapshot,
+        max_inputs=max_inputs,
         is_class=is_class,
         class_parameter_info=class_parameter_info,
         app_layout=app_layout,
@@ -1332,7 +1332,7 @@ def test_concurrent_inputs_sync_function(servicer):
         "test.supports.functions",
         "sleep_700_sync",
         inputs=_get_inputs(n=n_inputs),
-        allow_concurrent_inputs=n_parallel,
+        max_concurrent_inputs=n_parallel,
     )
 
     expected_execution = n_inputs / n_parallel * SLEEP_TIME
@@ -1355,7 +1355,7 @@ def test_concurrent_inputs_async_function(servicer):
         "test.supports.functions",
         "sleep_700_async",
         inputs=_get_inputs(n=n_inputs),
-        allow_concurrent_inputs=n_parallel,
+        max_concurrent_inputs=n_parallel,
     )
 
     expected_execution = n_inputs / n_parallel * SLEEP_TIME
@@ -1726,8 +1726,8 @@ def _run_container_process(
     function_name,
     *,
     inputs: list[tuple[str, tuple, dict[str, Any]]],
-    allow_concurrent_inputs: Optional[int] = None,
     max_concurrent_inputs: Optional[int] = None,
+    target_concurrent_inputs: Optional[int] = None,
     cls_params: tuple[tuple, dict[str, Any]] = ((), {}),
     _print=False,  # for debugging - print directly to stdout/stderr instead of pipeing
     env={},
@@ -1736,8 +1736,8 @@ def _run_container_process(
     container_args = _container_args(
         module_name,
         function_name,
-        allow_concurrent_inputs=allow_concurrent_inputs,
         max_concurrent_inputs=max_concurrent_inputs,
+        target_concurrent_inputs=target_concurrent_inputs,
         serialized_params=serialize(cls_params),
         is_class=is_class,
     )
@@ -1833,7 +1833,7 @@ def test_cancellation_stops_subset_of_async_concurrent_inputs(servicer, tmp_path
             "test.supports.functions",
             "delay_async",
             inputs=[("", (1,), {})] * num_inputs,
-            allow_concurrent_inputs=num_inputs,
+            target_concurrent_inputs=num_inputs,
         )
         input_lock.wait()
         input_lock.wait()
@@ -1864,7 +1864,7 @@ def test_sigint_concurrent_async_cancel_doesnt_reraise(servicer, tmp_path):
             "test.supports.functions",
             "async_cancel_doesnt_reraise",
             inputs=[("", (1,), {})] * 2,  # two inputs
-            allow_concurrent_inputs=2,
+            max_concurrent_inputs=2,
         )
         input_lock.wait()
         input_lock.wait()
@@ -1889,7 +1889,7 @@ def test_cancellation_stops_task_with_concurrent_inputs(servicer, tmp_path):
             "test.supports.functions",
             "delay",
             inputs=[("", (20,), {})] * 2,  # two inputs
-            allow_concurrent_inputs=2,
+            max_concurrent_inputs=2,
         )
         input_lock.wait()
         input_lock.wait()
@@ -2055,7 +2055,7 @@ def test_sigint_termination_input_concurrent(servicer, tmp_path):
             "LifecycleCls.*",
             inputs=[("delay", (10,), {})] * 3,
             cls_params=((), {"print_at_exit": True}),
-            allow_concurrent_inputs=2,
+            max_concurrent_inputs=2,
             is_class=True,
         )
         input_barrier.wait()  # get one input
@@ -2366,8 +2366,8 @@ def test_max_concurrency(servicer):
         "test.supports.functions",
         "get_input_concurrency",
         inputs=_get_inputs(((1,), {}), n=n_inputs),
-        allow_concurrent_inputs=target_concurrency,
         max_concurrent_inputs=max_concurrency,
+        target_concurrent_inputs=target_concurrency,
     )
 
     outputs = [deserialize(item.result.data, ret.client) for item in ret.items]
@@ -2386,8 +2386,8 @@ def test_set_local_input_concurrency(servicer):
         "test.supports.functions",
         "set_input_concurrency",
         inputs=_get_inputs(((now,), {}), n=n_inputs),
-        allow_concurrent_inputs=target_concurrency,
         max_concurrent_inputs=max_concurrency,
+        target_concurrent_inputs=target_concurrency,
     )
 
     outputs = [int(deserialize(item.result.data, ret.client)) for item in ret.items]


### PR DESCRIPTION
## Describe your changes

Fixes an issue that popped up in the integration tests (https://modal-com.slack.com/archives/C087VMPHL5Q/p1743040279110469)

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

