### PR TITLE
Add RDMA as a flag to the clustered decorator

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -475,6 +475,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         i6pn_enabled: bool = False,
         # Experimental: Clustered functions
         cluster_size: Optional[int] = None,
+        rdma: Optional[bool] = None,
         max_inputs: Optional[int] = None,
         ephemeral_disk: Optional[int] = None,
         # current default: first-party, future default: main-package
@@ -897,7 +898,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
 
                         function_definition_copy.resources.CopyFrom(
                             convert_fn_config_to_resources_config(
-                                cpu=cpu, memory=memory, gpu=_gpu, ephemeral_disk=ephemeral_disk
+                                cpu=cpu, memory=memory, gpu=_gpu, ephemeral_disk=ephemeral_disk, rdma=rdma
                             ),
                         )
                         ranked_function = api_pb2.FunctionData.RankedFunction(
@@ -912,7 +913,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                     # assert isinstance(gpu, GPU_T)  # includes the case where gpu==None case
                     function_definition.resources.CopyFrom(
                         convert_fn_config_to_resources_config(
-                            cpu=cpu, memory=memory, gpu=gpu, ephemeral_disk=ephemeral_disk
+                            cpu=cpu, memory=memory, gpu=gpu, ephemeral_disk=ephemeral_disk, rdma=rdma
                         ),
                     )
 

--- a/modal/_partial_function.py
+++ b/modal/_partial_function.py
@@ -77,6 +77,7 @@ class _PartialFunctionParams:
     max_concurrent_inputs: Optional[int] = None
     target_concurrent_inputs: Optional[int] = None
     build_timeout: Optional[int] = None
+    rdma: Optional[bool] = None
 
     def update(self, other: "_PartialFunctionParams") -> None:
         """Update self with params set in other."""
@@ -900,7 +901,7 @@ def _concurrent(
 
 
 # NOTE: clustered is currently exposed through modal.experimental, not the top-level namespace
-def _clustered(size: int, broadcast: bool = True):
+def _clustered(size: int, broadcast: bool = True, rdma: bool = False):
     """Provision clusters of colocated and networked containers for the Function.
 
     Parameters:
@@ -918,7 +919,7 @@ def _clustered(size: int, broadcast: bool = True):
         raise ValueError("cluster size must be greater than 0")
 
     flags = _PartialFunctionFlags.CLUSTERED
-    params = _PartialFunctionParams(cluster_size=size)
+    params = _PartialFunctionParams(cluster_size=size, rdma=rdma)
 
     def wrapper(
         obj: Union[_PartialFunction[P, ReturnType, ReturnType], Callable[P, ReturnType]],

--- a/modal/_resources.py
+++ b/modal/_resources.py
@@ -13,6 +13,7 @@ def convert_fn_config_to_resources_config(
     memory: Optional[Union[int, tuple[int, int]]],
     gpu: GPU_T,
     ephemeral_disk: Optional[int],
+    rdma: Optional[bool] = None,
 ) -> api_pb2.Resources:
     gpu_config = parse_gpu_config(gpu)
     if cpu and isinstance(cpu, tuple):
@@ -48,4 +49,5 @@ def convert_fn_config_to_resources_config(
         memory_mb=memory_mb,
         memory_mb_max=memory_mb_max,
         ephemeral_disk_mb=ephemeral_disk,
+        rdma=rdma or False,
     )

--- a/modal/app.py
+++ b/modal/app.py
@@ -747,6 +747,7 @@ class _App:
                     )
                 i6pn_enabled = i6pn or (f.flags & _PartialFunctionFlags.CLUSTERED)
                 cluster_size = f.params.cluster_size  # Experimental: Clustered functions
+                rdma = f.params.rdma
 
                 info = FunctionInfo(f.raw_f, serialized=serialized, name_override=name)
                 raw_f = f.raw_f
@@ -799,6 +800,7 @@ class _App:
                 target_concurrent_inputs = None
 
                 cluster_size = None  # Experimental: Clustered functions
+                rdma = None
                 i6pn_enabled = i6pn
 
             if info.function_name.endswith(".app"):
@@ -850,6 +852,7 @@ class _App:
                 scheduler_placement=scheduler_placement,
                 i6pn_enabled=i6pn_enabled,
                 cluster_size=cluster_size,  # Experimental: Clustered functions
+                rdma=rdma,
                 include_source=include_source if include_source is not None else self._include_source_default,
                 experimental_options={k: str(v) for k, v in (experimental_options or {}).items()},
                 _experimental_proxy_ip=_experimental_proxy_ip,


### PR DESCRIPTION
RDMA makes sense here since it's only going to be allowed for clustered functions, and as we ship to clients, we need a better interface than experimental options.

## Describe your changes

Adds an `rdma` field to experimental functions.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

