### PR TITLE
Support relative paths in ignore files

### DIFF
--- a/modal/file_pattern_matcher.py
+++ b/modal/file_pattern_matcher.py
@@ -94,6 +94,8 @@ class FilePatternMatcher(_AbstractPatternMatcher):
                     raise ValueError('Illegal exclusion pattern: "!"')
                 new_pattern.exclusion = True
                 pattern = pattern[1:]
+            if os.path.isabs(pattern):
+                raise ValueError("Ignore patterns cannot be absolute paths")
             # In Python, we can proceed without explicit syntax checking
             new_pattern.cleaned_pattern = pattern
             new_pattern.dirs = pattern.split(os.path.sep)

--- a/modal/image.py
+++ b/modal/image.py
@@ -279,8 +279,9 @@ def _create_context_mount(
     include_fn = FilePatternMatcher(*copy_patterns)
 
     def ignore_with_include(source: Path) -> bool:
-        relative_source = source.relative_to(context_dir)
-        if not include_fn(relative_source) or ignore_fn(relative_source):
+        if source.is_absolute():
+            source = source.relative_to(context_dir)
+        if not include_fn(source) or ignore_fn(source):
             return True
 
         return False

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -339,8 +339,8 @@ class _Mount(_Object, type_prefix="mo"):
         return _Mount._new()._extend(
             _MountDir(
                 local_dir=local_path,
-                ignore=ignore,
                 remote_path=remote_path,
+                ignore=ignore,
                 recursive=True,
             ),
         )

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -153,9 +153,9 @@ class _MountDir(_MountEntry):
 
         for local_filename in gen:
             local_path = Path(local_filename)
-            if not self.ignore(local_path):
-                local_relpath = local_path.expanduser().absolute().relative_to(local_dir)
-                mount_path = self.remote_path / local_relpath.as_posix()
+            rel_local_path = local_path.relative_to(local_dir)
+            if not self.ignore(rel_local_path):
+                mount_path = self.remote_path / rel_local_path.as_posix()
                 yield local_path.resolve(), mount_path
 
     def watch_entry(self):

--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -7,7 +7,7 @@ from ._version_generated import build_number
 major_number = 0
 
 # Bump this manually on breaking changes, then reset the number in _version_generated.py
-minor_number = 74
+minor_number = 75
 
 # Right now, automatically increment the patch number in CI
 __version__ = f"{major_number}.{minor_number}.{max(build_number, 0)}"

--- a/modal_version/_version_generated.py
+++ b/modal_version/_version_generated.py
@@ -1,4 +1,4 @@
 # Copyright Modal Labs 2025
 
 # Note: Reset this value to -1 whenever you make a minor `0.X` release of the client.
-build_number = 63  # git: b53b755
+build_number = -1

--- a/test/file_pattern_matcher_test.py
+++ b/test/file_pattern_matcher_test.py
@@ -272,6 +272,11 @@ def test_match():
             assert FilePatternMatcher(pattern)._matches(text) is expected
 
 
+def test_absolute_path_error():
+    with pytest.raises(ValueError, match="cannot be absolute paths"):
+        FilePatternMatcher("/home/data/")
+
+
 def __helper_get_file_paths(tmp_path: Path) -> list[Path]:
     file_paths = []
     for root, _, files in os.walk(tmp_path):

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -948,7 +948,7 @@ def test_dockerfile_context_dir(builder_version, servicer, client):
         (Path(context_dir) / "file.py").write_text("world")
 
         image = Image.debian_slim().dockerfile_commands(["COPY . /"], context_dir=context_dir)
-        app = App()
+        app = App(include_source=False)
         app.function(image=image)(dummy)
         with app.run(client=client):
             layers = get_image_layers(image.object_id, servicer)
@@ -1812,8 +1812,8 @@ def test_image_local_dir_ignore_patterns(servicer, client, tmp_path_with_content
 
 @pytest.mark.parametrize("copy", [True, False])
 def test_image_add_local_dir_ignore_callable(servicer, client, tmp_path_with_content, copy):
-    def ignore(x):
-        return x != tmp_path_with_content / "data.txt"
+    def ignore(x: Path):
+        return str(x) != "data.txt"
 
     expected = {"/place/data.txt"}
     app = App()


### PR DESCRIPTION
## Describe your changes

Currently we pass absolute paths into `ignore` functions, so relative patterns like `*.txt` don't properly ignore `.txt` files in the top-level of the context dir.

Not 100% sure about the consequences here. I think we want to do this for all string-based ignore patterns (i.e. `ignore=["*.txt"]` _and _ when a `dockerignore` file is in use). But this changes behavior also for when users pass an ignore _function_. OTOH I think we basically want some consistency between pattern-based and function-based ignoring. So maybe we just live with the change?

Needs a thoughtful changelog at least...

- Fixes CLI-373
- Fixes #3048

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Fixes the behavior of `ignore=` in `modal.Image` methods. Exclusion patterns are now correctly interpreted as relative to the directory being added (e.g., `*.json` will now ignore all json files in the top-level of the directory). The fix also affects the interpretation of patterns in `.dockerignore` files used by `modal.Image.from_dockerfile`. **This involves two breaking changes:**
    - When providing a custom function to `ignore=`, file paths passed into the function will now be _relative_, rather than absolute.
    - When providing ignore patterns (either as strings or in a `dockerignore` file), an error will be raised if any of the pattens are absolute paths.