### PR TITLE
Misc deprecation cleanup

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -41,7 +41,7 @@ from ._utils.async_utils import (
     synchronizer,
     warn_if_generator_is_not_consumed,
 )
-from ._utils.deprecation import deprecation_error, deprecation_warning
+from ._utils.deprecation import deprecation_warning
 from ._utils.function_utils import (
     ATTEMPT_TIMEOUT_GRACE_PERIOD,
     OUTPUTS_TIMEOUT,
@@ -404,12 +404,6 @@ class FunctionStats:
 
     backlog: int
     num_total_runners: int
-
-    def __getattr__(self, name):
-        if name == "num_active_runners":
-            msg = "'FunctionStats.num_active_runners' is no longer available."
-            deprecation_error((2024, 6, 14), msg)
-        raise AttributeError(f"'FunctionStats' object has no attribute '{name}'")
 
 
 def _parse_retries(

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1184,7 +1184,8 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
 
     @live_method
     async def keep_warm(self, warm_pool_size: int) -> None:
-        """Set the warm pool size for the Function.
+        """mdmd:hidden
+        Set the warm pool size for the Function.
 
         DEPRECATED: Please adapt your code to use the more general `update_autoscaler` method instead:
 
@@ -1288,7 +1289,8 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
     ) -> "_Function":
-        """Lookup a Function from a deployed App by its name.
+        """mdmd:hidden
+        Lookup a Function from a deployed App by its name.
 
         DEPRECATED: This method is deprecated in favor of `modal.Function.from_name`.
 
@@ -1412,7 +1414,8 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
     @property
     @live_method
     async def web_url(self) -> Optional[str]:
-        """Deprecated. Use the `Function.get_web_url()` method instead.
+        """mdmd:hidden
+        Deprecated. Use the `Function.get_web_url()` method instead.
 
         URL of a Function running as a web endpoint.
         """
@@ -1855,7 +1858,8 @@ class _FunctionCall(typing.Generic[ReturnType], _Object, type_prefix="fc"):
 
 
 async def _gather(*function_calls: _FunctionCall[T]) -> typing.Sequence[T]:
-    """Deprecated: Please use `modal.FunctionCall.gather()` instead."""
+    """mdmd:hidden
+    Deprecated: Please use `modal.FunctionCall.gather()` instead."""
     deprecation_warning(
         (2025, 2, 24),
         "`modal.functions.gather()` is deprecated; please use `modal.FunctionCall.gather()` instead.",

--- a/modal/_partial_function.py
+++ b/modal/_partial_function.py
@@ -649,7 +649,7 @@ def _web_server(
 def _build(
     _warn_parentheses_missing=None, *, force: bool = False, timeout: int = 86400
 ) -> Callable[[Union[_PartialFunction, NullaryMethod]], _PartialFunction]:
-    """
+    """mdmd:hidden
     Decorator for methods that execute at _build time_ to create a new Image layer.
 
     **Deprecated**: This function is deprecated. We recommend using `modal.Volume`

--- a/modal/app.py
+++ b/modal/app.py
@@ -535,14 +535,6 @@ class _App:
         return self._local_entrypoints
 
     @property
-    def indexed_objects(self) -> dict[str, _Object]:
-        deprecation_warning(
-            (2024, 11, 25),
-            "`app.indexed_objects` is deprecated! Use `app.registered_functions` or `app.registered_classes` instead.",
-        )
-        return dict(**self._functions, **self._classes)
-
-    @property
     def registered_web_endpoints(self) -> list[str]:
         """Names of web endpoint (ie. webhook) functions registered on the app."""
         return self._web_endpoints

--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -11,7 +11,6 @@ from typer import Argument
 
 from modal._object import _get_environment_name
 from modal._utils.async_utils import synchronizer
-from modal._utils.deprecation import deprecation_warning
 from modal.client import _Client
 from modal.environments import ensure_env
 from modal_proto import api_pb2
@@ -41,18 +40,6 @@ async def get_app_id(app_identifier: str, env: Optional[str], client: Optional[_
     if re.match(r"^ap-[a-zA-Z0-9]{22}$", app_identifier):
         return app_identifier
     return await get_app_id_from_name.aio(app_identifier, env, client)
-
-
-def warn_on_name_option(command: str, app_identifier: str, name: str) -> str:
-    if name:
-        message = (
-            "Passing an App name using --name is deprecated;"
-            " App names can now be passed directly as positional arguments:"
-            f"\n\n    modal app {command} {name} ..."
-        )
-        deprecation_warning((2024, 8, 15), message, show_source=False)
-        return name
-    return app_identifier
 
 
 @app_cli.command("list")
@@ -96,7 +83,6 @@ async def list_(env: Optional[str] = ENV_OPTION, json: bool = False):
 def logs(
     app_identifier: str = APP_IDENTIFIER,
     *,
-    name: str = NAME_OPTION,
     env: Optional[str] = ENV_OPTION,
 ):
     """Show App logs, streaming while active.
@@ -116,7 +102,6 @@ def logs(
     ```
 
     """
-    app_identifier = warn_on_name_option("logs", app_identifier, name)
     app_id = get_app_id(app_identifier, env)
     stream_app_logs(app_id)
 
@@ -176,11 +161,9 @@ async def rollback(
 async def stop(
     app_identifier: str = APP_IDENTIFIER,
     *,
-    name: str = NAME_OPTION,
     env: Optional[str] = ENV_OPTION,
 ):
     """Stop an app."""
-    app_identifier = warn_on_name_option("stop", app_identifier, name)
     client = await _Client.from_env()
     app_id = await get_app_id.aio(app_identifier, env)
     req = api_pb2.AppStopRequest(app_id=app_id, source=api_pb2.APP_STOP_SOURCE_CLI)
@@ -193,7 +176,6 @@ async def history(
     app_identifier: str = APP_IDENTIFIER,
     *,
     env: Optional[str] = ENV_OPTION,
-    name: str = NAME_OPTION,
     json: bool = False,
 ):
     """Show App deployment history, for a currently deployed app
@@ -213,7 +195,6 @@ async def history(
     ```
 
     """
-    app_identifier = warn_on_name_option("history", app_identifier, name)
     env = ensure_env(env)
     client = await _Client.from_env()
     app_id = await get_app_id.aio(app_identifier, env, client)

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -594,7 +594,6 @@ More information on class parameterization can be found here: https://modal.com/
         *,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name: Optional[str] = None,
-        workspace: Optional[str] = None,  # Deprecated and unused
     ) -> "_Cls":
         """Reference a Cls from a deployed App by its name.
 
@@ -608,18 +607,12 @@ More information on class parameterization can be found here: https://modal.com/
         """
         _environment_name = environment_name or config.get("environment")
 
-        if workspace is not None:
-            deprecation_warning(
-                (2025, 1, 27), "The `workspace` argument is no longer used and will be removed in a future release."
-            )
-
         async def _load_remote(self: _Cls, resolver: Resolver, existing_object_id: Optional[str]):
             request = api_pb2.ClassGetRequest(
                 app_name=app_name,
                 object_tag=name,
                 namespace=namespace,
                 environment_name=_environment_name,
-                lookup_published=workspace is not None,
                 only_class_function=True,
             )
             try:
@@ -792,7 +785,6 @@ More information on class parameterization can be found here: https://modal.com/
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
-        workspace: Optional[str] = None,  # Deprecated and unused
     ) -> "_Cls":
         """mdmd:hidden
         Lookup a Cls from a deployed App by its name.
@@ -815,7 +807,10 @@ More information on class parameterization can be found here: https://modal.com/
             "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
         )
         obj = _Cls.from_name(
-            app_name, name, namespace=namespace, environment_name=environment_name, workspace=workspace
+            app_name,
+            name,
+            namespace=namespace,
+            environment_name=environment_name,
         )
         if client is None:
             client = await _Client.from_env()

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -276,7 +276,8 @@ class _Obj:
         )
 
     async def keep_warm(self, warm_pool_size: int) -> None:
-        """Set the warm pool size for the class containers
+        """mdmd:hidden
+        Set the warm pool size for the class containers
 
         DEPRECATED: Please adapt your code to use the more general `update_autoscaler` method instead:
 
@@ -793,7 +794,8 @@ More information on class parameterization can be found here: https://modal.com/
         environment_name: Optional[str] = None,
         workspace: Optional[str] = None,  # Deprecated and unused
     ) -> "_Cls":
-        """Lookup a Cls from a deployed App by its name.
+        """mdmd:hidden
+        Lookup a Cls from a deployed App by its name.
 
         DEPRECATED: This method is deprecated in favor of `modal.Cls.from_name`.
 

--- a/modal/config.py
+++ b/modal/config.py
@@ -91,14 +91,12 @@ import logging
 import os
 import typing
 import warnings
-from textwrap import dedent
 from typing import Any, Callable, Optional
 
 from google.protobuf.empty_pb2 import Empty
 
 from modal_proto import api_pb2
 
-from ._utils.deprecation import deprecation_error
 from ._utils.logger import configure_logger
 from .exception import InvalidError
 
@@ -186,16 +184,12 @@ def _check_config() -> None:
             f"({user_config_path})."
         )
     elif num_profiles > 1 and num_active == 0 and _profile == "default":
-        # Eventually we plan to have num_profiles > 1 with num_active = 0 be an error
-        # But we want to give users time to activate one of their profiles without disruption
-        message = dedent(
-            """
-            Support for using an implicit 'default' profile is deprecated.
-            Please use `modal profile activate` to activate one of your profiles.
-            (Use `modal profile list` to see the options.)
-            """
+        # TODO: We should get rid of the `_profile = "default"` concept entirely now
+        raise InvalidError(
+            "No Modal profile is active.\n\n"
+            "Please fix by running `modal profile activate` or by editing your Modal config file "
+            f"({user_config_path})."
         )
-        deprecation_error((2024, 2, 6), message)
 
 
 _profile = os.environ.get("MODAL_PROFILE") or _config_active_profile()

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -166,7 +166,8 @@ class _Dict(_Object, type_prefix="di"):
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
     ) -> "_Dict":
-        """Lookup a named Dict.
+        """mdmd:hidden
+        Lookup a named Dict.
 
         DEPRECATED: This method is deprecated in favor of `modal.Dict.from_name`.
 

--- a/modal/image.py
+++ b/modal/image.py
@@ -193,18 +193,6 @@ def _validate_packages(packages: list[str]) -> bool:
     return not any(pkg.startswith("-") for pkg in packages)
 
 
-def _warn_invalid_packages(old_command: str) -> None:
-    deprecation_warning(
-        (2024, 7, 3),
-        "Passing flags to `pip` via the `packages` argument of `pip_install` is deprecated."
-        " Please pass flags via the `extra_options` argument instead."
-        "\nNote that this will cause a rebuild of this image layer."
-        " To avoid rebuilding, you can pass the following to `run_commands` instead:"
-        f'\n`image.run_commands("{old_command}")`',
-        show_source=False,
-    )
-
-
 def _make_pip_install_args(
     find_links: Optional[str] = None,  # Passes -f (--find-links) pip install
     index_url: Optional[str] = None,  # Passes -i (--index-url) to pip install

--- a/modal/image.py
+++ b/modal/image.py
@@ -673,7 +673,7 @@ class _Image(_Object, type_prefix="im"):
         return obj
 
     def copy_mount(self, mount: _Mount, remote_path: Union[str, Path] = ".") -> "_Image":
-        """
+        """mdmd:hidden
         **Deprecated**: Use image.add_local_dir(..., copy=True) or similar instead.
 
         Copy the entire contents of a `modal.Mount` into an image.
@@ -803,7 +803,8 @@ class _Image(_Object, type_prefix="im"):
         return self._add_mount_layer_or_copy(mount, copy=copy)
 
     def copy_local_file(self, local_path: Union[str, Path], remote_path: Union[str, Path] = "./") -> "_Image":
-        """Copy a file into the image as a part of building it.
+        """mdmd:hidden
+        Copy a file into the image as a part of building it.
 
         This works in a similar way to [`COPY`](https://docs.docker.com/engine/reference/builder/#copy)
         works in a `Dockerfile`.
@@ -876,7 +877,7 @@ class _Image(_Object, type_prefix="im"):
         # Which follows dockerignore syntax.
         ignore: Union[Sequence[str], Callable[[Path], bool]] = [],
     ) -> "_Image":
-        """
+        """mdmd:hidden
         **Deprecated**: Use image.add_local_dir instead
 
         Copy a directory into the image as a part of building the image.

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -172,7 +172,8 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
     ) -> "_NetworkFileSystem":
-        """Lookup a named NetworkFileSystem.
+        """mdmd:hidden
+        Lookup a named NetworkFileSystem.
 
         DEPRECATED: This method is deprecated in favor of `modal.NetworkFileSystem.from_name`.
 

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -185,7 +185,8 @@ class _Queue(_Object, type_prefix="qu"):
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
     ) -> "_Queue":
-        """Lookup a named Queue.
+        """mdmd:hidden
+        Lookup a named Queue.
 
         DEPRECATED: This method is deprecated in favor of `modal.Queue.from_name`.
 

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -19,7 +19,6 @@ from ._object import _get_environment_name, _Object
 from ._resolver import Resolver
 from ._resources import convert_fn_config_to_resources_config
 from ._utils.async_utils import TaskContext, synchronize_api
-from ._utils.deprecation import deprecation_error
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.mount_utils import validate_network_file_systems, validate_volumes
 from .client import _Client
@@ -315,14 +314,12 @@ class _Sandbox(_Object, type_prefix="sb"):
             app_id = container_app.app_id
             app_client = container_app._client
         else:
-            arglist = ", ".join(repr(s) for s in entrypoint_args)
-            deprecation_error(
-                (2024, 9, 14),
-                "Creating a `Sandbox` without an `App` is deprecated.\n\n"
-                "You may pass in an `App` object, or reference one by name with `App.lookup`:\n\n"
+            raise InvalidError(
+                "Sandboxes require an App when created outside of a Modal container.\n\n"
+                "Run an ephemeral App (`with app.run(): ...`), or reference a deployed App using `App.lookup`:\n\n"
                 "```\n"
-                "app = modal.App.lookup('sandbox-app', create_if_missing=True)\n"
-                f"sb = modal.Sandbox.create({arglist}, app=app)\n"
+                'app = modal.App.lookup("sandbox-app", create_if_missing=True)\n'
+                "sb = modal.Sandbox.create(..., app=app)\n"
                 "```",
             )
 

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -251,7 +251,8 @@ class _Volume(_Object, type_prefix="vo"):
         create_if_missing: bool = False,
         version: "typing.Optional[modal_proto.api_pb2.VolumeFsVersion.ValueType]" = None,
     ) -> "_Volume":
-        """Lookup a named Volume.
+        """mdmd:hidden
+        Lookup a named Volume.
 
         DEPRECATED: This method is deprecated in favor of `modal.Volume.from_name`.
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -694,7 +694,7 @@ message ClassGetRequest {
   DeploymentNamespace namespace = 3;
   string environment_name = 4;
 
-  bool lookup_published = 8; // Lookup class on app published by another workspace
+  reserved 8; // lookup_published
   reserved 9; // workspace_name
   bool only_class_function = 10; // True starting with 0.67.x clients, which don't create method placeholder functions
 }

--- a/test/async_utils_test.py
+++ b/test/async_utils_test.py
@@ -730,6 +730,7 @@ async def test_callable_to_agen():
 
 
 @pytest.mark.parametrize("in_order", [True, False])
+@pytest.mark.asyncio
 async def test_async_map(in_order):
     result = []
     states = []

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -8,7 +8,7 @@ from google.protobuf.empty_pb2 import Empty
 from grpclib import GRPCError, Status
 
 from modal import Client
-from modal.exception import AuthError, ConnectionError, DeprecationError, InvalidError, ServerWarning
+from modal.exception import AuthError, ConnectionError, InvalidError, ServerWarning
 from modal_proto import api_pb2
 
 from .supports.skip import skip_windows, skip_windows_unix_socket
@@ -171,7 +171,7 @@ def test_implicit_default_profile_warning(servicer, modal_config, server_url_env
     token_secret = 'as_xyz'
     """
     with modal_config(config):
-        with pytest.raises(DeprecationError, match="Support for using an implicit 'default' profile is deprecated."):
+        with pytest.raises(InvalidError, match="No Modal profile is active"):
             Client.from_env()
 
     config = """

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -6,7 +6,7 @@ import time
 from pathlib import Path
 
 from modal import App, Image, Mount, NetworkFileSystem, Proxy, Sandbox, SandboxSnapshot, Secret
-from modal.exception import DeprecationError, InvalidError
+from modal.exception import InvalidError
 from modal.stream_type import StreamType
 from modal_proto import api_pb2
 
@@ -265,7 +265,7 @@ def test_app_sandbox(client, servicer):
     image = Image.debian_slim().pip_install("xyz").add_local_file(__file__, remote_path="/xyz")
     secret = Secret.from_dict({"FOO": "bar"})
 
-    with pytest.raises(DeprecationError, match="Creating a `Sandbox` without an `App`"):
+    with pytest.raises(InvalidError, match="require an App"):
         Sandbox.create("bash", "-c", "echo bye >&2 && echo hi", image=image, secrets=[secret])
 
     app = App()


### PR DESCRIPTION
## Describe your changes

Cleaning up some small-bore deprecation stuff, mostly just removing `deprecation_error` and replacing with a more forward-looking error type / message or falling back to Python error handling (for `AttributeError` cases, etc.).

I also hid a bunch of deprecated methods from the the reference docs; we'll keep supporting these for TBD interval, but this takes another step towards ridding ourselves of them.

- Closes CLI-401

<details> <summary>Checklists</summary>

---

</details>

## Changelog
