### PR TITLE
Improve UX for container heartbeat warnings

### DIFF
--- a/modal/_runtime/container_io_manager.py
+++ b/modal/_runtime/container_io_manager.py
@@ -352,29 +352,42 @@ class _ContainerIOManager:
         await self._client.stub.ContainerHello(Empty())
 
     async def _run_heartbeat_loop(self):
+        t_last_success = time.monotonic()
         while 1:
             t0 = time.monotonic()
             try:
                 if await self._heartbeat_handle_cancellations():
-                    # got a cancellation event, fine to start another heartbeat immediately
-                    # since the cancellation queue should be empty on the worker server
-                    # however, we wait at least 1s to prevent short-circuiting the heartbeat loop
-                    # in case there is ever a bug. This means it will take at least 1s between
-                    # two subsequent cancellations on the same task at the moment
+                    # Got a cancellation event, so it is fine to start another heartbeat immediately
+                    # since the cancellation queue should be empty on the worker server.
+                    # However, we wait at least 1s to prevent short-circuiting the heartbeat loop
+                    # in case there is ever a bug.
+                    # This means it will take at least 1s between two subsequent cancellations on the
+                    # same task at the moment.
                     await asyncio.sleep(1.0)
                     continue
+                t_last_success = time.monotonic()
             except ClientClosed:
                 logger.info("Stopping heartbeat loop due to client shutdown")
                 break
             except Exception as exc:
                 # don't stop heartbeat loop if there are transient exceptions!
-                time_elapsed = time.monotonic() - t0
+                attempt_dur = time.monotonic() - t0
+                time_since_heartbeat_success = time.monotonic() - t_last_success
                 error = exc
-                logger.warning(f"Heartbeat attempt failed ({time_elapsed=}, {error=})")
+                logger.warning(
+                    f"Heartbeat attempt failed ({attempt_dur=:.2f}, {time_since_heartbeat_success=:.2f}, {error=})"
+                )
+                if time_since_heartbeat_success > HEARTBEAT_INTERVAL * 50:
+                    trouble_mins = time_since_heartbeat_success / 60
+                    logger.warning(
+                        f"Heartbeat attempts have been failing for over {trouble_mins:.2f} minutes. "
+                        "Container will eventually be marked unhealthy. "
+                        "See https://modal.com/docs/guide/troubleshooting#heartbeat-timeout. "
+                    )
 
             heartbeat_duration = time.monotonic() - t0
-            time_until_next_hearbeat = max(0.0, HEARTBEAT_INTERVAL - heartbeat_duration)
-            await asyncio.sleep(time_until_next_hearbeat)
+            time_until_next_heartbeat = max(0.0, HEARTBEAT_INTERVAL - heartbeat_duration)
+            await asyncio.sleep(time_until_next_heartbeat)
 
     async def _heartbeat_handle_cancellations(self) -> bool:
         # Return True if a cancellation event was received, in that case

--- a/modal/_runtime/container_io_manager.py
+++ b/modal/_runtime/container_io_manager.py
@@ -356,7 +356,9 @@ class _ContainerIOManager:
         while 1:
             t0 = time.monotonic()
             try:
-                if await self._heartbeat_handle_cancellations():
+                got_cancellation = await self._heartbeat_handle_cancellations()
+                t_last_success = time.monotonic()
+                if got_cancellation:
                     # Got a cancellation event, so it is fine to start another heartbeat immediately
                     # since the cancellation queue should be empty on the worker server.
                     # However, we wait at least 1s to prevent short-circuiting the heartbeat loop
@@ -365,7 +367,6 @@ class _ContainerIOManager:
                     # same task at the moment.
                     await asyncio.sleep(1.0)
                     continue
-                t_last_success = time.monotonic()
             except ClientClosed:
                 logger.info("Stopping heartbeat loop due to client shutdown")
                 break

--- a/modal/_runtime/container_io_manager.py
+++ b/modal/_runtime/container_io_manager.py
@@ -376,12 +376,14 @@ class _ContainerIOManager:
                 time_since_heartbeat_success = time.monotonic() - t_last_success
                 error = exc
                 logger.warning(
-                    f"Heartbeat attempt failed ({attempt_dur=:.2f}, {time_since_heartbeat_success=:.2f}, {error=})"
+                    f"Modal Client → Modal Worker Heartbeat attempt failed "
+                    f"({attempt_dur=:.2f}, {time_since_heartbeat_success=:.2f}, {error=})"
                 )
                 if time_since_heartbeat_success > HEARTBEAT_INTERVAL * 50:
                     trouble_mins = time_since_heartbeat_success / 60
                     logger.warning(
-                        f"Heartbeat attempts have been failing for over {trouble_mins:.2f} minutes. "
+                        "Modal Client → Modal Worker heartbeat attempts have been failing for "
+                        f"over {trouble_mins:.2f} minutes. "
                         "Container will eventually be marked unhealthy. "
                         "See https://modal.com/docs/guide/troubleshooting#heartbeat-timeout. "
                     )


### PR DESCRIPTION
## Describe your changes

Status quo is this, which I think is not as readable and understandable as it could be

```
[Thread-1 (thread_inner)] 2025-04-22T20:56:05+0000 Heartbeat attempt failed (time_elapsed=156.61637557400036, error=ConnectionError('Deadline exceeded'))
```

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
    -   logging change only
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
    -   logging change only

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>
