### PR TITLE
Allow empty commit when tagging releases

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -56,10 +56,11 @@ jobs:
 
       - uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9
         with:
-          add: modal_version/__init__.py CHANGELOG.md
-          tag: ${{ steps.tag.outputs.release_tag }}
-          message: "[auto-commit] [skip ci] Bump the build number"
           pull: "--rebase --autostash"
+          add: modal_version/__init__.py CHANGELOG.md
+          commit: "--allow-empty"
+          message: "[auto-commit] [skip ci] Bump the build number"
+          tag: ${{ steps.tag.outputs.release_tag }}
           default_author: github_actions
 
       - name: Get release hash


### PR DESCRIPTION
Should avoid the problem we ran into where because "release" commits manually update the version and changelog, there's nothing changed in the `client-versioning` workflow so the `add-and-commit` action bails out early and fails to tag the release.