### PR TITLE
Update id to timestamp_ns for TaskLog

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -30,7 +30,6 @@ from ._partial_function import (
 )
 from ._utils.async_utils import synchronize_api
 from ._utils.deprecation import (
-    deprecation_error,
     deprecation_warning,
     warn_on_renamed_autoscaler_settings,
 )

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2786,7 +2786,7 @@ message TaskLogs {
   TaskProgress task_progress = 9;
   string function_call_id = 10;
   string input_id = 11;
-  string id = 12;
+  uint64 timestamp_ns = 12;
 }
 
 message TaskLogsBatch {


### PR DESCRIPTION
We decided to use `timestamp_ns` instead of `id` here. (`id` was a concatenation of task_id and timestamp_ns but now we'll just send timestamp_ns and concatenate a unique on the FE.)