### PR TITLE
remove link to guide in .watch

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -738,10 +738,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         recursive: Optional[bool] = None,
         timeout: Optional[int] = None,
     ) -> AsyncIterator[FileWatchEvent]:
-        """Watch a file or directory in the Sandbox for changes.
-
-        See the [guide](/docs/guide/sandbox-files#file-watching) for usage information.
-        """
+        """Watch a file or directory in the Sandbox for changes."""
         task_id = await self._get_task_id()
         async for event in _FileIO.watch(path, self._client, task_id, filter, recursive, timeout):
             yield event


### PR DESCRIPTION
## Describe your changes

I'm removing the guide section temporarily until we improve this method's reliability. And I can't remove the guide section while this reference exists. 

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [x] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [x] Changelog has been cleaned up and given an appropriate subhead

---

</details>

