### PR TITLE
Reapply #3050 (lazy Cls hydration)

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -970,7 +970,9 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         parent = self
 
         async def _load(param_bound_func: _Function, resolver: Resolver, existing_object_id: Optional[str]):
-            await parent.hydrate()
+            if not parent.is_hydrated:
+                # While the base Object.hydrate() method appears to be idempotent, it's not always safe
+                await parent.hydrate()
             assert parent._client and parent._client.stub
 
             if (

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -973,6 +973,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
             if not parent.is_hydrated:
                 # While the base Object.hydrate() method appears to be idempotent, it's not always safe
                 await parent.hydrate()
+
             assert parent._client and parent._client.stub
 
             if (

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -970,20 +970,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         parent = self
 
         async def _load(param_bound_func: _Function, resolver: Resolver, existing_object_id: Optional[str]):
-            try:
-                identity = f"{parent.info.function_name} class service function"
-            except Exception:
-                # Can't always look up the function name that way, so fall back to generic message
-                identity = "class service function for a parametrized class"
-            if not parent.is_hydrated:
-                if parent.app._running_app is None:
-                    reason = ", because the App it is defined on is not running"
-                else:
-                    reason = ""
-                raise ExecutionError(
-                    f"The {identity} has not been hydrated with the metadata it needs to run on Modal{reason}."
-                )
-
+            await parent.hydrate()
             assert parent._client and parent._client.stub
 
             if (

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -669,6 +669,34 @@ def test_cls_keep_warm(client, servicer):
         assert instance_service_function.warm_pool_size == 5
 
 
+def test_cls_lookup_keep_warm(client, servicer):
+    app = App(name := "my-cls-app")
+
+    @app.cls(serialized=True)
+    class ClsWithMethod:
+        arg: str = modal.parameter(default="")
+
+        @method()
+        def bar(self): ...
+
+    C_pre_deploy = ClsWithMethod()
+    with pytest.raises(ExecutionError, match="has not been hydrated"):
+        C_pre_deploy.keep_warm(1)  # type: ignore
+
+    deploy_app(app, name, client=client)
+
+    C = Cls.from_name(name, "ClsWithMethod")
+    obj = C()
+    obj.keep_warm(3)
+
+    service_function_id = obj._cached_service_function().object_id
+    assert servicer.app_functions[service_function_id].warm_pool_size == 3
+
+    with servicer.intercept() as ctx:
+        obj.keep_warm(4)
+        assert len(ctx.get_requests("FunctionBindParams")) == 0  # We did not re-bind
+
+
 with pytest.warns(DeprecationError, match="@modal.build"):
 
     class ClsWithHandlers:


### PR DESCRIPTION
Now passes the internal regression test. Also cleans up some apparently uneccessary code that was part of why the test broke.

Fixes #2979