### PR TITLE
perf: make Sandbox.terminate faster

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -516,7 +516,7 @@ class _Sandbox(_Object, type_prefix="sb"):
 
         return self._tunnels
 
-    async def terminate(self):
+    async def terminate(self) -> None:
         """Terminate Sandbox execution.
 
         This is a no-op if the Sandbox has already finished running."""
@@ -524,7 +524,6 @@ class _Sandbox(_Object, type_prefix="sb"):
         await retry_transient_errors(
             self._client.stub.SandboxTerminate, api_pb2.SandboxTerminateRequest(sandbox_id=self.object_id)
         )
-        await self.wait(raise_on_termination=False)
 
     async def poll(self) -> Optional[int]:
         """Check if the Sandbox has finished running.
@@ -540,7 +539,7 @@ class _Sandbox(_Object, type_prefix="sb"):
 
         return self.returncode
 
-    async def _get_task_id(self):
+    async def _get_task_id(self) -> str:
         while not self._task_id:
             resp = await self._client.stub.SandboxGetTaskId(api_pb2.SandboxGetTaskIdRequest(sandbox_id=self.object_id))
             self._task_id = resp.task_id


### PR DESCRIPTION
## Describe your changes

- _Provide Linear issue reference (e.g. CLI-1234) if available._

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

- `Sandbox.terminate` not longer waits for container shutdown completion, but still ensures that a terminated container will shutdown imminently. 
