### PR TITLE
volume: Use VolumeGetFile2 for volumes version 1, too

### DIFF
--- a/modal/volume.py
+++ b/modal/volume.py
@@ -45,7 +45,6 @@ from ._utils.blob_utils import (
     BLOCK_SIZE,
     FileUploadSpec,
     FileUploadSpec2,
-    blob_iter,
     blob_upload_file,
     get_file_upload_spec_from_fileobj,
     get_file_upload_spec_from_path,
@@ -400,7 +399,7 @@ class _Volume(_Object, type_prefix="vo"):
         return [entry async for entry in self.iterdir(path, recursive=recursive)]
 
     @live_method_gen
-    def read_file(self, path: str) -> AsyncIterator[bytes]:
+    async def read_file(self, path: str) -> AsyncIterator[bytes]:
         """
         Read a file from the modal.Volume.
 
@@ -414,23 +413,6 @@ class _Volume(_Object, type_prefix="vo"):
         print(len(data))  # == 1024 * 1024
         ```
         """
-        return self._read_file1(path) if self._is_v1 else self._read_file2(path)
-
-    async def _read_file1(self, path: str) -> AsyncIterator[bytes]:
-        req = api_pb2.VolumeGetFileRequest(volume_id=self.object_id, path=path)
-        try:
-            response = await retry_transient_errors(self._client.stub.VolumeGetFile, req)
-        except GRPCError as exc:
-            raise FileNotFoundError(exc.message) if exc.status == Status.NOT_FOUND else exc
-        # TODO(Jonathon): use ranged requests.
-        if response.WhichOneof("data_oneof") == "data":
-            yield response.data
-            return
-        else:
-            async for data in blob_iter(response.data_blob_id, self._client.stub):
-                yield data
-
-    async def _read_file2(self, path: str) -> AsyncIterator[bytes]:
         req = api_pb2.VolumeGetFile2Request(volume_id=self.object_id, path=path)
 
         try:
@@ -461,36 +443,9 @@ class _Volume(_Object, type_prefix="vo"):
         Read volume file into file-like IO object.
         """
         if progress_cb is None:
-
             def progress_cb(*_, **__):
                 pass
 
-        if self._is_v1:
-            return await self._read_file_into_fileobj1(path, fileobj, progress_cb)
-        else:
-            return await self._read_file_into_fileobj2(path, fileobj, progress_cb)
-
-    async def _read_file_into_fileobj1(
-        self, path: str, fileobj: typing.IO[bytes], progress_cb: Callable[..., Any]
-    ) -> int:
-        num_bytes_written = 0
-
-        async for chunk in self._read_file1(path):
-            num_chunk_bytes_written = 0
-
-            while num_chunk_bytes_written < len(chunk):
-                # TODO(dflemstr): this is a small write, but nonetheless might block the event loop for some time:
-                n = fileobj.write(chunk)
-                num_chunk_bytes_written += n
-                progress_cb(advance=n)
-
-            num_bytes_written += len(chunk)
-
-        return num_bytes_written
-
-    async def _read_file_into_fileobj2(
-        self, path: str, fileobj: typing.IO[bytes], progress_cb: Callable[..., Any]
-    ) -> int:
         req = api_pb2.VolumeGetFile2Request(volume_id=self.object_id, path=path)
 
         try:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -67,7 +67,8 @@ class VolumeFile:
     data: bytes
     mode: int
     data_blob_id: Optional[str] = None
-    block_hashes: list[bytes] = dataclasses.field(default_factory=list)
+    data_sha256_hex: Optional[str] = None
+    block_hashes: Optional[list[bytes]] = None
 
 
 @dataclasses.dataclass
@@ -154,7 +155,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
     client_addr: str
     container_addr: str
 
-    def __init__(self, blob_host, blobs, blocks, credentials, port):
+    def __init__(self, blob_host, blobs, blocks, files_sha2data, credentials, port):
         self.default_published_client_mount = "mo-123"
         self.use_blob_outputs = False
         self.put_outputs_barrier = threading.Barrier(
@@ -212,7 +213,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.n_mount_files = 0
         self.mount_contents = {self.default_published_client_mount: {"/pkg/modal_client.py": "0x1337"}}
         self.files_name2sha = {}
-        self.files_sha2data = {}
+        self.files_sha2data = files_sha2data
         self.function_id_for_function_call = {}
         self.client_calls = {}
         self.sync_client_retries_enabled = False
@@ -1926,23 +1927,44 @@ class MockClientServicer(api_grpc.ModalClientBase):
         def ceildiv(a: int, b: int) -> int:
             return -(a // -b)
 
+        if vol_file.data_blob_id:
+            file_size = len(self.blobs[vol_file.data_blob_id])
+        else:
+            file_size = len(vol_file.data)
+
         total_start = req.start
-        total_end = req.start + (req.len or len(vol_file.data))
+        total_end = req.start + (req.len or file_size)
 
-        block_start = min(total_start // BLOCK_SIZE, len(vol_file.block_hashes))
-        block_end = min(ceildiv(total_end, BLOCK_SIZE), len(vol_file.block_hashes))
-
-        for idx, block_hash in enumerate(vol_file.block_hashes[block_start:block_end]):
+        def slice_block(block_idx: int):
             # Crude port of internal `blocks_for_byte_slice` algorithm:
-            start = total_start % BLOCK_SIZE if idx == 0 else 0
-            end = (
+            slice_start = total_start % BLOCK_SIZE if block_idx == 0 else 0
+            slice_end = (
                 (((total_end - 1) % BLOCK_SIZE) + 1 if total_end > 0 else 0)
-                if idx == (block_end - block_start - 1)
+                if block_idx == (block_end - block_start - 1)
                 else BLOCK_SIZE
             )
-            length = end - start
+            return slice_start, slice_end
 
-            get_urls.append(f"{self.blob_host}/block/test-get-request:{block_hash.hex()}:{start}:{length}")
+        # Check if file was created using VolumePutFiles instead of VolumePutFiles2, which is supported since
+        # VolumePutFiles2 should support volumefs1 volumes now.
+        if vol_file.block_hashes is None:
+            block_start = min(total_start, file_size) // BLOCK_SIZE
+            block_end = ceildiv(min(total_end, file_size), BLOCK_SIZE)
+            assert vol_file.data_sha256_hex is not None
+
+            for idx in range(block_start, block_end):
+                start, end = slice_block(idx)
+                length = end - start
+                get_urls.append(f"{self.blob_host}/block/test-get-request:v1:{vol_file.data_sha256_hex}:{idx}:{start}:{length}")
+        else:
+            block_start = min(total_start // BLOCK_SIZE, len(vol_file.block_hashes))
+            block_end = min(ceildiv(total_end, BLOCK_SIZE), len(vol_file.block_hashes))
+            assert vol_file.data_blob_id is None
+
+            for idx, block_hash in enumerate(vol_file.block_hashes[block_start:block_end]):
+                start, end = slice_block(idx)
+                length = end - start
+                get_urls.append(f"{self.blob_host}/block/test-get-request:v2:{block_hash.hex()}:{start}:{length}")
 
         response = api_pb2.VolumeGetFile2Response(
             get_urls=get_urls, size=len(vol_file.data), start=total_start, len=total_end - total_start
@@ -2022,6 +2044,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
             self.volumes[req.volume_id].files[file.filename] = VolumeFile(
                 data=blob_data["data"],
                 data_blob_id=blob_data["data_blob_id"],
+                data_sha256_hex=file.sha256_hex,
                 mode=file.mode,
             )
         await stream.send_message(Empty())
@@ -2152,6 +2175,7 @@ def blob_server():
     blobs = {}
     blob_parts: dict[str, dict[int, bytes]] = defaultdict(dict)
     blocks = {}
+    files_sha2data: dict[str, dict] = {}
 
     async def upload(request):
         blob_id = request.query["blob_id"]
@@ -2207,14 +2231,29 @@ def blob_server():
     async def get_block(request):
         token = request.match_info["token"]
 
-        magic, block_id, start, length = token.split(":")
+        magic, version, *rest = token.split(":")
         if magic != "test-get-request":
             return aiohttp.web.Response(status=400, text="bad token")
 
-        start = int(start)
-        length = int(length)
+        if version == "v1":
+            file_sha256_hex, block_idx, start, length = rest
+            start = BLOCK_SIZE * int(block_idx) + int(start)
+            length = int(length)
+            file_data = files_sha2data[file_sha256_hex]
+            blob_id = file_data["data_blob_id"]
+            if blob_id:
+                body = blobs[blob_id][start:start + length]
+            else:
+                body = file_data["data"][start : start + length]
+        elif version == "v2":
+            block_id, start, length = rest
+            start = int(start)
+            length = int(length)
+            body = blocks[block_id][start : start + length]
+        else:
+            return aiohttp.web.Response(status=404)
 
-        return aiohttp.web.Response(body=blocks[block_id][start : start + length])
+        return aiohttp.web.Response(body=body)
 
     app = aiohttp.web.Application()
     app.add_routes([aiohttp.web.put("/upload", upload)])
@@ -2251,7 +2290,7 @@ def blob_server():
     thread = threading.Thread(target=run_server_other_thread)
     thread.start()
     started.wait()
-    yield host, blobs, blocks
+    yield host, blobs, blocks, files_sha2data
     stop_server.set()
     thread.join()
 
@@ -2303,8 +2342,8 @@ def credentials():
 async def servicer(blob_server, temporary_sock_path, credentials):
     port = find_free_port()
 
-    blob_host, blobs, blocks = blob_server
-    servicer = MockClientServicer(blob_host, blobs, blocks, credentials, port)  # type: ignore
+    blob_host, blobs, blocks, files_sha2data = blob_server
+    servicer = MockClientServicer(blob_host, blobs, blocks, files_sha2data, credentials, port)  # type: ignore
 
     if platform.system() != "Windows":
         async with run_server(servicer, host="0.0.0.0", port=port):

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -959,7 +959,7 @@ async def test_map_large_inputs(client, servicer, monkeypatch, blob_server):
     app = App()
     dummy_modal = app.function()(dummy)
 
-    _, blobs, _ = blob_server
+    _, blobs, _, _ = blob_server
     async with app.run.aio(client=client):
         assert len(blobs) == 0
         assert [a async for a in dummy_modal.map.aio(range(100))] == [i**2 for i in range(100)]

--- a/test/network_file_system_test.py
+++ b/test/network_file_system_test.py
@@ -92,7 +92,7 @@ async def test_network_file_system_handle_big_file(client, tmp_path, servicer, b
         assert servicer.nfs_files[object_id]["/bigfile"].data == b""
         assert servicer.nfs_files[object_id]["/bigfile"].data_blob_id == "bl-1"
 
-        _, blobs, _ = blob_server
+        _, blobs, _, _ = blob_server
         assert blobs["bl-1"] == b"hello world, this is a lot of text"
 
 

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -96,10 +96,16 @@ async def test_volume_get(servicer, client, tmp_path, version, file_contents_siz
     data = b""
     for chunk in vol.read_file(file_path):
         data += chunk
+
+    # Faster assert to avoid huge error when there are large content differences:
+    assert len(data) == file_contents_size
     assert data == file_contents
 
     output = io.BytesIO()
     vol.read_file_into_fileobj(file_path, output)
+
+    # Faster assert to avoid huge error when there are large content differences:
+    assert len(output.getvalue()) == file_contents_size
     assert output.getvalue() == file_contents
 
     with pytest.raises(FileNotFoundError):
@@ -267,7 +273,7 @@ async def test_volume_upload_large_file(client, tmp_path, servicer, blob_server)
         assert servicer.volumes[object_id].files["/a"].data == b""
         assert servicer.volumes[object_id].files["/a"].data_blob_id == "bl-1"
 
-        _, blobs, _ = blob_server
+        _, blobs, _, _ = blob_server
         assert blobs["bl-1"] == b"hello world, this is a lot of text"
 
 
@@ -308,7 +314,7 @@ async def test_volume_upload_large_stream(client, servicer, blob_server):
         assert servicer.volumes[object_id].files["/a"].data == b""
         assert servicer.volumes[object_id].files["/a"].data_blob_id == "bl-1"
 
-        _, blobs, _ = blob_server
+        _, blobs, _, _ = blob_server
         assert blobs["bl-1"] == b"hello world, this is a lot of text"
 
 


### PR DESCRIPTION
## Describe your changes

- Uses the more efficient download path that was originally built for version 2 volumes, now also available for version 1 volumes!

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
