### PR TITLE
Add `return_exceptions` argument to `modal.FunctionCall.gather`.

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1768,7 +1768,7 @@ class _FunctionCall(typing.Generic[ReturnType], _Object, type_prefix="fc"):
         `Function.spawn()`).
 
         By default, this will raise an exception from the first failing function call. If `return_exceptions=True`, it
-        will instead return a list of results, with exceptions aggregated in the results list.
+        will instead aggregate exceptions in the results list.
 
         Examples:
 

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1760,7 +1760,10 @@ class _FunctionCall(typing.Generic[ReturnType], _Object, type_prefix="fc"):
         return fc
 
     @staticmethod
-    async def gather(*function_calls: "_FunctionCall[T]") -> typing.Sequence[T]:
+    async def gather(
+        *function_calls: "_FunctionCall[T]",
+        return_exceptions: bool = False,  # propagate exceptions (False) or aggregate them in the results list (True)
+    ) -> typing.Sequence[T | BaseException]:
         """Wait until all Modal FunctionCall objects have results before returning.
 
         Accepts a variable number of `FunctionCall` objects, as returned by `Function.spawn()`.
@@ -1779,6 +1782,9 @@ class _FunctionCall(typing.Generic[ReturnType], _Object, type_prefix="fc"):
 
         *Added in v0.73.69*: This method replaces the deprecated `modal.functions.gather` function.
         """
+        if return_exceptions:
+            return await asyncio.gather(*[fc.get() for fc in function_calls], return_exceptions=True)
+
         try:
             return await TaskContext.gather(*[fc.get() for fc in function_calls])
         except Exception as exc:

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1764,12 +1764,11 @@ class _FunctionCall(typing.Generic[ReturnType], _Object, type_prefix="fc"):
         *function_calls: "_FunctionCall[T]",
         return_exceptions: bool = False,  # propagate exceptions (False) or aggregate them in the results list (True)
     ) -> typing.Sequence[T | BaseException]:
-        """Wait until all Modal FunctionCall objects have results before returning.
+        """Returns a list of results from a variable number of Modal `FunctionCall` objects (as returned by
+        `Function.spawn()`).
 
-        Accepts a variable number of `FunctionCall` objects, as returned by `Function.spawn()`.
-
-        Returns a list of results from each FunctionCall, or raises an exception
-        from the first failing function call.
+        By default, this will raise an exception from the first failing function call. If `return_exceptions=True`, it
+        will instead return a list of results, with exceptions aggregated in the results list.
 
         Examples:
 


### PR DESCRIPTION
## Describe your changes

This is possible in the async context by using asyncio.gather directly, but we want to expose this in a sync way for users as well.

## Changelog

- Adds a `return_exceptions` argument to `modal.FunctionCall.gather` to allow gathering failed and successful results from a collection of `FunctionCall` objects.
