### PR TITLE
[FS-209] modal_proto: Add VolumePutFiles2 RPC

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2880,11 +2880,17 @@ message VolumeMount {
 }
 
 message VolumePutFiles2Request {
-  // Id of volume to put files into.
-  string volume_id = 1;
-
   // List of files, sorted lexicographically by `path`.
-  repeated File files = 2;
+  repeated File files = 1;
+
+  // The last time the client called `VolumePutFiles2` for this file, it was
+  // told that some blocks were missing. This field contains information
+  // about the client having uploaded those missing blocks.
+  repeated NewBlock new_blocks = 2;
+
+  // If set to true, prevent overwriting existing files. (Note that we don't
+  // allow overwriting existing directories with uploaded files regardless.)
+  bool disallow_overwrite_existing_files = 3;
 
   message File {
     // Destination path of the file to be uploaded, including any parent dirs
@@ -2897,28 +2903,23 @@ message VolumePutFiles2Request {
     // SHA-256 checksum of each 8MiB block of the file's contents, in binary
     // (ie 32 raw bytes) format for compactness.
     repeated bytes blocks_sha256 = 3;
-
-    // The last time the client called `VolumePutFiles2` for this file, it was
-    // told that some blocks were missing. This field contains information
-    // about the client having uploaded those missing blocks.
-    repeated NewBlock new_blocks = 4;
   }
 
   message NewBlock {
-    // The index of the block, ie. offset into the file in units of 8MiB.
-    uint64 index = 1;
+    // Index of the file in the `files` field.
+    uint64 file_index = 1;
+
+    // The index of the block in `files[file_index].blocks_sha256`.
+    uint64 block_index = 2;
 
     // The raw bytes of the body that was returned from the HTTP PUT request
     // when the client made a request for the `put_url` returned in the
     // previous `VolumePutFiles2Response`.
-    bytes put_response = 2;
+    bytes put_response = 3;
   }
 }
 
 message VolumePutFiles2Response {
-  // Id from the original `VolumePutFiles2Request`
-  string volume_id = 1;
-
   // Blocks that are currently missing in the volume, because the file did not
   // exist, or because the block checksum from `blocks_sha256` in the request
   // did not match the current contents of the file.
@@ -2927,7 +2928,7 @@ message VolumePutFiles2Response {
   //
   // If this field is empty, it means that the files were uploaded successfully
   // and/or that the request was an idempotent no-op.
-  repeated MissingBlock missing_blocks = 2;
+  repeated MissingBlock missing_blocks = 1;
 
   message MissingBlock {
     // Index of the file in the original `files` field of the request.

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2894,18 +2894,18 @@ message VolumePutFiles2Request {
     // The total size of the file, in bytes.
     uint64 size = 2;
 
-    // SHA-256 checksum of each 8MiB chunk of the file's contents, in binary
+    // SHA-256 checksum of each 8MiB block of the file's contents, in binary
     // (ie 32 raw bytes) format for compactness.
-    repeated bytes chunks_sha256 = 3;
+    repeated bytes blocks_sha256 = 3;
 
     // The last time the client called `VolumePutFiles2` for this file, it was
-    // told that some chunks were missing. This field contains information
-    // about the client having uploaded those missing chunks.
-    repeated NewChunk new_chunks = 4;
+    // told that some blocks were missing. This field contains information
+    // about the client having uploaded those missing blocks.
+    repeated NewBlock new_blocks = 4;
   }
 
-  message NewChunk {
-    // The index of the chunk, ie. offset into the file in units of 8MiB.
+  message NewBlock {
+    // The index of the block, ie. offset into the file in units of 8MiB.
     uint64 index = 1;
 
     // The raw bytes of the body that was returned from the HTTP PUT request
@@ -2919,25 +2919,25 @@ message VolumePutFiles2Response {
   // Id from the original `VolumePutFiles2Request`
   string volume_id = 1;
 
-  // Chunks that are currently missing in the volume, because the file did not
-  // exist, or because the chunk checksum from `chunks_sha256` in the request
+  // Blocks that are currently missing in the volume, because the file did not
+  // exist, or because the block checksum from `blocks_sha256` in the request
   // did not match the current contents of the file.
   //
-  // Values will be returned sorted by `(file_index, chunk_index)`.
+  // Values will be returned sorted by `(file_index, block_index)`.
   //
   // If this field is empty, it means that the files were uploaded successfully
   // and/or that the request was an idempotent no-op.
-  repeated MissingChunk missing_chunks = 2;
+  repeated MissingBlock missing_blocks = 2;
 
-  message MissingChunk {
+  message MissingBlock {
     // Index of the file in the original `files` field of the request.
     uint64 file_index = 1;
 
-    // The index of the chunk in the original
-    // `files[file_index].chunks_sha256`.
-    uint64 chunk_index = 2;
+    // The index of the block in the original
+    // `files[file_index].blocks_sha256`.
+    uint64 block_index = 2;
 
-    // Make a HTTP PUT request to this endpoint with the chunks' contents as
+    // Make a HTTP PUT request to this endpoint with the blocks' contents as
     // the body.
     string put_url = 3;
   }

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2879,6 +2879,70 @@ message VolumeMount {
   bool read_only = 4;
 }
 
+message VolumePutFiles2Request {
+  // Id of volume to put files into.
+  string volume_id = 1;
+
+  // List of files, sorted lexicographically by `path`.
+  repeated File files = 2;
+
+  message File {
+    // Destination path of the file to be uploaded, including any parent dirs
+    // etc.; for example "foo/bar/baz.txt"
+    string path = 1;
+
+    // The total size of the file, in bytes.
+    uint64 size = 2;
+
+    // SHA-256 checksum of each 8MiB chunk of the file's contents, in binary
+    // (ie 32 raw bytes) format for compactness.
+    repeated bytes chunks_sha256 = 3;
+
+    // The last time the client called `VolumePutFiles2` for this file, it was
+    // told that some chunks were missing. This field contains information
+    // about the client having uploaded those missing chunks.
+    repeated NewChunk new_chunks = 4;
+  }
+
+  message NewChunk {
+    // The index of the chunk, ie. offset into the file in units of 8MiB.
+    uint64 index = 1;
+
+    // The raw bytes of the body that was returned from the HTTP PUT request
+    // when the client made a request for the `put_url` returned in the
+    // previous `VolumePutFiles2Response`.
+    bytes put_response = 2;
+  }
+}
+
+message VolumePutFiles2Response {
+  // Id from the original `VolumePutFiles2Request`
+  string volume_id = 1;
+
+  // Chunks that are currently missing in the volume, because the file did not
+  // exist, or because the chunk checksum from `chunks_sha256` in the request
+  // did not match the current contents of the file.
+  //
+  // Values will be returned sorted by `(file_index, chunk_index)`.
+  //
+  // If this field is empty, it means that the files were uploaded successfully
+  // and/or that the request was an idempotent no-op.
+  repeated MissingChunk missing_chunks = 2;
+
+  message MissingChunk {
+    // Index of the file in the original `files` field of the request.
+    uint64 file_index = 1;
+
+    // The index of the chunk in the original
+    // `files[file_index].chunks_sha256`.
+    uint64 chunk_index = 2;
+
+    // Make a HTTP PUT request to this endpoint with the chunks' contents as
+    // the body.
+    string put_url = 3;
+  }
+}
+
 message VolumePutFilesRequest {
   string volume_id = 1;
   // TODO(staffan): This is obviously unfortunately named, but provides what we need - consider renaming.
@@ -3120,6 +3184,7 @@ service ModalClient {
   rpc VolumeList(VolumeListRequest) returns (VolumeListResponse);
   rpc VolumeListFiles(VolumeListFilesRequest) returns (stream VolumeListFilesResponse);
   rpc VolumePutFiles(VolumePutFilesRequest) returns (google.protobuf.Empty);
+  rpc VolumePutFiles2(VolumePutFiles2Request) returns (VolumePutFiles2Response);
   rpc VolumeReload(VolumeReloadRequest) returns (google.protobuf.Empty);
   rpc VolumeRemoveFile(VolumeRemoveFileRequest) returns (google.protobuf.Empty);
   rpc VolumeRename(VolumeRenameRequest) returns (google.protobuf.Empty);


### PR DESCRIPTION
## Describe your changes

Adds a proposed schema for the new API to upload files into a version 2 volume.

The idea is that the client will call `VolumePutFiles2` repeatedly, until the server no longer reports any missing chunks, at which point the upload is complete.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
