### PR TITLE
Add experimental update_autoscaler function

### DIFF
--- a/modal/experimental/__init__.py
+++ b/modal/experimental/__init__.py
@@ -7,11 +7,14 @@ from typing import Literal, Optional, Union
 from modal_proto import api_pb2
 
 from .._clustered_functions import ClusterInfo, get_cluster_info as _get_cluster_info
+from .._functions import _Function
 from .._object import _get_environment_name
 from .._partial_function import _clustered
 from .._runtime.container_io_manager import _ContainerIOManager
 from .._utils.async_utils import synchronize_api, synchronizer
+from .._utils.grpc_utils import retry_transient_errors
 from ..client import _Client
+from ..cls import _Obj
 from ..exception import InvalidError
 from ..image import DockerfileSpec, ImageBuilderVersion, _Image, _ImageRegistryConfig
 from ..secret import _Secret
@@ -157,3 +160,35 @@ async def raw_registry_image(
         image_registry_config=registry_config,
         force_build=force_build,
     )
+
+
+@synchronizer.create_blocking
+async def update_autoscaler(
+    obj: Union[_Function, _Obj],
+    *,
+    min_containers: Optional[int] = None,
+    max_containers: Optional[int] = None,
+    buffer_containers: Optional[int] = None,
+    scaledown_window: Optional[int] = None,
+    client: Optional[_Client] = None,
+) -> None:
+    """Update the autoscaler settings for a Function or Obj (instance of a Cls).
+
+    This is an experimental interface for a feature that we will be adding to
+    replace the existing `.keep_warm()` method. The stable form of this interface
+    may look different (i.e., it may be a standalone function or a method).
+
+    """
+    f = obj if isinstance(obj, _Function) else obj._cached_service_function()
+
+    if client is None:
+        client = await _Client.from_env()
+
+    settings = api_pb2.AutoscalerSettings(
+        min_containers=min_containers,
+        max_containers=max_containers,
+        buffer_containers=buffer_containers,
+        scaledown_window=scaledown_window,
+    )
+    request = api_pb2.FunctionUpdateSchedulingParamsRequest(function_id=f.object_id, settings=settings)
+    await retry_transient_errors(client.stub.FunctionUpdateSchedulingParams, request)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -62,11 +62,14 @@ class VolumeFile:
     data_blob_id: str
     mode: int
 
+
 @dataclasses.dataclass
 class GrpcErrorAndCount:
-    """ Helper class that holds a gRPC error and the number of times it should be raised. """
+    """Helper class that holds a gRPC error and the number of times it should be raised."""
+
     grpc_error: Status
     count: int
+
 
 # TODO: Isolate all test config from the host
 @pytest.fixture(scope="function", autouse=True)
@@ -1285,8 +1288,10 @@ class MockClientServicer(api_grpc.ModalClientBase):
         # update function definition
         fn_definition = self.app_functions[req.function_id]
         assert isinstance(fn_definition, api_pb2.Function)
-        fn_definition.warm_pool_size = req.warm_pool_size_override  # hacky
-
+        # Hacky that we're modifying the function definition directly
+        # In the server we track autoscaler updates separately
+        fn_definition.warm_pool_size = req.warm_pool_size_override
+        fn_definition.autoscaler_settings.MergeFrom(req.settings)
         await stream.send_message(api_pb2.FunctionUpdateSchedulingParamsResponse())
 
     ### Image

--- a/test/experimental_test.py
+++ b/test/experimental_test.py
@@ -31,13 +31,13 @@ def test_update_autoscaler(client, servicer, which):
 
     with app.run(client=client):
         obj: Union[modal.Function, modal.cls.Obj]
+        # Hardcode the object ID based on what we expect from the mock servicer
+        # which is pretty janky, but avoids hydrating the object in the test so that
+        # we can properly assert that update_autoscaler handles unhydrated objects correctly.
         if which == "function":
-            obj = f
-            obj_id = obj.object_id
+            obj, obj_id = f, "fu-1"
         else:
-            obj = cast(modal.cls.Obj, C())
-            # This is ugly
-            obj_id = obj._cached_service_function().object_id  # type: ignore
+            obj, obj_id = cast(modal.cls.Obj, C()), "fu-2"
 
         modal.experimental.update_autoscaler(obj, client=client, **overrides)  # type: ignore
 

--- a/test/experimental_test.py
+++ b/test/experimental_test.py
@@ -1,0 +1,47 @@
+# Copyright Modal Labs 2025
+
+import pytest
+
+import modal
+import modal.experimental
+
+app = modal.App(include_source=False)
+
+
+@app.function()
+def f():
+    pass
+
+
+@app.cls()
+class C:
+    @modal.method()
+    def method(self):
+        pass
+
+
+@pytest.mark.parametrize("which", ["function", "cls"])
+def test_update_autoscaler(client, servicer, which):
+    overrides = {
+        "min_containers": 1,
+        "max_containers": 5,
+        "buffer_containers": 2,
+        "scaledown_window": 10,
+    }
+
+    with app.run(client=client):
+        if which == "function":
+            obj = f
+            obj_id = obj.object_id
+        else:
+            obj = C()
+            # This is ugly
+            obj_id = obj._cached_service_function().object_id  # type: ignore
+
+        modal.experimental.update_autoscaler(obj, client=client, **overrides)  # type: ignore
+
+        settings = servicer.app_functions[obj_id].autoscaler_settings  # type: ignore
+        assert settings.min_containers == overrides["min_containers"]
+        assert settings.max_containers == overrides["max_containers"]
+        assert settings.buffer_containers == overrides["buffer_containers"]
+        assert settings.scaledown_window == overrides["scaledown_window"]

--- a/test/experimental_test.py
+++ b/test/experimental_test.py
@@ -60,8 +60,9 @@ def test_update_autoscaler_after_lookup(client, servicer, which):
         "scaledown_window": 10,
     }
 
-    # See above for why we're hardcoding the object ID.
+    # See above for why we're hardcoding the object IDs.
     # Would be much nicer to be able to look up the internal definition by the *name*...
+    obj: Union[modal.Function, modal.cls.Obj]
     if which == "function":
         obj = modal.Function.from_name("test", "f")
         obj_id = "fu-1"

--- a/test/experimental_test.py
+++ b/test/experimental_test.py
@@ -1,6 +1,6 @@
 # Copyright Modal Labs 2025
-
 import pytest
+from typing import Union, cast
 
 import modal
 import modal.experimental
@@ -30,11 +30,12 @@ def test_update_autoscaler(client, servicer, which):
     }
 
     with app.run(client=client):
+        obj: Union[modal.Function, modal.cls.Obj]
         if which == "function":
             obj = f
             obj_id = obj.object_id
         else:
-            obj = C()
+            obj = cast(modal.cls.Obj, C())
             # This is ugly
             obj_id = obj._cached_service_function().object_id  # type: ignore
 


### PR DESCRIPTION
A few users have expressed interested in expanded autoscaler overrides, which are fully built on the backend but pending in the client on some decisions about the interface.

In the short-term, we can ship the functionality in the experimental namespace: `modal.experimental.update_autoscaler`. While the final form is likely to be a method, this is a standalone function that can be called on either a Function or an Obj.