### PR TITLE
Add `modal.Image.uv_sync()` for `uv sync` workflows

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,7 +28,7 @@ jobs:
       release-hash: ${{ steps.release-data.outputs.hash }}
 
     steps:
-      - name: Generate token for Github PR Bot
+      - name: Generate token for GitHub PR Bot
         id: generate_token
         uses: tibdex/github-app-token@32691ba7c9e7063bd457bd8f2a5703138591fa58 # v1
         with:

--- a/modal/image.py
+++ b/modal/image.py
@@ -1034,14 +1034,14 @@ class _Image(_Object, type_prefix="im"):
         """
         Install a list of Python packages from private git repositories using pip.
 
-        This method currently supports Github and Gitlab only.
+        This method currently supports GitHub and GitLab only.
 
-        - **Github:** Provide a `modal.Secret` that contains a `GITHUB_TOKEN` key-value pair
-        - **Gitlab:** Provide a `modal.Secret` that contains a `GITLAB_TOKEN` key-value pair
+        - **GitHub:** Provide a `modal.Secret` that contains a `GITHUB_TOKEN` key-value pair
+        - **GitLab:** Provide a `modal.Secret` that contains a `GITLAB_TOKEN` key-value pair
 
         These API tokens should have permissions to read the list of private repositories provided as arguments.
 
-        We recommend using Github's ['fine-grained' access tokens](https://github.blog/2022-10-18-introducing-fine-grained-personal-access-tokens-for-github/).
+        We recommend using GitHub's ['fine-grained' access tokens](https://github.blog/2022-10-18-introducing-fine-grained-personal-access-tokens-for-github/).
         These tokens are repo-scoped, and avoid granting read permission across all of a user's private repos.
 
         **Example**


### PR DESCRIPTION
## Describe your changes

Assumes you have a `pyproject.toml` and `uv.lock` in your project.

Notably will run your Modal app in a virtual environment, as opposed to the pip commands that install packages in the system Python environment in the container.

## Changelog

- Adds a `modal.Image.uv_sync()` method for [`uv sync` style workflows](https://docs.astral.sh/uv/reference/cli/#uv-sync).
