### PR TITLE
modal_proto: Add support for `mode` in VolumePutFiles2

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2946,6 +2946,9 @@ message VolumePutFiles2Request {
 
     // The blocks, in units of 8MiB, that this file consists of.
     repeated Block blocks = 3;
+
+    // Unix file permission bits `st_mode`.
+    optional uint32 mode = 4;
   }
 
   message Block {


### PR DESCRIPTION
## Describe your changes

- Adds support for a `mode` param to match the `VolumePutFiles` RPC.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
