### PR TITLE
Upgrade warning on passing flagged options to Image.pip_install

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -1011,13 +1011,16 @@ class _Image(_Object, type_prefix="im"):
         pkgs = _flatten_str_args("pip_install", "packages", packages)
         if not pkgs:
             return self
+        elif not _validate_packages(pkgs):
+            raise InvalidError(
+                "Package list for `Image.pip_install` cannot contain other arguments;"
+                " try the `extra_args` parameter instead."
+            )
 
         def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:
             package_args = shlex.join(sorted(pkgs))
             extra_args = _make_pip_install_args(find_links, index_url, extra_index_url, pre, extra_options)
             commands = ["FROM base", f"RUN python -m pip install {package_args} {extra_args}"]
-            if not _validate_packages(pkgs):
-                _warn_invalid_packages(commands[-1].split("RUN ")[-1])
             if version > "2023.12":  # Back-compat for legacy trailing space with empty extra_args
                 commands = [cmd.strip() for cmd in commands]
             return DockerfileSpec(commands=commands, context_files={})

--- a/modal/image.py
+++ b/modal/image.py
@@ -1014,7 +1014,7 @@ class _Image(_Object, type_prefix="im"):
         elif not _validate_packages(pkgs):
             raise InvalidError(
                 "Package list for `Image.pip_install` cannot contain other arguments;"
-                " try the `extra_args` parameter instead."
+                " try the `extra_options` parameter instead."
             )
 
         def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -205,7 +205,7 @@ def test_image_python_packages(builder_version, servicer, client):
         )
         assert any("pip install pandas" + 2 * " " + "--pre" in cmd for cmd in layers[0].dockerfile_commands)
 
-    with pytest.warns(DeprecationError):
+    with pytest.raises(InvalidError, match="try the `extra_args` parameter instead"):
         app = App(image=Image.debian_slim().pip_install("--no-build-isolation", "flash-attn"))
         app.function()(dummy)
         with app.run(client=client):

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -205,7 +205,7 @@ def test_image_python_packages(builder_version, servicer, client):
         )
         assert any("pip install pandas" + 2 * " " + "--pre" in cmd for cmd in layers[0].dockerfile_commands)
 
-    with pytest.raises(InvalidError, match="try the `extra_args` parameter instead"):
+    with pytest.raises(InvalidError, match="try the `extra_options` parameter instead"):
         app = App(image=Image.debian_slim().pip_install("--no-build-isolation", "flash-attn"))
         app.function()(dummy)
         with app.run(client=client):


### PR DESCRIPTION
This was a pretty old deprecation; I think it's fine to make it an error now.

Note that we have similar issues in a few other "list of arguments" Image methods but I think we might need to live with them for 1.0.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Passing flagged options to the `Image.pip_install` package list will now raise an error. Use the `extra_options`  parameter for additional flags that aren't exposed through the `Image.pip_install` signature:
  ```python
  image.pip_install("flash-attn", "--no-build-isolation")  # This is now an error!
  image.pip_install("flash-attn", extra_options="--no-build-isolation")  # Correct spelling
  ```
