### PR TITLE
Revert "Fix lazy hydration of Cls (#3050)"

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -970,7 +970,20 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         parent = self
 
         async def _load(param_bound_func: _Function, resolver: Resolver, existing_object_id: Optional[str]):
-            await parent.hydrate()
+            try:
+                identity = f"{parent.info.function_name} class service function"
+            except Exception:
+                # Can't always look up the function name that way, so fall back to generic message
+                identity = "class service function for a parametrized class"
+            if not parent.is_hydrated:
+                if parent.app._running_app is None:
+                    reason = ", because the App it is defined on is not running"
+                else:
+                    reason = ""
+                raise ExecutionError(
+                    f"The {identity} has not been hydrated with the metadata it needs to run on Modal{reason}."
+                )
+
             assert parent._client and parent._client.stub
 
             if (


### PR DESCRIPTION
This reverts commit 89e7c15df3e2b28d541d324e4340a8288c9142e4.

Caused some regression tests around snapshot rehydration to fail.
