### PR TITLE
Replace .web_url property with .get_web_url() method

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1348,9 +1348,19 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
     @property
     @live_method
     async def web_url(self) -> Optional[str]:
+        """Deprecated. Use the `Function.get_web_url()` method instead.
+
+        URL of a Function running as a web endpoint.
+        """
+        deprecation_msg = """The Function.web_url property will be removed in a future version of Modal.
+Use the `Function.get_web_url()` method instead.
+"""
+        deprecation_warning((2025, 5, 6), deprecation_msg)  #  pending=True)
+        return self._web_url
+
+    @live_method
+    async def get_web_url(self) -> Optional[str]:
         """URL of a Function running as a web endpoint."""
-        # TODO If we remove the @live_method above, we may want to provide better feedback when the underlying
-        # attribute is None because the object is not hydrated, rather than because it's not a web endpoint.
         return self._web_url
 
     @property

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1355,7 +1355,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         deprecation_msg = """The Function.web_url property will be removed in a future version of Modal.
 Use the `Function.get_web_url()` method instead.
 """
-        deprecation_warning((2025, 5, 6), deprecation_msg)  #  pending=True)
+        deprecation_warning((2025, 5, 6), deprecation_msg, pending=True)
         return self._web_url
 
     @live_method

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -761,8 +761,8 @@ class WebCls:
 def test_web_cls(client):
     with web_app_app.run(client=client):
         c = WebCls()
-        assert c.endpoint.web_url == "http://endpoint.internal"
-        assert c.asgi.web_url == "http://asgi.internal"
+        assert c.endpoint.get_web_url() == "http://endpoint.internal"
+        assert c.asgi.get_web_url() == "http://asgi.internal"
 
 
 handler_app = App("handler-app", include_source=True)

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -643,7 +643,7 @@ def test_local_execution_on_web_endpoint(client, servicer):
 
     function_id = foo.object_id
     assert function_id
-    assert foo.web_url
+    assert foo.get_web_url()
 
     res = foo.local("hello")
     assert res == "hello!"
@@ -671,7 +671,7 @@ def test_local_execution_on_asgi_app(client, servicer):
 
     function_id = foo.object_id
     assert function_id
-    assert foo.web_url
+    assert foo.get_web_url()
 
     res = foo.local()
     assert type(res) is FastAPI
@@ -690,7 +690,7 @@ def test_invalid_remote_executor_on_web_endpoint(client, servicer, remote_execut
 
     function_id = foo.object_id
     assert function_id
-    assert foo.web_url
+    assert foo.get_web_url()
 
     with pytest.raises(InvalidError) as excinfo:
         f = getattr(foo, remote_executor)
@@ -722,7 +722,7 @@ def test_invalid_remote_executor_on_asgi_app(client, servicer, remote_executor):
 
     function_id = foo.object_id
     assert function_id
-    assert foo.web_url
+    assert foo.get_web_url()
 
     with pytest.raises(InvalidError) as excinfo:
         f = getattr(foo, remote_executor)
@@ -787,7 +787,7 @@ def test_serialize_deserialize_function_handle(servicer, client):
         rehydrated_function_handle = deserialize(blob, client)
         assert rehydrated_function_handle.object_id == my_handle.object_id
         assert isinstance(rehydrated_function_handle, Function)
-        assert rehydrated_function_handle.web_url == "http://xyz.internal"
+        assert rehydrated_function_handle.get_web_url() == "http://xyz.internal"
 
 
 def test_default_cloud_provider(client, servicer, monkeypatch):
@@ -1107,7 +1107,7 @@ def test_from_name_web_url(servicer, set_env_client):
                 function_id="fu-1", handle_metadata=api_pb2.FunctionHandleMetadata(web_url="test.internal")
             ),
         )
-        assert f.web_url == "test.internal"
+        assert f.get_web_url() == "test.internal"
 
 
 @pytest.mark.parametrize(

--- a/test/live_reload_test.py
+++ b/test/live_reload_test.py
@@ -49,7 +49,7 @@ def test_file_changes_trigger_reloads(import_ref, server_url_env, token_env, ser
     with serve_app(app, import_ref, _watcher=fake_watch()):
         watcher_done.wait()  # wait until watcher loop is done
         foo: Function = app.registered_functions["foo"]
-        assert foo.web_url.startswith("http://")
+        assert foo.get_web_url().startswith("http://")
 
     stderr = capfd.readouterr().err
     print(stderr)

--- a/test/lookup_test.py
+++ b/test/lookup_test.py
@@ -52,7 +52,7 @@ def test_fastapi_endpoint_lookup(servicer, client):
     deploy_app(app, "my-webhook", client=client)
 
     f = Function.from_name("my-webhook", "square").hydrate(client)
-    assert f.web_url
+    assert f.get_web_url()
 
 
 def test_web_endpoint_legacy_lookup(servicer, client):
@@ -62,7 +62,7 @@ def test_web_endpoint_legacy_lookup(servicer, client):
     deploy_app(app, "my-webhook", client=client)
 
     f = Function.from_name("my-webhook", "square").hydrate(client)
-    assert f.web_url
+    assert f.get_web_url()
 
 
 def test_deploy_exists(servicer, client):

--- a/test/supports/sibling_hydration_app.py
+++ b/test/supports/sibling_hydration_app.py
@@ -35,7 +35,7 @@ def function_calling_method(x, y, z):
 def check_sibling_hydration(x):
     assert square.is_hydrated
     assert fastapi_app.is_hydrated
-    assert fastapi_app.web_url
+    assert fastapi_app.get_web_url()
     assert fun_returning_gen.is_hydrated
     assert fun_returning_gen.is_generator
 

--- a/test/webhook_test.py
+++ b/test/webhook_test.py
@@ -26,7 +26,7 @@ async def f(x):
 @pytest.mark.asyncio
 async def test_webhook(servicer, client, reset_container_app):
     async with app.run(client=client):
-        assert f.web_url
+        assert f.get_web_url()
 
         assert servicer.app_functions["fu-1"].webhook_config.type == api_pb2.WEBHOOK_TYPE_FUNCTION
         assert servicer.app_functions["fu-1"].webhook_config.method == "PATCH"
@@ -40,7 +40,7 @@ async def test_webhook(servicer, client, reset_container_app):
         container_app = RunningApp(app.app_id)
         app._init_container(client, container_app)
         assert isinstance(f, Function)
-        assert f.web_url
+        assert f.get_web_url()
 
 
 def test_webhook_cors():


### PR DESCRIPTION
TODO:
- [x] Make pending=True before merging

## Changelog

* Deprecates `Function.web_url` in favor of a new `Function.get_web_url()` method. This also allows the url of a `Function` to be retrieved in an async manner using `Function.get_web_url.aio()` (like all other io-bearing methods in the Modal API)