### PR TITLE
Fix blob uploads for input plane invocations

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -375,7 +375,9 @@ class _InputPlaneInvocation:
         stub = await client.get_stub(input_plane_url)
 
         function_id = function.object_id
-        input_item = await _create_input(args, kwargs, stub, method_name=function._use_method_name)
+        control_plane_stub = client.stub
+        # Note: Blob upload is done on the control plane stub, not the input plane stub!
+        input_item = await _create_input(args, kwargs, control_plane_stub, method_name=function._use_method_name)
 
         request = api_pb2.AttemptStartRequest(
             function_id=function_id,


### PR DESCRIPTION
Thanks @gongy for catching this. Blob uploads should happen against the control plane, not the input plane.

```py
import modal
import time

app = modal.App(name="test-input")


@app.function(cloud="aws", region="us-west-2", experimental_options={"input_plane_region":"us-west"})
def hello(x):
    return "Hello, World!"


@app.local_entrypoint()
def main():
    for i in range(1000):
        start_time = time.time()
        result = hello.remote("A" * 1024 * 1024 * 3)
        elapsed_ms = (time.time() - start_time) * 1000
        print(f"{result} (took {elapsed_ms:.2f}ms)")
```