### PR TITLE
Improve repr for Dict

### DIFF
--- a/modal/dict.py
+++ b/modal/dict.py
@@ -158,7 +158,7 @@ class _Dict(_Object, type_prefix="di"):
         if environment_name is None:
             obj_repr = f"Dict.from_name('{name}')"
         else:
-            obj_repr = f"Dict.fromt_name('{name}', environment_name='{environment_name}')"
+            obj_repr = f"Dict.from_name('{name}', environment_name='{environment_name}')"
 
         obj = _Dict._from_loader(_load, obj_repr, is_another_app=True, hydrate_lazily=True)
         return obj

--- a/test/dict_test.py
+++ b/test/dict_test.py
@@ -21,7 +21,7 @@ def test_dict_app(servicer, client):
     assert str(d) == "Dict.from_name('my-amazing-dict')"
 
     d = Dict.from_name("my-other-dict", create_if_missing=True, environment_name="my-env").hydrate(client)
-    assert str(d) == "Dict.from_name('my-amazing-dict', environment_name='my-env')"
+    assert str(d) == "Dict.from_name('my-other-dict', environment_name='my-env')"
 
     d.clear()
     assert d.len() == 0


### PR DESCRIPTION
## Describe your changes

Related to https://linear.app/modal-labs/issue/CLI-428/python-client-api-for-object-management

For object management, I think it's important to have a nice repr. With this PR, `Dict` gets an improved repr along with a `name` attribute.


<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->

- Improves `repr` to `Dict` and adds `name` to `Dict`. You can now access the Dict's name:

```python
d = Dict.from_name("custom-dict")
print(d.name)
```
