### PR TITLE
Allow users to restrict Function's modal resource access

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -452,6 +452,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         is_auto_snapshot: bool = False,
         enable_memory_snapshot: bool = False,
         block_network: bool = False,
+        restrict_modal_access: bool = False,
         i6pn_enabled: bool = False,
         # Experimental: Clustered functions
         cluster_size: Optional[int] = None,
@@ -812,6 +813,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                     checkpointing_enabled=enable_memory_snapshot,
                     object_dependencies=object_dependencies,
                     block_network=block_network,
+                    untrusted=restrict_modal_access,
                     max_inputs=max_inputs or 0,
                     cloud_bucket_mounts=cloud_bucket_mounts_to_proto(cloud_bucket_mounts),
                     scheduler_placement=scheduler_placement.proto if scheduler_placement else None,
@@ -868,6 +870,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                         snapshot_debug=function_definition.snapshot_debug,
                         runtime_perf_record=function_definition.runtime_perf_record,
                         function_schema=function_schema,
+                        untrusted=function_definition.untrusted,
                     )
 
                     ranked_functions = []

--- a/modal/app.py
+++ b/modal/app.py
@@ -607,6 +607,7 @@ class _App:
         region: Optional[Union[str, Sequence[str]]] = None,  # Region or regions to run the function on.
         enable_memory_snapshot: bool = False,  # Enable memory checkpointing for faster cold starts.
         block_network: bool = False,  # Whether to block network access
+        restrict_modal_access: bool = False,  # Whether to allow this function access to other Modal resources
         # Maximum number of inputs a container should handle before shutting down.
         # With `max_inputs = 1`, containers will be single-use.
         max_inputs: Optional[int] = None,
@@ -779,6 +780,7 @@ class _App:
                 webhook_config=webhook_config,
                 enable_memory_snapshot=enable_memory_snapshot,
                 block_network=block_network,
+                restrict_modal_access=restrict_modal_access,
                 max_inputs=max_inputs,
                 scheduler_placement=scheduler_placement,
                 i6pn_enabled=i6pn_enabled,
@@ -834,6 +836,7 @@ class _App:
         region: Optional[Union[str, Sequence[str]]] = None,  # Region or regions to run the function on.
         enable_memory_snapshot: bool = False,  # Enable memory checkpointing for faster cold starts.
         block_network: bool = False,  # Whether to block network access
+        restrict_modal_access: bool = False,  # Whether to allow this class access to other Modal resources
         # Limits the number of inputs a container handles before shutting down.
         # Use `max_inputs = 1` for single-use containers.
         max_inputs: Optional[int] = None,
@@ -947,6 +950,7 @@ class _App:
                 cloud=cloud,
                 enable_memory_snapshot=enable_memory_snapshot,
                 block_network=block_network,
+                restrict_modal_access=restrict_modal_access,
                 max_inputs=max_inputs,
                 scheduler_placement=scheduler_placement,
                 include_source=include_source if include_source is not None else self._include_source_default,

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -1403,3 +1403,30 @@ def test_experimental_options(client, servicer, decorator):
             ...
 
     assert ctx.get_requests("FunctionCreate")[0].function.experimental_options == {"foo": "2", "bar": "True"}
+
+
+def test_restrict_modal_access(client, servicer):
+    app = App()
+
+    @app.function(serialized=True, restrict_modal_access=True)
+    def f():
+        pass
+
+    with servicer.intercept() as ctx:
+        with app.run(client=client):
+            pass
+
+    assert ctx.get_requests("FunctionCreate")[0].function.untrusted == True
+
+    # Test that by default, untrusted is False
+    app2 = App()
+
+    @app2.function(serialized=True)
+    def g():
+        pass
+
+    with servicer.intercept() as ctx:
+        with app2.run(client=client):
+            pass
+
+    assert ctx.get_requests("FunctionCreate")[0].function.untrusted == False


### PR DESCRIPTION
## Describe your changes

This commit adds a new `restrict_modal_access` field which prevents functions from performing any operations other than getting inputs and responding to those inputs.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- A new parameter, `restrict_modal_access`, can be provided on a Function to prevent it from interacting with other resources in your Modal Workspace like Queues, Volumes, or other Functions. This can be useful for running user-provided or LLM-written code in a safe way.