### PR TITLE
Add support for calling input plane server

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1383,6 +1383,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         self._class_parameter_info = metadata.class_parameter_info
         self._method_handle_metadata = dict(metadata.method_handle_metadata)
         self._definition_id = metadata.definition_id
+        self._input_plane_url = metadata.input_plane_url
 
     def _get_metadata(self):
         # Overridden concrete implementation of base class method
@@ -1397,6 +1398,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
             definition_id=self._definition_id,
             method_handle_metadata=self._method_handle_metadata,
             function_schema=self._metadata.function_schema if self._metadata else None,
+            input_plane_url=self._input_plane_url
         )
 
     def _check_no_web_url(self, fn_name: str):
@@ -1468,16 +1470,14 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                 yield item
 
     async def _call_function(self, args, kwargs) -> ReturnType:
-        input_plane_url = config.get("input_plane_url")
-
         invocation: Union[_Invocation, _InputPlaneInvocation]
-        if input_plane_url is not None:
+        if self._input_plane_url:
             invocation = await _InputPlaneInvocation.create(
                 self,
                 args,
                 kwargs,
                 client=self.client,
-                input_plane_url=input_plane_url,
+                input_plane_url=self._input_plane_url,
             )
         else:
             invocation = await _Invocation.create(

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -336,6 +336,67 @@ class _Invocation:
                     break
 
 
+class _InputPlaneInvocation:
+    """Internal client representation of a single-input call to a Modal Function using the input
+    plane server API. As of 4/22/2025, this class is experimental and not used in production.
+    It is OK to make breaking changes to this class."""
+
+    stub: ModalClientModal
+
+    def __init__(
+        self,
+        stub: ModalClientModal,
+        attempt_token: str,
+        client: _Client,
+    ):
+        self.stub = stub
+        self.client = client  # Used by the deserializer.
+        self.attempt_token = attempt_token
+
+    @staticmethod
+    async def create(
+        function: "_Function",
+        args,
+        kwargs,
+        *,
+        client: _Client,
+        input_plane_url: str,
+    ) -> "_InputPlaneInvocation":
+        stub = await client.get_stub(input_plane_url)
+
+        function_id = function.object_id
+        item = await _create_input(args, kwargs, stub, method_name=function._use_method_name)
+
+        request = api_pb2.AttemptStartRequest(
+            function_id=function_id,
+            parent_input_id=current_input_id() or "",
+            input=item,
+        )
+        response = await retry_transient_errors(stub.AttemptStart, request)
+        attempt_token = response.attempt_token
+
+        return _InputPlaneInvocation(stub, attempt_token, client)
+
+    async def run_function(self) -> Any:
+        # TODO(nathan): add retry logic
+        while True:
+            request = api_pb2.AttemptAwaitRequest(
+                attempt_token=self.attempt_token,
+                timeout_secs=OUTPUTS_TIMEOUT,
+                requested_at=time.time(),
+            )
+            response: api_pb2.AttemptAwaitResponse = await retry_transient_errors(
+                self.stub.AttemptAwait,
+                request,
+                attempt_timeout=OUTPUTS_TIMEOUT + ATTEMPT_TIMEOUT_GRACE_PERIOD,
+            )
+
+            if response.HasField("output"):
+                return await _process_result(
+                    response.output.result, response.output.data_format, self.stub, self.client
+                )
+
+
 # Wrapper type for api_pb2.FunctionStats
 @dataclass(frozen=True)
 class FunctionStats:
@@ -1407,13 +1468,25 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                 yield item
 
     async def _call_function(self, args, kwargs) -> ReturnType:
-        invocation = await _Invocation.create(
-            self,
-            args,
-            kwargs,
-            client=self.client,
-            function_call_invocation_type=api_pb2.FUNCTION_CALL_INVOCATION_TYPE_SYNC,
-        )
+        input_plane_url = config.get("input_plane_url")
+
+        invocation: Union[_Invocation, _InputPlaneInvocation]
+        if input_plane_url is not None:
+            invocation = await _InputPlaneInvocation.create(
+                self,
+                args,
+                kwargs,
+                client=self.client,
+                input_plane_url=input_plane_url,
+            )
+        else:
+            invocation = await _Invocation.create(
+                self,
+                args,
+                kwargs,
+                client=self.client,
+                function_call_invocation_type=api_pb2.FUNCTION_CALL_INVOCATION_TYPE_SYNC,
+            )
 
         return await invocation.run_function()
 

--- a/modal/config.py
+++ b/modal/config.py
@@ -251,7 +251,6 @@ _SETTINGS = {
     "cuda_checkpoint_path": _Setting("/__modal/.bin/cuda-checkpoint"),  # Used for snapshotting GPU memory.
     "function_schemas": _Setting(False, transform=_to_boolean),
     "build_validation": _Setting("error", transform=_check_value(["error", "warn", "ignore"])),
-    "input_plane_url": _Setting(None),  # For internal use only.
 }
 
 

--- a/modal/config.py
+++ b/modal/config.py
@@ -251,6 +251,7 @@ _SETTINGS = {
     "cuda_checkpoint_path": _Setting("/__modal/.bin/cuda-checkpoint"),  # Used for snapshotting GPU memory.
     "function_schemas": _Setting(False, transform=_to_boolean),
     "build_validation": _Setting("error", transform=_check_value(["error", "warn", "ignore"])),
+    "input_plane_url": _Setting(None),  # For internal use only.
 }
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -394,7 +394,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.container_heartbeat_response = response
         self.container_heartbeat_abort.set()
 
-    def _get_input_plane_url(self, definition: api_pb2.Function):
+    def _get_input_plane_url(self, definition: Union[api_pb2.Function, api_pb2.FunctionData]) -> Optional[str]:
         input_plane_region = definition.experimental_options.get("input_plane_region")
         return f"http://127.0.0.1:{self.port}" if input_plane_region else None
 

--- a/test/input_plane_test.py
+++ b/test/input_plane_test.py
@@ -1,0 +1,24 @@
+# Copyright Modal Labs 2025
+import modal
+from modal import App
+from modal.functions import Function
+from modal.runner import deploy_app
+
+app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+
+
+@app.function(experimental_options={"input_plane_region": "us-east"})
+def foo():
+    return "foo"
+
+def test_foo(client, servicer):
+    # This verifies that FunctionCreate returns the input_plane_url in the response, and we then call the input plane.
+    with app.run(client=client):
+        assert foo.remote() == "attempt_await_bogus_response"
+
+def test_lookup_foo(client, servicer):
+    # This verifies that FunctionGet returns the input_plane_url in the response, and we then call the input plane.
+    modal.App()
+    deploy_app(app, "app", client=client)
+    f = Function.from_name("app", "foo").hydrate(client)
+    assert f.remote() == "attempt_await_bogus_response"


### PR DESCRIPTION
This PR adds support for calling input plane functions.

Calls to FunctionGet and FunctionCreate return the input_plane_url, so the client can then connect to the input plane in the correct region for the function.

Closes SVC-492

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
