### PR TITLE
Add bug report template and links to slack for support / feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yaml
@@ -1,0 +1,34 @@
+name: Bug report
+description: Report an error or unexpected behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping to improve Modal!
+        We generally prefer to receive bug reports over [Slack](https://modal.com/slack), which is monitored by a larger support team and plugs into our internal ticketing system.
+        If that is not an option, you can file a bug report here, although we may be slower to respond.
+
+  - type: textarea
+    attributes:
+      label: Summary
+      description: |
+        A clear and concise description of the bug, ideally including a minimal reproducible example (e.g. a script that we can `modal run` to observe the defective behavior).
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Version
+      description: The version of the modal client you are using (`modal --version`)
+      placeholder: e.g., 0.70.123
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: App ID
+      description: If the bug pertains to an existing App, please share the ID. Sharing an ID implies permission for Modal engineers to view the App logs.
+      placeholder: e.g., ap-123abc567xyz
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+contact_links:
+  - name: User Support
+    url: https://modal.com/slack
+    about: Please ask for support using Modal on Slack (#general)
+  - name: Feature Requests
+    url: https://modal.com/slack
+    about: Please reach out with feature requests on Slack (#feature-requests)
+


### PR DESCRIPTION
We generally prefer communication over slack, because it plugs into our internal ticketing system and more engineers will see it (issues in the `modal-client` repo are monitored only by the small team that work directly on the SDK).