### PR TITLE
Drop fastapi as a library dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
     "aiohttp",
     "certifi",
     "click>=8.1.0",
-    "fastapi",
     "grpclib==0.4.7",
     "protobuf>=3.19,<6.0,!=4.24.0",
     "rich>=12.0.0",

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,6 +1,7 @@
 # Development requirements
 
 black==23.11.0
+fastapi~=0.115
 flaky~=3.7
 grpcio-tools==1.48.0;python_version<'3.11'  # TODO: remove when we drop client support for Protobuf 3.19
 grpcio-tools==1.59.2;python_version>='3.11' and python_version<'3.13'


### PR DESCRIPTION
I don't think theres a clear reason for us to continue declaring `fastapi` as a library dependency. It's not needed for using Modal itself locally. `fastapi` is also no longer installed by default in our container images.

Some users will have `fastapi` imported in the global scope of their Apps, and they'd need `fastapi` installed locally for this to work. But I'm not sure it's beneficial to treat `fastapi` from any other common App dependencies here. Users _can_ include it in their project dependencies if they want that to work.

I moved it to the `requirements.dev.txt` to minimize potential disruption to our development workflows although I'm not sure if we need it there.

Part of CLI-216

## Changelog

- The `modal` clien no longer includes `fastapi` as a library dependency.