### PR TITLE
Improve error messages for failed Function and Cls lookups

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1110,7 +1110,10 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                 response = await retry_transient_errors(resolver.client.stub.FunctionGet, request)
             except GRPCError as exc:
                 if exc.status == Status.NOT_FOUND:
-                    raise NotFoundError(exc.message)
+                    env_context = f" (in the '{environment_name}' environment)" if environment_name else ""
+                    raise NotFoundError(
+                        f"Lookup failed for Function '{name}' from the '{app_name}' app{env_context}: {exc.message}."
+                    )
                 else:
                     raise
 

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -557,7 +557,10 @@ class _Cls(_Object, type_prefix="cs"):
                 response = await retry_transient_errors(resolver.client.stub.ClassGet, request)
             except GRPCError as exc:
                 if exc.status == Status.NOT_FOUND:
-                    raise NotFoundError(exc.message)
+                    env_context = f" (in the '{environment_name}' environment)" if environment_name else ""
+                    raise NotFoundError(
+                        f"Lookup failed for Cls '{name}' from the '{app_name}' app{env_context}: {exc.message}."
+                    )
                 elif exc.status == Status.FAILED_PRECONDITION:
                     raise InvalidError(exc.message)
                 else:

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -460,6 +460,14 @@ def test_lookup_lazy_spawn(client, servicer):
     assert function_call.get() == 7693
 
 
+def test_failed_lookup_error(client, servicer):
+    with pytest.raises(NotFoundError, match="Lookup failed for Cls 'Foo' from the 'my-cls-app' app"):
+        Cls.from_name("my-cls-app", "Foo").hydrate(client=client)
+
+    with pytest.raises(NotFoundError, match="in the 'some-env' environment"):
+        Cls.from_name("my-cls-app", "Foo", environment_name="some-env").hydrate(client=client)
+
+
 baz_app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
 
 

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -15,7 +15,7 @@ import modal
 from modal import App, Image, NetworkFileSystem, Proxy, asgi_app, batched, fastapi_endpoint
 from modal._utils.async_utils import synchronize_api
 from modal._vendor import cloudpickle
-from modal.exception import DeprecationError, ExecutionError, InvalidError
+from modal.exception import DeprecationError, ExecutionError, InvalidError, NotFoundError
 from modal.functions import Function, FunctionCall
 from modal.runner import deploy_app
 from modal_proto import api_pb2
@@ -1388,3 +1388,11 @@ def test_class_schema_recording(client, servicer):
     assert modal.cls._get_method_schemas(modal.Cls.from_name("app", "F")) == method_schemas
     (looked_up_construct_arg,) = modal.cls._get_constructor_args(modal.Cls.from_name("app", "F"))
     assert looked_up_construct_arg == constructor_arg
+
+
+def test_failed_lookup_error(client, servicer):
+    with pytest.raises(NotFoundError, match="Lookup failed for Function 'f' from the 'app' app"):
+        Function.from_name("app", "f").hydrate(client=client)
+
+    with pytest.raises(NotFoundError, match="in the 'some-env' environment"):
+        Function.from_name("app", "f", environment_name="some-env").hydrate(client=client)


### PR DESCRIPTION
When Function or Cls lookups fail with a NotFound status, the server doesn't include the name of the object that was not found. This can make it hard to diagnose issues if you are looking up an object programatically. We have that information on the client side, so we can enrich the Python exception that we raise:

<img width="708" alt="image" src="https://github.com/user-attachments/assets/4fd9a9f3-e28f-4218-983a-596ec431284b" />
