### PR TITLE
volumes: Fix upload for version 2

### DIFF
--- a/modal/volume.py
+++ b/modal/volume.py
@@ -933,7 +933,7 @@ async def _put_missing_blocks(
                 progress_report_cb=functools.partial(progress_cb, progress_task_id)
             )
 
-            async with ClientSessionRegistry.get_session().put(
+            async with ClientSessionRegistry.get_session().post(
                 missing_block.put_url,
                 data=payload,
             ) as response:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2083,7 +2083,7 @@ def blob_server():
     app.add_routes([aiohttp.web.post("/complete_multipart", complete_multipart)])
 
     # API used for volume version 2 blocks:
-    app.add_routes([aiohttp.web.put("/block", put_block)])
+    app.add_routes([aiohttp.web.post("/block", put_block)])
 
     started = threading.Event()
     stop_server = threading.Event()


### PR DESCRIPTION
Use POST instead of PUT for uploading blocks.

Doing a minimal fix for now - leaving the door open for changing the server-side to use PUT instead.
