### PR TITLE
proto changes for client dependency mounting

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1369,13 +1369,17 @@ message Function {
   // Note the value type as string. Internally we'll coerce all values to string with str().
   // On the server, it's necessary to convert back to the most natural type (e.g. int) when relevant.
   map<string, string> experimental_options = 81;
+
+  // If set, client deps will be mounted into the container, and are
+  // no longer expected to exist in the image itself.
+  bool mount_client_dependencies = 82;
 }
 
 message FunctionAsyncInvokeRequest {
   string function_id = 1;
   string parent_input_id = 2;
   FunctionInput input = 3;
-} 
+}
 
 message FunctionAsyncInvokeResponse {
   bool retry_with_blob_upload = 1;


### PR DESCRIPTION
## Describe your changes

Flag on Function for requesting dependency mounts at runtime. Additional
associated metadata on ImageMetadata.

<details> <summary>Backward/forward compatibility checks</summary>

---

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>