### PR TITLE
Add protobuf for sandbox tags

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2503,6 +2503,7 @@ message SandboxInfo {
   double created_at = 3;
   TaskInfo task_info = 4;
   string app_id = 5;
+  repeated SandboxTag tags = 6; // TODO: Not yet exposed in client library.
 
   reserved 2; // modal.client.Sandbox definition
 }


### PR DESCRIPTION
Just so we can start returning them in the server. But API for getting the tags is up to client team.

https://modal-com.slack.com/archives/C069MLUT4SJ/p1750105612068659

Part of CLI-457