### PR TITLE
Improves error messages for local file & dir mounts

### DIFF
--- a/modal/mount.py
+++ b/modal/mount.py
@@ -115,7 +115,8 @@ class _MountFile(_MountEntry):
     def get_files_to_upload(self):
         local_file = self.local_file.resolve()
         if not local_file.exists():
-            raise FileNotFoundError(local_file)
+            msg = f"Local file: {os.fspath(local_file)} does not exists"
+            raise FileNotFoundError(msg)
 
         rel_filename = self.remote_path
         yield local_file, rel_filename
@@ -144,10 +145,12 @@ class _MountDir(_MountEntry):
         local_dir = self.local_dir.expanduser().absolute()
 
         if not local_dir.exists():
-            raise FileNotFoundError(local_dir)
+            msg = f"Local dir: {os.fspath(local_dir)} does not exist"
+            raise FileNotFoundError(msg)
 
         if not local_dir.is_dir():
-            raise NotADirectoryError(local_dir)
+            msg = f"Local dir: {os.fspath(local_dir)} is not a directory"
+            raise NotADirectoryError(msg)
 
         if self.recursive:
             gen = (os.path.join(root, name) for root, dirs, files in os.walk(local_dir) for name in files)

--- a/test/mount_test.py
+++ b/test/mount_test.py
@@ -3,6 +3,7 @@ import hashlib
 import os
 import platform
 import pytest
+import re
 from pathlib import Path, PurePosixPath
 
 import modal
@@ -71,15 +72,26 @@ def test_create_mount(servicer, client):
     assert repr(Path(local_dir)) in repr(m)
 
 
-def test_create_mount_file_errors(servicer, tmpdir, client):
-    m = Mount._from_local_dir(Path(tmpdir) / "xyz", remote_path="/xyz")
-    with pytest.raises(FileNotFoundError):
+def test_create_mount_file_errors(servicer, tmp_path, client):
+    invalid_dir = tmp_path / "xyz"
+    m = Mount._from_local_dir(invalid_dir, remote_path="/xyz")
+    msg = re.escape(f"Local dir: {os.fspath(invalid_dir)} does not exist")
+    with pytest.raises(FileNotFoundError, match=msg):
         m._deploy("my-mount", client=client)
 
-    with open(tmpdir / "abc", "w"):
+    invalid_file = tmp_path / "xyz.txt"
+    m = Mount._from_local_file(invalid_file, remote_path="/xyz.txt")
+    msg = re.escape(f"Local file: {os.fspath(invalid_file)} does not exist")
+    with pytest.raises(FileNotFoundError, match=msg):
+        m._deploy("my-mount", client=client)
+
+    not_a_dir = tmp_path / "abc"
+    with open(not_a_dir, "w"):
         pass
-    m = Mount._from_local_dir(Path(tmpdir) / "abc", remote_path="/abc")
-    with pytest.raises(NotADirectoryError):
+    m = Mount._from_local_dir(not_a_dir, remote_path="/abc")
+
+    msg = re.escape(f"Local dir: {os.fspath(not_a_dir)} is not a directory")
+    with pytest.raises(NotADirectoryError, match=msg):
         m._deploy("my-mount", client=client)
 
 


### PR DESCRIPTION
## Describe your changes

Improves error message for `Image.add_local_file` and `Image.add_local_dir` when files or directories does not exist: https://linear.app/modal-labs/issue/CLI-367/suppressed-traceback-for-missing-add-local-file-makes-error-difficult
 
<details> <summary>Checklists</summary>

---

## Compatibility checklist

Client only changes

---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

Improves error message for `Image.add_local_file` and `Image.add_local_dir` when files or directories does not exist.