### PR TITLE
emit warning if client dependency mount is not expected to exist

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -72,7 +72,7 @@ from .exception import (
 )
 from .gpu import GPU_T, parse_gpu_config
 from .image import _Image
-from .mount import _get_client_mount, _Mount, PYTHON_STANDALONE_VERSIONS
+from .mount import PYTHON_STANDALONE_VERSIONS, _get_client_mount, _Mount
 from .network_file_system import _NetworkFileSystem, network_file_system_mount_protos
 from .output import _get_output_manager
 from .parallel_map import (

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -915,7 +915,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         else:
             environment_id = f"en-{len(self.environments) + 1}"
             self.environments[name] = environment_id
-        image_builder_version = max(get_args(ImageBuilderVersion))
+        image_builder_version = max([v for v in get_args(ImageBuilderVersion) if v != "PREVIEW"])
         settings = api_pb2.EnvironmentSettings(image_builder_version=image_builder_version)
         metadata = api_pb2.EnvironmentMetadata(name=name, settings=settings)
         await stream.send_message(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -915,7 +915,13 @@ class MockClientServicer(api_grpc.ModalClientBase):
         else:
             environment_id = f"en-{len(self.environments) + 1}"
             self.environments[name] = environment_id
-        image_builder_version = max([v for v in get_args(ImageBuilderVersion) if v != "PREVIEW"])
+
+        versions = get_args(ImageBuilderVersion)
+        if len(versions) == 1:
+            image_builder_version = versions[0]
+        else:
+            image_builder_version = max([v for v in versions if v != "PREVIEW"])
+
         settings = api_pb2.EnvironmentSettings(image_builder_version=image_builder_version)
         metadata = api_pb2.EnvironmentMetadata(name=name, settings=settings)
         await stream.send_message(


### PR DESCRIPTION
## Describe your changes

Prints some warnings if client dependency mounts are needed, but none are expected to be found for the chose image. This is for image builder version > `2024.10` only.
