### PR TITLE
Add general `.update_autoscaler` method to replace `.keep_warm`

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1050,20 +1050,68 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         return fun
 
     @live_method
-    async def keep_warm(self, warm_pool_size: int) -> None:
-        """Set the warm pool size for the function.
+    async def update_autoscaler(
+        self,
+        *,
+        min_containers: Optional[int] = None,
+        max_containers: Optional[int] = None,
+        buffer_containers: Optional[int] = None,
+        scaledown_window: Optional[int] = None,
+    ) -> None:
+        """Override the current autoscaler behavior for this Function.
 
-        Please exercise care when using this advanced feature!
-        Setting and forgetting a warm pool on functions can lead to increased costs.
+        Unspecified parameters will retain their current value, i.e. either the static value
+        from the function decorator, or an override value from a previous call to this method.
+
+        Subsequent deployments of the App containing this Function will reset the autoscaler back to
+        its static configuration.
+
+        Examples:
 
         ```python notest
-        # Usage on a regular function.
         f = modal.Function.from_name("my-app", "function")
+
+        # Always have at least 2 containers running, with an extra buffer when the Function is active
+        f.update_autoscaler(min_containers=2, buffer_containers=1)
+
+        # Limit this Function to avoid spinning up more than 5 containers
+        f.update_autoscaler(max_containers=5)
+
+        # Extend the scaledown window to increase the amount of time that idle containers stay alive
+        f.update_autoscaler(scaledown_window=300)
+
+        ```
+
+        """
+        if self._is_method:
+            raise InvalidError("Cannot call .update_autoscaler() on a method. Call it on the class instance instead.")
+
+        settings = api_pb2.AutoscalerSettings(
+            min_containers=min_containers,
+            max_containers=max_containers,
+            buffer_containers=buffer_containers,
+            scaledown_window=scaledown_window,
+        )
+        request = api_pb2.FunctionUpdateSchedulingParamsRequest(function_id=self.object_id, settings=settings)
+        await retry_transient_errors(self.client.stub.FunctionUpdateSchedulingParams, request)
+
+        # One idea would be for FunctionUpdateScheduleParams to return the current (coalesced) settings
+        # and then we could return them here (would need some ad hoc dataclass, which I don't love)
+
+    @live_method
+    async def keep_warm(self, warm_pool_size: int) -> None:
+        """Set the warm pool size for the Function.
+
+        DEPRECATED: Please adapt your code to use the more general `update_autoscaler` method instead:
+
+        ```python notest
+        f = modal.Function.from_name("my-app", "function")
+
+        # Old pattern (deprecated)
         f.keep_warm(2)
 
-        # Usage on a parametrized function.
-        Model = modal.Cls.from_name("my-app", "Model")
-        Model("fine-tuned-model").keep_warm(2)  # note that this applies to the class instance, not a method
+        # New pattern
+        f.update_autoscaler(min_containers=2)
         ```
         """
         if self._is_method:
@@ -1077,10 +1125,15 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
             """
                 )
             )
-        request = api_pb2.FunctionUpdateSchedulingParamsRequest(
-            function_id=self.object_id, warm_pool_size_override=warm_pool_size
+
+        deprecation_warning(
+            (2025, 5, 5),
+            "The .keep_warm() method has been deprecated in favor of the more general "
+            ".update_autoscaler(min_containers=...) method.",
+            pending=True,
+            show_source=True,
         )
-        await retry_transient_errors(self.client.stub.FunctionUpdateSchedulingParams, request)
+        await self.update_autoscaler(min_containers=warm_pool_size)
 
     @classmethod
     def _from_name(cls, app_name: str, name: str, namespace, environment_name: Optional[str]):

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1130,7 +1130,6 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
             (2025, 5, 5),
             "The .keep_warm() method has been deprecated in favor of the more general "
             ".update_autoscaler(min_containers=...) method.",
-            pending=True,
             show_source=True,
         )
         await self.update_autoscaler(min_containers=warm_pool_size)

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -292,7 +292,6 @@ class _Obj:
             (2025, 5, 5),
             "The .keep_warm() method has been deprecated in favor of the more general "
             ".update_autoscaler(min_containers=...) method.",
-            pending=True,
             show_source=True,
         )
         await self._cached_service_function().update_autoscaler(min_containers=warm_pool_size)

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -231,22 +231,71 @@ class _Obj:
         user_cls_instance._modal_functions = instance_methods
         return user_cls_instance
 
+    async def update_autoscaler(
+        self,
+        *,
+        min_containers: Optional[int] = None,
+        max_containers: Optional[int] = None,
+        scaledown_window: Optional[int] = None,
+        buffer_containers: Optional[int] = None,
+    ) -> None:
+        """Override the current autoscaler behavior for this Cls instance.
+
+        Unspecified parameters will retain their current value, i.e. either the static value
+        from the function decorator, or an override value from a previous call to this method.
+
+        Subsequent deployments of the App containing this Cls will reset the autoscaler back to
+        its static configuration.
+
+        Note: When calling this method on a Cls that is defined locally, static type checkers will
+        issue an error, because the object will appear to have the user-defined type.
+
+        Examples:
+
+        ```python notest
+        Model = modal.Cls.from_name("my-app", "Model")
+        model = Model()  # This method is called on an *instance* of the class
+
+        # Always have at least 2 containers running, with an extra buffer when the Function is active
+        model.update_autoscaler(min_containers=2, buffer_containers=1)
+
+        # Limit this Function to avoid spinning up more than 5 containers
+        f.update_autoscaler(max_containers=5)
+        ```
+
+        """
+        return await self._cached_service_function().update_autoscaler(
+            min_containers=min_containers,
+            max_containers=max_containers,
+            scaledown_window=scaledown_window,
+            buffer_containers=buffer_containers,
+        )
+
     async def keep_warm(self, warm_pool_size: int) -> None:
         """Set the warm pool size for the class containers
 
-        Please exercise care when using this advanced feature!
-        Setting and forgetting a warm pool on functions can lead to increased costs.
-
-        Note that all Modal methods and web endpoints of a class share the same set
-        of containers and the warm_pool_size affects that common container pool.
+        DEPRECATED: Please adapt your code to use the more general `update_autoscaler` method instead:
 
         ```python notest
-        # Usage on a parametrized function.
         Model = modal.Cls.from_name("my-app", "Model")
-        Model("fine-tuned-model").keep_warm(2)
+        model = Model()  # This method is called on an *instance* of the class
+
+        # Old pattern (deprecated)
+        model.keep_warm(2)
+
+        # New pattern
+        model.update_autoscaler(min_containers=2)
         ```
+
         """
-        await self._cached_service_function().keep_warm(warm_pool_size)
+        deprecation_warning(
+            (2025, 5, 5),
+            "The .keep_warm() method has been deprecated in favor of the more general "
+            ".update_autoscaler(min_containers=...) method.",
+            pending=True,
+            show_source=True,
+        )
+        await self._cached_service_function().update_autoscaler(min_containers=warm_pool_size)
 
     def _cached_user_cls_instance(self):
         """Get or construct the local object

--- a/modal/experimental/__init__.py
+++ b/modal/experimental/__init__.py
@@ -182,7 +182,7 @@ async def update_autoscaler(
     """
     deprecation_warning(
         (2025, 5, 5),
-        "The experimenta.update_autoscaler() function is now deprecated in favor of"
+        "The modal.experimental.update_autoscaler(...) function is now deprecated in favor of"
         " a stable `.update_autoscaler(...) method on the corresponding object.",
         show_source=True,
     )

--- a/modal/experimental/__init__.py
+++ b/modal/experimental/__init__.py
@@ -12,6 +12,7 @@ from .._object import _get_environment_name
 from .._partial_function import _clustered
 from .._runtime.container_io_manager import _ContainerIOManager
 from .._utils.async_utils import synchronize_api, synchronizer
+from .._utils.deprecation import deprecation_warning
 from .._utils.grpc_utils import retry_transient_errors
 from ..client import _Client
 from ..cls import _Obj
@@ -179,6 +180,13 @@ async def update_autoscaler(
     may look different (i.e., it may be a standalone function or a method).
 
     """
+    deprecation_warning(
+        (2025, 5, 5),
+        "The experimenta.update_autoscaler() function is now deprecated in favor of"
+        " a stable `.update_autoscaler(...) method on the corresponding object.",
+        show_source=True,
+    )
+
     settings = api_pb2.AutoscalerSettings(
         min_containers=min_containers,
         max_containers=max_containers,

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -668,7 +668,7 @@ def test_cls_update_autoscaler(client, servicer):
         assert len(servicer.app_functions) == 3  # base + 2 x instance service function
         assert cls_service_fun.warm_pool_size == 0  # base still has no warm
 
-        instance_service_function_id = param_obj._cached_service_function().object_id
+        instance_service_function_id = param_obj._cached_service_function().object_id  # type: ignore
         instance_service_defn = servicer.app_functions[instance_service_function_id]
         instance_autoscaler_settings = instance_service_defn.autoscaler_settings
         assert instance_service_defn.warm_pool_size == instance_autoscaler_settings.min_containers == 5

--- a/test/experimental_test.py
+++ b/test/experimental_test.py
@@ -5,6 +5,7 @@ from typing import Union, cast
 import modal
 import modal.experimental
 import modal.runner
+from modal.exception import DeprecationError
 
 app = modal.App(include_source=False)
 
@@ -40,7 +41,8 @@ def test_update_autoscaler(client, servicer, which):
         else:
             obj, obj_id = cast(modal.cls.Obj, C()), "fu-2"
 
-        modal.experimental.update_autoscaler(obj, client=client, **overrides)  # type: ignore
+        with pytest.warns(DeprecationError):
+            modal.experimental.update_autoscaler(obj, client=client, **overrides)  # type: ignore
 
         settings = servicer.app_functions[obj_id].autoscaler_settings  # type: ignore
         assert settings.min_containers == overrides["min_containers"]
@@ -71,7 +73,8 @@ def test_update_autoscaler_after_lookup(client, servicer, which):
         obj = C()
         obj_id = "fu-2"
 
-    modal.experimental.update_autoscaler(obj, client=client, **overrides)  # type: ignore
+    with pytest.warns(DeprecationError):
+        modal.experimental.update_autoscaler(obj, client=client, **overrides)  # type: ignore
 
     settings = servicer.app_functions[obj_id].autoscaler_settings  # type: ignore
     assert settings.min_containers == overrides["min_containers"]

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -1673,7 +1673,7 @@ def test_add_locals_are_attached_to_classes(servicer, client, supports_on_path, 
 
     obj = ACls(some_arg="foo")  # type: ignore
     # hacky way to force hydration of the *parameter bound* function (instance service function):
-    obj.keep_warm(0)  #  type: ignore
+    obj.update_autoscaler(min_containers=0)  #  type: ignore
 
     obj_fun_def = servicer.function_by_name("A.*", ((), {"some_arg": "foo"}))  # instance service function
     added_mounts = set(obj_fun_def.mount_ids) - control_func_mounts


### PR DESCRIPTION
## Describe your changes

- Closes CLI-338

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Introduces a new `.update_autoscaler()` method, which will replace the existing `.keep_warm()` method with the ability to dynamically change the entire autoscaler configuration (`min_containers`, `max_containers`, `buffer_containers`, and `scaledown_window`).