### PR TITLE
Update modal.Dict docstring to reflect new Dict behavior.

### DIFF
--- a/modal/dict.py
+++ b/modal/dict.py
@@ -38,6 +38,10 @@ class _Dict(_Object, type_prefix="di"):
     An individual Dict entry will expire after 7 days of inactivity (no reads or writes). The
     Dict entries are written to durable storage.
 
+    Legacy Dicts (created before 2025-05-21) will still have entries expire 30 days after being
+    last added. Additionally, data are stored in memory on the Modal server and could be lost due to
+    unexpected server restarts. Eventually, these Dicts will be fully sunset.
+
     **Usage**
 
     ```python

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -35,10 +35,8 @@ class _Dict(_Object, type_prefix="di"):
 
     **Lifetime of a Dict and its items**
 
-    An individual dict entry will expire 30 days after it was last added to its Dict object.
-    Additionally, data are stored in memory on the Modal server and could be lost due to
-    unexpected server restarts. Because of this, `Dict` is best suited for storing short-term
-    state and is not recommended for durable storage.
+    An individual Dict entry will expire after 7 days of inactivity (no reads or writes). The
+    Dict entries are written to durable storage.
 
     **Usage**
 

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -38,7 +38,7 @@ class _Dict(_Object, type_prefix="di"):
     An individual Dict entry will expire after 7 days of inactivity (no reads or writes). The
     Dict entries are written to durable storage.
 
-    Legacy Dicts (created before 2025-05-21) will still have entries expire 30 days after being
+    Legacy Dicts (created before 2025-05-20) will still have entries expire 30 days after being
     last added. Additionally, data are stored in memory on the Modal server and could be lost due to
     unexpected server restarts. Eventually, these Dicts will be fully sunset.
 


### PR DESCRIPTION
## Describe your changes

SVC-519

Won't submit until all new dicts have the new backend enabled.

## Changelog

- New `modal.Dict`s (forthcoming on 2025-05-20) use a new durable storage backend that is more "cache-like" - items expire after 7 days of inactivity (no reads or writes). Previously created `modal.Dict`s will continue to use the old backend, but support will eventually be dropped.
