### PR TITLE
Deprecate passing data directly to Dict constructors

### DIFF
--- a/modal/dict.py
+++ b/modal/dict.py
@@ -73,7 +73,7 @@ class _Dict(_Object, type_prefix="di"):
     @asynccontextmanager
     async def ephemeral(
         cls: type["_Dict"],
-        data: Optional[dict] = None,
+        data: Optional[dict] = None,  # DEPRECATED
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         _heartbeat_sleep: float = EPHEMERAL_OBJECT_HEARTBEAT_SLEEP,
@@ -95,6 +95,11 @@ class _Dict(_Object, type_prefix="di"):
         """
         if client is None:
             client = await _Client.from_env()
+        if data:
+            deprecation_warning(
+                (2025, 5, 6),
+                "Passing data to `modal.Dict.ephemeral` is deprecated and will stop working in a future release.",
+            )
         serialized = _serialize_dict(data if data is not None else {})
         request = api_pb2.DictGetOrCreateRequest(
             object_creation_type=api_pb2.OBJECT_CREATION_TYPE_EPHEMERAL,
@@ -111,7 +116,7 @@ class _Dict(_Object, type_prefix="di"):
     @renamed_parameter((2024, 12, 18), "label", "name")
     def from_name(
         name: str,
-        data: Optional[dict] = None,
+        data: Optional[dict] = None,  # DEPRECATED
         *,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
@@ -129,6 +134,12 @@ class _Dict(_Object, type_prefix="di"):
         ```
         """
         check_object_name(name, "Dict")
+
+        if data:
+            deprecation_warning(
+                (2025, 5, 6),
+                "Passing data to `modal.Dict.from_name` is deprecated and will stop working in a future release.",
+            )
 
         async def _load(self: _Dict, resolver: Resolver, existing_object_id: Optional[str]):
             serialized = _serialize_dict(data if data is not None else {})

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -157,7 +157,8 @@ async def test_rpc_wrapping_restores(container_client, servicer, tmpdir):
     io_manager = ContainerIOManager(api_pb2.ContainerArguments(checkpoint_id="ch-123"), container_client)
     restore_path = temp_restore_path(tmpdir)
 
-    d = modal.Dict.from_name("my-amazing-dict", {"xyz": 123}, create_if_missing=True).hydrate(container_client)
+    d = modal.Dict.from_name("my-amazing-dict", create_if_missing=True).hydrate(container_client)
+    d["xyz"] = 123
     d["abc"] = 42
 
     with set_env_vars(restore_path, servicer.container_addr):

--- a/test/dict_test.py
+++ b/test/dict_test.py
@@ -33,11 +33,10 @@ def test_dict_app(servicer, client):
 
 def test_dict_ephemeral(servicer, client):
     assert servicer.n_dict_heartbeats == 0
-    with Dict.ephemeral({"bar": 123}, client=client, _heartbeat_sleep=1) as d:
+    with Dict.ephemeral(client=client, _heartbeat_sleep=1) as d:
         d["foo"] = 42
-        assert d.len() == 2
+        assert d.len() == 1
         assert d["foo"] == 42
-        assert d["bar"] == 123
         time.sleep(1.5)  # Make time for 2 heartbeats
     assert servicer.n_dict_heartbeats == 2
 

--- a/test/dict_test.py
+++ b/test/dict_test.py
@@ -7,7 +7,8 @@ from modal.exception import InvalidError, NotFoundError
 
 
 def test_dict_app(servicer, client):
-    d = Dict.from_name("my-amazing-dict", {"xyz": 123}, create_if_missing=True).hydrate(client)
+    d = Dict.from_name("my-amazing-dict", create_if_missing=True).hydrate(client)
+    d["xyz"] = 123
     d["foo"] = 42
     d["foo"] += 5
     assert d["foo"] == 47


### PR DESCRIPTION
## Describe your changes

This has its uses, but it's an odd one-off pattern with Modal objects, and the semantics in the case of `modal.Dict.from_name` are poorly defined.

Closes CLI-390

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Adds a deprecation warning when data is passed directly to `modal.Dict.from_name` or `modal.Dict.ephemeral`. Going forward, it will be necessary to separate `Dict` population from creation.