### PR TITLE
Remove backwards compatibility for  synonyms in object methods

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -41,7 +41,7 @@ from ._utils.async_utils import (
     synchronizer,
     warn_if_generator_is_not_consumed,
 )
-from ._utils.deprecation import deprecation_error, deprecation_warning, renamed_parameter
+from ._utils.deprecation import deprecation_error, deprecation_warning
 from ._utils.function_utils import (
     ATTEMPT_TIMEOUT_GRACE_PERIOD,
     OUTPUTS_TIMEOUT,
@@ -1255,7 +1255,6 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         return cls._from_loader(_load_remote, rep, is_another_app=True, hydrate_lazily=True)
 
     @classmethod
-    @renamed_parameter((2024, 12, 18), "tag", "name")
     def from_name(
         cls: type["_Function"],
         app_name: str,
@@ -1288,7 +1287,6 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         return cls._from_name(app_name, name, namespace, environment_name)
 
     @staticmethod
-    @renamed_parameter((2024, 12, 18), "tag", "name")
     async def lookup(
         app_name: str,
         name: str,

--- a/modal/app.py
+++ b/modal/app.py
@@ -32,7 +32,6 @@ from ._utils.async_utils import synchronize_api
 from ._utils.deprecation import (
     deprecation_error,
     deprecation_warning,
-    renamed_parameter,
     warn_on_renamed_autoscaler_settings,
 )
 from ._utils.function_utils import FunctionInfo, is_global_object, is_method_fn
@@ -251,7 +250,6 @@ class _App:
         return self._description
 
     @staticmethod
-    @renamed_parameter((2024, 12, 18), "label", "name")
     async def lookup(
         name: str,
         *,

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -25,7 +25,7 @@ from ._serialization import check_valid_cls_constructor_arg
 from ._traceback import print_server_warnings
 from ._type_manager import parameter_serde_registry
 from ._utils.async_utils import synchronize_api, synchronizer
-from ._utils.deprecation import deprecation_warning, renamed_parameter, warn_on_renamed_autoscaler_settings
+from ._utils.deprecation import deprecation_warning, warn_on_renamed_autoscaler_settings
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.mount_utils import validate_volumes
 from .client import _Client
@@ -586,7 +586,6 @@ More information on class parameterization can be found here: https://modal.com/
         return cls
 
     @classmethod
-    @renamed_parameter((2024, 12, 18), "tag", "name")
     def from_name(
         cls: type["_Cls"],
         app_name: str,
@@ -786,7 +785,6 @@ More information on class parameterization can be found here: https://modal.com/
         return cls
 
     @staticmethod
-    @renamed_parameter((2024, 12, 18), "tag", "name")
     async def lookup(
         app_name: str,
         name: str,

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -11,7 +11,7 @@ from ._object import EPHEMERAL_OBJECT_HEARTBEAT_SLEEP, _get_environment_name, _O
 from ._resolver import Resolver
 from ._serialization import deserialize, serialize
 from ._utils.async_utils import TaskContext, synchronize_api
-from ._utils.deprecation import deprecation_warning, renamed_parameter
+from ._utils.deprecation import deprecation_warning
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from .client import _Client
@@ -115,7 +115,6 @@ class _Dict(_Object, type_prefix="di"):
             yield cls._new_hydrated(response.dict_id, client, None, is_another_app=True)
 
     @staticmethod
-    @renamed_parameter((2024, 12, 18), "label", "name")
     def from_name(
         name: str,
         data: Optional[dict] = None,  # DEPRECATED
@@ -159,7 +158,6 @@ class _Dict(_Object, type_prefix="di"):
         return _Dict._from_loader(_load, "Dict()", is_another_app=True, hydrate_lazily=True)
 
     @staticmethod
-    @renamed_parameter((2024, 12, 18), "label", "name")
     async def lookup(
         name: str,
         data: Optional[dict] = None,
@@ -200,7 +198,6 @@ class _Dict(_Object, type_prefix="di"):
         return obj
 
     @staticmethod
-    @renamed_parameter((2024, 12, 18), "label", "name")
     async def delete(
         name: str,
         *,

--- a/modal/environments.py
+++ b/modal/environments.py
@@ -11,7 +11,7 @@ from modal_proto import api_pb2
 from ._object import _Object
 from ._resolver import Resolver
 from ._utils.async_utils import synchronize_api, synchronizer
-from ._utils.deprecation import deprecation_warning, renamed_parameter
+from ._utils.deprecation import deprecation_warning
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from .client import _Client
@@ -50,7 +50,6 @@ class _Environment(_Object, type_prefix="en"):
         )
 
     @staticmethod
-    @renamed_parameter((2024, 12, 18), "label", "name")
     def from_name(
         name: str,
         *,
@@ -81,7 +80,6 @@ class _Environment(_Object, type_prefix="en"):
         return _Environment._from_loader(_load, "Environment()", is_another_app=True, hydrate_lazily=True)
 
     @staticmethod
-    @renamed_parameter((2024, 12, 18), "label", "name")
     async def lookup(
         name: str,
         client: Optional[_Client] = None,

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -26,7 +26,7 @@ from ._object import _get_environment_name, _Object
 from ._resolver import Resolver
 from ._utils.async_utils import aclosing, async_map, synchronize_api
 from ._utils.blob_utils import FileUploadSpec, blob_upload_file, get_file_upload_spec_from_path
-from ._utils.deprecation import deprecation_warning, renamed_parameter
+from ._utils.deprecation import deprecation_warning
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from ._utils.package_utils import get_module_mount_info
@@ -691,7 +691,6 @@ class _Mount(_Object, type_prefix="mo"):
         return mount
 
     @staticmethod
-    @renamed_parameter((2024, 12, 18), "label", "name")
     def from_name(
         name: str,
         *,
@@ -712,7 +711,6 @@ class _Mount(_Object, type_prefix="mo"):
         return _Mount._from_loader(_load, "Mount()", hydrate_lazily=True)
 
     @classmethod
-    @renamed_parameter((2024, 12, 18), "label", "name")
     async def lookup(
         cls: type["_Mount"],
         name: str,

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -22,7 +22,7 @@ from ._object import (
 from ._resolver import Resolver
 from ._utils.async_utils import TaskContext, aclosing, async_map, sync_or_async_iter, synchronize_api
 from ._utils.blob_utils import LARGE_FILE_LIMIT, blob_iter, blob_upload_file
-from ._utils.deprecation import deprecation_warning, renamed_parameter
+from ._utils.deprecation import deprecation_warning
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.hash_utils import get_sha256_hex
 from ._utils.name_utils import check_object_name
@@ -89,7 +89,6 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
     """
 
     @staticmethod
-    @renamed_parameter((2024, 12, 18), "label", "name")
     def from_name(
         name: str,
         *,
@@ -166,7 +165,6 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
             yield cls._new_hydrated(response.shared_volume_id, client, None, is_another_app=True)
 
     @staticmethod
-    @renamed_parameter((2024, 12, 18), "label", "name")
     async def lookup(
         name: str,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
@@ -222,7 +220,6 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         return resp.shared_volume_id
 
     @staticmethod
-    @renamed_parameter((2024, 12, 18), "label", "name")
     async def delete(name: str, client: Optional[_Client] = None, environment_name: Optional[str] = None):
         obj = await _NetworkFileSystem.from_name(name, environment_name=environment_name).hydrate(client)
         req = api_pb2.SharedVolumeDeleteRequest(shared_volume_id=obj.object_id)

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -14,7 +14,7 @@ from ._object import EPHEMERAL_OBJECT_HEARTBEAT_SLEEP, _get_environment_name, _O
 from ._resolver import Resolver
 from ._serialization import deserialize, serialize
 from ._utils.async_utils import TaskContext, synchronize_api, warn_if_generator_is_not_consumed
-from ._utils.deprecation import deprecation_warning, renamed_parameter
+from ._utils.deprecation import deprecation_warning
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from .client import _Client
@@ -145,7 +145,6 @@ class _Queue(_Object, type_prefix="qu"):
             yield cls._new_hydrated(response.queue_id, client, None, is_another_app=True)
 
     @staticmethod
-    @renamed_parameter((2024, 12, 18), "label", "name")
     def from_name(
         name: str,
         *,
@@ -179,7 +178,6 @@ class _Queue(_Object, type_prefix="qu"):
         return _Queue._from_loader(_load, "Queue()", is_another_app=True, hydrate_lazily=True)
 
     @staticmethod
-    @renamed_parameter((2024, 12, 18), "label", "name")
     async def lookup(
         name: str,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
@@ -215,7 +213,6 @@ class _Queue(_Object, type_prefix="qu"):
         return obj
 
     @staticmethod
-    @renamed_parameter((2024, 12, 18), "label", "name")
     async def delete(name: str, *, client: Optional[_Client] = None, environment_name: Optional[str] = None):
         obj = await _Queue.from_name(name, environment_name=environment_name).hydrate(client)
         req = api_pb2.QueueDeleteRequest(queue_id=obj.object_id)

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -10,7 +10,7 @@ from ._object import _get_environment_name, _Object
 from ._resolver import Resolver
 from ._runtime.execution_context import is_local
 from ._utils.async_utils import synchronize_api
-from ._utils.deprecation import deprecation_warning, renamed_parameter
+from ._utils.deprecation import deprecation_warning
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from .client import _Client
@@ -162,7 +162,6 @@ class _Secret(_Object, type_prefix="st"):
         return _Secret._from_loader(_load, "Secret.from_dotenv()", hydrate_lazily=True)
 
     @staticmethod
-    @renamed_parameter((2024, 12, 18), "label", "name")
     def from_name(
         name: str,
         *,
@@ -206,7 +205,6 @@ class _Secret(_Object, type_prefix="st"):
         return _Secret._from_loader(_load, "Secret()", hydrate_lazily=True)
 
     @staticmethod
-    @renamed_parameter((2024, 12, 18), "label", "name")
     async def lookup(
         name: str,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -49,7 +49,7 @@ from ._utils.blob_utils import (
     get_file_upload_spec_from_fileobj,
     get_file_upload_spec_from_path,
 )
-from ._utils.deprecation import deprecation_error, deprecation_warning, renamed_parameter
+from ._utils.deprecation import deprecation_error, deprecation_warning
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.http_utils import ClientSessionRegistry
 from ._utils.name_utils import check_object_name
@@ -149,7 +149,6 @@ class _Volume(_Object, type_prefix="vo"):
         return self._lock
 
     @staticmethod
-    @renamed_parameter((2024, 12, 18), "label", "name")
     def from_name(
         name: str,
         *,
@@ -244,7 +243,6 @@ class _Volume(_Object, type_prefix="vo"):
             yield cls._new_hydrated(response.volume_id, client, response.metadata, is_another_app=True)
 
     @staticmethod
-    @renamed_parameter((2024, 12, 18), "label", "name")
     async def lookup(
         name: str,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
@@ -595,7 +593,6 @@ class _Volume(_Object, type_prefix="vo"):
         )
 
     @staticmethod
-    @renamed_parameter((2024, 12, 18), "label", "name")
     async def delete(name: str, client: Optional[_Client] = None, environment_name: Optional[str] = None):
         obj = await _Volume.from_name(name, environment_name=environment_name).hydrate(client)
         req = api_pb2.VolumeDeleteRequest(volume_id=obj.object_id)


### PR DESCRIPTION
## Describe your changes

- Closes CLI-397

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

</details>

## Changelog

- Removed backwards compatibility for using `label=` or `tag=` keywords in object lookup methods. We standardized these methods to use `name=` as the parameter name, but we recommend using positional arguments:
  ```python
  f = modal.Function.from_name("my-app", tag="f")  # No longer supported! Will raise an error!
  f = modal.Function.from_name("my-app", "f")  # Preferred spelling
  ```