### PR TITLE
Note that context_mount is deprecated in Image docstrings

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -1309,8 +1309,7 @@ class _Image(_Object, type_prefix="im"):
         context_files: dict[str, str] = {},
         secrets: Sequence[_Secret] = [],
         gpu: GPU_T = None,
-        # modal.Mount with local files to supply as build context for COPY commands
-        context_mount: Optional[_Mount] = None,
+        context_mount: Optional[_Mount] = None,  # Deprecated: the context is now inferred
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
         ignore: Union[Sequence[str], Callable[[Path], bool]] = AUTO_DOCKERIGNORE,
     ) -> "_Image":
@@ -1706,9 +1705,7 @@ class _Image(_Object, type_prefix="im"):
     def from_dockerfile(
         # Filepath to Dockerfile.
         path: Union[str, Path],
-        # modal.Mount with local files to supply as build context for COPY commands.
-        # NOTE: The remote_path of the Mount should match the Dockerfile's WORKDIR.
-        context_mount: Optional[_Mount] = None,
+        context_mount: Optional[_Mount] = None,  # Deprecated: the context is now inferred
         # Ignore cached builds, similar to 'docker build --no-cache'
         force_build: bool = False,
         *,


### PR DESCRIPTION
Adds comments to Image docstrings that have a `context_mount`. We fire a runtime warning about this being deprecated (we now infer the context from the Dockerfile commands so theres no obligation to provide an explicit Mount). A user pointed out that it wasn't clear from the docs that they shouldn't go down this path.

I noticed also that `from_dockerfile` has `context_mount` as the second, non-kwarg-required parameter. That's going to make it annoying to fully remove.