### PR TITLE
Add input_plane_url to FunctionHandleMetadata proto

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1653,6 +1653,7 @@ message FunctionHandleMetadata {
   // Mapping of method names to their metadata, only non-empty for class service functions
   map<string, FunctionHandleMetadata> method_handle_metadata = 44;
   FunctionSchema function_schema = 45;
+  string input_plane_url = 46;
 }
 
 message FunctionInput {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1653,7 +1653,7 @@ message FunctionHandleMetadata {
   // Mapping of method names to their metadata, only non-empty for class service functions
   map<string, FunctionHandleMetadata> method_handle_metadata = 44;
   FunctionSchema function_schema = 45;
-  string input_plane_url = 46;
+  optional string input_plane_url = 46;
 }
 
 message FunctionInput {


### PR DESCRIPTION
Part of SVC-492

Add `input_plane_url` to `FunctionHandleMetadata` proto so that we can return it in `FunctionGet` and `FunctionCreate`. This is how the client knows which input plane to connect to.

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
