### PR TITLE
Add experimental_options passthrough and handle server warnings

### DIFF
--- a/modal/__main__.py
+++ b/modal/__main__.py
@@ -2,7 +2,7 @@
 import sys
 
 from ._traceback import reduce_traceback_to_user_code
-from .cli._traceback import highlight_modal_deprecation_warnings, setup_rich_traceback
+from .cli._traceback import highlight_modal_warnings, setup_rich_traceback
 from .cli.entry_point import entrypoint_cli
 from .cli.import_refs import _CliUserExecutionError
 from .config import config
@@ -11,7 +11,7 @@ from .config import config
 def main():
     # Setup rich tracebacks, but only on user's end, when using the Modal CLI.
     setup_rich_traceback()
-    highlight_modal_deprecation_warnings()
+    highlight_modal_warnings()
 
     try:
         entrypoint_cli()

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -459,6 +459,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         ephemeral_disk: Optional[int] = None,
         # current default: first-party, future default: main-package
         include_source: Optional[bool] = None,
+        experimental_options: Optional[dict[str, str]] = None,
         _experimental_proxy_ip: Optional[str] = None,
         _experimental_custom_scaling_factor: Optional[float] = None,
         _experimental_enable_gpu_snapshot: bool = False,
@@ -819,6 +820,8 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                     i6pn_enabled=i6pn_enabled,
                     schedule=schedule.proto_message if schedule is not None else None,
                     snapshot_debug=config.get("snapshot_debug"),
+                    experimental_options=experimental_options or {},
+                    # ---
                     _experimental_group_size=cluster_size or 0,  # Experimental: Clustered functions
                     _experimental_concurrent_cancellations=True,
                     _experimental_proxy_ip=_experimental_proxy_ip,
@@ -856,6 +859,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                         use_method_name=function_definition.use_method_name,
                         method_definitions=function_definition.method_definitions,
                         method_definitions_set=function_definition.method_definitions_set,
+                        experimental_options=experimental_options or {},
                         _experimental_group_size=function_definition._experimental_group_size,
                         _experimental_buffer_containers=function_definition._experimental_buffer_containers,
                         _experimental_custom_scaling=function_definition._experimental_custom_scaling,
@@ -913,6 +917,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                         raise InvalidError(f"Function {info.function_name} is too large to deploy.")
                     raise
                 function_creation_status.set_response(response)
+
             # needed for modal.serve file watching
             serve_mounts = {m for m in all_mounts if m.is_local()}
             serve_mounts |= image._serve_mounts

--- a/modal/_resolver.py
+++ b/modal/_resolver.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING, Optional
 
 from grpclib import GRPCError, Status
 
+from modal_proto import api_pb2
+
 from ._utils.async_utils import TaskContext
 from .client import _Client
 from .exception import NotFoundError
@@ -33,6 +35,10 @@ class StatusRow:
     def message(self, message):
         if self._spinner is not None:
             self._spinner.update(text=message)
+
+    def warning(self, warning: api_pb2.Warning):
+        if self._step_node is not None:
+            self._step_node.add(f"[yellow]:warning:[/yellow] {warning.message}")
 
     def finish(self, message):
         if self._step_node is not None and self._spinner is not None:

--- a/modal/_utils/function_utils.py
+++ b/modal/_utils/function_utils.py
@@ -584,6 +584,8 @@ class FunctionCreationStatus:
             suffix = _get_suffix_from_web_url_info(url_info)
             # TODO: this is only printed when we're showing progress. Maybe move this somewhere else.
             web_url = self.response.handle_metadata.web_url
+            for warning in self.response.server_warnings:
+                self.status_row.warning(warning)
             self.status_row.finish(
                 f"Created web function {self.tag} => [magenta underline]{web_url}[/magenta underline]"
                 f"{proxy_auth_suffix}{suffix}"
@@ -595,7 +597,10 @@ class FunctionCreationStatus:
                 custom_domain_status_row.finish(
                     f"Custom domain for {self.tag} => [magenta underline]{custom_domain.url}[/magenta underline]"
                 )
+
         else:
+            for warning in self.response.server_warnings:
+                self.status_row.warning(warning)
             self.status_row.finish(f"Created function {self.tag}.")
             if self.response.function.method_definitions_set:
                 for method_definition in self.response.function.method_definitions.values():

--- a/modal/app.py
+++ b/modal/app.py
@@ -613,6 +613,7 @@ class _App:
         i6pn: Optional[bool] = None,  # Whether to enable IPv6 container networking within the region.
         # Whether the function's home package should be included in the image - defaults to True
         include_source: Optional[bool] = None,  # When `False`, don't automatically add the App source to the container.
+        experimental_options: Optional[dict[str, Any]] = None,
         # Parameters below here are experimental. Use with caution!
         _experimental_scheduler_placement: Optional[
             SchedulerPlacement
@@ -780,10 +781,11 @@ class _App:
                 block_network=block_network,
                 max_inputs=max_inputs,
                 scheduler_placement=scheduler_placement,
-                _experimental_proxy_ip=_experimental_proxy_ip,
                 i6pn_enabled=i6pn_enabled,
                 cluster_size=cluster_size,  # Experimental: Clustered functions
                 include_source=include_source if include_source is not None else self._include_source_default,
+                experimental_options={k: str(v) for k, v in (experimental_options or {}).items()},
+                _experimental_proxy_ip=_experimental_proxy_ip,
                 _experimental_enable_gpu_snapshot=_experimental_enable_gpu_snapshot,
             )
 
@@ -836,6 +838,7 @@ class _App:
         # Use `max_inputs = 1` for single-use containers.
         max_inputs: Optional[int] = None,
         include_source: Optional[bool] = None,  # When `False`, don't automatically add the App source to the container.
+        experimental_options: Optional[dict[str, Any]] = None,
         # Parameters below here are experimental. Use with caution!
         _experimental_scheduler_placement: Optional[
             SchedulerPlacement
@@ -947,6 +950,7 @@ class _App:
                 max_inputs=max_inputs,
                 scheduler_placement=scheduler_placement,
                 include_source=include_source if include_source is not None else self._include_source_default,
+                experimental_options={k: str(v) for k, v in (experimental_options or {}).items()},
                 _experimental_proxy_ip=_experimental_proxy_ip,
                 _experimental_custom_scaling_factor=_experimental_custom_scaling_factor,
                 _experimental_enable_gpu_snapshot=_experimental_enable_gpu_snapshot,

--- a/modal/cli/_traceback.py
+++ b/modal/cli/_traceback.py
@@ -161,8 +161,8 @@ def setup_rich_traceback() -> None:
     install(suppress=[synchronicity, grpclib, click, typer], extra_lines=1)
 
 
-def highlight_modal_deprecation_warnings() -> None:
-    """Patch the warnings module to make client deprecation warnings more salient in the CLI."""
+def highlight_modal_warnings() -> None:
+    """Patch the warnings module to make certain warnings more salient in the CLI."""
     base_showwarning = warnings.showwarning
 
     def showwarning(warning, category, filename, lineno, file=None, line=None):

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1341,6 +1341,11 @@ message Function {
 
   AutoscalerSettings autoscaler_settings = 79;  // Bundle of parameters related to autoscaling
   FunctionSchema function_schema = 80;
+
+  // For server-side experimental functionality. Prefer using this over individual _experimental_* fields.
+  // Note the value type as string. Internally we'll coerce all values to string with str().
+  // On the server, it's necessary to convert back to the most natural type (e.g. int) when relevant.
+  map<string, string> experimental_options = 81;
 }
 
 message FunctionAsyncInvokeRequest {
@@ -1425,6 +1430,7 @@ message FunctionCreateResponse {
   string __deprecated_web_url = 2  [ deprecated = true];  // Used up until 0.62.212
   Function function = 4;
   FunctionHandleMetadata handle_metadata = 5;
+  repeated Warning server_warnings = 6;
 }
 
 message FunctionData {
@@ -1490,6 +1496,8 @@ message FunctionData {
 
   AutoscalerSettings autoscaler_settings = 31;  // Bundle of parameters related to autoscaling
   FunctionSchema function_schema = 32;
+
+  map<string, string> experimental_options = 33;
 }
 
 message FunctionExtended {
@@ -3028,6 +3036,7 @@ message Warning {
     WARNING_TYPE_UNSPECIFIED = 0;
     WARNING_TYPE_CLIENT_DEPRECATION = 1;
     WARNING_TYPE_RESOURCE_LIMIT = 2;
+    WARNING_TYPE_FUNCTION_CONFIGURATION = 3;
   }
   WarningType type = 1;
   string message = 2;

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -1255,3 +1255,8 @@ def test_cli_run_variadic_args(servicer, set_env_client, test_dir, func, disable
     assert "args: ('abc', '--foo=123', '--bar=456')" in res.stdout
 
     _run(["run", f"{app_file.as_posix()}::{func}_invalid", "--foo=123"], expected_exit_code=1)
+
+
+def test_server_warnings(servicer, set_env_client, supports_dir):
+    res = _run(["run", f"{supports_dir / 'app_run_tests' / 'uses_experimental_options.py'}::gets_warning"])
+    assert "You have been warned!" in res.stdout

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1047,7 +1047,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
             self.function2schedule[function_id] = function_defn.schedule
 
         warnings = []
-        if int(function_defn.experimental_options["warn_me"]):
+        if int(function_defn.experimental_options.get("warn_me", "0")):
             warnings.append(api_pb2.Warning(message="You have been warned!"))
 
         await stream.send_message(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1046,6 +1046,10 @@ class MockClientServicer(api_grpc.ModalClientBase):
         if function_defn.schedule:
             self.function2schedule[function_id] = function_defn.schedule
 
+        warnings = []
+        if int(function_defn.experimental_options["warn_me"]):
+            warnings.append(api_pb2.Warning(message="You have been warned!"))
+
         await stream.send_message(
             api_pb2.FunctionCreateResponse(
                 function_id=function_id,
@@ -1072,6 +1076,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
                     class_parameter_info=function_defn.class_parameter_info,
                     function_schema=function_defn.function_schema,
                 ),
+                server_warnings=warnings,
             )
         )
 

--- a/test/supports/app_run_tests/uses_experimental_options.py
+++ b/test/supports/app_run_tests/uses_experimental_options.py
@@ -1,0 +1,10 @@
+# Copyright Modal Labs 2025
+
+import modal
+
+app = modal.App()
+
+
+@app.function(experimental_options={"warn_me": 1})
+def gets_warning():
+    print("Done!")


### PR DESCRIPTION
## Describe your changes

Adds `experimental_options` to `@app.function` and `@app.cls` (external) and `api_pb2.Function` (internal).

We'll use this going forward for testing features that depend only on server-side configuration. The advantage of passing through the options is that we don't need to tie server-side features to specific client upgrades, nor to we need to do the housekeeping involved with adding (and eventually removing) specific options to the decorators / proto messages.

This PR also adds a concept of server-side warnings for Function configuration:

<img width="453" alt="image" src="https://github.com/user-attachments/assets/38cffb93-a7ee-45cc-8188-7a7ce1827d09" />

It's relevant here because we want to be able to indicate when "experimental" options are deprecated server-side (and anyone using them should migrate to whatever stable API we've added, if relevant). But it could be generally useful for other cases where we want to warn based on some server side logic / limits / etc. without actually stopping the build.

We're not currently using this for anything but I might migrate some of the `_experimental_*` flags to this system in subsequent PRs.

- Client side of CLI-369

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- The `@app.function` and `@app.cls` decorators now support `experimental_options`, which we'll use going forward when testing experimental functionality that depends only on server-side configuration.