### PR TITLE
Add `timezone` to `Schedule.Cron` proto

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2586,6 +2586,7 @@ message SandboxWaitResponse {
 message Schedule {
   message Cron {
     string cron_string = 1;
+    string timezone = 2;
   }
   message Period {
     int32 years = 1;


### PR DESCRIPTION
Preparing for #3173.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.
