### PR TITLE
Revert traceback.print_exc() in resolver

### DIFF
--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -154,11 +154,7 @@ class Resolver:
                 self._deduplication_cache[deduplication_key] = cached_future
 
         # TODO(elias): print original exception/trace rather than the Resolver-internal trace
-        try:
-            return await cached_future
-        except Exception:
-            traceback.print_exc()
-            raise
+        return await cached_future
 
     def objects(self) -> list["modal._object._Object"]:
         unique_objects: dict[str, "modal._object._Object"] = {}

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2023
 import asyncio
 import contextlib
-import traceback
 import typing
 from asyncio import Future
 from collections.abc import Hashable


### PR DESCRIPTION
Reverts a small exception handling change in #2967

See https://github.com/modal-labs/modal-client/pull/2967/files/a77171c0638189509dfd13b21b91fc289ec47b36#r2019709823

Part of SPR-65