### PR TITLE
[WRK-1048] Add secrets to modal-shell

### DIFF
--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -27,6 +27,7 @@ from ..functions import Function
 from ..image import Image
 from ..output import enable_output
 from ..runner import deploy_app, interactive_shell, run_app
+from ..secret import Secret
 from ..serving import serve_app
 from ..volume import Volume
 from .import_refs import (
@@ -531,6 +532,10 @@ def shell(
             " Can be used multiple times."
         ),
     ),
+    secret: Optional[list[str]] = typer.Option(
+        default=None,
+        help=("Name of a `modal.Secret` to mount inside the shell (if not using REF). Can be used multiple times."),
+    ),
     cpu: Optional[int] = typer.Option(default=None, help="Number of CPUs to allocate to the shell (if not using REF)."),
     memory: Optional[int] = typer.Option(
         default=None, help="Memory to allocate for the shell, in MiB (if not using REF)."
@@ -660,6 +665,7 @@ def shell(
     else:
         modal_image = Image.from_registry(image, add_python=add_python) if image else None
         volumes = {} if volume is None else {f"/mnt/{vol}": Volume.from_name(vol) for vol in volume}
+        secrets = [] if secret is None else [Secret.from_name(s) for s in secret]
         start_shell = partial(
             interactive_shell,
             image=modal_image,
@@ -668,6 +674,7 @@ def shell(
             gpu=gpu,
             cloud=cloud,
             volumes=volumes,
+            secrets=secrets,
             region=region.split(",") if region else [],
             pty=pty,
         )


### PR DESCRIPTION
## Describe your changes

[WRK-1048] Currently, we don't support specifying secrets to run in a modal shell. This PR adds that functionality.

Prior to merge, double checked to ensure it works locally.

Follow-up PR will emit warnings for ignored flags in the `modal shell myapp.py <flags>` use case to ensure users know when their flags are being suppressed.

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

</details>

## Changelog

- Added support for `modal shell --secret SECRET_NAME`

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
