### PR TITLE
Don't assert False if anext called without aiter

### DIFF
--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -302,18 +302,21 @@ class _StreamReader(Generic[T]):
                     line, self._line_buffer = self._line_buffer.split(b"\n", 1)
                     yield line + b"\n"
 
-    def __aiter__(self) -> AsyncIterator[T]:
-        """mdmd:hidden"""
+    def _ensure_stream(self) -> None:
         if not self._stream:
             if self._by_line:
                 self._stream = self._get_logs_by_line()
             else:
                 self._stream = self._get_logs()
+
+    def __aiter__(self) -> AsyncIterator[T]:
+        """mdmd:hidden"""
+        self._ensure_stream()
         return self
 
     async def __anext__(self) -> T:
         """mdmd:hidden"""
-        assert self._stream is not None
+        self._ensure_stream()
 
         value = await self._stream.__anext__()
 

--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -302,12 +302,13 @@ class _StreamReader(Generic[T]):
                     line, self._line_buffer = self._line_buffer.split(b"\n", 1)
                     yield line + b"\n"
 
-    def _ensure_stream(self) -> None:
+    def _ensure_stream(self) -> AsyncGenerator[Optional[bytes], None]:
         if not self._stream:
             if self._by_line:
                 self._stream = self._get_logs_by_line()
             else:
                 self._stream = self._get_logs()
+        return self._stream
 
     def __aiter__(self) -> AsyncIterator[T]:
         """mdmd:hidden"""
@@ -316,9 +317,9 @@ class _StreamReader(Generic[T]):
 
     async def __anext__(self) -> T:
         """mdmd:hidden"""
-        self._ensure_stream()
+        stream = self._ensure_stream()
 
-        value = await self._stream.__anext__()
+        value = await stream.__anext__()
 
         # The stream yields None if it receives an EOF batch.
         if value is None:

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -207,6 +207,20 @@ def test_sandbox_stdout(app, servicer):
 
 
 @skip_non_subprocess
+def test_sandbox_stdout_next(app, servicer):
+    """Test that we can iterate on a StreamReader directly, without a call to __aiter__()."""
+
+    # normal sequence of reads
+    sb = Sandbox.create("bash", "-c", "for i in $(seq 1 3); do echo foo $i; done", app=app)
+    line = next(sb.stdout)
+    assert line == "foo 1\n"
+    line = next(sb.stdout)
+    assert line == "foo 2\n"
+    line = next(sb.stdout)
+    assert line == "foo 3\n"
+
+
+@skip_non_subprocess
 @pytest.mark.asyncio
 async def test_sandbox_async_for(app, servicer):
     sb = await Sandbox.create.aio("bash", "-c", "echo hello && echo world && echo bye >&2", app=app)


### PR DESCRIPTION
## Describe your changes

`_StreamReader` acts as an iterator, but `next()` will fail with an assertion error if `iter()` is not called first, as in this example:

```python
sb = Sandbox.create("bash", "-c", "for i in $(seq 1 3); do echo foo $i; done", app=app)
next(sb.stdout)
```

This PR fixes it by initializing the stream in `__anext__` if it has not been initialized.