### PR TITLE
volume: Add fast path for downloading files into file-like object

### DIFF
--- a/modal/volume.py
+++ b/modal/volume.py
@@ -528,9 +528,9 @@ class _Volume(_Object, type_prefix="vo"):
 
             return num_bytes_written
 
-        tasks = (asyncio.create_task(download_block(idx, url)) for idx, url in enumerate(response.get_urls))
+        coros = [download_block(idx, url) for idx, url in enumerate(response.get_urls)]
 
-        total_size = sum(await asyncio.gather(*tasks))
+        total_size = sum(await asyncio.gather(*coros))
         fileobj.seek(start_pos + total_size)
 
         return total_size

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -447,6 +447,96 @@ class _Volume(_Object, type_prefix="vo"):
 
 
     @live_method
+    async def read_file_into_fileobj(
+        self,
+        path: str,
+        fileobj: typing.IO[bytes],
+        progress_cb: Optional[Callable[..., Any]] = None
+    ) -> int:
+        """mdmd:hidden
+        Read volume file into file-like IO object.
+        """
+        if progress_cb is None:
+            def progress_cb(*_, **__):
+                pass
+
+        if self._is_v1:
+            return await self._read_file_into_fileobj1(path, fileobj, progress_cb)
+        else:
+            return await self._read_file_into_fileobj2(path, fileobj, progress_cb)
+
+
+    async def _read_file_into_fileobj1(
+        self,
+        path: str,
+        fileobj: typing.IO[bytes],
+        progress_cb: Callable[..., Any]
+    ) -> int:
+        num_bytes_written = 0
+
+        async for chunk in self._read_file1(path):
+            num_chunk_bytes_written = 0
+
+            while num_chunk_bytes_written < len(chunk):
+                # TODO(dflemstr): this is a small write, but nonetheless might block the event loop for some time:
+                n = fileobj.write(chunk)
+                num_chunk_bytes_written += n
+                progress_cb(advance=n)
+
+            num_bytes_written += len(chunk)
+
+        return num_bytes_written
+
+
+    async def _read_file_into_fileobj2(
+        self,
+        path: str,
+        fileobj: typing.IO[bytes],
+        progress_cb: Callable[..., Any]
+    ) -> int:
+        req = api_pb2.VolumeGetFile2Request(volume_id=self.object_id, path=path)
+
+        try:
+            response = await retry_transient_errors(self._client.stub.VolumeGetFile2, req)
+        except GRPCError as exc:
+            raise FileNotFoundError(exc.message) if exc.status == Status.NOT_FOUND else exc
+
+        # TODO(dflemstr): Sane default limit? Make configurable?
+        download_semaphore = asyncio.Semaphore(multiprocessing.cpu_count())
+        write_lock = asyncio.Lock()
+        start_pos = fileobj.tell()
+
+        async def download_block(idx, url) -> int:
+            block_start_pos = start_pos + idx * BLOCK_SIZE
+            num_bytes_written = 0
+
+            async with download_semaphore, ClientSessionRegistry.get_session().get(url) as get_response:
+                async for chunk in get_response.content:
+                    num_chunk_bytes_written = 0
+
+                    while num_chunk_bytes_written < len(chunk):
+                        async with write_lock:
+                            fileobj.seek(block_start_pos + num_bytes_written + num_chunk_bytes_written)
+                            # TODO(dflemstr): this is a small write, but nonetheless might block the event loop for some
+                            #  time:
+                            n = fileobj.write(chunk)
+
+                        num_chunk_bytes_written += n
+                        progress_cb(advance=n)
+
+                    num_bytes_written += len(chunk)
+
+            return num_bytes_written
+
+        tasks = (asyncio.create_task(download_block(idx, url)) for idx, url in enumerate(response.get_urls))
+
+        total_size = sum(await asyncio.gather(*tasks))
+        fileobj.seek(start_pos + total_size)
+
+        return total_size
+
+
+    @live_method
     async def remove_file(self, path: str, recursive: bool = False) -> None:
         """Remove a file or directory from a volume."""
         req = api_pb2.VolumeRemoveFileRequest(volume_id=self.object_id, path=path, recursive=recursive)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2015,7 +2015,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
                         assert len(block_data) == BLOCK_SIZE
                     # If this is the last block, it must be at most BLOCK_SIZE
                     if block_index + 1 == len(file.blocks):
-                        assert len(block_data) < BLOCK_SIZE
+                        assert len(block_data) <= BLOCK_SIZE
                     blocks.append(block_data)
                 else:
                     missing_block = api_pb2.VolumePutFiles2Response.MissingBlock(


### PR DESCRIPTION
## Describe your changes

- This resurrects the old `Volume.read_file_into_fileobj` with correct write semantics.
- It is beneficial to use this method for CLI `volume get` since it will concurrently download blocks and do scattered writes to disk in a scalable way.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
