### PR TITLE
Relax grpclib constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "aiohttp",
     "certifi",
     "click~=8.1.0",
-    "grpclib==0.4.7",
+    "grpclib>=0.4.7",
     "protobuf>=3.19,<7.0,!=4.24.0",
     "rich>=12.0.0",
     "synchronicity~=0.9.15",


### PR DESCRIPTION
Based on our internal testing the client still works fine with the next version of `grpclib`