### PR TITLE
Protobuf Changes for HTTP/2 Tunnels

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2153,6 +2153,7 @@ message PTYInfo {
 message PortSpec {
   uint32 port = 1;
   bool unencrypted = 2;
+  optional string tunnel_type = 3;
 }
 
 message PortSpecs {
@@ -2876,6 +2877,7 @@ message TunnelData {
 message TunnelStartRequest {
   uint32 port = 1;
   bool unencrypted = 2;
+  optional string tunnel_type = 3;
 }
 
 message TunnelStartResponse {


### PR DESCRIPTION
[WRK-940](https://linear.app/modal-labs/issue/WRK-940/support-http2-in-relays), [ Design doc](https://www.notion.so/modal-com/H2-Tunnel-Support-1f81e7f16949806cb0c8d34fb299c7c2?pvs=4)


## Summary of Changes
Enable tunnels to support H2 (HTTP/2 with TLS)

There will be 4 sequential PRs to roll out this feature. In order to being merged. This is the Protobuf changes PR.

1. `modal-client` [Protobuf changes](https://github.com/modal-labs/modal-client/pull/3177)
2. [Relay changes](https://github.com/modal-labs/modal/pull/22697)
3. [Worker changes](https://github.com/modal-labs/modal/pull/22874)
4. `modal-client` [Client API changes](https://github.com/modal-labs/modal-client/pull/3159)

The new relay changes are backwards compatible with the old worker. The changed interface between the worker and relay is in `modal-relay/src/protocol.rs`, adding a new field called `tunnel_type` to the `ClientMessage::HelloNew` enum variant. It is marked as optional with `#[serde(default)]`.

The `modal-client` protobuf changes is backwards compatible with the old worker. It adds a new field to two protobuf enums, which can be optionally used by the worker.
