### PR TITLE
add --no-deps and --no-cache when building client dep mounts

### DIFF
--- a/modal_global_objects/mounts/modal_client_dependencies.py
+++ b/modal_global_objects/mounts/modal_client_dependencies.py
@@ -48,6 +48,8 @@ def create_client_dependencies(
                 "pip",
                 "install",
                 "--strict",
+                "--no-deps",
+                "--no-cache",
                 "-r",
                 requirements,
                 "--compile-bytecode",


### PR DESCRIPTION
With this change, `google/_upb/_message.abi3.so` is created. Before, it was not. Seems important that it is.
