### PR TITLE
volume: Add support for VolumePutFiles2 RPC

### DIFF
--- a/modal/_utils/blob_utils.py
+++ b/modal/_utils/blob_utils.py
@@ -1,15 +1,25 @@
 # Copyright Modal Labs 2022
 import asyncio
 import dataclasses
+import functools
 import hashlib
-import io
 import os
 import platform
 import time
 from collections.abc import AsyncIterator
 from contextlib import AbstractContextManager, contextmanager
+from io import BytesIO, FileIO
 from pathlib import Path, PurePosixPath
-from typing import TYPE_CHECKING, Any, BinaryIO, Callable, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    BinaryIO,
+    Callable,
+    ContextManager,
+    Optional,
+    Union,
+    cast,
+)
 from urllib.parse import urlparse
 
 from modal_proto import api_pb2
@@ -42,6 +52,9 @@ DEFAULT_SEGMENT_CHUNK_SIZE = 2**24
 # well, but the limit will never be raised.
 # TODO(dano): remove this once we stop requiring md5 for blobs
 MULTIPART_UPLOAD_THRESHOLD = 1024**3
+
+# For block based storage like volumefs2: the size of a block
+BLOCK_SIZE: int = 8 * 1024 * 1024
 
 
 @retry(n_attempts=5, base_delay=0.5, timeout=None)
@@ -94,7 +107,7 @@ async def _upload_to_s3_url(
 
 
 async def perform_multipart_upload(
-    data_file: Union[BinaryIO, io.BytesIO, io.FileIO],
+    data_file: Union[BinaryIO, BytesIO, FileIO],
     *,
     content_length: int,
     max_part_size: int,
@@ -112,9 +125,9 @@ async def perform_multipart_upload(
     # Give each part its own IO reader object to avoid needing to
     # lock access to the reader's position pointer.
     data_file_readers: list[BinaryIO]
-    if isinstance(data_file, io.BytesIO):
+    if isinstance(data_file, BytesIO):
         view = data_file.getbuffer()  # does not copy data
-        data_file_readers = [io.BytesIO(view) for _ in range(len(part_urls))]
+        data_file_readers = [BytesIO(view) for _ in range(len(part_urls))]
     else:
         filename = data_file.name
         data_file_readers = [open(filename, "rb") for _ in range(len(part_urls))]
@@ -174,7 +187,7 @@ async def _blob_upload(
     upload_hashes: UploadHashes, data: Union[bytes, BinaryIO], stub, progress_report_cb: Optional[Callable] = None
 ) -> str:
     if isinstance(data, bytes):
-        data = io.BytesIO(data)
+        data = BytesIO(data)
 
     content_length = get_content_length(data)
 
@@ -367,6 +380,125 @@ def get_file_upload_spec_from_fileobj(fp: BinaryIO, mount_filename: PurePosixPat
         mount_filename,
         mode,
     )
+
+_FileUploadSource2 = Callable[[], ContextManager[BinaryIO]]
+
+@dataclasses.dataclass
+class FileUploadSpec2:
+    source: _FileUploadSource2
+    source_description: Union[str, Path]
+
+    path: str
+    # Raw (unencoded 32 byte) SHA256 sum per 8MiB file block
+    blocks_sha256: list[bytes]
+    mode: int  # file permission bits (last 12 bits of st_mode)
+    size: int
+
+
+    @staticmethod
+    async def from_path(
+        filename: Path,
+        mount_filename: PurePosixPath,
+        mode: Optional[int] = None,
+    ) -> "FileUploadSpec2":
+        # Python appears to give files 0o666 bits on Windows (equal for user, group, and global),
+        # so we mask those out to 0o755 for compatibility with POSIX-based permissions.
+        mode = mode or os.stat(filename).st_mode & (0o7777 if platform.system() != "Windows" else 0o7755)
+
+        def source():
+            return open(filename, "rb")
+
+        return await FileUploadSpec2._create(
+            source,
+            filename,
+            mount_filename,
+            mode,
+        )
+
+
+    @staticmethod
+    async def from_fileobj(
+        source_fp: Union[BinaryIO, BytesIO],
+        mount_filename: PurePosixPath,
+        mode: int
+    ) -> "FileUploadSpec2":
+        try:
+            fileno = source_fp.fileno()
+            def source():
+                new_fd = os.dup(fileno)
+                fp = os.fdopen(new_fd, "rb")
+                fp.seek(0)
+                return fp
+
+        except OSError:
+            # `.fileno()` not available; assume BytesIO-like type
+            source_fp = cast(BytesIO, source_fp)
+            buffer = source_fp.getbuffer()
+            def source():
+                return BytesIO(buffer)
+
+        return await FileUploadSpec2._create(
+            source,
+            str(source),
+            mount_filename,
+            mode,
+        )
+
+
+    @staticmethod
+    async def _create(
+        source: _FileUploadSource2,
+        source_description: Union[str, Path],
+        mount_filename: PurePosixPath,
+        mode: int,
+    ) -> "FileUploadSpec2":
+        # Current position is ignored - we always upload from position 0
+        with source() as source_fp:
+            source_fp.seek(0, os.SEEK_END)
+            size = source_fp.tell()
+
+        blocks_sha256 = await hash_blocks_sha256(source, size)
+
+        return FileUploadSpec2(
+            source=source,
+            source_description=source_description,
+            path=mount_filename.as_posix(),
+            blocks_sha256=blocks_sha256,
+            mode=mode & 0o7777,
+            size=size,
+        )
+
+
+async def hash_blocks_sha256(
+    source: _FileUploadSource2,
+    size: int,
+) -> list[bytes]:
+    def ceildiv(a: int, b: int) -> int:
+        return -(a // -b)
+
+    num_blocks = ceildiv(size, BLOCK_SIZE)
+
+    def hash_block_sha256(block_idx: int) -> bytes:
+        sha256_hash = hashlib.sha256()
+        block_start = block_idx * BLOCK_SIZE
+
+        with source() as block_fp:
+            block_fp.seek(block_start)
+
+            num_bytes_read = 0
+            while num_bytes_read < BLOCK_SIZE:
+                chunk = block_fp.read(BLOCK_SIZE - num_bytes_read)
+
+                if not chunk:
+                    break
+
+                num_bytes_read += len(chunk)
+                sha256_hash.update(chunk)
+
+        return sha256_hash.digest()
+
+    tasks = (asyncio.to_thread(functools.partial(hash_block_sha256, idx)) for idx in range(num_blocks))
+    return await asyncio.gather(*tasks)
 
 
 def use_md5(url: str) -> bool:

--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -19,7 +19,7 @@ from modal.cli._download import _volume_download
 from modal.cli.utils import ENV_OPTION, YES_OPTION, display_table, timestamp_to_local
 from modal.client import _Client
 from modal.environments import ensure_env
-from modal.volume import _Volume, _VolumeUploadContextManager
+from modal.volume import _AbstractVolumeUploadContextManager, _Volume
 from modal_proto import api_pb2
 
 volume_cli = Typer(
@@ -198,8 +198,8 @@ async def put(
     if Path(local_path).is_dir():
         with progress_handler.live:
             try:
-                async with _VolumeUploadContextManager(
-                    vol.object_id, vol._client, progress_cb=progress_handler.progress, force=force
+                async with _AbstractVolumeUploadContextManager.resolve(
+                    vol._version, vol.object_id, vol._client, progress_cb=progress_handler.progress, force=force
                 ) as batch:
                     batch.put_directory(local_path, remote_path)
             except FileExistsError as exc:
@@ -210,8 +210,8 @@ async def put(
     else:
         with progress_handler.live:
             try:
-                async with _VolumeUploadContextManager(
-                    vol.object_id, vol._client, progress_cb=progress_handler.progress, force=force
+                async with _AbstractVolumeUploadContextManager.resolve(
+                    vol._version, vol.object_id, vol._client, progress_cb=progress_handler.progress, force=force
                 ) as batch:
                     batch.put_file(local_path, remote_path)
 

--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -199,7 +199,11 @@ async def put(
         with progress_handler.live:
             try:
                 async with _AbstractVolumeUploadContextManager.resolve(
-                    vol._version, vol.object_id, vol._client, progress_cb=progress_handler.progress, force=force
+                    vol._metadata.version,
+                    vol.object_id,
+                    vol._client,
+                    progress_cb=progress_handler.progress,
+                    force=force
                 ) as batch:
                     batch.put_directory(local_path, remote_path)
             except FileExistsError as exc:
@@ -211,7 +215,11 @@ async def put(
         with progress_handler.live:
             try:
                 async with _AbstractVolumeUploadContextManager.resolve(
-                    vol._version, vol.object_id, vol._client, progress_cb=progress_handler.progress, force=force
+                    vol._metadata.version,
+                    vol.object_id,
+                    vol._client,
+                    progress_cb=progress_handler.progress,
+                    force=force
                 ) as batch:
                     batch.put_file(local_path, remote_path)
 

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -581,11 +581,14 @@ class _AbstractVolumeUploadContextManager:
         progress_cb: Optional[Callable[..., Any]] = None,
         force: bool = False
     ) -> "_AbstractVolumeUploadContextManager":
-        from modal_proto.api_pb2 import VolumeFsVersion
 
-        if version in [None, VolumeFsVersion.VOLUME_FS_VERSION_UNSPECIFIED, VolumeFsVersion.VOLUME_FS_VERSION_V1]:
+        if version in [
+            None,
+            api_pb2.VolumeFsVersion.VOLUME_FS_VERSION_UNSPECIFIED,
+            api_pb2.VolumeFsVersion.VOLUME_FS_VERSION_V1
+        ]:
             return _VolumeUploadContextManager(object_id, client, progress_cb=progress_cb, force=force)
-        elif version == VolumeFsVersion.VOLUME_FS_VERSION_V2:
+        elif version == api_pb2.VolumeFsVersion.VOLUME_FS_VERSION_V2:
             return _VolumeUploadContextManager2(object_id, client, progress_cb=progress_cb, force=force)
         else:
             raise RuntimeError(f"unsupported volume version: {version}")

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -10,16 +10,19 @@ import time
 import typing
 from collections.abc import AsyncGenerator, AsyncIterator, Generator, Sequence
 from dataclasses import dataclass
+from io import BytesIO
 from pathlib import Path, PurePosixPath
 from typing import (
     IO,
     Any,
+    Awaitable,
     BinaryIO,
     Callable,
     Optional,
     Union,
 )
 
+from google.protobuf.message import Message
 from grpclib import GRPCError, Status
 from synchronicity.async_wrap import asynccontextmanager
 
@@ -31,7 +34,9 @@ from ._object import EPHEMERAL_OBJECT_HEARTBEAT_SLEEP, _get_environment_name, _O
 from ._resolver import Resolver
 from ._utils.async_utils import TaskContext, aclosing, async_map, asyncnullcontext, synchronize_api
 from ._utils.blob_utils import (
+    BLOCK_SIZE,
     FileUploadSpec,
+    FileUploadSpec2,
     blob_iter,
     blob_upload_file,
     get_file_upload_spec_from_fileobj,
@@ -39,6 +44,7 @@ from ._utils.blob_utils import (
 )
 from ._utils.deprecation import deprecation_error, deprecation_warning, renamed_parameter
 from ._utils.grpc_utils import retry_transient_errors
+from ._utils.http_utils import ClientSessionRegistry
 from ._utils.name_utils import check_object_name
 from .client import _Client
 from .config import logger
@@ -119,6 +125,7 @@ class _Volume(_Object, type_prefix="vo"):
     """
 
     _lock: Optional[asyncio.Lock] = None
+    _version: "typing.Optional[modal_proto.api_pb2.VolumeFsVersion.ValueType]"
 
     async def _get_lock(self):
         # To (mostly*) prevent multiple concurrent operations on the same volume, which can cause problems under
@@ -171,9 +178,20 @@ class _Volume(_Object, type_prefix="vo"):
                 version=version,
             )
             response = await resolver.client.stub.VolumeGetOrCreate(req)
-            self._hydrate(response.volume_id, resolver.client, None)
+            self._hydrate(response.volume_id, resolver.client, response.metadata)
 
         return _Volume._from_loader(_load, "Volume()", hydrate_lazily=True)
+
+    def _hydrate_metadata(self, metadata: Optional[Message]):
+        if metadata and isinstance(metadata, api_pb2.VolumeMetadata):
+            self._version = metadata.version
+        else:
+            raise TypeError(
+                "_hydrate_metadata() requires an `api_pb2.VolumeGetOrCreateResponse` to determine volume version"
+            )
+
+    def _get_metadata(self) -> Optional[Message]:
+        return api_pb2.VolumeMetadata(version=self._version)
 
     @classmethod
     @asynccontextmanager
@@ -209,7 +227,7 @@ class _Volume(_Object, type_prefix="vo"):
         async with TaskContext() as tc:
             request = api_pb2.VolumeHeartbeatRequest(volume_id=response.volume_id)
             tc.infinite_loop(lambda: client.stub.VolumeHeartbeat(request), sleep=_heartbeat_sleep)
-            yield cls._new_hydrated(response.volume_id, client, None, is_another_app=True)
+            yield cls._new_hydrated(response.volume_id, client, response.metadata, is_another_app=True)
 
     @staticmethod
     @renamed_parameter((2024, 12, 18), "label", "name")
@@ -481,7 +499,7 @@ class _Volume(_Object, type_prefix="vo"):
         await retry_transient_errors(self._client.stub.VolumeCopyFiles, request, base_delay=1)
 
     @live_method
-    async def batch_upload(self, force: bool = False) -> "_VolumeUploadContextManager":
+    async def batch_upload(self, force: bool = False) -> "_AbstractVolumeUploadContextManager":
         """
         Initiate a batched upload to a volume.
 
@@ -499,7 +517,8 @@ class _Volume(_Object, type_prefix="vo"):
             batch.put_file(io.BytesIO(b"some data"), "/foobar")
         ```
         """
-        return _VolumeUploadContextManager(self.object_id, self._client, force=force)
+        return _AbstractVolumeUploadContextManager.resolve(self._version, self.object_id, self._client, force=force)
+
 
     @live_method
     async def _instance_delete(self):
@@ -527,7 +546,54 @@ class _Volume(_Object, type_prefix="vo"):
         await retry_transient_errors(obj._client.stub.VolumeRename, req)
 
 
-class _VolumeUploadContextManager:
+Volume = synchronize_api(_Volume)
+
+# TODO(dflemstr): Find a way to add ABC or AbstractAsyncContextManager superclasses while keeping synchronicity happy.
+class _AbstractVolumeUploadContextManager:
+    async def __aenter__(self):
+        ...
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        ...
+
+
+    def put_file(
+        self,
+        local_file: Union[Path, str, BinaryIO, BytesIO],
+        remote_path: Union[PurePosixPath, str],
+        mode: Optional[int] = None,
+    ):
+        ...
+
+    def put_directory(
+        self,
+        local_path: Union[Path, str],
+        remote_path: Union[PurePosixPath, str],
+        recursive: bool = True,
+    ):
+        ...
+
+    @staticmethod
+    def resolve(
+        version: "modal_proto.api_pb2.VolumeFsVersion.ValueType",
+        object_id: str,
+        client,
+        progress_cb: Optional[Callable[..., Any]] = None,
+        force: bool = False
+    ) -> "_AbstractVolumeUploadContextManager":
+        from modal_proto.api_pb2 import VolumeFsVersion
+
+        if version in [None, VolumeFsVersion.VOLUME_FS_VERSION_UNSPECIFIED, VolumeFsVersion.VOLUME_FS_VERSION_V1]:
+            return _VolumeUploadContextManager(object_id, client, progress_cb=progress_cb, force=force)
+        elif version == VolumeFsVersion.VOLUME_FS_VERSION_V2:
+            return _VolumeUploadContextManager2(object_id, client, progress_cb=progress_cb, force=force)
+        else:
+            raise RuntimeError(f"unsupported volume version: {version}")
+
+
+AbstractVolumeUploadContextManager = synchronize_api(_AbstractVolumeUploadContextManager)
+
+class _VolumeUploadContextManager(_AbstractVolumeUploadContextManager):
     """Context manager for batch-uploading files to a Volume."""
 
     _volume_id: str
@@ -585,7 +651,7 @@ class _VolumeUploadContextManager:
 
     def put_file(
         self,
-        local_file: Union[Path, str, BinaryIO],
+        local_file: Union[Path, str, BinaryIO, BytesIO],
         remote_path: Union[PurePosixPath, str],
         mode: Optional[int] = None,
     ):
@@ -678,8 +744,203 @@ class _VolumeUploadContextManager:
         )
 
 
-Volume = synchronize_api(_Volume)
 VolumeUploadContextManager = synchronize_api(_VolumeUploadContextManager)
+
+_FileUploader2 = Callable[[], Awaitable[FileUploadSpec2]]
+
+class _VolumeUploadContextManager2(_AbstractVolumeUploadContextManager):
+    """Context manager for batch-uploading files to a Volume version 2."""
+
+    _volume_id: str
+    _client: _Client
+    _force: bool
+    _progress_cb: Callable[..., Any]
+    _uploader_generators: list[Generator[_FileUploader2]]
+
+    def __init__(
+        self, volume_id: str, client: _Client, progress_cb: Optional[Callable[..., Any]] = None, force: bool = False
+    ):
+        """mdmd:hidden"""
+        self._volume_id = volume_id
+        self._client = client
+        self._uploader_generators = []
+        self._progress_cb = progress_cb or (lambda *_, **__: None)
+        self._force = force
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        if not exc_val:
+            # Flatten all the uploads yielded by the upload generators in the batch
+            def gen_upload_providers():
+                for gen in self._uploader_generators:
+                    yield from gen
+
+            async def gen_file_upload_specs() -> list[FileUploadSpec2]:
+                uploads = [asyncio.create_task(fut()) for fut in gen_upload_providers()]
+                logger.debug(f"Computing checksums for {len(uploads)} files")
+
+                file_specs = []
+                for file_spec in asyncio.as_completed(uploads):
+                    file_specs.append(await file_spec)
+                return file_specs
+
+            upload_specs = await gen_file_upload_specs()
+            await self._put_file_specs(upload_specs)
+
+
+    def put_file(
+        self,
+        local_file: Union[Path, str, BinaryIO, BytesIO],
+        remote_path: Union[PurePosixPath, str],
+        mode: Optional[int] = None,
+    ):
+        """Upload a file from a local file or file-like object.
+
+        Will create any needed parent directories automatically.
+
+        If `local_file` is a file-like object it must remain readable for the lifetime of the batch.
+        """
+        remote_path = PurePosixPath(remote_path).as_posix()
+        if remote_path.endswith("/"):
+            raise ValueError(f"remote_path ({remote_path}) must refer to a file - cannot end with /")
+
+        def gen():
+            if isinstance(local_file, str) or isinstance(local_file, Path):
+                yield lambda: FileUploadSpec2.from_path(local_file, PurePosixPath(remote_path), mode)
+            else:
+                yield lambda: FileUploadSpec2.from_fileobj(local_file, PurePosixPath(remote_path), mode or 0o644)
+
+        self._uploader_generators.append(gen())
+
+    def put_directory(
+        self,
+        local_path: Union[Path, str],
+        remote_path: Union[PurePosixPath, str],
+        recursive: bool = True,
+    ):
+        """
+        Upload all files in a local directory.
+
+        Will create any needed parent directories automatically.
+        """
+        local_path = Path(local_path)
+        assert local_path.is_dir()
+        remote_path = PurePosixPath(remote_path)
+
+        def create_spec(subpath):
+            relpath_str = subpath.relative_to(local_path)
+            return lambda: FileUploadSpec2.from_path(subpath, remote_path / relpath_str)
+
+        def gen():
+            glob = local_path.rglob("*") if recursive else local_path.glob("*")
+            for subpath in glob:
+                # Skip directories and unsupported file types (e.g. block devices)
+                if subpath.is_file():
+                    yield create_spec(subpath)
+
+        self._uploader_generators.append(gen())
+
+    async def _put_file_specs(self, file_specs: list[FileUploadSpec2]):
+        put_responses = {}
+        # num_blocks_total = sum(len(file_spec.blocks_sha256) for file_spec in file_specs)
+
+        # We should only need two iterations: Once to possibly get some missing_blocks; the second time we should have
+        # all blocks uploaded
+        for _ in range(2):
+            files = []
+
+            for file_spec in file_specs:
+                blocks = [
+                    api_pb2.VolumePutFiles2Request.Block(
+                        contents_sha256=block_sha256,
+                        put_response=put_responses.get(block_sha256)
+                    ) for block_sha256 in file_spec.blocks_sha256
+                ]
+                files.append(api_pb2.VolumePutFiles2Request.File(
+                    path=file_spec.path,
+                    mode=file_spec.mode,
+                    size=file_spec.size,
+                    blocks=blocks
+                ))
+
+            request = api_pb2.VolumePutFiles2Request(
+                volume_id=self._volume_id,
+                files=files,
+                disallow_overwrite_existing_files=not self._force,
+            )
+
+            try:
+                response = await retry_transient_errors(self._client.stub.VolumePutFiles2, request, base_delay=1)
+            except GRPCError as exc:
+                raise FileExistsError(exc.message) if exc.status == Status.ALREADY_EXISTS else exc
+
+            if not response.missing_blocks:
+                break
+
+            await _put_missing_blocks(file_specs, response.missing_blocks, put_responses, self._progress_cb)
+        else:
+            raise RuntimeError("Did not succeed at uploading all files despite supplying all missing blocks")
+
+        self._progress_cb(complete=True)
+
+
+VolumeUploadContextManager2 = synchronize_api(_VolumeUploadContextManager2)
+
+
+async def _put_missing_blocks(
+    file_specs: list[FileUploadSpec2],
+    # TODO(dflemstr): Element type is `api_pb2.VolumePutFiles2Response.MissingBlock` but synchronicity gets confused
+    # by the nested class (?)
+    missing_blocks: list,
+    put_responses: dict[bytes, bytes],
+    progress_cb: Callable[..., Any]
+):
+    async def put_missing_block(
+        # TODO(dflemstr): Type is `api_pb2.VolumePutFiles2Response.MissingBlock` but synchronicity gets confused
+        # by the nested class (?)
+        missing_block
+    ) -> (bytes, bytes):
+        # Lazily import to keep the eager loading time of this module down
+        from ._utils.bytes_io_segment_payload import BytesIOSegmentPayload
+
+        assert isinstance(missing_block, api_pb2.VolumePutFiles2Response.MissingBlock)
+
+        file_spec = file_specs[missing_block.file_index]
+        # TODO(dflemstr): What if the underlying file has changed here in the meantime; should we check the
+        #  hash again just to be sure?
+        block_sha256 = file_spec.blocks_sha256[missing_block.block_index]
+        block_start = missing_block.block_index * BLOCK_SIZE
+        block_length = min(BLOCK_SIZE, file_spec.size - block_start)
+
+        progress_name = f"{file_spec.path} block {missing_block.block_index + 1} / {len(file_spec.blocks_sha256)}"
+        progress_task_id = progress_cb(name=progress_name, size=file_spec.size)
+
+        with file_spec.source() as source_fp:
+            payload = BytesIOSegmentPayload(
+                source_fp,
+                block_start,
+                block_length,
+                progress_report_cb=functools.partial(progress_cb, progress_task_id)
+            )
+
+            async with ClientSessionRegistry.get_session().put(
+                missing_block.put_url,
+                data=payload,
+            ) as response:
+                response.raise_for_status()
+                resp_data = await response.content.read()
+
+        return block_sha256, resp_data
+
+    tasks = [
+        asyncio.create_task(put_missing_block(missing_block))
+        for missing_block in missing_blocks
+    ]
+    for task_result in asyncio.as_completed(tasks):
+        digest, resp = await task_result
+        put_responses[digest] = resp
 
 
 def _open_files_error_annotation(mount_path: str) -> Optional[str]:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -18,13 +18,12 @@ import tempfile
 import textwrap
 import threading
 import traceback
-import typing
 import uuid
 from collections import defaultdict
 from collections.abc import Iterator
 from pathlib import Path
 from types import ModuleType
-from typing import Any, get_args
+from typing import Any, Optional, Union, get_args
 
 import aiohttp.web
 import aiohttp.web_runner
@@ -40,6 +39,7 @@ from modal._functions import _Function
 from modal._runtime.container_io_manager import _ContainerIOManager
 from modal._serialization import deserialize, deserialize_params, serialize_data_format
 from modal._utils.async_utils import asyncify, synchronize_api
+from modal._utils.blob_utils import BLOCK_SIZE
 from modal._utils.grpc_testing import patch_mock_servicer
 from modal._utils.grpc_utils import find_free_port
 from modal._utils.http_utils import run_temporary_http_server
@@ -57,10 +57,16 @@ VALID_CLOUD_PROVIDERS = ["AWS", "GCP", "OCI", "AUTO", "XYZ"]
 
 
 @dataclasses.dataclass
+class Volume:
+    version: "api_pb2.VolumeFsVersion.ValueType"
+    files: dict[str, VolumeFile]
+
+@dataclasses.dataclass
 class VolumeFile:
     data: bytes
-    data_blob_id: str
     mode: int
+    data_blob_id: Optional[str] = None
+    block_hashes: list[bytes] = dataclasses.field(default_factory=list)
 
 
 @dataclasses.dataclass
@@ -147,7 +153,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
     client_addr: str
     container_addr: str
 
-    def __init__(self, blob_host, blobs, credentials):
+    def __init__(self, blob_host, blobs, blocks, credentials):
         self.default_published_client_mount = "mo-123"
         self.use_blob_outputs = False
         self.put_outputs_barrier = threading.Barrier(
@@ -163,6 +169,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.n_blobs = 0
         self.blob_host = blob_host
         self.blobs = blobs  # shared dict
+        self.blocks = blocks  # shared dict
         self.requests = []
         self.done = False
         self.rate_limit_sleep_duration = None
@@ -221,7 +228,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.task_result = None
 
         self.nfs_files: dict[str, dict[str, api_pb2.SharedVolumePutFileRequest]] = defaultdict(dict)
-        self.volume_files: dict[str, dict[str, VolumeFile]] = defaultdict(dict)
+        self.volumes: dict[str, Volume] = {}
         self.images = {}
         self.image_build_function_ids = {}
         self.image_builder_versions = {}
@@ -426,6 +433,10 @@ class MockClientServicer(api_grpc.ModalClientBase):
         elif object_id.startswith("sb-"):
             sandbox_handle_metadata = api_pb2.SandboxHandleMetadata(result=self.sandbox_result)
             res = api_pb2.Object(sandbox_handle_metadata=sandbox_handle_metadata)
+
+        elif object_id.startswith("vo-"):
+            volume_metadata = api_pb2.VolumeMetadata(version=self.volumes[object_id].version)
+            res = api_pb2.Object(volume_metadata=volume_metadata)
 
         else:
             res = api_pb2.Object()
@@ -1034,7 +1045,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
             function.CopyFrom(request.function)
 
         assert (function is None) != (function_data is None)
-        function_defn: typing.Union[api_pb2.Function, api_pb2.FunctionData] = function or function_data
+        function_defn: Union[api_pb2.Function, api_pb2.FunctionData] = function or function_data
         assert function_defn
         if function_defn.webhook_config.type:
             function_defn.web_url = "http://xyz.internal"
@@ -1789,24 +1800,26 @@ class MockClientServicer(api_grpc.ModalClientBase):
                 raise GRPCError(Status.NOT_FOUND, f"Volume {k} not found")
             volume_id = self.deployed_volumes[k]
         elif request.object_creation_type == api_pb2.OBJECT_CREATION_TYPE_EPHEMERAL:
-            volume_id = f"vo-{len(self.volume_files)}"
-            self.volume_files[volume_id] = {}
+            volume_id = f"vo-{len(self.volumes)}"
+            self.volumes[volume_id] = Volume(version=request.version, files={})
         elif request.object_creation_type == api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING:
             if k not in self.deployed_volumes:
-                volume_id = f"vo-{len(self.volume_files)}"
-                self.volume_files[volume_id] = {}
+                volume_id = f"vo-{len(self.volumes)}"
+                self.volumes[volume_id] = Volume(version=request.version, files={})
                 self.deployed_volumes[k] = volume_id
             volume_id = self.deployed_volumes[k]
         elif request.object_creation_type == api_pb2.OBJECT_CREATION_TYPE_CREATE_FAIL_IF_EXISTS:
             if k in self.deployed_volumes:
                 raise GRPCError(Status.ALREADY_EXISTS, f"Volume {k} already exists")
-            volume_id = f"vo-{len(self.volume_files)}"
-            self.volume_files[volume_id] = {}
+            volume_id = f"vo-{len(self.volumes)}"
+            self.volumes[volume_id] = Volume(version=request.version, files={})
             self.deployed_volumes[k] = volume_id
         else:
             raise GRPCError(Status.INVALID_ARGUMENT, "unsupported object creation type")
 
-        await stream.send_message(api_pb2.VolumeGetOrCreateResponse(volume_id=volume_id))
+        metadata = api_pb2.VolumeMetadata(version=request.version)
+        response = api_pb2.VolumeGetOrCreateResponse(volume_id=volume_id, version=request.version, metadata=metadata)
+        await stream.send_message(response)
 
     async def VolumeList(self, stream):
         req = await stream.recv_message()
@@ -1833,7 +1846,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def VolumeDelete(self, stream):
         req: api_pb2.VolumeDeleteRequest = await stream.recv_message()
-        self.volume_files.pop(req.volume_id)
+        self.volumes.pop(req.volume_id)
         self.deployed_volumes = {k: vol_id for k, vol_id in self.deployed_volumes.items() if vol_id != req.volume_id}
         await stream.send_message(Empty())
 
@@ -1845,9 +1858,9 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def VolumeGetFile(self, stream):
         req = await stream.recv_message()
-        if req.path not in self.volume_files[req.volume_id]:
+        if req.path not in self.volumes[req.volume_id].files:
             raise GRPCError(Status.NOT_FOUND, "File not found")
-        vol_file = self.volume_files[req.volume_id][req.path]
+        vol_file = self.volumes[req.volume_id].files[req.path]
         if vol_file.data_blob_id:
             await stream.send_message(api_pb2.VolumeGetFileResponse(data_blob_id=vol_file.data_blob_id))
         else:
@@ -1863,9 +1876,9 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def VolumeRemoveFile(self, stream):
         req = await stream.recv_message()
-        if req.path not in self.volume_files[req.volume_id]:
+        if req.path not in self.volumes[req.volume_id].files:
             raise GRPCError(Status.INVALID_ARGUMENT, "File not found")
-        del self.volume_files[req.volume_id][req.path]
+        del self.volumes[req.volume_id].files[req.path]
         await stream.send_message(Empty())
 
     async def VolumeRename(self, stream):
@@ -1885,7 +1898,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
             path = path[:-1]
 
         found_file = False  # empty directory detection is not handled here!
-        for k, vol_file in self.volume_files[req.volume_id].items():
+        for k, vol_file in self.volumes[req.volume_id].files.items():
             if not path or k == path or (k.startswith(path + "/") and (req.recursive or "/" not in k[len(path) + 1 :])):
                 entry = api_pb2.FileEntry(path=k, type=api_pb2.FileEntry.FileType.FILE, size=len(vol_file.data))
                 await stream.send_message(api_pb2.VolumeListFilesResponse(entries=[entry]))
@@ -1899,7 +1912,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         for file in req.files:
             blob_data = self.files_sha2data[file.sha256_hex]
 
-            if file.filename in self.volume_files[req.volume_id] and req.disallow_overwrite_existing_files:
+            if file.filename in self.volumes[req.volume_id].files and req.disallow_overwrite_existing_files:
                 raise GRPCError(
                     Status.ALREADY_EXISTS,
                     (
@@ -1908,19 +1921,85 @@ class MockClientServicer(api_grpc.ModalClientBase):
                     ),
                 )
 
-            self.volume_files[req.volume_id][file.filename] = VolumeFile(
+            self.volumes[req.volume_id].files[file.filename] = VolumeFile(
                 data=blob_data["data"],
                 data_blob_id=blob_data["data_blob_id"],
                 mode=file.mode,
             )
         await stream.send_message(Empty())
 
+    async def VolumePutFiles2(self, stream):
+        req = await stream.recv_message()
+        missing_blocks = []
+        files_to_create = {}
+
+        for file_index, file in enumerate(req.files):
+            if file.path in self.volumes[req.volume_id].files and req.disallow_overwrite_existing_files:
+                raise GRPCError(
+                    Status.ALREADY_EXISTS,
+                    (
+                        f"{file.path}: already exists "
+                        f"(disallow_overwrite_existing_files={req.disallow_overwrite_existing_files}"
+                    ),
+                )
+
+            blocks = []
+            block_hashes = []
+            file_missing_blocks = []
+
+            for block_index, block in enumerate(file.blocks):
+                block_hashes.append(block.contents_sha256)
+                actual_block_id = block.contents_sha256.hex()
+                block_data = self.blocks.get(actual_block_id)
+
+                # TODO(dflemstr): here, we assume that all blocks that the user uploads are always new; we could check
+                #  if the block blob already exists, and not generate a MissingBlock for those block blobs, but then it
+                #  would get trickier to validate the put_url response loop here...
+                put_response = block.put_response
+                if put_response:
+                    prefix = b"test-put-response:"
+                    expected_block_id = put_response[len(prefix):].decode('utf-8')
+                    valid_put_response = put_response.startswith(prefix) and expected_block_id == actual_block_id
+                else:
+                    valid_put_response = False
+
+                if block_data is not None and valid_put_response:
+                    # If this is not the last block, it needs to have size BLOCK_SIZE
+                    if block_index + 1 < len(file.blocks):
+                        assert len(block_data) == BLOCK_SIZE
+                    # If this is the last block, it must be at most BLOCK_SIZE
+                    if block_index + 1 == len(file.blocks):
+                        assert len(block_data) < BLOCK_SIZE
+                    blocks.append(block_data)
+                else:
+                    missing_block = api_pb2.VolumePutFiles2Response.MissingBlock(
+                        file_index=file_index,
+                        block_index=block_index,
+                        put_url=f"{self.blob_host}/block?token=test-put-request",
+                    )
+                    file_missing_blocks.append(missing_block)
+
+            if file_missing_blocks:
+                missing_blocks.extend(file_missing_blocks)
+            else:
+                files_to_create[file.path] = VolumeFile(
+                    data=b''.join(blocks),
+                    data_blob_id=None,
+                    mode=file.mode,
+                    block_hashes=block_hashes,
+                )
+
+        if not missing_blocks:
+            self.volumes[req.volume_id].files.update(files_to_create)
+
+        await stream.send_message(api_pb2.VolumePutFiles2Response(missing_blocks=missing_blocks))
+
     async def VolumeCopyFiles(self, stream):
         req = await stream.recv_message()
         for src_path in req.src_paths:
-            if src_path not in self.volume_files[req.volume_id]:
+            if src_path not in self.volumes[req.volume_id].files:
                 raise GRPCError(Status.NOT_FOUND, f"Source file not found: {src_path}")
-            src_file = self.volume_files[req.volume_id][src_path]
+            src_file = self.volumes[req.volume_id].files[src_path]
             if len(req.src_paths) > 1:
                 # check to make sure dst is a directory
                 if req.dst_path.endswith(("/", "\\")) or not os.path.splitext(os.path.basename(req.dst_path))[1]:
@@ -1929,7 +2008,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
                     raise GRPCError(Status.INVALID_ARGUMENT, f"{dst_path} is not a directory.")
             else:
                 dst_path = req.dst_path
-            self.volume_files[req.volume_id][dst_path] = src_file
+            self.volumes[req.volume_id].files[dst_path] = src_file
         await stream.send_message(Empty())
 
 
@@ -1937,6 +2016,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
 def blob_server():
     blobs = {}
     blob_parts: dict[str, dict[int, bytes]] = defaultdict(dict)
+    blocks = {}
 
     async def upload(request):
         blob_id = request.query["blob_id"]
@@ -1973,10 +2053,29 @@ def blob_server():
             return aiohttp.web.Response(status=500)
         return aiohttp.web.Response(body=blobs[blob_id])
 
+    async def put_block(request):
+        token = request.query["token"]
+        if token != "test-put-request":
+            return aiohttp.web.Response(status=400, text="bad token")
+
+        content = await request.content.read()
+        if content == b"FAILURE":
+            return aiohttp.web.Response(status=500, text="simulated server error")
+
+        if len(content) > BLOCK_SIZE:
+            return aiohttp.web.Response(status=413, text="block too big")
+
+        block_id = hashlib.sha256(content).hexdigest()
+        blocks[block_id] = content
+        return aiohttp.web.Response(text=f"test-put-response:{block_id}")
+
     app = aiohttp.web.Application()
     app.add_routes([aiohttp.web.put("/upload", upload)])
     app.add_routes([aiohttp.web.get("/download", download)])
     app.add_routes([aiohttp.web.post("/complete_multipart", complete_multipart)])
+
+    # API used for volume version 2 blocks:
+    app.add_routes([aiohttp.web.put("/block", put_block)])
 
     started = threading.Event()
     stop_server = threading.Event()
@@ -2004,7 +2103,7 @@ def blob_server():
     thread = threading.Thread(target=run_server_other_thread)
     thread.start()
     started.wait()
-    yield host, blobs
+    yield host, blobs, blocks
     stop_server.set()
     thread.join()
 
@@ -2056,8 +2155,8 @@ def credentials():
 async def servicer(blob_server, temporary_sock_path, credentials):
     port = find_free_port()
 
-    blob_host, blobs = blob_server
-    servicer = MockClientServicer(blob_host, blobs, credentials)  # type: ignore
+    blob_host, blobs, blocks = blob_server
+    servicer = MockClientServicer(blob_host, blobs, blocks, credentials)  # type: ignore
 
     if platform.system() != "Windows":
         async with run_server(servicer, host="0.0.0.0", port=port):

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -1009,7 +1009,7 @@ async def test_map_large_inputs(client, servicer, monkeypatch, blob_server):
     app = App()
     dummy_modal = app.function()(dummy)
 
-    _, blobs = blob_server
+    _, blobs, _ = blob_server
     async with app.run.aio(client=client):
         assert len(blobs) == 0
         assert [a async for a in dummy_modal.map.aio(range(100))] == [i**2 for i in range(100)]

--- a/test/network_file_system_test.py
+++ b/test/network_file_system_test.py
@@ -92,7 +92,7 @@ async def test_network_file_system_handle_big_file(client, tmp_path, servicer, b
         assert servicer.nfs_files[object_id]["/bigfile"].data == b""
         assert servicer.nfs_files[object_id]["/bigfile"].data_blob_id == "bl-1"
 
-        _, blobs = blob_server
+        _, blobs, _ = blob_server
         assert blobs["bl-1"] == b"hello world, this is a lot of text"
 
 

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -204,7 +204,7 @@ async def test_volume_upload_large_file(client, tmp_path, servicer, blob_server,
         assert servicer.volume_files[object_id]["/a"].data == b""
         assert servicer.volume_files[object_id]["/a"].data_blob_id == "bl-1"
 
-        _, blobs = blob_server
+        _, blobs, _ = blob_server
         assert blobs["bl-1"] == b"hello world, this is a lot of text"
 
 
@@ -222,7 +222,7 @@ async def test_volume_upload_large_stream(client, servicer, blob_server, *args):
         assert servicer.volume_files[object_id]["/a"].data == b""
         assert servicer.volume_files[object_id]["/a"].data_blob_id == "bl-1"
 
-        _, blobs = blob_server
+        _, blobs, _ = blob_server
         assert blobs["bl-1"] == b"hello world, this is a lot of text"
 
 

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -11,18 +11,23 @@ from pathlib import Path
 from unittest import mock
 
 import modal
+from modal._utils.blob_utils import BLOCK_SIZE
 from modal.exception import InvalidError, NotFoundError, VolumeUploadTimeoutError
 from modal.volume import _open_files_error_annotation
 from modal_proto import api_pb2
 
+VERSIONS = [
+    None,
+    api_pb2.VOLUME_FS_VERSION_V2,
+]
 
 def dummy():
     pass
 
-
-def test_volume_mount(client, servicer):
+@pytest.mark.parametrize("version", VERSIONS)
+def test_volume_mount(client, servicer, version):
     app = modal.App()
-    vol = modal.Volume.from_name("xyz", create_if_missing=True)
+    vol = modal.Volume.from_name("xyz", create_if_missing=True, version=version)
 
     _ = app.function(volumes={"/root/foo": vol})(dummy)
 
@@ -73,8 +78,9 @@ def test_volume_commit(client, servicer, skip_reload):
 
 
 @pytest.mark.asyncio
-async def test_volume_get(servicer, client, tmp_path):
-    await modal.Volume.create_deployed.aio("my-vol", client=client)
+@pytest.mark.parametrize("version", VERSIONS)
+async def test_volume_get(servicer, client, tmp_path, version):
+    await modal.Volume.create_deployed.aio("my-vol", client=client, version=version)
     vol = await modal.Volume.from_name("my-vol").hydrate.aio(client=client)
 
     file_contents = b"hello world"
@@ -108,7 +114,8 @@ def test_volume_reload(client, servicer):
 
 
 @pytest.mark.asyncio
-async def test_volume_batch_upload(servicer, client, tmp_path):
+@pytest.mark.parametrize("version", VERSIONS)
+async def test_volume_batch_upload(servicer, client, tmp_path, version):
     local_file_path = tmp_path / "some_file"
     local_file_path.write_text("hello world")
 
@@ -120,7 +127,7 @@ async def test_volume_batch_upload(servicer, client, tmp_path):
     subdir.mkdir()
     (subdir / "other").write_text("####")
 
-    async with modal.Volume.ephemeral(client=client) as vol:
+    async with modal.Volume.ephemeral(client=client, version=version) as vol:
         with open(local_file_path, "rb") as fp:
             with vol.batch_upload() as batch:
                 batch.put_file(local_file_path, "/some_file")
@@ -130,7 +137,7 @@ async def test_volume_batch_upload(servicer, client, tmp_path):
                 batch.put_file(fp, "/filelike2")
         object_id = vol.object_id
 
-    assert servicer.volume_files[object_id].keys() == {
+    assert servicer.volumes[object_id].files.keys() == {
         "/some_file",
         "/some_dir/smol",
         "/some_dir/subdir/other",
@@ -138,51 +145,105 @@ async def test_volume_batch_upload(servicer, client, tmp_path):
         "/non-recursive/smol",
         "/filelike2",
     }
-    assert servicer.volume_files[object_id]["/some_file"].data == b"hello world"
-    assert servicer.volume_files[object_id]["/some_dir/smol"].data == b"###"
-    assert servicer.volume_files[object_id]["/some_dir/subdir/other"].data == b"####"
-    assert servicer.volume_files[object_id]["/filelike"].data == b"data from a file-like object"
-    assert servicer.volume_files[object_id]["/filelike"].mode == 0o600
-    assert servicer.volume_files[object_id]["/non-recursive/smol"].data == b"###"
-    assert servicer.volume_files[object_id]["/filelike2"].data == b"hello world"
-    assert servicer.volume_files[object_id]["/filelike2"].mode == 0o644
+    assert servicer.volumes[object_id].files["/some_file"].data == b"hello world"
+    assert servicer.volumes[object_id].files["/some_dir/smol"].data == b"###"
+    assert servicer.volumes[object_id].files["/some_dir/subdir/other"].data == b"####"
+    assert servicer.volumes[object_id].files["/filelike"].data == b"data from a file-like object"
+    assert servicer.volumes[object_id].files["/filelike"].mode == 0o600
+    assert servicer.volumes[object_id].files["/non-recursive/smol"].data == b"###"
+    assert servicer.volumes[object_id].files["/filelike2"].data == b"hello world"
+    assert servicer.volumes[object_id].files["/filelike2"].mode == 0o644
 
 
 @pytest.mark.asyncio
-async def test_volume_batch_upload_force(servicer, client, tmp_path):
+@pytest.mark.parametrize("version", VERSIONS)
+async def test_volume_batch_upload_bytesio(servicer, client, tmp_path, version):
+    async with modal.Volume.ephemeral(client=client, version=version) as vol:
+        with vol.batch_upload() as batch:
+            batch.put_file(io.BytesIO(b"data from a file-like object"), "/filelike", mode=0o600)
+        object_id = vol.object_id
+
+    assert servicer.volumes[object_id].files.keys() == {
+        "/filelike",
+    }
+    assert servicer.volumes[object_id].files["/filelike"].data == b"data from a file-like object"
+    assert servicer.volumes[object_id].files["/filelike"].mode == 0o600
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("version", VERSIONS)
+async def test_volume_batch_upload_opened_file(servicer, client, tmp_path, version):
+    local_file_path = tmp_path / "some_file"
+    local_file_path.write_text("hello world")
+
+    async with modal.Volume.ephemeral(client=client, version=version) as vol:
+        with open(local_file_path, "rb") as fp, vol.batch_upload() as batch:
+            batch.put_file(fp, "/filelike2", mode=0o600)
+        object_id = vol.object_id
+
+    assert servicer.volumes[object_id].files.keys() == {
+        "/filelike2",
+    }
+    assert servicer.volumes[object_id].files["/filelike2"].data == b"hello world"
+    assert servicer.volumes[object_id].files["/filelike2"].mode == 0o600
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("version", VERSIONS)
+async def test_volume_batch_upload_force(servicer, client, tmp_path, version):
     local_file_path = tmp_path / "some_file"
     local_file_path.write_text("hello world")
 
     local_file_path2 = tmp_path / "some_file2"
     local_file_path2.write_text("overwritten")
 
-    async with modal.Volume.ephemeral(client=client) as vol:
+    async with modal.Volume.ephemeral(client=client, version=version) as vol:
         with servicer.intercept() as ctx:
             # Seed the volume
             with vol.batch_upload() as batch:
                 batch.put_file(local_file_path, "/some_file")
-            assert ctx.pop_request("VolumePutFiles").disallow_overwrite_existing_files
+
+            if version == api_pb2.VOLUME_FS_VERSION_V2:
+                # The batch should involve two calls; once with a missing_blocks response
+                assert ctx.pop_request("VolumePutFiles2").disallow_overwrite_existing_files
+                assert ctx.pop_request("VolumePutFiles2").disallow_overwrite_existing_files
+            else:
+                assert ctx.pop_request("VolumePutFiles").disallow_overwrite_existing_files
 
             # Attempting to overwrite the file with force=False should result in an error
             with pytest.raises(FileExistsError):
                 with vol.batch_upload(force=False) as batch:
                     batch.put_file(local_file_path, "/some_file")
-            assert ctx.pop_request("VolumePutFiles").disallow_overwrite_existing_files
-            assert servicer.volume_files[vol.object_id]["/some_file"].data == b"hello world"
+
+            if version == api_pb2.VOLUME_FS_VERSION_V2:
+                # The batch should fail on the first call since force=False
+                assert ctx.pop_request("VolumePutFiles2").disallow_overwrite_existing_files
+            else:
+                assert ctx.pop_request("VolumePutFiles").disallow_overwrite_existing_files
+
+            assert servicer.volumes[vol.object_id].files["/some_file"].data == b"hello world"
 
             # Overwriting should work with force=True
             with vol.batch_upload(force=True) as batch:
                 batch.put_file(local_file_path2, "/some_file")
-            assert not ctx.pop_request("VolumePutFiles").disallow_overwrite_existing_files
-            assert servicer.volume_files[vol.object_id]["/some_file"].data == b"overwritten"
+
+            if version == api_pb2.VOLUME_FS_VERSION_V2:
+                # The batch should involve two calls; once with a missing_blocks response
+                assert not ctx.pop_request("VolumePutFiles2").disallow_overwrite_existing_files
+                assert not ctx.pop_request("VolumePutFiles2").disallow_overwrite_existing_files
+            else:
+                assert not ctx.pop_request("VolumePutFiles").disallow_overwrite_existing_files
+
+            assert servicer.volumes[vol.object_id].files["/some_file"].data == b"overwritten"
 
 
 @pytest.mark.asyncio
-async def test_volume_upload_removed_file(servicer, client, tmp_path):
+@pytest.mark.parametrize("version", VERSIONS)
+async def test_volume_upload_removed_file(servicer, client, tmp_path, version):
     local_file_path = tmp_path / "some_file"
     local_file_path.write_text("hello world")
 
-    async with modal.Volume.ephemeral(client=client) as vol:
+    async with modal.Volume.ephemeral(client=client, version=version) as vol:
         with pytest.raises(FileNotFoundError):
             with vol.batch_upload() as batch:
                 batch.put_file(local_file_path, "/dest")
@@ -190,7 +251,7 @@ async def test_volume_upload_removed_file(servicer, client, tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_volume_upload_large_file(client, tmp_path, servicer, blob_server, *args):
+async def test_volume_upload_large_file(client, tmp_path, servicer, blob_server):
     with mock.patch("modal._utils.blob_utils.LARGE_FILE_LIMIT", 10):
         local_file_path = tmp_path / "bigfile"
         local_file_path.write_text("hello world, this is a lot of text")
@@ -200,16 +261,39 @@ async def test_volume_upload_large_file(client, tmp_path, servicer, blob_server,
                 batch.put_file(local_file_path, "/a")
             object_id = vol.object_id
 
-        assert servicer.volume_files[object_id].keys() == {"/a"}
-        assert servicer.volume_files[object_id]["/a"].data == b""
-        assert servicer.volume_files[object_id]["/a"].data_blob_id == "bl-1"
+        assert servicer.volumes[object_id].files.keys() == {"/a"}
+        assert servicer.volumes[object_id].files["/a"].data == b""
+        assert servicer.volumes[object_id].files["/a"].data_blob_id == "bl-1"
 
         _, blobs, _ = blob_server
         assert blobs["bl-1"] == b"hello world, this is a lot of text"
 
 
 @pytest.mark.asyncio
-async def test_volume_upload_large_stream(client, servicer, blob_server, *args):
+async def test_volume2_upload_large_file(client, tmp_path, servicer, blob_server):
+    # Volumes version 2 don't use `modal._utils.blob_utils.LARGE_FILE_LIMIT`
+    # Instead, we need to go over 8MiB to trigger different behavior (ie spilling into multiple blocks), but in this
+    # unit test context there isn't much of a semantic difference.
+
+    # Create a byte buffer that is larger than 8MiB
+    data = b"hello world, this is a lot of text" * 250_000
+    assert len(data) > BLOCK_SIZE
+
+    local_file_path = tmp_path / "bigfile"
+    local_file_path.write_bytes(data)
+
+    async with modal.Volume.ephemeral(client=client, version=api_pb2.VOLUME_FS_VERSION_V2) as vol:
+        async with vol.batch_upload() as batch:
+            batch.put_file(local_file_path, "/a")
+        object_id = vol.object_id
+
+    assert servicer.volumes[object_id].files.keys() == {"/a"}
+    # Volumes version 2 don't use blob entities
+    assert servicer.volumes[object_id].files["/a"].data == data
+
+
+@pytest.mark.asyncio
+async def test_volume_upload_large_stream(client, servicer, blob_server):
     with mock.patch("modal._utils.blob_utils.LARGE_FILE_LIMIT", 10):
         stream = io.BytesIO(b"hello world, this is a lot of text")
 
@@ -218,12 +302,33 @@ async def test_volume_upload_large_stream(client, servicer, blob_server, *args):
                 batch.put_file(stream, "/a")
             object_id = vol.object_id
 
-        assert servicer.volume_files[object_id].keys() == {"/a"}
-        assert servicer.volume_files[object_id]["/a"].data == b""
-        assert servicer.volume_files[object_id]["/a"].data_blob_id == "bl-1"
+        assert servicer.volumes[object_id].files.keys() == {"/a"}
+        assert servicer.volumes[object_id].files["/a"].data == b""
+        assert servicer.volumes[object_id].files["/a"].data_blob_id == "bl-1"
 
         _, blobs, _ = blob_server
         assert blobs["bl-1"] == b"hello world, this is a lot of text"
+
+
+@pytest.mark.asyncio
+async def test_volume2_upload_large_stream(client, servicer, blob_server):
+    # Volumes version 2 don't use `modal._utils.blob_utils.LARGE_FILE_LIMIT`
+    # Instead, we need to go over 8MiB to trigger different behavior (ie spilling into multiple blocks), but in this
+    # unit test context there isn't much of a semantic difference.
+
+    # Create a byte buffer that is larger than 8MiB
+    data = b"hello world, this is a lot of text" * 250_000
+    assert len(data) > BLOCK_SIZE
+
+    stream = io.BytesIO(data)
+
+    async with modal.Volume.ephemeral(client=client, version=api_pb2.VOLUME_FS_VERSION_V2) as vol:
+        async with vol.batch_upload() as batch:
+            batch.put_file(stream, "/a")
+        object_id = vol.object_id
+
+    assert servicer.volumes[object_id].files.keys() == {"/a"}
+    assert servicer.volumes[object_id].files["/a"].data == data
 
 
 @pytest.mark.asyncio
@@ -252,14 +357,15 @@ async def test_volume_upload_file_timeout(client, tmp_path, servicer, blob_serve
 
 
 @pytest.mark.asyncio
-async def test_volume_copy_1(client, tmp_path, servicer):
+@pytest.mark.parametrize("version", VERSIONS)
+async def test_volume_copy_1(client, tmp_path, servicer, version):
     ## test 1: copy src path to dst path ##
     src_path = "original.txt"
     dst_path = "copied.txt"
     local_file_path = tmp_path / src_path
     local_file_path.write_text("test copy")
 
-    async with modal.Volume.ephemeral(client=client) as vol:
+    async with modal.Volume.ephemeral(client=client, version=version) as vol:
         # add local file to volume
         async with vol.batch_upload() as batch:
             batch.put_file(local_file_path, src_path)
@@ -268,18 +374,19 @@ async def test_volume_copy_1(client, tmp_path, servicer):
         # copy file from src_path to dst_path
         vol.copy_files([src_path], dst_path)
 
-    assert servicer.volume_files[object_id].keys() == {src_path, dst_path}
+    assert servicer.volumes[object_id].files.keys() == {src_path, dst_path}
 
-    assert servicer.volume_files[object_id][src_path].data == b"test copy"
-    assert servicer.volume_files[object_id][dst_path].data == b"test copy"
+    assert servicer.volumes[object_id].files[src_path].data == b"test copy"
+    assert servicer.volumes[object_id].files[dst_path].data == b"test copy"
 
 
 @pytest.mark.asyncio
-async def test_volume_copy_2(client, tmp_path, servicer):
+@pytest.mark.parametrize("version", VERSIONS)
+async def test_volume_copy_2(client, tmp_path, servicer, version):
     ## test 2: copy multiple files into a directory ##
     file_paths = ["file1.txt", "file2.txt"]
 
-    async with modal.Volume.ephemeral(client=client) as vol:
+    async with modal.Volume.ephemeral(client=client, version=version) as vol:
         for file_path in file_paths:
             local_file_path = tmp_path / file_path
             local_file_path.write_text("test copy")
@@ -289,7 +396,7 @@ async def test_volume_copy_2(client, tmp_path, servicer):
 
         vol.copy_files(file_paths, "test_dir")
 
-    returned_volume_files = [Path(file) for file in servicer.volume_files[object_id].keys()]
+    returned_volume_files = [Path(file) for file in servicer.volumes[object_id].files.keys()]
     expected_volume_files = [
         Path(file) for file in ["file1.txt", "file2.txt", "test_dir/file1.txt", "test_dir/file2.txt"]
     ]
@@ -297,30 +404,31 @@ async def test_volume_copy_2(client, tmp_path, servicer):
     assert returned_volume_files == expected_volume_files
 
     returned_file_data = {
-        Path(entry): servicer.volume_files[object_id][entry] for entry in servicer.volume_files[object_id]
+        Path(entry): servicer.volumes[object_id].files[entry] for entry in servicer.volumes[object_id].files
     }
     assert returned_file_data[Path("test_dir/file1.txt")].data == b"test copy"
     assert returned_file_data[Path("test_dir/file2.txt")].data == b"test copy"
 
 
 @pytest.mark.parametrize("delete_as_instance_method", [True, False])
-def test_persisted(servicer, client, delete_as_instance_method):
+@pytest.mark.parametrize("version", VERSIONS)
+def test_persisted(servicer, client, delete_as_instance_method, version):
     # Lookup should fail since it doesn't exist
     with pytest.raises(NotFoundError):
-        modal.Volume.from_name("xyz").hydrate(client)
+        modal.Volume.from_name("xyz", version=version).hydrate(client)
 
     # Create it
-    modal.Volume.from_name("xyz", create_if_missing=True).hydrate(client)
+    modal.Volume.from_name("xyz", create_if_missing=True, version=version).hydrate(client)
 
     # Lookup should succeed now
-    modal.Volume.from_name("xyz").hydrate(client)
+    modal.Volume.from_name("xyz", version=version).hydrate(client)
 
     # Delete it
     modal.Volume.delete("xyz", client=client)
 
     # Lookup should fail again
     with pytest.raises(NotFoundError):
-        modal.Volume.from_name("xyz").hydrate(client)
+        modal.Volume.from_name("xyz", version=version).hydrate(client)
 
 
 def test_ephemeral(servicer, client):


### PR DESCRIPTION
## Describe your changes

- Adds support for version 2 `volume.batch_upload()` via the new block-based API used by `VolumePutFiles2`

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
