### PR TITLE
Address race condition in .map

### DIFF
--- a/modal/parallel_map.py
+++ b/modal/parallel_map.py
@@ -156,11 +156,12 @@ async def _map_invocation(
 
         # close queue iterator
         await input_queue.put(None)
+        have_all_inputs = True
         yield
 
     async def pump_inputs():
         assert client.stub
-        nonlocal have_all_inputs, inputs_created, inputs_sent
+        nonlocal inputs_created, inputs_sent
         async for items in queue_batch_iterator(input_queue, max_batch_size=MAP_INVOCATION_CHUNK_SIZE):
             # Add items to the manager. Their state will be SENDING.
             await map_items_manager.add_items(items)
@@ -182,7 +183,6 @@ async def _map_invocation(
                 f"Successfully pushed {len(items)} inputs to server. "
                 f"Num queued inputs awaiting push is {input_queue.qsize()}."
             )
-        have_all_inputs = True
         yield
 
     async def retry_inputs():

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -19,6 +19,7 @@ from modal.exception import DeprecationError, ExecutionError, InvalidError
 from modal.functions import Function, FunctionCall
 from modal.runner import deploy_app
 from modal_proto import api_pb2
+from test.conftest import GrpcErrorAndCount
 from test.helpers import deploy_app_externally
 
 app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
@@ -1167,37 +1168,22 @@ def f():
     assert len(mounts) == expected_mounts
 
 
-_map_retry_servicer = None
-_map_attempt_count = 0
-
-
-def _maybe_fail(i):
-    global _map_attempt_count
-    if _map_attempt_count >= 10:
-        assert _map_retry_servicer
-        _map_retry_servicer.fail_put_inputs_with_grpc_error = None
-        _map_retry_servicer.fail_put_inputs_with_stream_terminated_error = False
-    _map_attempt_count += 1
-    return i
-
-
 def test_map_retry_with_internal_error(client, servicer, monkeypatch, caplog):
     """
     This test forces pump_inputs to fail with INTERNAL for 10 times, and then succeed. This tests that the error
-    is caught and retried error, and does not propagate up.
+    is caught and retried error, and does not propagate up. It also tests that we don't log the warning
+    intended for RESOURCE_EXHAUSTED only. The warning is logged every 8 attempts, which is why we retry 10 times.
     """
-    global _map_retry_servicer, _map_attempt_count
     monkeypatch.setattr("modal.parallel_map.PUMP_INPUTS_MAX_RETRY_DELAY", 0.0001)
     app = App()
-    _map_retry_servicer = servicer
-    # reset count from any previous tests
-    _map_attempt_count = 0
-    maybe_fail = app.function()(_maybe_fail)
-    servicer.function_body(_maybe_fail)
-    servicer.fail_put_inputs_with_grpc_error = Status.INTERNAL
+    pow2 = app.function()(_pow2)
+    servicer.function_body(_pow2)
+    servicer.fail_put_inputs_with_grpc_error = GrpcErrorAndCount(Status.INTERNAL, 10)
     with app.run(client=client):
-        for _ in maybe_fail.map(range(1), order_outputs=False):
+        for _ in pow2.map(range(1)):
             pass
+    # Verify there are zero attempts remaining
+    assert servicer.fail_put_inputs_with_grpc_error.count == 0
     # Verify we don't log the warning that is intended for RESOURCE_EXHAUSTED only
     assert not [r for r in caplog.records if r.levelno == logging.WARNING]
 
@@ -1205,20 +1191,19 @@ def test_map_retry_with_internal_error(client, servicer, monkeypatch, caplog):
 def test_map_retry_with_resource_exhausted(client, servicer, monkeypatch, caplog):
     """
     This test forces pump_inputs to fail with RESOURCE_EXHAUSTED for 10 times, and then succeed. This tests that
-    the error is caught and retried error, and does not propagate up.
+    the error is caught and retried error, and does not propagate up. It also tests that we don't log the warning
+    intended for RESOURCE_EXHAUSTED only. The warning is logged every 8 attempts, which is why we retry 10 times.
     """
-    global _map_retry_servicer, _map_attempt_count
     monkeypatch.setattr("modal.parallel_map.PUMP_INPUTS_MAX_RETRY_DELAY", 0.0001)
     app = App()
-    _map_retry_servicer = servicer
-    # reset count from any previous tests
-    _map_attempt_count = 0
-    maybe_fail = app.function()(_maybe_fail)
-    servicer.function_body(_maybe_fail)
-    servicer.fail_put_inputs_with_grpc_error = Status.RESOURCE_EXHAUSTED
+    pow2 = app.function()(_pow2)
+    servicer.function_body(_pow2)
+    servicer.fail_put_inputs_with_grpc_error = GrpcErrorAndCount(Status.RESOURCE_EXHAUSTED, 10)
     with app.run(client=client):
-        for _ in maybe_fail.map(range(1), order_outputs=False):
+        for _ in pow2.map(range(1), order_outputs=False):
             pass
+    # Verify there are zero attempts remaining
+    assert servicer.fail_put_inputs_with_grpc_error.count == 0
     # Verify we log the warning for RESOURCE_EXHAUSTED
     warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
     assert len(warnings) == 1
@@ -1227,20 +1212,19 @@ def test_map_retry_with_resource_exhausted(client, servicer, monkeypatch, caplog
 def test_map_retry_with_stream_terminated_error(client, servicer, monkeypatch, caplog):
     """
     This test forces pump_inputs to fail with StreamTerminatedError for 10 times, and then succeed. This tests that
-    the error is caught and retried error, and does not propagate up.
+    the error is caught and retried error, and does not propagate up. It also tests that we don't log the warning
+    intended for RESOURCE_EXHAUSTED only. The warning is logged every 8 attempts, which is why we retry 10 times.
     """
-    global _map_retry_servicer, _map_attempt_count
     monkeypatch.setattr("modal.parallel_map.PUMP_INPUTS_MAX_RETRY_DELAY", 0.0001)
     app = App()
-    _map_retry_servicer = servicer
-    # reset count from any previous tests
-    _map_attempt_count = 0
-    maybe_fail = app.function()(_maybe_fail)
-    servicer.function_body(_maybe_fail)
-    servicer.fail_put_inputs_with_stream_terminated_error = True
+    pow2 = app.function()(_pow2)
+    servicer.function_body(_pow2)
+    servicer.fail_put_inputs_with_stream_terminated_error = 10
     with app.run(client=client):
-        for _ in maybe_fail.map(range(1), order_outputs=False):
+        for _ in pow2.map(range(1), order_outputs=False):
             pass
+    # Verify there are zero attempts remaining
+    assert servicer.fail_put_inputs_with_stream_terminated_error == 0
     # Verify we don't log the warning that is intended for RESOURCE_EXHAUSTED only
     assert not [r for r in caplog.records if r.levelno == logging.WARNING]
 


### PR DESCRIPTION
Closes SVC-444

## Issue 
There is a race condition in .map which causes us to make an extra call to `FunctionGetOutputs`, even though we've already received all the outputs. We then wait 55 seconds for the `FunctionGetOuputs` call to time out. Then .map see that we have all the outputs and returns.

Our HFMs hit this because the .map calls do no work, and return immediately. Our HFMs timeout after 20 seconds, so they are reporting this as a failure. For a user, the call would succeed, it would just take 55 seconds longer than it should. 

This happens if we receive all the outputs before `pump_inputs` has a chance to mark the `have_all_inputs` flag as true. 

Here is the sequence of events:
1. `have_all_inputs` is false
2. `pump_inputs` pushes all inputs to the server, but due to async behavior, the function does not complete and yields to someone else
3. the server process all inputs and sends outputs
4. `get_all_outputs` sees that `have_all_outputs` is false, and makes another call to `FunctionGetOutputs`
5. `pump_inputs` resumes, sees there are no more inputs to consume, and marks `have_all_inputs` as False
6. After 55 seconds, `FunctionGetOuputs` returns and .map completes 


## How to address it
This PR makes it so we set `have_all_inputs` to True in `drain_input_generator` instead of `pump_inputs`. This means we set the flag much sooner, reducing the chances of hitting the race condition. 

From a few hours of testing this change, it greatly improves things, but the issue can still happen. It looks to me like fixing it completely would mean non-trivial changes. I'm not sure if it's worth the effort at this point, given this seems like an edge case. I propose we go with this fix for now and see what impact it has on the HFMs.

The top box is without the fix, and the bottom box is with it.
<img width="647" alt="image" src="https://github.com/user-attachments/assets/bd92195c-c33b-4410-a314-f2b6f48ac860" />

#

## Changes to tests
There were a few tests which took advantage of the extra call to FunctionGetOutputs to change state in the tests. The changes to the tests are so that the tests no longer rely on this issue. 


#
Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
