### PR TITLE
Remove explicit use of synchronicity.UserCodeException

### DIFF
--- a/modal/_utils/function_utils.py
+++ b/modal/_utils/function_utils.py
@@ -10,7 +10,6 @@ from typing import Any, Callable, Literal, Optional
 
 from grpclib import GRPCError
 from grpclib.exceptions import StreamTerminatedError
-from synchronicity.exceptions import UserCodeException
 
 import modal_proto
 from modal_proto import api_pb2
@@ -497,7 +496,7 @@ async def _process_result(result: api_pb2.GenericResult, data_format: int, stub,
                     append_modal_tb(exc, tb_dict, line_cache)
                 except Exception:
                     pass
-            uc_exc = UserCodeException(exc_with_hints(exc))
+            uc_exc = exc_with_hints(exc)
             raise uc_exc
         raise RemoteError(result.exception)
 


### PR DESCRIPTION
This wrapping was introduced back in 0.0.35 (https://github.com/modal-labs/modal-client/commit/eeecd9e60b1302ff9cfa6c640b2a2d6cdde9bdcc), but I'm not sure we need it?

Experiment to see if this breaks anything

## Describe your changes

- _Provide Linear issue reference (e.g. CLI-1234) if available._

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
