### PR TITLE
volume: Don't read downloaded blocks linewise

### DIFF
--- a/modal/volume.py
+++ b/modal/volume.py
@@ -499,7 +499,7 @@ class _Volume(_Object, type_prefix="vo"):
             num_bytes_written = 0
 
             async with download_semaphore, ClientSessionRegistry.get_session().get(url) as get_response:
-                async for chunk in get_response.content:
+                async for chunk in get_response.content.iter_any():
                     num_chunk_bytes_written = 0
 
                     while num_chunk_bytes_written < len(chunk):


### PR DESCRIPTION
## Describe your changes

- Using the default `__aiter__` of `aiohttp` response objects traverses data line-by-line. This might make us hit the high water mark of the receive buffer if the data doesn't happen to contain newlines frequently enough.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
