### PR TITLE
Remove or re-type antiquated deprecation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ We appreciate your patience while we speedily work towards a stable release of t
 #### 1.0.0.dev4 (2025-05-14)
 
 - Removed the `.resolve()` method on Modal objects. This method had not been publicly documented, but where used it can be replaced straightforwardly with `.hydrate()`. Note that explicit hydration should rarely be necessary: in most cases you can rely on lazy hydration semantics (i.e., objects will be hydrated when the first method that requires server metadata is called).
+- Passing flagged options to the `Image.pip_install` package list will now raise an error. Use the `extra_options`  parameter for additional flags that aren't exposed through the `Image.pip_install` signature:
+  ```python
+  image.pip_install("flash-attn", "--no-build-isolation")  # This is now an error!
+  image.pip_install("flash-attn", extra_options="--no-build-isolation")  # Correct spelling
+  ```
 
 
 #### 1.0.0.dev3 (2025-05-14)

--- a/modal/app.py
+++ b/modal/app.py
@@ -1037,44 +1037,6 @@ class _App:
 
         return wrapper
 
-    async def spawn_sandbox(
-        self,
-        *entrypoint_args: str,
-        image: Optional[_Image] = None,  # The image to run as the container for the sandbox.
-        mounts: Sequence[_Mount] = (),  # Mounts to attach to the sandbox.
-        secrets: Sequence[_Secret] = (),  # Environment variables to inject into the sandbox.
-        network_file_systems: dict[Union[str, PurePosixPath], _NetworkFileSystem] = {},
-        timeout: Optional[int] = None,  # Maximum execution time of the sandbox in seconds.
-        workdir: Optional[str] = None,  # Working directory of the sandbox.
-        gpu: GPU_T = None,
-        cloud: Optional[str] = None,
-        region: Optional[Union[str, Sequence[str]]] = None,  # Region or regions to run the sandbox on.
-        # Specify, in fractional CPU cores, how many CPU cores to request.
-        # Or, pass (request, limit) to additionally specify a hard limit in fractional CPU cores.
-        # CPU throttling will prevent a container from exceeding its specified limit.
-        cpu: Optional[Union[float, tuple[float, float]]] = None,
-        # Specify, in MiB, a memory request which is the minimum memory required.
-        # Or, pass (request, limit) to additionally specify a hard limit in MiB.
-        memory: Optional[Union[int, tuple[int, int]]] = None,
-        block_network: bool = False,  # Whether to block network access
-        volumes: dict[
-            Union[str, PurePosixPath], Union[_Volume, _CloudBucketMount]
-        ] = {},  # Mount points for Modal Volumes and CloudBucketMounts
-        pty_info: Optional[api_pb2.PTYInfo] = None,
-        _experimental_scheduler_placement: Optional[
-            SchedulerPlacement
-        ] = None,  # Experimental controls over fine-grained scheduling (alpha).
-    ) -> None:
-        """mdmd:hidden"""
-        arglist = ", ".join(repr(s) for s in entrypoint_args)
-        message = (
-            "`App.spawn_sandbox` is deprecated.\n\n"
-            "Sandboxes can be created using the `Sandbox` object:\n\n"
-            f"```\nsb = Sandbox.create({arglist}, app=app)\n```\n\n"
-            "See https://modal.com/docs/guide/sandbox for more info on working with sandboxes."
-        )
-        deprecation_error((2024, 7, 5), message)
-
     def include(self, /, other_app: "_App") -> typing_extensions.Self:
         """Include another App's objects in this one.
 

--- a/modal/container_process.py
+++ b/modal/container_process.py
@@ -6,7 +6,6 @@ from typing import Generic, Optional, TypeVar
 from modal_proto import api_pb2
 
 from ._utils.async_utils import TaskContext, synchronize_api
-from ._utils.deprecation import deprecation_error
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.shell_utils import stream_from_stdin, write_to_fd
 from .client import _Client
@@ -118,17 +117,10 @@ class _ContainerProcess(Generic[T]):
                 self._returncode = resp.exit_code
                 return self._returncode
 
-    async def attach(self, *, pty: Optional[bool] = None):
+    async def attach(self):
         if platform.system() == "Windows":
             print("interactive exec is not currently supported on Windows.")
             return
-
-        if pty is not None:
-            deprecation_error(
-                (2024, 12, 9),
-                "The `pty` argument to `modal.container_process.attach(pty=...)` is deprecated, "
-                "as only PTY mode is supported. Please remove the argument.",
-            )
 
         from rich.console import Console
 

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -27,7 +27,6 @@ from ._pty import get_pty_info
 from ._resolver import Resolver
 from ._traceback import print_server_warnings, traceback_contains_remote_call
 from ._utils.async_utils import TaskContext, gather_cancel_on_exc, synchronize_api
-from ._utils.deprecation import deprecation_error
 from ._utils.git_utils import get_git_commit_info
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name, is_valid_tag
@@ -632,24 +631,7 @@ async def _interactive_shell(
                 raise
 
 
-def _run_stub(*args: Any, **kwargs: Any):
-    """mdmd:hidden
-    `run_stub` has been renamed to `run_app` and is deprecated. Please update your code.
-    """
-    deprecation_error(
-        (2024, 5, 1), "`run_stub` has been renamed to `run_app` and is deprecated. Please update your code."
-    )
-
-
-def _deploy_stub(*args: Any, **kwargs: Any):
-    """mdmd:hidden"""
-    message = "`deploy_stub` has been renamed to `deploy_app`. Please update your code."
-    deprecation_error((2024, 5, 1), message)
-
-
 run_app = synchronize_api(_run_app)
 serve_update = synchronize_api(_serve_update)
 deploy_app = synchronize_api(_deploy_app)
 interactive_shell = synchronize_api(_interactive_shell)
-run_stub = synchronize_api(_run_stub)
-deploy_stub = synchronize_api(_deploy_stub)

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -762,23 +762,3 @@ class _Sandbox(_Object, type_prefix="sb"):
 
 
 Sandbox = synchronize_api(_Sandbox)
-
-
-def __getattr__(name):
-    if name == "LogsReader":
-        deprecation_error(
-            (2024, 8, 12),
-            "`modal.sandbox.LogsReader` is deprecated. Please import `modal.io_streams.StreamReader` instead.",
-        )
-        from .io_streams import StreamReader
-
-        return StreamReader
-    elif name == "StreamWriter":
-        deprecation_error(
-            (2024, 8, 12),
-            "`modal.sandbox.StreamWriter` is deprecated. Please import `modal.io_streams.StreamWriter` instead.",
-        )
-        from .io_streams import StreamWriter
-
-        return StreamWriter
-    raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/modal/serving.py
+++ b/modal/serving.py
@@ -11,7 +11,6 @@ from synchronicity.async_wrap import asynccontextmanager
 from modal._output import OutputManager
 
 from ._utils.async_utils import TaskContext, asyncify, synchronize_api, synchronizer
-from ._utils.deprecation import deprecation_error
 from ._utils.logger import logger
 from ._watcher import watch
 from .cli.import_refs import ImportRef, import_app_from_ref
@@ -122,9 +121,4 @@ async def _serve_app(
             yield app
 
 
-def _serve_stub(*args, **kwargs):
-    deprecation_error((2024, 5, 1), "`serve_stub` is deprecated. Please use `serve_app` instead.")
-
-
 serve_app = synchronize_api(_serve_app)
-serve_stub = synchronize_api(_serve_stub)

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -27,7 +27,7 @@ from grpclib import GRPCError, Status
 from synchronicity.async_wrap import asynccontextmanager
 
 import modal_proto.api_pb2
-from modal.exception import VolumeUploadTimeoutError
+from modal.exception import InvalidError, VolumeUploadTimeoutError
 from modal_proto import api_pb2
 
 from ._object import EPHEMERAL_OBJECT_HEARTBEAT_SLEEP, _get_environment_name, _Object, live_method, live_method_gen
@@ -49,7 +49,7 @@ from ._utils.blob_utils import (
     get_file_upload_spec_from_fileobj,
     get_file_upload_spec_from_path,
 )
-from ._utils.deprecation import deprecation_error, deprecation_warning
+from ._utils.deprecation import deprecation_warning
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.http_utils import ClientSessionRegistry
 from ._utils.name_utils import check_object_name
@@ -364,21 +364,14 @@ class _Volume(_Object, type_prefix="vo"):
         recursively.
         """
         if path.endswith("**"):
-            msg = (
+            raise InvalidError(
                 "Glob patterns in `volume get` and `Volume.listdir()` are deprecated. "
                 "Please pass recursive=True instead. For the CLI, just remove the glob suffix."
             )
-            deprecation_error(
-                (2024, 4, 23),
-                msg,
-            )
         elif path.endswith("*"):
-            deprecation_error(
-                (2024, 4, 23),
-                (
-                    "Glob patterns in `volume get` and `Volume.listdir()` are deprecated. "
-                    "Please remove the glob `*` suffix."
-                ),
+            raise InvalidError(
+                "Glob patterns in `volume get` and `Volume.listdir()` are deprecated. "
+                "Please remove the glob `*` suffix."
             )
 
         req = api_pb2.VolumeListFilesRequest(volume_id=self.object_id, path=path, recursive=recursive)

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -10,7 +10,7 @@ from modal import App, Image, Mount, Secret, Stub, Volume, enable_output, fastap
 from modal._partial_function import _parse_custom_domains
 from modal._utils.async_utils import synchronizer
 from modal.exception import DeprecationError, ExecutionError, InvalidError, NotFoundError
-from modal.runner import deploy_stub, run_app
+from modal.runner import run_app
 from modal_proto import api_pb2
 
 from .supports import module_1, module_2
@@ -359,12 +359,6 @@ def test_function_named_app():
 def test_stub():
     with pytest.warns(match="App"):
         Stub()
-
-
-def test_deploy_stub():
-    app = App("xyz")
-    with pytest.raises(DeprecationError, match="deploy_app"):
-        deploy_stub(app)
 
 
 def test_app_logs(servicer, client):

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -271,9 +271,6 @@ def test_app_sandbox(client, servicer):
     app = App()
     with app.run(client=client):
         # Create sandbox
-        with pytest.raises(DeprecationError, match="`App.spawn_sandbox` is deprecated"):
-            app.spawn_sandbox("bash", "-c", "echo bye >&2 && echo hi", image=image, secrets=[secret])
-
         sb = Sandbox.create("bash", "-c", "echo bye >&2 && echo hi", image=image, secrets=[secret], app=app)
         sb.wait()
         assert sb.stderr.read() == "bye\n"


### PR DESCRIPTION
## Describe your changes

Some of these are old deprecation errors that we can just remove entirely, others are cases where we issued a deprecation error because behavior had changed, but the prior context is no longer relevant.

None of these were major changes.

- Part of CLI-401

<details> <summary>Checklists</summary>

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

</details>
