### PR TITLE
stop passing default sandbox entrypoint_args

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -108,9 +108,6 @@ class _Sandbox(_Object, type_prefix="sb"):
     ) -> "_Sandbox":
         """mdmd:hidden"""
 
-        if len(entrypoint_args) == 0:
-            raise InvalidError("entrypoint_args must not be empty")
-
         validated_network_file_systems = validate_network_file_systems(network_file_systems)
 
         scheduler_placement: Optional[SchedulerPlacement] = _experimental_scheduler_placement
@@ -259,12 +256,6 @@ class _Sandbox(_Object, type_prefix="sb"):
         from .app import _App
 
         environment_name = _get_environment_name(environment_name)
-
-        # If there are no entrypoint args, we'll sleep forever so that the sandbox will stay
-        # alive long enough for the user to interact with it.
-        if len(entrypoint_args) == 0:
-            max_sleep_time = 60 * 60 * 24 * 2  # 2 days is plenty since workers roll every 24h
-            entrypoint_args = ("sleep", str(max_sleep_time))
 
         _validate_exec_args(entrypoint_args)
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1446,7 +1446,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
     async def SandboxCreate(self, stream):
         request: api_pb2.SandboxCreateRequest = await stream.recv_message()
         self.sandbox = await asyncio.subprocess.create_subprocess_exec(
-            *request.definition.entrypoint_args,
+            *(request.definition.entrypoint_args or ["sleep", f"{48 * 3600}"]),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             stdin=asyncio.subprocess.PIPE,


### PR DESCRIPTION
Stop replacing blank entrypoint_args with `sleep 48h` in `Sandbox.create()`.

For images built at version `<= 2024.10`, worker defaults to `sleep` which preserves the current
behavior. For later images, it will instead run the default entrypoint arguments, a.k.a. the image's
`CMD`.
