### PR TITLE
Add support for specifying timezone on `Cron` schedules

### DIFF
--- a/modal/schedule.py
+++ b/modal/schedule.py
@@ -30,15 +30,28 @@ class Cron(Schedule):
     We can specify different schedules with cron strings, for example:
 
     ```python
-    modal.Cron("5 4 * * *")  # run at 4:05am every night
-    modal.Cron("0 9 * * 4")  # runs every Thursday 9am
+    modal.Cron("5 4 * * *")  # run at 4:05am UTC every night
+    modal.Cron("0 9 * * 4")  # runs every Thursday at 9am UTC
     ```
 
+    We can also optionally specify a timezone, for example:
+
+    ```python
+    # Run daily at 6am New York time, regardless of whether daylight saving
+    # is in effect (i.e. at 11am UTC in the winter, and 10am UTC in the summer):
+    modal.Cron("0 6 * * *", timezone="America/New_York")
+    ```
+
+    If no timezone is specified, the default is UTC.
     """
 
-    def __init__(self, cron_string: str) -> None:
+    def __init__(
+        self,
+        cron_string: str,
+        timezone: str = "UTC",
+    ) -> None:
         """Construct a schedule that runs according to a cron expression string."""
-        cron = api_pb2.Schedule.Cron(cron_string=cron_string)
+        cron = api_pb2.Schedule.Cron(cron_string=cron_string, timezone=timezone)
         super().__init__(api_pb2.Schedule(cron=cron))
 
 


### PR DESCRIPTION
## Describe your changes
<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Added support for specifying a timezone on `Cron` schedules, helpful if you e.g. want a `Function` to run at 6am local time, regardless of whether daylight saving is in effect or not, for example:
  ```
  import modal
  app = modal.App()
  
  
  @app.function(schedule=modal.Cron("* 6 * * *"), timezone="America/New_York")
  def f():
      print("This function will run every day at 6am New York time.")
  ```
