### PR TITLE
Move blob uploads on async function calls to the client

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -141,7 +141,13 @@ class _Invocation:
         stub = client.stub
 
         function_id = function.object_id
-        item = await _create_input(args, kwargs, stub, method_name=function._use_method_name)
+        item = await _create_input(
+            args,
+            kwargs,
+            stub,
+            method_name=function._use_method_name,
+            function_call_invocation_type=function_call_invocation_type,
+        )
 
         request = api_pb2.FunctionMapRequest(
             function_id=function_id,

--- a/modal/_utils/blob_utils.py
+++ b/modal/_utils/blob_utils.py
@@ -38,6 +38,9 @@ if TYPE_CHECKING:
 # Max size for function inputs and outputs.
 MAX_OBJECT_SIZE_BYTES = 2 * 1024 * 1024  # 2 MiB
 
+# Max size for async function inputs and outputs.
+MAX_ASYNC_OBJECT_SIZE_BYTES = 8 * 1024  # 8 KiB
+
 #  If a file is LARGE_FILE_LIMIT bytes or larger, it's uploaded to blob store (s3) instead of going through grpc
 #  It will also make sure to chunk the hash calculation to avoid reading the entire file into memory
 LARGE_FILE_LIMIT = 4 * 1024 * 1024  # 4 MiB

--- a/test/should_upload_test.py
+++ b/test/should_upload_test.py
@@ -1,0 +1,39 @@
+# Copyright Modal Labs 2025
+from dataclasses import dataclass
+
+from modal._utils.blob_utils import MAX_ASYNC_OBJECT_SIZE_BYTES, MAX_OBJECT_SIZE_BYTES
+from modal._utils.function_utils import should_upload
+from modal_proto import api_pb2
+
+
+@dataclass
+class Input:
+    size: int
+    is_async: bool
+    should_use_blob: bool
+
+
+def test_should_upload():
+    SMALL = MAX_ASYNC_OBJECT_SIZE_BYTES // 2
+    LARGE = MAX_ASYNC_OBJECT_SIZE_BYTES * 2
+    HUGE = MAX_OBJECT_SIZE_BYTES * 2
+    test_cases = [
+        Input(size=SMALL, is_async=True, should_use_blob=False),
+        Input(size=SMALL, is_async=False, should_use_blob=False),
+        Input(size=LARGE, is_async=True, should_use_blob=True),
+        Input(size=LARGE, is_async=False, should_use_blob=False),
+        Input(size=HUGE, is_async=True, should_use_blob=True),
+        Input(size=HUGE, is_async=False, should_use_blob=True),
+    ]
+
+    for case in test_cases:
+        used_blob = should_upload(
+            case.size,
+            function_call_invocation_type=(
+                api_pb2.FUNCTION_CALL_INVOCATION_TYPE_ASYNC
+                if case.is_async
+                else api_pb2.FUNCTION_CALL_INVOCATION_TYPE_SYNC
+            ),
+        )
+
+        assert used_blob == case.should_use_blob


### PR DESCRIPTION
Makes the client perform blob uploads that previously the server was doing (on the async path).