### PR TITLE
Add libmodal client type

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -78,11 +78,12 @@ enum CheckpointStatus {
 
 enum ClientType {
   CLIENT_TYPE_UNSPECIFIED = 0;
-  CLIENT_TYPE_CLIENT = 1;
-  CLIENT_TYPE_WORKER = 2;
-  CLIENT_TYPE_CONTAINER = 3;
-  CLIENT_TYPE_WEB_SERVER = 5;
-  CLIENT_TYPE_NOTEBOOK_KERNEL = 6;
+  CLIENT_TYPE_CLIENT = 1; // modal-client: Modal Python SDK
+  CLIENT_TYPE_WORKER = 2; // modal-worker
+  CLIENT_TYPE_CONTAINER = 3; // modal-client from inside containers
+  CLIENT_TYPE_WEB_SERVER = 5; // modal-web
+  CLIENT_TYPE_NOTEBOOK_KERNEL = 6; // kernelshim.py from notebooks
+  CLIENT_TYPE_LIBMODAL = 7; // libmodal: experimental client library
 }
 
 enum CloudProvider {


### PR DESCRIPTION
Needs new client type. This is experimental for now but eventually we'll need to make a stable one, with its own versioning system, depending on how we version this between different languages.

For now I'm just adding this because `x-modal-client-version` is required for `CLIENT_TYPE_CLIENT` and I've been setting it to some value like `9000` in my tests. Which is probably not very hygienic. I should stop doing that.