### PR TITLE
Fix client checkout in CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           token: ${{ steps.generate_token.outputs.token }}
-          depth: 2  # Needed so that we can check whether the version file was modified
+          fetch-depth: 2  # Needed so that we can check whether the version file was modified
 
       - uses: ./.github/actions/setup-cached-python
         with:


### PR DESCRIPTION
Followup to #3115. Used the wrong name for a github actions option.