### PR TITLE
Fix issue with .spawn_map producing wrong number of arguments

### DIFF
--- a/modal/parallel_map.py
+++ b/modal/parallel_map.py
@@ -496,7 +496,7 @@ async def _spawn_map_async(self, *input_iterators, kwargs={}) -> None:
         errors, log a warning that the function call is waiting to be created.
         """
 
-        return self._spawn_map_inner.aio(args, kwargs, api_pb2.FUNCTION_CALL_INVOCATION_TYPE_ASYNC)
+        return self._spawn_map_inner.aio(*args, **kwargs)
 
     input_gen = async_zip(*[sync_or_async_iter(it) for it in input_iterators])
 


### PR DESCRIPTION
## Describe your changes

- _Provide Linear issue reference (e.g. MOD-1234) if available._

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Fixed issue with .spawn_map producing wrong number of arguments

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
