### PR TITLE
Abandon use of local info (git hash) in dev versions

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -325,7 +325,7 @@ def bump_dev_version(ctx, dry_run: bool = False, force: bool = False):
     """
     version_file = "modal_version/__init__.py"
     commit_files = ctx.run("git diff --name-only HEAD~1 HEAD", hide="out").stdout.splitlines()
-    if version_file in commit_files:
+    if version_file in commit_files and not force:
         print(f"Aborting: {version_file} was modified by the most recent commit")
         return
 
@@ -333,16 +333,14 @@ def bump_dev_version(ctx, dry_run: bool = False, force: bool = False):
 
     v = Version(__version__)
 
-    git_hash = ctx.run("git rev-parse --short=8 HEAD", hide="out").stdout.rstrip()
-
     if v.is_prerelease:
         if not v.is_devrelease:
             raise RuntimeError("We only know how to auto-bump dev versions")
         # For dev releases, increment the dev suffix
-        next_version = f"{v.major}.{v.minor}.{v.micro}.dev{v.dev + 1}+{git_hash}"
+        next_version = f"{v.major}.{v.minor}.{v.micro}.dev{v.dev + 1}"
     else:
         # If the most recent commit was *not* a dev release, start the next cycle
-        next_version = f"{v.major}.{v.minor}.{v.micro + 1}.dev0+{git_hash}"
+        next_version = f"{v.major}.{v.minor}.{v.micro + 1}.dev0"
 
     version_file_contents = version_file_contents_template.format(next_version)
     if dry_run:


### PR DESCRIPTION
Dropping the `+{git-hash}` from our development version scheme; didn't realize this was blocked by PyPI. Since you're either getting the client from PyPI or using it via a git checkout, it doesn't seem like it adds much info.

It does seem to be a relatively common scheme, but now I'm not sure why; I guess if you log your version you get the get metadata as a bonus. We can revisit it the reverse lookup from dev version to commit feels a lot harder going forward. (Previously we had a tag for every commit, so it was a bit more straightforward).