### PR TITLE
Get releases working again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ We appreciate your patience while we speedily work towards a stable release of t
 <!-- NEW CONTENT GENERATED BELOW. PLEASE PRESERVE THIS COMMENT. -->
 
 
+
 ### 0.73.121 (2025-03-24)
 
 - Adds a new "commit info" column to the `modal app history` command. It shows the short git hash at the time of deployment, with an asterisk `*` if the repository had uncommitted changes.


### PR DESCRIPTION
We've discovered an annoying circular dependency. If we yank a client release without publishing a subsequent version, client doctests will hit prod with the yanked version, get rejected, fail CI, and block the release of the fix.

But we still merge the fix to main, so _another_ PR will have the "new" client version (which wasn't actually published to PyPI, but _did_ get a Modal client mount created) and *should* 🤞  work.
