### PR TITLE
[SVC-421] Implement primitive for spawning many calls

### DIFF
--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -432,6 +432,19 @@ def warn_if_generator_is_not_consumed(function_name: Optional[str] = None):
     return decorator
 
 
+def run_coroutine_in_temporary_event_loop(coro: typing.Coroutine[None, None, T], nested_async_message: str) -> T:
+    """Compatibility function to run an async coroutine in a temporary event loop.
+
+    This is needed for compatibility with the async implementation of Function.spawn_map. The future plan is
+    to have separate implementations so there is no issue with nested event loops.
+    """
+    try:
+        with Runner() as runner:
+            return runner.run(coro)
+    except NestedEventLoops:
+        raise InvalidError(nested_async_message)
+
+
 class AsyncOrSyncIterable:
     """Compatibility class for non-synchronicity wrapped async iterables to get
     both async and sync interfaces in the same way that synchronicity does (but on the main thread)

--- a/modal/parallel_map.py
+++ b/modal/parallel_map.py
@@ -508,11 +508,24 @@ async def _spawn_map_async(self, *input_iterators, kwargs={}) -> None:
 
 
 def _spawn_map_sync(self, *input_iterators, kwargs={}) -> None:
-    """mdmd:hidden
-    For compatibility, we use a temporary event loop to run the async implementation.
+    """Spawn parallel execution over a set of inputs, exiting as soon as the inputs are created (without waiting
+    for the map to complete).
 
-    In the future, the intention is to have separate implementations so there is no
-    issue with nested event loops.
+    Takes one iterator argument per argument in the function being mapped over.
+
+    Example:
+    ```python
+    @app.function()
+    def my_func(a):
+        return a ** 2
+
+
+    @app.local_entrypoint()
+    def main():
+        my_func.spawn_map([1, 2, 3, 4])
+    ```
+
+    Programmatic retrieval of results will be supported in a future update.
     """
 
     return run_coroutine_in_temporary_event_loop(
@@ -522,7 +535,7 @@ def _spawn_map_sync(self, *input_iterators, kwargs={}) -> None:
 
 
 def _for_each_sync(self, *input_iterators, kwargs={}, ignore_exceptions: bool = False):
-    """Execute function for all inputs, ignoring outputs.
+    """Execute function for all inputs, ignoring outputs. Waits for completion of the inputs.
 
     Convenient alias for `.map()` in cases where the function just needs to be called.
     as the caller doesn't have to consume the generator to process the inputs.

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1673,6 +1673,7 @@ message FunctionMapRequest {
   FunctionCallType function_call_type = 4;
   repeated FunctionPutInputsItem pipelined_inputs = 5;
   FunctionCallInvocationType function_call_invocation_type = 6;
+  bool from_spawn_map = 7;
 }
 
 message FunctionMapResponse {


### PR DESCRIPTION
## Describe your changes

- _Provide Linear issue reference (e.g. MOD-1234) if available._

Added a method for spawning many calls in parallel using `async_map` under the hood.

Approximate performance at time of testing: ~1000 calls/s. To increase this performance, we can later add a `async_foreach` method which foregoes `async_merge`.

</details>

## Changelog

- Added a method for spawning many calls in parallel.

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
