### PR TITLE
volume: Direct volume rm/ls to new Volume*2 RPCs

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -23,7 +23,7 @@ from collections import defaultdict
 from collections.abc import Iterator
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Optional, Union, get_args
+from typing import Any, Callable, Optional, Union, get_args
 
 import aiohttp.web
 import aiohttp.web_runner
@@ -1940,10 +1940,18 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def VolumeRemoveFile(self, stream):
         req = await stream.recv_message()
+        self._volume_remove_file(req)
+        await stream.send_message(Empty())
+
+    async def VolumeRemoveFile2(self, stream):
+        req = await stream.recv_message()
+        self._volume_remove_file(req)
+        await stream.send_message(Empty())
+
+    def _volume_remove_file(self, req: Union[api_pb2.VolumeRemoveFileRequest, api_pb2.VolumeRemoveFile2Request]):
         if req.path not in self.volumes[req.volume_id].files:
             raise GRPCError(Status.INVALID_ARGUMENT, "File not found")
         del self.volumes[req.volume_id].files[req.path]
-        await stream.send_message(Empty())
 
     async def VolumeRename(self, stream):
         req = await stream.recv_message()
@@ -1955,6 +1963,21 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def VolumeListFiles(self, stream):
         req = await stream.recv_message()
+        await self._volume_list_files(stream, req, lambda entries: api_pb2.VolumeListFilesResponse(entries=entries))
+
+    async def VolumeListFiles2(self, stream):
+        req = await stream.recv_message()
+        await self._volume_list_files(stream, req, lambda entries: api_pb2.VolumeListFiles2Response(entries=entries))
+
+    async def _volume_list_files(
+        self,
+        stream,
+        req: Union[api_pb2.VolumeListFilesRequest, api_pb2.VolumeListFiles2Request],
+        make_resp: Callable[
+            [list[api_pb2.FileEntry]],
+            Union[api_pb2.VolumeListFilesResponse, api_pb2.VolumeListFiles2Response]
+        ]
+    ):
         path = req.path if req.path else "/"
         if path.startswith("/"):
             path = path[1:]
@@ -1965,7 +1988,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         for k, vol_file in self.volumes[req.volume_id].files.items():
             if not path or k == path or (k.startswith(path + "/") and (req.recursive or "/" not in k[len(path) + 1 :])):
                 entry = api_pb2.FileEntry(path=k, type=api_pb2.FileEntry.FileType.FILE, size=len(vol_file.data))
-                await stream.send_message(api_pb2.VolumeListFilesResponse(entries=[entry]))
+                await stream.send_message(make_resp([entry]))
                 found_file = True
 
         if path and not found_file:


### PR DESCRIPTION
## Describe your changes

- Volume remove and list are routed to new backend RPCs for version 2, which are semantically identical to the previous RPCs but with a new name to evolve independently.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
