### PR TITLE
Remove Object.resolve method

### DIFF
--- a/modal/_object.py
+++ b/modal/_object.py
@@ -10,7 +10,6 @@ from typing_extensions import Self
 
 from ._resolver import Resolver
 from ._utils.async_utils import aclosing
-from ._utils.deprecation import deprecation_warning
 from .client import _Client
 from .config import config, logger
 from .exception import ExecutionError, InvalidError
@@ -236,19 +235,6 @@ class _Object:
             return []
 
         return self._deps if self._deps is not None else default_deps
-
-    async def resolve(self, client: Optional[_Client] = None):
-        """mdmd:hidden"""
-        obj = self.__class__.__name__.strip("_")
-        deprecation_warning(
-            (2025, 1, 16),
-            f"The `{obj}.resolve` method is deprecated and will be removed in a future release."
-            f" Please use `{obj}.hydrate()` or `await {obj}.hydrate.aio()` instead."
-            "\n\nNote that it is rarely necessary to explicitly hydrate objects, as most methods"
-            " will lazily hydrate when needed.",
-            show_source=False,  # synchronicity interferes with attributing source correctly
-        )
-        await self.hydrate(client)
 
     async def hydrate(self, client: Optional[_Client] = None) -> Self:
         """Synchronize the local object with its identity on the Modal server.

--- a/test/object_test.py
+++ b/test/object_test.py
@@ -4,7 +4,7 @@ import pytest
 from modal import Secret
 from modal._object import _Object
 from modal.dict import Dict, _Dict
-from modal.exception import DeprecationError, InvalidError
+from modal.exception import InvalidError
 from modal.queue import _Queue
 
 
@@ -24,14 +24,6 @@ def test_new_hydrated(client):
 
 def test_on_demand_hydration(client):
     obj = Dict.from_name("test-dict", create_if_missing=True).hydrate(client)
-    assert obj.object_id is not None
-
-
-def test_resolve_deprecation(client):
-    obj = Dict.from_name("test-dict", create_if_missing=True)
-    warning = r"Please use `Dict.hydrate\(\)` or `await Dict.hydrate.aio\(\)`"
-    with pytest.warns(DeprecationError, match=warning):
-        obj.resolve(client)
     assert obj.object_id is not None
 
 


### PR DESCRIPTION
## Describe your changes

- Closes CLI-399
 
<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

</details>

## Changelog

- Removed the `.resolve()` method on Modal objects. This method had not been publicly documented, but where used it can be replaced straightforwardly with `.hydrate()`. Note that explicit hydration should rarely be necessary: in most cases you can rely on lazy hydration semantics (i.e., objects will be hydrated when the first method that requires server metadata is called).