### PR TITLE
Fix comment on workdir (very confusing)

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1945,13 +1945,21 @@ message ImageJoinStreamingResponse {
 message ImageMetadata {
   // The output of `python -VV. Not set if missing
   optional string python_version_info = 1;
+
   // Installed python packages, as listed by by `pip list`.
   // package name -> version. Empty if missing
   map<string, string> python_packages = 2;
-  // The work directory of the image, defaulting to "/". Not set if missing
+
+  // The working directory of the image, defaulting to "/". Not set if missing.
+  //
+  // Note that this is NOT the working directory for most runner tasks if
+  // `image.manifest.workdir` is not set, which defaults to `/root`, but this
+  // field will be detected as `/` instead. (It is very confusing.)
   optional string workdir = 3;
-  // The image's libc version
+
+  // The version of glibc in this image, if any.
   optional string libc_version_info = 4;
+
   // The builder version for/with which the image was created.
   optional string image_builder_version = 5;
 }

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1952,9 +1952,9 @@ message ImageMetadata {
 
   // The working directory of the image, defaulting to "/". Not set if missing.
   //
-  // Note that this is NOT the working directory for most runner tasks if
-  // `image.manifest.workdir` is not set, which defaults to `/root`, but this
-  // field will be detected as `/` instead. (It is very confusing.)
+  // Note that this is NOT the actual working directory of the image, especially
+  // for runner tasks. Please see `ImageManifest.workdir` instead. This field
+  // should not be used in any future code.
   optional string workdir = 3;
 
   // The version of glibc in this image, if any.


### PR DESCRIPTION
Extremely confusing field called `workdir` on `ImageMetadata` which is not actually used by any of our systems, `ImageManifest.workdir` is the actual workdir. This is wrong in 99% of images.