### PR TITLE
mount client dependencies at runtime, as of builder version 'PREVIEW'

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -791,6 +791,9 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                 if app and app.name:
                     app_name = app.name
 
+                # on builder > 2024.10 we mount client dependencies at runtime
+                mount_client_dependencies = image._metadata.image_builder_version > "2024.10"
+
                 # Relies on dicts being ordered (true as of Python 3.6).
                 volume_mounts = [
                     api_pb2.VolumeMount(
@@ -860,6 +863,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                     schedule=schedule.proto_message if schedule is not None else None,
                     snapshot_debug=config.get("snapshot_debug"),
                     experimental_options=experimental_options or {},
+                    mount_client_dependencies=mount_client_dependencies,
                     # ---
                     _experimental_group_size=cluster_size or 0,  # Experimental: Clustered functions
                     _experimental_concurrent_cancellations=True,

--- a/modal_global_objects/mounts/modal_client_dependencies.py
+++ b/modal_global_objects/mounts/modal_client_dependencies.py
@@ -1,0 +1,87 @@
+# Copyright Modal Labs 2025
+import subprocess
+import tempfile
+
+from modal.config import config
+from modal.exception import NotFoundError
+from modal.image import ImageBuilderVersion
+from modal.mount import (
+    PYTHON_STANDALONE_VERSIONS,
+    Mount,
+)
+from modal_proto import api_pb2
+
+REMOTE_PACKAGES_PATH = "/__modal/.client_pkgs"
+REMOTE_SITECUSTOMIZE_PATH = "/pkg/sitecustomize.py"
+
+def create_client_dependencies(
+    builder_version: ImageBuilderVersion,
+    python_version: str,
+    platform: str,
+    arch: str,
+):
+    profile_environment = config.get("environment")
+
+    abi_tag = "cp" + python_version.replace(".", "")
+    mount_name = f"{builder_version}-{abi_tag}-{platform}-{arch}"
+
+    try:
+        Mount.from_name(mount_name, namespace=api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL).hydrate()
+        print(f"✅ Found existing mount {mount_name} in global namespace.")
+        return
+    except NotFoundError:
+        pass
+
+    with tempfile.TemporaryDirectory() as tmpd:
+        print(f"📦 Building {mount_name}.")
+        requirements = f"modal/requirements/{builder_version}.txt"
+        subprocess.run(
+            [
+                "uv",
+                "pip",
+                "install",
+                "-r",
+                requirements,
+                "--compile-bytecode",
+                "--target",
+                tmpd,
+                "--python-platform",
+                f"{arch}-{platform}",
+                "--python-version",
+                python_version,
+            ],
+            check=True,
+            capture_output=True,
+        )
+        print(f"🌐 Downloaded and unpacked packages to {tmpd}.")
+
+        python_mount = Mount._from_local_dir(tmpd, remote_path=REMOTE_PACKAGES_PATH)
+
+        with tempfile.NamedTemporaryFile() as sitecustomize:
+            sitecustomize.write(
+                "import sys; sys.path.append('/__modal/.client_pkgs')\n".encode("utf-8"),
+            )
+            sitecustomize.flush()
+
+            python_mount = python_mount.add_local_file(
+                sitecustomize.name,
+                remote_path=REMOTE_SITECUSTOMIZE_PATH,
+            )
+            print(f"📜 Added sitecustomize.py to {REMOTE_SITECUSTOMIZE_PATH}.")
+
+            python_mount._deploy(
+                mount_name,
+                api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL,
+                environment_name=profile_environment,
+            )
+            print(f"✅ Deployed mount {mount_name} to global namespace.")
+
+
+def main(client=None):
+    for python_version in PYTHON_STANDALONE_VERSIONS:
+        for platform in ["manylinux_2_17"]:
+            create_client_dependencies("PREVIEW", python_version, platform, "x86_64")
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks.py
+++ b/tasks.py
@@ -270,7 +270,7 @@ def _check_prod(no_confirm: bool):
 def publish_base_mounts(ctx, no_confirm: bool = False):
     """Publish the client mount and other mounts."""
     _check_prod(no_confirm)
-    for mount in ["modal_client_package", "python_standalone"]:
+    for mount in ["modal_client_package", "python_standalone", "modal_client_dependencies"]:
         ctx.run(f"{sys.executable} modal_global_objects/mounts/{mount}.py", pty=True)
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1340,7 +1340,10 @@ class MockClientServicer(api_grpc.ModalClientBase):
         request: api_pb2.ImageGetOrCreateRequest = await stream.recv_message()
         for image_id, image in self.images.items():
             if request.image.SerializeToString() == image.SerializeToString():
-                await stream.send_message(api_pb2.ImageGetOrCreateResponse(image_id=image_id))
+                await stream.send_message(api_pb2.ImageGetOrCreateResponse(
+                    image_id=image_id,
+                    metadata=api_pb2.ImageMetadata(image_builder_version=self.image_builder_versions[image_id]),
+                ))
                 return
         idx = len(self.images) + 1
         image_id = f"im-{idx}"
@@ -1350,10 +1353,13 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.image_builder_versions[image_id] = request.builder_version
         if request.force_build:
             self.force_built_images.append(image_id)
-        await stream.send_message(api_pb2.ImageGetOrCreateResponse(image_id=image_id))
+        await stream.send_message(api_pb2.ImageGetOrCreateResponse(
+            image_id=image_id,
+            metadata=api_pb2.ImageMetadata(image_builder_version=request.builder_version),
+        ))
 
     async def ImageJoinStreaming(self, stream):
-        await stream.recv_message()
+        req = await stream.recv_message()
 
         if self.image_join_sleep_duration is not None:
             await asyncio.sleep(self.image_join_sleep_duration)
@@ -1368,7 +1374,10 @@ class MockClientServicer(api_grpc.ModalClientBase):
         await stream.send_message(api_pb2.ImageJoinStreamingResponse(task_logs=[task_log_1, task_log_2, task_log_3]))
         await stream.send_message(
             api_pb2.ImageJoinStreamingResponse(
-                result=api_pb2.GenericResult(status=api_pb2.GenericResult.GENERIC_STATUS_SUCCESS)
+                result=api_pb2.GenericResult(status=api_pb2.GenericResult.GENERIC_STATUS_SUCCESS),
+                metadata=api_pb2.ImageMetadata(
+                    image_builder_version=self.image_builder_versions.get(req.image_id),
+                )
             )
         )
 


### PR DESCRIPTION
## Describe your changes

For image builder version > "2024.10", stop adding modal client dependencies directly to container images. Instead, pass a flag on Function to request the dependencies get mounted at runtime.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [ x Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.