### PR TITLE
fix: ignore pyright warnings about incompat pathlib types

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -285,7 +285,7 @@ def _create_context_mount(
 
         return False
 
-    return _Mount._add_local_dir(context_dir, PurePosixPath("/"), ignore=ignore_with_include)
+    return _Mount._add_local_dir(context_dir, PurePosixPath("/"), ignore=ignore_with_include)  # pyright: ignore [reportGeneralTypeIssues=false]
 
 
 def _create_context_mount_function(
@@ -739,7 +739,7 @@ class _Image(_Object, type_prefix="im"):
         if remote_path.endswith("/"):
             remote_path = remote_path + Path(local_path).name
 
-        mount = _Mount._from_local_file(local_path, remote_path)
+        mount = _Mount._from_local_file(local_path, remote_path)  # pyright: ignore [reportGeneralTypeIssues=false]
         return self._add_mount_layer_or_copy(mount, copy=copy)
 
     def add_local_dir(
@@ -810,7 +810,7 @@ class _Image(_Object, type_prefix="im"):
             #  + make default remote_path="./"
             raise InvalidError("image.add_local_dir() currently only supports absolute remote_path values")
 
-        mount = _Mount._add_local_dir(Path(local_path), PurePosixPath(remote_path), ignore=_ignore_fn(ignore))
+        mount = _Mount._add_local_dir(Path(local_path), PurePosixPath(remote_path), ignore=_ignore_fn(ignore))  # pyright: ignore [reportGeneralTypeIssues=false]
         return self._add_mount_layer_or_copy(mount, copy=copy)
 
     def copy_local_file(self, local_path: Union[str, Path], remote_path: Union[str, Path] = "./") -> "_Image":
@@ -831,11 +831,14 @@ class _Image(_Object, type_prefix="im"):
         return _Image._from_args(
             base_images={"base": self},
             dockerfile_function=build_dockerfile,
-            context_mount_function=lambda: _Mount._from_local_file(local_path, remote_path=f"/{basename}"),
+            context_mount_function=lambda: _Mount._from_local_file(local_path, remote_path=f"/{basename}"),  # pyright: ignore [reportGeneralTypeIssues=false]
         )
 
     def add_local_python_source(
-        self, *modules: str, copy: bool = False, ignore: Union[Sequence[str], Callable[[Path], bool]] = NON_PYTHON_FILES
+        self,
+        *modules: str,
+        copy: bool = False,
+        ignore: Optional[Union[Sequence[str], Callable[[Path], bool]]] = NON_PYTHON_FILES,
     ) -> "_Image":
         """Adds locally available Python packages/modules to containers
 
@@ -873,7 +876,7 @@ class _Image(_Object, type_prefix="im"):
         """
         if not all(isinstance(module, str) for module in modules):
             raise InvalidError("Local Python modules must be specified as strings.")
-        mount = _Mount._from_local_python_packages(*modules, ignore=ignore)
+        mount = _Mount._from_local_python_packages(*modules, ignore=ignore)  # pyright: ignore [reportGeneralTypeIssues=false]
         img = self._add_mount_layer_or_copy(mount, copy=copy)
         img._added_python_source_set |= set(modules)
         return img
@@ -946,7 +949,9 @@ class _Image(_Object, type_prefix="im"):
             base_images={"base": self},
             dockerfile_function=build_dockerfile,
             context_mount_function=lambda: _Mount._add_local_dir(
-                Path(local_path), PurePosixPath("/"), ignore=_ignore_fn(ignore)
+                Path(local_path),
+                PurePosixPath("/"),
+                ignore=_ignore_fn(ignore),  # pyright: ignore [reportGeneralTypeIssues=false]
             ),
         )
 


### PR DESCRIPTION
Running `inv type-check` shows lots of `"pathlib._local.Path" is not assignable
to "pathlib.Path"` warnings. These seem harmless and caused by either the type
checker's inability to see they're the same class or some upstream pathlib bug.

In any case, this change disables pyright's `reportGeneralTypeIssues` for these
specific lines to make the `inv type-check` output less noisy.

<details>
<summary>Before</summary>

```shell
$ inv type-check
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/_clustered_functions.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/_runtime/container_io_manager.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/_runtime/execution_context.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/_tunnel.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/app.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/client.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/cloud_bucket_mount.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/cls.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/container_process.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/dict.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/environments.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/file_io.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/functions.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/image.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/io_streams.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/mount.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/network_file_system.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/object.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/parallel_map.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/partial_function.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/proxy.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/queue.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/runner.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/sandbox.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/secret.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/serving.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/snapshot.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/token_flow.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/volume.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/_clustered_functions.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/_runtime/container_io_manager.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/_runtime/execution_context.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/_tunnel.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/app.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/client.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/cloud_bucket_mount.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/cls.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/container_process.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/dict.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/environments.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/file_io.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/functions.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/image.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/io_streams.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/mount.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/network_file_system.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/object.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/parallel_map.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/partial_function.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/proxy.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/queue.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/runner.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/sandbox.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/secret.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/serving.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/snapshot.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/token_flow.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/volume.pyi
29 files reformatted
Success: no issues found in 308 source files
/Users/dxia/src/github.com/modal-labs/modal-client/modal/image.py
  /Users/dxia/src/github.com/modal-labs/modal-client/modal/image.py:288:34 - error: Argument of type "Path" cannot be assigned to parameter "local_path" of type "Path" in function "_add_local_dir"
    "pathlib.Path" is not assignable to "pathlib._local.Path" (reportArgumentType)
  /Users/dxia/src/github.com/modal-labs/modal-client/modal/image.py:288:47 - error: Argument of type "PurePosixPath" cannot be assigned to parameter "remote_path" of type "PurePosixPath" in function "_add_local_dir"
    "pathlib.PurePosixPath" is not assignable to "pathlib._local.PurePosixPath" (reportArgumentType)
  /Users/dxia/src/github.com/modal-labs/modal-client/modal/image.py:288:74 - error: Argument of type "(source: Path) -> bool" cannot be assigned to parameter "ignore" of type "(Path) -> bool" in function "_add_local_dir"
    Type "(source: Path) -> bool" is not assignable to type "(Path) -> bool"
      Parameter 1: type "Path" is incompatible with type "Path"
        "pathlib._local.Path" is not assignable to "pathlib.Path" (reportArgumentType)
  /Users/dxia/src/github.com/modal-labs/modal-client/modal/image.py:742:41 - error: Argument of type "str | Path" cannot be assigned to parameter "local_path" of type "str | Path" in function "_from_local_file"
    Type "builtins.str | pathlib.Path" is not assignable to type "builtins.str | pathlib._local.Path"
      Type "Path" is not assignable to type "str | Path"
        "Path" is not assignable to "str"
        "pathlib.Path" is not assignable to "pathlib._local.Path" (reportArgumentType)
  /Users/dxia/src/github.com/modal-labs/modal-client/modal/image.py:813:39 - error: Argument of type "Path" cannot be assigned to parameter "local_path" of type "Path" in function "_add_local_dir"
    "pathlib.Path" is not assignable to "pathlib._local.Path" (reportArgumentType)
  /Users/dxia/src/github.com/modal-labs/modal-client/modal/image.py:813:57 - error: Argument of type "PurePosixPath" cannot be assigned to parameter "remote_path" of type "PurePosixPath" in function "_add_local_dir"
    "pathlib.PurePosixPath" is not assignable to "pathlib._local.PurePosixPath" (reportArgumentType)
  /Users/dxia/src/github.com/modal-labs/modal-client/modal/image.py:813:92 - error: Argument of type "(Path) -> bool" cannot be assigned to parameter "ignore" of type "(Path) -> bool" in function "_add_local_dir"
    Type "(pathlib.Path) -> builtins.bool" is not assignable to type "(pathlib._local.Path) -> builtins.bool"
      Parameter 1: type "Path" is incompatible with type "Path"
        "pathlib._local.Path" is not assignable to "pathlib.Path" (reportArgumentType)
  /Users/dxia/src/github.com/modal-labs/modal-client/modal/image.py:834:68 - error: Argument of type "str | Path" cannot be assigned to parameter "local_path" of type "str | Path" in function "_from_local_file"
    Type "builtins.str | pathlib.Path" is not assignable to type "builtins.str | pathlib._local.Path"
      Type "Path" is not assignable to type "str | Path"
        "Path" is not assignable to "str"
        "pathlib.Path" is not assignable to "pathlib._local.Path" (reportArgumentType)
  /Users/dxia/src/github.com/modal-labs/modal-client/modal/image.py:876:69 - error: Argument of type "Sequence[str] | ((Path) -> bool)" cannot be assigned to parameter "ignore" of type "Sequence[str] | ((Path) -> bool) | None" in function "_from_local_python_packages"
    Type "Sequence[str] | ((Path) -> bool)" is not assignable to type "Sequence[str] | ((Path) -> bool) | None"
      Type "(Path) -> bool" is not assignable to type "Sequence[str] | ((Path) -> bool) | None"
        "function" is not assignable to "Sequence[str]"
        Type "(pathlib.Path) -> builtins.bool" is not assignable to type "(pathlib._local.Path) -> builtins.bool"
          Parameter 1: type "Path" is incompatible with type "Path"
            "pathlib._local.Path" is not assignable to "pathlib.Path"
        "function" is not assignable to "None" (reportArgumentType)
  /Users/dxia/src/github.com/modal-labs/modal-client/modal/image.py:949:17 - error: Argument of type "Path" cannot be assigned to parameter "local_path" of type "Path" in function "_add_local_dir"
    "pathlib.Path" is not assignable to "pathlib._local.Path" (reportArgumentType)
  /Users/dxia/src/github.com/modal-labs/modal-client/modal/image.py:949:35 - error: Argument of type "PurePosixPath" cannot be assigned to parameter "remote_path" of type "PurePosixPath" in function "_add_local_dir"
    "pathlib.PurePosixPath" is not assignable to "pathlib._local.PurePosixPath" (reportArgumentType)
  /Users/dxia/src/github.com/modal-labs/modal-client/modal/image.py:949:62 - error: Argument of type "(Path) -> bool" cannot be assigned to parameter "ignore" of type "(Path) -> bool" in function "_add_local_dir"
    Type "(pathlib.Path) -> builtins.bool" is not assignable to type "(pathlib._local.Path) -> builtins.bool"
      Parameter 1: type "Path" is incompatible with type "Path"
        "pathlib._local.Path" is not assignable to "pathlib.Path" (reportArgumentType)
12 errors, 0 warnings, 0 informations
```
</details>

<details>
<summary>After</summary>

```shell
$ inv type-check
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/_clustered_functions.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/_runtime/container_io_manager.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/_runtime/execution_context.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/_tunnel.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/app.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/client.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/cloud_bucket_mount.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/cls.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/container_process.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/dict.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/environments.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/file_io.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/functions.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/image.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/io_streams.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/mount.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/network_file_system.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/object.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/parallel_map.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/partial_function.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/proxy.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/queue.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/runner.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/sandbox.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/secret.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/serving.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/snapshot.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/token_flow.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/volume.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/_clustered_functions.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/_runtime/container_io_manager.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/_runtime/execution_context.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/_tunnel.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/app.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/client.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/cloud_bucket_mount.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/cls.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/container_process.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/dict.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/environments.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/file_io.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/functions.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/image.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/io_streams.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/mount.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/network_file_system.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/object.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/parallel_map.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/partial_function.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/proxy.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/queue.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/runner.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/sandbox.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/secret.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/serving.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/snapshot.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/token_flow.pyi
Wrote /Users/dxia/src/github.com/modal-labs/modal-client/modal/volume.pyi
29 files reformatted
Success: no issues found in 308 source files
0 errors, 0 warnings, 0 informations
```
</details>