### PR TITLE
Make App.include return self

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -1070,7 +1070,7 @@ class _App:
         )
         deprecation_error((2024, 7, 5), message)
 
-    def include(self, /, other_app: "_App"):
+    def include(self, /, other_app: "_App") -> typing_extensions.Self:
         """Include another App's objects in this one.
 
         Useful for splitting up Modal Apps across different self-contained files.
@@ -1106,6 +1106,7 @@ class _App:
                 )
 
             self._add_class(tag, cls)
+        return self
 
     async def _logs(self, client: Optional[_Client] = None) -> AsyncGenerator[str, None]:
         """Stream logs from the app.

--- a/test/supports/multifile_project/main.py
+++ b/test/supports/multifile_project/main.py
@@ -4,9 +4,7 @@ from modal import enter, fastapi_endpoint, method
 
 from . import a, b
 
-app = modal.App()
-app.include(a.app)
-app.include(b.app)
+app = modal.App().include(a.app).include(b.app)
 
 
 @app.function()


### PR DESCRIPTION
Closes #1859

## Changelog

- The `App.include` method now returns `self` so it's possible to build up an App through chained calls:

    ```python
    app = modal.App("main-app").include(sub_app_1).include(sub_app_2)
    ```