### PR TITLE
Patch sending of websocket bytes/text messages

### DIFF
--- a/modal/_serialization.py
+++ b/modal/_serialization.py
@@ -324,8 +324,8 @@ def _deserialize_asgi(asgi: api_pb2.Asgi) -> Any:
     elif msg_type == "websocket_send":
         return {
             "type": "websocket.send",
-            "bytes": asgi.websocket_send.bytes if asgi.websocket_send.HasField("bytes") else None,
-            "text": asgi.websocket_send.text if asgi.websocket_send.HasField("text") else None,
+            **({"bytes": asgi.websocket_send.bytes} if asgi.websocket_send.HasField("bytes") else {}),
+            **({"text": asgi.websocket_send.text} if asgi.websocket_send.HasField("text") else {}),
         }
     elif msg_type == "websocket_disconnect":
         return {


### PR DESCRIPTION
The python-engineio library has a small bug in its ASGI server implementation, which I reported here https://github.com/miguelgrinberg/python-engineio/pull/405

Anyway we can also make the Modal client send messages in a way that doesn't trigger this bug.
