### PR TITLE
Support full dict.update API in modal.Dict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "grpclib==0.4.7",
     "protobuf>=3.19,<7.0,!=4.24.0",
     "rich>=12.0.0",
-    "synchronicity~=0.9.10",
+    "synchronicity~=0.9.12",
     "toml",
     "typer>=0.9",
     "types-certifi",

--- a/test/dict_test.py
+++ b/test/dict_test.py
@@ -55,3 +55,10 @@ def test_dict_lazy_hydrate_named(set_env_client, servicer):
 def test_invalid_name(servicer, client, name):
     with pytest.raises(InvalidError, match="Invalid Dict name"):
         Dict.from_name(name).hydrate(client)
+
+
+def test_dict_update(servicer, client):
+    with Dict.ephemeral(client=client, _heartbeat_sleep=1) as d:
+        d.update({"foo": 1, "bar": 2}, foo=3, baz=4)
+        items = list(d.items())
+        assert sorted(items) == [("bar", 2), ("baz", 4), ("foo", 3)]


### PR DESCRIPTION
Noticed that this didn't work as expected.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- `modal.Dict.update` now also accepts a positional Mapping, like Python's `dict` type:

    ```python
    d = modal.Dict.from_name("some-dict")
    d.update({"a_key": 1, "another_key": "b"}, some_kwarg=True)
    ```