### PR TITLE
Update client version in channel tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -423,7 +423,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
                 for method_name, method_definition in definition.method_definitions.items()
             },
             function_schema=definition.function_schema,
-            input_plane_url=self._get_input_plane_url(definition)
+            input_plane_url=self._get_input_plane_url(definition),
         )
 
     def get_object_metadata(self, object_id) -> api_pb2.Object:
@@ -1101,7 +1101,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
                     },
                     class_parameter_info=function_defn.class_parameter_info,
                     function_schema=function_defn.function_schema,
-                    input_plane_url=self._get_input_plane_url(function_defn)
+                    input_plane_url=self._get_input_plane_url(function_defn),
                 ),
                 server_warnings=warnings,
             )
@@ -2102,6 +2102,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
                 )
             )
         )
+
 
 @pytest.fixture
 def blob_server():

--- a/test/grpc_utils_test.py
+++ b/test/grpc_utils_test.py
@@ -4,6 +4,7 @@ import time
 
 from grpclib import GRPCError, Status
 
+from modal import __version__
 from modal._utils.async_utils import synchronize_api
 from modal._utils.grpc_utils import connect_channel, create_channel, retry_transient_errors
 from modal_proto import api_grpc, api_pb2
@@ -17,7 +18,7 @@ async def test_http_channel(servicer, credentials):
     metadata = {
         "x-modal-client-type": str(api_pb2.CLIENT_TYPE_CLIENT),
         "x-modal-python-version": "3.12.1",
-        "x-modal-client-version": "0.99",
+        "x-modal-client-version": __version__,
         "x-modal-token-id": token_id,
         "x-modal-token-secret": token_secret,
     }
@@ -38,7 +39,7 @@ async def test_unix_channel(servicer):
     metadata = {
         "x-modal-client-type": str(api_pb2.CLIENT_TYPE_CONTAINER),
         "x-modal-python-version": "3.12.1",
-        "x-modal-client-version": "0.99",
+        "x-modal-client-version": __version__,
     }
     assert servicer.container_addr.startswith("unix://")
     channel = create_channel(servicer.container_addr)


### PR DESCRIPTION
I don't really understand why these were hardcoded, but they broken when I set the version to `1.0.0.dev0`.