### PR TITLE
URL encode platform metadata

### DIFF
--- a/modal/client.py
+++ b/modal/client.py
@@ -3,6 +3,7 @@ import asyncio
 import os
 import platform
 import sys
+import urllib.parse
 import warnings
 from collections.abc import AsyncGenerator, AsyncIterator, Collection, Mapping
 from typing import (
@@ -50,8 +51,8 @@ def _get_metadata(client_type: int, credentials: Optional[tuple[str, str]], vers
         "x-modal-client-version": version,
         "x-modal-client-type": str(client_type),
         "x-modal-python-version": python_version,
-        "x-modal-node": platform.node(),
-        "x-modal-platform": platform_str,
+        "x-modal-node": urllib.parse.quote(platform.node()),
+        "x-modal-platform": urllib.parse.quote(platform_str),
     }
     if credentials and client_type == api_pb2.CLIENT_TYPE_CLIENT:
         token_id, token_secret = credentials

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -3,6 +3,7 @@ import platform
 import pytest
 import subprocess
 import sys
+import urllib.parse
 
 from google.protobuf.empty_pb2 import Empty
 from grpclib import GRPCError, Status
@@ -24,9 +25,24 @@ def test_client_type(servicer, client):
     assert servicer.last_metadata["x-modal-client-type"] == str(api_pb2.CLIENT_TYPE_CLIENT)
 
 
+CHALLENGING_PLATFORM_NODE = "\0äbc \n"
+
+
+@pytest.fixture
+def _patch_platform_node(monkeypatch):
+    # Platform info is read when the client is created, so have to patch it before the fixture is requested
+    monkeypatch.setattr("modal.client.platform.node", lambda: CHALLENGING_PLATFORM_NODE)
+
+
+def test_client_node_string(servicer, _patch_platform_node, client):
+    client.hello()
+    platform_str = urllib.parse.unquote(servicer.last_metadata["x-modal-node"])
+    assert platform_str == CHALLENGING_PLATFORM_NODE
+
+
 def test_client_platform_string(servicer, client):
     client.hello()
-    platform_str = servicer.last_metadata["x-modal-platform"]
+    platform_str = urllib.parse.unquote(servicer.last_metadata["x-modal-platform"])
     system, release, machine = platform_str.split("-")
     if platform.system() == "Darwin":
         assert system == "macOS"


### PR DESCRIPTION
Otherwise it fails with `Invalid metadata value` when it's non-ASCII.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers: 

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

</details>
