### PR TITLE
Require setting serialized=True when overriding function name

### DIFF
--- a/modal/_utils/function_utils.py
+++ b/modal/_utils/function_utils.py
@@ -140,7 +140,7 @@ class FunctionInfo:
     def __init__(
         self,
         f: Optional[Callable[..., Any]],
-        serialized=False,
+        serialized: bool = False,
         name_override: Optional[str] = None,
         user_cls: Optional[type] = None,
     ):
@@ -148,6 +148,10 @@ class FunctionInfo:
         self.user_cls = user_cls
 
         if name_override is not None:
+            if not serialized:
+                # We may relax this constraint in the future, but currently we don't track the distinction between
+                # the Function's name inside modal and the name of the object that we need to import in a container.
+                raise InvalidError("Setting a custom `name=` also requires setting `serialized=True`")
             self.function_name = name_override
         elif f is None and user_cls:
             # "service function" for running all methods of a class

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -234,8 +234,8 @@ def test_set_image_on_app_as_attribute():
 def test_redeploy_delete_objects(servicer, client):
     # Deploy an app with objects d1 and d2
     app = App()
-    app.function(name="d1")(dummy)
-    app.function(name="d2")(dummy)
+    app.function(name="d1", serialized=True)(dummy)
+    app.function(name="d2", serialized=True)(dummy)
     app.deploy(name="xyz", client=client)
 
     # Check objects
@@ -243,8 +243,8 @@ def test_redeploy_delete_objects(servicer, client):
 
     # Deploy an app with objects d2 and d3
     app = App()
-    app.function(name="d2")(dummy)
-    app.function(name="d3")(dummy)
+    app.function(name="d2", serialized=True)(dummy)
+    app.function(name="d3", serialized=True)(dummy)
     app.deploy(name="xyz", client=client)
 
     # Make sure d1 is deleted

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -592,6 +592,13 @@ def test_closure_valued_serialized_function(client, servicer):
     assert functions["ret_bar"]() == "bar"
 
 
+def test_custom_name_requires_serialized():
+    app = App()
+
+    with pytest.raises(InvalidError, match="`serialized=True`"):
+        app.function(name="foo")(dummy)
+
+
 def test_new_hydrated_internal(client, servicer):
     obj: FunctionCall[typing.Any] = FunctionCall._new_hydrated("fc-123", client, None)
     assert obj.object_id == "fc-123"


### PR DESCRIPTION
When you set `name=` in `@app.function`, we try to import that name from the module where the function is defined during container startup. This will fail (or worse, pull in the some other object).

This isn't a problem for the standard pattern using `name=` along with `serialized=True` (i.e., defining functions "on the fly"), because then we don't try to import the name from the app module.

In theory we could track these pieces of information separately, but that would be a larger change, and it's not obvious that overriding the function name while not also setting `serialized=True` has much feature value. In the meantime, we'll help users avoid an annoying runtime error by blocking the incompatible parameterization at build time.

- Fixes CLI-383

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- When setting a custom `name=` in `@app.function()`, an error is now raised unless `serialized=True` is also set.