### PR TITLE
fix: simulate_preemption should not accept zero

### DIFF
--- a/modal/exception.py
+++ b/modal/exception.py
@@ -161,6 +161,8 @@ def simulate_preemption(wait_seconds: int, jitter_seconds: int = 0):
     See https://modal.com/docs/guide/preemption for more details on preemption
     handling.
     """
+    if wait_seconds <= 0:
+        raise ValueError("Time to wait must be greater than 0")
     signal.signal(signal.SIGALRM, _simulate_preemption_interrupt)
     jitter = random.randrange(0, jitter_seconds) if jitter_seconds else 0
     signal.alarm(wait_seconds + jitter)


### PR DESCRIPTION
## Describe your changes

Reported by a user after they tried `0` and found that doing that breaks https://docs.python.org/3/library/signal.html#signal.alarm

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [x] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [x] Changelog has been cleaned up and given an appropriate subhead

---

</details>
