### PR TITLE
Add App.deploy as primary interface for programmatic deployment

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -448,7 +448,7 @@ class _App:
                 "Examples:\n"
                 'app.deploy(name="some-name")\n\n'
                 "or\n"
-                'app = App("some-name")'
+                'app = modal.App("some-name")'
             )
         result = await _deploy_app(self, name=name, environment_name=environment_name, tag=tag, client=client)
         self._app_id = result.app_id

--- a/modal/app.py
+++ b/modal/app.py
@@ -333,11 +333,11 @@ class _App:
         interactive: bool = False,
         environment_name: Optional[str] = None,
     ) -> AsyncGenerator["_App", None]:
-        """Context manager that runs an app on Modal.
+        """Context manager that runs an ephemeral app on Modal.
 
         Use this as the main entry point for your Modal application. All calls
-        to Modal functions should be made within the scope of this context
-        manager, and they will correspond to the current app.
+        to Modal Functions should be made within the scope of this context
+        manager, and they will correspond to the current App.
 
         **Example**
 
@@ -346,7 +346,7 @@ class _App:
             some_modal_function.remote()
         ```
 
-        To enable output printing, use `modal.enable_output()`:
+        To enable output printing (i.e., to see App logs), use `modal.enable_output()`:
 
         ```python notest
         with modal.enable_output():
@@ -354,10 +354,10 @@ class _App:
                 some_modal_function.remote()
         ```
 
-        Note that you cannot invoke this in global scope of a file where you have
-        Modal functions or Classes, since that would run the block when the function
-        or class is imported in your containers as well. If you want to run it as
-        your entrypoint, consider wrapping it:
+        Note that you should not invoke this in global scope of a file where you have
+        Modal Functions or Classes defined, since that would run the block when the Function
+        or Cls is imported in your containers as well. If you want to run it as your entrypoint,
+        consider protecting it:
 
         ```python
         if __name__ == "__main__":
@@ -371,9 +371,6 @@ class _App:
         python app_module.py
         ```
 
-        Note that this method used to return a separate "App" object. This is
-        no longer useful since you can use the app itself for access to all
-        objects. For backwards compatibility reasons, it returns the same app.
         """
         from .runner import _run_app  # Defer import of runner.py, which imports a lot from Rich
 
@@ -391,6 +388,71 @@ class _App:
             self, client=client, detach=detach, interactive=interactive, environment_name=environment_name
         ):
             yield self
+
+    async def deploy(
+        self,
+        *,
+        name: Optional[str] = None,  # Name for the deployment, overriding any set on the App
+        environment_name: Optional[str] = None,  # Environment to deploy the App in
+        tag: str = "",  # Optional metadata that will be visible in the deployment history
+        client: Optional[_Client] = None,  # Alternate client to use for RPCs
+    ):
+        """Deploy the App so that it is available persistently.
+
+        Deployed Apps will be avaible for lookup or web-based invocations until they are stopped.
+        Unlike with `App.run`, this method will return as soon as the deployment completes.
+
+        This method is a programmatic alternative to the `modal deploy` CLI command.
+
+        Examples:
+
+        ```python notest
+        app = App("my-app")
+        app.deploy()
+        ```
+
+        To enable output printing (i.e., to see build logs), use `modal.enable_output()`:
+
+        ```python notest
+        app = App("my-app")
+        with modal.enable_output():
+            app.deploy()
+        ```
+
+        Unlike with `App.run`, Function logs will not stream back to the local client after the
+        App is deployed.
+
+        Note that you should not invoke this method in global scope, as that would redeploy
+        the App every time the file is imported. If you want to write a programmatic deployment
+        script, protect this call so that it only runs when the file is executed directly:
+
+        ```python notest
+        if __name__ == "__main__":
+            with modal.enable_output():
+                app.deploy()
+        ```
+
+        Then you can deploy your app with:
+
+        ```shell
+        python app_module.py
+        ```
+
+        """
+        from .runner import _deploy_app  # Defer import of runner.py, which imports a lot from Rich
+
+        if name is None and self._name is None:
+            raise InvalidError(
+                "You need to either supply a deployment name or have a name set on the app.\n"
+                "\n"
+                "Examples:\n"
+                'app.deploy(name="some-name")\n\n'
+                "or\n"
+                'app = App("some-name")'
+            )
+        result = await _deploy_app(self, name=name, environment_name=environment_name, tag=tag, client=client)
+        self._app_id = result.app_id
+        return self
 
     def _get_default_image(self):
         if self._image:

--- a/modal/app.py
+++ b/modal/app.py
@@ -396,7 +396,7 @@ class _App:
         environment_name: Optional[str] = None,  # Environment to deploy the App in
         tag: str = "",  # Optional metadata that will be visible in the deployment history
         client: Optional[_Client] = None,  # Alternate client to use for RPCs
-    ):
+    ) -> typing_extensions.Self:
         """Deploy the App so that it is available persistently.
 
         Deployed Apps will be avaible for lookup or web-based invocations until they are stopped.

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -444,8 +444,17 @@ def deploy(
     import_ref = parse_import_ref(app_ref, use_module_mode=use_module_mode)
     app = import_app_from_ref(import_ref, base_cmd="modal deploy")
 
-    if name is None:
-        name = app.name
+    name = name or app.name or ""
+    if not name:
+        raise ExecutionError(
+            "You need to either supply an explicit deployment name on the command line "
+            "or have a name set on the app.\n"
+            "\n"
+            "Examples:\n"
+            'app = App("some-name")'
+            "or\n"
+            "modal deploy ... --name=some-name"
+        )
 
     with enable_output():
         res = deploy_app(app, name=name, environment_name=env or "", tag=tag)

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -451,7 +451,7 @@ def deploy(
             "or have a name set on the app.\n"
             "\n"
             "Examples:\n"
-            'app = App("some-name")'
+            'app = modal.App("some-name")'
             "or\n"
             "modal deploy ... --name=some-name"
         )

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2025
 """Internal module for building and running Apps."""
 # Note: While this is mostly internal code, the `modal.runner.deploy_app` function was
-# the only way to programatically deploy Apps for some time, so users have reached into here.
+# the only way to programmatically deploy Apps for some time, so users have reached into here.
 # We may eventually deprecate it from the public API, but for now we should keep that in mind.
 
 import asyncio
@@ -491,9 +491,9 @@ async def _deploy_app(
             "You need to either supply a deployment name or have a name set on the app.\n"
             "\n"
             "Examples:\n"
-            'deploy_app(app, name="some_name")\n\n'
+            'modal.runner.deploy_app(app, name="some_name")\n\n'
             "or\n"
-            'app = App("some-name")'
+            'app = modal.App("some-name")'
         )
     else:
         check_object_name(name, "App")

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -473,38 +473,20 @@ async def _deploy_app(
     environment_name: Optional[str] = None,
     tag: str = "",
 ) -> DeployResult:
-    """Deploy an app and export its objects persistently.
+    """Internal function for deploying an App.
 
-    Typically, using the command-line tool `modal deploy <module or script>`
-    should be used, instead of this method.
-
-    **Usage:**
-
-    ```python
-    if __name__ == "__main__":
-        deploy_app(app)
-    ```
-
-    Deployment has two primary purposes:
-
-    * Persists all of the objects in the app, allowing them to live past the
-      current app run. For schedules this enables headless "cron"-like
-      functionality where scheduled functions continue to be invoked after
-      the client has disconnected.
-    * Allows for certain kinds of these objects, _deployment objects_, to be
-      referred to and used by other apps.
+    Users should prefer the `modal deploy` CLI or the `App.deploy` method.
     """
     if environment_name is None:
         environment_name = typing.cast(str, config.get("environment"))
 
-    name = name or app.name
+    name = name or app.name or ""
     if not name:
         raise InvalidError(
-            "You need to either supply an explicit deployment name to the deploy command, "
-            "or have a name set on the app.\n"
+            "You need to either supply a deployment name or have a name set on the app.\n"
             "\n"
             "Examples:\n"
-            'app.deploy("some_name")\n\n'
+            'deploy_app(app, name="some_name")\n\n'
             "or\n"
             'app = App("some-name")'
         )

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -1,4 +1,9 @@
 # Copyright Modal Labs 2025
+"""Internal module for building and running Apps."""
+# Note: While this is mostly internal code, the `modal.runner.deploy_app` function was
+# the only way to programatically deploy Apps for some time, so users have reached into here.
+# We may eventually deprecate it from the public API, but for now we should keep that in mind.
+
 import asyncio
 import dataclasses
 import os

--- a/modal_docs/gen_reference_docs.py
+++ b/modal_docs/gen_reference_docs.py
@@ -79,7 +79,6 @@ def run(output_dir: str = None):
         ("modal.call_graph", "modal.call_graph"),
         ("modal.container_process", "modal.container_process"),
         ("modal.gpu", "modal.gpu"),
-        ("modal.runner", "modal.runner"),
         ("modal.io_streams", "modal.io_streams"),
         ("modal.file_io", "modal.file_io"),
     ]

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -10,7 +10,7 @@ from modal import App, Image, Mount, Secret, Stub, Volume, enable_output, fastap
 from modal._partial_function import _parse_custom_domains
 from modal._utils.async_utils import synchronizer
 from modal.exception import DeprecationError, ExecutionError, InvalidError, NotFoundError
-from modal.runner import deploy_app, deploy_stub, run_app
+from modal.runner import deploy_stub, run_app
 from modal_proto import api_pb2
 
 from .supports import module_1, module_2
@@ -26,26 +26,26 @@ async def test_redeploy(servicer, client):
     app.function()(square)
 
     # Deploy app
-    res = await deploy_app.aio(app, "my-app", client=client)
-    assert res.app_id == "ap-1"
+    await app.deploy.aio(name="my-app", client=client)
+    assert app.app_id == "ap-1"
     assert servicer.app_objects["ap-1"]["square"] == "fu-1"
-    assert servicer.app_state_history[res.app_id] == [api_pb2.APP_STATE_INITIALIZING, api_pb2.APP_STATE_DEPLOYED]
+    assert servicer.app_state_history[app.app_id] == [api_pb2.APP_STATE_INITIALIZING, api_pb2.APP_STATE_DEPLOYED]
 
     # Redeploy, make sure all ids are the same
-    res = await deploy_app.aio(app, "my-app", client=client)
-    assert res.app_id == "ap-1"
+    await app.deploy.aio(name="my-app", client=client)
+    assert app.app_id == "ap-1"
     assert servicer.app_objects["ap-1"]["square"] == "fu-1"
-    assert servicer.app_state_history[res.app_id] == [
+    assert servicer.app_state_history[app.app_id] == [
         api_pb2.APP_STATE_INITIALIZING,
         api_pb2.APP_STATE_DEPLOYED,
         api_pb2.APP_STATE_DEPLOYED,
     ]
 
     # Deploy to a different name, ids should change
-    res = await deploy_app.aio(app, "my-app-xyz", client=client)
-    assert res.app_id == "ap-2"
+    await app.deploy.aio(name="my-app-xyz", client=client)
+    assert app.app_id == "ap-2"
     assert servicer.app_objects["ap-2"]["square"] == "fu-2"
-    assert servicer.app_state_history[res.app_id] == [api_pb2.APP_STATE_INITIALIZING, api_pb2.APP_STATE_DEPLOYED]
+    assert servicer.app_state_history[app.app_id] == [api_pb2.APP_STATE_INITIALIZING, api_pb2.APP_STATE_DEPLOYED]
 
 
 def dummy():
@@ -89,13 +89,13 @@ def test_create_object_invalid_exception(servicer, client):
 
 def test_deploy_falls_back_to_app_name(servicer, client):
     named_app = App(name="foo_app")
-    deploy_app(named_app, client=client)
+    named_app.deploy(client=client)
     assert "foo_app" in servicer.deployed_apps
 
 
 def test_deploy_uses_deployment_name_if_specified(servicer, client):
     named_app = App(name="foo_app")
-    deploy_app(named_app, "bar_app", client=client)
+    named_app.deploy(name="bar_app", client=client)
     assert "bar_app" in servicer.deployed_apps
     assert "foo_app" not in servicer.deployed_apps
 
@@ -144,8 +144,8 @@ def test_run_state(client, servicer):
 
 def test_deploy_state(client, servicer):
     app = App()
-    res = deploy_app(app, "foobar", client=client)
-    assert servicer.app_state_history[res.app_id] == [api_pb2.APP_STATE_INITIALIZING, api_pb2.APP_STATE_DEPLOYED]
+    app.deploy(name="foobar", client=client)
+    assert servicer.app_state_history[app.app_id] == [api_pb2.APP_STATE_INITIALIZING, api_pb2.APP_STATE_DEPLOYED]
 
 
 def test_detach_state(client, servicer):
@@ -236,19 +236,19 @@ def test_redeploy_delete_objects(servicer, client):
     app = App()
     app.function(name="d1")(dummy)
     app.function(name="d2")(dummy)
-    res = deploy_app(app, "xyz", client=client)
+    app.deploy(name="xyz", client=client)
 
     # Check objects
-    assert set(servicer.app_objects[res.app_id].keys()) == {"d1", "d2"}
+    assert set(servicer.app_objects[app.app_id].keys()) == {"d1", "d2"}
 
     # Deploy an app with objects d2 and d3
     app = App()
     app.function(name="d2")(dummy)
     app.function(name="d3")(dummy)
-    res = deploy_app(app, "xyz", client=client)
+    app.deploy(name="xyz", client=client)
 
     # Make sure d1 is deleted
-    assert set(servicer.app_objects[res.app_id].keys()) == {"d2", "d3"}
+    assert set(servicer.app_objects[app.app_id].keys()) == {"d2", "d3"}
 
 
 @pytest.mark.asyncio
@@ -301,7 +301,7 @@ async def test_deploy_disconnect(servicer, client):
     app.function(secrets=[Secret.from_name("nonexistent-secret")])(square)
 
     with pytest.raises(NotFoundError):
-        await deploy_app.aio(app, "my-app", client=client)
+        await app.deploy.aio(name="my-app", client=client)
 
     assert servicer.app_state_history["ap-1"] == [
         api_pb2.APP_STATE_INITIALIZING,
@@ -321,7 +321,7 @@ def test_hydrated_other_app_object_gets_referenced(servicer, client):
     with servicer.intercept() as ctx:
         with Volume.ephemeral(client=client) as vol:
             app.function(volumes={"/vol": vol})(dummy)  # implicitly load vol
-            deploy_app(app, client=client)
+            app.deploy(client=client)
             function_create_req: api_pb2.FunctionCreateRequest = ctx.pop_request("FunctionCreate")
             assert vol.object_id in {obj.object_id for obj in function_create_req.function.object_dependencies}
 
@@ -361,11 +361,10 @@ def test_stub():
         Stub()
 
 
-def test_deploy_stub(servicer, client):
+def test_deploy_stub():
     app = App("xyz")
-    deploy_app(app, client=client)
     with pytest.raises(DeprecationError, match="deploy_app"):
-        deploy_stub(app, client=client)
+        deploy_stub(app)
 
 
 def test_app_logs(servicer, client):
@@ -438,10 +437,9 @@ async def test_deploy_from_container(servicer, container_client):
     app.function()(square)
 
     # Deploy app
-    res = await deploy_app.aio(app, "my-app", client=container_client)
-    assert res.app_id == "ap-1"
+    await app.deploy.aio(name="my-app", client=container_client)
     assert servicer.app_objects["ap-1"]["square"] == "fu-1"
-    assert servicer.app_state_history[res.app_id] == [api_pb2.APP_STATE_INITIALIZING, api_pb2.APP_STATE_DEPLOYED]
+    assert servicer.app_state_history[app.app_id] == [api_pb2.APP_STATE_INITIALIZING, api_pb2.APP_STATE_DEPLOYED]
 
 
 def test_app_create_bad_environment_name_error(client):


### PR DESCRIPTION
## Describe your changes

Prefer this interface over `modal.runner.deploy_app` in examples of the public API.

`modal.runner.deploy_app` has been the only way to do this thus far and even though we think of that module as "internal", it's probably not worth breaking it to change the name right now.

Closes CLI-370
 
<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Adds a `.deploy()` method to the `App` object. This method allows you programmatically deploy Apps from Python:

    ```python
    app = modal.App("programmatic-deploy")
    ...
    app.deploy()
    ```