### PR TITLE
Add AttemptRetry to client protos

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -584,6 +584,17 @@ message AttemptAwaitResponse {
   optional FunctionGetOutputsItem output = 1;
 }
 
+message AttemptRetryRequest {
+  string function_id = 1;
+  string parent_input_id = 2;
+  FunctionPutInputsItem input = 3;
+  string attempt_token = 4;
+}
+
+message AttemptRetryResponse {
+  string attempt_token = 1;
+}
+
 message AttemptStartRequest {
   string function_id = 1;
   string parent_input_id = 2;
@@ -3132,6 +3143,7 @@ service ModalClient {
   // These RPCs are experimental, not deployed to production, and can be changed / removed
   // without needing to worry about backwards compatibility.
   rpc AttemptAwait(AttemptAwaitRequest) returns (AttemptAwaitResponse);
+  rpc AttemptRetry(AttemptRetryRequest) returns (AttemptRetryResponse);
   rpc AttemptStart(AttemptStartRequest) returns (AttemptStartResponse);
 
   // Blobs


### PR DESCRIPTION
This is a new API being added for the new input plane service.

Closes SVC-491
---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
