### PR TITLE
Prune out ignored directories early in `MountDir.get_files_to_upload()`

### DIFF
--- a/modal/file_pattern_matcher.py
+++ b/modal/file_pattern_matcher.py
@@ -199,8 +199,8 @@ class FilePatternMatcher(_AbstractPatternMatcher):
         Returns True if this pattern matcher allows safe early directory pruning.
 
         Directory pruning is safe when matching directories can be skipped entirely
-        without missing any files that should be included. This is only safe when
-        there are no exclusion patterns (patterns starting with '!').
+        without missing any files that should be included. This is for example not
+        safe when we have inverted/negated ignore patterns (e.g. "!**/*.py").
         """
         return not any(pattern.exclusion for pattern in self.patterns)
 

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -141,6 +141,8 @@ class _MountDir(_MountEntry):
 
     def _walk_and_prune(self, top_dir: Path) -> Generator[str, None, None]:
         for root, dirs, files in os.walk(top_dir, topdown=True):
+            # with topdown=True, os.walk allows modifying the dirnames list in-place, and will only
+            # recurse into dirs that are not ignored.
             dirs[:] = [d for d in dirs if not self.ignore(Path(os.path.join(root, d)).relative_to(top_dir))]
             for file in files:
                 yield os.path.join(root, file)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2476,7 +2476,7 @@ def mock_dir_factory():
         cwd = os.getcwd()
         try:
             os.chdir(root_dir)
-            yield
+            yield root_dir
         finally:
             os.chdir(cwd)
             shutil.rmtree(root_dir, ignore_errors=True)

--- a/test/file_pattern_matcher_test.py
+++ b/test/file_pattern_matcher_test.py
@@ -352,3 +352,22 @@ def test_from_file(as_type):
     lff = FilePatternMatcher.from_file(as_type(ignore_file))
     assert lff(Path("top/data.txt"))
     assert not lff(Path("top/data.py"))
+
+
+@pytest.mark.parametrize(
+    "patterns,expected",
+    [
+        (("*.tmp", "node_modules", "dist/**"), True),
+        (("**", "!*.py"), False),
+        (("node_modules", "!node_modules/keep.txt"), False),
+        ((), True),
+    ],
+)
+def test_can_prune_directories(patterns, expected):
+    matcher = FilePatternMatcher(*patterns)
+    assert matcher.can_prune_directories() is expected
+
+
+def test_can_prune_directories_negated():
+    matcher_negated = ~FilePatternMatcher("*.py")
+    assert matcher_negated.can_prune_directories() is False

--- a/test/mounted_files_test.py
+++ b/test/mounted_files_test.py
@@ -136,19 +136,19 @@ def test_get_files_to_upload_ignore(mock_dir):
         included_files = set(mount_dir._walk_and_prune(mock_path))
         assert len(included_files) == 3
         expected_files = {
-            (mock_path / "dir_a" / "dir_a_a" / "file_a_a").as_posix(),
-            (mock_path / "dir_b" / "dir_b_a" / "file_b_a").as_posix(),
-            (mock_path / "dir_c" / "venv").as_posix(),  # a file named venv, not ignored
+            str(mock_path / "dir_a" / "dir_a_a" / "file_a_a"),
+            str(mock_path / "dir_b" / "dir_b_a" / "file_b_a"),
+            str(mock_path / "dir_c" / "venv"),  # a file named venv, not ignored
         }
         assert included_files == expected_files
 
         # after get_files_to_upload, both files and directories should be pruned out
         files = list(mount_dir.get_files_to_upload())
         assert len(files) == 2
-        included_files = {file[0].as_posix() for file in files}
+        included_files = {str(file[0]) for file in files}
         expected_files = {
-            (mock_path / "dir_a" / "dir_a_a" / "file_a_a").as_posix(),
-            (mock_path / "dir_b" / "dir_b_a" / "file_b_a").as_posix(),
+            str(mock_path / "dir_a" / "dir_a_a" / "file_a_a"),
+            str(mock_path / "dir_b" / "dir_b_a" / "file_b_a"),
         }
         assert included_files == expected_files
 


### PR DESCRIPTION
## Describe your changes

If you e.g. `image.add_local_dir("dir", ignore=["**/venv"])`, this will prune out any `venv` directories early when evaluating which files to include, avoiding searching through all files within.

CLI-433

## Changelog

- Optimized handling of the `ignore` parameter to `Image.add_local_dir` and similar functions. If you e.g. `image.add_local_dir("dir", ignore=["**/venv"])`, we now prune out any `venv` directories early when evaluating which files to include, avoiding traversing through all files within.