### PR TITLE
Dont use internal synchronicity UserCodeException type

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1522,8 +1522,11 @@ Use the `Function.get_web_url()` method instead.
             client=self.client,
             function_call_invocation_type=api_pb2.FUNCTION_CALL_INVOCATION_TYPE_SYNC_LEGACY,
         )
-        async for res in invocation.run_generator():
-            yield res
+        try:
+            async for res in invocation.run_generator():
+                yield res
+        except _ContainerException as container_exc:
+            raise container_exc.unwrap()
 
     @synchronizer.no_io_translation
     @live_method

--- a/modal/exception.py
+++ b/modal/exception.py
@@ -23,8 +23,11 @@ class Error(Exception):
 
 
 class _ContainerException(Exception):
-    # internal wrapper that distinguishes errors raised by user code in containers
-    # from internal errors in the Modal SDK or server
+    # Internal wrapper that distinguishes errors raised by user code in containers
+    # from internal errors in the Modal SDK or server.
+
+    # This should never be raised into user code
+
     def __init__(self, ex: BaseException):
         self.ex = ex
 

--- a/modal/exception.py
+++ b/modal/exception.py
@@ -28,7 +28,7 @@ class _ContainerException(Exception):
     def __init__(self, ex: BaseException):
         self.ex = ex
 
-    def unwrap(self):
+    def unwrap(self) -> BaseException:
         return self.ex
 
 

--- a/modal/exception.py
+++ b/modal/exception.py
@@ -22,6 +22,16 @@ class Error(Exception):
     """
 
 
+class _ContainerException(Exception):
+    # internal wrapper that distinguishes errors raised by user code in containers
+    # from internal errors in the Modal SDK or server
+    def __init__(self, ex: BaseException):
+        self.ex = ex
+
+    def unwrap(self):
+        return self.ex
+
+
 class RemoteError(Error):
     """Raised when an error occurs on the Modal server."""
 

--- a/modal/parallel_map.py
+++ b/modal/parallel_map.py
@@ -34,7 +34,6 @@ from modal._utils.function_utils import (
 from modal._utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES, RetryWarningMessage, retry_transient_errors
 from modal._utils.jwt_utils import DecodedJwt
 from modal.config import logger
-from modal.exception import _ContainerException
 from modal.retries import RetryManager
 from modal_proto import api_pb2
 
@@ -314,8 +313,6 @@ async def _map_invocation(
         try:
             output = await _process_result(item.result, item.data_format, client.stub, client)
         except Exception as e:
-            if isinstance(e, _ContainerException):
-                e = e.unwrap()
             if return_exceptions:
                 output = e
             else:

--- a/modal/parallel_map.py
+++ b/modal/parallel_map.py
@@ -34,6 +34,7 @@ from modal._utils.function_utils import (
 from modal._utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES, RetryWarningMessage, retry_transient_errors
 from modal._utils.jwt_utils import DecodedJwt
 from modal.config import logger
+from modal.exception import _ContainerException
 from modal.retries import RetryManager
 from modal_proto import api_pb2
 
@@ -313,6 +314,8 @@ async def _map_invocation(
         try:
             output = await _process_result(item.result, item.data_format, client.stub, client)
         except Exception as e:
+            if isinstance(e, _ContainerException):
+                e = e.unwrap()
             if return_exceptions:
                 output = e
             else:

--- a/test/function_retry_test.py
+++ b/test/function_retry_test.py
@@ -57,7 +57,8 @@ def test_all_retries_fail_raises_error(client, setup_app_and_function, monkeypat
     with app.run(client=client):
         with pytest.raises(FunctionCallCountException) as exc_info:
             # The client should give up after the 4th call.
-            f.remote(5)
+            res = f.remote(5)
+            print(res)
         # Assert the function was called 4 times - the original call plus 3 retries
         assert exc_info.value.function_call_count == 4
 

--- a/test/function_retry_test.py
+++ b/test/function_retry_test.py
@@ -57,8 +57,8 @@ def test_all_retries_fail_raises_error(client, setup_app_and_function, monkeypat
     with app.run(client=client):
         with pytest.raises(FunctionCallCountException) as exc_info:
             # The client should give up after the 4th call.
-            res = f.remote(5)
-            print(res)
+            f.remote(5)
+
         # Assert the function was called 4 times - the original call plus 3 retries
         assert exc_info.value.function_call_count == 4
 

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -307,7 +307,7 @@ def later():
     return "hello"
 
 
-def test_function_future(client, servicer):
+def test_function_spawn(client, servicer):
     app = App()
 
     servicer.function_body(later)
@@ -338,7 +338,7 @@ def test_function_future(client, servicer):
 
 
 @pytest.mark.asyncio
-async def test_function_future_async(client, servicer):
+async def test_function_spawn_async(client, servicer):
     app = App()
 
     servicer.function_body(later)
@@ -366,6 +366,23 @@ def test_function_spawn_exception(client, servicer):
         function_call = failure_modal_func.spawn()
         with pytest.raises(CustomException):
             function_call.get()
+
+
+def failure_gen():
+    raise CustomException("foo")
+    yield
+
+
+def test_generator_exception(client, servicer):
+    app = App()
+
+    servicer.function_body(failure_gen)
+    failure_modal_func = app.function()(failure_gen)
+
+    with app.run(client=client):
+        with pytest.raises(CustomException):
+            for res in failure_modal_func.remote_gen():
+                assert False
 
 
 def later_gen():
@@ -449,7 +466,7 @@ async def test_generator_async(client, servicer):
 
 
 @pytest.mark.asyncio
-async def test_generator_future(client, servicer):
+async def test_generator_spawn(client, servicer):
     app = App()
 
     servicer.function_body(later_gen)


### PR DESCRIPTION
This turned out to be a bit of a rabbit hole.

* The client has abused the fact that synchronicity unwraps synchronicity.UserCodeExceptions and wrapped any exceptions returned by containers
* I believe the original intent of this was to piggy back off synchronicity's use of this to exclude certain internal frames in tracebacks
* More recently, we've also started using it for client-side retries, since it has been a way for us to disambiguate internal errors from errors in user remote containers (things that should be retried)
* Synchronicity only unwraps these exceptions when they are *raised*, so an unfortunate side effect has been that `map(return_exceptions=True)` has returned actual synchronicity.UserCodeException objects instead of the actual exception (!)

This PR removes the usage of this internal synchronicity exception type in favor of an explicit modal-specific exception wrapper type, `_ContainerException` (open to other names). This means we also need to explicitly unwrap these whenever exceptions can be returned to users.

Unfortunately, this is is a breaking change for `.map(return_exceptions=True)` in that it will no longer wrap the user exceptions... But I believe that has never actually been the intent of the functionality, and it's quite ugly that it has been returning a *synchronicity* exception type (!).

Closes CLI-419

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
