### PR TITLE
Override server NOT_FOUND error message to include object name

### DIFF
--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -123,10 +123,13 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
                 response = await resolver.client.stub.SharedVolumeGetOrCreate(req)
                 self._hydrate(response.shared_volume_id, resolver.client, None)
             except GRPCError as exc:
-                if exc.status == Status.NOT_FOUND and exc.message == "App has wrong entity vo":
-                    raise InvalidError(
-                        f"Attempted to mount: `{name}` as a NetworkFileSystem " + "which already exists as a Volume"
-                    )
+                if exc.status == Status.NOT_FOUND:
+                    if exc.message == "App has wrong entity vo":
+                        raise InvalidError(
+                            f"Attempted to mount: `{name}` as a NetworkFileSystem " + "which already exists as a Volume"
+                        )
+                    else:
+                        exc.message = f"NetworkFileSystem '{name}' not found"
                 raise
 
         return _NetworkFileSystem._from_loader(_load, "NetworkFileSystem()", hydrate_lazily=True)

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -172,7 +172,12 @@ class _Queue(_Object, type_prefix="qu"):
                 environment_name=_get_environment_name(environment_name, resolver),
                 object_creation_type=(api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING if create_if_missing else None),
             )
-            response = await resolver.client.stub.QueueGetOrCreate(req)
+            try:
+                response = await resolver.client.stub.QueueGetOrCreate(req)
+            except GRPCError as e:
+                if e.status == Status.NOT_FOUND:
+                    e.message = f"Queue '{name}' not found"
+                raise e
             self._hydrate(response.queue_id, resolver.client, None)
 
         return _Queue._from_loader(_load, "Queue()", is_another_app=True, hydrate_lazily=True)

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -187,7 +187,12 @@ class _Volume(_Object, type_prefix="vo"):
                 object_creation_type=(api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING if create_if_missing else None),
                 version=version,
             )
-            response = await resolver.client.stub.VolumeGetOrCreate(req)
+            try:
+                response = await resolver.client.stub.VolumeGetOrCreate(req)
+            except GRPCError as e:
+                if e.status == Status.NOT_FOUND:
+                    e.message = f"Volume '{name}' not found"
+                raise e
             self._hydrate(response.volume_id, resolver.client, response.metadata)
 
         return _Volume._from_loader(_load, "Volume()", hydrate_lazily=True)


### PR DESCRIPTION
## Describe your changes

When `.from_name` methods pass a name that does not exist (and do not set `create_if_missing=True`) the server-side error is generic ("{Object} not found"). The reason we do this is for grouping server errors in our observability tooling. But the consequence is to obscure many easily-debuggable issues.

One nicer thing we can do is manually catch the `NotFound` status errors and interpolate the requested name in the client-side context where we know it.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---
