### PR TITLE
Revert "Support relative paths in ignore files (#3049)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,7 @@ We appreciate your patience while we speedily work towards a stable release of t
 
 ### 0.75.0 (2025-05-08)
 
-- Fixes the behavior of `ignore=` in `modal.Image` methods. Exclusion patterns are now correctly interpreted as relative to the directory being added (e.g., `*.json` will now ignore all json files in the top-level of the directory). The fix also affects the interpretation of patterns in `.dockerignore` files used by `modal.Image.from_dockerfile`. **This involves two breaking changes:**
-    - When providing a custom function to `ignore=`, file paths passed into the function will now be _relative_, rather than absolute.
-    - When providing ignore patterns (either as strings or in a `dockerignore` file), an error will be raised if any of the pattens are absolute paths.
-
+- This release contained some changes to the interpretation of `ignore=` patterns and `.dockerignore` contents that were reverted in a subsequent release due to defects.
 
 
 ### 0.74.63 (2025-05-08)

--- a/modal/file_pattern_matcher.py
+++ b/modal/file_pattern_matcher.py
@@ -94,8 +94,6 @@ class FilePatternMatcher(_AbstractPatternMatcher):
                     raise ValueError('Illegal exclusion pattern: "!"')
                 new_pattern.exclusion = True
                 pattern = pattern[1:]
-            if os.path.isabs(pattern):
-                raise ValueError("Ignore patterns cannot be absolute paths")
             # In Python, we can proceed without explicit syntax checking
             new_pattern.cleaned_pattern = pattern
             new_pattern.dirs = pattern.split(os.path.sep)

--- a/modal/image.py
+++ b/modal/image.py
@@ -279,9 +279,8 @@ def _create_context_mount(
     include_fn = FilePatternMatcher(*copy_patterns)
 
     def ignore_with_include(source: Path) -> bool:
-        if source.is_absolute():
-            source = source.relative_to(context_dir)
-        if not include_fn(source) or ignore_fn(source):
+        relative_source = source.relative_to(context_dir)
+        if not include_fn(relative_source) or ignore_fn(relative_source):
             return True
 
         return False

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -153,9 +153,9 @@ class _MountDir(_MountEntry):
 
         for local_filename in gen:
             local_path = Path(local_filename)
-            rel_local_path = local_path.relative_to(local_dir)
-            if not self.ignore(rel_local_path):
-                mount_path = self.remote_path / rel_local_path.as_posix()
+            if not self.ignore(local_path):
+                local_relpath = local_path.expanduser().absolute().relative_to(local_dir)
+                mount_path = self.remote_path / local_relpath.as_posix()
                 yield local_path.resolve(), mount_path
 
     def watch_entry(self):
@@ -339,8 +339,8 @@ class _Mount(_Object, type_prefix="mo"):
         return _Mount._new()._extend(
             _MountDir(
                 local_dir=local_path,
-                remote_path=remote_path,
                 ignore=ignore,
+                remote_path=remote_path,
                 recursive=True,
             ),
         )

--- a/modal_version/_version_generated.py
+++ b/modal_version/_version_generated.py
@@ -1,4 +1,4 @@
 # Copyright Modal Labs 2025
 
 # Note: Reset this value to -1 whenever you make a minor `0.X` release of the client.
-build_number = 1  # git: 0f5c526
+build_number = 1

--- a/test/file_pattern_matcher_test.py
+++ b/test/file_pattern_matcher_test.py
@@ -272,11 +272,6 @@ def test_match():
             assert FilePatternMatcher(pattern)._matches(text) is expected
 
 
-def test_absolute_path_error():
-    with pytest.raises(ValueError, match="cannot be absolute paths"):
-        FilePatternMatcher("/home/data/")
-
-
 def __helper_get_file_paths(tmp_path: Path) -> list[Path]:
     file_paths = []
     for root, _, files in os.walk(tmp_path):

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -906,47 +906,6 @@ def test_image_dockerfile_copy_ignore_from_file(builder_version, servicer, clien
         }
 
 
-@pytest.mark.parametrize("use_dockerfile", (True, False))
-@pytest.mark.usefixtures("tmp_cwd")
-def test_image_dockerfile_ignore_context_dir(builder_version, servicer, client, use_dockerfile):
-    rel_top_dir = Path("top")
-    rel_top_dir.mkdir()
-    (rel_top_dir / "data.txt").write_text("world")
-    (rel_top_dir / "file.py").write_text("world")
-
-    sub_dir = rel_top_dir / "sub"
-    sub_dir.mkdir()
-    (sub_dir / "notes.txt").write_text("whatever")
-
-    docker_cmd = "COPY . /dummy"
-    dockerfile = rel_top_dir / "Dockerfile"
-    dockerfile.write_text(docker_cmd + "\n")
-
-    dockerignore = rel_top_dir / ".dockerignore"
-    dockerignore.write_text("*.txt")
-
-    app = App()
-    if use_dockerfile:
-        image = Image.debian_slim().from_dockerfile(dockerfile, context_dir=rel_top_dir)
-        layer = 1
-    else:
-        image = Image.debian_slim().dockerfile_commands([docker_cmd], context_dir=rel_top_dir)
-        layer = 0
-    app.function(image=image)(dummy)
-
-    with app.run(client=client):
-        layers = get_image_layers(image.object_id, servicer)
-        assert docker_cmd in layers[layer].dockerfile_commands
-        mount_id = layers[layer].context_mount_id
-        files = set(Path(fn) for fn in servicer.mount_contents[mount_id].keys())
-        assert files == {
-            Path("/") / "Dockerfile",
-            Path("/") / ".dockerignore",
-            Path("/") / "file.py",
-            Path("/") / "sub" / "notes.txt",
-        }
-
-
 @pytest.mark.parametrize("use_callable", (True, False))
 @pytest.mark.parametrize("use_dockerfile", (True, False))
 @pytest.mark.usefixtures("tmp_cwd")
@@ -989,7 +948,7 @@ def test_dockerfile_context_dir(builder_version, servicer, client):
         (Path(context_dir) / "file.py").write_text("world")
 
         image = Image.debian_slim().dockerfile_commands(["COPY . /"], context_dir=context_dir)
-        app = App(include_source=False)
+        app = App()
         app.function(image=image)(dummy)
         with app.run(client=client):
             layers = get_image_layers(image.object_id, servicer)
@@ -1844,37 +1803,17 @@ def test_image_local_dir_ignore_patterns(servicer, client, tmp_path_with_content
             assert len(img._mount_layers) == 0
             layers = get_image_layers(img.object_id, servicer)
             mount_id = layers[0].context_mount_id
+            assert set(servicer.mount_contents[mount_id].keys()) == {f"/place{f}" for f in expected}
         else:
             assert len(img._mount_layers) == 1
             mount_id = img._mount_layers[0].object_id
-        assert servicer.mount_contents[mount_id].keys() == {f"/place{f}" for f in expected}
-
-
-@pytest.mark.parametrize("copy", [True, False])
-def test_image_local_dir_ignore_relative(servicer, client, tmp_path_with_content, copy):
-    assert (tmp_path_with_content / "data.txt").exists()
-    app = App()
-
-    img = Image.from_registry("unknown_image").add_local_dir(
-        tmp_path_with_content, "/place", ignore=["*.txt"], copy=copy
-    )
-
-    app.function(image=img)(dummy)
-    with app.run(client=client):
-        if copy:
-            assert len(img._mount_layers) == 0
-            layers = get_image_layers(img.object_id, servicer)
-            mount_id = layers[0].context_mount_id
-        else:
-            assert len(img._mount_layers) == 1
-            mount_id = img._mount_layers[0].object_id
-        assert "/place/data.txt" not in servicer.mount_contents[mount_id].keys()
+            assert set(servicer.mount_contents[mount_id].keys()) == {f"/place{f}" for f in expected}
 
 
 @pytest.mark.parametrize("copy", [True, False])
 def test_image_add_local_dir_ignore_callable(servicer, client, tmp_path_with_content, copy):
-    def ignore(x: Path):
-        return str(x) != "data.txt"
+    def ignore(x):
+        return x != tmp_path_with_content / "data.txt"
 
     expected = {"/place/data.txt"}
     app = App()


### PR DESCRIPTION
This reverts commit 0f7fb1e88fe4c3843c89697185134182eab53ab4.

## Changelog

- Reverts defective changes to the interpretation of `ignore=` patterns and `.dockerignore` files that were introduced in v0.75.0.