### PR TITLE
Remove automount concept

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -34,12 +34,6 @@ def running_app():
     return modal.App.lookup("pytest-markdown-docs-running-app", create_if_missing=True)
 
 
-@pytest.fixture(autouse=True)
-def disable_auto_mount(monkeypatch):
-    monkeypatch.setenv("MODAL_AUTOMOUNT", "0")
-    yield
-
-
 @register_runner()
 class ModalRunner(DefaultRunner):
     def runtest(self, test, args):

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -71,7 +71,7 @@ from .exception import (
 )
 from .gpu import GPU_T, parse_gpu_config
 from .image import _Image
-from .mount import _get_client_mount, _Mount, get_sys_modules_mounts
+from .mount import _get_client_mount, _Mount
 from .network_file_system import _NetworkFileSystem, network_file_system_mount_protos
 from .output import _get_output_manager
 from .parallel_map import (
@@ -580,30 +580,6 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
             *explicit_mounts,
             *entrypoint_mounts.values(),
         ]
-
-        if include_source_mode is IncludeSourceMode.INCLUDE_FIRST_PARTY and is_local():
-            auto_mounts = get_sys_modules_mounts()
-            # don't need to add entrypoint modules to automounts:
-            for entrypoint_module in entrypoint_mounts:
-                auto_mounts.pop(entrypoint_module, None)
-
-            warn_missing_modules = set(auto_mounts.keys()) - image._added_python_source_set
-
-            if warn_missing_modules:
-                python_stringified_modules = ", ".join(f'"{mod}"' for mod in sorted(warn_missing_modules))
-                deprecation_warning(
-                    (2025, 2, 3),
-                    (
-                        'Modal will stop implicitly adding local Python modules to the Image ("automounting") in a '
-                        "future update. The following modules need to be explicitly added for future "
-                        "compatibility:\n"
-                    )
-                    + "\n".join(sorted([f"* {m}" for m in warn_missing_modules]))
-                    + "\n\n"
-                    + (f"e.g.:\nimage_with_source = my_image.add_local_python_source({python_stringified_modules})\n\n")
-                    + "For more information, see https://modal.com/docs/guide/modal-1-0-migration",
-                )
-            all_mounts += auto_mounts.values()
 
         retry_policy = _parse_retries(
             retries, f"Function '{info.get_tag()}'" if info.raw_f else f"Class '{info.get_tag()}'"

--- a/modal/_utils/function_utils.py
+++ b/modal/_utils/function_utils.py
@@ -23,7 +23,7 @@ from .._serialization import (
     signature_to_parameter_specs,
 )
 from .._traceback import append_modal_tb
-from ..config import config, logger
+from ..config import logger
 from ..exception import (
     DeserializationError,
     ExecutionError,
@@ -627,8 +627,7 @@ class FunctionCreationStatus:
 
 class IncludeSourceMode(enum.Enum):
     INCLUDE_NOTHING = False  # can only be set in source, can't be set in config
-    INCLUDE_MAIN_PACKAGE = True  # also represented by AUTOMOUNT=0 in config
-    INCLUDE_FIRST_PARTY = "legacy"  # mounts all "local" modules in sys.modules - represented by AUTOMOUNT=1 in config
+    INCLUDE_MAIN_PACKAGE = True  # Default behavior
 
 
 def get_include_source_mode(function_or_app_specific) -> IncludeSourceMode:
@@ -650,6 +649,4 @@ def get_include_source_mode(function_or_app_specific) -> IncludeSourceMode:
         # explicitly set in app/function
         return IncludeSourceMode(function_or_app_specific)
 
-    # note that the automount config boolean isn't a 1-1 mapping with include_source!
-    legacy_automount_mode: bool = config.get("automount")
-    return IncludeSourceMode.INCLUDE_FIRST_PARTY if legacy_automount_mode else IncludeSourceMode.INCLUDE_MAIN_PACKAGE
+    return IncludeSourceMode.INCLUDE_MAIN_PACKAGE

--- a/modal/app.py
+++ b/modal/app.py
@@ -30,7 +30,6 @@ from ._partial_function import (
 )
 from ._utils.async_utils import synchronize_api
 from ._utils.deprecation import (
-    deprecation_error,
     deprecation_warning,
     warn_on_renamed_autoscaler_settings,
 )

--- a/modal/cli/programs/run_jupyter.py
+++ b/modal/cli/programs/run_jupyter.py
@@ -15,7 +15,7 @@ from modal import App, Image, Queue, Secret, Volume, forward
 # Passed by `modal launch` locally via CLI, plumbed to remote runner through secrets.
 args: dict[str, Any] = json.loads(os.environ.get("MODAL_LAUNCH_ARGS", "{}"))
 
-app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+app = App()
 
 image = Image.from_registry(args.get("image"), add_python=args.get("add_python")).pip_install("jupyterlab")
 

--- a/modal/cli/programs/vscode.py
+++ b/modal/cli/programs/vscode.py
@@ -22,7 +22,7 @@ CODE_SERVER_ENTRYPOINT = (
 FIXUD_INSTALLER = "https://github.com/boxboat/fixuid/releases/download/v0.6.0/fixuid-0.6.0-linux-$ARCH.tar.gz"
 
 
-app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+app = App()
 image = (
     Image.from_registry(args.get("image"), add_python="3.11")
     .apt_install("curl", "dumb-init", "git", "git-lfs")

--- a/modal/config.py
+++ b/modal/config.py
@@ -51,10 +51,6 @@ Other possible configuration options are:
   Defaults to 10.
   Number of seconds to wait for logs to drain when closing the session,
   before giving up.
-* `automount` (in the .toml file) / `MODAL_AUTOMOUNT` (as an env var).
-  Defaults to True.
-  By default, Modal automatically mounts modules imported in the current scope, that
-  are deemed to be "local". This can be turned off by setting this to False.
 * `force_build` (in the .toml file) / `MODAL_FORCE_BUILD` (as an env var).
   Defaults to False.
   When set, ignores the Image cache and builds all Image layers. Note that this
@@ -233,7 +229,6 @@ _SETTINGS = {
     "sync_entrypoint": _Setting(),
     "logs_timeout": _Setting(10, float),
     "image_id": _Setting(),
-    "automount": _Setting(True, transform=_to_boolean),
     "heartbeat_interval": _Setting(15, float),
     "function_runtime": _Setting(),
     "function_runtime_debug": _Setting(False, transform=_to_boolean),  # For internal debugging use.

--- a/test/cli_imports_test.py
+++ b/test/cli_imports_test.py
@@ -27,8 +27,8 @@ def main():
 """
 python_module_src = """
 import modal
-app = modal.App("FOO", include_source=True)  # TODO: remove include_source=True)
-other_app = modal.App("BAR", include_source=True)  # TODO: remove include_source=True)
+app = modal.App("FOO")
+other_app = modal.App("BAR")
 @other_app.function()
 def func():
     pass
@@ -43,8 +43,8 @@ assert not __package__
 
 python_package_src = """
 import modal
-app = modal.App("FOO", include_source=True)  # TODO: remove include_source=True)
-other_app = modal.App("BAR", include_source=True)  # TODO: remove include_source=True)
+app = modal.App("FOO")
+other_app = modal.App("BAR")
 @other_app.function()
 def func():
     pass
@@ -53,8 +53,8 @@ assert __package__ == "pack005"
 
 python_subpackage_src = """
 import modal
-app = modal.App("FOO", include_source=True)  # TODO: remove include_source=True)
-other_app = modal.App("BAR", include_source=True)  # TODO: remove include_source=True)
+app = modal.App("FOO")
+other_app = modal.App("BAR")
 @other_app.function()
 def func():
     pass
@@ -63,8 +63,8 @@ assert __package__ == "pack007.sub009"
 
 python_file_src = """
 import modal
-app = modal.App("FOO", include_source=True)  # TODO: remove include_source=True)
-other_app = modal.App("BAR", include_source=True)  # TODO: remove include_source=True)
+app = modal.App("FOO")
+other_app = modal.App("BAR")
 @other_app.function()
 def func():
     pass

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -35,7 +35,7 @@ import modal
 
 import other_module
 
-app = modal.App("my_app", include_source=True)  # TODO: remove include_source=True)
+app = modal.App("my_app")
 
 # Sanity check that the module is imported properly
 import sys
@@ -164,7 +164,11 @@ def test_run(servicer, set_env_client, supports_dir, monkeypatch, run_command, e
 
 
 def test_run_warns_without_module_flag(
-    servicer, set_env_client, supports_dir, recwarn, monkeypatch, disable_auto_mount
+    servicer,
+    set_env_client,
+    supports_dir,
+    recwarn,
+    monkeypatch,
 ):
     monkeypatch.chdir(supports_dir)
     _run(["run", "-m", f"{app_module}::foo"])
@@ -270,9 +274,7 @@ def test_run_write_result(servicer, set_env_client, test_dir):
         (["--name=deployment_name", "-m", app_module], True, ""),
     ],
 )
-def test_deploy(
-    servicer, set_env_client, supports_dir, monkeypatch, args, success, expected_warning, disable_auto_mount, recwarn
-):
+def test_deploy(servicer, set_env_client, supports_dir, monkeypatch, args, success, expected_warning, recwarn):
     monkeypatch.chdir(supports_dir)
     _run(["deploy"] + args, expected_exit_code=0 if success else 1)
     if success:
@@ -372,7 +374,7 @@ def test_run_parse_args_entrypoint(servicer, set_env_client, test_dir):
         assert "unsupported operand" in str(res.exception)
 
 
-def test_run_parse_args_function(servicer, set_env_client, test_dir, recwarn, disable_auto_mount):
+def test_run_parse_args_function(servicer, set_env_client, test_dir, recwarn):
     app_file = test_dir / "supports" / "app_run_tests" / "cli_args.py"
     res = _run(["run", app_file.as_posix()], expected_exit_code=1, expected_stderr=None)
     assert "Specify a Modal Function or local entrypoint to run" in res.stderr
@@ -1192,7 +1194,7 @@ def test_container_exec(servicer, set_env_client, mock_shell_pty, app):
     sb.terminate()
 
 
-def test_can_run_all_listed_functions_with_includes(supports_on_path, monkeypatch, set_env_client, disable_auto_mount):
+def test_can_run_all_listed_functions_with_includes(supports_on_path, monkeypatch, set_env_client):
     monkeypatch.setenv("TERM", "dumb")  # prevents looking at ansi escape sequences
 
     res = _run(["run", "-m", "multifile_project.main"], expected_exit_code=1)
@@ -1241,14 +1243,14 @@ def test_run_file_with_global_lookups(servicer, set_env_client, supports_dir):
     assert len(ctx.get_requests("FunctionGet")) == 0
 
 
-def test_run_auto_infer_prefer_target_module(servicer, supports_dir, set_env_client, monkeypatch, disable_auto_mount):
+def test_run_auto_infer_prefer_target_module(servicer, supports_dir, set_env_client, monkeypatch):
     monkeypatch.syspath_prepend(supports_dir / "app_run_tests")
     res = _run(["run", "-m", "multifile.util"])
     assert "ran util\nmain func" in res.stdout
 
 
 @pytest.mark.parametrize("func", ["va_entrypoint", "va_function", "VaClass.va_method"])
-def test_cli_run_variadic_args(servicer, set_env_client, test_dir, func, disable_auto_mount):
+def test_cli_run_variadic_args(servicer, set_env_client, test_dir, func):
     app_file = test_dir / "supports" / "app_run_tests" / "variadic_args.py"
 
     @servicer.function_body

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -31,7 +31,7 @@ from modal_proto import api_pb2
 
 from .supports.base_class import BaseCls2
 
-app = App("app", include_source=True)
+app = App("app")
 
 
 @pytest.fixture(autouse=True)
@@ -230,7 +230,7 @@ def test_with_options_from_name(servicer):
 # Reusing the app runs into an issue with stale function handles.
 # TODO (akshat): have all the client tests use separate apps, and throw
 # an exception if the user tries to reuse an app.
-app_remote = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+app_remote = App()
 
 
 @app_remote.cls(cpu=42)
@@ -263,7 +263,7 @@ def test_call_cls_remote_invalid_type(client):
         assert "function" in str(exc)
 
 
-app_2 = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+app_2 = App()
 
 
 @app_2.cls(cpu=42)
@@ -305,7 +305,7 @@ def test_run_class_serialized(client, servicer):
     assert bound_bar(100) == 1000000
 
 
-app_remote_2 = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+app_remote_2 = App()
 
 
 @app_remote_2.cls(cpu=42)
@@ -325,7 +325,7 @@ async def test_call_cls_remote_async(client):
         assert await bar_remote.baz.remote.aio(8) == 64  # Mock servicer just squares the argument
 
 
-app_local = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+app_local = App()
 
 
 @app_local.cls(cpu=42, enable_memory_snapshot=True)
@@ -369,7 +369,7 @@ def test_can_call_remotely_from_local(client):
         assert foo.baz.remote(9) == 81
 
 
-app_remote_3 = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+app_remote_3 = App()
 
 
 @app_remote_3.cls(cpu=42)
@@ -488,7 +488,7 @@ def test_failed_lookup_error(client, servicer):
         Cls.from_name("my-cls-app", "Foo", environment_name="some-env").hydrate(client=client)
 
 
-baz_app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+baz_app = App()
 
 
 @baz_app.cls()
@@ -505,7 +505,7 @@ def test_call_not_modal_method():
     assert baz.not_modal_method(7) == 35
 
 
-cls_with_enter_app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+cls_with_enter_app = App()
 
 
 def get_thread_id():
@@ -575,7 +575,7 @@ async def test_async_enter_on_local_modal_call():
     assert obj.entered
 
 
-inheritance_app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+inheritance_app = App()
 
 
 class BaseCls:
@@ -599,7 +599,7 @@ def test_derived_cls(client, servicer):
         assert DerivedCls().run.remote(3) == 9
 
 
-inheritance_app_2 = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+inheritance_app_2 = App()
 
 
 @inheritance_app_2.cls()
@@ -634,7 +634,7 @@ def test_rehydrate(client, servicer, reset_container_app):
     assert obj.bar.local(7) == 343
 
 
-app_unhydrated = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+app_unhydrated = App()
 
 
 @app_unhydrated.cls()
@@ -649,7 +649,7 @@ def test_unhydrated():
         foo.bar.remote(42)
 
 
-app_method_args = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+app_method_args = App()
 
 
 @app_method_args.cls(min_containers=5)
@@ -774,7 +774,7 @@ def test_handlers():
     assert list(pfs.keys()) == ["my_exit"]
 
 
-web_app_app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+web_app_app = App()
 
 
 @web_app_app.cls()
@@ -795,7 +795,7 @@ def test_web_cls(client):
         assert c.asgi.get_web_url() == "http://asgi.internal"
 
 
-handler_app = App("handler-app", include_source=True)
+handler_app = App("handler-app")
 
 
 image = Image.debian_slim().pip_install("xyz")
@@ -823,7 +823,7 @@ def test_build_image(client, servicer):
         assert servicer.force_built_images == []
 
 
-other_handler_app = App("other-handler-app", include_source=True)
+other_handler_app = App("other-handler-app")
 
 
 with pytest.warns(DeprecationError, match="@modal.build"):
@@ -848,7 +848,7 @@ def test_force_build_image(client, servicer):
         assert servicer.force_built_images == ["im-3"]
 
 
-build_timeout_handler_app = App("build-timeout-handler-app", include_source=True)
+build_timeout_handler_app = App("build-timeout-handler-app")
 
 
 with pytest.warns(DeprecationError, match="@modal.build"):
@@ -961,7 +961,7 @@ def test_cross_process_userclass_serde(supports_dir):
     assert revived_cls().method() == "a"  # this should be bound to the object
 
 
-app2 = App("app2", include_source=True)
+app2 = App("app2")
 
 
 @app2.cls()
@@ -1052,7 +1052,7 @@ class ParametrizedClass3:
         pass
 
 
-app_batched = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+app_batched = App()
 
 
 def test_batched_method_duplicate_error(client):
@@ -1129,7 +1129,7 @@ def test_unsupported_function_decorators_on_methods():
                 pass
 
 
-def test_using_method_on_uninstantiated_cls(recwarn, disable_auto_mount):
+def test_using_method_on_uninstantiated_cls(recwarn):
     app = App()
 
     @app.cls(serialized=True)

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -150,16 +150,16 @@ async def test_workspace_lookup(servicer, server_url_env):
     assert resp.username == "test-username"
 
 
-@pytest.mark.parametrize("automount", ["false", "'false'", "'False'", "'0'", 0, "''"])
-def test_config_boolean(modal_config, automount):
+@pytest.mark.parametrize("arg", ["false", "'false'", "'False'", "'0'", 0, "''"])
+def test_config_boolean(modal_config, arg):
     modal_toml = f"""
     [prof-1]
     token_id = 'ak-abc'
     token_secret = 'as_xyz'
-    automount = {automount}
+    force_build = {arg}
     """
     with modal_config(modal_toml):
-        assert not Config().get("automount", "prof-1")
+        assert not Config().get("force_build", "prof-1")
 
 
 def test_malformed_config_better(modal_config):

--- a/test/container_buffer_test.py
+++ b/test/container_buffer_test.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2024
 from modal import App
 
-app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+app = App()
 
 
 @app.function(

--- a/test/gpu_fallbacks_test.py
+++ b/test/gpu_fallbacks_test.py
@@ -2,7 +2,7 @@
 from modal import App
 from modal_proto import api_pb2
 
-app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+app = App()
 
 
 @app.function(gpu=["a10g"])

--- a/test/i6pn_clustered_test.py
+++ b/test/i6pn_clustered_test.py
@@ -3,7 +3,7 @@ import modal
 import modal.experimental
 from modal import App
 
-app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+app = App()
 
 
 @app.function()

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -41,14 +41,6 @@ SUPPORTED_IMAGE_BUILDER_VERSIONS = [
 ]
 
 
-@pytest.fixture(autouse=True)
-def no_automount(monkeypatch):
-    # no tests in here use automounting, but a lot of them implicitly create
-    # functions w/ lots of modules is sys.modules which will automount
-    # which takes a lot of time, so we disable it
-    monkeypatch.setenv("MODAL_AUTOMOUNT", "0")
-
-
 def dummy() -> None:
     return None
 
@@ -757,7 +749,7 @@ def test_image_add_local_dir(servicer, client, tmp_path_with_content, copy, remo
 
 
 @pytest.mark.usefixtures("tmp_cwd")
-def test_image_docker_command_no_copy_commands(builder_version, servicer, client, disable_auto_mount):
+def test_image_docker_command_no_copy_commands(builder_version, servicer, client):
     # make sure that no mount is created if there are no copy commands
     Path("data.txt").write_text("hello")
     app = App()
@@ -1193,7 +1185,7 @@ def test_hydration_metadata(servicer, client):
             assert_metadata(img, dummy_metadata)
 
 
-cls_app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+cls_app = App()
 
 VARIABLE_5 = 1
 VARIABLE_6 = 1
@@ -1581,7 +1573,7 @@ def test_image_stability_on_2024_10(force_2024_10, servicer, client, test_dir):
     assert get_hash(img) == "78d579f243c21dcaa59e5daf97f732e2453b004bc2122de692617d4d725c6184"
 
 
-parallel_app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+parallel_app = App()
 
 
 @parallel_app.function(image=Image.debian_slim().run_commands("sleep 1", "echo hi"))

--- a/test/input_plane_test.py
+++ b/test/input_plane_test.py
@@ -4,17 +4,19 @@ from modal import App
 from modal.functions import Function
 from modal.runner import deploy_app
 
-app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+app = App()
 
 
 @app.function(experimental_options={"input_plane_region": "us-east"})
 def foo():
     return "foo"
 
+
 def test_foo(client, servicer):
     # This verifies that FunctionCreate returns the input_plane_url in the response, and we then call the input plane.
     with app.run(client=client):
         assert foo.remote() == "attempt_await_bogus_response"
+
 
 def test_lookup_foo(client, servicer):
     # This verifies that FunctionGet returns the input_plane_url in the response, and we then call the input plane.

--- a/test/mount_test.py
+++ b/test/mount_test.py
@@ -8,7 +8,6 @@ from pathlib import Path, PurePosixPath
 from modal import App, FilePatternMatcher
 from modal._utils.blob_utils import LARGE_FILE_LIMIT
 from modal.mount import Mount, client_mount_name, module_mount_condition, module_mount_ignore_condition
-from test.helpers import deploy_app_externally
 
 
 @pytest.mark.asyncio
@@ -169,36 +168,6 @@ def test_mount_from_local_dir_ignore(test_dir, tmp_path_with_content):
 
     file_names = [file.mount_filename for file in Mount._get_files(entries=mount.entries)]
     assert set(file_names) == expected
-
-
-def test_missing_python_source_warning(servicer, credentials, supports_dir, monkeypatch):
-    # should warn if function doesn't have an imported non-third-party package attached
-    # either through add OR copy mode, unless automount=False mode is used
-    monkeypatch.delenv("MODAL_AUTOMOUNT")  # prevent autoused disable_automount fixture
-
-    def has_warning(output: str):
-        return '.add_local_python_source("pkg_a")' in output
-
-    output = deploy_app_externally(servicer, credentials, "pkg_d.main", cwd=supports_dir, capture_output=True)
-    assert has_warning(output)
-
-    # adding the source to the image should make the warning disappear
-    output = deploy_app_externally(
-        servicer, credentials, "pkg_d.main", cwd=supports_dir, capture_output=True, env={"ADD_SOURCE": "add"}
-    )
-    assert not has_warning(output)
-
-    # *copying* the source to the image should make the warning disappear too
-    output = deploy_app_externally(
-        servicer, credentials, "pkg_d.main", cwd=supports_dir, capture_output=True, env={"ADD_SOURCE": "copy"}
-    )
-    assert not has_warning(output)
-
-    # disabling auto-mount explicitly should make warning disappear
-    output = deploy_app_externally(
-        servicer, credentials, "pkg_d.main", cwd=supports_dir, capture_output=True, env={"MODAL_AUTOMOUNT": "0"}
-    )
-    assert not has_warning(output)
 
 
 def test_client_mount_name():

--- a/test/schedule_test.py
+++ b/test/schedule_test.py
@@ -2,7 +2,7 @@
 from modal import App, Period
 from modal_proto import api_pb2
 
-app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+app = App()
 
 
 @app.function(schedule=Period(seconds=5))

--- a/test/scheduler_placement_test.py
+++ b/test/scheduler_placement_test.py
@@ -4,7 +4,7 @@ from modal_proto import api_pb2
 
 from .supports.skip import skip_windows
 
-app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+app = App()
 
 
 @app.function(

--- a/test/supports/app_run_tests/app_with_lookups.py
+++ b/test/supports/app_run_tests/app_with_lookups.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 import modal
 
-app = modal.App("my-app", include_source=True)  # TODO: remove include_source=True)
+app = modal.App("my-app")
 
 nfs = modal.NetworkFileSystem.from_name("volume_app").hydrate()
 

--- a/test/supports/app_run_tests/cli_args.py
+++ b/test/supports/app_run_tests/cli_args.py
@@ -4,7 +4,7 @@ from typing import Optional, Union
 
 from modal import App, method
 
-app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+app = App()
 
 
 @app.local_entrypoint()

--- a/test/supports/app_run_tests/variadic_args.py
+++ b/test/supports/app_run_tests/variadic_args.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 from modal import App, method
 
-app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+app = App()
 
 
 @app.cls()

--- a/test/supports/app_run_tests/webhook.py
+++ b/test/supports/app_run_tests/webhook.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 from modal import App, fastapi_endpoint
 
-app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+app = App()
 
 
 @app.function()

--- a/test/supports/class_hierarchy.py
+++ b/test/supports/class_hierarchy.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2024
 import modal
 
-app = modal.App("class-hierarchy", include_source=True)  # TODO: remove include_source=True)
+app = modal.App("class-hierarchy")
 
 
 class Base:

--- a/test/supports/experimental.py
+++ b/test/supports/experimental.py
@@ -8,7 +8,7 @@ from modal import (
     method,
 )
 
-app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+app = App()
 
 
 @app.cls()

--- a/test/supports/functions.py
+++ b/test/supports/functions.py
@@ -29,7 +29,7 @@ from modal.experimental import get_local_input_concurrency, set_local_input_conc
 
 SLEEP_DELAY = 0.1
 
-app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+app = App()
 
 
 @app.function()

--- a/test/supports/image_run_function.py
+++ b/test/supports/image_run_function.py
@@ -1,8 +1,8 @@
 # Copyright Modal Labs 2022
 import modal
 
-app = modal.App("a", include_source=True)  # TODO: remove include_source=True)
-other = modal.App("b", include_source=True)  # TODO: remove include_source=True)
+app = modal.App("a")
+other = modal.App("b")
 
 
 def builder_function():

--- a/test/supports/import_and_filter_source.py
+++ b/test/supports/import_and_filter_source.py
@@ -1,9 +1,7 @@
 # Copyright Modal Labs 2025
 from modal import App, asgi_app, fastapi_endpoint, method
 
-app_with_one_web_function = App(
-    include_source=True
-)  # TODO: remove include_source=True when automount is disabled by default
+app_with_one_web_function = App()
 
 
 @app_with_one_web_function.function()
@@ -12,9 +10,7 @@ def web1():
     pass
 
 
-app_with_one_function_one_web_endpoint = App(
-    include_source=True
-)  # TODO: remove include_source=True when automount is disabled by default
+app_with_one_function_one_web_endpoint = App()
 
 
 @app_with_one_function_one_web_endpoint.function()
@@ -28,9 +24,7 @@ def web2():
     pass
 
 
-app_with_one_web_method = App(
-    include_source=True
-)  # TODO: remove include_source=True when automount is disabled by default
+app_with_one_web_method = App()
 
 
 @app_with_one_web_method.cls()
@@ -40,9 +34,7 @@ class C1:
         pass
 
 
-app_with_one_web_method_one_method = App(
-    include_source=True
-)  # TODO: remove include_source=True when automount is disabled by default
+app_with_one_web_method_one_method = App()
 
 
 @app_with_one_web_method_one_method.cls()
@@ -56,9 +48,7 @@ class C2:
         pass
 
 
-app_with_local_entrypoint_and_function = App(
-    include_source=True
-)  # TODO: remove include_source=True when automount is disabled by default
+app_with_local_entrypoint_and_function = App()
 
 
 @app_with_local_entrypoint_and_function.local_entrypoint()

--- a/test/supports/imports_ast.py
+++ b/test/supports/imports_ast.py
@@ -3,7 +3,7 @@ import ast  # noqa
 
 import modal
 
-app = modal.App("imports_ast", include_source=True)  # TODO: remove include_source=True)
+app = modal.App("imports_ast")
 
 
 @app.function()

--- a/test/supports/imports_six.py
+++ b/test/supports/imports_six.py
@@ -3,7 +3,7 @@ import six  # noqa
 
 import modal
 
-app = modal.App("imports_six", include_source=True)  # TODO: remove include_source=True)
+app = modal.App("imports_six")
 
 
 @app.function()

--- a/test/supports/lazy_hydration.py
+++ b/test/supports/lazy_hydration.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2024
 from modal import App, Image, Queue, Volume
 
-app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+app = App()
 
 image = Image.debian_slim().pip_install("xyz")
 volume = Volume.from_name("my-vol")

--- a/test/supports/mount_dedupe.py
+++ b/test/supports/mount_dedupe.py
@@ -1,28 +1,22 @@
 # Copyright Modal Labs 2023
-import os
 
 import modal
 
 app = modal.App()
-import pkg_a  # noqa
 
 
-if int(os.environ["USE_EXPLICIT"]):
-    image_1 = modal.Image.debian_slim().add_local_python_source("pkg_a")  # this should be reused
-    # same as above, but different instance - should be app-deduplicated:
-    image_2 = (
-        modal.Image.debian_slim()
-        .add_local_python_source("pkg_a")  # identical to first explicit mount and auto mounts
-        .add_local_python_source(
-            # custom ignore condition, include normally_not_included.pyc (but skip __pycache__)
-            "pkg_a",
-            ignore=["**/__pycache__"],
-        )
+image_1 = modal.Image.debian_slim().add_local_python_source("pkg_a")  # this should be reused
+
+# same as above, but different instance - should be app-deduplicated:
+image_2 = (
+    modal.Image.debian_slim()
+    .add_local_python_source("pkg_a")  # identical to first explicit mount and auto mounts
+    .add_local_python_source(
+        # custom ignore condition, include normally_not_included.pyc (but skip __pycache__)
+        "pkg_a",
+        ignore=["**/__pycache__"],
     )
-else:
-    # only use automounting
-    image_1 = modal.Image.debian_slim()
-    image_2 = modal.Image.debian_slim()
+)
 
 
 @app.function(image=image_1)

--- a/test/supports/multiapp_privately_decorated_named_app.py
+++ b/test/supports/multiapp_privately_decorated_named_app.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2023
 import modal
 
-app = modal.App("dummy", include_source=True)  # TODO: remove include_source=True)
+app = modal.App("dummy")
 
 
 def foo(i):

--- a/test/supports/multiapp_same_name.py
+++ b/test/supports/multiapp_same_name.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2023
 import modal
 
-app = modal.App("dummy", include_source=True)  # TODO: remove include_source=True)
+app = modal.App("dummy")
 
 
 def foo(i):
@@ -11,7 +11,7 @@ def foo(i):
 foo_handle = app.function()(foo)
 
 
-other_app = modal.App("dummy", include_source=True)  # TODO: remove include_source=True)
+other_app = modal.App("dummy")
 
 
 @other_app.function()

--- a/test/supports/multifile_project/c.py
+++ b/test/supports/multifile_project/c.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2024
 import modal
 
-app = modal.App("c", include_source=True)  # TODO: remove include_source=True)
+app = modal.App("c")
 
 
 @app.function()

--- a/test/supports/package_mount.py
+++ b/test/supports/package_mount.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 from modal import App, Image
 
-app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+app = App()
 
 # just make sure that non-existing package doesn't cause this to crash in containers:
 image = Image.debian_slim().add_local_python_source("non_existing_package_123154")

--- a/test/supports/pkg_a/serialized_fn.py
+++ b/test/supports/pkg_a/serialized_fn.py
@@ -1,12 +1,5 @@
 # Copyright Modal Labs 2022
-import a  # noqa
-import b  # noqa
-import b.c  # noqa
-import pkg_b  # noqa
-import six  # noqa
-
-import modal  # noqa
-
+import modal
 
 app = modal.App()
 

--- a/test/supports/pkg_d/main.py
+++ b/test/supports/pkg_d/main.py
@@ -1,8 +1,6 @@
 # Copyright Modal Labs 2025
 import os
 
-from pkg_a import a  # noqa  # this would cause an automount warning
-
 import modal
 
 app = modal.App()

--- a/test/supports/startup_failure.py
+++ b/test/supports/startup_failure.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 import modal
 
-app = modal.App("hello-world", include_source=True)  # TODO: remove include_source=True)
+app = modal.App("hello-world")
 
 if not modal.is_local():
     import nonexistent_package  # noqa

--- a/test/supports/user_code_import_samples/cls.py
+++ b/test/supports/user_code_import_samples/cls.py
@@ -2,7 +2,7 @@
 import modal
 from modal import App
 
-app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+app = App()
 
 
 class C:

--- a/test/supports/user_code_import_samples/func.py
+++ b/test/supports/user_code_import_samples/func.py
@@ -2,8 +2,7 @@
 
 from modal import App
 
-# TODO: remove include_source=True when automount is disabled by default
-app = App(name="user_code_import_samples_func_app", include_source=True)
+app = App(name="user_code_import_samples_func_app")
 
 
 @app.function()

--- a/test/supports/volume_local.py
+++ b/test/supports/volume_local.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2024
 from modal import App, Volume
 
-app2 = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+app2 = App()
 
 
 @app2.function(volumes={"/foo": Volume.from_name("my-vol")})

--- a/test/watcher_test.py
+++ b/test/watcher_test.py
@@ -50,7 +50,7 @@ def test_watch_mounts_requires_running_app():
         app._get_watch_mounts()
 
 
-def test_watch_mounts_includes_function_mounts(client, supports_dir, monkeypatch, disable_auto_mount):
+def test_watch_mounts_includes_function_mounts(client, supports_dir, monkeypatch):
     # TODO: remove this test once public Mount constructions are fully deprecated
     monkeypatch.syspath_prepend(supports_dir)
     app = modal.App()
@@ -65,7 +65,7 @@ def test_watch_mounts_includes_function_mounts(client, supports_dir, monkeypatch
     assert watch_mounts == [pkg_a_mount]
 
 
-def test_watch_mounts_includes_cls_mounts(client, supports_dir, monkeypatch, disable_auto_mount):
+def test_watch_mounts_includes_cls_mounts(client, supports_dir, monkeypatch):
     # TODO: remove this test once public Mount constructions are fully deprecated
     monkeypatch.syspath_prepend(supports_dir)
     app = modal.App()
@@ -82,7 +82,7 @@ def test_watch_mounts_includes_cls_mounts(client, supports_dir, monkeypatch, dis
     assert watch_mounts == [pkg_a_mount]
 
 
-def test_watch_mounts_includes_image_mounts(client, supports_dir, monkeypatch, disable_auto_mount):
+def test_watch_mounts_includes_image_mounts(client, supports_dir, monkeypatch):
     # TODO: remove this test once public Mount constructions are fully deprecated
     monkeypatch.syspath_prepend(supports_dir)
     app = modal.App()
@@ -98,7 +98,7 @@ def test_watch_mounts_includes_image_mounts(client, supports_dir, monkeypatch, d
     assert watch_mounts == [pkg_a_mount]
 
 
-def test_watch_mounts_ignore_non_local(disable_auto_mount, client, servicer):
+def test_watch_mounts_ignore_non_local(client, servicer):
     app = modal.App()
 
     # uses the published client mount - should not be included in watch items
@@ -113,7 +113,7 @@ def test_watch_mounts_ignore_non_local(disable_auto_mount, client, servicer):
     assert len(mounts) == 0
 
 
-def test_add_local_mount_included_in_serve_watchers(servicer, client, supports_on_path, disable_auto_mount):
+def test_add_local_mount_included_in_serve_watchers(servicer, client, supports_on_path):
     deb_slim = modal.Image.debian_slim()
     img = deb_slim.add_local_python_source("pkg_a")
     app = modal.App()

--- a/test/webhook_test.py
+++ b/test/webhook_test.py
@@ -14,7 +14,7 @@ from modal.functions import Function
 from modal.running_app import RunningApp
 from modal_proto import api_pb2
 
-app = App(include_source=True)  # TODO: remove include_source=True when automount is disabled by default
+app = App()
 
 
 @app.function(cpu=42)


### PR DESCRIPTION
## Describe your changes

- Closes CLI-400

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- We've made some breaking changes to Modal's "automounting" behavior:
  - Previously, Modal containers would automatically include the source for local Python packages that were imported by your Modal App. Going forward, it will be necessary to explicitly include such packages in the Image (i.e., with `modal.Image.add_local_python_source`). If you've not already adapted your source code in response to warnings about changes in the automount behavior, Apps built with 1.0+ will have different files included and may not run as expected.
  - Support for the `automount` configuration (`MODAL_AUTOMOUNT`) has been removed; this environment variable will no longer have any effect.
  - Modal will continue to automatically include the Python module or package where the Function is defined. This is narrower in scope than the old automounting behavior: it's limited to at most a single package, and it includes only `.py` files. The limited automounting can also be disabled in cases where your Image definition already includes the package defining the App: set `include_source=False` in the `modal.App` constructor or `@app.function` decorator.