### PR TITLE
Remove `show_progress=` from `App.run`

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -328,7 +328,6 @@ class _App:
         self,
         *,
         client: Optional[_Client] = None,
-        show_progress: Optional[bool] = None,
         detach: bool = False,
         interactive: bool = False,
         environment_name: Optional[str] = None,
@@ -373,16 +372,6 @@ class _App:
 
         """
         from .runner import _run_app  # Defer import of runner.py, which imports a lot from Rich
-
-        # See Github discussion here: https://github.com/modal-labs/modal-client/pull/2030#issuecomment-2237266186
-
-        if show_progress is True:
-            deprecation_error(
-                (2024, 11, 20),
-                "`show_progress=True` is no longer supported. Use `with modal.enable_output():` instead.",
-            )
-        elif show_progress is False:
-            deprecation_warning((2024, 11, 20), "`show_progress=False` is deprecated (and has no effect)")
 
         async with _run_app(
             self, client=client, detach=detach, interactive=interactive, environment_name=environment_name

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -417,20 +417,6 @@ def test_app_interactive_no_output(servicer, client):
             assert not app.is_interactive
 
 
-def test_show_progress_deprecations(client, monkeypatch):
-    app = App()
-
-    # If show_progress is set to True, raise that this is deprecated
-    with pytest.raises(DeprecationError, match="enable_output"):
-        with app.run(client=client, show_progress=True):
-            pass
-
-    # If show_progress is set to False, warn that this has no effect
-    with pytest.warns(DeprecationError, match="no effect"):
-        with app.run(client=client, show_progress=False):
-            pass
-
-
 @pytest.mark.asyncio
 async def test_deploy_from_container(servicer, container_client):
     app = App(image=Image.debian_slim().pip_install("pandas"))


### PR DESCRIPTION
## Describe your changes

- Part of CLI-401

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

- Removed the `show_progress` parameter from `modal.App.run`. This parameter has been replaced by the `modal.enable_output` context manager:
  ```python
  with modal.enable_output(), app.run():
    ...  # Will produce verbose Modal output
  ```