### PR TITLE
Remove public `modal.Mount` concept and `mounts=` arguments

### DIFF
--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -20,7 +20,6 @@ try:
     from .file_pattern_matcher import FilePatternMatcher
     from .functions import Function, FunctionCall
     from .image import Image
-    from .mount import Mount
     from .network_file_system import NetworkFileSystem
     from .output import enable_output
     from .partial_function import (
@@ -66,7 +65,6 @@ __all__ = [
     "Function",
     "FunctionCall",
     "Image",
-    "Mount",
     "NetworkFileSystem",
     "Period",
     "Proxy",

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -737,16 +737,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
 
         def _deps(only_explicit_mounts=False) -> list[_Object]:
             deps: list[_Object] = list(secrets)
-            if only_explicit_mounts:
-                # TODO: this is a bit hacky, but all_mounts may differ in the container vs locally
-                # We don't want the function dependencies to change, so we have this way to force it to
-                # only include its declared dependencies.
-                # Only objects that need interaction within a user's container actually need to be
-                # included when only_explicit_mounts=True, so omitting auto mounts here
-                # wouldn't be a problem as long as Mounts are "passive" and only loaded by the
-                # worker runtime
-                pass
-            else:
+            if not only_explicit_mounts:
                 deps += list(all_mounts)
             if proxy:
                 deps.append(proxy)

--- a/modal/app.py
+++ b/modal/app.py
@@ -45,7 +45,6 @@ from .exception import ExecutionError, InvalidError
 from .functions import Function
 from .gpu import GPU_T
 from .image import _Image
-from .mount import _Mount
 from .network_file_system import _NetworkFileSystem
 from .partial_function import PartialFunction
 from .proxy import _Proxy
@@ -162,7 +161,6 @@ class _App:
     _classes: dict[str, _Cls]
 
     _image: Optional[_Image]
-    _mounts: Sequence[_Mount]
     _secrets: Sequence[_Secret]
     _volumes: dict[Union[str, PurePosixPath], _Volume]
     _web_endpoints: list[str]  # Used by the CLI
@@ -180,7 +178,6 @@ class _App:
         name: Optional[str] = None,
         *,
         image: Optional[_Image] = None,  # default image for all functions (default is `modal.Image.debian_slim()`)
-        mounts: Sequence[_Mount] = [],  # default mounts for all functions
         secrets: Sequence[_Secret] = [],  # default secrets for all functions
         volumes: dict[Union[str, PurePosixPath], _Volume] = {},  # default volumes for all functions
         include_source: Optional[bool] = None,
@@ -201,7 +198,6 @@ class _App:
         self._description = name
         self._include_source_default = include_source
 
-        check_sequence(mounts, _Mount, "`mounts=` has to be a list or tuple of `modal.Mount` objects")
         check_sequence(secrets, _Secret, "`secrets=` has to be a list or tuple of `modal.Secret` objects")
         validate_volumes(volumes)
 
@@ -211,7 +207,6 @@ class _App:
         self._functions = {}
         self._classes = {}
         self._image = image
-        self._mounts = mounts
         self._secrets = secrets
         self._volumes = volumes
         self._local_entrypoints = {}
@@ -452,9 +447,7 @@ class _App:
         if not self._running_app:
             raise ExecutionError("`_get_watch_mounts` requires a running app.")
 
-        all_mounts = [
-            *self._mounts,
-        ]
+        all_mounts = []
         for function in self.registered_functions.values():
             all_mounts.extend(function._serve_mounts)
 
@@ -618,7 +611,6 @@ class _App:
             GPU_T, list[GPU_T]
         ] = None,  # GPU request as string ("any", "T4", ...), object (`modal.GPU.A100()`, ...), or a list of either
         serialized: bool = False,  # Whether to send the function over using cloudpickle.
-        mounts: Sequence[_Mount] = (),  # Modal Mounts added to the container
         network_file_systems: dict[
             Union[str, PurePosixPath], _NetworkFileSystem
         ] = {},  # Mountpoints for Modal NetworkFileSystems
@@ -804,7 +796,6 @@ class _App:
                 schedule=schedule,
                 is_generator=is_generator,
                 gpu=gpu,
-                mounts=[*self._mounts, *mounts],
                 network_file_systems=network_file_systems,
                 volumes={**self._volumes, **volumes},
                 cpu=cpu,
@@ -855,7 +846,6 @@ class _App:
             GPU_T, list[GPU_T]
         ] = None,  # GPU request as string ("any", "T4", ...), object (`modal.GPU.A100()`, ...), or a list of either
         serialized: bool = False,  # Whether to send the function over using cloudpickle.
-        mounts: Sequence[_Mount] = (),
         network_file_systems: dict[
             Union[str, PurePosixPath], _NetworkFileSystem
         ] = {},  # Mountpoints for Modal NetworkFileSystems
@@ -977,7 +967,6 @@ class _App:
                 image=image or self._get_default_image(),
                 secrets=[*self._secrets, *secrets],
                 gpu=gpu,
-                mounts=[*self._mounts, *mounts],
                 network_file_systems=network_file_systems,
                 volumes={**self._volumes, **volumes},
                 cpu=cpu,

--- a/modal/image.py
+++ b/modal/image.py
@@ -1892,7 +1892,6 @@ class _Image(_Object, type_prefix="im"):
         *,
         secrets: Sequence[_Secret] = (),  # Optional Modal Secret objects with environment variables for the container
         gpu: Union[GPU_T, list[GPU_T]] = None,  # Requested GPU or or list of acceptable GPUs( e.g. ["A10", "A100"])
-        mounts: Sequence[_Mount] = (),  # Mounts attached to the function
         volumes: dict[Union[str, PurePosixPath], Union[_Volume, _CloudBucketMount]] = {},  # Volume mount paths
         network_file_systems: dict[Union[str, PurePosixPath], _NetworkFileSystem] = {},  # NFS mount paths
         cpu: Optional[float] = None,  # How many CPU cores to request. This is a soft limit.
@@ -1950,7 +1949,6 @@ class _Image(_Object, type_prefix="im"):
             image=self,  # type: ignore[reportArgumentType]  # TODO: probably conflict with type stub?
             secrets=secrets,
             gpu=gpu,
-            mounts=mounts,
             volumes=volumes,
             network_file_systems=network_file_systems,
             cloud=cloud,

--- a/modal/image.py
+++ b/modal/image.py
@@ -437,7 +437,7 @@ class _Image(_Object, type_prefix="im"):
 
     def _add_mount_layer_or_copy(self, mount: _Mount, copy: bool = False):
         if copy:
-            return self.copy_mount(mount, remote_path="/")
+            return self._copy_mount(mount, remote_path="/")
 
         base_image = self
 
@@ -672,23 +672,9 @@ class _Image(_Object, type_prefix="im"):
         )
         return obj
 
-    def copy_mount(self, mount: _Mount, remote_path: Union[str, Path] = ".") -> "_Image":
+    def _copy_mount(self, mount: _Mount, remote_path: Union[str, Path] = ".") -> "_Image":
         """mdmd:hidden
-        **Deprecated**: Use image.add_local_dir(..., copy=True) or similar instead.
-
-        Copy the entire contents of a `modal.Mount` into an image.
-        Useful when files only available locally are required during the image
-        build process.
-
-        **Example**
-
-        ```python notest
-        static_images_dir = "./static"
-        # place all static images in root of mount
-        mount = modal.Mount.from_local_dir(static_images_dir, remote_path="/")
-        # place mount's contents into /static directory of image.
-        image = modal.Image.debian_slim().copy_mount(mount, remote_path="/static")
-        ```
+        Internal
         """
         if not isinstance(mount, _Mount):
             raise InvalidError("The mount argument to copy has to be a Modal Mount object")

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -601,8 +601,9 @@ async def _interactive_shell(
             "MODAL_ENVIRONMENT": _get_environment_name(),
         }
         secrets = kwargs.pop("secrets", []) + [_Secret.from_dict(sandbox_env)]
+
         with enable_output():  # show any image build logs
-            sandbox = await _Sandbox.create(
+            sandbox = await _Sandbox._create(
                 "sleep",
                 "100000",
                 app=_app,

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -12,6 +12,7 @@ from grpclib import GRPCError, Status
 
 from modal._tunnel import Tunnel
 from modal.cloud_bucket_mount import _CloudBucketMount, cloud_bucket_mounts_to_proto
+from modal.mount import _Mount
 from modal.volume import _Volume
 from modal_proto import api_pb2
 
@@ -92,6 +93,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         region: Optional[Union[str, Sequence[str]]] = None,
         cpu: Optional[float] = None,
         memory: Optional[Union[int, tuple[int, int]]] = None,
+        mounts: Sequence[_Mount] = (),
         network_file_systems: dict[Union[str, os.PathLike], _NetworkFileSystem] = {},
         block_network: bool = False,
         cidr_allowlist: Optional[Sequence[str]] = None,
@@ -128,7 +130,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         validated_volumes = [(k, v) for k, v in validated_volumes if isinstance(v, _Volume)]
 
         def _deps() -> list[_Object]:
-            deps: list[_Object] = [image] + list(secrets)
+            deps: list[_Object] = [image] + list(mounts) + list(secrets)
             for _, vol in validated_network_file_systems:
                 deps.append(vol)
             for _, vol in validated_volumes:
@@ -176,7 +178,7 @@ class _Sandbox(_Object, type_prefix="sb"):
             definition = api_pb2.Sandbox(
                 entrypoint_args=entrypoint_args,
                 image_id=image.object_id,
-                mount_ids=[mount.object_id for mount in image._mount_layers],
+                mount_ids=[mount.object_id for mount in mounts] + [mount.object_id for mount in image._mount_layers],
                 secret_ids=[secret.object_id for secret in secrets],
                 timeout_secs=timeout,
                 workdir=workdir,
@@ -261,6 +263,76 @@ class _Sandbox(_Object, type_prefix="sb"):
         sandbox.wait()
         ```
         """
+        return await _Sandbox._create(
+            *entrypoint_args,
+            app=app,
+            environment_name=environment_name,
+            image=image,
+            secrets=secrets,
+            network_file_systems=network_file_systems,
+            timeout=timeout,
+            workdir=workdir,
+            gpu=gpu,
+            cloud=cloud,
+            region=region,
+            cpu=cpu,
+            memory=memory,
+            block_network=block_network,
+            cidr_allowlist=cidr_allowlist,
+            volumes=volumes,
+            pty_info=pty_info,
+            encrypted_ports=encrypted_ports,
+            unencrypted_ports=unencrypted_ports,
+            proxy=proxy,
+            _experimental_enable_snapshot=_experimental_enable_snapshot,
+            _experimental_scheduler_placement=_experimental_scheduler_placement,
+            client=client,
+        )
+
+    @staticmethod
+    async def _create(
+        *entrypoint_args: str,
+        app: Optional["modal.app._App"] = None,  # Optionally associate the sandbox with an app
+        environment_name: Optional[str] = None,  # Optionally override the default environment
+        image: Optional[_Image] = None,  # The image to run as the container for the sandbox.
+        secrets: Sequence[_Secret] = (),  # Environment variables to inject into the sandbox.
+        mounts: Sequence[_Mount] = (),
+        network_file_systems: dict[Union[str, os.PathLike], _NetworkFileSystem] = {},
+        timeout: Optional[int] = None,  # Maximum execution time of the sandbox in seconds.
+        workdir: Optional[str] = None,  # Working directory of the sandbox.
+        gpu: GPU_T = None,
+        cloud: Optional[str] = None,
+        region: Optional[Union[str, Sequence[str]]] = None,  # Region or regions to run the sandbox on.
+        # Specify, in fractional CPU cores, how many CPU cores to request.
+        # Or, pass (request, limit) to additionally specify a hard limit in fractional CPU cores.
+        # CPU throttling will prevent a container from exceeding its specified limit.
+        cpu: Optional[Union[float, tuple[float, float]]] = None,
+        # Specify, in MiB, a memory request which is the minimum memory required.
+        # Or, pass (request, limit) to additionally specify a hard limit in MiB.
+        memory: Optional[Union[int, tuple[int, int]]] = None,
+        block_network: bool = False,  # Whether to block network access
+        # List of CIDRs the sandbox is allowed to access. If None, all CIDRs are allowed.
+        cidr_allowlist: Optional[Sequence[str]] = None,
+        volumes: dict[
+            Union[str, os.PathLike], Union[_Volume, _CloudBucketMount]
+        ] = {},  # Mount points for Modal Volumes and CloudBucketMounts
+        pty_info: Optional[api_pb2.PTYInfo] = None,
+        # List of ports to tunnel into the sandbox. Encrypted ports are tunneled with TLS.
+        encrypted_ports: Sequence[int] = [],
+        # List of ports to tunnel into the sandbox without encryption.
+        unencrypted_ports: Sequence[int] = [],
+        # Reference to a Modal Proxy to use in front of this Sandbox.
+        proxy: Optional[_Proxy] = None,
+        # Enable memory snapshots.
+        _experimental_enable_snapshot: bool = False,
+        _experimental_scheduler_placement: Optional[
+            SchedulerPlacement
+        ] = None,  # Experimental controls over fine-grained scheduling (alpha).
+        client: Optional[_Client] = None,
+    ):
+        # This method exposes some internal arguments (currently `mounts`) which are not in the public API
+        # `mounts` is currently only used by modal shell (cli) to provide a function's mounts to the
+        # sandbox that runs the shell session
         from .app import _App
 
         environment_name = _get_environment_name(environment_name)
@@ -279,6 +351,7 @@ class _Sandbox(_Object, type_prefix="sb"):
             region=region,
             cpu=cpu,
             memory=memory,
+            mounts=mounts,
             network_file_systems=network_file_systems,
             block_network=block_network,
             cidr_allowlist=cidr_allowlist,

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -6,7 +6,7 @@ import time
 
 from grpclib import GRPCError, Status
 
-from modal import App, Image, Mount, Secret, Stub, Volume, enable_output, fastapi_endpoint, web_endpoint
+from modal import App, Image, Secret, Stub, Volume, enable_output, fastapi_endpoint, web_endpoint
 from modal._partial_function import _parse_custom_domains
 from modal._utils.async_utils import synchronizer
 from modal.exception import DeprecationError, ExecutionError, InvalidError, NotFoundError
@@ -218,7 +218,6 @@ def test_init_types():
     App(
         image=Image.debian_slim().pip_install("pandas"),
         secrets=[Secret.from_dict()],
-        mounts=[Mount._from_local_file(__file__)],  # TODO: remove
     )
 
 

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -762,7 +762,7 @@ def test_volume_rename(servicer, server_url_env, set_env_client):
     assert old_name not in _run(["volume", "list"]).stdout
 
 
-@pytest.mark.parametrize("command", [["run"], ["deploy"], ["serve", "--timeout=1"], ["shell"]])
+@pytest.mark.parametrize("command", [["shell"]])
 @pytest.mark.usefixtures("set_env_client", "mock_shell_pty")
 @skip_windows("modal shell is not supported on Windows.")
 def test_environment_flag(test_dir, servicer, command):

--- a/test/mount_test.py
+++ b/test/mount_test.py
@@ -5,6 +5,7 @@ import platform
 import pytest
 from pathlib import Path, PurePosixPath
 
+import modal
 from modal import App, FilePatternMatcher
 from modal._utils.blob_utils import LARGE_FILE_LIMIT
 from modal.mount import Mount, client_mount_name, module_mount_condition, module_mount_ignore_condition
@@ -86,12 +87,12 @@ def dummy():
     pass
 
 
-def test_from_local_python_packages(servicer, client, test_dir, monkeypatch):
+def test_add_local_python_source(servicer, client, test_dir, monkeypatch):
     app = App()
 
     monkeypatch.syspath_prepend((test_dir / "supports").as_posix())
 
-    app.function(mounts=[Mount._from_local_python_packages("pkg_a", "pkg_b", "standalone_file")])(dummy)
+    app.function(image=modal.Image.debian_slim().add_local_python_source("pkg_a", "pkg_b", "standalone_file"))(dummy)
 
     with app.run(client=client):
         files = set(servicer.files_name2sha.keys())

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -5,7 +5,7 @@ import pytest
 import time
 from pathlib import Path
 
-from modal import App, Image, Mount, NetworkFileSystem, Proxy, Sandbox, SandboxSnapshot, Secret
+from modal import App, Image, NetworkFileSystem, Proxy, Sandbox, SandboxSnapshot, Secret
 from modal.exception import InvalidError
 from modal.stream_type import StreamType
 from modal_proto import api_pb2
@@ -41,18 +41,6 @@ def test_sandbox(app, servicer):
 
     assert sb.returncode == 42
     assert sb.poll() == 42
-
-
-@skip_non_subprocess
-def test_sandbox_mount(app, servicer, tmpdir):
-    # TODO: remove once Mounts are fully deprecated (replaced by test_sandbox_mount_layer)
-    tmpdir.join("a.py").write(b"foo")
-
-    sb = Sandbox.create("echo", "hi", mounts=[Mount._from_local_dir(Path(tmpdir), remote_path="/m")], app=app)
-    sb.wait()
-
-    sha = hashlib.sha256(b"foo").hexdigest()
-    assert servicer.files_sha2data[sha]["data"] == b"foo"
 
 
 @skip_non_subprocess

--- a/test/watcher_test.py
+++ b/test/watcher_test.py
@@ -7,10 +7,9 @@ from pathlib import Path
 from watchfiles import Change
 
 import modal
-from modal import method
 from modal._watcher import _watch_args_from_mounts
 from modal.exception import ExecutionError
-from modal.mount import _get_client_mount, _Mount
+from modal.mount import _Mount
 
 
 @pytest.mark.asyncio
@@ -50,60 +49,12 @@ def test_watch_mounts_requires_running_app():
         app._get_watch_mounts()
 
 
-def test_watch_mounts_includes_function_mounts(client, supports_dir, monkeypatch):
-    # TODO: remove this test once public Mount constructions are fully deprecated
-    monkeypatch.syspath_prepend(supports_dir)
-    app = modal.App()
-    pkg_a_mount = modal.Mount._from_local_python_packages("pkg_a")
-
-    @app.function(mounts=[pkg_a_mount], serialized=True)
-    def f():
-        pass
-
-    with app.run(client=client):
-        watch_mounts = app._get_watch_mounts()
-    assert watch_mounts == [pkg_a_mount]
-
-
-def test_watch_mounts_includes_cls_mounts(client, supports_dir, monkeypatch):
-    # TODO: remove this test once public Mount constructions are fully deprecated
-    monkeypatch.syspath_prepend(supports_dir)
-    app = modal.App()
-    pkg_a_mount = modal.Mount._from_local_python_packages("pkg_a")
-
-    @app.cls(mounts=[pkg_a_mount], serialized=True)
-    class A:
-        @method()
-        def foo(self):
-            pass
-
-    with app.run(client=client):
-        watch_mounts = app._get_watch_mounts()
-    assert watch_mounts == [pkg_a_mount]
-
-
-def test_watch_mounts_includes_image_mounts(client, supports_dir, monkeypatch):
-    # TODO: remove this test once public Mount constructions are fully deprecated
-    monkeypatch.syspath_prepend(supports_dir)
-    app = modal.App()
-    pkg_a_mount = modal.Mount._from_local_python_packages("pkg_a")
-    image = modal.Image.debian_slim().copy_mount(pkg_a_mount)
-
-    @app.function(image=image, serialized=True)
-    def f():
-        pass
-
-    with app.run(client=client):
-        watch_mounts = app._get_watch_mounts()
-    assert watch_mounts == [pkg_a_mount]
-
-
 def test_watch_mounts_ignore_non_local(client, servicer):
     app = modal.App()
 
     # uses the published client mount - should not be included in watch items
     # serialized=True avoids auto-mounting the entrypoint
-    @app.function(mounts=[_get_client_mount()], serialized=True)
+    @app.function(serialized=True)
     def dummy():
         pass
 


### PR DESCRIPTION
## Describe your changes

- Closes CLI-403

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

- Removed `modal.Mount` as a public object along with the various `mount=` parameters where Mounts could be passed into the Modal API. Usage can be replaced with `modal.Image` methods, e.g.:
  ```python
  @app.function(image=image, mounts=[modal.Mount.from_local_dir("data", "/root/data")])  # This is now an error!
  @app.function(image=image.add_local_dir("data", "/root/data"))  # Correct spelling
  ```