### PR TITLE
chore: upgrade pyright dev dep to 1.1.399

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -31,8 +31,7 @@ wheel~=0.37.1
 nbclient==0.6.8
 notebook==6.5.1
 jupytext==1.14.1
-pyright==1.1.351
+pyright==1.1.399
 python-json-logger==2.0.7  # unpinned transitive dependency of jupytext breaking on later versions
 pdm==2.12.4  # used for testing pdm cache behavior w/ automounts
 console-ctrl==0.1.0
-


### PR DESCRIPTION
from 1.1.351.

Right now running `inv type-check` shows the following warning. pyright seems to release pretty often so upgrading this once is probably only a temporary reprieve from this kind of aggressive warning. But it's probably good to periodically upgrade the version.

## Before

```shell
$ inv type-check

Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/_clustered_functions.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/_runtime/container_io_manager.pyi
...
29 files reformatted
Success: no issues found in 308 source files
WARNING: there is a new pyright version available (v1.1.351 -> v1.1.399).
Please install the new version or set PYRIGHT_PYTHON_FORCE_VERSION to `latest`
...
12 errors, 0 warnings, 0 informations
```

## After

```shell
$ inv type-check

Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/_clustered_functions.pyi
Removed /Users/dxia/src/github.com/modal-labs/modal-client/modal/_runtime/container_io_manager.pyi
...
29 files reformatted
Success: no issues found in 308 source files
...
12 errors, 0 warnings, 0 informations
```