### PR TITLE
[input-plane] Return FunctionRetryPolicy in FunctionHandleMetadata

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1667,6 +1667,7 @@ message FunctionHandleMetadata {
   map<string, FunctionHandleMetadata> method_handle_metadata = 44;
   FunctionSchema function_schema = 45;
   optional string input_plane_url = 46;
+  FunctionRetryPolicy retry_policy = 47;
 }
 
 message FunctionInput {


### PR DESCRIPTION
Closes SVC-491

Currently we return the retry policy in FunctionMap. With the new input-plane, this would mean we need to return the retry policy in AttemptStart. But we can simplify things if we instead return the policy in FunctionCreate/FunctionGet. That way this information can come from the control plane, and the input plane doesn't have to know about it at all. See [this section of the input-plane API doc](https://www.notion.so/modal-com/Standalone-IO-Microservice-API-1b61e7f1694980ffbafec4478ec92269?pvs=4#1c01e7f16949800a9137dafdaeb1896c) for more info.


---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
