### PR TITLE
Relax grpclib constraint to allow 0.4.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "aiohttp",
     "certifi",
     "click~=8.1.0",
-    "grpclib==0.4.7",
+    "grpclib>=0.4.7,<0.4.9",
     "protobuf>=3.19,<7.0,!=4.24.0",
     "rich>=12.0.0",
     "synchronicity~=0.9.15",


### PR DESCRIPTION
Given that grpclib is critical to nearly all client behaviors and that they've had breaking chances in patch releases before ([e.g.](https://grpclib.readthedocs.io/en/latest/changelog/#id2)) we'll err on the side of caution and keep a strict upper bound pin on known-to-work versions.