### PR TITLE
Added verbose to sandboxes in client

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -105,6 +105,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         proxy: Optional[_Proxy] = None,
         _experimental_scheduler_placement: Optional[SchedulerPlacement] = None,
         enable_snapshot: bool = False,
+        verbose: bool = False,
     ) -> "_Sandbox":
         """mdmd:hidden"""
 
@@ -205,6 +206,7 @@ class _Sandbox(_Object, type_prefix="sb"):
                 network_access=network_access,
                 proxy_id=(proxy.object_id if proxy else None),
                 enable_snapshot=enable_snapshot,
+                verbose=verbose,
             )
 
             # Note - `resolver.app_id` will be `None` for app-less sandboxes
@@ -259,6 +261,7 @@ class _Sandbox(_Object, type_prefix="sb"):
             SchedulerPlacement
         ] = None,  # Experimental controls over fine-grained scheduling (alpha).
         client: Optional[_Client] = None,
+        verbose: bool = False,
     ) -> "_Sandbox":
         """
         Create a new Sandbox to run untrusted, arbitrary code. The Sandbox's corresponding container
@@ -298,6 +301,7 @@ class _Sandbox(_Object, type_prefix="sb"):
             _experimental_enable_snapshot=_experimental_enable_snapshot,
             _experimental_scheduler_placement=_experimental_scheduler_placement,
             client=client,
+            verbose=verbose,
         )
 
     @staticmethod
@@ -342,6 +346,7 @@ class _Sandbox(_Object, type_prefix="sb"):
             SchedulerPlacement
         ] = None,  # Experimental controls over fine-grained scheduling (alpha).
         client: Optional[_Client] = None,
+        verbose: bool = False,
     ):
         # This method exposes some internal arguments (currently `mounts`) which are not in the public API
         # `mounts` is currently only used by modal shell (cli) to provide a function's mounts to the
@@ -376,6 +381,7 @@ class _Sandbox(_Object, type_prefix="sb"):
             proxy=proxy,
             _experimental_scheduler_placement=_experimental_scheduler_placement,
             enable_snapshot=_experimental_enable_snapshot,
+            verbose=verbose,
         )
         obj._enable_snapshot = _experimental_enable_snapshot
 

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -255,13 +255,14 @@ class _Sandbox(_Object, type_prefix="sb"):
         unencrypted_ports: Sequence[int] = [],
         # Reference to a Modal Proxy to use in front of this Sandbox.
         proxy: Optional[_Proxy] = None,
+        # Enable verbose logging for sandbox operations.
+        verbose: bool = False,
         # Enable memory snapshots.
         _experimental_enable_snapshot: bool = False,
         _experimental_scheduler_placement: Optional[
             SchedulerPlacement
         ] = None,  # Experimental controls over fine-grained scheduling (alpha).
         client: Optional[_Client] = None,
-        verbose: bool = False,
     ) -> "_Sandbox":
         """
         Create a new Sandbox to run untrusted, arbitrary code. The Sandbox's corresponding container


### PR DESCRIPTION
Added verbose to sandboxes in client.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

- When `verbose=True` is set in `Sandbox.create()`, execs and file system operations are logged in the sandbox logs. For example, 
```
p = sb.exec("python", "-c", "print('hello')")
```
logs
<img width="538" alt="image" src="https://github.com/user-attachments/assets/597ef68f-71b7-40d7-b6a6-7a563a582faa" />
