### PR TITLE
[prototype] modal torchrun wrapper

### DIFF
--- a/modal/experimental/__init__.py
+++ b/modal/experimental/__init__.py
@@ -9,7 +9,7 @@ from modal_proto import api_pb2
 from .._clustered_functions import ClusterInfo, get_cluster_info as _get_cluster_info
 from .._functions import _Function
 from .._object import _get_environment_name
-from .._partial_function import _clustered
+from .._partial_function import _clustered, _torchrun
 from .._runtime.container_io_manager import _ContainerIOManager
 from .._utils.async_utils import synchronize_api, synchronizer
 from .._utils.deprecation import deprecation_warning
@@ -46,6 +46,7 @@ def get_cluster_info() -> ClusterInfo:
 
 
 clustered = synchronize_api(_clustered, target_module=__name__)
+torchrun = synchronize_api(_torchrun, target_module=__name__)
 
 
 @dataclass


### PR DESCRIPTION
this prototypes a new decorator, `@modal.experimental.torchrun` for multinode jobs that allows the user to specify in a more modal-esque way the function they want to run. we handle the torchrunning behind the scenes.

this is 100% ai coded so the implementation is a bit jank, but i really like the interface here! it seems like a natural way to extend the modal way of doing things to multi-node.

i tested this out by migrating our [benchmark code](https://github.com/modal-labs/multinode-training-guide/blob/14beb9bd50ee659faeb2edc473210988c74074a1/benchmark/modal_train.py) to this script. it looks like this now:

```python
"""
Improved multi-node benchmark using @modal.experimental.torchrun decorator.

This version eliminates the need for a separate train.py file and manual torchrun setup.
All the benchmark logic is contained within a single decorated function.
"""

import os
import modal
import modal.experimental

cuda_version = "12.4.0"  # should be no greater than host CUDA version
flavor = "devel"  # includes full CUDA toolkit
operating_sys = "ubuntu22.04"
tag = f"{cuda_version}-{flavor}-{operating_sys}"

# Benchmark configuration
N_NODES = 2
N_PROC_PER_NODE = 8

# Benchmark parameters (from EleutherAI cookbook)
WARMUP_ITERS, TRIALS = 5, 50
# These emulate the payload which will become a M * N * 4-sized tensor
N = 500000
M = 2000

# Create the image with necessary dependencies
image = (
    modal.Image.from_registry(f"nvidia/cuda:{tag}", add_python="3.12")
    .apt_install(
        "libibverbs-dev",
        "libibverbs1",
    )
    .pip_install(
        "torch==2.6.0",
        "numpy",
        "importlib-metadata",
    )
)

with image.imports():
    import torch
    import torch.distributed as dist

app = modal.App("multinode-benchmark-improved")


@app.function(
    gpu="H100:8",
    cloud="oci",
    image=image,
    timeout=60 * 10,  # 10 minutes
)
@modal.experimental.clustered(size=N_NODES, rdma=True)
@modal.experimental.torchrun(nproc_per_node=N_PROC_PER_NODE)
def run_benchmark():
    """
    Run a simple benchmark that measures all-reduce bandwidth across nodes.

    This function runs in "data mode" - the torchrun orchestration is handled
    automatically by the decorator. No separate train.py file needed!
    """
    # Get local rank from environment
    local_rank = int(os.environ["LOCAL_RANK"])
    global_rank = int(os.environ["RANK"])
    world_size = int(os.environ["WORLD_SIZE"])

    # Initialize the process group
    torch.cuda.set_device(local_rank)
    dist.init_process_group(
        backend="nccl", device_id=torch.device(f"cuda:{local_rank}")
    )

    if global_rank == 0:
        print(
            f"Starting benchmark with {world_size} total processes across {N_NODES} nodes"
        )
        print(f"Each node has {N_PROC_PER_NODE} processes")
        print(f"Total payload size: {M * N * 4 / 1e9:.2f} GB")

    # Helper functions for synchronization
    def sync_all():
        torch.cuda.synchronize()
        dist.barrier()

    def timed_allreduce(mat, start_event, end_event, warmup_iters, iters):
        sync_all()

        # Warmup iterations
        for _ in range(warmup_iters):
            dist.all_reduce(mat)
        sync_all()

        # Timed iterations
        start_event.record()
        for _ in range(iters):
            dist.all_reduce(mat)
        end_event.record()

        sync_all()

        # Calculate bandwidth
        duration = start_event.elapsed_time(end_event) / 1000  # Convert to seconds
        avg_duration = duration / iters

        size = M * N * 4  # 4 bytes per float32
        # Following the same math as NVIDIA/nccl-tests
        algbw = torch.tensor([size / avg_duration]).cuda(local_rank)

        # Calculate mean across all ranks
        dist.reduce(algbw, dst=0, op=dist.ReduceOp.SUM)
        algbw /= world_size

        return algbw.item()

    # Create the test tensor
    mat = torch.rand(N, M, dtype=torch.float32).cuda(local_rank)

    # Create CUDA events for timing
    start_event = torch.cuda.Event(enable_timing=True)
    end_event = torch.cuda.Event(enable_timing=True)

    # Run the benchmark
    algbw = timed_allreduce(
        mat, start_event, end_event, warmup_iters=WARMUP_ITERS, iters=TRIALS
    )

    # Calculate bus bandwidth
    # The 2*(n-1)/n correction factor for all-reduce is explained here:
    # https://github.com/NVIDIA/nccl-tests/blob/master/doc/PERFORMANCE.md#allreduce
    busbw = algbw * (2 * (world_size - 1) / world_size)

    # Report results from rank 0
    if global_rank == 0:
        print("\n" + "=" * 60)
        print(f"Benchmark Results:")
        print(f"Payload size: {M * N * 4 / 1e9:.2f} GB")
        print(f"Number of trials: {TRIALS}")
        print(
            f"Total ranks: {world_size} ({N_NODES} nodes × {N_PROC_PER_NODE} processes/node)"
        )
        print("-" * 60)
        print(
            f"Algorithm bandwidth: {algbw / 1e9:.3f} GB/s ({algbw * 8 / 1e9:.1f} Gb/s)"
        )
        print(
            f"Bus bandwidth:       {busbw / 1e9:.3f} GB/s ({busbw * 8 / 1e9:.1f} Gb/s)"
        )
        print("=" * 60 + "\n")

    # Clean up
    sync_all()
    dist.destroy_process_group()

    if global_rank == 0:
        print("Benchmark completed successfully!")


@app.local_entrypoint()
def main():
    """
    Entry point for running the benchmark.

    Notice how simple this is now - just call .remote() on the decorated function!
    All the torchrun orchestration happens automatically.
    """
    print("Starting multi-node benchmark...")
    print(f"Configuration: {N_NODES} nodes, {N_PROC_PER_NODE} GPUs per node")
    print(f"This will launch {N_NODES * N_PROC_PER_NODE} total processes")

    run_benchmark.remote()

    print("Benchmark submission completed!")


if __name__ == "__main__":
    main()
```

Shockingly, it works!

```
(modal) ➜  benchmark git:(3cefdab) ✗ MODAL_SYNC_ENTRYPOINT=1 modal run improved_bench.py
✓ Initialized. View run at https://modal.com/apps/modal-labs/peyton-dev/ap-6DjFo0FPcFIStDondn8O16
✓ Created objects.
├── 🔨 Created mount /home/ec2-user/projects/multinode-training-guide/benchmark/improved_bench.py
├── 🔨 Created mount /home/ec2-user/projects/client/modal, /home/ec2-user/projects/client/modal_proto, 
│   /home/ec2-user/projects/client/modal_version, 
│   /home/ec2-user/projects/modal/venv/lib64/python3.11/site-packages/synchronicity
└── 🔨 Created function run_benchmark.
Starting multi-node benchmark...
Configuration: 2 nodes, 8 GPUs per node
This will launch 16 total processes
Acknowledged cluster creation request for modal.Function fu-j5QAcIGElHtTCFsf9TTbOn. Expected p95 wait time: 3.0 minutes.
Made reservation of 2 GPUType.H100 workers for clustered modal.Function fu-j5QAcIGElHtTCFsf9TTbOn. Waiting for workers to be ready...

.......

Container rank 1: Executing torchrun
Command: /usr/local/bin/python -m torch.distributed.run --nnodes=2 --nproc-per-node=8 --node-rank=1 --master-addr=fdaa:5137:3ebf:b64:80f:84a:a192:7732 --master-port=29500 /tmp/tmpdk7e4u6s_torchrun_wrapper.py
Container rank 0: Executing torchrun
Command: /usr/local/bin/python -m torch.distributed.run --nnodes=2 --nproc-per-node=8 --node-rank=0 --master-addr=fdaa:5137:3ebf:b64:80f:84a:a192:7732 --master-port=29500 /tmp/tmpyonshjlx_torchrun_wrapper.py
Made reservation of 2 GPUType.H100 workers for clustered modal.Function fu-j5QAcIGElHtTCFsf9TTbOn. Waiting for workers to be ready...
Starting benchmark with 16 total processes across 2 nodes
Each node has 8 processes
Total payload size: 4.00 GB

============================================================
Benchmark Results:
Payload size: 4.00 GB
Number of trials: 50
Total ranks: 16 (2 nodes × 8 processes/node)
------------------------------------------------------------
Algorithm bandwidth: 245.881 GB/s (1967.0 Gb/s)
Bus bandwidth:       461.027 GB/s (3688.2 Gb/s)
============================================================

Benchmark completed successfully!
```