### PR TITLE
Mention in Sandbox.create() docstring that the container is created asynchronously

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -252,7 +252,8 @@ class _Sandbox(_Object, type_prefix="sb"):
         client: Optional[_Client] = None,
     ) -> "_Sandbox":
         """
-        Create a new Sandbox to run untrusted, arbitrary code.
+        Create a new Sandbox to run untrusted, arbitrary code. The Sandbox's corresponding container
+        will be created asynchronously.
 
         **Usage**
 


### PR DESCRIPTION
We never say this explicitly in the docs -- seems worth adding.
