### PR TITLE
Warn when creating a new token that will be ignored

### DIFF
--- a/modal/token_flow.py
+++ b/modal/token_flow.py
@@ -158,6 +158,12 @@ async def _set_token(
         f"[magenta]{profile}[/magenta].[/green]"
     )
 
+    if os.environ.get("MODAL_TOKEN_ID"):
+        console.print(
+            "Warning: The MODAL_TOKEN_ID environment variable is set; this will override your new token.",
+            style="yellow",
+        )
+
 
 def _open_url(url: str) -> bool:
     """Opens url in web browser, making sure we use a modern one (not Lynx etc)"""

--- a/modal/token_flow.py
+++ b/modal/token_flow.py
@@ -158,12 +158,17 @@ async def _set_token(
         f"[magenta]{profile}[/magenta].[/green]"
     )
 
-    for var, item in [("MODAL_TOKEN_ID", "token"), ("MODAL_TOKEN_SECRET", "secret")]:
-        if os.environ.get(var):
-            console.print(
-                f"Warning: The {var} environment variable is set; this will override your new {item}.",
-                style="yellow",
-            )
+    # Warn the user if their token will be ignored
+    env_vars = [var if os.environ.get(var) else None for var in ["MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET"]]
+    env_vars_used = [var for var in env_vars if var is not None]
+    env_vars_str = " / ".join(env_vars_used)
+    if env_vars_used:
+        s = "s" if len(env_vars_used) > 1 else ""
+        verb = "are" if len(env_vars_used) > 1 else "is"
+        console.print(
+            f"Warning: The {env_vars_str} environment variable{s} {verb} set; this will override your new credentials.",
+            style="yellow",
+        )
 
 
 def _open_url(url: str) -> bool:

--- a/modal/token_flow.py
+++ b/modal/token_flow.py
@@ -158,11 +158,12 @@ async def _set_token(
         f"[magenta]{profile}[/magenta].[/green]"
     )
 
-    if os.environ.get("MODAL_TOKEN_ID"):
-        console.print(
-            "Warning: The MODAL_TOKEN_ID environment variable is set; this will override your new token.",
-            style="yellow",
-        )
+    for var, item in [("MODAL_TOKEN_ID", "token"), ("MODAL_TOKEN_SECRET", "secret")]:
+        if os.environ.get(var):
+            console.print(
+                f"Warning: The {var} environment variable is set; this will override your new {item}.",
+                style="yellow",
+            )
 
 
 def _open_url(url: str) -> bool:

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -116,6 +116,14 @@ def test_app_token_new(servicer, set_env_client, server_url_env, modal_config):
         assert "_test" in toml.load(config_file_path)
 
 
+def test_token_env_var_warning(servicer, set_env_client, server_url_env, modal_config, monkeypatch):
+    monkeypatch.setenv("MODAL_TOKEN_ID", "ak-123")
+    servicer.required_creds = {"abc": "xyz"}
+    with modal_config():
+        res = _run(["token", "new"])
+        assert "MODAL_TOKEN_ID environment variable" in res.stdout
+
+
 def test_app_setup(servicer, set_env_client, server_url_env, modal_config):
     servicer.required_creds = {"abc": "xyz"}
     with modal_config() as config_file_path:

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -117,11 +117,16 @@ def test_app_token_new(servicer, set_env_client, server_url_env, modal_config):
 
 
 def test_token_env_var_warning(servicer, set_env_client, server_url_env, modal_config, monkeypatch):
-    monkeypatch.setenv("MODAL_TOKEN_ID", "ak-123")
     servicer.required_creds = {"abc": "xyz"}
+    monkeypatch.setenv("MODAL_TOKEN_ID", "ak-123")
     with modal_config():
         res = _run(["token", "new"])
-        assert "MODAL_TOKEN_ID environment variable" in res.stdout
+        assert "MODAL_TOKEN_ID environment variable is" in res.stdout
+
+    monkeypatch.setenv("MODAL_TOKEN_SECRET", "as-xyz")
+    with modal_config():
+        res = _run(["token", "new"])
+        assert "MODAL_TOKEN_ID / MODAL_TOKEN_SECRET environment variables are" in res.stdout
 
 
 def test_app_setup(servicer, set_env_client, server_url_env, modal_config):


### PR DESCRIPTION
If the `MODAL_TOKEN_ID` environment variable is set, it will take precedence over any tokens set in the `.modal.toml` config. We can catch this when the user does `modal token new` or `modal token set`:

<img width="746" alt="image" src="https://github.com/user-attachments/assets/70d13baa-3d52-4782-93a6-efa8abaafc13" />

This should help avoid some confusion, as the clear user intent here is "use this new token", but that won't happen until they unset the environment variable.