### PR TITLE
Api change to allow server to configure max outstanding inputs

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1619,6 +1619,7 @@ message FunctionMapResponse {
   FunctionRetryPolicy retry_policy = 3;
   string function_call_jwt = 4;
   bool sync_client_retries_enabled = 5;
+  uint32 max_inputs_outstanding = 6;
 }
 
 message FunctionOptions {


### PR DESCRIPTION
Part of SVC-442

Adds `max_inputs_outstanding` to `FunctionMapResponse` so from the server we can control the number outstanding inputs in the client during a .map call.


Check these boxes or delete any item (or this section) if not relevant for this PR.

- [X] Client+Server: this change is compatible with old servers
- [X] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
