### PR TITLE
Deprecate terminate_container_on_exit and doc pty_info

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -800,7 +800,10 @@ message ContainerExecPutInputRequest {
 message ContainerExecRequest {
   string task_id = 1;
   repeated string command = 2;
-  PTYInfo pty_info = 3;
+  // If pty_info is provided, open a PTY, but also this container exec is treated an
+  // "interactive shell" request, and it will be terminated if messages are not periodically
+  // sent on the stdin stream on some interval (currently 40 seconds).
+  optional PTYInfo pty_info = 3;
   // Send SIGTERM to running container on exit of exec command.
   bool terminate_container_on_exit = 4 [deprecated=true];
   bool runtime_debug = 5; // For internal debugging use only.

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -802,7 +802,7 @@ message ContainerExecRequest {
   repeated string command = 2;
   PTYInfo pty_info = 3;
   // Send SIGTERM to running container on exit of exec command.
-  bool terminate_container_on_exit = 4;
+  bool terminate_container_on_exit = 4 [deprecated=true];
   bool runtime_debug = 5; // For internal debugging use only.
   ExecOutputOption stdout_output = 6;
   ExecOutputOption stderr_output = 7;


### PR DESCRIPTION
Unused and as of the worker rewrite, this will be unhandled as well
