### PR TITLE
Declare support for protobuf 6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "click>=8.1.0",
     "fastapi",
     "grpclib==0.4.7",
-    "protobuf>=3.19,<6.0,!=4.24.0",
+    "protobuf>=3.19,<7.0,!=4.24.0",
     "rich>=12.0.0",
     "synchronicity~=0.9.10",
     "toml",


### PR DESCRIPTION
Protobuf 6.30.0 was released on Mar 4; they've done two micro releases since then and have an rc for the next minor release.

## Changelog

- The `modal` client library can now be installed with Protobuf 6.