### PR TITLE
Fix Sandbox.list having `returncode==0` for running sandboxes [CLI-406]

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -775,7 +775,6 @@ class _Sandbox(_Object, type_prefix="sb"):
     @property
     def returncode(self) -> Optional[int]:
         """Return code of the Sandbox process if it has finished running, else `None`."""
-
         if self._result is None:
             return None
         # Statuses are converted to exitcodes so we can conform to subprocess API.
@@ -819,8 +818,10 @@ class _Sandbox(_Object, type_prefix="sb"):
                 return
 
             for sandbox_info in resp.sandboxes:
+                sandbox_info: api_pb2.SandboxInfo
                 obj = _Sandbox._new_hydrated(sandbox_info.id, client, None)
-                obj._result = sandbox_info.task_info.result
+                if sandbox_info.task_info.result.status:
+                    obj._result = sandbox_info.task_info.result
                 yield obj
 
             # Fetch the next batch starting from the end of the current one.

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -485,3 +485,28 @@ def test_sandbox_list_sets_correct_returncode_for_running(client, servicer):
         )  # list will loop for older sandboxes until no more arrive
         (list_result,) = list(Sandbox.list(client=client))
     assert list_result.returncode is None
+
+
+def test_sandbox_list_sets_correct_returncode_for_stopped(client, servicer):
+    with servicer.intercept() as ctx:
+        # test generic status
+        ctx.add_response(
+            "SandboxList",
+            api_pb2.SandboxListResponse(
+                sandboxes=[
+                    api_pb2.SandboxInfo(
+                        id="sb-123",
+                        task_info=api_pb2.TaskInfo(
+                            result=api_pb2.GenericResult(
+                                status=api_pb2.GenericResult.GENERIC_STATUS_SUCCESS, exitcode=0
+                            )
+                        ),
+                    )
+                ]
+            ),
+        )
+        ctx.add_response(
+            "SandboxList", api_pb2.SandboxListResponse(sandboxes=[])
+        )  # list will loop for older sandboxes until no more arrive
+        (list_result,) = list(Sandbox.list(client=client))
+    assert list_result.returncode == 0


### PR DESCRIPTION
## Changelog

* Fixes a bug where objects returned by `Sandbox.list` had `returncode==0` for *running* sandboxes
