### PR TITLE
Add version added note to modal.concurrent docstring

### DIFF
--- a/modal/_partial_function.py
+++ b/modal/_partial_function.py
@@ -867,6 +867,9 @@ def _concurrent(
 
     ```
 
+    *Added in v0.73.148:* This decorator replaces the `allow_concurrent_inputs` parameter
+    in `@app.function()` and `@app.cls()`.
+
     """
     if _warn_parentheses_missing is not None:
         raise InvalidError(


### PR DESCRIPTION
Small docs change.

Technically we added this a few versions earlier but there were a few kinks to shake out. The provided version will work better than earlier ones.