### PR TITLE
modal_proto: Add back accidentally deleted volume_id request field

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2893,12 +2893,15 @@ message VolumeMount {
 }
 
 message VolumePutFiles2Request {
+  // The ID of the volume to put/upload files into.
+  string volume_id = 1;
+
   // List of files to put/upload.
-  repeated File files = 1;
+  repeated File files = 2;
 
   // If set to true, prevent overwriting existing files. (Note that we don't
   // allow overwriting existing directories with uploaded files regardless.)
-  bool disallow_overwrite_existing_files = 2;
+  bool disallow_overwrite_existing_files = 3;
 
   message File {
     // Destination path of the file to be uploaded, including any parent dirs


### PR DESCRIPTION
## Describe your changes

Accidentally a whole field; added it back now. Still safe to change the schema as the server side is not implemented yet.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
