### PR TITLE
Add RDMA resource for expressing whether a task can use RDMA

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2228,6 +2228,7 @@ message Resources {
   uint32 memory_mb_max = 5; // MiB
   uint32 ephemeral_disk_mb = 6;  // MiB
   uint32 milli_cpu_max = 7; // milli CPU cores
+  bool rdma = 8; // Whether to use RDMA interfaces
 }
 
 message RuntimeInputMessage {


### PR DESCRIPTION
## Describe your changes

This will enable the client to selectively use RDMA or normal i6pn networking.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

