### PR TITLE
Adds support for doing GPU memory snapshots in multiple CUDA sessions

### DIFF
--- a/modal/_runtime/gpu_memory_snapshot.py
+++ b/modal/_runtime/gpu_memory_snapshot.py
@@ -6,10 +6,12 @@
 #
 # [1] https://github.com/NVIDIA/cuda-checkpoint
 
-import os
 import subprocess
 import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from enum import Enum
+from pathlib import Path
 
 from modal.config import config, logger
 
@@ -29,73 +31,169 @@ class CudaCheckpointException(Exception):
     pass
 
 
-def toggle():
-    """Toggle CUDA checkpoint state for current process, moving GPU memory to the
-    CPU and back depending on the current process state when called."""
-    pid = get_own_pid()
-    logger.debug(f"Toggling CUDA checkpoint state for PID {pid}")
+@dataclass
+class CudaCheckpointProcess:
+    """Contains a reference to a PID with active CUDA session. This also provides
+    methods for checkpointing and restoring GPU memory."""
 
-    try:
-        subprocess.run(
-            [
-                CUDA_CHECKPOINT_PATH,
-                "--toggle",
-                "--pid",
-                str(pid),
-            ],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-        logger.debug("Successfully toggled CUDA checkpoint state")
+    pid: int
+    state: CudaCheckpointState
 
-    except subprocess.CalledProcessError as e:
-        logger.debug(f"Failed to toggle CUDA checkpoint state: {e.stderr}")
-        raise CudaCheckpointException(e.stderr)
+    def toggle(self, target_state: CudaCheckpointState, timeout_secs: float = 5 * 60.0):
+        """Toggle CUDA checkpoint state for current process, moving GPU memory to the
+        CPU and back depending on the current process state when called."""
+        logger.debug(f"PID: {self.pid} Toggling CUDA checkpoint state to {target_state.value}")
 
+        start_time = time.monotonic()
 
-def get_state() -> CudaCheckpointState:
-    """Get current CUDA checkpoint state for this process."""
-    pid = get_own_pid()
+        while self._should_continue_toggle(target_state, start_time, timeout_secs):
+            self._execute_toggle_command()
+            time.sleep(0.1)
 
-    try:
-        result = subprocess.run(
-            [CUDA_CHECKPOINT_PATH, "--get-state", "--pid", str(pid)], check=True, capture_output=True, text=True
-        )
+        logger.debug(f"PID: {self.pid} Target state {target_state.value} reached")
 
-        # Parse output to get state
-        state_str = result.stdout.strip().lower()
-        return CudaCheckpointState(state_str)
+    def _should_continue_toggle(
+        self, target_state: CudaCheckpointState, start_time: float, timeout_secs: float
+    ) -> bool:
+        """Check if toggle operation should continue based on current state and timeout."""
+        self.refresh_state()
 
-    except subprocess.CalledProcessError as e:
-        logger.debug(f"Failed to get CUDA checkpoint state: {e.stderr}")
-        raise CudaCheckpointException(e.stderr)
+        if self.state == target_state:
+            return False
 
-
-def wait_for_state(target_state: CudaCheckpointState, timeout_secs: float = 5.0):
-    """Wait for CUDA checkpoint to reach a specific state."""
-    logger.debug(f"Waiting for CUDA checkpoint state {target_state.value}")
-    start_time = time.monotonic()
-
-    while True:
-        current_state = get_state()
-
-        if current_state == target_state:
-            logger.debug(f"Target state {target_state.value} reached")
-            break
-
-        if current_state == CudaCheckpointState.FAILED:
-            raise CudaCheckpointException(f"CUDA process state is {current_state}")
+        if self.state == CudaCheckpointState.FAILED:
+            raise CudaCheckpointException(f"PID: {self.pid} CUDA process state is {self.state}")
 
         elapsed = time.monotonic() - start_time
         if elapsed >= timeout_secs:
-            raise CudaCheckpointException(f"Timeout after {elapsed:.2f}s waiting for state {target_state.value}")
+            raise CudaCheckpointException(
+                f"PID: {self.pid} Timeout after {elapsed:.2f}s waiting for state {target_state.value}. "
+                f"Current state: {self.state}"
+            )
 
-        time.sleep(0.1)
+        return True
+
+    def _execute_toggle_command(self):
+        """Execute the cuda-checkpoint toggle command."""
+        try:
+            subprocess.run(
+                [CUDA_CHECKPOINT_PATH, "--toggle", "--pid", str(self.pid)],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            logger.debug(f"PID: {self.pid} Successfully toggled CUDA checkpoint state")
+        except subprocess.CalledProcessError as e:
+            logger.debug(f"PID: {self.pid} Failed to toggle CUDA checkpoint state: {e.stderr}")
+            raise CudaCheckpointException(e.stderr)
+
+    def refresh_state(self) -> None:
+        """Refreshes the current CUDA checkpoint state for this process."""
+        try:
+            result = subprocess.run(
+                [CUDA_CHECKPOINT_PATH, "--get-state", "--pid", str(self.pid)],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+
+            state_str = result.stdout.strip().lower()
+            self.state = CudaCheckpointState(state_str)
+
+        except subprocess.CalledProcessError as e:
+            logger.debug(f"PID: {self.pid} Failed to get CUDA checkpoint state: {e.stderr}")
+            raise CudaCheckpointException(e.stderr)
 
 
-def get_own_pid():
-    """Returns the Process ID (PID) of the current Python process
-    using only the standard library.
-    """
-    return os.getpid()
+class CudaCheckpointSession:
+    """Manages the checkpointing state of processes with active CUDA sessions."""
+
+    def __init__(self):
+        self.cuda_processes = self._get_cuda_pids()
+        logger.debug(f"PIDs with CUDA sessions: {[c.pid for c in self.cuda_processes]}")
+
+    def _get_cuda_pids(self) -> list[CudaCheckpointProcess]:
+        """Iterates over all PIDs and identifies the ones that have running
+        CUDA sessions."""
+        cuda_pids: list[CudaCheckpointProcess] = []
+
+        # Get all active process IDs from /proc directory
+        proc_dir = Path("/proc")
+        if not proc_dir.exists():
+            raise CudaCheckpointException(
+                "OS does not have /proc path rendering it incompatible with GPU memory snapshots."
+            )
+
+        for entry in proc_dir.iterdir():
+            if not entry.name.isdigit():
+                continue
+
+            pid = int(entry.name)
+            try:
+                # Call cuda-checkpoint to check if this PID has a CUDA session
+                result = subprocess.run(
+                    [CUDA_CHECKPOINT_PATH, "--get-state", "--pid", str(pid)],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+
+                # If the command succeeds (return code 0), this PID has a CUDA session
+                if result.returncode == 0:
+                    state_str = result.stdout.strip().lower()
+                    state = CudaCheckpointState(state_str)
+
+                    cuda_checkpoint_process = CudaCheckpointProcess(pid=pid, state=state)
+                    cuda_pids.append(cuda_checkpoint_process)
+
+            # Command failed, which is expected for PIDs without CUDA sessions
+            except subprocess.CalledProcessError:
+                continue
+
+            # Raise other exceptions
+            except subprocess.TimeoutExpired:
+                raise CudaCheckpointException(f"Failed to get CUDA state for PID {pid}")
+            except Exception as e:
+                raise CudaCheckpointException(e)
+
+        # Sort PIDs for ordered checkpointing
+        cuda_pids.sort(key=lambda x: x.pid)
+        return cuda_pids
+
+    def checkpoint(self) -> None:
+        # Validate all states first
+        for proc in self.cuda_processes:
+            if proc.state != CudaCheckpointState.RUNNING:
+                raise CudaCheckpointException(f"CUDA session not in {CudaCheckpointState.RUNNING} state.")
+
+        # Moving state from GPU to CPU can take several seconds per CUDA session.
+        # Make a parallel call per CUDA session.
+        start = time.perf_counter()
+
+        def checkpoint_impl(proc: CudaCheckpointProcess):
+            proc.toggle(CudaCheckpointState.CHECKPOINTED)
+
+        with ThreadPoolExecutor() as executor:
+            list(executor.map(checkpoint_impl, self.cuda_processes))
+
+        elapsed = time.perf_counter() - start
+        logger.debug(f"Checkpointing CUDA sessions took => {elapsed:.3f}s")
+
+    def restore(self) -> None:
+        # Validate all states first
+        for proc in self.cuda_processes:
+            if proc.state != CudaCheckpointState.CHECKPOINTED:
+                raise CudaCheckpointException(f"CUDA session not in {CudaCheckpointState.CHECKPOINTED} state.")
+
+        # See checkpoint() for rationale about parallelism.
+        start = time.perf_counter()
+
+        def restore_process(proc: CudaCheckpointProcess):
+            proc.toggle(CudaCheckpointState.RUNNING)
+
+        with ThreadPoolExecutor() as executor:
+            list(executor.map(restore_process, self.cuda_processes))
+
+        elapsed = time.perf_counter() - start
+        logger.debug(f"Restoring CUDA sessions took => {elapsed:.3f}s")


### PR DESCRIPTION
Updates the experimental GPU snapshotting interface (using [cuda-checkpoint](https://github.com/NVIDIA/cuda-checkpoint)) to snapshot all PIDs with CUDA sessions. We would only snapshot the main process PID before this change, but many programs would start many processes with many CUDA sessions including vLLM, `transformers`, etc. 