### PR TITLE
Support recursive copy in the CLI

### DIFF
--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -265,12 +265,13 @@ async def rm(
 async def cp(
     volume_name: str,
     paths: list[str],  # accepts multiple paths, last path is treated as destination path
+    recursive: bool = Option(False, "-r", "--recursive", help="Copy directories recursively"),
     env: Optional[str] = ENV_OPTION,
 ):
     ensure_env(env)
     volume = _Volume.from_name(volume_name, environment_name=env)
     *src_paths, dst_path = paths
-    await volume.copy_files(src_paths, dst_path)
+    await volume.copy_files(src_paths, dst_path, recursive)
 
 
 @volume_cli.command(

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -498,7 +498,7 @@ class _Volume(_Object, type_prefix="vo"):
             await retry_transient_errors(self._client.stub.VolumeRemoveFile2, req)
 
     @live_method
-    async def copy_files(self, src_paths: Sequence[str], dst_path: str) -> None:
+    async def copy_files(self, src_paths: Sequence[str], dst_path: str, recursive: bool = False) -> None:
         """
         Copy files within the volume from src_paths to dst_path.
         The semantics of the copy operation follow those of the UNIX cp command.
@@ -523,10 +523,17 @@ class _Volume(_Object, type_prefix="vo"):
         the volume mounted as a filesystem, e.g. when running a script on your local computer.
         """
         if self._is_v1:
-            request = api_pb2.VolumeCopyFilesRequest(volume_id=self.object_id, src_paths=src_paths, dst_path=dst_path)
+            if recursive:
+                raise ValueError("`recursive` is not supported for V1 volumes")
+
+            request = api_pb2.VolumeCopyFilesRequest(
+                volume_id=self.object_id, src_paths=src_paths, dst_path=dst_path, recursive=recursive
+            )
             await retry_transient_errors(self._client.stub.VolumeCopyFiles, request, base_delay=1)
         else:
-            request = api_pb2.VolumeCopyFiles2Request(volume_id=self.object_id, src_paths=src_paths, dst_path=dst_path)
+            request = api_pb2.VolumeCopyFiles2Request(
+                volume_id=self.object_id, src_paths=src_paths, dst_path=dst_path, recursive=recursive
+            )
             await retry_transient_errors(self._client.stub.VolumeCopyFiles2, request, base_delay=1)
 
     @live_method

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -380,7 +380,7 @@ async def test_volume_copy_1(client, tmp_path, servicer, version):
         object_id = vol.object_id
 
         # copy file from src_path to dst_path
-        vol.copy_files([src_path], dst_path)
+        vol.copy_files([src_path], dst_path, False)
 
     assert servicer.volumes[object_id].files.keys() == {src_path, dst_path}
 
@@ -402,7 +402,7 @@ async def test_volume_copy_2(client, tmp_path, servicer, version):
                 batch.put_file(local_file_path, file_path)
             object_id = vol.object_id
 
-        vol.copy_files(file_paths, "test_dir")
+        vol.copy_files(file_paths, "test_dir", False)
 
     returned_volume_files = [Path(file) for file in servicer.volumes[object_id].files.keys()]
     expected_volume_files = [


### PR DESCRIPTION
This is not supported in the backend for V1 volumes but it works for V2 volumes.

I didn't update the docstring for this since it's not supported for V1 volumes, so it seems like something we don't want to advertise until V2 becomes mainstream.

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

