### PR TITLE
Make spawn_map a live method

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1585,6 +1585,15 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
 
     @synchronizer.no_input_translation
     @live_method
+    async def _spawn_map_inner(self, *args: P.args, **kwargs: P.kwargs) -> None:
+        self._check_no_web_url("spawn_map")
+        if self._is_generator:
+            raise Exception("Cannot `spawn_map` over a generator function.")
+
+        await self._call_function_nowait(args, kwargs, api_pb2.FUNCTION_CALL_INVOCATION_TYPE_ASYNC, from_spawn_map=True)
+
+    @synchronizer.no_input_translation
+    @live_method
     async def spawn(self, *args: P.args, **kwargs: P.kwargs) -> "_FunctionCall[ReturnType]":
         """Calls the function with the given arguments, without waiting for the results.
 

--- a/modal/parallel_map.py
+++ b/modal/parallel_map.py
@@ -496,9 +496,7 @@ async def _spawn_map_async(self, *input_iterators, kwargs={}) -> None:
         errors, log a warning that the function call is waiting to be created.
         """
 
-        return self._call_function_nowait.aio(
-            args, kwargs, api_pb2.FUNCTION_CALL_INVOCATION_TYPE_ASYNC, from_spawn_map=True
-        )
+        return self._spawn_map_inner.aio(args, kwargs, api_pb2.FUNCTION_CALL_INVOCATION_TYPE_ASYNC)
 
     input_gen = async_zip(*[sync_or_async_iter(it) for it in input_iterators])
 


### PR DESCRIPTION
## Describe your changes

Fixes an issue where `.spawn_map` does not work on `Function.from_name`.

## Changelog

- Added functionality for `.spawn_map` on a function instantiated from `Function.from_name`.
