### PR TITLE
Remove `@modal.build` decorator

### DIFF
--- a/modal/__init__.py
+++ b/modal/__init__.py
@@ -26,7 +26,6 @@ try:
     from .partial_function import (
         asgi_app,
         batched,
-        build,
         concurrent,
         enter,
         exit,
@@ -82,7 +81,6 @@ __all__ = [
     "Volume",
     "asgi_app",
     "batched",
-    "build",
     "concurrent",
     "current_function_call_id",
     "current_input_id",

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -659,7 +659,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         validated_network_file_systems = validate_network_file_systems(network_file_systems)
 
         # Validate image
-        if image is not None and not isinstance(image, _Image):
+        if image is not None and not isinstance(image, _Image):  # type: ignore
             raise InvalidError(f"Expected modal.Image object. Got {type(image)}.")
 
         method_definitions: Optional[dict[str, api_pb2.MethodDefinition]] = None

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -600,35 +600,6 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
             proxy=proxy,
         )
 
-        if info.user_cls and not is_auto_snapshot:
-            build_functions = _find_partial_methods_for_user_cls(info.user_cls, _PartialFunctionFlags.BUILD).items()
-            for k, pf in build_functions:
-                build_function = pf.raw_f
-                snapshot_info = FunctionInfo(build_function, user_cls=info.user_cls)
-                snapshot_function = _Function.from_local(
-                    snapshot_info,
-                    app=None,
-                    image=image,
-                    secrets=secrets,
-                    gpu=gpu,
-                    mounts=mounts,
-                    network_file_systems=network_file_systems,
-                    volumes=volumes,
-                    memory=memory,
-                    timeout=pf.params.build_timeout,
-                    cpu=cpu,
-                    ephemeral_disk=ephemeral_disk,
-                    is_builder_function=True,
-                    is_auto_snapshot=True,
-                    scheduler_placement=scheduler_placement,
-                    include_source=include_source,
-                )
-                image = _Image._from_args(
-                    base_images={"base": image},
-                    build_function=snapshot_function,
-                    force_build=image.force_build or bool(pf.params.force_build),
-                )
-
         # Note that we also do these checks in FunctionCreate; could drop them here
         if min_containers is not None and not isinstance(min_containers, int):
             raise InvalidError(f"`min_containers` must be an int, not {type(min_containers).__name__}")

--- a/modal/_partial_function.py
+++ b/modal/_partial_function.py
@@ -31,22 +31,21 @@ if typing.TYPE_CHECKING:
 
 class _PartialFunctionFlags(enum.IntFlag):
     # Lifecycle method flags
-    BUILD = 1  # Deprecated, will be removed
-    ENTER_PRE_SNAPSHOT = 2
-    ENTER_POST_SNAPSHOT = 4
-    EXIT = 8
+    ENTER_PRE_SNAPSHOT = 1
+    ENTER_POST_SNAPSHOT = 2
+    EXIT = 4
     # Interface flags
-    CALLABLE_INTERFACE = 16
-    WEB_INTERFACE = 32
+    CALLABLE_INTERFACE = 8
+    WEB_INTERFACE = 16
     # Service decorator flags
     # It's, unclear if we need these, as we can also generally infer based on some params being set
     # In the current state where @modal.batched is used _instead_ of `@modal.method`, we need to give
     # `@modal.batched` two roles (exposing the callable interface, adding batching semantics).
     # But it's probably better to make `@modal.batched` and `@modal.method` stackable, or to move
     # `@modal.batched` to be a class-level decorator since it primarily governs service behavior.
-    BATCHED = 64
-    CONCURRENT = 128
-    CLUSTERED = 256  # Experimental: Clustered functions
+    BATCHED = 32
+    CONCURRENT = 64
+    CLUSTERED = 128  # Experimental: Clustered functions
 
     @staticmethod
     def all() -> int:
@@ -55,8 +54,7 @@ class _PartialFunctionFlags(enum.IntFlag):
     @staticmethod
     def lifecycle_flags() -> int:
         return (
-            _PartialFunctionFlags.BUILD  # Deprecated, will be removed
-            | _PartialFunctionFlags.ENTER_PRE_SNAPSHOT
+            _PartialFunctionFlags.ENTER_PRE_SNAPSHOT
             | _PartialFunctionFlags.ENTER_POST_SNAPSHOT
             | _PartialFunctionFlags.EXIT
         )
@@ -70,7 +68,6 @@ class _PartialFunctionFlags(enum.IntFlag):
 class _PartialFunctionParams:
     webhook_config: Optional[api_pb2.WebhookConfig] = None
     is_generator: Optional[bool] = None
-    force_build: Optional[bool] = None
     batch_max_size: Optional[int] = None
     batch_wait_ms: Optional[int] = None
     cluster_size: Optional[int] = None
@@ -646,59 +643,6 @@ def _web_server(
     return wrapper
 
 
-def _build(
-    _warn_parentheses_missing=None, *, force: bool = False, timeout: int = 86400
-) -> Callable[[Union[_PartialFunction, NullaryMethod]], _PartialFunction]:
-    """mdmd:hidden
-    Decorator for methods that execute at _build time_ to create a new Image layer.
-
-    **Deprecated**: This function is deprecated. We recommend using `modal.Volume`
-    to store large assets (such as model weights) instead of writing them to the
-    Image during the build process. For other use cases, you can replace this
-    decorator with the `Image.run_function` method.
-
-    **Usage**
-
-    ```python notest
-    @app.cls(gpu="A10G")
-    class AlpacaLoRAModel:
-        @build()
-        def download_models(self):
-            model = LlamaForCausalLM.from_pretrained(
-                base_model,
-            )
-            PeftModel.from_pretrained(model, lora_weights)
-            LlamaTokenizer.from_pretrained(base_model)
-    ```
-    """
-    if _warn_parentheses_missing is not None:
-        raise InvalidError(
-            "Positional arguments are not allowed. Did you forget parentheses? Suggestion: `@modal.build()`."
-        )
-
-    deprecation_warning(
-        (2025, 1, 15),
-        "The `@modal.build` decorator is deprecated and will be removed in a future release."
-        "\n\nWe now recommend storing large assets (such as model weights) using a `modal.Volume`"
-        " instead of writing them directly into the `modal.Image` filesystem."
-        " For other use cases we recommend using `Image.run_function` instead."
-        "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
-    )
-
-    flags = _PartialFunctionFlags.BUILD
-    params = _PartialFunctionParams(force_build=force, build_timeout=timeout)
-
-    def wrapper(obj: Union[_PartialFunction, NullaryMethod]) -> _PartialFunction:
-        if isinstance(obj, _PartialFunction):
-            pf = obj.stack(flags, params)
-        else:
-            pf = _PartialFunction(obj, flags, params)
-        pf.validate_obj_compatibility("build")
-        return pf
-
-    return wrapper
-
-
 def _enter(
     _warn_parentheses_missing=None,
     *,
@@ -716,7 +660,7 @@ def _enter(
     params = _PartialFunctionParams()
 
     def wrapper(obj: Union[_PartialFunction, NullaryMethod]) -> _PartialFunction:
-        # TODO: reject stacking once depreceate @modal.build
+        # TODO: we've removed `modal.build` so we should catch stacking with `@modal.enter` earlier
         if isinstance(obj, _PartialFunction):
             pf = obj.stack(flags, params)
         else:

--- a/modal/partial_function.py
+++ b/modal/partial_function.py
@@ -3,7 +3,6 @@
 from ._partial_function import (
     _asgi_app,
     _batched,
-    _build,
     _concurrent,
     _enter,
     _exit,
@@ -25,7 +24,6 @@ fastapi_endpoint = synchronize_api(_fastapi_endpoint, target_module=__name__)
 asgi_app = synchronize_api(_asgi_app, target_module=__name__)
 wsgi_app = synchronize_api(_wsgi_app, target_module=__name__)
 web_server = synchronize_api(_web_server, target_module=__name__)
-build = synchronize_api(_build, target_module=__name__)
 enter = synchronize_api(_enter, target_module=__name__)
 exit = synchronize_api(_exit, target_module=__name__)
 batched = synchronize_api(_batched, target_module=__name__)

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -1752,39 +1752,6 @@ def test_volume_commit_on_exit_doesnt_fail_container(servicer):
 
 
 @skip_github_non_linux
-def test_build_decorator_cls(servicer):
-    ret = _run_container(
-        servicer,
-        "test.supports.functions",
-        # note: builder functions are still run as standalone functions from their class service function
-        "BuildCls.build1",
-        inputs=_get_inputs(((), {})),
-        is_builder_function=True,
-        is_auto_snapshot=True,
-    )
-    assert _unwrap_scalar(ret) == 101
-    # TODO: this is GENERIC_STATUS_FAILURE when `@exit` fails,
-    # but why is it not set when `@exit` is successful?
-    # assert ret.task_result.status == api_pb2.GenericResult.GENERIC_STATUS_SUCCESS
-    assert ret.task_result is None
-
-
-@skip_github_non_linux
-def test_multiple_build_decorator_cls(servicer):
-    ret = _run_container(
-        servicer,
-        "test.supports.functions",
-        # note: builder functions are still run as standalone functions from their class service function
-        "BuildCls.build2",
-        inputs=_get_inputs(((), {})),
-        is_builder_function=True,
-        is_auto_snapshot=True,
-    )
-    assert _unwrap_scalar(ret) == 1001
-    assert ret.task_result is None
-
-
-@skip_github_non_linux
 @pytest.mark.timeout(10.0)
 def test_function_io_doesnt_inspect_args_or_return_values(monkeypatch, servicer):
     synchronizer = async_utils.synchronizer

--- a/test/supports/functions.py
+++ b/test/supports/functions.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2022
 import asyncio
 import contextlib
-import pytest
 import threading
 import time
 
@@ -11,7 +10,6 @@ from modal import (
     Sandbox,
     asgi_app,
     batched,
-    build,
     concurrent,
     current_function_call_id,
     current_input_id,
@@ -24,7 +22,6 @@ from modal import (
     wsgi_app,
 )
 from modal._utils.deprecation import deprecation_warning
-from modal.exception import DeprecationError
 from modal.experimental import get_local_input_concurrency, set_local_input_concurrency
 
 SLEEP_DELAY = 0.1
@@ -545,41 +542,6 @@ def cube(x):
     # regardless of the actual funtion.
     assert square.is_hydrated
     return square.remote(x) * x
-
-
-with pytest.warns(DeprecationError, match="@modal.build"):
-
-    @app.cls()
-    class BuildCls:
-        @property
-        def _k(self):
-            return self.__dict__.setdefault("__k", 1)
-
-        @_k.setter
-        def _k(self, v):
-            self.__dict__["__k"] = v
-
-        @enter()
-        def enter1(self):
-            self._k += 10
-
-        @build()
-        def build1(self):
-            self._k += 100
-            return self._k
-
-        @build()
-        def build2(self):
-            self._k += 1000
-            return self._k
-
-        @exit()
-        def exit1(self):
-            raise Exception("exit called!")
-
-        @method()
-        def f(self, x):
-            return self._k * x
 
 
 @app.cls(enable_memory_snapshot=True)


### PR DESCRIPTION
## Describe your changes

Provisional — not fully committed to doing this for 1.0 itself.

Doesn't contain all of the cleanup that's unlocked by this API change.

- Closes CLI-404
 
<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
