### PR TITLE
Revert "[input-plane] Retry inputs failed due to preemption (#3146)"

### DIFF
--- a/modal/_utils/function_utils.py
+++ b/modal/_utils/function_utils.py
@@ -466,10 +466,7 @@ async def _process_result(result: api_pb2.GenericResult, data_format: int, stub,
 
     if result.status == api_pb2.GenericResult.GENERIC_STATUS_TIMEOUT:
         raise FunctionTimeoutError(result.exception)
-    elif result.status in [
-        api_pb2.GenericResult.GENERIC_STATUS_INTERNAL_FAILURE,
-        api_pb2.GenericResult.GENERIC_STATUS_TERMINATED,
-    ]:
+    elif result.status == api_pb2.GenericResult.GENERIC_STATUS_INTERNAL_FAILURE:
         raise InternalFailure(result.exception)
     elif result.status != api_pb2.GenericResult.GENERIC_STATUS_SUCCESS:
         if data:

--- a/test/input_plane_test.py
+++ b/test/input_plane_test.py
@@ -1,9 +1,6 @@
 # Copyright Modal Labs 2025
-import pytest
-
 import modal
 from modal import App
-from modal.exception import InternalFailure
 from modal.functions import Function
 from modal.runner import deploy_app
 
@@ -27,26 +24,3 @@ def test_lookup_foo(client, servicer):
     deploy_app(app, "app", client=client)
     f = Function.from_name("app", "foo").hydrate(client)
     assert f.remote() == "attempt_await_bogus_response"
-
-@app.function(experimental_options={"input_plane_region": "us-east"})
-def maybe_fail():
-    raise ValueError("fail")
-
-def test_retry(client, servicer):
-    # Tell the servicer to fail once, and then succeed. The client should retry the failed attempt.
-    servicer.attempts_to_fail = 1
-    with app.run(client=client):
-        assert foo.remote() == "attempt_await_bogus_response"
-    # We don't have a great way to verify the call was actually retried. We can at least check that the servicer
-    # decremented the attempts_to_fail counter, which indicates that the call was retried.
-    assert servicer.attempts_to_fail == 0
-
-def test_retry_limit(client, servicer, monkeypatch):
-    monkeypatch.setattr("modal._functions.MAX_INTERNAL_FAILURE_COUNT", 2)
-    # Tell the servicer to fail once, and then succeed. The client should retry the failed attempt.
-    servicer.attempts_to_fail = 3
-    with pytest.raises(InternalFailure):
-        with app.run(client=client):
-            foo.remote()
-    # Verify that the mock server's failure counter was decremented by 2.
-    assert servicer.attempts_to_fail == 1


### PR DESCRIPTION
Failing integration tests