### PR TITLE
Add retry to connect_channel

### DIFF
--- a/modal/_utils/grpc_utils.py
+++ b/modal/_utils/grpc_utils.py
@@ -28,6 +28,7 @@ from grpclib.protocol import H2Protocol
 from modal.exception import AuthError, ConnectionError
 from modal_version import __version__
 
+from .async_utils import retry
 from .logger import logger
 
 RequestType = TypeVar("RequestType", bound=Message)
@@ -167,6 +168,7 @@ def create_channel(
     return channel
 
 
+@retry(n_attempts=10, base_delay=0.1)
 async def connect_channel(channel: grpclib.client.Channel):
     """Connects socket (potentially raising errors raising to connectivity."""
     await channel.__connect__()

--- a/modal/_utils/grpc_utils.py
+++ b/modal/_utils/grpc_utils.py
@@ -170,7 +170,7 @@ def create_channel(
 
 @retry(n_attempts=5, base_delay=0.1)
 async def connect_channel(channel: grpclib.client.Channel):
-    """Connect to socket and potentially raising errors when we are unable to connect."""
+    """Connect to socket and raise exceptions when there is a connection issue."""
     await channel.__connect__()
 
 

--- a/modal/_utils/grpc_utils.py
+++ b/modal/_utils/grpc_utils.py
@@ -168,9 +168,9 @@ def create_channel(
     return channel
 
 
-@retry(n_attempts=10, base_delay=0.1)
+@retry(n_attempts=5, base_delay=0.1)
 async def connect_channel(channel: grpclib.client.Channel):
-    """Connects socket (potentially raising errors raising to connectivity."""
+    """Connect to socket and potentially raising errors when we are unable to connect."""
     await channel.__connect__()
 
 


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/modal-labs/issue/CLI-448/retry-api-connection

This PR adds `retry` to `connect_channel`. I retrying both `create_channel` & `connect_channel` together, but the error report raised `Could not connect to the Modal server.`, which meant that `connect_channel` itself was erroring out.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
- Improves reliability of the CLI when connecting to Modal.