### PR TITLE
Add 'modal cluster' subcommand

### DIFF
--- a/modal/cli/cluster.py
+++ b/modal/cli/cluster.py
@@ -1,0 +1,83 @@
+# Copyright Modal Labs 2022
+from typing import Optional, Union
+
+import typer
+from rich.console import Console
+from rich.text import Text
+
+from modal._object import _get_environment_name
+from modal._pty import get_pty_info
+from modal._utils.async_utils import synchronizer
+from modal.cli.utils import ENV_OPTION, display_table, is_tty, timestamp_to_local
+from modal.client import _Client
+from modal.config import config
+from modal.container_process import _ContainerProcess
+from modal.environments import ensure_env
+from modal.stream_type import StreamType
+from modal_proto import api_pb2
+
+cluster_cli = typer.Typer(
+    name="cluster", help="Manage and connect to running multi-node clusters.", no_args_is_help=True
+)
+
+
+@cluster_cli.command("list")
+@synchronizer.create_blocking
+async def list_(env: Optional[str] = ENV_OPTION, json: bool = False):
+    """List all clusters that are currently running."""
+    env = ensure_env(env)
+    client = await _Client.from_env()
+    environment_name = _get_environment_name(env)
+    res: api_pb2.ClusterListResponse = await client.stub.ClusterList(
+        api_pb2.ClusterListRequest(environment_name=environment_name)
+    )
+
+    column_names = ["Cluster ID", "App ID", "Start Time", "Nodes"]
+    rows: list[list[Union[Text, str]]] = []
+    res.clusters.sort(key=lambda c: c.started_at, reverse=True)
+
+    for c in res.clusters:
+        rows.append(
+            [
+                c.cluster_id,
+                c.app_id,
+                timestamp_to_local(c.started_at, json) if c.started_at else "Pending",
+                str(len(c.task_ids)),
+            ]
+        )
+
+    display_table(column_names, rows, json=json, title=f"Active Multi-node Clusters in environment: {environment_name}")
+
+
+@cluster_cli.command("shell")
+@synchronizer.create_blocking
+async def shell(
+    cluster_id: str = typer.Argument(help="Cluster ID"),
+    rank: int = typer.Option(default=0, help="Rank of the node to shell into"),
+):
+    """Open a shell to a multi-node cluster node."""
+    client = await _Client.from_env()
+    res: api_pb2.ClusterGetResponse = await client.stub.ClusterGet(api_pb2.ClusterGetRequest(cluster_id=cluster_id))
+    if len(res.cluster.task_ids) <= rank:
+        raise typer.Abort(f"No node with rank {rank} in cluster {cluster_id}")
+    task_id = res.cluster.task_ids[rank]
+    console = Console()
+    is_main = "(main)" if rank == 0 else ""
+    console.print(
+        f"Opening shell to node {rank} {is_main} of cluster {cluster_id} (container {task_id})", style="green"
+    )
+
+    pty = is_tty()
+    req = api_pb2.ContainerExecRequest(
+        task_id=task_id,
+        command=["/bin/bash"],
+        pty_info=get_pty_info(shell=True) if pty else None,
+        runtime_debug=config.get("function_runtime_debug"),
+    )
+    res: api_pb2.ContainerExecResponse = await client.stub.ContainerExec(req)
+
+    if pty:
+        await _ContainerProcess(res.exec_id, client).attach()
+    else:
+        # TODO: redirect stderr to its own stream?
+        await _ContainerProcess(res.exec_id, client, stdout=StreamType.STDOUT, stderr=StreamType.STDOUT).wait()

--- a/modal/cli/cluster.py
+++ b/modal/cli/cluster.py
@@ -74,10 +74,9 @@ async def shell(
         pty_info=get_pty_info(shell=True) if pty else None,
         runtime_debug=config.get("function_runtime_debug"),
     )
-    res: api_pb2.ContainerExecResponse = await client.stub.ContainerExec(req)
-
+    exec_res: api_pb2.ContainerExecResponse = await client.stub.ContainerExec(req)
     if pty:
-        await _ContainerProcess(res.exec_id, client).attach()
+        await _ContainerProcess(exec_res.exec_id, client).attach()
     else:
         # TODO: redirect stderr to its own stream?
-        await _ContainerProcess(res.exec_id, client, stdout=StreamType.STDOUT, stderr=StreamType.STDOUT).wait()
+        await _ContainerProcess(exec_res.exec_id, client, stdout=StreamType.STDOUT, stderr=StreamType.STDOUT).wait()

--- a/modal/cli/entry_point.py
+++ b/modal/cli/entry_point.py
@@ -10,6 +10,7 @@ from modal._utils.async_utils import synchronizer
 
 from . import run
 from .app import app_cli
+from .cluster import cluster_cli
 from .config import config_cli
 from .container import container_cli
 from .dict import dict_cli
@@ -92,6 +93,8 @@ entrypoint_cli_typer.add_typer(launch_cli)
 # Deployments
 entrypoint_cli_typer.add_typer(app_cli, rich_help_panel="Deployments")
 entrypoint_cli_typer.add_typer(container_cli, rich_help_panel="Deployments")
+# TODO: cluster is hidden while multi-node is in beta/experimental
+entrypoint_cli_typer.add_typer(cluster_cli, rich_help_panel="Deployments", hidden=True)
 
 # Storage
 entrypoint_cli_typer.add_typer(dict_cli, rich_help_panel="Storage")


### PR DESCRIPTION
## Describe your changes

Minimal convenient CLI functionality for multi-node users.

```
 Usage: modal cluster [OPTIONS] COMMAND [ARGS]...

 Manage and connect to running multi-node clusters.

╭─ Options ─────────────────────────────────────────────────────────────────────╮
│ --help          Show this message and exit.                                   │
╰───────────────────────────────────────────────────────────────────────────────╯
╭─ Commands ────────────────────────────────────────────────────────────────────╮
│ list    List all clusters that are currently running.                         │
│ shell   Open a shell to a multi-node cluster node.                            │
╰───────────────────────────────────────────────────────────────────────────────╯
```

<img width="927" alt="image" src="https://github.com/user-attachments/assets/220a519a-534f-49a8-82cc-6668fd431ad0" />

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

* Experimental `modal cluster` subcommand is added.
