### PR TITLE
Report non-function Image build failures better

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -647,7 +647,13 @@ class _Image(_Object, type_prefix="im"):
                     metadata = resp.metadata
 
             if result.status == api_pb2.GenericResult.GENERIC_STATUS_FAILURE:
-                raise RemoteError(f"Image build for {image_id} failed with the exception:\n{result.exception}")
+                if result.exception:
+                    raise RemoteError(f"Image build for {image_id} failed with the exception:\n{result.exception}")
+                else:
+                    msg = f"Image build for {image_id} failed. See build logs for more details."
+                    if not _get_output_manager():
+                        msg += " Use `modal.enable_output()` to print logs from the process building the Image."
+                    raise RemoteError(msg)
             elif result.status == api_pb2.GenericResult.GENERIC_STATUS_TERMINATED:
                 raise RemoteError(f"Image build for {image_id} terminated due to external shut-down. Please try again.")
             elif result.status == api_pb2.GenericResult.GENERIC_STATUS_TIMEOUT:


### PR DESCRIPTION
## Describe your changes

When Image builds fail, we try to print the `result.exception`. Unless the failing step is a `.run_function`, this will be empty, so we print an unhelpful message like

```
Image build for im-DEHjPnPEudJASdtbmWLtgW failed with the exception:\n'
```

This PR handles the empty exception case better, directing the user to the build logs.

In the case where output is not enabled, we add a hint suggesting `modal.enable_output`. Otherwise there won't be any obvious "build logs" for the user to refer to.

This is still a little unhelpful (i.e., in the case where the build failed without output enabled, you need to run the build again, and that might take a while). I think we can potentially capture more failure information from the worker and propagate it back to the client. But it will take some more changes.

- Closes CLI-412

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

</details>

