### PR TITLE
volume: Limit hash/put concurrency by a semaphore

### DIFF
--- a/modal/_utils/blob_utils.py
+++ b/modal/_utils/blob_utils.py
@@ -399,6 +399,7 @@ class FileUploadSpec2:
     async def from_path(
         filename: Path,
         mount_filename: PurePosixPath,
+        hash_semaphore: asyncio.Semaphore,
         mode: Optional[int] = None,
     ) -> "FileUploadSpec2":
         # Python appears to give files 0o666 bits on Windows (equal for user, group, and global),
@@ -413,6 +414,7 @@ class FileUploadSpec2:
             filename,
             mount_filename,
             mode,
+            hash_semaphore,
         )
 
 
@@ -420,7 +422,8 @@ class FileUploadSpec2:
     async def from_fileobj(
         source_fp: Union[BinaryIO, BytesIO],
         mount_filename: PurePosixPath,
-        mode: int
+        hash_semaphore: asyncio.Semaphore,
+        mode: int,
     ) -> "FileUploadSpec2":
         try:
             fileno = source_fp.fileno()
@@ -442,6 +445,7 @@ class FileUploadSpec2:
             str(source),
             mount_filename,
             mode,
+            hash_semaphore,
         )
 
 
@@ -451,13 +455,14 @@ class FileUploadSpec2:
         source_description: Union[str, Path],
         mount_filename: PurePosixPath,
         mode: int,
+        hash_semaphore: asyncio.Semaphore,
     ) -> "FileUploadSpec2":
         # Current position is ignored - we always upload from position 0
         with source() as source_fp:
             source_fp.seek(0, os.SEEK_END)
             size = source_fp.tell()
 
-        blocks_sha256 = await hash_blocks_sha256(source, size)
+        blocks_sha256 = await hash_blocks_sha256(source, size, hash_semaphore)
 
         return FileUploadSpec2(
             source=source,
@@ -472,13 +477,14 @@ class FileUploadSpec2:
 async def hash_blocks_sha256(
     source: _FileUploadSource2,
     size: int,
+    hash_semaphore: asyncio.Semaphore,
 ) -> list[bytes]:
     def ceildiv(a: int, b: int) -> int:
         return -(a // -b)
 
     num_blocks = ceildiv(size, BLOCK_SIZE)
 
-    def hash_block_sha256(block_idx: int) -> bytes:
+    def blocking_hash_block_sha256(block_idx: int) -> bytes:
         sha256_hash = hashlib.sha256()
         block_start = block_idx * BLOCK_SIZE
 
@@ -497,7 +503,11 @@ async def hash_blocks_sha256(
 
         return sha256_hash.digest()
 
-    tasks = (asyncio.to_thread(functools.partial(hash_block_sha256, idx)) for idx in range(num_blocks))
+    async def hash_block_sha256(block_idx: int) -> bytes:
+        async with hash_semaphore:
+            return await asyncio.to_thread(functools.partial(blocking_hash_block_sha256, block_idx))
+
+    tasks = (hash_block_sha256(idx) for idx in range(num_blocks))
     return await asyncio.gather(*tasks)
 
 

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -3,6 +3,7 @@ import asyncio
 import concurrent.futures
 import enum
 import functools
+import multiprocessing
 import os
 import platform
 import re
@@ -755,19 +756,27 @@ class _VolumeUploadContextManager(_AbstractVolumeUploadContextManager):
 
 VolumeUploadContextManager = synchronize_api(_VolumeUploadContextManager)
 
-_FileUploader2 = Callable[[], Awaitable[FileUploadSpec2]]
+_FileUploader2 = Callable[[asyncio.Semaphore], Awaitable[FileUploadSpec2]]
 
 class _VolumeUploadContextManager2(_AbstractVolumeUploadContextManager):
     """Context manager for batch-uploading files to a Volume version 2."""
 
     _volume_id: str
     _client: _Client
-    _force: bool
     _progress_cb: Callable[..., Any]
+    _force: bool
+    _hash_concurrency: int
+    _put_concurrency: int
     _uploader_generators: list[Generator[_FileUploader2]]
 
     def __init__(
-        self, volume_id: str, client: _Client, progress_cb: Optional[Callable[..., Any]] = None, force: bool = False
+        self,
+        volume_id: str,
+        client: _Client,
+        progress_cb: Optional[Callable[..., Any]] = None,
+        force: bool = False,
+        hash_concurrency: int = multiprocessing.cpu_count(),
+        put_concurrency: int = multiprocessing.cpu_count(),
     ):
         """mdmd:hidden"""
         self._volume_id = volume_id
@@ -775,6 +784,8 @@ class _VolumeUploadContextManager2(_AbstractVolumeUploadContextManager):
         self._uploader_generators = []
         self._progress_cb = progress_cb or (lambda *_, **__: None)
         self._force = force
+        self._hash_concurrency = hash_concurrency
+        self._put_concurrency = put_concurrency
 
     async def __aenter__(self):
         return self
@@ -787,7 +798,9 @@ class _VolumeUploadContextManager2(_AbstractVolumeUploadContextManager):
                     yield from gen
 
             async def gen_file_upload_specs() -> list[FileUploadSpec2]:
-                uploads = [asyncio.create_task(fut()) for fut in gen_upload_providers()]
+                hash_semaphore = asyncio.Semaphore(self._hash_concurrency)
+
+                uploads = [asyncio.create_task(fut(hash_semaphore)) for fut in gen_upload_providers()]
                 logger.debug(f"Computing checksums for {len(uploads)} files")
 
                 file_specs = []
@@ -817,9 +830,19 @@ class _VolumeUploadContextManager2(_AbstractVolumeUploadContextManager):
 
         def gen():
             if isinstance(local_file, str) or isinstance(local_file, Path):
-                yield lambda: FileUploadSpec2.from_path(local_file, PurePosixPath(remote_path), mode)
+                yield lambda hash_semaphore: FileUploadSpec2.from_path(
+                    local_file,
+                    PurePosixPath(remote_path),
+                    hash_semaphore,
+                    mode
+                )
             else:
-                yield lambda: FileUploadSpec2.from_fileobj(local_file, PurePosixPath(remote_path), mode or 0o644)
+                yield lambda hash_semaphore: FileUploadSpec2.from_fileobj(
+                    local_file,
+                    PurePosixPath(remote_path),
+                    hash_semaphore,
+                    mode or 0o644
+                )
 
         self._uploader_generators.append(gen())
 
@@ -840,7 +863,7 @@ class _VolumeUploadContextManager2(_AbstractVolumeUploadContextManager):
 
         def create_spec(subpath):
             relpath_str = subpath.relative_to(local_path)
-            return lambda: FileUploadSpec2.from_path(subpath, remote_path / relpath_str)
+            return lambda hash_semaphore: FileUploadSpec2.from_path(subpath, remote_path / relpath_str, hash_semaphore)
 
         def gen():
             glob = local_path.rglob("*") if recursive else local_path.glob("*")
@@ -854,6 +877,8 @@ class _VolumeUploadContextManager2(_AbstractVolumeUploadContextManager):
     async def _put_file_specs(self, file_specs: list[FileUploadSpec2]):
         put_responses = {}
         # num_blocks_total = sum(len(file_spec.blocks_sha256) for file_spec in file_specs)
+
+        logger.debug(f"Ensuring {len(file_specs)} files are uploaded...")
 
         # We should only need two iterations: Once to possibly get some missing_blocks; the second time we should have
         # all blocks uploaded
@@ -888,7 +913,13 @@ class _VolumeUploadContextManager2(_AbstractVolumeUploadContextManager):
             if not response.missing_blocks:
                 break
 
-            await _put_missing_blocks(file_specs, response.missing_blocks, put_responses, self._progress_cb)
+            await _put_missing_blocks(
+                file_specs,
+                response.missing_blocks,
+                put_responses,
+                self._put_concurrency,
+                self._progress_cb
+            )
         else:
             raise RuntimeError("Did not succeed at uploading all files despite supplying all missing blocks")
 
@@ -904,8 +935,13 @@ async def _put_missing_blocks(
     # by the nested class (?)
     missing_blocks: list,
     put_responses: dict[bytes, bytes],
+    put_concurrency: int,
     progress_cb: Callable[..., Any]
 ):
+    put_semaphore = asyncio.Semaphore(multiprocessing.cpu_count())
+
+    logger.debug(f"Uploading {len(missing_blocks)} missing blocks...")
+
     async def put_missing_block(
         # TODO(dflemstr): Type is `api_pb2.VolumePutFiles2Response.MissingBlock` but synchronicity gets confused
         # by the nested class (?)
@@ -926,20 +962,21 @@ async def _put_missing_blocks(
         progress_name = f"{file_spec.path} block {missing_block.block_index + 1} / {len(file_spec.blocks_sha256)}"
         progress_task_id = progress_cb(name=progress_name, size=file_spec.size)
 
-        with file_spec.source() as source_fp:
-            payload = BytesIOSegmentPayload(
-                source_fp,
-                block_start,
-                block_length,
-                progress_report_cb=functools.partial(progress_cb, progress_task_id)
-            )
+        async with put_semaphore:
+            with file_spec.source() as source_fp:
+                payload = BytesIOSegmentPayload(
+                    source_fp,
+                    block_start,
+                    block_length,
+                    progress_report_cb=functools.partial(progress_cb, progress_task_id)
+                )
 
-            async with ClientSessionRegistry.get_session().put(
-                missing_block.put_url,
-                data=payload,
-            ) as response:
-                response.raise_for_status()
-                resp_data = await response.content.read()
+                async with ClientSessionRegistry.get_session().put(
+                    missing_block.put_url,
+                    data=payload,
+                ) as response:
+                    response.raise_for_status()
+                    resp_data = await response.content.read()
 
         return block_sha256, resp_data
 


### PR DESCRIPTION
## Describe your changes

- This limits the concurrency of block hashing/uploads for huge files, where it might be too expensive to open all blocks simultaneously. This avoids issues with running out of file descriptors or similar.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
