### PR TITLE
chore: use consistent synchronicity version

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r modal/requirements/${{ matrix.image-builder-version }}.txt
-          pip install synchronicity
+          pip install synchronicity~=0.9.10
 
       - name: Compile protos
         run: |


### PR DESCRIPTION
in ci-cd.yml Github worklow as the one specified in `pyproject.toml` to avoid any surprises in the future.
