### PR TITLE
Add `--timestamps` flag to `modal app logs`, that prepends timestamps

### DIFF
--- a/modal/_utils/time_utils.py
+++ b/modal/_utils/time_utils.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+
+
+def timestamp_to_local(ts: float, isotz: bool = True) -> str:
+    if ts > 0:
+        locale_tz = datetime.now().astimezone().tzinfo
+        dt = datetime.fromtimestamp(ts, tz=locale_tz)
+        if isotz:
+            return dt.isoformat(sep=" ", timespec="seconds")
+        else:
+            return f"{datetime.strftime(dt, '%Y-%m-%d %H:%M')} {locale_tz.tzname(dt)}"
+    else:
+        return None

--- a/modal/_utils/time_utils.py
+++ b/modal/_utils/time_utils.py
@@ -1,7 +1,9 @@
+# Copyright Modal Labs 2025
 from datetime import datetime
+from typing import Optional
 
 
-def timestamp_to_local(ts: float, isotz: bool = True) -> str:
+def timestamp_to_local(ts: float, isotz: bool = True) -> Optional[str]:
     if ts > 0:
         locale_tz = datetime.now().astimezone().tzinfo
         dt = datetime.fromtimestamp(ts, tz=locale_tz)

--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -16,7 +16,8 @@ from modal.client import _Client
 from modal.environments import ensure_env
 from modal_proto import api_pb2
 
-from .utils import ENV_OPTION, display_table, get_app_id_from_name, stream_app_logs, timestamp_to_local
+from .._utils.time_utils import timestamp_to_local
+from .utils import ENV_OPTION, display_table, get_app_id_from_name, stream_app_logs
 
 APP_IDENTIFIER = Argument("", help="App name or ID")
 NAME_OPTION = typer.Option("", "-n", "--name", help="Deprecated: Pass App name as a positional argument")

--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -99,6 +99,7 @@ def logs(
     *,
     name: str = NAME_OPTION,
     env: Optional[str] = ENV_OPTION,
+    timestamps: bool = typer.Option(False, "--timestamps", help="Show timestamps for each log line"),
 ):
     """Show App logs, streaming while active.
 
@@ -119,7 +120,7 @@ def logs(
     """
     app_identifier = warn_on_name_option("logs", app_identifier, name)
     app_id = get_app_id(app_identifier, env)
-    stream_app_logs(app_id)
+    stream_app_logs(app_id, show_timestamps=timestamps)
 
 
 @app_cli.command("rollback", no_args_is_help=True, context_settings={"ignore_unknown_options": True})

--- a/modal/cli/cluster.py
+++ b/modal/cli/cluster.py
@@ -8,7 +8,8 @@ from rich.text import Text
 from modal._object import _get_environment_name
 from modal._pty import get_pty_info
 from modal._utils.async_utils import synchronizer
-from modal.cli.utils import ENV_OPTION, display_table, is_tty, timestamp_to_local
+from modal._utils.time_utils import timestamp_to_local
+from modal.cli.utils import ENV_OPTION, display_table, is_tty
 from modal.client import _Client
 from modal.config import config
 from modal.container_process import _ContainerProcess

--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -8,7 +8,8 @@ from modal._object import _get_environment_name
 from modal._pty import get_pty_info
 from modal._utils.async_utils import synchronizer
 from modal._utils.grpc_utils import retry_transient_errors
-from modal.cli.utils import ENV_OPTION, display_table, is_tty, stream_app_logs, timestamp_to_local
+from modal._utils.time_utils import timestamp_to_local
+from modal.cli.utils import ENV_OPTION, display_table, is_tty, stream_app_logs
 from modal.client import _Client
 from modal.config import config
 from modal.container_process import _ContainerProcess

--- a/modal/cli/dict.py
+++ b/modal/cli/dict.py
@@ -8,7 +8,8 @@ from typer import Argument, Option, Typer
 from modal._resolver import Resolver
 from modal._utils.async_utils import synchronizer
 from modal._utils.grpc_utils import retry_transient_errors
-from modal.cli.utils import ENV_OPTION, YES_OPTION, display_table, timestamp_to_local
+from modal._utils.time_utils import timestamp_to_local
+from modal.cli.utils import ENV_OPTION, YES_OPTION, display_table
 from modal.client import _Client
 from modal.dict import _Dict
 from modal.environments import ensure_env

--- a/modal/cli/network_file_system.py
+++ b/modal/cli/network_file_system.py
@@ -17,8 +17,9 @@ from modal._location import display_location
 from modal._output import OutputManager, ProgressHandler
 from modal._utils.async_utils import synchronizer
 from modal._utils.grpc_utils import retry_transient_errors
+from modal._utils.time_utils import timestamp_to_local
 from modal.cli._download import _volume_download
-from modal.cli.utils import ENV_OPTION, YES_OPTION, display_table, timestamp_to_local
+from modal.cli.utils import ENV_OPTION, YES_OPTION, display_table
 from modal.client import _Client
 from modal.environments import ensure_env
 from modal.network_file_system import _NetworkFileSystem

--- a/modal/cli/queues.py
+++ b/modal/cli/queues.py
@@ -8,7 +8,8 @@ from typer import Argument, Option, Typer
 from modal._resolver import Resolver
 from modal._utils.async_utils import synchronizer
 from modal._utils.grpc_utils import retry_transient_errors
-from modal.cli.utils import ENV_OPTION, YES_OPTION, display_table, timestamp_to_local
+from modal._utils.time_utils import timestamp_to_local
+from modal.cli.utils import ENV_OPTION, YES_OPTION, display_table
 from modal.client import _Client
 from modal.environments import ensure_env
 from modal.queue import _Queue

--- a/modal/cli/secret.py
+++ b/modal/cli/secret.py
@@ -13,7 +13,8 @@ from typer import Argument
 
 from modal._utils.async_utils import synchronizer
 from modal._utils.grpc_utils import retry_transient_errors
-from modal.cli.utils import ENV_OPTION, YES_OPTION, display_table, timestamp_to_local
+from modal._utils.time_utils import timestamp_to_local
+from modal.cli.utils import ENV_OPTION, YES_OPTION, display_table
 from modal.client import _Client
 from modal.environments import ensure_env
 from modal.secret import _Secret

--- a/modal/cli/utils.py
+++ b/modal/cli/utils.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2022
 import asyncio
 from collections.abc import Sequence
-from datetime import datetime
 from json import dumps
 from typing import Optional, Union
 
@@ -59,18 +58,6 @@ async def get_app_id_from_name(name: str, env: Optional[str], client: Optional[_
         env_comment = f" in the '{env_name}' environment" if env_name else ""
         raise NotFoundError(f"Could not find a deployed app named '{name}'{env_comment}.")
     return resp.app_id
-
-
-def timestamp_to_local(ts: float, isotz: bool = True) -> str:
-    if ts > 0:
-        locale_tz = datetime.now().astimezone().tzinfo
-        dt = datetime.fromtimestamp(ts, tz=locale_tz)
-        if isotz:
-            return dt.isoformat(sep=" ", timespec="seconds")
-        else:
-            return f"{datetime.strftime(dt, '%Y-%m-%d %H:%M')} {locale_tz.tzname(dt)}"
-    else:
-        return None
 
 
 def _plain(text: Union[Text, str]) -> str:

--- a/modal/cli/utils.py
+++ b/modal/cli/utils.py
@@ -22,10 +22,13 @@ from ..exception import NotFoundError
 
 @synchronizer.create_blocking
 async def stream_app_logs(
-    app_id: Optional[str] = None, task_id: Optional[str] = None, app_logs_url: Optional[str] = None
+    app_id: Optional[str] = None,
+    task_id: Optional[str] = None,
+    app_logs_url: Optional[str] = None,
+    show_timestamps: bool = False,
 ):
     client = await _Client.from_env()
-    output_mgr = OutputManager(status_spinner_text=f"Tailing logs for {app_id}")
+    output_mgr = OutputManager(status_spinner_text=f"Tailing logs for {app_id}", show_timestamps=show_timestamps)
     try:
         with output_mgr.show_status_spinner():
             await get_app_logs_loop(client, output_mgr, app_id=app_id, task_id=task_id, app_logs_url=app_logs_url)

--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -15,8 +15,9 @@ import modal
 from modal._output import OutputManager, ProgressHandler
 from modal._utils.async_utils import synchronizer
 from modal._utils.grpc_utils import retry_transient_errors
+from modal._utils.time_utils import timestamp_to_local
 from modal.cli._download import _volume_download
-from modal.cli.utils import ENV_OPTION, YES_OPTION, display_table, timestamp_to_local
+from modal.cli.utils import ENV_OPTION, YES_OPTION, display_table
 from modal.client import _Client
 from modal.environments import ensure_env
 from modal.volume import _AbstractVolumeUploadContextManager, _Volume
@@ -203,7 +204,7 @@ async def put(
                     vol.object_id,
                     vol._client,
                     progress_cb=progress_handler.progress,
-                    force=force
+                    force=force,
                 ) as batch:
                     batch.put_directory(local_path, remote_path)
             except FileExistsError as exc:
@@ -219,7 +220,7 @@ async def put(
                     vol.object_id,
                     vol._client,
                     progress_cb=progress_handler.progress,
-                    force=force
+                    force=force,
                 ) as batch:
                     batch.put_file(local_path, remote_path)
 


### PR DESCRIPTION
## Describe your changes

Resolves CLI-387.

## Changelog

- Added a `--timestamps` flag to `modal app logs`, that prepends the timestamp to each log line.

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
