### PR TITLE
Support specified poetry version and update default spec in next image builder

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -1252,7 +1252,7 @@ class _Image(_Object, type_prefix="im"):
             context_files = {"/.pyproject.toml": os.path.expanduser(poetry_pyproject_toml)}
 
             if poetry_version is None:
-                poetry_spec = "~=1.7" if version <= "2024.10" else "~=2.0"
+                poetry_spec = "~=1.7" if version <= "2024.10" else ""
             else:
                 poetry_spec = f"=={poetry_version}"
             commands = ["FROM base", f"RUN python -m pip install poetry{poetry_spec}"]

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -17,7 +17,7 @@ from modal import App, Dict, Image, Secret, build, environments, method
 from modal._serialization import serialize
 from modal._utils.async_utils import synchronizer
 from modal.client import Client
-from modal.exception import DeprecationError, InvalidError, ModuleNotMountable, VersionError
+from modal.exception import DeprecationError, InvalidError, ModuleNotMountable, NotFoundError, VersionError
 from modal.experimental import raw_dockerfile_image, raw_registry_image
 from modal.file_pattern_matcher import FilePatternMatcher
 from modal.image import (
@@ -646,22 +646,30 @@ def test_image_run_function_with_cloud_selection(servicer, client):
     assert func_def.cloud_provider_str == "oci"
 
 
-def test_poetry(builder_version, servicer, client):
+def test_poetry_files(builder_version, servicer, client):
     path = os.path.join(os.path.dirname(__file__), "supports/pyproject.toml")
 
     # No lockfile provided and there's no lockfile found
-    # TODO we deferred the exception until _load runs, not sure how to test that here
-    # with pytest.raises(NotFoundError):
-    #     Image.debian_slim().poetry_install_from_file(path)
+    image = Image.debian_slim().poetry_install_from_file(path)
+    app = App()
+    app.function(image=image)(dummy)
+    with pytest.raises(NotFoundError):
+        with app.run(client=client):
+            pass
 
     # Explicitly ignore lockfile - this should work
-    Image.debian_slim().poetry_install_from_file(path, ignore_lockfile=True)
+    image = Image.debian_slim().poetry_install_from_file(path, ignore_lockfile=True)
+    app = App()
+    app.function(image=image)(dummy)
+    with app.run(client=client):
+        layers = get_image_layers(image.object_id, servicer)
+        context_files = {f.filename for layer in layers for f in layer.context_files}
+        assert "/.pyproject.toml" in context_files
+        assert "/.poetry.lock" not in context_files
 
     # Provide lockfile explicitly - this should also work
     lockfile_path = os.path.join(os.path.dirname(__file__), "supports/special_poetry.lock")
     image = Image.debian_slim().poetry_install_from_file(path, lockfile_path)
-
-    # Build iamge
     app = App()
     app.function(image=image)(dummy)
     with app.run(client=client):
@@ -671,6 +679,30 @@ def test_poetry(builder_version, servicer, client):
             assert context_files == {"/.poetry.lock", "/.pyproject.toml", "/modal_requirements.txt"}
         else:
             assert context_files == {"/.poetry.lock", "/.pyproject.toml"}
+
+
+@pytest.mark.parametrize("poetry_version", [None, "2.1.2"])
+def test_poetry_commands(builder_version, servicer, client, poetry_version):
+    path = os.path.join(os.path.dirname(__file__), "supports/pyproject.toml")
+    app = App()
+    image = Image.debian_slim().poetry_install_from_file(
+        path,
+        ignore_lockfile=True,
+        with_=["foo", "bar"],
+        without=["buz"],
+        poetry_version=poetry_version,
+    )
+    app.function(image=image)(dummy)
+    with app.run(client=client):
+        layers = get_image_layers(image.object_id, servicer)
+        dockerfile_commands = " ".join(layers[0].dockerfile_commands)
+        if builder_version <= "2024.10":
+            poetry_spec = "~=1.7" if poetry_version is None else f"=={poetry_version}"
+        else:
+            poetry_spec = "~=2.0" if poetry_version is None else f"=={poetry_version}"
+        assert f"python -m pip install poetry{poetry_spec}" in dockerfile_commands
+        assert "poetry config virtualenvs.create false" in dockerfile_commands
+        assert "poetry install --no-root --with foo,bar --without buz" in dockerfile_commands
 
 
 def test_image_add_local_file_error(tmp_path, client):

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -699,7 +699,7 @@ def test_poetry_commands(builder_version, servicer, client, poetry_version):
         if builder_version <= "2024.10":
             poetry_spec = "~=1.7" if poetry_version is None else f"=={poetry_version}"
         else:
-            poetry_spec = "~=2.0" if poetry_version is None else f"=={poetry_version}"
+            poetry_spec = "" if poetry_version is None else f"=={poetry_version}"
         assert f"python -m pip install poetry{poetry_spec}" in dockerfile_commands
         assert "poetry config virtualenvs.create false" in dockerfile_commands
         assert "poetry install --no-root --with foo,bar --without buz" in dockerfile_commands


### PR DESCRIPTION
## Describe your changes

- Closes CLI-441

Also improved the tests a bit.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

- Added a `poetry_version` parameter to `modal.Image.poetry_install_from_file`, which supports installing a specific version of `poetry`. It's also possible to set `poetry_version=None` to skip the install step, i.e. when poetry is already available in the Image.