### PR TITLE
Upgrade to synchronicity 0.9.13 [CLI-415]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "grpclib==0.4.7",
     "protobuf>=3.19,<7.0,!=4.24.0",
     "rich>=12.0.0",
-    "synchronicity~=0.9.12",
+    "synchronicity~=0.9.13",
     "toml",
     "typer>=0.9",
     "types-certifi",


### PR DESCRIPTION
Fixes thread race condition that could sometimes make .map calls deadlock
