### PR TITLE
Fixes issue where an empty map would stall for 55s before completing [CLI-416]

### DIFF
--- a/modal/parallel_map.py
+++ b/modal/parallel_map.py
@@ -243,9 +243,12 @@ async def _map_invocation(
             retried_outputs
 
         last_entry_id = "0-0"
-
+        print("HAVE ALL", have_all_inputs, outputs_completed < inputs_created)
         while not have_all_inputs or outputs_completed < inputs_created:
-            logger.debug(f"Requesting outputs. Have {outputs_completed} outputs, {inputs_created} inputs.")
+            logger.debug(
+                f"Requesting outputs. Have {outputs_completed} outputs, {inputs_created} inputs. {repr(have_all_inputs)}"
+            )
+            print()
             # Get input_jwts of all items in the WAITING_FOR_OUTPUT state.
             # The server uses these to track for lost inputs.
             input_jwts = [input_jwt for input_jwt in map_items_manager.get_input_jwts_waiting_for_output()]

--- a/modal/parallel_map.py
+++ b/modal/parallel_map.py
@@ -3,6 +3,7 @@ import asyncio
 import enum
 import time
 import typing
+from asyncio import FIRST_COMPLETED
 from dataclasses import dataclass
 from typing import Any, Callable, Optional
 
@@ -110,6 +111,7 @@ async def _map_invocation(
     max_inputs_outstanding = response.max_inputs_outstanding or MAX_INPUTS_OUTSTANDING_DEFAULT
 
     have_all_inputs = False
+    map_done_event = asyncio.Event()
     inputs_created = 0
     inputs_sent = 0
     inputs_retried = 0
@@ -122,10 +124,6 @@ async def _map_invocation(
     stale_retry_duplicates = 0
     no_context_duplicates = 0
 
-    def count_update():
-        if count_update_callback is not None:
-            count_update_callback(outputs_completed, inputs_created)
-
     retry_queue = TimestampPriorityQueue()
     completed_outputs: set[str] = set()  # Set of input_ids whose outputs are complete (expecting no more values)
     input_queue: asyncio.Queue[api_pb2.FunctionPutInputsItem | None] = asyncio.Queue()
@@ -134,9 +132,8 @@ async def _map_invocation(
     )
 
     async def create_input(argskwargs):
-        nonlocal inputs_created
         idx = inputs_created
-        inputs_created += 1
+        update_state(set_inputs_created=inputs_created + 1)
         (args, kwargs) = argskwargs
         return await _create_input(args, kwargs, client.stub, idx=idx, method_name=function._use_method_name)
 
@@ -147,9 +144,27 @@ async def _map_invocation(
                 break
             yield raw_input  # args, kwargs
 
-    async def drain_input_generator():
-        nonlocal have_all_inputs
+    def update_state(set_have_all_inputs=None, set_inputs_created=None, set_outputs_completed=None):
+        # This should be the only method that needs nonlocal of the following vars
+        nonlocal have_all_inputs, inputs_created, outputs_completed
+        assert set_have_all_inputs is not False  # not allowed
+        assert set_inputs_created is None or set_inputs_created > inputs_created
+        assert set_outputs_completed is None or set_outputs_completed > outputs_completed
+        if set_have_all_inputs is not None:
+            have_all_inputs = set_have_all_inputs
+        if set_inputs_created is not None:
+            inputs_created = set_inputs_created
+        if set_outputs_completed is not None:
+            outputs_completed = set_outputs_completed
 
+        if count_update_callback is not None:
+            count_update_callback(outputs_completed, inputs_created)
+
+        if have_all_inputs and outputs_completed >= inputs_created:
+            # map is done
+            map_done_event.set()
+
+    async def drain_input_generator():
         # Parallelize uploading blobs
         async with aclosing(
             async_map_ordered(input_iter(), create_input, concurrency=BLOB_MAX_PARALLELISM)
@@ -159,12 +174,12 @@ async def _map_invocation(
 
         # close queue iterator
         await input_queue.put(None)
-        have_all_inputs = True
+        update_state(set_have_all_inputs=True)
         yield
 
     async def pump_inputs():
         assert client.stub
-        nonlocal inputs_created, inputs_sent
+        nonlocal inputs_sent
         async for items in queue_batch_iterator(input_queue, max_batch_size=MAP_INVOCATION_CHUNK_SIZE):
             # Add items to the manager. Their state will be SENDING.
             await map_items_manager.add_items(items)
@@ -178,7 +193,6 @@ async def _map_invocation(
             )
 
             resp = await send_inputs(client.stub.FunctionPutInputs, request)
-            count_update()
             inputs_sent += len(items)
             # Change item state to WAITING_FOR_OUTPUT, and set the input_id and input_jwt which are in the response.
             map_items_manager.handle_put_inputs_response(resp.inputs)
@@ -231,11 +245,8 @@ async def _map_invocation(
     async def get_all_outputs():
         assert client.stub
         nonlocal \
-            inputs_created, \
             successful_completions, \
             failed_completions, \
-            outputs_completed, \
-            have_all_inputs, \
             outputs_received, \
             already_complete_duplicates, \
             no_context_duplicates, \
@@ -243,12 +254,9 @@ async def _map_invocation(
             retried_outputs
 
         last_entry_id = "0-0"
-        print("HAVE ALL", have_all_inputs, outputs_completed < inputs_created)
-        while not have_all_inputs or outputs_completed < inputs_created:
-            logger.debug(
-                f"Requesting outputs. Have {outputs_completed} outputs, {inputs_created} inputs. {repr(have_all_inputs)}"
-            )
-            print()
+
+        while not map_done_event.is_set():
+            logger.debug(f"Requesting outputs. Have {outputs_completed} outputs, {inputs_created} inputs.")
             # Get input_jwts of all items in the WAITING_FOR_OUTPUT state.
             # The server uses these to track for lost inputs.
             input_jwts = [input_jwt for input_jwt in map_items_manager.get_input_jwts_waiting_for_output()]
@@ -261,12 +269,26 @@ async def _map_invocation(
                 requested_at=time.time(),
                 input_jwts=input_jwts,
             )
-            response = await retry_transient_errors(
-                client.stub.FunctionGetOutputs,
-                request,
-                max_retries=20,
-                attempt_timeout=OUTPUTS_TIMEOUT + ATTEMPT_TIMEOUT_GRACE_PERIOD,
+            get_response_task = asyncio.create_task(
+                retry_transient_errors(
+                    client.stub.FunctionGetOutputs,
+                    request,
+                    max_retries=20,
+                    attempt_timeout=OUTPUTS_TIMEOUT + ATTEMPT_TIMEOUT_GRACE_PERIOD,
+                )
             )
+            map_done_task = asyncio.create_task(map_done_event.wait())
+            done, pending = await asyncio.wait([get_response_task, map_done_task], return_when=FIRST_COMPLETED)
+            if get_response_task in done:
+                map_done_task.cancel()
+                response = get_response_task.result()
+            else:
+                assert map_done_event.is_set()
+                # map is done, cancel the pending call
+                get_response_task.cancel()
+                # not strictly necessary - don't leave dangling task
+                await asyncio.gather(get_response_task, return_exceptions=True)
+                return
 
             last_entry_id = response.last_entry_id
             now_seconds = int(time.time())
@@ -291,7 +313,7 @@ async def _map_invocation(
 
                 if output_type == _OutputType.SUCCESSFUL_COMPLETION or output_type == _OutputType.FAILED_COMPLETION:
                     completed_outputs.add(item.input_id)
-                    outputs_completed += 1
+                    update_state(set_outputs_completed=outputs_completed + 1)
                     yield item
 
     async def get_all_outputs_and_clean_up():
@@ -331,7 +353,6 @@ async def _map_invocation(
             async_map_ordered(get_all_outputs_and_clean_up(), fetch_output, concurrency=BLOB_MAX_PARALLELISM)
         ) as streamer:
             async for idx, output in streamer:
-                count_update()
                 if not order_outputs:
                     yield _OutputValue(output)
                 else:

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -295,7 +295,7 @@ def test_run_custom_app(servicer, set_env_client, test_dir):
 def test_run_aiofunc(servicer, set_env_client, test_dir):
     app_file = test_dir / "supports" / "app_run_tests" / "async_app.py"
     _run(["run", app_file.as_posix()])
-    assert len(servicer.client_calls) == 1
+    assert len(servicer.function_call_inputs) == 1
 
 
 def test_run_local_entrypoint(servicer, set_env_client, test_dir):
@@ -303,11 +303,11 @@ def test_run_local_entrypoint(servicer, set_env_client, test_dir):
 
     res = _run(["run", app_file.as_posix() + "::app.main"])  # explicit name
     assert "called locally" in res.stdout
-    assert len(servicer.client_calls) == 2
+    assert len(servicer.function_call_inputs) == 2
 
     res = _run(["run", app_file.as_posix()])  # only one entry-point, no name needed
     assert "called locally" in res.stdout
-    assert len(servicer.client_calls) == 4
+    assert len(servicer.function_call_inputs) == 4
 
 
 def test_run_local_entrypoint_invalid_with_app_run(servicer, set_env_client, test_dir):
@@ -316,7 +316,7 @@ def test_run_local_entrypoint_invalid_with_app_run(servicer, set_env_client, tes
     res = _run(["run", app_file.as_posix()], expected_exit_code=1)
     assert "app is already running" in str(res.exception.__cause__).lower()
     assert "unreachable" not in res.stdout
-    assert len(servicer.client_calls) == 0
+    assert len(servicer.function_call_inputs) == 0
 
 
 def test_run_parse_args_entrypoint(servicer, set_env_client, test_dir):
@@ -353,7 +353,7 @@ def test_run_parse_args_entrypoint(servicer, set_env_client, test_dir):
     for args, expected in valid_call_args:
         res = _run(args)
         assert expected in res.stdout
-        assert len(servicer.client_calls) == 0
+        assert len(servicer.function_call_inputs) == 0
 
     res = _run(["run", f"{app_file.as_posix()}::unparseable_annot", "--i=20"], expected_exit_code=1)
     assert "Parameter `i` has unparseable annotation: typing.Union[int, str]" in str(res.exception)

--- a/test/function_serialization_test.py
+++ b/test/function_serialization_test.py
@@ -25,10 +25,10 @@ async def test_serialize_deserialize_function(servicer, client):
 
     foo_def = servicer.app_functions[object_id]
 
-    assert len(servicer.client_calls) == 0
+    assert len(servicer.function_call_inputs) == 0
 
     deserialized_function_body = deserialize(foo_def.function_serialized, client)
     deserialized_function_body()  # call locally as if in container, this should trigger a "remote" foo() call
-    assert len(servicer.client_calls) == 1
-    function_call_id = list(servicer.client_calls.keys())[0]
+    assert len(servicer.function_call_inputs) == 1
+    function_call_id = list(servicer.function_call_inputs.keys())[0]
     assert servicer.function_id_for_function_call[function_call_id] == object_id

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -891,7 +891,7 @@ def test_calls_should_not_unwrap_modal_objects(servicer, client):
             assert type(ret) is modal.Dict
         foo.for_each([some_modal_object])
 
-    assert len(servicer.client_calls) == 5
+    assert len(servicer.function_call_inputs) == 5
 
 
 def assert_is_wrapped_dict_gen(some_arg):
@@ -910,7 +910,7 @@ def test_calls_should_not_unwrap_modal_objects_gen(servicer, client):
         with pytest.raises(InvalidError, match="Cannot `spawn` a generator function."):
             foo.spawn(some_modal_object)
 
-    assert len(servicer.client_calls) == 1
+    assert len(servicer.function_call_inputs) == 1
 
 
 def test_function_deps_have_ids(client, servicer, monkeypatch, test_dir, set_env_client):

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -157,6 +157,19 @@ def synchronicity_loop_delay_tracker():
     done = True
 
 
+def test_map_empty_input(client):
+    app = App()
+
+    @app.function(serialized=True)
+    def f():
+        pass
+
+    with app.run(client=client):
+        l = list(f.starmap(() for _ in range(0)))
+        print(l)
+        assert l == []
+
+
 def test_map_blocking_iterator_blocking_synchronicity_loop(client):
     app = App()
     SLEEP_DUR = 0.5

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -157,6 +157,7 @@ def synchronicity_loop_delay_tracker():
     done = True
 
 
+@pytest.mark.timeout(5)
 def test_map_empty_input(client):
     app = App()
 


### PR DESCRIPTION
Empty maps would seemingly "stall forever" (although technically 55s, I think) due to FunctionGetOutputs longpolling not getting aborted when the map completion criteria is met (=all inputs have been created + number of emitted outputs match the number of created inputs).

While this scenario could _possibly_ happen at other points in a map lifecycle (under very rare conditions), the empty input iterator would with almost 100% likelyhood reproduce this since the initial FunctionGetOutputs gets sent immediately.

The fix is to set up an event that is triggered whenever the map is complete, which can be concurrently listened to while waiting for FunctionGetOutputs. This also gave me the opportunity to refactor some of the `nonlocal` mess and bring the most important of those state changes in under a common `update_state()` function, which would also be responsible for setting the completion criteria event.

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

* Fixed an issue where `Function.map()` and similar methods would stall for 55 seconds when passed an empty iterator as input, instead of completing immediately.