### PR TITLE
[input-plane] Retry inputs failed due to preemption

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -348,10 +348,14 @@ class _InputPlaneInvocation:
         stub: ModalClientModal,
         attempt_token: str,
         client: _Client,
+        input_item: api_pb2.FunctionPutInputsItem,
+        function_id: str
     ):
         self.stub = stub
         self.client = client  # Used by the deserializer.
         self.attempt_token = attempt_token
+        self.input_item = input_item
+        self.function_id = function_id
 
     @staticmethod
     async def create(
@@ -365,36 +369,48 @@ class _InputPlaneInvocation:
         stub = await client.get_stub(input_plane_url)
 
         function_id = function.object_id
-        item = await _create_input(args, kwargs, stub, method_name=function._use_method_name)
+        input_item = await _create_input(args, kwargs, stub, method_name=function._use_method_name)
 
         request = api_pb2.AttemptStartRequest(
             function_id=function_id,
             parent_input_id=current_input_id() or "",
-            input=item,
+            input=input_item,
         )
         response = await retry_transient_errors(stub.AttemptStart, request)
         attempt_token = response.attempt_token
 
-        return _InputPlaneInvocation(stub, attempt_token, client)
+        return _InputPlaneInvocation(stub, attempt_token, client, input_item, function_id)
 
     async def run_function(self) -> Any:
-        # TODO(nathan): add retry logic
+        # This will retry when the server returns GENERIC_STATUS_INTERNAL_FAILURE, i.e. lost inputs or worker preemption
+        # TODO(ryan): add logic to retry for user defined
         while True:
-            request = api_pb2.AttemptAwaitRequest(
+            await_request = api_pb2.AttemptAwaitRequest(
                 attempt_token=self.attempt_token,
                 timeout_secs=OUTPUTS_TIMEOUT,
                 requested_at=time.time(),
             )
-            response: api_pb2.AttemptAwaitResponse = await retry_transient_errors(
+            await_response: api_pb2.AttemptAwaitResponse = await retry_transient_errors(
                 self.stub.AttemptAwait,
-                request,
+                await_request,
                 attempt_timeout=OUTPUTS_TIMEOUT + ATTEMPT_TIMEOUT_GRACE_PERIOD,
             )
 
-            if response.HasField("output"):
+            try:
                 return await _process_result(
-                    response.output.result, response.output.data_format, self.stub, self.client
+                    await_response.output.result, await_response.output.data_format, self.stub, self.client
                 )
+            except InternalFailure:
+                # For system failures on the server, we retry immediately,
+                # and the failure does not count towards the retry policy.
+                retry_request = api_pb2.AttemptRetryRequest(
+                    function_id=self.function_id,
+                    parent_input_id=current_input_id() or "",
+                    input=self.input_item,
+                    attempt_token=self.attempt_token
+                )
+                retry_response = await retry_transient_errors(self.stub.AttemptRetry, retry_request)
+                self.attempt_token = retry_response.attempt_token
 
 
 # Wrapper type for api_pb2.FunctionStats

--- a/modal/_utils/function_utils.py
+++ b/modal/_utils/function_utils.py
@@ -466,7 +466,10 @@ async def _process_result(result: api_pb2.GenericResult, data_format: int, stub,
 
     if result.status == api_pb2.GenericResult.GENERIC_STATUS_TIMEOUT:
         raise FunctionTimeoutError(result.exception)
-    elif result.status == api_pb2.GenericResult.GENERIC_STATUS_INTERNAL_FAILURE:
+    elif result.status in [
+        api_pb2.GenericResult.GENERIC_STATUS_INTERNAL_FAILURE,
+        api_pb2.GenericResult.GENERIC_STATUS_TERMINATED,
+    ]:
         raise InternalFailure(result.exception)
     elif result.status != api_pb2.GenericResult.GENERIC_STATUS_SUCCESS:
         if data:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -310,6 +310,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.function_get_server_warnings = None
         self.resp_jitter_secs: float = 0.0
         self.port = port
+        self.attempts_to_fail = 0
 
         @self.function_body
         def default_function_body(*args, **kwargs):
@@ -2085,16 +2086,22 @@ class MockClientServicer(api_grpc.ModalClientBase):
         )
 
     async def AttemptAwait(self, stream):
-        # TODO(ryan): Eventually we want to invoke the user's function and return a result.
-        # For now we just return a dummy response which allows the test to verify that the input_plane_region param
-        # was honored, and we hit this endpoint rather than get_outputs.
+        # TODO(ryan): Eventually we may want to invoke the user's function and return a result.
+        # For now we just return a dummy response
+
+        # To test client retries, test can configure outputs to fail some number of times.
+        status = api_pb2.GenericResult.GENERIC_STATUS_SUCCESS
+        if self.attempts_to_fail > 0:
+            status = api_pb2.GenericResult.GENERIC_STATUS_TERMINATED
+            self.attempts_to_fail = self.attempts_to_fail - 1
+
         await stream.send_message(
             api_pb2.AttemptAwaitResponse(
                 output=api_pb2.FunctionGetOutputsItem(
                     input_id="in-1",
                     idx=0,
                     result=api_pb2.GenericResult(
-                        status=api_pb2.GenericResult.GENERIC_STATUS_SUCCESS,
+                        status=status,
                         data=serialize_data_format("attempt_await_bogus_response", api_pb2.DATA_FORMAT_PICKLE),
                     ),
                     data_format=api_pb2.DATA_FORMAT_PICKLE,
@@ -2102,6 +2109,9 @@ class MockClientServicer(api_grpc.ModalClientBase):
                 )
             )
         )
+
+    async def AttemptRetry(self, stream):
+        await stream.send_message(api_pb2.AttemptRetryResponse(attempt_token="bogus_retry_token"))
 
 
 @pytest.fixture

--- a/test/input_plane_test.py
+++ b/test/input_plane_test.py
@@ -24,3 +24,17 @@ def test_lookup_foo(client, servicer):
     deploy_app(app, "app", client=client)
     f = Function.from_name("app", "foo").hydrate(client)
     assert f.remote() == "attempt_await_bogus_response"
+
+@app.function(experimental_options={"input_plane_region": "us-east"})
+def maybe_fail():
+    raise ValueError("fail")
+
+def test_retry(client, servicer):
+    # Tell the servicer to fail once, and then succeed. The client should retry the failed attempt.
+    servicer.attempts_to_fail = 1
+    with app.run(client=client):
+        assert foo.remote() == "attempt_await_bogus_response"
+    # We don't have a great way to verify the call was actually retried. We can at least check that the servicer
+    # decremented the attempts_to_fail counter, which indicates that the call was retried.
+    assert servicer.attempts_to_fail == 0
+


### PR DESCRIPTION
Closes SVC-595

When a worker is preempted, the input plane will return an output with status `GENERIC_STATUS_TERMINATED`. The client should retry these.

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
