### PR TITLE
Test & fix propagating starmap iterator exception

### DIFF
--- a/modal/parallel_map.py
+++ b/modal/parallel_map.py
@@ -388,9 +388,7 @@ async def _map_helper(
     order_outputs: bool = True,  # return outputs in order
     return_exceptions: bool = False,  # propagate exceptions (False) or aggregate them in the results list (True)
 ) -> typing.AsyncGenerator[Any, None]:
-    """mdmd:hidden
-
-    Core implementation that supports `_map_async()`, `_starmap_async()` and `_for_each_async()`.
+    """Core implementation that supports `_map_async()`, `_starmap_async()` and `_for_each_async()`.
 
     Runs in an event loop on the main thread. Concurrently feeds new input to the input queue and yields available
     outputs to the caller.
@@ -527,8 +525,7 @@ def _map_sync(
 
 
 async def _spawn_map_async(self, *input_iterators, kwargs={}) -> None:
-    """mdmd:hidden
-    This runs in an event loop on the main thread. It consumes inputs from the input iterators and creates async
+    """This runs in an event loop on the main thread. It consumes inputs from the input iterators and creates async
     function calls for each.
     """
 

--- a/modal/parallel_map.py
+++ b/modal/parallel_map.py
@@ -381,6 +381,96 @@ async def _map_invocation(
     await log_debug_stats_task
 
 
+async def _map_helper(
+    self: "modal.functions.Function",
+    async_input_gen: typing.AsyncGenerator[Any, None],
+    kwargs={},  # any extra keyword arguments for the function
+    order_outputs: bool = True,  # return outputs in order
+    return_exceptions: bool = False,  # propagate exceptions (False) or aggregate them in the results list (True)
+) -> typing.AsyncGenerator[Any, None]:
+    """mdmd:hidden
+
+    Core implementation that supports `_map_async()`, `_starmap_async()` and `_for_each_async()`.
+
+    Runs in an event loop on the main thread. Concurrently feeds new input to the input queue and yields available
+    outputs to the caller.
+
+    Note that since the iterator(s) can block, it's a bit opaque how often the event
+    loop decides to get a new input vs how often it will emit a new output.
+
+    We could make this explicit as an improvement or even let users decide what they
+    prefer: throughput (prioritize queueing inputs) or latency (prioritize yielding results)
+    """
+
+    raw_input_queue: Any = SynchronizedQueue()  # type: ignore
+    raw_input_queue.init()
+
+    async def feed_queue():
+        async with aclosing(async_input_gen) as streamer:
+            async for args in streamer:
+                await raw_input_queue.put.aio((args, kwargs))
+        await raw_input_queue.put.aio(None)  # end-of-input sentinel
+        if False:
+            # make this a never yielding generator so we can async_merge it below
+            # this is important so any exception raised in feed_queue will be propagated
+            yield
+
+    # note that `map()`, `map.aio()`, `starmap()`, `starmap.aio()`, `for_each()`, `for_each.aio()` are not
+    # synchronicity-wrapped, since they accept executable code in the form of iterators that we don't want to run inside
+    # the synchronicity thread. Instead, we delegate to `._map()` with a safer Queue as input.
+    async with aclosing(
+        async_merge(self._map.aio(raw_input_queue, order_outputs, return_exceptions), feed_queue())
+    ) as map_output_stream:
+        async for output in map_output_stream:
+            yield output
+
+
+@warn_if_generator_is_not_consumed(function_name="Function.map.aio")
+async def _map_async(
+    self: "modal.functions.Function",
+    *input_iterators: typing.Union[
+        typing.Iterable[Any], typing.AsyncIterable[Any]
+    ],  # one input iterator per argument in the mapped-over function/generator
+    kwargs={},  # any extra keyword arguments for the function
+    order_outputs: bool = True,  # return outputs in order
+    return_exceptions: bool = False,  # propagate exceptions (False) or aggregate them in the results list (True)
+) -> typing.AsyncGenerator[Any, None]:
+    async_input_gen = async_zip(*[sync_or_async_iter(it) for it in input_iterators])
+    async for output in _map_helper(
+        self, async_input_gen, kwargs=kwargs, order_outputs=order_outputs, return_exceptions=return_exceptions
+    ):
+        yield output
+
+
+@warn_if_generator_is_not_consumed(function_name="Function.starmap.aio")
+async def _starmap_async(
+    self,
+    input_iterator: typing.Union[typing.Iterable[typing.Sequence[Any]], typing.AsyncIterable[typing.Sequence[Any]]],
+    *,
+    kwargs={},
+    order_outputs: bool = True,
+    return_exceptions: bool = False,
+) -> typing.AsyncIterable[Any]:
+    async for output in _map_helper(
+        self,
+        sync_or_async_iter(input_iterator),
+        kwargs=kwargs,
+        order_outputs=order_outputs,
+        return_exceptions=return_exceptions,
+    ):
+        yield output
+
+
+async def _for_each_async(self, *input_iterators, kwargs={}, ignore_exceptions: bool = False) -> None:
+    # TODO(erikbern): it would be better if this is more like a map_spawn that immediately exits
+    # rather than iterating over the result
+    async_input_gen = async_zip(*[sync_or_async_iter(it) for it in input_iterators])
+    async for _ in _map_helper(
+        self, async_input_gen, kwargs=kwargs, order_outputs=False, return_exceptions=ignore_exceptions
+    ):
+        pass
+
+
 @warn_if_generator_is_not_consumed(function_name="Function.map")
 def _map_sync(
     self,
@@ -431,55 +521,9 @@ def _map_sync(
             self, *input_iterators, kwargs=kwargs, order_outputs=order_outputs, return_exceptions=return_exceptions
         ),
         nested_async_message=(
-            "You can't iter(Function.map()) or Function.for_each() from an async function. "
-            "Use async for ... Function.map.aio() or Function.for_each.aio() instead."
+            "You can't iter(Function.map()) from an async function. Use async for ... in Function.map.aio() instead."
         ),
     )
-
-
-@warn_if_generator_is_not_consumed(function_name="Function.map.aio")
-async def _map_async(
-    self: "modal.functions.Function",
-    *input_iterators: typing.Union[
-        typing.Iterable[Any], typing.AsyncIterable[Any]
-    ],  # one input iterator per argument in the mapped-over function/generator
-    kwargs={},  # any extra keyword arguments for the function
-    order_outputs: bool = True,  # return outputs in order
-    return_exceptions: bool = False,  # propagate exceptions (False) or aggregate them in the results list (True)
-) -> typing.AsyncGenerator[Any, None]:
-    """mdmd:hidden
-    This runs in an event loop on the main thread
-
-    It concurrently feeds new input to the input queue and yields available outputs
-    to the caller.
-    Note that since the iterator(s) can block, it's a bit opaque how often the event
-    loop decides to get a new input vs how often it will emit a new output.
-    We could make this explicit as an improvement or even let users decide what they
-    prefer: throughput (prioritize queueing inputs) or latency (prioritize yielding results)
-    """
-    raw_input_queue: Any = SynchronizedQueue()  # type: ignore
-    raw_input_queue.init()
-
-    async def feed_queue():
-        # This runs in a main thread event loop, so it doesn't block the synchronizer loop
-        async with aclosing(async_zip(*[sync_or_async_iter(it) for it in input_iterators])) as streamer:
-            async for args in streamer:
-                await raw_input_queue.put.aio((args, kwargs))
-        await raw_input_queue.put.aio(None)  # end-of-input sentinel
-        if False:
-            # make this a never yielding generator so we can async_merge it below
-            # this is important so any exception raised in feed_queue will be propagated
-            yield
-
-    # note that `map()` and `map.aio()` are not synchronicity-wrapped, since
-    # they accept executable code in the form of
-    # iterators that we don't want to run inside the synchronicity thread.
-    # Instead, we delegate to `._map()` with a safer Queue as input
-    async with aclosing(
-        async_merge(self._map.aio(raw_input_queue, order_outputs, return_exceptions), feed_queue())
-    ) as map_output_stream:
-        async for output in map_output_stream:
-            yield output
 
 
 async def _spawn_map_async(self, *input_iterators, kwargs={}) -> None:
@@ -538,47 +582,16 @@ def _for_each_sync(self, *input_iterators, kwargs={}, ignore_exceptions: bool = 
     Convenient alias for `.map()` in cases where the function just needs to be called.
     as the caller doesn't have to consume the generator to process the inputs.
     """
-    # TODO(erikbern): it would be better if this is more like a map_spawn that immediately exits
-    # rather than iterating over the result
-    for _ in self.map(*input_iterators, kwargs=kwargs, order_outputs=False, return_exceptions=ignore_exceptions):
-        pass
 
-
-async def _for_each_async(self, *input_iterators, kwargs={}, ignore_exceptions: bool = False):
-    async for _ in self.map.aio(  # type: ignore
-        *input_iterators, kwargs=kwargs, order_outputs=False, return_exceptions=ignore_exceptions
-    ):
-        pass
+    return run_coroutine_in_temporary_event_loop(
+        _for_each_async(self, *input_iterators, kwargs=kwargs, ignore_exceptions=ignore_exceptions),
+        nested_async_message=(
+            "You can't run `Function.for_each()` from an async function. Use `await Function.for_each.aio()` instead."
+        ),
+    )
 
 
 @warn_if_generator_is_not_consumed(function_name="Function.starmap")
-async def _starmap_async(
-    self,
-    input_iterator: typing.Union[typing.Iterable[typing.Sequence[Any]], typing.AsyncIterable[typing.Sequence[Any]]],
-    *,
-    kwargs={},
-    order_outputs: bool = True,
-    return_exceptions: bool = False,
-) -> typing.AsyncIterable[Any]:
-    raw_input_queue: Any = SynchronizedQueue()  # type: ignore
-    raw_input_queue.init()
-
-    async def feed_queue():
-        # This runs in a main thread event loop, so it doesn't block the synchronizer loop
-        async with aclosing(sync_or_async_iter(input_iterator)) as streamer:
-            async for args in streamer:
-                await raw_input_queue.put.aio((args, kwargs))
-        await raw_input_queue.put.aio(None)  # end-of-input sentinel
-
-    feed_input_task = asyncio.create_task(feed_queue())
-    try:
-        async for output in self._map.aio(raw_input_queue, order_outputs, return_exceptions):  # type: ignore[reportFunctionMemberAccess]
-            yield output
-    finally:
-        feed_input_task.cancel()  # should only be needed in case of exceptions
-
-
-@warn_if_generator_is_not_consumed(function_name="Function.starmap.aio")
 def _starmap_sync(
     self,
     input_iterator: typing.Iterable[typing.Sequence[Any]],
@@ -608,8 +621,8 @@ def _starmap_sync(
             self, input_iterator, kwargs=kwargs, order_outputs=order_outputs, return_exceptions=return_exceptions
         ),
         nested_async_message=(
-            "You can't run Function.map() or Function.for_each() from an async function. "
-            "Use Function.map.aio()/Function.for_each.aio() instead."
+            "You can't `iter(Function.starmap())` from an async function. "
+            "Use `async for ... in Function.starmap.aio()` instead."
         ),
     )
 

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -99,10 +99,8 @@ def test_nested_map(client):
         assert final_results == [1, 16]
 
 
-# TODO(gongy): Fix this test for starmap.
-# @pytest.mark.parametrize("maptype", ["map", "starmap", "spawn_map"])
-@pytest.mark.parametrize("maptype", ["map", "spawn_map"])
-def test_map_with_exception_in_input_iterator(client, maptype):
+@pytest.mark.parametrize("map_type", ["map", "starmap", "spawn_map"])
+def test_exception_in_input_iterator(client, map_type):
     class CustomException(Exception):
         pass
 
@@ -115,11 +113,11 @@ def test_map_with_exception_in_input_iterator(client, maptype):
 
     with app.run(client=client):
         with pytest.raises(CustomException):
-            if maptype == "map":
+            if map_type == "map":
                 list(dummy_modal.map(input_gen()))
-            elif maptype == "starmap":
+            elif map_type == "starmap":
                 list(dummy_modal.starmap(input_gen()))
-            elif maptype == "spawn_map":
+            elif map_type == "spawn_map":
                 dummy_modal.spawn_map(input_gen())
 
 


### PR DESCRIPTION
Kind of a yak-shave refactor, but I think `parallel_map.py` becomes easier to read and reason about. Removes some duplicate code as well.

The initial goal was to fix error surfacing in `.starmap` -- the bug was a result of having this much duplicate code.

Added a core function `_map_helper` which powers `_map_async`, `_starmap_async` and `_for_each`.