### PR TITLE
sandboxes: reduce timeouts within while loops; add repr

### DIFF
--- a/modal/container_process.py
+++ b/modal/container_process.py
@@ -59,6 +59,9 @@ class _ContainerProcess(Generic[T]):
         )
         self._stdin = _StreamWriter(process_id, "container_process", self._client)
 
+    def __repr__(self) -> str:
+        return f"ContainerProcess(process_id={self._process_id!r})"
+
     @property
     def stdout(self) -> _StreamReader[T]:
         """StreamReader for the container process's stdout stream."""
@@ -107,7 +110,7 @@ class _ContainerProcess(Generic[T]):
             return self._returncode
 
         while True:
-            req = api_pb2.ContainerExecWaitRequest(exec_id=self._process_id, timeout=50)
+            req = api_pb2.ContainerExecWaitRequest(exec_id=self._process_id, timeout=10)
             resp: api_pb2.ContainerExecWaitResponse = await retry_transient_errors(
                 self._client.stub.ContainerExecWait, req
             )

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -408,7 +408,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         """Wait for the Sandbox to finish running."""
 
         while True:
-            req = api_pb2.SandboxWaitRequest(sandbox_id=self.object_id, timeout=50)
+            req = api_pb2.SandboxWaitRequest(sandbox_id=self.object_id, timeout=10)
             resp = await retry_transient_errors(self._client.stub.SandboxWait, req)
             if resp.result.status:
                 self._result = resp.result

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -285,6 +285,7 @@ def test_sandbox_exec(app, servicer):
     sb = Sandbox.create("sleep", "infinity", app=app)
 
     cp = sb.exec("bash", "-c", "while read line; do echo $line; done")
+    assert str(cp) == "ContainerProcess(process_id='container_exec_id')"
 
     cp.stdin.write(b"foo\n")
     cp.stdin.write(b"bar\n")


### PR DESCRIPTION
## Describe your changes

This is intended to lower the maximum time these loops can be 'stuck' waiting on an existing RPC. We should rework the RPCs themselves to better support this long-polling, but in the short term I don't see a downside to using a much lower but still large timeout. 

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>
