### PR TITLE
Classes: hydrate service function using container args [CLI-326, CLI-289]

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -407,8 +407,6 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
                 param_args = ()
                 param_kwargs = {}
 
-            service_function_hydration_data: Optional[api_pb2.Object] = None
-
             if function_def.is_class:
                 # this is a bit ugly - match the function and class based on function name to get metadata
                 # This metadata is required in order to hydrate the class in case it's not globally

--- a/modal/_runtime/user_code_imports.py
+++ b/modal/_runtime/user_code_imports.py
@@ -340,7 +340,10 @@ def import_class_service(
         service_deps = None  # we can't infer service deps for now
         active_app = get_active_app_fallback(function_def)
         class_service_function = modal.Function._new_hydrated(
-            service_function_hydration_data.object_id, client, service_function_hydration_data.function_handle_metadata
+            service_function_hydration_data.object_id,
+            client,
+            service_function_hydration_data.function_handle_metadata,
+            is_another_app=True,
         )
         cls = modal.cls.Cls.from_local(cls, active_app, class_service_function)
 

--- a/modal/_runtime/user_code_imports.py
+++ b/modal/_runtime/user_code_imports.py
@@ -181,8 +181,11 @@ class ImportedClass(Service):
 def get_user_class_instance(_cls: modal.cls._Cls, args: tuple, kwargs: dict[str, Any]) -> typing.Any:
     """Returns instance of the underlying class to be used as the `self`
 
-    The input `cls` can either be the raw Python class the user has declared ("user class"),
-    or an @app.cls-decorated version of it which is a modal.Cls-instance wrapping the user class.
+    For the time being, this is an instance of the underlying user defined type, with
+    some extra attributes like parameter values and _modal_functions set, allowing
+    its methods to be used as modal Function objects with .remote() and .local() etc.
+
+    TODO: Could possibly change this to use an Obj to clean up the data model? would invalidate isinstance checks though
     """
     cls = synchronizer._translate_out(_cls)  # ugly
     modal_obj: modal.cls.Obj = cls(*args, **kwargs)

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -139,7 +139,7 @@ def _bind_instance_method(cls: "_Cls", service_function: _Function, method_name:
             # ugly - needed for .local()  TODO (elias): Clean up!
             partial_function.raw_f,
             user_cls=cls._user_cls,
-            serialized=service_function.info.is_serialized(),
+            serialized=True,  # service_function.info.is_serialized(),
         )
 
     fun._obj = service_function._obj

--- a/test/supports/user_code_import_samples/cls.py
+++ b/test/supports/user_code_import_samples/cls.py
@@ -18,6 +18,10 @@ class C:
     def calls_f_remote(self, arg):
         return self.f.remote(arg)
 
+    @modal.method()
+    def self_ref(self):
+        return self
+
 
 UndecoratedC = C  # keep a reference to original class before overwriting
 


### PR DESCRIPTION
# Background 
Before this patch, all function and class hydration in the container entrypoint was done via "app references" that are created as a side effect when running `@app.cls` / `@app.function` decorators, inside of the container entrypoint as part of importing the user code.

This had the unfortunate effect that hydration, even of the entrypoint function itself, *does not work* if the decorators never run inside the container entrypoint, which is the case for:
* Globally defined but locally decorated functions, e.g.
```py
def myfunc():
    ...

if modal.is_local():
     # non-global decoration, can be useful for parametric deployments etc.
     app.function(gpu="A100")(myfunc)
```
* `serialized=True` functions (since these never load modules)

This hasn't been a huge issue, since these are pretty rare use cases and even in these cases most code has been able to run anyways. But in particular for classes (serialized or locally decorated) this caused a few issues:
* `self` references inside the container would not have hydrated methods, so you can't call `self.other.remote()`
* modal.parameter()-based synthetic constructors of classes wouldn't work, so containers with such parameters couldn't even be initialized

# The fix

This fixes the issue by using the AppLayout information to do name-based (arguably a bit janky but probably safe) inference of the currently running class + class service function metadata, and hydrate the currently executing class using that metadata. This then lets us use the same object instantiation logic inside containers regardless of the definition methods, and ensures that the bound `self` is a fully hydrated variant of the user class.

This patch should also let us potentially migrate to using an `Obj` as the `self` inside of container runs, which hasn't been the case so far, but would probably be good for consistency, since it would make `self` inside containers behave the same as the class instance at the class construction site.

# The scary part
This does introduce a hard dependency on a a proper AppLayout being provided by the worker, but this should be the case for any deploys using the current version (and the changed container entrypoint would not get used by older apps anyway), so I think this should be safe

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

* Fixes a bug where `serialized=True` classes could not `self.` reference other methods on the class, or use `modal.parameter()` synthetic constructors
