### PR TITLE
Add support for Dict put skip_if_exists.

### DIFF
--- a/modal/dict.py
+++ b/modal/dict.py
@@ -35,10 +35,12 @@ class _Dict(_Object, type_prefix="di"):
 
     **Lifetime of a Dict and its items**
 
-    An individual dict entry will expire 30 days after it was last added to its Dict object.
-    Additionally, data are stored in memory on the Modal server and could be lost due to
-    unexpected server restarts. Because of this, `Dict` is best suited for storing short-term
-    state and is not recommended for durable storage.
+    An individual Dict entry will expire after 7 days of inactivity (no reads or writes). The
+    Dict entries are written to durable storage.
+
+    Legacy Dicts (created before 2025-05-20) will still have entries expire 30 days after being
+    last added. Additionally, data are stored in memory on the Modal server and could be lost due to
+    unexpected server restarts. Eventually, these Dicts will be fully sunset.
 
     **Usage**
 

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -275,11 +275,11 @@ class _Dict(_Object, type_prefix="di"):
                 raise exc
 
     @live_method
-    async def put(self, key: Any, value: Any) -> None:
+    async def put(self, key: Any, value: Any, *, if_not_exists: bool = False) -> None:
         """Add a specific key-value pair to the dictionary."""
         updates = {key: value}
         serialized = _serialize_dict(updates)
-        req = api_pb2.DictUpdateRequest(dict_id=self.object_id, updates=serialized)
+        req = api_pb2.DictUpdateRequest(dict_id=self.object_id, updates=serialized, if_not_exists=if_not_exists)
         try:
             await retry_transient_errors(self._client.stub.DictUpdate, req)
         except GRPCError as exc:

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -275,15 +275,15 @@ class _Dict(_Object, type_prefix="di"):
                 raise exc
 
     @live_method
-    async def put(self, key: Any, value: Any, *, if_not_exists: bool = False) -> bool:
+    async def put(self, key: Any, value: Any, *, skip_if_exists: bool = False) -> bool:
         """Add a specific key-value pair to the dictionary.
 
         Returns True if the key-value pair was added and False if it wasn't because the key already existed and
-        `if_not_exists` was set.
+        `skip_if_exists` was set.
         """
         updates = {key: value}
         serialized = _serialize_dict(updates)
-        req = api_pb2.DictUpdateRequest(dict_id=self.object_id, updates=serialized, if_not_exists=if_not_exists)
+        req = api_pb2.DictUpdateRequest(dict_id=self.object_id, updates=serialized, if_not_exists=skip_if_exists)
         try:
             resp = await retry_transient_errors(self._client.stub.DictUpdate, req)
             return resp.created

--- a/test/dict_test.py
+++ b/test/dict_test.py
@@ -64,9 +64,9 @@ def test_dict_update(servicer, client):
         assert sorted(items) == [("bar", 2), ("baz", 4), ("foo", 3)]
 
 
-def test_dict_put_if_not_exists(client):
+def test_dict_put_skip_if_exists(client):
     with Dict.ephemeral(client=client, _heartbeat_sleep=1) as d:
-        assert d.put("foo", 1, if_not_exists=True)
-        assert not d.put("foo", 2, if_not_exists=True)
+        assert d.put("foo", 1, skip_if_exists=True)
+        assert not d.put("foo", 2, skip_if_exists=True)
         items = list(d.items())
         assert items == [("foo", 1)]

--- a/test/dict_test.py
+++ b/test/dict_test.py
@@ -62,3 +62,11 @@ def test_dict_update(servicer, client):
         d.update({"foo": 1, "bar": 2}, foo=3, baz=4)
         items = list(d.items())
         assert sorted(items) == [("bar", 2), ("baz", 4), ("foo", 3)]
+
+
+def test_dict_put_if_not_exists(client):
+    with Dict.ephemeral(client=client, _heartbeat_sleep=1) as d:
+        assert d.put("foo", 1, if_not_exists=True)
+        assert not d.put("foo", 2, if_not_exists=True)
+        items = list(d.items())
+        assert items == [("foo", 1)]


### PR DESCRIPTION
## Describe your changes

SVC-519

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [X] Client+Server: this change is compatible with old servers
- [X] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

## Changelog

- New `modal.Dict`s (forthcoming on 2025-05-20) use a new durable storage backend with more "cache-like" behavior - items expire after 7 days of inactivity (no reads or writes). Previously created `modal.Dict`s will continue to use the old backend, but support will eventually be dropped.
- `modal.Dict.put` now supports an `skip_if_exists` flag that can be used to avoid overwriting the value for existing keys:

  ```
  item_created = my_dict.put("foo", "bar", skip_if_exists=True)
  assert item_created
  new_item_created = my_dict.put("foo", "baz", skip_if_exists=True)
  assert not new_item_created
  ```

  Note that this flag only works for `modal.Dict` objects with the new backend (forthcoming on 2025-05-20) and will raise an error otherwise.