### PR TITLE
Add initial msgs for clusters

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -757,13 +757,6 @@ message CloudBucketMount {
   optional string oidc_auth_role_arn = 9;
 }
 
-message ClusterStats {
-  string app_id = 1;
-  repeated string task_ids = 2;
-  string region = 3;
-  double started_at = 4; // Defined as start time of the first task in the cluster
-}
-
 message ClusterGetRequest {
   string cluster_id = 1;
 }
@@ -778,6 +771,13 @@ message ClusterListRequest {
 
 message ClusterListResponse {
   repeated ClusterStats clusters = 1;
+}
+
+message ClusterStats {
+  string app_id = 1;
+  repeated string task_ids = 2;
+  string region = 3;
+  double started_at = 4; // Defined as start time of the first task in the cluster
 }
 
 message CommitInfo {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -757,6 +757,29 @@ message CloudBucketMount {
   optional string oidc_auth_role_arn = 9;
 }
 
+message ClusterStats {
+  string app_id = 1;
+  repeated string task_ids = 2;
+  string region = 3;
+  double started_at = 4; // Defined as start time of the first task in the cluster
+}
+
+message ClusterGetRequest {
+  string cluster_id = 1;
+}
+
+message ClusterGetResponse {
+  ClusterStats cluster = 1;
+}
+
+message ClusterListRequest {
+  string environment_name = 1;
+}
+
+message ClusterListResponse {
+  repeated ClusterStats clusters = 1;
+}
+
 message CommitInfo {
   string vcs = 1; // Only git is supported for now
   string branch = 2;
@@ -3051,6 +3074,10 @@ service ModalClient {
 
   // Clients
   rpc ClientHello(google.protobuf.Empty) returns (ClientHelloResponse);
+
+  // Clusters
+  rpc ClusterGet(ClusterGetRequest) returns (ClusterGetResponse);
+  rpc ClusterList(ClusterListRequest) returns (ClusterListResponse);
 
   // Container
   rpc ContainerCheckpoint(ContainerCheckpointRequest) returns (google.protobuf.Empty);


### PR DESCRIPTION
## Describe your changes

Adding these so I can start PoCing improved cluster DX

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>
