### PR TITLE
Overwrite mount for preview image builder and speed up creation

### DIFF
--- a/modal/mount.py
+++ b/modal/mount.py
@@ -290,6 +290,7 @@ class _Mount(_Object, type_prefix="mo"):
     _deployment_name: Optional[str] = None
     _namespace: Optional[int] = None
     _environment_name: Optional[str] = None
+    _allow_overwrite: bool = False
     _content_checksum_sha256_hex: Optional[str] = None
 
     @staticmethod
@@ -600,11 +601,16 @@ class _Mount(_Object, type_prefix="mo"):
         # Build the mount.
         status_row.message(f"Creating mount {message_label}: Finalizing index of {len(files)} files")
         if self._deployment_name:
+            creation_type = (
+                api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING
+                if self._allow_overwrite
+                else api_pb2.OBJECT_CREATION_TYPE_CREATE_FAIL_IF_EXISTS
+            )
             req = api_pb2.MountGetOrCreateRequest(
                 deployment_name=self._deployment_name,
                 namespace=self._namespace,
                 environment_name=self._environment_name,
-                object_creation_type=api_pb2.OBJECT_CREATION_TYPE_CREATE_FAIL_IF_EXISTS,
+                object_creation_type=creation_type,
                 files=files,
             )
         elif resolver.app_id is not None:
@@ -736,7 +742,9 @@ class _Mount(_Object, type_prefix="mo"):
         self: "_Mount",
         deployment_name: Optional[str] = None,
         namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        *,
         environment_name: Optional[str] = None,
+        allow_overwrite: bool = False,
         client: Optional[_Client] = None,
     ) -> None:
         check_object_name(deployment_name, "Mount")
@@ -744,6 +752,7 @@ class _Mount(_Object, type_prefix="mo"):
         self._deployment_name = deployment_name
         self._namespace = namespace
         self._environment_name = environment_name
+        self._allow_overwrite = allow_overwrite
         if client is None:
             client = await _Client.from_env()
         resolver = Resolver(client=client, environment_name=environment_name)
@@ -826,7 +835,7 @@ import sys; sys.path.append('{REMOTE_PACKAGES_PATH}')
 """.strip()
 
 
-async def _create_single_mount(
+async def _create_single_client_dependency_mount(
     client: _Client,
     builder_version: str,
     python_version: str,
@@ -834,8 +843,8 @@ async def _create_single_mount(
     arch: str,
     uv_python_platform: str = None,
     check_if_exists: bool = True,
+    allow_overwrite: bool = False,
 ):
-    import subprocess
     import tempfile
 
     profile_environment = config.get("environment")
@@ -846,15 +855,15 @@ async def _create_single_mount(
     if check_if_exists:
         try:
             await Mount.from_name(mount_name, namespace=api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL).hydrate.aio(client)
-            print(f"✅ Found existing mount {mount_name} in global namespace.")
+            print(f"➖ Found existing mount {mount_name} in global namespace.")
             return
         except modal.exception.NotFoundError:
             pass
 
-    with tempfile.TemporaryDirectory() as tmpd:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpd:
         print(f"📦 Building {mount_name}.")
         requirements = os.path.join(os.path.dirname(__file__), f"requirements/{builder_version}.txt")
-        subprocess.run(
+        cmd = " ".join(
             [
                 "uv",
                 "pip",
@@ -871,10 +880,19 @@ async def _create_single_mount(
                 uv_python_platform,
                 "--python-version",
                 python_version,
-            ],
-            check=True,
-            capture_output=True,
+            ]
         )
+        proc = await asyncio.create_subprocess_shell(
+            cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        await proc.wait()
+        if proc.returncode:
+            stdout, stderr = await proc.communicate()
+            print(stdout.decode("utf-8"))
+            print(stderr.decode("utf-8"))
+            raise RuntimeError(f"Subprocess failed with {proc.returncode}", proc.args)
 
         print(f"🌐 Downloaded and unpacked packages to {tmpd}.")
 
@@ -895,6 +913,7 @@ async def _create_single_mount(
                 mount_name,
                 api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL,
                 environment_name=profile_environment,
+                allow_overwrite=allow_overwrite,
                 client=client,
             )
             print(f"✅ Deployed mount {mount_name} to global namespace.")
@@ -902,34 +921,37 @@ async def _create_single_mount(
 
 async def _create_client_dependency_mounts(
     client=None,
-    check_if_exists=True,
     python_versions: list[str] = list(PYTHON_STANDALONE_VERSIONS),
+    check_if_exists=True,
 ):
     coros = []
-    for python_version in python_versions:
-        # glibc >= 2.17
-        coros.append(
-            _create_single_mount(
-                client,
-                "PREVIEW",
-                python_version,
-                "manylinux_2_17",
-                "x86_64",
-                check_if_exists=check_if_exists,
+    for builder_version in ["PREVIEW"]:
+        for python_version in python_versions:
+            # glibc >= 2.17
+            coros.append(
+                _create_single_client_dependency_mount(
+                    client,
+                    builder_version,
+                    python_version,
+                    "manylinux_2_17",
+                    "x86_64",
+                    check_if_exists=check_if_exists,
+                    allow_overwrite=builder_version != "PREVIEW",
+                )
             )
-        )
-        # musl >= 1.2
-        coros.append(
-            _create_single_mount(
-                client,
-                "PREVIEW",
-                python_version,
-                "musllinux_1_2",
-                "x86_64",
-                uv_python_platform="x86_64-unknown-linux-musl",
-                check_if_exists=check_if_exists,
+            # musl >= 1.2
+            coros.append(
+                _create_single_client_dependency_mount(
+                    client,
+                    builder_version,
+                    python_version,
+                    "musllinux_1_2",
+                    "x86_64",
+                    uv_python_platform="x86_64-unknown-linux-musl",
+                    check_if_exists=check_if_exists,
+                    allow_overwrite=builder_version != "PREVIEW",
+                )
             )
-        )
     await TaskContext.gather(*coros)
 
 

--- a/modal_global_objects/mounts/modal_client_package.py
+++ b/modal_global_objects/mounts/modal_client_package.py
@@ -1,6 +1,8 @@
 # Copyright Modal Labs 2022
 from modal.config import config
+from modal.exception import NotFoundError
 from modal.mount import (
+    Mount,
     client_mount_name,
     create_client_mount,
 )
@@ -11,14 +13,17 @@ def publish_client_mount(client):
     mount = create_client_mount()
     name = client_mount_name()
     profile_environment = config.get("environment")
-    # TODO: change how namespaces work, so we don't have to use unrelated workspaces when deploying to global?.
-    mount._deploy(
-        client_mount_name(),
-        api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL,
-        client=client,
-        environment_name=profile_environment,
-    )
-    print(f"✅ Deployed client mount {name} to global namespace.")
+    try:
+        Mount.from_name(name, namespace=api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL).hydrate(client)
+        print(f"✅ Found existing mount {name} in global namespace.")
+    except NotFoundError:
+        mount._deploy(
+            name,
+            api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL,
+            client=client,
+            environment_name=profile_environment,
+        )
+        print(f"✅ Deployed client mount {name} to global namespace.")
 
 
 def main(client=None):

--- a/modal_global_objects/mounts/modal_client_package.py
+++ b/modal_global_objects/mounts/modal_client_package.py
@@ -15,7 +15,7 @@ def publish_client_mount(client):
     profile_environment = config.get("environment")
     try:
         Mount.from_name(name, namespace=api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL).hydrate(client)
-        print(f"✅ Found existing mount {name} in global namespace.")
+        print(f"➖ Found existing mount {name} in global namespace.")
     except NotFoundError:
         mount._deploy(
             name,

--- a/modal_global_objects/mounts/python_standalone.py
+++ b/modal_global_objects/mounts/python_standalone.py
@@ -27,7 +27,7 @@ def publish_python_standalone_mount(client, version: str) -> None:
     mount_name = python_standalone_mount_name(f"{version}-{libc}")
     try:
         Mount.from_name(mount_name, namespace=api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL).hydrate(client)
-        print(f"✅ Found existing mount {mount_name} in global namespace.")
+        print(f"➖ Found existing mount {mount_name} in global namespace.")
     except NotFoundError:
         print(f"📦 Unpacking python-build-standalone for {version}-{libc}.")
         with tempfile.TemporaryDirectory() as d:


### PR DESCRIPTION
## Describe your changes

- Allow Mount deployment to overwrite an existing Mount of the same name
- Request this behavior when deploying the PREVIEW image builder so we can iterate on it
- Speed up client dependency mount creation by using async subprocess call

Requires a server change to work as expected.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
