### PR TITLE
Add `go_package` to client protos

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+option go_package = "github.com/modal-labs/modal/go/proto";
+
 package modal.client;
 
 import "modal_proto/options.proto";

--- a/modal_proto/options.proto
+++ b/modal_proto/options.proto
@@ -3,6 +3,8 @@
 // Reference: https://protobuf.dev/programming-guides/proto2/#customoptions
 syntax = "proto3";
 
+option go_package = "github.com/modal-labs/modal/go/proto";
+
 import "google/protobuf/descriptor.proto";
 
 package modal.options;


### PR DESCRIPTION
Our Go server needs access to client protos, so we need to add a `go_package` path to these proto files.