### PR TITLE
improve cluster proto msg

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -776,7 +776,7 @@ message ClusterListResponse {
 message ClusterStats {
   string app_id = 1;
   repeated string task_ids = 2;
-  string region = 3;
+  string cluster_id = 3;
   double started_at = 4; // Defined as start time of the first task in the cluster
 }
 


### PR DESCRIPTION
## Describe your changes

Turns out I don't want to expose `region` because it's not valid to say that a cluster only has one region. That's _currently_ the case, but it's not a restriction we want binding us in the future (e.g. DiLiCo cluster with GPUs spread across multiple regions in a cloud). 

Because nothing is consuming this proto I'll just swap out the name for a field I do need, `cluster_id`. Realized I was stupid and I need the ID in the list response. 

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---
