### PR TITLE
Include base class modal.parameters in class schema [CLI-450]

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -54,7 +54,9 @@ def _get_class_constructor_signature(user_cls: type) -> inspect.Signature:
         return inspect.signature(user_cls)
     else:
         constructor_parameters = []
-        for name, annotation_value in user_cls.__dict__.get("__annotations__", {}).items():
+        for name, annotation_value in typing.get_type_hints(
+            user_cls
+        ).items():  # .__dict__.get("__annotations__", {}).items():
             if hasattr(user_cls, name):
                 parameter_spec = getattr(user_cls, name)
                 if is_parameter(parameter_spec):

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -54,9 +54,7 @@ def _get_class_constructor_signature(user_cls: type) -> inspect.Signature:
         return inspect.signature(user_cls)
     else:
         constructor_parameters = []
-        for name, annotation_value in typing.get_type_hints(
-            user_cls
-        ).items():  # .__dict__.get("__annotations__", {}).items():
+        for name, annotation_value in typing.get_type_hints(user_cls).items():
             if hasattr(user_cls, name):
                 parameter_spec = getattr(user_cls, name)
                 if is_parameter(parameter_spec):

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -1330,8 +1330,7 @@ def test_parameter_inheritance(client):
 
     @app.cls(serialized=True)
     class ChangingParameterDefinitions(Base):
-        # change type of base class parameter - not allowed
-        # this is similar to how type checkers normally don't let you do this
+        # change type of base class parameter, allowed but frowned upon
         a: str = modal.parameter()  # type: ignore  # this isn't allowed by type checkers
 
     with app.run(client=client):

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -1332,11 +1332,12 @@ def test_parameter_inheritance(client):
     class ChangingParameterDefinitions(Base):
         # change type of base class parameter - not allowed
         # this is similar to how type checkers normally don't let you do this
-        a: str = modal.parameter()
+        a: str = modal.parameter()  # type: ignore  # this isn't allowed by type checkers
 
     with app.run(client=client):
-        ConcatenatingParams(a=10, b="hello").update_autoscaler()  # stupid way of hydrating the class
-        RepeatingParams(a=10, b="hello").update_autoscaler()
+        # use .update_autoscaler()
+        ConcatenatingParams(a=10, b="hello").update_autoscaler()  # type: ignore
+        RepeatingParams(a=10, b="hello").update_autoscaler()  # type: ignore
         with pytest.raises(TypeError):
-            ChangingParameterDefinitions(a=10).update_autoscaler()
-        ChangingParameterDefinitions(a="10").update_autoscaler()
+            ChangingParameterDefinitions(a=10).update_autoscaler()  # type: ignore
+        ChangingParameterDefinitions(a="10").update_autoscaler()  # type: ignore


### PR DESCRIPTION
Some users making use of class inheritance ran into issues when migrating from explicit constructors to `modal.parameter` based parameterization, since base class parameters weren't included in the schema of the class.
By switching to `get_type_hints` instead of `.__dict__["__annotations__"]` we automatically get base class resolution.

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

* When an `@app.cls()`-decorated class inherits from other classes and those classes have `modal.parameter()` definitions, the base class parameters will be included in the parameter set for the modal Cls.