### PR TITLE
Update pytest dependencies

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -13,11 +13,11 @@ mypy~=1.11.2
 mypy-protobuf~=3.3.0  # TODO: can't use mypy-protobuf>=3.4 because of protobuf==3.19 support
 pre-commit>=2.21,<4
 packaging>=24.2
-pytest~=8.0.0
+pytest~=8.4.0
 pytest-asyncio @ git+https://github.com/modal-labs/pytest-asyncio.git@b535db05f6e43019700483c442ab6686f132a415
-pytest-env~=0.6.2
-pytest-markdown-docs==0.8.0
-pytest-timeout~=2.1.0
+pytest-env~=1.1.5
+pytest-markdown-docs==0.9.0
+pytest-timeout~=2.4.0
 python-dotenv~=1.0.0;python_version>='3.8'
 requests~=2.31.0
 ruff==0.9.6


### PR DESCRIPTION
## Describe your changes

Fixes https://linear.app/modal-labs/issue/CLI-194/update-pytest-markdown-docs-to-work-with-pytest810

This could be fixed here: https://github.com/modal-labs/pytest-markdown-docs/commit/a482ed588e6aae1fa968d1ffd4bcfa8f074acb1c

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>