### PR TITLE
Less ambitious partial_functions refactor

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -552,7 +552,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         if info.user_cls and not is_auto_snapshot:
             build_functions = _find_partial_methods_for_user_cls(info.user_cls, _PartialFunctionFlags.BUILD).items()
             for k, pf in build_functions:
-                build_function = pf.obj
+                build_function = pf.raw_f
                 snapshot_info = FunctionInfo(build_function, user_cls=info.user_cls)
                 snapshot_function = _Function.from_local(
                     snapshot_info,

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -644,8 +644,10 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
 
         if info.user_cls:
             method_definitions = {}
-            partial_functions = _find_partial_methods_for_user_cls(info.user_cls, _PartialFunctionFlags.FUNCTION)
-            for method_name, partial_function in partial_functions.items():
+            interface_methods = _find_partial_methods_for_user_cls(
+                info.user_cls, _PartialFunctionFlags.interface_flags()
+            )
+            for method_name, partial_function in interface_methods.items():
                 function_type = get_function_type(partial_function.is_generator)
                 function_name = f"{info.user_cls.__name__}.{method_name}"
                 method_definition = api_pb2.MethodDefinition(

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -552,7 +552,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         if info.user_cls and not is_auto_snapshot:
             build_functions = _find_partial_methods_for_user_cls(info.user_cls, _PartialFunctionFlags.BUILD).items()
             for k, pf in build_functions:
-                build_function = pf.raw_f
+                build_function = pf.obj
                 snapshot_info = FunctionInfo(build_function, user_cls=info.user_cls)
                 snapshot_function = _Function.from_local(
                     snapshot_info,

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -564,7 +564,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                     network_file_systems=network_file_systems,
                     volumes=volumes,
                     memory=memory,
-                    timeout=pf.build_timeout,
+                    timeout=pf.params.build_timeout,
                     cpu=cpu,
                     ephemeral_disk=ephemeral_disk,
                     is_builder_function=True,
@@ -575,7 +575,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                 image = _Image._from_args(
                     base_images={"base": image},
                     build_function=snapshot_function,
-                    force_build=image.force_build or pf.force_build,
+                    force_build=image.force_build or bool(pf.params.force_build),
                 )
 
         # Note that we also do these checks in FunctionCreate; could drop them here
@@ -648,10 +648,10 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                 info.user_cls, _PartialFunctionFlags.interface_flags()
             )
             for method_name, partial_function in interface_methods.items():
-                function_type = get_function_type(partial_function.is_generator)
+                function_type = get_function_type(partial_function.params.is_generator)
                 function_name = f"{info.user_cls.__name__}.{method_name}"
                 method_definition = api_pb2.MethodDefinition(
-                    webhook_config=partial_function.webhook_config,
+                    webhook_config=partial_function.params.webhook_config,
                     function_type=function_type,
                     function_name=function_name,
                 )

--- a/modal/_partial_function.py
+++ b/modal/_partial_function.py
@@ -94,15 +94,6 @@ class _PartialFunction(typing.Generic[P, ReturnType, OriginalReturnType]):
     params: _PartialFunctionParams
     wrapped: bool  # TODO rename ("registered?")
 
-    # --- # TODO delete these after other typing issues are sorted out
-    webhook_config: Optional[api_pb2.WebhookConfig]
-    is_generator: bool
-    batch_max_size: Optional[int]
-    batch_wait_ms: Optional[int]
-    cluster_size: Optional[int]  # Experimental: Clustered functions
-    build_timeout: Optional[int]
-    force_build: bool
-
     def __init__(
         self,
         wrapped_obj: Callable[P, ReturnType],
@@ -119,10 +110,6 @@ class _PartialFunction(typing.Generic[P, ReturnType, OriginalReturnType]):
     def raw_f(self) -> Callable[P, ReturnType]:
         # TODO(michael): temporary to avoid needing changes elsewhere in the library
         return self.wrapped_obj
-
-    def __getattr__(self, name: str) -> Any:
-        # TODO(michael): temporary to avoid needing changes elsewhere in the library
-        return getattr(self.params, name)
 
     @property
     def wrapped_function(self) -> Callable[P, ReturnType]:
@@ -198,9 +185,9 @@ class _PartialFunction(typing.Generic[P, ReturnType, OriginalReturnType]):
         return self.wrapped_obj
 
     def _is_web_endpoint(self) -> bool:
-        if self.webhook_config is None:
+        if self.params.webhook_config is None:
             return False
-        return self.webhook_config.type != api_pb2.WEBHOOK_TYPE_UNSPECIFIED
+        return self.params.webhook_config.type != api_pb2.WEBHOOK_TYPE_UNSPECIFIED
 
     def __get__(self, obj, objtype=None) -> _Function[P, ReturnType, OriginalReturnType]:
         # to type checkers, any @method or similar function on a modal class, would appear to be

--- a/modal/_partial_function.py
+++ b/modal/_partial_function.py
@@ -78,15 +78,13 @@ class _PartialFunctionParams:
     target_concurrent_inputs: Optional[int] = None
     build_timeout: Optional[int] = None
 
-    def update(self, other: "_PartialFunctionParams") -> "_PartialFunctionParams":
+    def update(self, other: "_PartialFunctionParams") -> None:
         """Update self with params set in other."""
         for key, val in asdict(other).items():
             if val is not None:
                 setattr(self, key, val)
 
 
-P = typing_extensions.ParamSpec("P")
-ReturnType = typing_extensions.TypeVar("ReturnType", covariant=True)
 P = typing_extensions.ParamSpec("P")
 ReturnType = typing_extensions.TypeVar("ReturnType", covariant=True)
 OriginalReturnType = typing_extensions.TypeVar("OriginalReturnType", covariant=True)
@@ -326,7 +324,10 @@ def _fastapi_endpoint(
     custom_domains: Optional[Iterable[str]] = None,  # Custom fully-qualified domain name (FQDN) for the endpoint.
     docs: bool = False,  # Whether to enable interactive documentation for this endpoint at /docs.
     requires_proxy_auth: bool = False,  # Require Modal-Key and Modal-Secret HTTP Headers on requests.
-) -> Callable[[Callable[P, ReturnType]], _PartialFunction[P, ReturnType, ReturnType]]:
+) -> Callable[
+    [Union[_PartialFunction[P, ReturnType, ReturnType], Callable[P, ReturnType]]],
+    _PartialFunction[P, ReturnType, ReturnType],
+]:
     """Convert a function into a basic web endpoint by wrapping it with a FastAPI App.
 
     Modal will internally use [FastAPI](https://fastapi.tiangolo.com/) to expose a
@@ -388,7 +389,10 @@ def _web_endpoint(
         Iterable[str]
     ] = None,  # Create an endpoint using a custom domain fully-qualified domain name (FQDN).
     requires_proxy_auth: bool = False,  # Require Modal-Key and Modal-Secret HTTP Headers on requests.
-) -> Callable[[Callable[P, ReturnType]], _PartialFunction[P, ReturnType, ReturnType]]:
+) -> Callable[
+    [Union[_PartialFunction[P, ReturnType, ReturnType], Callable[P, ReturnType]]],
+    _PartialFunction[P, ReturnType, ReturnType],
+]:
     """Register a basic web endpoint with this application.
 
     DEPRECATED: This decorator has been renamed to `@modal.fastapi_endpoint`.

--- a/modal/_partial_function.py
+++ b/modal/_partial_function.py
@@ -40,7 +40,7 @@ class _PartialFunctionFlags(enum.IntFlag):
     WEB_INTERFACE = 32
     # Service decorator flags
     # It's, unclear if we need these, as we can also generally infer based on some params being set
-    # In the current state where @modal.batched is used _insead_ of `@modal.method`, we need to give
+    # In the current state where @modal.batched is used _instead_ of `@modal.method`, we need to give
     # `@modal.batched` two roles (exposing the callable interface, adding batching semantics).
     # But it's probably better to make `@modal.batched` and `@modal.method` stackable, or to move
     # `@modal.batched` to be a class-level decorator since it primarily governs service behavior.
@@ -82,6 +82,8 @@ class _PartialFunctionParams:
         """Update self with params set in other."""
         for key, val in asdict(other).items():
             if val is not None:
+                if getattr(self, key, None) is not None:
+                    raise InvalidError(f"Cannot set `{key}` twice.")
                 setattr(self, key, val)
 
 

--- a/modal/_partial_function.py
+++ b/modal/_partial_function.py
@@ -178,6 +178,11 @@ class _PartialFunction(typing.Generic[P, ReturnType, OriginalReturnType]):
                     "default parameters in a future release.",
                 )
 
+    def get_wrapped_obj(self) -> Callable[P, ReturnType]:
+        # Consider having separate get_wrapped_func / get_wrapped_cls (/ get_wrapped_method?)
+        # with stricter type annotation / runtime check.
+        return self.obj
+
     def _is_web_endpoint(self) -> bool:
         if self.params.webhook_config is None:
             return False

--- a/modal/_partial_function.py
+++ b/modal/_partial_function.py
@@ -78,7 +78,15 @@ class _PartialFunctionParams:
     target_concurrent_inputs: Optional[int] = None
     build_timeout: Optional[int] = None
 
+    def update(self, other: "_PartialFunctionParams") -> "_PartialFunctionParams":
+        """Update self with params set in other."""
+        for key, val in asdict(other).items():
+            if val is not None:
+                setattr(self, key, val)
 
+
+P = typing_extensions.ParamSpec("P")
+ReturnType = typing_extensions.TypeVar("ReturnType", covariant=True)
 P = typing_extensions.ParamSpec("P")
 ReturnType = typing_extensions.TypeVar("ReturnType", covariant=True)
 OriginalReturnType = typing_extensions.TypeVar("OriginalReturnType", covariant=True)
@@ -112,7 +120,7 @@ class _PartialFunction(typing.Generic[P, ReturnType, OriginalReturnType]):
     def stack(self, flags: _PartialFunctionFlags, params: _PartialFunctionParams) -> typing_extensions.Self:
         """Implement decorator composition by combining the flags and params."""
         self.flags |= flags
-        self.params = _PartialFunctionParams(**(asdict(self.params) | asdict(params)))
+        self.params.update(params)
         self.validate_flag_composition()
         return self
 

--- a/modal/_runtime/user_code_imports.py
+++ b/modal/_runtime/user_code_imports.py
@@ -146,7 +146,7 @@ class ImportedClass(Service):
         finalized_functions = {}
         for method_name, partial in self._partial_functions.items():
             partial = synchronizer._translate_in(partial)  # ugly
-            user_func = partial.obj
+            user_func = partial.raw_f
             # Check this property before we turn it into a method (overriden by webhooks)
             is_async = get_is_async(user_func)
             # Use the function definition for whether this is a generator (overriden by webhooks)

--- a/modal/_runtime/user_code_imports.py
+++ b/modal/_runtime/user_code_imports.py
@@ -150,8 +150,8 @@ class ImportedClass(Service):
             # Check this property before we turn it into a method (overriden by webhooks)
             is_async = get_is_async(user_func)
             # Use the function definition for whether this is a generator (overriden by webhooks)
-            is_generator = partial.is_generator
-            webhook_config = partial.webhook_config
+            is_generator = partial.params.is_generator
+            webhook_config = partial.params.webhook_config
 
             bound_func = user_func.__get__(self.user_cls_instance)
 

--- a/modal/_runtime/user_code_imports.py
+++ b/modal/_runtime/user_code_imports.py
@@ -146,7 +146,7 @@ class ImportedClass(Service):
         finalized_functions = {}
         for method_name, partial in self._partial_functions.items():
             partial = synchronizer._translate_in(partial)  # ugly
-            user_func = partial.raw_f
+            user_func = partial.obj
             # Check this property before we turn it into a method (overriden by webhooks)
             is_async = get_is_async(user_func)
             # Use the function definition for whether this is a generator (overriden by webhooks)

--- a/modal/app.py
+++ b/modal/app.py
@@ -655,7 +655,7 @@ class _App:
                 f.registered = True
 
                 # but we don't support @app.function wrapping a method.
-                if is_method_fn(f.raw_f.__qualname__):
+                if is_method_fn(f.obj.__qualname__):
                     raise InvalidError(
                         "The `@app.function` decorator cannot be used on class methods. "
                         "Swap with `@modal.method` or one of the web endpoint decorators. "
@@ -672,8 +672,8 @@ class _App:
                 i6pn_enabled = i6pn or (f.flags & _PartialFunctionFlags.CLUSTERED)
                 cluster_size = f.params.cluster_size  # Experimental: Clustered functions
 
-                info = FunctionInfo(f.raw_f, serialized=serialized, name_override=name)
-                raw_f = f.raw_f
+                info = FunctionInfo(f.obj, serialized=serialized, name_override=name)
+                raw_f = f.obj
                 webhook_config = f.params.webhook_config
                 is_generator = f.params.is_generator
                 batch_max_size = f.params.batch_max_size
@@ -858,7 +858,7 @@ class _App:
             # Check if the decorated object is a class
             if isinstance(wrapped_cls, _PartialFunction):
                 wrapped_cls.registered = True
-                user_cls = wrapped_cls.raw_f
+                user_cls = wrapped_cls.obj
                 if wrapped_cls.flags & _PartialFunctionFlags.CONCURRENT:
                     max_concurrent_inputs = wrapped_cls.params.max_concurrent_inputs
                     target_concurrent_inputs = wrapped_cls.params.target_concurrent_inputs

--- a/modal/app.py
+++ b/modal/app.py
@@ -652,7 +652,7 @@ class _App:
 
             if isinstance(f, _PartialFunction):
                 # typically for @function-wrapped @web_endpoint, @asgi_app, or @batched
-                f.wrapped = True
+                f.registered = True
 
                 # but we don't support @app.function wrapping a method.
                 if is_method_fn(f.raw_f.__qualname__):
@@ -857,7 +857,7 @@ class _App:
         def wrapper(wrapped_cls: Union[CLS_T, _PartialFunction]) -> CLS_T:
             # Check if the decorated object is a class
             if isinstance(wrapped_cls, _PartialFunction):
-                wrapped_cls.wrapped = True
+                wrapped_cls.registered = True
                 user_cls = wrapped_cls.raw_f
                 if wrapped_cls.flags & _PartialFunctionFlags.CONCURRENT:
                     max_concurrent_inputs = wrapped_cls.params.max_concurrent_inputs
@@ -894,7 +894,7 @@ class _App:
                 raise InvalidError("A class must have `enable_memory_snapshot=True` to use `snap=True` on its methods.")
 
             for method in _find_partial_methods_for_user_cls(user_cls, _PartialFunctionFlags.CONCURRENT).values():
-                method.wrapped = True  # Avoid warning about not registering the method (hacky!)
+                method.registered = True  # Avoid warning about not registering the method (hacky!)
                 raise InvalidError(
                     "The `@modal.concurrent` decorator cannot be used on methods; decorate the class instead."
                 )

--- a/modal/app.py
+++ b/modal/app.py
@@ -876,7 +876,7 @@ class _App:
             if batch_functions:
                 if len(batch_functions) > 1:
                     raise InvalidError(f"Modal class {user_cls.__name__} can only have one batched function.")
-                if len(_find_partial_methods_for_user_cls(user_cls, _PartialFunctionFlags.FUNCTION)) > 1:
+                if len(_find_partial_methods_for_user_cls(user_cls, _PartialFunctionFlags.interface_flags())) > 1:
                     raise InvalidError(
                         f"Modal class {user_cls.__name__} with a modal batched function cannot have other modal methods."  # noqa
                     )

--- a/modal/app.py
+++ b/modal/app.py
@@ -655,7 +655,7 @@ class _App:
                 f.registered = True
 
                 # but we don't support @app.function wrapping a method.
-                if is_method_fn(f.obj.__qualname__):
+                if is_method_fn(f.raw_f.__qualname__):
                     raise InvalidError(
                         "The `@app.function` decorator cannot be used on class methods. "
                         "Swap with `@modal.method` or one of the web endpoint decorators. "
@@ -672,8 +672,8 @@ class _App:
                 i6pn_enabled = i6pn or (f.flags & _PartialFunctionFlags.CLUSTERED)
                 cluster_size = f.params.cluster_size  # Experimental: Clustered functions
 
-                info = FunctionInfo(f.obj, serialized=serialized, name_override=name)
-                raw_f = f.obj
+                info = FunctionInfo(f.raw_f, serialized=serialized, name_override=name)
+                raw_f = f.raw_f
                 webhook_config = f.params.webhook_config
                 is_generator = f.params.is_generator
                 batch_max_size = f.params.batch_max_size
@@ -858,7 +858,7 @@ class _App:
             # Check if the decorated object is a class
             if isinstance(wrapped_cls, _PartialFunction):
                 wrapped_cls.registered = True
-                user_cls = wrapped_cls.obj
+                user_cls = wrapped_cls.user_cls
                 if wrapped_cls.flags & _PartialFunctionFlags.CONCURRENT:
                     max_concurrent_inputs = wrapped_cls.params.max_concurrent_inputs
                     target_concurrent_inputs = wrapped_cls.params.target_concurrent_inputs

--- a/modal/app.py
+++ b/modal/app.py
@@ -670,17 +670,17 @@ class _App:
                         "```\n"
                     )
                 i6pn_enabled = i6pn or (f.flags & _PartialFunctionFlags.CLUSTERED)
-                cluster_size = f.cluster_size  # Experimental: Clustered functions
+                cluster_size = f.params.cluster_size  # Experimental: Clustered functions
 
                 info = FunctionInfo(f.raw_f, serialized=serialized, name_override=name)
                 raw_f = f.raw_f
-                webhook_config = f.webhook_config
-                is_generator = f.is_generator
-                batch_max_size = f.batch_max_size
-                batch_wait_ms = f.batch_wait_ms
-                if f.max_concurrent_inputs:  # Using @modal.concurrent()
-                    max_concurrent_inputs = f.max_concurrent_inputs
-                    target_concurrent_inputs = f.target_concurrent_inputs
+                webhook_config = f.params.webhook_config
+                is_generator = f.params.is_generator
+                batch_max_size = f.params.batch_max_size
+                batch_wait_ms = f.params.batch_wait_ms
+                if f.flags & _PartialFunctionFlags.CONCURRENT:
+                    max_concurrent_inputs = f.params.max_concurrent_inputs
+                    target_concurrent_inputs = f.params.target_concurrent_inputs
                 else:
                     max_concurrent_inputs = allow_concurrent_inputs
                     target_concurrent_inputs = None
@@ -859,9 +859,9 @@ class _App:
             if isinstance(wrapped_cls, _PartialFunction):
                 wrapped_cls.wrapped = True
                 user_cls = wrapped_cls.raw_f
-                if wrapped_cls.max_concurrent_inputs:  # Using @modal.concurrent()
-                    max_concurrent_inputs = wrapped_cls.max_concurrent_inputs
-                    target_concurrent_inputs = wrapped_cls.target_concurrent_inputs
+                if wrapped_cls.flags & _PartialFunctionFlags.CONCURRENT:
+                    max_concurrent_inputs = wrapped_cls.params.max_concurrent_inputs
+                    target_concurrent_inputs = wrapped_cls.params.target_concurrent_inputs
                 else:
                     max_concurrent_inputs = allow_concurrent_inputs
                     target_concurrent_inputs = None

--- a/modal/app.py
+++ b/modal/app.py
@@ -893,11 +893,11 @@ class _App:
             ):
                 raise InvalidError("A class must have `enable_memory_snapshot=True` to use `snap=True` on its methods.")
 
-            for method in _find_partial_methods_for_user_cls(user_cls, _PartialFunctionFlags.FUNCTION).values():
-                if method.max_concurrent_inputs:
-                    raise InvalidError(
-                        "The `@modal.concurrent` decorator cannot be used on methods; decorate the class instead."
-                    )
+            for method in _find_partial_methods_for_user_cls(user_cls, _PartialFunctionFlags.CONCURRENT).values():
+                method.wrapped = True  # Avoid warning about not registering the method (hacky!)
+                raise InvalidError(
+                    "The `@modal.concurrent` decorator cannot be used on methods; decorate the class instead."
+                )
 
             info = FunctionInfo(None, serialized=serialized, user_cls=user_cls)
 

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -241,7 +241,7 @@ def _get_click_command_for_cls(app: App, method_ref: MethodReference):
             )
 
     partial_function = partial_functions[method_name]
-    fun_signature = _get_signature(partial_function.get_wrapped_obj(), is_method=True)
+    fun_signature = _get_signature(partial_function._get_raw_f(), is_method=True)
 
     # TODO(erikbern): assert there's no overlap?
     parameters = dict(**cls_signature.parameters, **fun_signature.parameters)  # Pool all arguments

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -241,7 +241,7 @@ def _get_click_command_for_cls(app: App, method_ref: MethodReference):
             )
 
     partial_function = partial_functions[method_name]
-    fun_signature = _get_signature(partial_function.obj, is_method=True)
+    fun_signature = _get_signature(partial_function.get_wrapped_obj(), is_method=True)
 
     # TODO(erikbern): assert there's no overlap?
     parameters = dict(**cls_signature.parameters, **fun_signature.parameters)  # Pool all arguments

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -241,7 +241,7 @@ def _get_click_command_for_cls(app: App, method_ref: MethodReference):
             )
 
     partial_function = partial_functions[method_name]
-    fun_signature = _get_signature(partial_function._get_raw_f(), is_method=True)
+    fun_signature = _get_signature(partial_function.obj, is_method=True)
 
     # TODO(erikbern): assert there's no overlap?
     parameters = dict(**cls_signature.parameters, **fun_signature.parameters)  # Pool all arguments

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -137,7 +137,7 @@ def _bind_instance_method(cls: "_Cls", service_function: _Function, method_name:
 
         fun._info = FunctionInfo(
             # ugly - needed for .local()  TODO (elias): Clean up!
-            partial_function.raw_f,
+            partial_function.obj,
             user_cls=cls._user_cls,
             serialized=service_function.info.is_serialized(),
         )
@@ -492,7 +492,7 @@ class _Cls(_Object, type_prefix="cs"):
 
         # Get all callables
         callables: dict[str, Callable] = {
-            k: pf.raw_f for k, pf in _find_partial_methods_for_user_cls(user_cls, _PartialFunctionFlags.all()).items()
+            k: pf.obj for k, pf in _find_partial_methods_for_user_cls(user_cls, _PartialFunctionFlags.all()).items()
         }
 
         def _deps() -> list[_Function]:

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -137,7 +137,7 @@ def _bind_instance_method(cls: "_Cls", service_function: _Function, method_name:
 
         fun._info = FunctionInfo(
             # ugly - needed for .local()  TODO (elias): Clean up!
-            partial_function.obj,
+            partial_function.raw_f,
             user_cls=cls._user_cls,
             serialized=service_function.info.is_serialized(),
         )
@@ -492,7 +492,9 @@ class _Cls(_Object, type_prefix="cs"):
 
         # Get all callables
         callables: dict[str, Callable] = {
-            k: pf.obj for k, pf in _find_partial_methods_for_user_cls(user_cls, _PartialFunctionFlags.all()).items()
+            k: pf.raw_f
+            for k, pf in _find_partial_methods_for_user_cls(user_cls, _PartialFunctionFlags.all()).items()
+            if pf.raw_f is not None  # Should be true for _find_partial_methods output, but hard to annotate
         }
 
         def _deps() -> list[_Function]:

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -482,13 +482,13 @@ class _Cls(_Object, type_prefix="cs"):
             if partial_function.params.webhook_config is not None:
                 full_name = f"{user_cls.__name__}.{method_name}"
                 app._web_endpoints.append(full_name)
-            partial_function.wrapped = True
+            partial_function.registered = True
 
         # Disable the warning that lifecycle methods are not wrapped
         for partial_function in _find_partial_methods_for_user_cls(
             user_cls, ~_PartialFunctionFlags.interface_flags()
         ).values():
-            partial_function.wrapped = True
+            partial_function.registered = True
 
         # Get all callables
         callables: dict[str, Callable] = {

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -225,7 +225,7 @@ class _Obj:
 
         # user cls instances are only created locally, so we have all partial functions available
         instance_methods = {}
-        for method_name in _find_partial_methods_for_user_cls(self._user_cls, _PartialFunctionFlags.FUNCTION):
+        for method_name in _find_partial_methods_for_user_cls(self._user_cls, _PartialFunctionFlags.interface_flags()):
             instance_methods[method_name] = getattr(self, method_name)
 
         user_cls_instance._modal_functions = instance_methods
@@ -475,7 +475,7 @@ class _Cls(_Object, type_prefix="cs"):
         _Cls.validate_construction_mechanism(user_cls)
 
         method_partials: dict[str, _PartialFunction] = _find_partial_methods_for_user_cls(
-            user_cls, _PartialFunctionFlags.FUNCTION
+            user_cls, _PartialFunctionFlags.interface_flags()
         )
 
         for method_name, partial_function in method_partials.items():
@@ -485,7 +485,9 @@ class _Cls(_Object, type_prefix="cs"):
             partial_function.wrapped = True
 
         # Disable the warning that lifecycle methods are not wrapped
-        for partial_function in _find_partial_methods_for_user_cls(user_cls, ~_PartialFunctionFlags.FUNCTION).values():
+        for partial_function in _find_partial_methods_for_user_cls(
+            user_cls, ~_PartialFunctionFlags.interface_flags()
+        ).values():
             partial_function.wrapped = True
 
         # Get all callables

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -479,7 +479,7 @@ class _Cls(_Object, type_prefix="cs"):
         )
 
         for method_name, partial_function in method_partials.items():
-            if partial_function.webhook_config is not None:
+            if partial_function.params.webhook_config is not None:
                 full_name = f"{user_cls.__name__}.{method_name}"
                 app._web_endpoints.append(full_name)
             partial_function.wrapped = True

--- a/modal/experimental/__init__.py
+++ b/modal/experimental/__init__.py
@@ -9,7 +9,7 @@ from modal_proto import api_pb2
 from .._clustered_functions import ClusterInfo, get_cluster_info as _get_cluster_info
 from .._functions import _Function
 from .._object import _get_environment_name
-from .._partial_function import _PartialFunction, _PartialFunctionFlags
+from .._partial_function import _PartialFunction, _PartialFunctionFlags, _PartialFunctionParams
 from .._runtime.container_io_manager import _ContainerIOManager
 from .._utils.async_utils import synchronizer
 from ..client import _Client
@@ -55,6 +55,12 @@ def clustered(size: int, broadcast: bool = True):
     if size <= 0:
         raise ValueError("cluster size must be greater than 0")
 
+    return _PartialFunction.from_wrapper(
+        "clustered",
+        _PartialFunctionFlags.CALLABLE_INTERFACE | _PartialFunctionFlags.CLUSTERED,
+        _PartialFunctionParams(cluster_size=size),
+    )
+
     def wrapper(raw_f: Callable[..., Any]) -> _PartialFunction:
         if isinstance(raw_f, _Function):
             raw_f = raw_f.get_raw_f()
@@ -63,7 +69,7 @@ def clustered(size: int, broadcast: bool = True):
                 "@app.function()\n@modal.clustered()\ndef clustered_function():\n    ..."
             )
         return _PartialFunction(
-            raw_f, _PartialFunctionFlags.FUNCTION | _PartialFunctionFlags.CLUSTERED, cluster_size=size
+            raw_f, _PartialFunctionFlags.CALLABLE_INTERFACE | _PartialFunctionFlags.CLUSTERED, cluster_size=size
         )
 
     return wrapper

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -1,5 +1,4 @@
 # Copyright Modal Labs 2025
-from modal._utils.async_utils import synchronize_api
 
 from ._partial_function import (
     _asgi_app,
@@ -15,6 +14,7 @@ from ._partial_function import (
     _web_server,
     _wsgi_app,
 )
+from ._utils.async_utils import synchronize_api
 
 # The only reason these are wrapped is to get translated type stubs, they
 # don't actually run any async code as of 2025-02-04:

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -819,12 +819,19 @@ def test_build_timeout_image(client, servicer):
 
 @pytest.mark.parametrize("decorator", [enter, exit])
 def test_disallow_lifecycle_decorators_with_method(decorator):
-    name = decorator.__name__.split("_")[-1]  # remove synchronicity prefix
-    with pytest.raises(InvalidError, match=f"Cannot use `@{name}` decorator with `@method`."):
+    with pytest.raises(InvalidError, match="cannot be combined with lifecycle decorators"):
 
-        class ClsDecoratorMethodStack:
+        class HasLifecycleOnMethod:
             @decorator()
             @method()
+            def f(self):
+                pass
+
+    with pytest.raises(InvalidError, match="cannot be combined with lifecycle decorators"):
+
+        class HasMethodOnLifecycle:
+            @method()
+            @decorator()
             def f(self):
                 pass
 

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -891,8 +891,8 @@ def test_partial_function_descriptors(client):
 
     # ensure that webhook metadata is kept
     web_partial_function: _PartialFunction = synchronizer._translate_in(revived_class.web)  # type: ignore
-    assert web_partial_function.webhook_config
-    assert web_partial_function.webhook_config.type == api_pb2.WEBHOOK_TYPE_FUNCTION
+    assert web_partial_function.params.webhook_config
+    assert web_partial_function.params.webhook_config.type == api_pb2.WEBHOOK_TYPE_FUNCTION
 
 
 def test_cross_process_userclass_serde(supports_dir):

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -1221,7 +1221,6 @@ def test_concurrent_decorator_on_method_error():
                 pass
 
 
-@pytest.mark.xfail(reason="modal.method does not implement stacking properly")
 def test_concurrent_decorator_stacked_with_method_decorator():
     app = modal.App()
 

--- a/test/decorator_test.py
+++ b/test/decorator_test.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2023
 import pytest
 
-from modal import App, asgi_app, batched, fastapi_endpoint, method, wsgi_app
+from modal import App, asgi_app, fastapi_endpoint, method, wsgi_app
 from modal.exception import InvalidError
 
 
@@ -75,24 +75,11 @@ def test_invalid_web_decorator_usage():
 def test_fastapi_endpoint_method():
     app = App()
 
-    with pytest.raises(InvalidError, match="remove the `@method`"):
+    with pytest.raises(InvalidError, match="cannot be combined"):
 
-        @app.cls()
+        @app.cls(serialized=True)
         class Container:
             @method()  # type: ignore
             @fastapi_endpoint()
-            def generate(self):
-                pass
-
-
-def test_batch_method():
-    app = App()
-
-    with pytest.raises(InvalidError, match="remove the `@method`"):
-
-        @app.cls()
-        class Container:
-            @method()  # type: ignore
-            @batched(max_batch_size=2, wait_ms=0)
             def generate(self):
                 pass

--- a/test/supports/concurrency_config.py
+++ b/test/supports/concurrency_config.py
@@ -25,8 +25,8 @@ def has_new_config_and_fastapi_endpoint():
 
 
 @app.function()
-@modal.concurrent(max_inputs=CONFIG_VALS["NEW_MAX"], target_inputs=CONFIG_VALS["TARGET"])
 @modal.fastapi_endpoint()
+@modal.concurrent(max_inputs=CONFIG_VALS["NEW_MAX"], target_inputs=CONFIG_VALS["TARGET"])
 def has_fastapi_endpoint_and_new_config():
     pass
 

--- a/test/webhook_test.py
+++ b/test/webhook_test.py
@@ -125,7 +125,7 @@ async def test_webhook_decorator_in_wrong_order(servicer, client):
         async def g(x):
             pass
 
-    assert "wrong order" in str(excinfo.value).lower()
+    assert "swap the order" in str(excinfo.value).lower()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Second attempt at #2973. This approach has more annoying code repetition, but avoids some of the type annotation issues I was running into while still improving the implementation of decorator stacking and validation.

TBH I don't fully understand the intention of making the PartialFunction class generic over the wrapped signature elements so there's some copy-paste from the existing code without that much thought behind it!

The main goal here is to (in a consistent way with minimal code duplication):
- support decorator stacking
- impose constraints on stacking (and on decorator <->wrapped compatibility)

## Changelog

- Improved handling of cases where `@modal.concurrent` is stacked with other decorators.