### PR TITLE
fix main (broken by https://github.com/pallets/click/pull/2889)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
 dependencies = [
     "aiohttp",
     "certifi",
-    "click>=8.1.0",
+    "click~=8.1.0",
     "grpclib==0.4.7",
     "protobuf>=3.19,<7.0,!=4.24.0",
     "rich>=12.0.0",


### PR DESCRIPTION
## Describe your changes

`8.2.0` released ~2 hours ago and broke our Typer usage.

```
...
│ /home/runner/work/modal/modal/.venv/lib/python3.11/site-packages/click/core. │
│ py:1002 in format_usage                                                      │
│                                                                              │
│ /home/runner/work/modal/modal/.venv/lib/python3.11/site-packages/click/core. │
│ py:1012 in collect_usage_pieces                                              │
│                                                                              │
│ /home/runner/work/modal/modal/.venv/lib/python3.11/site-packages/click/core. │
│ py:3104 in get_usage_pieces                                                  │
╰──────────────────────────────────────────────────────────────────────────────╯
TypeError: TyperArgument.make_metavar() takes 1 positional argument but 2 were 
given
Error: Process completed with exit code 1.
```

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>
