### PR TITLE
Update notebook_base_image.py to have nbformat

### DIFF
--- a/modal_global_objects/images/notebook_base_image.py
+++ b/modal_global_objects/images/notebook_base_image.py
@@ -40,6 +40,7 @@ def notebook_base_image(*, python_version: Optional[str] = None, force_build: bo
         "jax[cuda12]",
         "keras",
         "matplotlib",
+        "nbformat",
         "numba",
         "numpy",
         "openai",


### PR DESCRIPTION
Needed for plotly express MIME renderer
