### PR TITLE
Add experimental functions for building Image without client dependencies

### DIFF
--- a/modal/experimental/__init__.py
+++ b/modal/experimental/__init__.py
@@ -1,6 +1,8 @@
 # Copyright Modal Labs 2025
+import os
 from dataclasses import dataclass
-from typing import Any, Callable, Optional
+from pathlib import Path
+from typing import Any, Callable, Optional, Union
 
 from modal_proto import api_pb2
 
@@ -12,6 +14,7 @@ from .._runtime.container_io_manager import _ContainerIOManager
 from .._utils.async_utils import synchronizer
 from ..client import _Client
 from ..exception import InvalidError
+from ..image import DockerfileSpec, ImageBuilderVersion, _Image
 
 
 def stop_fetching_inputs():
@@ -103,3 +106,31 @@ async def list_deployed_apps(environment_name: str = "", client: Optional[_Clien
                 )
             )
     return app_infos
+
+
+@synchronizer.create_blocking
+async def raw_dockerfile_image(path: Union[str, Path], force_build: bool = False) -> _Image:
+    """
+    Build a Modal Image from a local Dockerfile recipe without any changes.
+
+    Unlike for `modal.Image.from_dockerfile`, the provided recipe will not be embellished with
+    steps to install dependencies for the Modal client package. As a consequence, the resulting
+    Image cannot be used with a modal Function unless those dependencies are added in a subsequent
+    layer. It _can_ be directly used with a modal Sandbox, which does not need the Modal client.
+
+    We expect to support this experimental function until the `2025.04` Modal Image Builder is
+    stable, at which point Modal Image recipes will no longer install the client dependencies
+    by default. At that point, users can upgrade their Image Builder Version and migrate to
+    `modal.Image.from_dockerfile` for usecases supported by this function.
+
+    """
+
+    def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:
+        with open(os.path.expanduser(path)) as f:
+            commands = f.read().split("\n")
+        return DockerfileSpec(commands=commands, context_files={})
+
+    return _Image._from_args(
+        dockerfile_function=build_dockerfile,
+        force_build=force_build,
+    )

--- a/modal/image.py
+++ b/modal/image.py
@@ -1552,7 +1552,7 @@ class _Image(_Object, type_prefix="im"):
         add_python: Optional[str] = None,
         **kwargs,
     ) -> "_Image":
-        """Build a Modal image from a public or private image registry, such as Docker Hub.
+        """Build a Modal Image from a public or private image registry, such as Docker Hub.
 
         The image must be built for the `linux/amd64` platform.
 


### PR DESCRIPTION
Adds `modal.experimental.raw_dockerfile_image` and `modal.experimental.raw_registry_image`.

These build a `modal.Image` directly from a provided Dockerfile/registry tag with no additional embellishment (i.e. no installation of modal client dependencies. Such Images will only work directly with Sandboxes (although it should be possible to manually install the client dependencies in subsequent image layers and then use the Image in a Function).

This is intended as a stop-gap helper until we ship Image Builder 2025.04 which will change how we include the client dependencies in our images.

Closes CLI-359