### PR TITLE
Add guidance about not using the CLI implementation as API

### DIFF
--- a/modal/cli/__init__.py
+++ b/modal/cli/__init__.py
@@ -1,1 +1,16 @@
 # Copyright Modal Labs 2022
+"""
+The `modal.cli` package contains the Python implementations for Modal's CLI.
+
+The functions defined in this package are intended to be called via the CLI,
+not from Python code. No backwards compatibility guarantees are made with
+respect to Python calling patterns (e.g., the order of parameters corresponding
+to CLI options may change in the Python signature without warning).
+
+Any utility or helper functions defined in this package are intended for use by
+the CLI commands and are not for external consumption; they should be
+considered private even if they do not use a private naming convention.
+
+Over time, we aspire to support feature parity between the CLI and the public
+Python API, although this remains a work in progress.
+"""


### PR DESCRIPTION
Trying to improve our clarity about what is "public API" in the Modal client. In general, user code should not call directly into any functions defined in the `modal.cli` subpackage.

Closes CLI-43