### PR TITLE
remove incorrect anchor link

### DIFF
--- a/modal/volume.py
+++ b/modal/volume.py
@@ -405,7 +405,7 @@ class _Volume(_Object, type_prefix="vo"):
 
         Note - this function is primarily intended to be used outside of a Modal App.
         For more information on downloading files from a Modal Volume, see
-        [here](/docs/guide/volumes#downloading-files-from-a-volume).
+        [the guide](/docs/guide/volumes).
 
         **Example:**
 


### PR DESCRIPTION
This anchor link was presumably trying to point at https://modal.com/docs/guide/volumes#downloading-a-file-from-a-volume, but instead pointed to https://modal.com/docs/guide/volumes#downloading-files-from-a-volume, which does not exist. Spot the differences!

A missing anchor ID, believe it or not, breaks frontend builds, because the vite SSR throws a fit and crashes, which blocks all merges to `modal` and `modal-examples` (see CI [here](https://github.com/modal-labs/modal-examples/actions/runs/15601026495/job/43940852755?pr=1217#step:12:1542)).

This PR drops the anchor, rather than fixing it.

If we're unwilling to suppress the error or put in a default handler for missing IDs because we can't countenance the possibility a bad anchor link might persist, we should either put in sufficient CI to catch issues when they are introduced (e.g. doing frontend preview on changes to this repo, as we do in `modal` and `modal-examples`) or avoid anchors.