### PR TITLE
Make dummy function in base image app serialized

### DIFF
--- a/modal_global_objects/images/base_images.py
+++ b/modal_global_objects/images/base_images.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
     for v in python_versions:
         image = constructor(python_version=v)
         images_map[v] = image
-        app.function(image=image, name=f"{v}")(dummy)
+        app.function(image=image, name=f"{v}", serialized=True)(dummy)
 
     with modal.enable_output():
         with app.run():


### PR DESCRIPTION
#3066 broke the "base image deployment" script, which creates a function on the fly with `name=`. Because this function is never actually executed, it doesn't run into the error that #3066 is intended to help avoid. But the consequence is that our CI is currently being marked as failing.

This reminds me that we don't need these workflows running on every client release _anyway_. But we need a reliable way to trigger them when they should.