### PR TITLE
Require keywords for some auxiliary parameters

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1129,6 +1129,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         cls: type["_Function"],
         app_name: str,
         name: str,
+        *,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
     ) -> "_Function":

--- a/modal/app.py
+++ b/modal/app.py
@@ -254,6 +254,7 @@ class _App:
     @renamed_parameter((2024, 12, 18), "label", "name")
     async def lookup(
         name: str,
+        *,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
@@ -327,6 +328,7 @@ class _App:
     @asynccontextmanager
     async def run(
         self,
+        *,
         client: Optional[_Client] = None,
         show_progress: Optional[bool] = None,
         detach: bool = False,

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -538,6 +538,7 @@ More information on class parameterization can be found here: https://modal.com/
         cls: type["_Cls"],
         app_name: str,
         name: str,
+        *,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
         workspace: Optional[str] = None,  # Deprecated and unused
@@ -601,6 +602,7 @@ More information on class parameterization can be found here: https://modal.com/
     @warn_on_renamed_autoscaler_settings
     def with_options(
         self: "_Cls",
+        *,
         cpu: Optional[Union[float, tuple[float, float]]] = None,
         memory: Optional[Union[int, tuple[int, int]]] = None,
         gpu: GPU_T = None,

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -111,6 +111,7 @@ class _Dict(_Object, type_prefix="di"):
     @renamed_parameter((2024, 12, 18), "label", "name")
     def from_name(
         name: str,
+        *,
         data: Optional[dict] = None,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -111,8 +111,8 @@ class _Dict(_Object, type_prefix="di"):
     @renamed_parameter((2024, 12, 18), "label", "name")
     def from_name(
         name: str,
-        *,
         data: Optional[dict] = None,
+        *,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,

--- a/modal/environments.py
+++ b/modal/environments.py
@@ -53,6 +53,7 @@ class _Environment(_Object, type_prefix="en"):
     @renamed_parameter((2024, 12, 18), "label", "name")
     def from_name(
         name: str,
+        *,
         create_if_missing: bool = False,
     ):
         if name:

--- a/modal/image.py
+++ b/modal/image.py
@@ -1236,10 +1236,9 @@ class _Image(_Object, type_prefix="im"):
     def poetry_install_from_file(
         self,
         poetry_pyproject_toml: str,
-        # Path to the lockfile. If not provided, uses poetry.lock in the same directory.
-        poetry_lockfile: Optional[str] = None,
-        # If set to True, it will not use poetry.lock
-        ignore_lockfile: bool = False,
+        poetry_lockfile: Optional[str] = None,  # Path to lockfile. If not provided, uses poetry.lock in same directory.
+        *,
+        ignore_lockfile: bool = False,  # If set to True, do not use poetry.lock, even when present
         # If set to True, use old installer. See https://github.com/python-poetry/poetry/issues/3336
         old_installer: bool = False,
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
@@ -1247,9 +1246,7 @@ class _Image(_Object, type_prefix="im"):
         with_: list[str] = [],
         # Selected optional dependency groups to exclude (See https://python-poetry.org/docs/cli/#install)
         without: list[str] = [],
-        # Only install dependency groups specifed in this list.
-        only: list[str] = [],
-        *,
+        only: list[str] = [],  # Only install dependency groups specifed in this list.
         secrets: Sequence[_Secret] = [],
         gpu: GPU_T = None,
     ) -> "_Image":
@@ -1556,8 +1553,8 @@ class _Image(_Object, type_prefix="im"):
     @staticmethod
     def from_registry(
         tag: str,
-        *,
         secret: Optional[_Secret] = None,
+        *,
         setup_dockerfile_commands: list[str] = [],
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
         add_python: Optional[str] = None,
@@ -1714,12 +1711,10 @@ class _Image(_Object, type_prefix="im"):
 
     @staticmethod
     def from_dockerfile(
-        # Filepath to Dockerfile.
-        path: Union[str, Path],
-        context_mount: Optional[_Mount] = None,  # Deprecated: the context is now inferred
-        # Ignore cached builds, similar to 'docker build --no-cache'
-        force_build: bool = False,
+        path: Union[str, Path],  # Filepath to Dockerfile.
         *,
+        context_mount: Optional[_Mount] = None,  # Deprecated: the context is now inferred
+        force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
         context_dir: Optional[Union[Path, str]] = None,  # Context for relative COPY commands
         secrets: Sequence[_Secret] = [],
         gpu: GPU_T = None,
@@ -1901,10 +1896,9 @@ class _Image(_Object, type_prefix="im"):
     def run_function(
         self,
         raw_f: Callable[..., Any],
+        *,
         secrets: Sequence[_Secret] = (),  # Optional Modal Secret objects with environment variables for the container
-        gpu: Union[
-            GPU_T, list[GPU_T]
-        ] = None,  # GPU request as string ("any", "T4", ...), object (`modal.GPU.A100()`, ...), or a list of either
+        gpu: Union[GPU_T, list[GPU_T]] = None,  # Requested GPU or or list of acceptable GPUs( e.g. ["A10", "A100"])
         mounts: Sequence[_Mount] = (),  # Mounts attached to the function
         volumes: dict[Union[str, PurePosixPath], Union[_Volume, _CloudBucketMount]] = {},  # Volume mount paths
         network_file_systems: dict[Union[str, PurePosixPath], _NetworkFileSystem] = {},  # NFS mount paths
@@ -1916,7 +1910,6 @@ class _Image(_Object, type_prefix="im"):
         region: Optional[Union[str, Sequence[str]]] = None,  # Region or regions to run the function on.
         args: Sequence[Any] = (),  # Positional arguments to the function.
         kwargs: dict[str, Any] = {},  # Keyword arguments to the function.
-        *,
         include_source: Optional[bool] = None,
     ) -> "_Image":
         """Run user-defined function `raw_f` as an image build step. The function runs just like an ordinary Modal

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -688,6 +688,7 @@ class _Mount(_Object, type_prefix="mo"):
     @renamed_parameter((2024, 12, 18), "label", "name")
     def from_name(
         name: str,
+        *,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
     ) -> "_Mount":

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -94,6 +94,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
     @renamed_parameter((2024, 12, 18), "label", "name")
     def from_name(
         name: str,
+        *,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,

--- a/modal/parallel_map.py
+++ b/modal/parallel_map.py
@@ -503,6 +503,7 @@ async def _for_each_async(self, *input_iterators, kwargs={}, ignore_exceptions: 
 async def _starmap_async(
     self,
     input_iterator: typing.Union[typing.Iterable[typing.Sequence[Any]], typing.AsyncIterable[typing.Sequence[Any]]],
+    *,
     kwargs={},
     order_outputs: bool = True,
     return_exceptions: bool = False,
@@ -529,6 +530,7 @@ async def _starmap_async(
 def _starmap_sync(
     self,
     input_iterator: typing.Iterable[typing.Sequence[Any]],
+    *,
     kwargs={},
     order_outputs: bool = True,
     return_exceptions: bool = False,

--- a/modal/proxy.py
+++ b/modal/proxy.py
@@ -18,6 +18,7 @@ class _Proxy(_Object, type_prefix="pr"):
     @staticmethod
     def from_name(
         name: str,
+        *,
         environment_name: Optional[str] = None,
     ) -> "_Proxy":
         """Reference a Proxy by its name.

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -148,6 +148,7 @@ class _Queue(_Object, type_prefix="qu"):
     @renamed_parameter((2024, 12, 18), "label", "name")
     def from_name(
         name: str,
+        *,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,

--- a/modal/schedule.py
+++ b/modal/schedule.py
@@ -74,6 +74,7 @@ class Period(Schedule):
 
     def __init__(
         self,
+        *,
         years: int = 0,
         months: int = 0,
         weeks: int = 0,

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -165,6 +165,7 @@ class _Secret(_Object, type_prefix="st"):
     @renamed_parameter((2024, 12, 18), "label", "name")
     def from_name(
         name: str,
+        *,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
         required_keys: list[

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -138,6 +138,7 @@ class _Volume(_Object, type_prefix="vo"):
     @renamed_parameter((2024, 12, 18), "label", "name")
     def from_name(
         name: str,
+        *,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -1163,7 +1163,7 @@ def test_keyboard_interrupt_during_app_run_detach(servicer, server_url_env, toke
 @pytest.fixture
 def app(client):
     app = App()
-    with app.run(client):
+    with app.run(client=client):
         yield app
 
 

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -170,7 +170,7 @@ def test_python_version(builder_version, servicer, client, python_version):
     expected_dockerhub_python = _dockerhub_python_version(builder_version, expected_python)
     expected_dockerhub_debian = _base_image_config("debian", builder_version)
     assert expected_dockerhub_python.startswith(expected_python)
-    with app.run(client):
+    with app.run(client=client):
         commands = get_all_dockerfile_commands(image.object_id, servicer)
         assert re.match(rf"FROM python:{expected_dockerhub_python}-slim-{expected_dockerhub_debian}", commands)
 
@@ -178,7 +178,7 @@ def test_python_version(builder_version, servicer, client, python_version):
     app.function(image=image)(dummy)
     if python_version is None and builder_version == "2023.12":
         expected_python = "3.9"
-    with app.run(client):
+    with app.run(client=client):
         commands = get_all_dockerfile_commands(image.object_id, servicer)
         assert re.search(rf"install.* python={expected_python}", commands)
 

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -18,7 +18,7 @@ skip_non_subprocess = skip_windows("Needs subprocess support")
 @pytest.fixture
 def app(client):
     app = App()
-    with app.run(client):
+    with app.run(client=client):
         yield app
 
 
@@ -269,7 +269,7 @@ def test_app_sandbox(client, servicer):
         Sandbox.create("bash", "-c", "echo bye >&2 && echo hi", image=image, secrets=[secret])
 
     app = App()
-    with app.run(client):
+    with app.run(client=client):
         # Create sandbox
         with pytest.raises(DeprecationError, match="`App.spawn_sandbox` is deprecated"):
             app.spawn_sandbox("bash", "-c", "echo bye >&2 && echo hi", image=image, secrets=[secret])
@@ -350,7 +350,7 @@ def test_sandbox_list_app(client, servicer):
 
     app = App()
 
-    with app.run(client):
+    with app.run(client=client):
         # Create sandbox
         sb = Sandbox.create("bash", "-c", "sleep 10000", image=image, secrets=[secret], app=app)
         assert len(list(Sandbox.list(app_id=app.app_id, client=client))) == 1

--- a/test/scheduler_placement_test.py
+++ b/test/scheduler_placement_test.py
@@ -57,7 +57,7 @@ def test_fn_scheduler_placement(servicer, client):
 
 @skip_windows("needs subprocess")
 def test_sandbox_scheduler_placement(client, servicer):
-    with app.run(client):
+    with app.run(client=client):
         Sandbox.create(
             "bash",
             "-c",


### PR DESCRIPTION
## Describe your changes

~⚠️ Needs some integration test updates before this can be merged.~ https://github.com/modal-labs/modal/pull/21900

- Closes CLI-310

## Changelog

- Marked some parameters in a small number of Modal functions as requiring keyword arguments (namely, `modal.App.run`, `modal.Cls.with_options`, all `.from_name` methods, and a few others). Code that calls these functions with positional arguments will now raise an error. This is expected to be minimally disruptive as the affected parameters are mostly "extra" options or positioned after parameters that have previously been deprecated.
