### PR TITLE
Add `Cls.with_concurrency` and `Cls.with_batching`

### DIFF
--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -157,7 +157,7 @@ def test_class_with_options(client, servicer):
             Foo.with_options(concurrency_limit=10)()  # type: ignore
 
 
-def test_class_multiple_overrides(client, servicer):
+def test_class_multiple_override_methods(client, servicer):
     foo = (
         Foo.with_options(max_containers=1)
         .with_batching(max_batch_size=10, wait_ms=10)
@@ -174,6 +174,17 @@ def test_class_multiple_overrides(client, servicer):
             assert function_bind_params.function_options.batch_linger_ms == 10
             assert function_bind_params.function_options.max_concurrent_inputs == 100
     assert res == 4
+
+
+def test_class_multiple_with_options_calls(client, servicer):
+    foo = Foo.with_options(max_containers=1).with_options(max_containers=2)()  # type: ignore
+
+    with app.run(client=client):
+        with servicer.intercept() as ctx:
+            _ = foo.bar.remote(2)
+            function_bind_params: api_pb2.FunctionBindParamsRequest
+            (function_bind_params,) = ctx.get_requests("FunctionBindParams")
+            assert function_bind_params.function_options.concurrency_limit == 2
 
 
 def test_with_options_from_name(servicer):

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -159,10 +159,10 @@ def test_class_with_options(client, servicer):
 
 def test_class_multiple_override_methods(client, servicer):
     foo = (
-        Foo.with_options(max_containers=1)
-        .with_batching(max_batch_size=10, wait_ms=10)
-        .with_concurrency(max_inputs=100)()
-    )  # type-ignore
+        Foo.with_options(max_containers=1)  # type: ignore
+        .with_batching(max_batch_size=10, wait_ms=10)  # type: ignore
+        .with_concurrency(max_inputs=100)()  # type: ignore
+    )
 
     with app.run(client=client):
         with servicer.intercept() as ctx:

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -157,6 +157,25 @@ def test_class_with_options(client, servicer):
             Foo.with_options(concurrency_limit=10)()  # type: ignore
 
 
+def test_class_multiple_overrides(client, servicer):
+    foo = (
+        Foo.with_options(max_containers=1)
+        .with_batching(max_batch_size=10, wait_ms=10)
+        .with_concurrency(max_inputs=100)()
+    )  # type-ignore
+
+    with app.run(client=client):
+        with servicer.intercept() as ctx:
+            res = foo.bar.remote(2)
+            function_bind_params: api_pb2.FunctionBindParamsRequest
+            (function_bind_params,) = ctx.get_requests("FunctionBindParams")
+            assert function_bind_params.function_options.concurrency_limit == 1
+            assert function_bind_params.function_options.batch_max_size == 10
+            assert function_bind_params.function_options.batch_linger_ms == 10
+            assert function_bind_params.function_options.max_concurrent_inputs == 100
+    assert res == 4
+
+
 def test_with_options_from_name(servicer):
     unhydrated_volume = modal.Volume.from_name("some_volume", create_if_missing=True)
     unhydrated_secret = modal.Secret.from_dict({"foo": "bar"})


### PR DESCRIPTION
## Describe your changes

- Closes CLI-364

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Introduced `modal.Cls.with_concurrency` and `modal.Cls.with_batching` for runtime configuration of functionality that is exposed through the `@modal.concurrent` and `@modal.batched` decorators.
  ```python
  model = Model.with_options(gpu="H100").with_concurrency(max_inputs=100)()
  ```
- Added a deprecation warning when using `allow_concurrent_inputs` in `modal.Cls.with_options`.
- Added `buffer_containers` to `modal.Cls.with_options`.
- *Behavior change:* when `modal.Cls.with_options` is called multiple times on the same object, the configurations will be merged rather than using the most recent.