### PR TITLE
[CLI-269] limit output batch to 20

### DIFF
--- a/test/supports/functions.py
+++ b/test/supports/functions.py
@@ -493,6 +493,12 @@ def batch_function_sync(x: tuple[int], y: tuple[int]):
 
 
 @app.function()
+@batched(max_batch_size=500, wait_ms=500)
+def batch_function_sync_large_batch(x: tuple[int], y: tuple[int]):
+    return [x_i / y_i for x_i, y_i in zip(x, y)]
+
+
+@app.function()
 @batched(max_batch_size=4, wait_ms=500)
 def batch_function_outputs_not_list(x: tuple[int], y: tuple[int]):
     return str(x)


### PR DESCRIPTION
## Describe your changes

- _Provide Linear issue reference (e.g. MOD-1234) if available._

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->

- Fix bug where containers hang with batch sizes above 100 (with `@modal.batched`).
- Fix bug where containers can fail with large outputs and batch sizes above 49 (with `@modal.batched`)