### PR TITLE
Add logger name prefix to client logs

### DIFF
--- a/modal/_utils/logger.py
+++ b/modal/_utils/logger.py
@@ -32,7 +32,7 @@ def configure_logger(logger: logging.Logger, log_level: str, log_format: str):
     else:
         if not (log_format_pattern := config.get("log_pattern")):
             # TODO: use `%(name)s` instead of `modal-client` as soon as we unify the loggers we use
-            log_format_pattern = "modal-client [%(threadName)s] %(asctime)s %(message)s"
+            log_format_pattern = "[modal-client] %(asctime)s %(message)s"
 
         ch.setFormatter(logging.Formatter(log_format_pattern, datefmt=datefmt))
 

--- a/modal/_utils/logger.py
+++ b/modal/_utils/logger.py
@@ -45,4 +45,3 @@ log_format = os.environ.get("MODAL_LOG_FORMAT", "STRING")
 
 logger = logging.getLogger("modal-utils")
 configure_logger(logger, log_level, log_format)
-logger.warning("hello")

--- a/modal/_utils/logger.py
+++ b/modal/_utils/logger.py
@@ -31,7 +31,8 @@ def configure_logger(logger: logging.Logger, log_level: str, log_format: str):
         ch.setFormatter(json_formatter)
     else:
         if not (log_format_pattern := config.get("log_pattern")):
-            log_format_pattern = "%(name)s [%(threadName)s] %(asctime)s %(message)s"
+            # TODO: use `%(name)s` instead of `modal-client` as soon as we unify the loggers we use
+            log_format_pattern = "modal-client [%(threadName)s] %(asctime)s %(message)s"
 
         ch.setFormatter(logging.Formatter(log_format_pattern, datefmt=datefmt))
 

--- a/modal/_utils/logger.py
+++ b/modal/_utils/logger.py
@@ -4,32 +4,36 @@ import os
 
 
 def configure_logger(logger: logging.Logger, log_level: str, log_format: str):
+    from modal.config import config
+
     ch = logging.StreamHandler()
     log_level_numeric = logging.getLevelName(log_level.upper())
     logger.setLevel(log_level_numeric)
     ch.setLevel(log_level_numeric)
-
+    datefmt = "%Y-%m-%dT%H:%M:%S%z"
     if log_format.upper() == "JSON":
         # This is primarily for modal internal use.
         # pythonjsonlogger is already installed in the environment.
         from pythonjsonlogger import jsonlogger
 
-        json_formatter = jsonlogger.JsonFormatter(
-            fmt=(
+        if not (log_format_pattern := config.get("log_pattern")):
+            log_format_pattern = (
                 "%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] "
                 "[dd.service=%(dd.service)s dd.env=%(dd.env)s dd.version=%(dd.version)s dd.trace_id=%(dd.trace_id)s "
                 "dd.span_id=%(dd.span_id)s] "
                 "- %(message)s"
-            ),
-            datefmt="%Y-%m-%dT%H:%M:%S%z",
-        )
+            )
 
+        json_formatter = jsonlogger.JsonFormatter(
+            fmt=log_format_pattern,
+            datefmt=datefmt,
+        )
         ch.setFormatter(json_formatter)
     else:
-        ch.setFormatter(
-            logging.Formatter("%(name)s [%(threadName)s] %(asctime)s %(message)s", datefmt="%Y-%m-%dT%H:%M:%S%z")
-        )
-        pass
+        if not (log_format_pattern := config.get("log_pattern")):
+            log_format_pattern = "%(name)s [%(threadName)s] %(asctime)s %(message)s"
+
+        ch.setFormatter(logging.Formatter(log_format_pattern, datefmt=datefmt))
 
     logger.addHandler(ch)
 
@@ -40,3 +44,4 @@ log_format = os.environ.get("MODAL_LOG_FORMAT", "STRING")
 
 logger = logging.getLogger("modal-utils")
 configure_logger(logger, log_level, log_format)
+logger.warning("hello")

--- a/modal/_utils/logger.py
+++ b/modal/_utils/logger.py
@@ -26,11 +26,15 @@ def configure_logger(logger: logging.Logger, log_level: str, log_format: str):
 
         ch.setFormatter(json_formatter)
     else:
-        ch.setFormatter(logging.Formatter("[%(threadName)s] %(asctime)s %(message)s", datefmt="%Y-%m-%dT%H:%M:%S%z"))
+        ch.setFormatter(
+            logging.Formatter("%(name)s [%(threadName)s] %(asctime)s %(message)s", datefmt="%Y-%m-%dT%H:%M:%S%z")
+        )
+        pass
 
     logger.addHandler(ch)
 
 
+# TODO: remove this distinct logger in favor of the one in modal.config?
 log_level = os.environ.get("MODAL_LOGLEVEL", "WARNING")
 log_format = os.environ.get("MODAL_LOG_FORMAT", "STRING")
 

--- a/modal/config.py
+++ b/modal/config.py
@@ -216,6 +216,7 @@ class _Setting(typing.NamedTuple):
 _SETTINGS = {
     "loglevel": _Setting("WARNING", lambda s: s.upper()),
     "log_format": _Setting("STRING", lambda s: s.upper()),
+    "log_pattern": _Setting(),  # optional override of the formatting pattern
     "server_url": _Setting("https://api.modal.com"),
     "token_id": _Setting(),
     "token_secret": _Setting(),

--- a/modal/config.py
+++ b/modal/config.py
@@ -70,6 +70,11 @@ Other possible configuration options are:
 * `traceback` (in the .toml file) / `MODAL_TRACEBACK` (as an env var).
   Defaults to False. Enables printing full tracebacks on unexpected CLI
   errors, which can be useful for debugging client issues.
+* `log_pattern` (in the .toml file) / MODAL_LOG_PATTERN` (as an env var).
+  Defaults to "[modal-client] %(asctime)s %(message)s"
+  The log formatting pattern that will be used by the modal client itself.
+  See https://docs.python.org/3/library/logging.html#logrecord-attributes for available
+  log attributes.
 
 Meta-configuration
 ------------------

--- a/test/logging_test.py
+++ b/test/logging_test.py
@@ -1,3 +1,4 @@
+# Copyright Modal Labs 2025
 import importlib
 import json
 import pytest

--- a/test/logging_test.py
+++ b/test/logging_test.py
@@ -33,7 +33,7 @@ loglevel = "INFO"
     logger = clean_logger(conf)
     logger.info("dummy")
     log_output = capsys.readouterr().err
-    assert re.match(r"^modal-client \[MainThread\] [^ ]+ dummy$", log_output)
+    assert re.match(r"^\[modal-client] [^ ]+ dummy$", log_output)
 
 
 def test_log_format_json(clean_logger, capsys):

--- a/test/logging_test.py
+++ b/test/logging_test.py
@@ -1,0 +1,58 @@
+import importlib
+import json
+import pytest
+import re
+
+import modal.config
+
+
+@pytest.fixture
+def clean_logger(modal_config):
+    # this makes sure a new logger is set up for every test using this,
+    # using a specific the modal.toml config
+    # Since the logging module is based on a bunch of side effects, this
+    # has to do some hacky module reloading and resetting of log handlers
+
+    def f(conf):
+        with modal_config(conf):
+            modal.config.logger.handlers.clear()
+            importlib.reload(modal.config)  # necessary since loggers are configured in global scope
+        return modal.config.logger
+
+    yield f
+    modal.config.logger.handlers.clear()
+    importlib.reload(modal.config)  # reset to normal log config
+
+
+def test_log_level_configuration(clean_logger, capsys):
+    conf = """[main]
+active = true
+loglevel = "INFO"
+"""
+    logger = clean_logger(conf)
+    logger.info("dummy")
+    log_output = capsys.readouterr().err
+    assert re.match(r"^modal-client \[MainThread\] [^ ]+ dummy$", log_output)
+
+
+def test_log_format_json(clean_logger, capsys):
+    conf = """[main]
+active = true
+log_format = "JSON"
+"""
+    logger = clean_logger(conf)
+    logger.warning("dummy")
+    json_line = capsys.readouterr().err
+    log_struct = json.loads(json_line)
+    assert log_struct["message"] == "dummy"
+    assert log_struct["levelname"] == "WARNING"
+
+
+def test_custom_log_pattern(clean_logger, capsys):
+    conf = """[main]
+active = true
+log_pattern = "custom %(message)s"
+"""
+    logger = clean_logger(conf)
+    logger.warning("dummy")
+    assert capsys.readouterr().err == "custom dummy\n"


### PR DESCRIPTION
---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

* Changes the log format of the modal client's default logger. Instead of `[%(threadName)s]`, the client now logs `[modal-client]` as the log line prefix.
* Adds a configuration option (MODAL_LOG_PATTERN) to the modal config for setting the log formatting pattern, in case users want to customize the format. To get the old format, use `MODAL_LOG_PATTERN='[%(threadName)s] %(asctime)s %(message)s'` (or add this to your `.modal.toml` in the `log_pattern` field).
