### PR TITLE
Add Sandbox.tags API for listed sandboxes

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -74,6 +74,7 @@ class _Sandbox(_Object, type_prefix="sb"):
     """
 
     _result: Optional[api_pb2.GenericResult]
+    _tags: dict[str, str]
     _stdout: _StreamReader[str]
     _stderr: _StreamReader[str]
     _stdin: _StreamWriter
@@ -764,6 +765,15 @@ class _Sandbox(_Object, type_prefix="sb"):
             yield event
 
     @property
+    def tags(self) -> dict[str, str]:
+        """Tags (key-value pairs) associated with the Sandbox.
+
+        Tags can be used to filter results in `Sandbox.list`, and they are updated with the
+        `set_tags()` function.
+        """
+        return dict(self._tags)
+
+    @property
     def stdout(self) -> _StreamReader[str]:
         """
         [`StreamReader`](https://modal.com/docs/reference/modal.io_streams#modalio_streamsstreamreader) for
@@ -839,6 +849,7 @@ class _Sandbox(_Object, type_prefix="sb"):
                 sandbox_info: api_pb2.SandboxInfo
                 obj = _Sandbox._new_hydrated(sandbox_info.id, client, None)
                 obj._result = sandbox_info.task_info.result  # TODO: send SandboxInfo as metadata to _new_hydrated?
+                obj._tags = {tag.tag_name: tag.tag_value for tag in sandbox_info.tags}
                 yield obj
 
             # Fetch the next batch starting from the end of the current one.

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2503,7 +2503,7 @@ message SandboxInfo {
   double created_at = 3;
   TaskInfo task_info = 4;
   string app_id = 5;
-  repeated SandboxTag tags = 6; // TODO: Not yet exposed in client library.
+  repeated SandboxTag tags = 6;
 
   reserved 2; // modal.client.Sandbox definition
 }

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -510,3 +510,24 @@ def test_sandbox_list_sets_correct_returncode_for_stopped(client, servicer):
         )  # list will loop for older sandboxes until no more arrive
         (list_result,) = list(Sandbox.list(client=client))
     assert list_result.returncode == 0
+
+
+def test_sandbox_list_returns_tags(client, servicer):
+    with servicer.intercept() as ctx:
+        # test generic status
+        ctx.add_response(
+            "SandboxList",
+            api_pb2.SandboxListResponse(
+                sandboxes=[
+                    api_pb2.SandboxInfo(
+                        id="sb-123",
+                        tags=[api_pb2.SandboxTag(tag_name="foo", tag_value="bar")],
+                    )
+                ]
+            ),
+        )
+        ctx.add_response(
+            "SandboxList", api_pb2.SandboxListResponse(sandboxes=[])
+        )  # list will loop for older sandboxes until no more arrive
+        (list_result,) = list(Sandbox.list(client=client))
+    assert list_result.tags == {"foo": "bar"}


### PR DESCRIPTION
## Describe your changes

Resolves CLI-457

This depends on https://github.com/modal-labs/modal/pull/23678 to be merged first. Also it doesn't work for Sandbox.from_id yet, I saw this comment from @freider but I think I'm getting in too deep now to fix it :')

```
# TODO: send SandboxInfo as metadata to _new_hydrated?
```


## Changelog

- Added `Sandbox.tags` property to objects returned by `Sandbox.list()`, which is a `dict[str, str]` that contains tags for each of the listed Sandboxes.