### PR TITLE
modal_proto: Fix VolumeGetOrCreateResponse.metadata being on wrong message

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2889,13 +2889,13 @@ message VolumeGetOrCreateRequest {
   string environment_name = 3;
   ObjectCreationType object_creation_type = 4;
   string app_id = 5;  // only used with OBJECT_CREATION_TYPE_ANONYMOUS_OWNED_BY_APP
-  VolumeFsVersion version = 6 [deprecated = true];
-  VolumeMetadata metadata = 7;
+  VolumeFsVersion version = 6;
 }
 
 message VolumeGetOrCreateResponse {
   string volume_id = 1;
-  VolumeFsVersion version = 2;
+  VolumeFsVersion version = 2 [deprecated = true];
+  VolumeMetadata metadata = 3;
 }
 
 message VolumeHeartbeatRequest {


### PR DESCRIPTION
## Describe your changes

- Due to trying to get this change out hastily, the field was unfortunately put on the wrong message :facepalm: 

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
