### PR TITLE
Support modal run against Cls.with_options

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -395,6 +395,7 @@ class _Cls(_Object, type_prefix="cs"):
 
     def _initialize_from_other(self, other: "_Cls"):
         super()._initialize_from_other(other)
+        self._app = other._app
         self._user_cls = other._user_cls
         self._class_service_function = other._class_service_function
         self._method_partials = other._method_partials
@@ -665,7 +666,6 @@ More information on class parameterization can be found here: https://modal.com/
             validated_volumes=validate_volumes(volumes),
             target_concurrent_inputs=allow_concurrent_inputs,
         )
-
         return cls
 
     @staticmethod

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -1254,3 +1254,8 @@ def test_cli_run_variadic_args(servicer, set_env_client, test_dir, func, disable
 def test_server_warnings(servicer, set_env_client, supports_dir):
     res = _run(["run", f"{supports_dir / 'app_run_tests' / 'uses_experimental_options.py'}::gets_warning"])
     assert "You have been warned!" in res.stdout
+
+
+def test_run_with_options(servicer, set_env_client, supports_dir):
+    app_file = supports_dir / "app_run_tests" / "uses_with_options.py"
+    _run(["run", f"{app_file.as_posix()}::C_with_gpu.f"])

--- a/test/supports/app_run_tests/uses_with_options.py
+++ b/test/supports/app_run_tests/uses_with_options.py
@@ -1,0 +1,15 @@
+# Copyright Modal Labs 2025
+
+import modal
+
+app = modal.App("uses-with-options")
+
+
+@app.cls()
+class C:
+    @modal.method()
+    def f(self):
+        print("Done!")
+
+
+C_with_gpu = C.with_options(gpu="H100")  # type: ignore  # Type masking is a problem for with_options


### PR DESCRIPTION
## Describe your changes

- Fixes CLI-384

## Changelog

- Fixed a bug that prevented doing `modal run` against an entrypoint defined by `Cls.with_options`.