### PR TITLE
[WRK-1002] Added sandbox user in api.proto and sandbox.py

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -106,6 +106,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         _experimental_scheduler_placement: Optional[SchedulerPlacement] = None,
         enable_snapshot: bool = False,
         verbose: bool = False,
+        user: Optional[api_pb2.ProcessUser] = None,
     ) -> "_Sandbox":
         """mdmd:hidden"""
 
@@ -207,6 +208,7 @@ class _Sandbox(_Object, type_prefix="sb"):
                 proxy_id=(proxy.object_id if proxy else None),
                 enable_snapshot=enable_snapshot,
                 verbose=verbose,
+                user=user,
             )
 
             # Note - `resolver.app_id` will be `None` for app-less sandboxes
@@ -257,6 +259,8 @@ class _Sandbox(_Object, type_prefix="sb"):
         proxy: Optional[_Proxy] = None,
         # Enable verbose logging for sandbox operations.
         verbose: bool = False,
+        # Set the user ID and group ID of the sandbox.
+        user: Optional[api_pb2.ProcessUser] = None,
         # Enable memory snapshots.
         _experimental_enable_snapshot: bool = False,
         _experimental_scheduler_placement: Optional[
@@ -299,10 +303,11 @@ class _Sandbox(_Object, type_prefix="sb"):
             h2_ports=h2_ports,
             unencrypted_ports=unencrypted_ports,
             proxy=proxy,
+            verbose=verbose,
+            user=user,
             _experimental_enable_snapshot=_experimental_enable_snapshot,
             _experimental_scheduler_placement=_experimental_scheduler_placement,
             client=client,
-            verbose=verbose,
         )
 
     @staticmethod
@@ -341,13 +346,16 @@ class _Sandbox(_Object, type_prefix="sb"):
         unencrypted_ports: Sequence[int] = [],
         # Reference to a Modal Proxy to use in front of this Sandbox.
         proxy: Optional[_Proxy] = None,
+        # Enable verbose logging for sandbox operations.
+        verbose: bool = False,
+        # Set the user ID and group ID of the sandbox.
+        user: Optional[api_pb2.ProcessUser] = None,
         # Enable memory snapshots.
         _experimental_enable_snapshot: bool = False,
         _experimental_scheduler_placement: Optional[
             SchedulerPlacement
         ] = None,  # Experimental controls over fine-grained scheduling (alpha).
         client: Optional[_Client] = None,
-        verbose: bool = False,
     ):
         # This method exposes some internal arguments (currently `mounts`) which are not in the public API
         # `mounts` is currently only used by modal shell (cli) to provide a function's mounts to the
@@ -380,9 +388,10 @@ class _Sandbox(_Object, type_prefix="sb"):
             h2_ports=h2_ports,
             unencrypted_ports=unencrypted_ports,
             proxy=proxy,
+            verbose=verbose,
+            user=user,
             _experimental_scheduler_placement=_experimental_scheduler_placement,
             enable_snapshot=_experimental_enable_snapshot,
-            verbose=verbose,
         )
         obj._enable_snapshot = _experimental_enable_snapshot
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2443,6 +2443,14 @@ message Sandbox {
 
   // If set, the sandbox will be created with verbose logging enabled.
   bool verbose = 29;
+
+  // If set, the sandbox will be created with the specified user.
+  optional ProcessUser user = 30;
+}
+
+message ProcessUser {
+  uint32 uid = 1;
+  uint32 gid = 2;
 }
 
 message SandboxCreateRequest {


### PR DESCRIPTION
Added sandbox user in api.proto and sandbox.py (for supporting non-root users in sandboxes using Sandbox.create())

WRK-1002

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

- When `Sanbox.create()` is called with with a specific `user` parameter, the Sandbox process will run with the specified UID and GID
