### PR TITLE
[FS-209] modal_proto: Re-visit structure of VolumePutFiles2Request

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2893,17 +2893,12 @@ message VolumeMount {
 }
 
 message VolumePutFiles2Request {
-  // List of files, sorted lexicographically by `path`.
+  // List of files to put/upload.
   repeated File files = 1;
-
-  // The last time the client called `VolumePutFiles2` for this file, it was
-  // told that some blocks were missing. This field contains information
-  // about the client having uploaded those missing blocks.
-  repeated NewBlock new_blocks = 2;
 
   // If set to true, prevent overwriting existing files. (Note that we don't
   // allow overwriting existing directories with uploaded files regardless.)
-  bool disallow_overwrite_existing_files = 3;
+  bool disallow_overwrite_existing_files = 2;
 
   message File {
     // Destination path of the file to be uploaded, including any parent dirs
@@ -2913,22 +2908,22 @@ message VolumePutFiles2Request {
     // The total size of the file, in bytes.
     uint64 size = 2;
 
-    // SHA-256 checksum of each 8MiB block of the file's contents, in binary
-    // (ie 32 raw bytes) format for compactness.
-    repeated bytes blocks_sha256 = 3;
+    // The blocks, in units of 8MiB, that this file consists of.
+    repeated Block blocks = 3;
   }
 
-  message NewBlock {
-    // Index of the file in the `files` field.
-    uint64 file_index = 1;
+  message Block {
+    // The SHA256 digest of the contents of this block, in raw (ie. 32 bytes)
+    // form for compactness.
+    bytes contents_sha256 = 1;
 
-    // The index of the block in `files[file_index].blocks_sha256`.
-    uint64 block_index = 2;
-
-    // The raw bytes of the body that was returned from the HTTP PUT request
-    // when the client made a request for the `put_url` returned in the
-    // previous `VolumePutFiles2Response`.
-    bytes put_response = 3;
+    // From a previous call to `VolumePutFiles2`, we might have gotten a
+    // response indicating that this block was missing.
+    //
+    // For such a block, this field contains the raw bytes of the body that
+    // was returned from the HTTP PUT request when the client made a request
+    // for the `put_url` returned in the previous `VolumePutFiles2Response`.
+    optional bytes put_response = 2;
   }
 }
 
@@ -2947,8 +2942,8 @@ message VolumePutFiles2Response {
     // Index of the file in the original `files` field of the request.
     uint64 file_index = 1;
 
-    // The index of the block in the original
-    // `files[file_index].blocks_sha256`.
+    // The index of the block in the original `files[file_index].blocks` of the
+    // request.
     uint64 block_index = 2;
 
     // Make a HTTP PUT request to this endpoint with the blocks' contents as


### PR DESCRIPTION
## Describe your changes

- Made some alterations based on feedback in #3004. It is safe to change this API in a backwards-incompatible way as it is not yet implemented on the server.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
