### PR TITLE
Fix the version filename when pushing back to main

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -58,7 +58,7 @@ jobs:
 
       - uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9
         with:
-          add: modal_version/_version_generated.py CHANGELOG.md
+          add: modal_version/__init__.py CHANGELOG.md
           tag: ${{ steps.metadata.outputs.release_tag }}
           message: "[auto-commit] [skip ci] Bump the build number"
           pull: "--rebase --autostash"

--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -1,4 +1,4 @@
 # Copyright Modal Labs 2025
 """Supplies the current version of the modal client library."""
 
-__version__ = "0.76.3"
+__version__ = "0.76.4.dev0"


### PR DESCRIPTION
Followup to #3115; forgot to update the name of the file that we explicitly add when updating the version.