### PR TITLE
Increase ASGI proxy client timeout

### DIFF
--- a/modal/_runtime/asgi.py
+++ b/modal/_runtime/asgi.py
@@ -468,7 +468,8 @@ async def _proxy_lifespan_request(base_url, scope, receive, send) -> None:
                 session = aiohttp.ClientSession(
                     base_url,
                     cookie_jar=aiohttp.DummyCookieJar(),
-                    timeout=aiohttp.ClientTimeout(total=3600),
+                    # "Disable" this by setting to max possible input timeout. Timeouts are handled on input level instead.
+                    timeout=aiohttp.ClientTimeout(total=3600 * 24),
                     auto_decompress=False,
                     read_bufsize=1024 * 1024,  # 1 MiB
                     connector=aiohttp.TCPConnector(

--- a/modal/_runtime/asgi.py
+++ b/modal/_runtime/asgi.py
@@ -468,7 +468,7 @@ async def _proxy_lifespan_request(base_url, scope, receive, send) -> None:
                 session = aiohttp.ClientSession(
                     base_url,
                     cookie_jar=aiohttp.DummyCookieJar(),
-                    # "Disable" this by setting to max possible input timeout. Timeouts are handled on input level instead.
+                    # "Disable" by setting to max possible input timeout. Timeouts are handled on input level instead.
                     timeout=aiohttp.ClientTimeout(total=3600 * 24),
                     auto_decompress=False,
                     read_bufsize=1024 * 1024,  # 1 MiB

--- a/modal/_runtime/asgi.py
+++ b/modal/_runtime/asgi.py
@@ -468,8 +468,8 @@ async def _proxy_lifespan_request(base_url, scope, receive, send) -> None:
                 session = aiohttp.ClientSession(
                     base_url,
                     cookie_jar=aiohttp.DummyCookieJar(),
-                    # "Disable" by setting to max possible input timeout. Timeouts are handled on input level instead.
-                    timeout=aiohttp.ClientTimeout(total=3600 * 24),
+                    # "Disable" timeout, since timeouts are handled on input level instead.
+                    timeout=aiohttp.ClientTimeout(total=None),
                     auto_decompress=False,
                     read_bufsize=1024 * 1024,  # 1 MiB
                     connector=aiohttp.TCPConnector(


### PR DESCRIPTION
Resolves #2752. Thank you @mwaskom for raising this.

Edit: I actually realized that I can just pass `None` to disable it fully. https://docs.aiohttp.org/en/stable/client_quickstart.html#timeouts