### PR TITLE
Add proto support for future put if_not_exists Dict feature.

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1112,9 +1112,11 @@ message DictPopResponse {
 message DictUpdateRequest {
   string dict_id = 1 [ (modal.options.audit_target_attr) = true ];
   repeated DictEntry updates = 2;
+  bool if_not_exists = 3;
 }
 
 message DictUpdateResponse {
+  bool created = 1;
 }
 
 message Domain {


### PR DESCRIPTION
## Describe your changes

SVC-519

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [X] Client+Server: this change is compatible with old servers
- [X] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.
