### PR TITLE
Support for modal run:ing class methods defined with modal.parameter

### DIFF
--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -10,7 +10,7 @@ import time
 import typing
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Callable, Optional, get_type_hints
+from typing import Any, Callable, Optional
 
 import click
 import typer
@@ -77,7 +77,7 @@ class CliRunnableSignature:
 
 def safe_get_type_hints(func_or_cls: typing.Union[Callable[..., Any], type]) -> dict[str, type]:
     try:
-        return get_type_hints(func_or_cls)
+        return typing.get_type_hints(func_or_cls)
     except Exception as exc:
         # E.g., if entrypoint type hints cannot be evaluated by local Python runtime
         msg = "Unable to generate command line interface for app entrypoint. See traceback above for details."
@@ -201,7 +201,7 @@ def _get_click_command_for_function(app: App, function: Function):
         raise InvalidError("`modal run` is not supported for generator functions")
 
     sig: inspect.Signature = inspect.signature(function.info.raw_f)
-    type_hints = typing.get_type_hints(function.info.raw_f)
+    type_hints = safe_get_type_hints(function.info.raw_f)
     signature: CliRunnableSignature = _get_cli_runnable_signature(sig, type_hints)
 
     def _inner(args, click_kwargs):
@@ -225,7 +225,7 @@ def _get_click_command_for_cls(app: App, method_ref: MethodReference):
     method_name = method_ref.method_name
 
     user_cls = cls._get_user_cls()
-    type_hints = typing.get_type_hints(user_cls)
+    type_hints = safe_get_type_hints(user_cls)
     sig: inspect.Signature = _get_class_constructor_signature(user_cls)
     cls_signature: CliRunnableSignature = _get_cli_runnable_signature(sig, type_hints)
 

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -80,7 +80,7 @@ def safe_get_type_hints(func_or_cls: typing.Union[Callable[..., Any], type]) -> 
         return typing.get_type_hints(func_or_cls)
     except Exception as exc:
         # E.g., if entrypoint type hints cannot be evaluated by local Python runtime
-        msg = "Unable to generate command line interface for app entrypoint. See traceback above for details."
+        msg = "Unable to generate command line interface for app entrypoint due to unparseable type hints:\n" + str(exc)
         raise ExecutionError(msg) from exc
 
 

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -7,6 +7,7 @@ import re
 import shlex
 import sys
 import time
+import typing
 from dataclasses import dataclass
 from functools import partial
 from typing import Any, Callable, Optional, get_type_hints
@@ -18,6 +19,7 @@ from typing_extensions import TypedDict
 
 from .._functions import _FunctionSpec
 from ..app import App, LocalEntrypoint
+from ..cls import _get_class_constructor_signature
 from ..config import config
 from ..environments import ensure_env
 from ..exception import ExecutionError, InvalidError, _CliUserExecutionError
@@ -42,7 +44,7 @@ class ParameterMetadata(TypedDict):
     name: str
     default: Any
     annotation: Any
-    type_hint: Any
+    type_hint: Any  # same as annotation but evaluated by typing.get_type_hints
     kind: Any
 
 
@@ -73,22 +75,19 @@ class FnSignature:
     has_variadic_args: bool
 
 
-def _get_signature(f: Callable[..., Any], is_method: bool = False) -> FnSignature:
+def safe_get_type_hints(func_or_cls: typing.Union[Callable[..., Any], type]) -> dict[str, type]:
     try:
-        type_hints = get_type_hints(f)
+        return get_type_hints(func_or_cls)
     except Exception as exc:
         # E.g., if entrypoint type hints cannot be evaluated by local Python runtime
         msg = "Unable to generate command line interface for app entrypoint. See traceback above for details."
         raise ExecutionError(msg) from exc
 
+
+def _get_signature(sig: inspect.Signature, type_hints: dict[str, type]) -> FnSignature:
     has_variadic_args = False
-
-    if is_method:
-        self = None  # Dummy, doesn't matter
-        f = functools.partial(f, self)
-
     signature: dict[str, ParameterMetadata] = {}
-    for param in inspect.signature(f).parameters.values():
+    for param in sig.parameters.values():
         if param.kind == inspect.Parameter.VAR_POSITIONAL:
             has_variadic_args = True
         else:
@@ -201,7 +200,9 @@ def _get_click_command_for_function(app: App, function: Function):
     if function.is_generator:
         raise InvalidError("`modal run` is not supported for generator functions")
 
-    signature = _get_signature(function.info.raw_f)
+    sig: inspect.Signature = inspect.signature(function.info.raw_f)
+    type_hints = typing.get_type_hints(function.info.raw_f)
+    signature: FnSignature = _get_signature(sig, type_hints)
 
     def _inner(args, click_kwargs):
         return function.remote(*args, **click_kwargs)
@@ -223,7 +224,10 @@ def _get_click_command_for_cls(app: App, method_ref: MethodReference):
     cls = method_ref.cls
     method_name = method_ref.method_name
 
-    cls_signature = _get_signature(cls._get_user_cls())
+    user_cls = cls._get_user_cls()
+    type_hints = typing.get_type_hints(user_cls)
+    sig: inspect.Signature = _get_class_constructor_signature(user_cls)
+    cls_signature: FnSignature = _get_signature(sig, type_hints)
 
     if cls_signature.has_variadic_args:
         raise InvalidError("Modal classes cannot have variable-length positional arguments (*args).")
@@ -241,7 +245,9 @@ def _get_click_command_for_cls(app: App, method_ref: MethodReference):
             )
 
     partial_function = partial_functions[method_name]
-    fun_signature = _get_signature(partial_function._get_raw_f(), is_method=True)
+    raw_f = partial_function._get_raw_f()
+    sig_without_self = inspect.signature(functools.partial(raw_f, None))
+    fun_signature = _get_signature(sig_without_self, typing.get_type_hints(raw_f))
 
     # TODO(erikbern): assert there's no overlap?
     parameters = dict(**cls_signature.parameters, **fun_signature.parameters)  # Pool all arguments
@@ -271,7 +277,7 @@ def _get_click_command_for_local_entrypoint(app: App, entrypoint: LocalEntrypoin
     func = entrypoint.info.raw_f
     isasync = inspect.iscoroutinefunction(func)
 
-    signature = _get_signature(func)
+    signature = _get_signature(inspect.signature(func), typing.get_type_hints(func))
 
     @click.pass_context
     def f(ctx, *args, **kwargs):

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -352,13 +352,17 @@ def test_run_parse_args_entrypoint(servicer, set_env_client, test_dir):
         assert expected in res.stdout
         assert len(servicer.client_calls) == 0
 
-    if sys.version_info >= (3, 10):
-        res = _run(["run", f"{app_file.as_posix()}::unparseable_annot", "--i=20"], expected_exit_code=1)
-        assert "Parameter `i` has unparseable annotation: typing.Union[int, str]" in str(res.exception)
+    res = _run(["run", f"{app_file.as_posix()}::unparseable_annot", "--i=20"], expected_exit_code=1)
+    assert "Parameter `i` has unparseable annotation: typing.Union[int, str]" in str(res.exception)
+
+    res = _run(["run", f"{app_file.as_posix()}::unevaluatable_annot", "--i=20"], expected_exit_code=1)
+    assert "Unable to generate command line interface" in str(res.exception)
+    assert "no go" in str(res.exception)
 
     if sys.version_info <= (3, 10):
         res = _run(["run", f"{app_file.as_posix()}::optional_arg_pep604"], expected_exit_code=1)
-        assert "Unable to generate command line interface for app entrypoint." in str(res.exception)
+        assert "Unable to generate command line interface for app entrypoint" in str(res.exception)
+        assert "unsupported operand" in str(res.exception)
 
 
 def test_run_parse_args_function(servicer, set_env_client, test_dir, recwarn, disable_auto_mount):

--- a/test/supports/app_run_tests/cli_args.py
+++ b/test/supports/app_run_tests/cli_args.py
@@ -71,3 +71,8 @@ def optional_arg_fn(i: Optional[int] = None):
 @app.local_entrypoint()
 def unparseable_annot(i: Union[int, str]):
     pass
+
+
+@app.local_entrypoint()
+def unevaluatable_annot(i: "nogo"):  # noqa
+    pass

--- a/test/supports/app_run_tests/cli_args.py
+++ b/test/supports/app_run_tests/cli_args.py
@@ -74,5 +74,5 @@ def unparseable_annot(i: Union[int, str]):
 
 
 @app.local_entrypoint()
-def unevaluatable_annot(i: "nogo"):  # noqa
+def unevaluatable_annot(i: "no go"):  # noqa
     pass

--- a/test/supports/app_run_tests/cli_args.py
+++ b/test/supports/app_run_tests/cli_args.py
@@ -74,5 +74,5 @@ def unparseable_annot(i: Union[int, str]):
 
 
 @app.local_entrypoint()
-def unevaluatable_annot(i: "no go"):  # noqa
+def unevaluatable_annot(i: "no go"):  # type: ignore  # noqa
     pass

--- a/test/supports/app_run_tests/cls.py
+++ b/test/supports/app_run_tests/cls.py
@@ -6,8 +6,7 @@ app = modal.App()
 
 @app.cls()
 class AParametrized:
-    def __init__(self, x: int):
-        self._x = x
+    x: int = modal.parameter()
 
     @modal.method()
     def some_method(self, y: int): ...


### PR DESCRIPTION
A bit of code repetition across different cases in order to have the same internal signature representation work for both classes and functions.

I am itching to rewrite this CLI signature stuff using the `_type_manager.py` we use for schemas and parameter serde, but won't do that right now

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

* Fixes a bug where `modal run` didn't recognize `modal.parameter()` class parameters