### PR TITLE
Accept JWTs from the server

### DIFF
--- a/modal/_utils/grpc_utils.py
+++ b/modal/_utils/grpc_utils.py
@@ -118,7 +118,16 @@ def create_channel(
 
         logger.debug(f"Sending request to {event.method_name}")
 
+    async def recv_trailing_metadata(trailing_metadata: grpclib.events.RecvTrailingMetadata) -> None:
+        # If we receive an auth token from the server, include it in all future requests.
+        # TODO(nathan): This isn't perfect because the metadata isn't propagated when the
+        # process is forked and a new channel is created. This is OK for now since this
+        # token is only used by the experimental input plane
+        if token := trailing_metadata.metadata.get("x-modal-auth-token"):
+            metadata["x-modal-auth-token"] = str(token)
+
     grpclib.events.listen(channel, grpclib.events.SendRequest, send_request)
+    grpclib.events.listen(channel, grpclib.events.RecvTrailingMetadata, recv_trailing_metadata)
 
     return channel
 


### PR DESCRIPTION
This PR allows the client to accept JWTs from the server, including them in future RPCs. This is useful for the distributed input plane.
