### PR TITLE
[SVC-677] Add ability for clients to attempt blob uploads to multiple urls on failure

### DIFF
--- a/modal/_utils/blob_utils.py
+++ b/modal/_utils/blob_utils.py
@@ -4,6 +4,7 @@ import dataclasses
 import hashlib
 import os
 import platform
+import random
 import time
 from collections.abc import AsyncIterator
 from contextlib import AbstractContextManager, contextmanager
@@ -54,6 +55,8 @@ MULTIPART_UPLOAD_THRESHOLD = 1024**3
 
 # For block based storage like volumefs2: the size of a block
 BLOCK_SIZE: int = 8 * 1024 * 1024
+
+HEALTHY_R2_UPLOAD_PERCENTAGE = 0.95
 
 
 @retry(n_attempts=5, base_delay=0.5, timeout=None)
@@ -182,6 +185,22 @@ def get_content_length(data: BinaryIO) -> int:
     return content_length - pos
 
 
+async def _blob_upload_with_fallback(items, blob_ids, callback):
+    for idx, (item, blob_id) in enumerate(zip(items, blob_ids)):
+        # We want to default to R2 95% of the time and S3 5% of the time.
+        # To ensure the failure path is continuously exercised.
+        if idx == 0 and len(items) > 1 and random.random() > HEALTHY_R2_UPLOAD_PERCENTAGE:
+            continue
+        try:
+            await callback(item)
+            return blob_id
+        except Exception as _:
+            # Ignore all errors except the last one, since we're out of fallback options.
+            if idx == len(items) - 1:
+                raise
+    raise ExecutionError("Failed to upload blob")
+
+
 async def _blob_upload(
     upload_hashes: UploadHashes, data: Union[bytes, BinaryIO], stub, progress_report_cb: Optional[Callable] = None
 ) -> str:
@@ -197,17 +216,23 @@ async def _blob_upload(
     )
     resp = await retry_transient_errors(stub.BlobCreate, req)
 
-    blob_id = resp.blob_id
+    if resp.WhichOneof("upload_types_oneof") == "multiparts":
 
-    if resp.WhichOneof("upload_type_oneof") == "multipart":
-        await perform_multipart_upload(
-            data,
-            content_length=content_length,
-            max_part_size=resp.multipart.part_length,
-            part_urls=resp.multipart.upload_urls,
-            completion_url=resp.multipart.completion_url,
-            upload_chunk_size=DEFAULT_SEGMENT_CHUNK_SIZE,
-            progress_report_cb=progress_report_cb,
+        async def upload_multipart_upload(part):
+            return await perform_multipart_upload(
+                data,
+                content_length=content_length,
+                max_part_size=part.part_length,
+                part_urls=part.upload_urls,
+                completion_url=part.completion_url,
+                upload_chunk_size=DEFAULT_SEGMENT_CHUNK_SIZE,
+                progress_report_cb=progress_report_cb,
+            )
+
+        blob_id = await _blob_upload_with_fallback(
+            resp.multiparts.items,
+            resp.blob_ids,
+            upload_multipart_upload,
         )
     else:
         from .bytes_io_segment_payload import BytesIOSegmentPayload
@@ -215,11 +240,19 @@ async def _blob_upload(
         payload = BytesIOSegmentPayload(
             data, segment_start=0, segment_length=content_length, progress_report_cb=progress_report_cb
         )
-        await _upload_to_s3_url(
-            resp.upload_url,
-            payload,
-            # for single part uploads, we use server side md5 checksums
-            content_md5_b64=upload_hashes.md5_base64,
+
+        async def upload_to_s3_url(url):
+            return await _upload_to_s3_url(
+                url,
+                payload,
+                # for single part uploads, we use server side md5 checksums
+                content_md5_b64=upload_hashes.md5_base64,
+            )
+
+        blob_id = await _blob_upload_with_fallback(
+            resp.upload_urls.items,
+            resp.blob_ids,
+            upload_to_s3_url,
         )
 
     if progress_report_cb:
@@ -380,7 +413,9 @@ def get_file_upload_spec_from_fileobj(fp: BinaryIO, mount_filename: PurePosixPat
         mode,
     )
 
+
 _FileUploadSource2 = Callable[[], ContextManager[BinaryIO]]
+
 
 @dataclasses.dataclass
 class FileUploadSpec2:
@@ -392,7 +427,6 @@ class FileUploadSpec2:
     blocks_sha256: list[bytes]
     mode: int  # file permission bits (last 12 bits of st_mode)
     size: int
-
 
     @staticmethod
     async def from_path(
@@ -416,7 +450,6 @@ class FileUploadSpec2:
             hash_semaphore,
         )
 
-
     @staticmethod
     async def from_fileobj(
         source_fp: Union[BinaryIO, BytesIO],
@@ -426,6 +459,7 @@ class FileUploadSpec2:
     ) -> "FileUploadSpec2":
         try:
             fileno = source_fp.fileno()
+
             def source():
                 new_fd = os.dup(fileno)
                 fp = os.fdopen(new_fd, "rb")
@@ -436,6 +470,7 @@ class FileUploadSpec2:
             # `.fileno()` not available; assume BytesIO-like type
             source_fp = cast(BytesIO, source_fp)
             buffer = source_fp.getbuffer()
+
             def source():
                 return BytesIO(buffer)
 
@@ -446,7 +481,6 @@ class FileUploadSpec2:
             mode,
             hash_semaphore,
         )
-
 
     @staticmethod
     async def _create(

--- a/test/grpc_utils_test.py
+++ b/test/grpc_utils_test.py
@@ -28,7 +28,7 @@ async def test_http_channel(servicer, credentials):
 
     req = api_pb2.BlobCreateRequest()
     resp = await client_stub.BlobCreate(req, metadata=metadata)
-    assert resp.blob_id
+    assert len(resp.blob_ids) > 0
 
     channel.close()
 
@@ -47,7 +47,7 @@ async def test_unix_channel(servicer):
 
     req = api_pb2.BlobCreateRequest()
     resp = await client_stub.BlobCreate(req, metadata=metadata)
-    assert resp.blob_id
+    assert len(resp.blob_ids) > 0
 
     channel.close()
 


### PR DESCRIPTION
Allows the client to accept a list of bucket-urls for different providers (S3, R2, etc.) from the server, and choose a different provider if one of them is unavailable.

## Compatibility checklist
- [x] Client+Server: this change is compatible with old servers
