### PR TITLE
Reapply changes to ignore pattern interpretation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,10 @@ We appreciate your patience while we speedily work towards a stable release of t
 
 ### 0.75.0 (2025-05-08)
 
-- This release contained some changes to the interpretation of `ignore=` patterns and `.dockerignore` contents that were reverted in a subsequent release due to defects.
+- Fixes the behavior of `ignore=` in `modal.Image` methods. Exclusion patterns are now correctly interpreted as relative to the directory being added (e.g., `*.json` will now ignore all json files in the top-level of the directory). The fix also affects the interpretation of patterns in `.dockerignore` files used by `modal.Image.from_dockerfile`. **This involves two breaking changes:**
+    - When providing a custom function to `ignore=`, file paths passed into the function will now be _relative_, rather than absolute.
+    - When providing ignore patterns (either as strings or in a `dockerignore` file), an error will be raised if any of the pattens are absolute paths.
+
 
 
 ### 0.74.63 (2025-05-08)

--- a/modal/file_pattern_matcher.py
+++ b/modal/file_pattern_matcher.py
@@ -84,7 +84,7 @@ class FilePatternMatcher(_AbstractPatternMatcher):
     def _set_patterns(self, patterns: Sequence[str]) -> None:
         self.patterns = []
         for pattern in list(patterns):
-            pattern = pattern.strip().strip("/")
+            pattern = pattern.strip().strip(os.path.sep)
             if not pattern:
                 continue
             pattern = os.path.normpath(pattern)

--- a/modal/file_pattern_matcher.py
+++ b/modal/file_pattern_matcher.py
@@ -84,7 +84,7 @@ class FilePatternMatcher(_AbstractPatternMatcher):
     def _set_patterns(self, patterns: Sequence[str]) -> None:
         self.patterns = []
         for pattern in list(patterns):
-            pattern = pattern.strip()
+            pattern = pattern.strip().strip("/")
             if not pattern:
                 continue
             pattern = os.path.normpath(pattern)

--- a/modal/file_pattern_matcher.py
+++ b/modal/file_pattern_matcher.py
@@ -94,6 +94,8 @@ class FilePatternMatcher(_AbstractPatternMatcher):
                     raise ValueError('Illegal exclusion pattern: "!"')
                 new_pattern.exclusion = True
                 pattern = pattern[1:]
+            if os.path.isabs(pattern):
+                raise ValueError("Ignore patterns cannot be absolute paths")
             # In Python, we can proceed without explicit syntax checking
             new_pattern.cleaned_pattern = pattern
             new_pattern.dirs = pattern.split(os.path.sep)

--- a/modal/file_pattern_matcher.py
+++ b/modal/file_pattern_matcher.py
@@ -94,8 +94,6 @@ class FilePatternMatcher(_AbstractPatternMatcher):
                     raise ValueError('Illegal exclusion pattern: "!"')
                 new_pattern.exclusion = True
                 pattern = pattern[1:]
-            if os.path.isabs(pattern):
-                raise ValueError("Ignore patterns cannot be absolute paths")
             # In Python, we can proceed without explicit syntax checking
             new_pattern.cleaned_pattern = pattern
             new_pattern.dirs = pattern.split(os.path.sep)

--- a/modal/image.py
+++ b/modal/image.py
@@ -279,8 +279,9 @@ def _create_context_mount(
     include_fn = FilePatternMatcher(*copy_patterns)
 
     def ignore_with_include(source: Path) -> bool:
-        relative_source = source.relative_to(context_dir)
-        if not include_fn(relative_source) or ignore_fn(relative_source):
+        if source.is_absolute():
+            source = source.relative_to(context_dir)
+        if not include_fn(source) or ignore_fn(source):
             return True
 
         return False

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -153,9 +153,9 @@ class _MountDir(_MountEntry):
 
         for local_filename in gen:
             local_path = Path(local_filename)
-            if not self.ignore(local_path):
-                local_relpath = local_path.expanduser().absolute().relative_to(local_dir)
-                mount_path = self.remote_path / local_relpath.as_posix()
+            rel_local_path = local_path.relative_to(local_dir)
+            if not self.ignore(rel_local_path):
+                mount_path = self.remote_path / rel_local_path.as_posix()
                 yield local_path.resolve(), mount_path
 
     def watch_entry(self):
@@ -339,8 +339,8 @@ class _Mount(_Object, type_prefix="mo"):
         return _Mount._new()._extend(
             _MountDir(
                 local_dir=local_path,
-                ignore=ignore,
                 remote_path=remote_path,
+                ignore=ignore,
                 recursive=True,
             ),
         )

--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -7,7 +7,7 @@ from ._version_generated import build_number
 major_number = 0
 
 # Bump this manually on breaking changes, then reset the number in _version_generated.py
-minor_number = 75
+minor_number = 76
 
 # Right now, automatically increment the patch number in CI
 __version__ = f"{major_number}.{minor_number}.{max(build_number, 0)}"

--- a/modal_version/_version_generated.py
+++ b/modal_version/_version_generated.py
@@ -1,4 +1,4 @@
 # Copyright Modal Labs 2025
 
 # Note: Reset this value to -1 whenever you make a minor `0.X` release of the client.
-build_number = 8  # git: 75ded48
+build_number = -1

--- a/test/file_pattern_matcher_test.py
+++ b/test/file_pattern_matcher_test.py
@@ -272,11 +272,6 @@ def test_match():
             assert FilePatternMatcher(pattern)._matches(text) is expected
 
 
-def test_absolute_path_error():
-    with pytest.raises(ValueError, match="cannot be absolute paths"):
-        FilePatternMatcher("/home/data/")
-
-
 def __helper_get_file_paths(tmp_path: Path) -> list[Path]:
     file_paths = []
     for root, _, files in os.walk(tmp_path):

--- a/test/file_pattern_matcher_test.py
+++ b/test/file_pattern_matcher_test.py
@@ -200,6 +200,7 @@ def test_clean_patterns_error_single_exception():
 
 def test_match():
     match_tests = [
+        # (pattern , text, should_match, expected_error)
         ("abc", "abc", True, None),
         ("*", "abc", True, None),
         ("*c", "abc", True, None),
@@ -238,6 +239,10 @@ def test_match():
         ("[\\-x]", "x", True, None),
         ("[\\-x]", "-", True, None),
         ("[\\-x]", "a", False, None),
+        ("/abc", "abc", True, None),
+        ("abc/", "abc", True, None),
+        ("/abc/xyz", "abc/xyz", True, None),
+        ("/abc/xyz/", "abc/xyz", True, None),
         # These do not return errors because the Python re.compile() method does
         # not raise an error on invalid syntax like Go does. We can omit the
         # tests though since it doesn't affect behavior on _correct_ syntax.

--- a/test/file_pattern_matcher_test.py
+++ b/test/file_pattern_matcher_test.py
@@ -272,6 +272,11 @@ def test_match():
             assert FilePatternMatcher(pattern)._matches(text) is expected
 
 
+def test_absolute_path_error():
+    with pytest.raises(ValueError, match="cannot be absolute paths"):
+        FilePatternMatcher("/home/data/")
+
+
 def __helper_get_file_paths(tmp_path: Path) -> list[Path]:
     file_paths = []
     for root, _, files in os.walk(tmp_path):

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -906,6 +906,47 @@ def test_image_dockerfile_copy_ignore_from_file(builder_version, servicer, clien
         }
 
 
+@pytest.mark.parametrize("use_dockerfile", (True, False))
+@pytest.mark.usefixtures("tmp_cwd")
+def test_image_dockerfile_ignore_context_dir(builder_version, servicer, client, use_dockerfile):
+    rel_top_dir = Path("top")
+    rel_top_dir.mkdir()
+    (rel_top_dir / "data.txt").write_text("world")
+    (rel_top_dir / "file.py").write_text("world")
+
+    sub_dir = rel_top_dir / "sub"
+    sub_dir.mkdir()
+    (sub_dir / "notes.txt").write_text("whatever")
+
+    docker_cmd = "COPY . /dummy"
+    dockerfile = rel_top_dir / "Dockerfile"
+    dockerfile.write_text(docker_cmd + "\n")
+
+    dockerignore = rel_top_dir / ".dockerignore"
+    dockerignore.write_text("*.txt")
+
+    app = App()
+    if use_dockerfile:
+        image = Image.debian_slim().from_dockerfile(dockerfile, context_dir=rel_top_dir)
+        layer = 1
+    else:
+        image = Image.debian_slim().dockerfile_commands([docker_cmd], context_dir=rel_top_dir)
+        layer = 0
+    app.function(image=image)(dummy)
+
+    with app.run(client=client):
+        layers = get_image_layers(image.object_id, servicer)
+        assert docker_cmd in layers[layer].dockerfile_commands
+        mount_id = layers[layer].context_mount_id
+        files = set(Path(fn) for fn in servicer.mount_contents[mount_id].keys())
+        assert files == {
+            Path("/") / "Dockerfile",
+            Path("/") / ".dockerignore",
+            Path("/") / "file.py",
+            Path("/") / "sub" / "notes.txt",
+        }
+
+
 @pytest.mark.parametrize("use_callable", (True, False))
 @pytest.mark.parametrize("use_dockerfile", (True, False))
 @pytest.mark.usefixtures("tmp_cwd")
@@ -948,7 +989,7 @@ def test_dockerfile_context_dir(builder_version, servicer, client):
         (Path(context_dir) / "file.py").write_text("world")
 
         image = Image.debian_slim().dockerfile_commands(["COPY . /"], context_dir=context_dir)
-        app = App()
+        app = App(include_source=False)
         app.function(image=image)(dummy)
         with app.run(client=client):
             layers = get_image_layers(image.object_id, servicer)
@@ -1803,17 +1844,37 @@ def test_image_local_dir_ignore_patterns(servicer, client, tmp_path_with_content
             assert len(img._mount_layers) == 0
             layers = get_image_layers(img.object_id, servicer)
             mount_id = layers[0].context_mount_id
-            assert set(servicer.mount_contents[mount_id].keys()) == {f"/place{f}" for f in expected}
         else:
             assert len(img._mount_layers) == 1
             mount_id = img._mount_layers[0].object_id
-            assert set(servicer.mount_contents[mount_id].keys()) == {f"/place{f}" for f in expected}
+        assert servicer.mount_contents[mount_id].keys() == {f"/place{f}" for f in expected}
+
+
+@pytest.mark.parametrize("copy", [True, False])
+def test_image_local_dir_ignore_relative(servicer, client, tmp_path_with_content, copy):
+    assert (tmp_path_with_content / "data.txt").exists()
+    app = App()
+
+    img = Image.from_registry("unknown_image").add_local_dir(
+        tmp_path_with_content, "/place", ignore=["*.txt"], copy=copy
+    )
+
+    app.function(image=img)(dummy)
+    with app.run(client=client):
+        if copy:
+            assert len(img._mount_layers) == 0
+            layers = get_image_layers(img.object_id, servicer)
+            mount_id = layers[0].context_mount_id
+        else:
+            assert len(img._mount_layers) == 1
+            mount_id = img._mount_layers[0].object_id
+        assert "/place/data.txt" not in servicer.mount_contents[mount_id].keys()
 
 
 @pytest.mark.parametrize("copy", [True, False])
 def test_image_add_local_dir_ignore_callable(servicer, client, tmp_path_with_content, copy):
-    def ignore(x):
-        return x != tmp_path_with_content / "data.txt"
+    def ignore(x: Path):
+        return str(x) != "data.txt"
 
     expected = {"/place/data.txt"}
     app = App()


### PR DESCRIPTION
## Describe your changes

-Closes CLI-393

Second attempt at #3049 

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Fixes the behavior of `ignore=` in `modal.Image` methods, including when `.dockerignore` files are implicitly used in docker-oriented methods. This may result in Image rebuilds with different final inventories:
  - When using `modal.Image.add_local_dir`, exclusion patterns are now correctly interpreted as relative to the directory being added (e.g., `*.json` will now ignore all json files in the top-level of the directory).
  - When using `modal.Image.from_dockerfile`, exclusion patterns are correctly interpreted as relative to the context directory.
  - As in Docker, leading or trailing path delimiters are stripped from the ignore patterns before being applied.
  - **Breaking change**: When providing a custom function to `ignore=`, file paths passed into the function will now be _relative_, rather than absolute.
