### PR TITLE
Remove modal.Stub

### DIFF
--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -11,7 +11,7 @@ from modal_version import __version__
 try:
     from ._runtime.execution_context import current_function_call_id, current_input_id, interact, is_local
     from ._tunnel import Tunnel, forward
-    from .app import App, Stub
+    from .app import App
     from .client import Client
     from .cloud_bucket_mount import CloudBucketMount
     from .cls import Cls, parameter
@@ -54,6 +54,7 @@ except Exception:
     print()
     raise
 
+
 __all__ = [
     "__version__",
     "App",
@@ -77,7 +78,6 @@ __all__ = [
     "SandboxSnapshot",
     "SchedulerPlacement",
     "Secret",
-    "Stub",
     "Tunnel",
     "Volume",
     "asgi_app",
@@ -99,3 +99,11 @@ __all__ = [
     "web_server",
     "wsgi_app",
 ]
+
+
+def __getattr__(name):
+    if name == "Stub":
+        raise AttributeError(
+            "Module 'modal' has no attribute 'Stub'. Use `modal.App` instead. This is a simple name change."
+        )
+    raise AttributeError(f"module 'modal' has no attribute '{name}'")

--- a/modal/app.py
+++ b/modal/app.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2022
 import inspect
 import typing
-import warnings
 from collections.abc import AsyncGenerator, Coroutine, Sequence
 from pathlib import PurePosixPath
 from textwrap import dedent
@@ -76,11 +75,6 @@ class _LocalEntrypoint:
 
     @property
     def app(self) -> "_App":
-        return self._app
-
-    @property
-    def stub(self) -> "_App":
-        # Deprecated soon, only for backwards compatibility
         return self._app
 
 
@@ -781,12 +775,6 @@ class _App:
                 rdma = None
                 i6pn_enabled = i6pn
 
-            if info.function_name.endswith(".app"):
-                warnings.warn(
-                    "Beware: the function name is `app`. Modal will soon rename `Stub` to `App`, "
-                    "so you might run into issues if you have code like `app = modal.App()` in the same scope"
-                )
-
             if is_generator is None:
                 is_generator = inspect.isgeneratorfunction(raw_f) or inspect.isasyncgenfunction(raw_f)
 
@@ -1096,23 +1084,3 @@ class _App:
 
 
 App = synchronize_api(_App)
-
-
-class _Stub(_App):
-    """mdmd:hidden
-    This enables using a "Stub" class instead of "App".
-
-    For most of Modal's history, the app class was called "Stub", so this exists for
-    backwards compatibility, in order to facilitate moving from "Stub" to "App".
-    """
-
-    def __new__(cls, *args, **kwargs):
-        deprecation_warning(
-            (2024, 4, 29),
-            'The use of "Stub" has been deprecated in favor of "App".'
-            " This is a pure name change with no other implications.",
-        )
-        return _App(*args, **kwargs)
-
-
-Stub = synchronize_api(_Stub)

--- a/modal/exception.py
+++ b/modal/exception.py
@@ -116,7 +116,7 @@ class InternalFailure(Error):
 
 class _CliUserExecutionError(Exception):
     """mdmd:hidden
-    Private wrapper for exceptions during when importing or running stubs from the CLI.
+    Private wrapper for exceptions during when importing or running Apps from the CLI.
 
     This intentionally does not inherit from `modal.exception.Error` because it
     is a private type that should never bubble up to users. Exceptions raised in

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -6,7 +6,7 @@ import time
 
 from grpclib import GRPCError, Status
 
-from modal import App, Image, Mount, Secret, Stub, Volume, enable_output, fastapi_endpoint, web_endpoint
+from modal import App, Image, Mount, Secret, Volume, enable_output, fastapi_endpoint, web_endpoint
 from modal._partial_function import _parse_custom_domains
 from modal._utils.async_utils import synchronizer
 from modal.exception import DeprecationError, ExecutionError, InvalidError, NotFoundError
@@ -342,23 +342,6 @@ def test_app(client):
 def test_non_string_app_name():
     with pytest.raises(InvalidError, match="Must be string"):
         App(Image.debian_slim())  # type: ignore
-
-
-def test_function_named_app():
-    # Make sure we have a helpful warning when a user's function is named "app"
-    # as it might collide with the App variable name (in particular if people
-    # find & replace "stub" with "app").
-    app = App()
-
-    with pytest.warns(match="app"):
-
-        @app.function(serialized=True)
-        def app(): ...
-
-
-def test_stub():
-    with pytest.warns(match="App"):
-        Stub()
 
 
 def test_app_logs(servicer, client):

--- a/test/cli_imports_test.py
+++ b/test/cli_imports_test.py
@@ -16,7 +16,7 @@ from modal.exception import DeprecationError, InvalidError
 from modal.functions import Function
 from modal.partial_function import method, web_server
 
-# Some helper vars for import_stub tests:
+# Some helper vars for import_app tests:
 local_entrypoint_src = """
 import modal
 

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -178,12 +178,6 @@ def test_run_warns_without_module_flag(
         _run(["run", f"{app_module}::foo"])
 
 
-def test_run_stub(servicer, set_env_client, test_dir):
-    app_file = test_dir / "supports" / "app_run_tests" / "app_was_once_stub.py"
-    with pytest.warns(match="App"):
-        _run(["run", app_file.as_posix() + "::foo"])
-
-
 def test_run_async(servicer, set_env_client, test_dir):
     sync_fn = test_dir / "supports" / "app_run_tests" / "local_entrypoint.py"
     res = _run(["run", sync_fn.as_posix()])

--- a/test/supports/app_run_tests/app_was_once_stub.py
+++ b/test/supports/app_run_tests/app_was_once_stub.py
@@ -1,9 +1,0 @@
-# Copyright Modal Labs 2024
-import modal
-
-app = modal.Stub()
-
-
-@app.function()
-def foo():
-    print("foo")


### PR DESCRIPTION
## Describe your changes

Makes it an error to reference `modal.Stub`, whereas previously we had kept `Stub` as an alias for `App`. It's an `AttributeError`, but we have a special error message pointing the user towards `modal.App`.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.



</details>

## Changelog

- Referencing the deprecated `modal.Stub` object will now raise an `AttributeError`, whereas previously it was an alias for `modal.App`. This is a simple name change.