### PR TITLE
Introduce `Image.uv_pip_install` with volume caching

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -331,11 +331,10 @@ def _uv_pip_install(pkgs: list[str], extra_options_args: list[str]):
     """Run uv pip install with pkgs and extra_options_args."""
     from subprocess import run
 
-    package_args = sorted(pkgs)
     run(
         ["uv", "pip", "install", "--python", sys.executable, "--compile-bytecode", "--link-mode", "copy"]
         + extra_options_args
-        + package_args
+        + pkgs
     )
 
 
@@ -1436,7 +1435,7 @@ class _Image(_Object, type_prefix="im"):
         return image.run_function(
             _uv_pip_install,
             volumes=volumes,
-            kwargs={"pkgs": pkgs, "extra_options_args": extra_options_args},
+            kwargs={"pkgs": sorted(pkgs), "extra_options_args": extra_options_args},
             force_build=force_build,
             secrets=secrets,
             gpu=gpu,

--- a/modal/image.py
+++ b/modal/image.py
@@ -1421,6 +1421,7 @@ class _Image(_Object, type_prefix="im"):
 
         extra_options_args = shlex.split(extra_options)
         remote_volume_path = "/uv_cache"
+
         if cache_volume is not None:
             volumes = {remote_volume_path: cache_volume}
             extra_options_args.append(f"--cache-dir={remote_volume_path}")


### PR DESCRIPTION
## Describe your changes

Adds `uv pip install` to `modal.Image`. With this PR, a user can provide a cache that is mounted during build time:

```python
cache_volume = modal.Volume.from_name(name="uv-cache-volume", create_if_missing=True)
image = modal.Image.debian_slim().uv_pip_install("torch", cache_volume=cache_volume)
```

This makes it fast to iterate on a project when adding additional packages when you already built an image.

Quick benchmarking: (install PyTorch + some random packages)
- uv pip install with a warm volume cache: 24s
- uv pip install without cache: 55s
- with normal `pip_install`: 93s

I have considered taking a string as a `cache_volume` (with a default value) to create the volume cache for the user, but I think it's a better to be explicit and `cache_volume` to be passed in.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->

Adds `uv_pip_install` to install packages with `uv`. You can also pass in a Volume for `uv` to use as a build cache:

```
import modal

cache_volume = modal.Volume.from_name(name="uv-cache-volume", create_if_missing=True)
image = modal.Image.debian_slim().uv_pip_install("torch", cache_volume=cache_volume)
```