### PR TITLE
Catch modification of Mount contents between build start and upload

### DIFF
--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2023
 import asyncio
 import contextlib
+import time
 import typing
 from asyncio import Future
 from collections.abc import Hashable
@@ -46,6 +47,7 @@ class Resolver:
     _app_id: Optional[str]
     _deduplication_cache: dict[Hashable, Future]
     _client: _Client
+    _build_start: float
 
     def __init__(
         self,
@@ -72,6 +74,7 @@ class Resolver:
         self._app_id = app_id
         self._environment_name = environment_name
         self._deduplication_cache = {}
+        self._build_start = time.time()
 
     @property
     def app_id(self) -> Optional[str]:
@@ -84,6 +87,10 @@ class Resolver:
     @property
     def environment_name(self):
         return self._environment_name
+
+    @property
+    def build_start(self) -> float:
+        return self._build_start
 
     async def preload(self, obj, existing_object_id: Optional[str]):
         if obj._preload is not None:

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -532,6 +532,12 @@ class _Mount(_Object, type_prefix="mo"):
                 n_finished += 1
                 return mount_file
 
+            if file_spec.mtime is not None and file_spec.mtime > resolver.build_start:
+                # TODO do we want a config switch to make this a warning?
+                raise modal.exception.ExecutionError(
+                    f"{file_spec.source_description} was modified during build process."
+                )
+
             request = api_pb2.MountPutFileRequest(sha256_hex=file_spec.sha256_hex)
             accounted_hashes.add(file_spec.sha256_hex)
             response = await retry_transient_errors(resolver.client.stub.MountPutFile, request, base_delay=1)


### PR DESCRIPTION
## Describe your changes

Some users have run into issues when they modify the local files included in their Modal App during a build (e.g., changing the git branch). Because some steps might need to run before we checksum the files and upload them to the Modal server, it's possible for the App to end up including the wrong contents.

Solving this in general is fairly challenging, but we can try to catch it when it happens. The approach here for the Resolver object to track when it was instantiated and to cross-reference the modification time of any files that we Mount against this baseline.

This is a little scary. It might make sense to include a config options that turns it into a warning? (Or ignores it altogether?)



- Fixes CLI-277
  
<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
