### PR TITLE
Add type hint for all Secret.from*

### DIFF
--- a/modal/secret.py
+++ b/modal/secret.py
@@ -34,7 +34,7 @@ class _Secret(_Object, type_prefix="st"):
         env_dict: dict[
             str, Union[str, None]
         ] = {},  # dict of entries to be inserted as environment variables in functions using the secret
-    ):
+    ) -> "_Secret":
         """Create a secret from a str-str dictionary. Values can also be `None`, which is ignored.
 
         Usage:
@@ -81,7 +81,7 @@ class _Secret(_Object, type_prefix="st"):
     @staticmethod
     def from_local_environ(
         env_keys: list[str],  # list of local env vars to be included for remote execution
-    ):
+    ) -> "_Secret":
         """Create secrets from local environment variables automatically."""
 
         if is_local():
@@ -96,7 +96,7 @@ class _Secret(_Object, type_prefix="st"):
         return _Secret.from_dict({})
 
     @staticmethod
-    def from_dotenv(path=None, *, filename=".env"):
+    def from_dotenv(path=None, *, filename=".env") -> "_Secret":
         """Create secrets from a .env file automatically.
 
         If no argument is provided, it will use the current working directory as the starting

--- a/test/supports/type_assertions.py
+++ b/test/supports/type_assertions.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2024
 import typing
-
 from importlib.util import find_spec
+
 from typing_extensions import assert_type
 
 import modal

--- a/test/supports/type_assertions.py
+++ b/test/supports/type_assertions.py
@@ -1,8 +1,7 @@
 # Copyright Modal Labs 2024
 import typing
-from pathlib import Path
-from tempfile import NamedTemporaryFile
 
+from importlib.util import find_spec
 from typing_extensions import assert_type
 
 import modal
@@ -110,15 +109,6 @@ assert_type(secret, modal.Secret)
 secret = modal.Secret.from_local_environ(["PATH"])
 assert_type(secret, modal.Secret)
 
-try:
-    from dotenv import set_key
-except ImportError:
-    pass
-else:
-    with NamedTemporaryFile() as f:
-        f.flush()
-        p = Path(f.name)
-        set_key(p, "FOO", "bar")
-
-        secret = modal.Secret.from_dotenv(path=p.parent, filename=p.name)
-        assert_type(secret, modal.Secret)
+if find_spec("dotenv"):
+    secret = modal.Secret.from_dotenv(filename="non-existing-dotenv")
+    assert_type(secret, modal.Secret)

--- a/test/supports/type_assertions.py
+++ b/test/supports/type_assertions.py
@@ -1,5 +1,7 @@
 # Copyright Modal Labs 2024
 import typing
+from pathlib import Path
+from tempfile import NamedTemporaryFile
 
 from typing_extensions import assert_type
 
@@ -100,3 +102,23 @@ file_io2 = sandbox.open("foo", "rb")
 assert_type(file_io2.read(), bytes)
 assert_type(file_io2.readline(), bytes)
 assert_type(file_io2.readlines(), typing.Sequence[bytes])
+
+# check secrets
+secret = modal.Secret.from_dict({})
+assert_type(secret, modal.Secret)
+
+secret = modal.Secret.from_local_environ(["PATH"])
+assert_type(secret, modal.Secret)
+
+try:
+    from dotenv import set_key
+except ImportError:
+    pass
+else:
+    with NamedTemporaryFile() as f:
+        f.flush()
+        p = Path(f.name)
+        set_key(p, "FOO", "bar")
+
+        secret = modal.Secret.from_dotenv(path=p.parent, filename=p.name)
+        assert_type(secret, modal.Secret)

--- a/test/supports/type_assertions.py
+++ b/test/supports/type_assertions.py
@@ -103,6 +103,9 @@ assert_type(file_io2.readline(), bytes)
 assert_type(file_io2.readlines(), typing.Sequence[bytes])
 
 # check secrets
+secret = modal.Secret.from_name("foo")
+assert_type(secret, modal.Secret)
+
 secret = modal.Secret.from_dict({})
 assert_type(secret, modal.Secret)
 

--- a/test/supports/type_assertions.py
+++ b/test/supports/type_assertions.py
@@ -109,7 +109,7 @@ assert_type(secret, modal.Secret)
 secret = modal.Secret.from_dict({})
 assert_type(secret, modal.Secret)
 
-secret = modal.Secret.from_local_environ(["PATH"])
+secret = modal.Secret.from_local_environ(["FOO"])
 assert_type(secret, modal.Secret)
 
 if find_spec("dotenv"):


### PR DESCRIPTION
## Describe your changes

Add missing return typing hints for all `Secret.from_*` methods.

## Changelog

Add missing return typing hints for all Secret.from methods.