### PR TITLE
Add read_only flag for VolumeMounts

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2875,6 +2875,7 @@ message VolumeMount {
   string volume_id = 1;
   string mount_path = 2;
   bool allow_background_commits = 3;
+  bool read_only = 4;
 }
 
 message VolumePutFilesRequest {


### PR DESCRIPTION
This is preparatory work to be able to make the backend changes needed to support mounting volumes read-only.