### PR TITLE
Accept auth token in initial metadata too

### DIFF
--- a/modal/_utils/grpc_utils.py
+++ b/modal/_utils/grpc_utils.py
@@ -148,15 +148,20 @@ def create_channel(
 
         logger.debug(f"Sending request to {event.method_name}")
 
-    async def recv_trailing_metadata(trailing_metadata: grpclib.events.RecvTrailingMetadata) -> None:
+    async def recv_initial_metadata(initial_metadata: grpclib.events.RecvInitialMetadata) -> None:
         # If we receive an auth token from the server, include it in all future requests.
         # TODO(nathan): This isn't perfect because the metadata isn't propagated when the
         # process is forked and a new channel is created. This is OK for now since this
         # token is only used by the experimental input plane
+        if token := initial_metadata.metadata.get("x-modal-auth-token"):
+            metadata["x-modal-auth-token"] = str(token)
+
+    async def recv_trailing_metadata(trailing_metadata: grpclib.events.RecvTrailingMetadata) -> None:
         if token := trailing_metadata.metadata.get("x-modal-auth-token"):
             metadata["x-modal-auth-token"] = str(token)
 
     grpclib.events.listen(channel, grpclib.events.SendRequest, send_request)
+    grpclib.events.listen(channel, grpclib.events.RecvInitialMetadata, recv_initial_metadata)
     grpclib.events.listen(channel, grpclib.events.RecvTrailingMetadata, recv_trailing_metadata)
 
     return channel


### PR DESCRIPTION
Auth tokens can be sent in either the initial metadata (from Rust) or the trailing metadata (from Python). This PR adds support for accepting auth tokens from initial metadata.

I think we should consider sending auth tokens exclusively in initial metadata at some point.