### PR TITLE
modal_proto: Remove deprecated field option while some code still uses it

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2894,7 +2894,7 @@ message VolumeGetOrCreateRequest {
 
 message VolumeGetOrCreateResponse {
   string volume_id = 1;
-  VolumeFsVersion version = 2 [deprecated = true];
+  VolumeFsVersion version = 2;
   VolumeMetadata metadata = 3;
 }
 


### PR DESCRIPTION
## Describe your changes

- This removes linting errors due to us still relying on this deprecated field for backwards compatibility in some places.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
