### PR TITLE
Manually update development version correctly

### DIFF
--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -1,4 +1,4 @@
 # Copyright Modal Labs 2025
 """Supplies the current version of the modal client library."""
 
-__version__ = "0.76.4.dev0"
+__version__ = "0.76.4.dev1"


### PR DESCRIPTION
Followup to #3118 

Fussy fussy; when manually updating the development version need to remember to set it to the _next_ version now.