### PR TITLE
Fix for aiohttp 3.12.1 enforcing BytesIO type

### DIFF
--- a/modal/_utils/bytes_io_segment_payload.py
+++ b/modal/_utils/bytes_io_segment_payload.py
@@ -8,14 +8,14 @@ from typing import BinaryIO, Callable, Optional
 # Note: this module needs to import aiohttp in global scope
 # This takes about 50ms and isn't needed in many cases for Modal execution
 # To avoid this, we import it in local scope when needed (blob_utils.py)
-from aiohttp import BytesIOPayload
+from aiohttp import Payload
 from aiohttp.abc import AbstractStreamWriter
 
 # read ~16MiB chunks by default
 DEFAULT_SEGMENT_CHUNK_SIZE = 2**24
 
 
-class BytesIOSegmentPayload(BytesIOPayload):
+class BytesIOSegmentPayload(Payload):
     """Modified bytes payload for concurrent sends of chunks from the same file.
 
     Adds:
@@ -25,6 +25,8 @@ class BytesIOSegmentPayload(BytesIOPayload):
 
     Feels like this should be in some standard lib...
     """
+
+    _value: BinaryIO
 
     def __init__(
         self,
@@ -36,6 +38,7 @@ class BytesIOSegmentPayload(BytesIOPayload):
     ):
         # not thread safe constructor!
         super().__init__(bytes_io)
+        self._size = segment_length
         self.initial_seek_pos = bytes_io.tell()
         self.segment_start = segment_start
         self.segment_length = segment_length
@@ -45,6 +48,9 @@ class BytesIOSegmentPayload(BytesIOPayload):
         self.chunk_size = chunk_size
         self.progress_report_cb = progress_report_cb or (lambda *_, **__: None)
         self.reset_state()
+
+    def decode(self, encoding: str = "utf-8", errors: str = "strict") -> str:
+        return self._value.read().decode(encoding, errors)
 
     def reset_state(self):
         self._md5_checksum = hashlib.md5()


### PR DESCRIPTION
Aiohttp 3.12.1 relies on `getbuffer()` to exist on the file like object passed to BytesIOPayload, whereas it previously worked with more general `BinaryIO` objects too (like `open("file", "rb")` handles

This "fixes" the issue by making our own Payload implementation a subclass of the Payload ABC rather than BytesIOPayload.

It may be that we could refactor our code to use aiohttp 3.12's reusable payload objects instead of having our own custom payload handler, but that's a larger project.


---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
