### PR TITLE
Remove support for parameters in `@modal.asgi_app` / `@modal.wsgi_app`

### DIFF
--- a/modal/_partial_function.py
+++ b/modal/_partial_function.py
@@ -18,7 +18,7 @@ from modal_proto import api_pb2
 from ._functions import _Function
 from ._utils.async_utils import synchronizer
 from ._utils.deprecation import deprecation_warning
-from ._utils.function_utils import callable_has_non_self_non_default_params, callable_has_non_self_params
+from ._utils.function_utils import callable_has_non_self_params
 from .config import logger
 from .exception import InvalidError
 
@@ -181,21 +181,11 @@ class _PartialFunction(typing.Generic[P, ReturnType, OriginalReturnType]):
 
             if require_sync and inspect.iscoroutinefunction(self.raw_f):
                 self.registered = True  # Hacky, avoid false-positive warning
-                raise InvalidError(f"`@modal.{decorator_name}` can't be applied to an async function.")
+                raise InvalidError(f"The `@modal.{decorator_name}` decorator can't be applied to an async function.")
 
             if require_nullary and callable_has_non_self_params(self.raw_f):
                 self.registered = True  # Hacky, avoid false-positive warning
-                if callable_has_non_self_non_default_params(self.raw_f):
-                    raise InvalidError(f"Functions obj by `@modal.{decorator_name}` can't have parameters.")
-                else:
-                    # TODO(michael): probably fine to just make this an error at this point
-                    # but best to do it in a separate PR
-                    deprecation_warning(
-                        (2024, 9, 4),
-                        f"The function obj by `@modal.{decorator_name}` has default parameters, "
-                        "but shouldn't have any parameters - Modal will drop support for "
-                        "default parameters in a future release.",
-                    )
+                raise InvalidError(f"Functions decorated by `@modal.{decorator_name}` can't have parameters.")
 
     def _get_raw_f(self) -> Callable[P, ReturnType]:
         assert self.raw_f is not None

--- a/test/webhook_test.py
+++ b/test/webhook_test.py
@@ -9,7 +9,7 @@ from fastapi.testclient import TestClient
 import modal
 from modal import App, asgi_app, fastapi_endpoint, wsgi_app
 from modal._runtime.asgi import magic_fastapi_app
-from modal.exception import DeprecationError, InvalidError
+from modal.exception import InvalidError
 from modal.functions import Function
 from modal.running_app import RunningApp
 from modal_proto import api_pb2
@@ -175,14 +175,14 @@ async def test_asgi_wsgi(servicer, client):
         def my_invalid_wsgi(x):
             pass
 
-    with pytest.warns(DeprecationError, match="default parameters"):
+    with pytest.raises(InvalidError, match="can't have parameters"):
 
         @app.function(serialized=True)
         @asgi_app()
         def my_deprecated_default_params_asgi(x=1):
             pass
 
-    with pytest.warns(DeprecationError, match="default parameters"):
+    with pytest.raises(InvalidError, match="can't have parameters"):
 
         @app.function(serialized=True)
         @wsgi_app()
@@ -206,11 +206,9 @@ async def test_asgi_wsgi(servicer, client):
     async with app.run(client=client):
         pass
 
-    assert len(servicer.app_functions) == 4
+    assert len(servicer.app_functions) == 2
     assert servicer.app_functions["fu-1"].webhook_config.type == api_pb2.WEBHOOK_TYPE_ASGI_APP
     assert servicer.app_functions["fu-2"].webhook_config.type == api_pb2.WEBHOOK_TYPE_WSGI_APP
-    assert servicer.app_functions["fu-3"].webhook_config.type == api_pb2.WEBHOOK_TYPE_ASGI_APP
-    assert servicer.app_functions["fu-4"].webhook_config.type == api_pb2.WEBHOOK_TYPE_WSGI_APP
 
 
 def test_positional_method(servicer, client):


### PR DESCRIPTION
## Describe your changes

- Closes CLI-398

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Functions decorated with `@modal.asgi_app` or `@modal.wsgi_app` are now required to be nullary. Previously, we only warned in the case where a function was defined with all parameters having default arguments.