### PR TITLE
Mark `allow_cross_region_volumes` as deprecated

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -430,7 +430,6 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         # TODO: maybe break this out into a separate decorator for notebooks.
         mounts: Collection[_Mount] = (),
         network_file_systems: dict[Union[str, PurePosixPath], _NetworkFileSystem] = {},
-        allow_cross_region_volumes: bool = False,
         volumes: dict[Union[str, PurePosixPath], Union[_Volume, _CloudBucketMount]] = {},
         webhook_config: Optional[api_pb2.WebhookConfig] = None,
         cpu: Optional[Union[float, tuple[float, float]]] = None,
@@ -788,9 +787,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                     autoscaler_settings=autoscaler_settings,
                     method_definitions=method_definitions,
                     method_definitions_set=True,
-                    shared_volume_mounts=network_file_system_mount_protos(
-                        validated_network_file_systems, allow_cross_region_volumes
-                    ),
+                    shared_volume_mounts=network_file_system_mount_protos(validated_network_file_systems),
                     volume_mounts=volume_mounts,
                     proxy_id=(proxy.object_id if proxy else None),
                     retry_policy=retry_policy,

--- a/modal/app.py
+++ b/modal/app.py
@@ -645,7 +645,6 @@ class _App:
         volumes: dict[
             Union[str, PurePosixPath], Union[_Volume, _CloudBucketMount]
         ] = {},  # Mount points for Modal Volumes & CloudBucketMounts
-        allow_cross_region_volumes: bool = False,  # Whether using network file systems from other regions is allowed.
         # Specify, in fractional CPU cores, how many CPU cores to request.
         # Or, pass (request, limit) to additionally specify a hard limit in fractional CPU cores.
         # CPU throttling will prevent a container from exceeding its specified limit.
@@ -689,6 +688,7 @@ class _App:
         container_idle_timeout: Optional[int] = None,  # Replaced with `scaledown_window`
         allow_concurrent_inputs: Optional[int] = None,  # Replaced with the `@modal.concurrent` decorator
         _experimental_buffer_containers: Optional[int] = None,  # Now stable API with `buffer_containers`
+        allow_cross_region_volumes: bool = True,  # Always True on the Modal backend now
     ) -> _FunctionDecoratorType:
         """Decorator to register a new Modal [Function](/docs/reference/modal.Function) with this App."""
         if isinstance(_warn_parentheses_missing, _Image):
@@ -821,7 +821,6 @@ class _App:
                 gpu=gpu,
                 mounts=[*self._mounts, *mounts],
                 network_file_systems=network_file_systems,
-                allow_cross_region_volumes=allow_cross_region_volumes,
                 volumes={**self._volumes, **volumes},
                 cpu=cpu,
                 memory=memory,
@@ -876,7 +875,6 @@ class _App:
         volumes: dict[
             Union[str, PurePosixPath], Union[_Volume, _CloudBucketMount]
         ] = {},  # Mount points for Modal Volumes & CloudBucketMounts
-        allow_cross_region_volumes: bool = False,  # Whether using network file systems from other regions is allowed.
         # Specify, in fractional CPU cores, how many CPU cores to request.
         # Or, pass (request, limit) to additionally specify a hard limit in fractional CPU cores.
         # CPU throttling will prevent a container from exceeding its specified limit.
@@ -914,6 +912,7 @@ class _App:
         container_idle_timeout: Optional[int] = None,  # Replaced with `scaledown_window`
         allow_concurrent_inputs: Optional[int] = None,  # Replaced with the `@modal.concurrent` decorator
         _experimental_buffer_containers: Optional[int] = None,  # Now stable API with `buffer_containers`
+        allow_cross_region_volumes: bool = True,  # Always True on the Modal backend now
     ) -> Callable[[Union[CLS_T, _PartialFunction]], CLS_T]:
         """
         Decorator to register a new Modal [Cls](/docs/reference/modal.Cls) with this App.

--- a/modal/app.py
+++ b/modal/app.py
@@ -688,7 +688,7 @@ class _App:
         container_idle_timeout: Optional[int] = None,  # Replaced with `scaledown_window`
         allow_concurrent_inputs: Optional[int] = None,  # Replaced with the `@modal.concurrent` decorator
         _experimental_buffer_containers: Optional[int] = None,  # Now stable API with `buffer_containers`
-        allow_cross_region_volumes: bool = True,  # Always True on the Modal backend now
+        allow_cross_region_volumes: Optional[bool] = None,  # Always True on the Modal backend now
     ) -> _FunctionDecoratorType:
         """Decorator to register a new Modal [Function](/docs/reference/modal.Function) with this App."""
         if isinstance(_warn_parentheses_missing, _Image):
@@ -707,6 +707,8 @@ class _App:
                 " Please use the `@modal.concurrent` decorator instead."
                 "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
             )
+        if allow_cross_region_volumes is not None:
+            deprecation_warning((2025, 4, 23), "The `allow_cross_region_volumes` parameter no longer has any effect.")
 
         secrets = [*self._secrets, *secrets]
 
@@ -912,7 +914,7 @@ class _App:
         container_idle_timeout: Optional[int] = None,  # Replaced with `scaledown_window`
         allow_concurrent_inputs: Optional[int] = None,  # Replaced with the `@modal.concurrent` decorator
         _experimental_buffer_containers: Optional[int] = None,  # Now stable API with `buffer_containers`
-        allow_cross_region_volumes: bool = True,  # Always True on the Modal backend now
+        allow_cross_region_volumes: Optional[bool] = None,  # Always True on the Modal backend now
     ) -> Callable[[Union[CLS_T, _PartialFunction]], CLS_T]:
         """
         Decorator to register a new Modal [Cls](/docs/reference/modal.Cls) with this App.
@@ -933,6 +935,8 @@ class _App:
                 " Please use the `@modal.concurrent` decorator instead."
                 "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
             )
+        if allow_cross_region_volumes is not None:
+            deprecation_warning((2025, 4, 23), "The `allow_cross_region_volumes` parameter no longer has any effect.")
 
         def wrapper(wrapped_cls: Union[CLS_T, _PartialFunction]) -> CLS_T:
             # Check if the decorated object is a class
@@ -989,7 +993,6 @@ class _App:
                 gpu=gpu,
                 mounts=[*self._mounts, *mounts],
                 network_file_systems=network_file_systems,
-                allow_cross_region_volumes=allow_cross_region_volumes,
                 volumes={**self._volumes, **volumes},
                 cpu=cpu,
                 memory=memory,

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -37,7 +37,6 @@ NETWORK_FILE_SYSTEM_PUT_FILE_CLIENT_TIMEOUT = (
 
 def network_file_system_mount_protos(
     validated_network_file_systems: list[tuple[str, "_NetworkFileSystem"]],
-    allow_cross_region_volumes: bool,
 ) -> list[api_pb2.SharedVolumeMount]:
     network_file_system_mounts = []
     # Relies on dicts being ordered (true as of Python 3.6).
@@ -46,7 +45,6 @@ def network_file_system_mount_protos(
             api_pb2.SharedVolumeMount(
                 mount_path=path,
                 shared_volume_id=volume.object_id,
-                allow_cross_region=allow_cross_region_volumes,
             )
         )
     return network_file_system_mounts

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -187,7 +187,7 @@ class _Sandbox(_Object, type_prefix="sb"):
                     cpu=cpu, memory=memory, gpu=gpu, ephemeral_disk=ephemeral_disk
                 ),
                 cloud_provider_str=cloud if cloud else None,  # Supersedes cloud_provider
-                nfs_mounts=network_file_system_mount_protos(validated_network_file_systems, False),
+                nfs_mounts=network_file_system_mount_protos(validated_network_file_systems),
                 runtime=config.get("function_runtime"),
                 runtime_debug=config.get("function_runtime_debug"),
                 cloud_bucket_mounts=cloud_bucket_mounts_to_proto(cloud_bucket_mounts),

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -753,39 +753,6 @@ def f(x):
     return x**2
 
 
-def test_allow_cross_region_volumes(client, servicer):
-    app = App()
-    vol1 = NetworkFileSystem.from_name("xyz-1", create_if_missing=True)
-    vol2 = NetworkFileSystem.from_name("xyz-2", create_if_missing=True)
-    # Should pass flag for all the function's NetworkFileSystemMounts
-    app.function(network_file_systems={"/sv-1": vol1, "/sv-2": vol2}, allow_cross_region_volumes=True)(dummy)
-
-    with app.run(client=client):
-        assert len(servicer.app_functions) == 1
-        for func in servicer.app_functions.values():
-            assert len(func.shared_volume_mounts) == 2
-            for svm in func.shared_volume_mounts:
-                assert svm.allow_cross_region
-
-
-def test_allow_cross_region_volumes_webhook(client, servicer):
-    # TODO(erikbern): this test seems a bit redundant
-    app = App()
-    vol1 = NetworkFileSystem.from_name("xyz-1", create_if_missing=True)
-    vol2 = NetworkFileSystem.from_name("xyz-2", create_if_missing=True)
-    # Should pass flag for all the function's NetworkFileSystemMounts
-    app.function(network_file_systems={"/sv-1": vol1, "/sv-2": vol2}, allow_cross_region_volumes=True)(
-        fastapi_endpoint()(dummy)
-    )
-
-    with app.run(client=client):
-        assert len(servicer.app_functions) == 1
-        for func in servicer.app_functions.values():
-            assert len(func.shared_volume_mounts) == 2
-            for svm in func.shared_volume_mounts:
-                assert svm.allow_cross_region
-
-
 def test_serialize_deserialize_function_handle(servicer, client):
     from modal._serialization import deserialize, serialize
 


### PR DESCRIPTION
## Describe your changes

We stopped respecting this on the backend a while back.

Closes CLI-358

## Changelog

- The `allow_cross_region_volumes` parameter of the `@app.function` and `@app.cls` decorators now issues a deprecation warning; the parameter is always treated as `True` on the Modal backend.