### PR TITLE
Deprecate namespace parameter

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1245,7 +1245,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         cls,
         app_name: str,
         name: str,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         environment_name: Optional[str] = None,
     ):
         # internal function lookup implementation that allows lookup of class "service functions"
@@ -1282,7 +1282,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         app_name: str,
         name: str,
         *,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         environment_name: Optional[str] = None,
     ) -> "_Function":
         """Reference a Function from a deployed App by its name.
@@ -1313,7 +1313,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
     async def lookup(
         app_name: str,
         name: str,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
     ) -> "_Function":

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1255,7 +1255,6 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
             request = api_pb2.FunctionGetRequest(
                 app_name=app_name,
                 object_tag=name,
-                namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
                 environment_name=_get_environment_name(environment_name, resolver) or "",
             )
             try:

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1306,8 +1306,8 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                 f"instance.{method_name}.remote(...)\n",
             )
 
-        namespace = warn_if_passing_namespace(namespace, "modal.Function")
-        return cls._from_name(app_name, name, namespace, environment_name)
+        warn_if_passing_namespace(namespace, "modal.Function")
+        return cls._from_name(app_name, name, api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, environment_name)
 
     @staticmethod
     async def lookup(
@@ -1335,8 +1335,10 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
             " It can be replaced with `modal.Function.from_name`."
             "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
         )
-        namespace = warn_if_passing_namespace(namespace, "modal.Function")
-        obj = _Function.from_name(app_name, name, namespace=namespace, environment_name=environment_name)
+        warn_if_passing_namespace(namespace, "modal.Function")
+        obj = _Function.from_name(
+            app_name, name, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, environment_name=environment_name
+        )
         if client is None:
             client = await _Client.from_env()
         resolver = Resolver(client=client)

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1306,7 +1306,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                 f"instance.{method_name}.remote(...)\n",
             )
 
-        warn_if_passing_namespace(namespace, "modal.Function")
+        warn_if_passing_namespace(namespace, "modal.Function.from_name")
         return cls._from_name(app_name, name, api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, environment_name)
 
     @staticmethod
@@ -1335,7 +1335,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
             " It can be replaced with `modal.Function.from_name`."
             "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
         )
-        warn_if_passing_namespace(namespace, "modal.Function")
+        warn_if_passing_namespace(namespace, "modal.Function.lookup")
         obj = _Function.from_name(
             app_name, name, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, environment_name=environment_name
         )

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1255,7 +1255,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
             request = api_pb2.FunctionGetRequest(
                 app_name=app_name,
                 object_tag=name,
-                namespace=namespace,  # type: ignore
+                namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
                 environment_name=_get_environment_name(environment_name, resolver) or "",
             )
             try:
@@ -1307,7 +1307,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
             )
 
         warn_if_passing_namespace(namespace, "modal.Function.from_name")
-        return cls._from_name(app_name, name, api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, environment_name)
+        return cls._from_name(app_name, name, environment_name=environment_name)
 
     @staticmethod
     async def lookup(
@@ -1336,9 +1336,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
             "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
         )
         warn_if_passing_namespace(namespace, "modal.Function.lookup")
-        obj = _Function.from_name(
-            app_name, name, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, environment_name=environment_name
-        )
+        obj = _Function.from_name(app_name, name, environment_name=environment_name)
         if client is None:
             client = await _Client.from_env()
         resolver = Resolver(client=client)

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -40,7 +40,7 @@ from ._utils.async_utils import (
     synchronizer,
     warn_if_generator_is_not_consumed,
 )
-from ._utils.deprecation import _ARGUMENT_NOT_PASSED, deprecation_warning, warn_if_passing_namespace
+from ._utils.deprecation import deprecation_warning, warn_if_passing_namespace
 from ._utils.function_utils import (
     ATTEMPT_TIMEOUT_GRACE_PERIOD,
     OUTPUTS_TIMEOUT,
@@ -1245,7 +1245,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         cls,
         app_name: str,
         name: str,
-        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
+        namespace=None,  # mdmd:line-hidden
         environment_name: Optional[str] = None,
     ):
         # internal function lookup implementation that allows lookup of class "service functions"
@@ -1282,7 +1282,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         app_name: str,
         name: str,
         *,
-        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
+        namespace=None,  # mdmd:line-hidden
         environment_name: Optional[str] = None,
     ) -> "_Function":
         """Reference a Function from a deployed App by its name.
@@ -1313,7 +1313,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
     async def lookup(
         app_name: str,
         name: str,
-        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
+        namespace=None,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
     ) -> "_Function":

--- a/modal/_utils/deprecation.py
+++ b/modal/_utils/deprecation.py
@@ -124,7 +124,6 @@ def warn_on_renamed_autoscaler_settings(func: Callable[P, R]) -> Callable[P, R]:
     return wrapper
 
 
-# Utilities for deprecating the namespace parameter across Modal resources
 def warn_if_passing_namespace(
     namespace: Any,
     resource_name: str,

--- a/modal/_utils/deprecation.py
+++ b/modal/_utils/deprecation.py
@@ -127,30 +127,20 @@ def warn_on_renamed_autoscaler_settings(func: Callable[P, R]) -> Callable[P, R]:
 
 
 # Utilities for deprecating the namespace parameter across Modal resources
-class _ArgumentNotPassedType:
-    """Sentinel object to detect when an argument is explicitly passed vs using default."""
-
-    def __repr__(self) -> str:
-        return f"{__name__}._ARGUMENT_NOT_PASSED"
-
-
-_ARGUMENT_NOT_PASSED = _ArgumentNotPassedType()
-
-
 def warn_if_passing_namespace(
-    namespace,
-    resource_name: str = "Modal resource",
+    namespace: Any,
+    resource_name: str,
 ) -> "api_pb2.DeploymentNamespace.ValueType":
     """Issue deprecation warning for namespace parameter and return appropriate default.
 
     Args:
-        namespace: The namespace parameter value (may be sentinel or actual value)
+        namespace: The namespace parameter value (may be None or actual value)
         resource_name: Name of the resource type for the warning message
 
     Returns:
         The appropriate namespace value to use
     """
-    if namespace is _ARGUMENT_NOT_PASSED:
+    if namespace is None:
         return api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE
     else:
         deprecation_warning(

--- a/modal/_utils/deprecation.py
+++ b/modal/_utils/deprecation.py
@@ -140,5 +140,4 @@ def warn_if_passing_namespace(
             f"The `namespace` parameter for `{resource_name}` is deprecated and will be"
             " removed in a future release. It is no longer needed, so can be removed"
             " from your code.",
-            pending=True,
         )

--- a/modal/_utils/deprecation.py
+++ b/modal/_utils/deprecation.py
@@ -7,8 +7,6 @@ from typing import Any, Callable, TypeVar
 
 from typing_extensions import ParamSpec  # Needed for Python 3.9
 
-from modal_proto import api_pb2
-
 from ..exception import DeprecationError, PendingDeprecationError
 
 _INTERNAL_MODULES = ["modal", "synchronicity"]
@@ -130,19 +128,14 @@ def warn_on_renamed_autoscaler_settings(func: Callable[P, R]) -> Callable[P, R]:
 def warn_if_passing_namespace(
     namespace: Any,
     resource_name: str,
-) -> "api_pb2.DeploymentNamespace.ValueType":
-    """Issue deprecation warning for namespace parameter and return appropriate default.
+) -> None:
+    """Issue deprecation warning for namespace parameter if non-None value is passed.
 
     Args:
         namespace: The namespace parameter value (may be None or actual value)
         resource_name: Name of the resource type for the warning message
-
-    Returns:
-        The appropriate namespace value to use
     """
-    if namespace is None:
-        return api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE
-    else:
+    if namespace is not None:
         deprecation_warning(
             (2025, 6, 17),
             f"The `namespace` parameter for `{resource_name}` is deprecated and will be"
@@ -150,4 +143,3 @@ def warn_if_passing_namespace(
             " from your code.",
             pending=True,
         )
-        return namespace  # type: ignore

--- a/modal/_utils/deprecation.py
+++ b/modal/_utils/deprecation.py
@@ -136,7 +136,7 @@ def warn_if_passing_namespace(
     """
     if namespace is not None:
         deprecation_warning(
-            (2025, 6, 17),
+            (2025, 6, 30),
             f"The `namespace` parameter for `{resource_name}` is deprecated and will be"
             " removed in a future release. It is no longer needed, so can be removed"
             " from your code.",

--- a/modal/cli/utils.py
+++ b/modal/cli/utils.py
@@ -48,9 +48,7 @@ async def get_app_id_from_name(name: str, env: Optional[str], client: Optional[_
     if client is None:
         client = await _Client.from_env()
     env_name = ensure_env(env)
-    request = api_pb2.AppGetByDeploymentNameRequest(
-        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, name=name, environment_name=env_name
-    )
+    request = api_pb2.AppGetByDeploymentNameRequest(name=name, environment_name=env_name)
     try:
         resp = await client.stub.AppGetByDeploymentName(request)
     except GRPCError as exc:

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -25,7 +25,12 @@ from ._serialization import check_valid_cls_constructor_arg
 from ._traceback import print_server_warnings
 from ._type_manager import parameter_serde_registry
 from ._utils.async_utils import synchronize_api, synchronizer
-from ._utils.deprecation import deprecation_warning, warn_on_renamed_autoscaler_settings
+from ._utils.deprecation import (
+    _ARGUMENT_NOT_PASSED,
+    deprecation_warning,
+    warn_if_passing_namespace,
+    warn_on_renamed_autoscaler_settings,
+)
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.mount_utils import validate_volumes
 from .client import _Client
@@ -612,7 +617,7 @@ More information on class parameterization can be found here: https://modal.com/
         app_name: str,
         name: str,
         *,
-        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        namespace: Any = _ARGUMENT_NOT_PASSED,
         environment_name: Optional[str] = None,
     ) -> "_Cls":
         """Reference a Cls from a deployed App by its name.
@@ -625,6 +630,7 @@ More information on class parameterization can be found here: https://modal.com/
         Model = modal.Cls.from_name("other-app", "Model")
         ```
         """
+        namespace = warn_if_passing_namespace(namespace, "modal.Cls")
         _environment_name = environment_name or config.get("environment")
 
         async def _load_remote(self: _Cls, resolver: Resolver, existing_object_id: Optional[str]):
@@ -823,7 +829,7 @@ More information on class parameterization can be found here: https://modal.com/
     async def lookup(
         app_name: str,
         name: str,
-        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        namespace=_ARGUMENT_NOT_PASSED,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
     ) -> "_Cls":
@@ -847,6 +853,7 @@ More information on class parameterization can be found here: https://modal.com/
             " It can be replaced with `modal.Cls.from_name`."
             "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
         )
+        namespace = warn_if_passing_namespace(namespace, "modal.Cls")
         obj = _Cls.from_name(
             app_name,
             name,

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -856,7 +856,6 @@ More information on class parameterization can be found here: https://modal.com/
         obj = _Cls.from_name(
             app_name,
             name,
-            namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
             environment_name=environment_name,
         )
         if client is None:

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -629,7 +629,7 @@ More information on class parameterization can be found here: https://modal.com/
         Model = modal.Cls.from_name("other-app", "Model")
         ```
         """
-        warn_if_passing_namespace(namespace, "modal.Cls")
+        warn_if_passing_namespace(namespace, "modal.Cls.from_name")
         _environment_name = environment_name or config.get("environment")
 
         async def _load_remote(self: _Cls, resolver: Resolver, existing_object_id: Optional[str]):
@@ -852,7 +852,7 @@ More information on class parameterization can be found here: https://modal.com/
             " It can be replaced with `modal.Cls.from_name`."
             "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
         )
-        warn_if_passing_namespace(namespace, "modal.Cls")
+        warn_if_passing_namespace(namespace, "modal.Cls.lookup")
         obj = _Cls.from_name(
             app_name,
             name,

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -617,7 +617,7 @@ More information on class parameterization can be found here: https://modal.com/
         app_name: str,
         name: str,
         *,
-        namespace: Any = _ARGUMENT_NOT_PASSED,
+        namespace: Any = _ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         environment_name: Optional[str] = None,
     ) -> "_Cls":
         """Reference a Cls from a deployed App by its name.
@@ -829,7 +829,7 @@ More information on class parameterization can be found here: https://modal.com/
     async def lookup(
         app_name: str,
         name: str,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
     ) -> "_Cls":

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -636,7 +636,6 @@ More information on class parameterization can be found here: https://modal.com/
             request = api_pb2.ClassGetRequest(
                 app_name=app_name,
                 object_tag=name,
-                namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
                 environment_name=_environment_name,
                 only_class_function=True,
             )

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -26,7 +26,6 @@ from ._traceback import print_server_warnings
 from ._type_manager import parameter_serde_registry
 from ._utils.async_utils import synchronize_api, synchronizer
 from ._utils.deprecation import (
-    _ARGUMENT_NOT_PASSED,
     deprecation_warning,
     warn_if_passing_namespace,
     warn_on_renamed_autoscaler_settings,
@@ -617,7 +616,7 @@ More information on class parameterization can be found here: https://modal.com/
         app_name: str,
         name: str,
         *,
-        namespace: Any = _ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
+        namespace: Any = None,  # mdmd:line-hidden
         environment_name: Optional[str] = None,
     ) -> "_Cls":
         """Reference a Cls from a deployed App by its name.
@@ -829,7 +828,7 @@ More information on class parameterization can be found here: https://modal.com/
     async def lookup(
         app_name: str,
         name: str,
-        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
+        namespace=None,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
     ) -> "_Cls":

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -629,14 +629,14 @@ More information on class parameterization can be found here: https://modal.com/
         Model = modal.Cls.from_name("other-app", "Model")
         ```
         """
-        namespace = warn_if_passing_namespace(namespace, "modal.Cls")
+        warn_if_passing_namespace(namespace, "modal.Cls")
         _environment_name = environment_name or config.get("environment")
 
         async def _load_remote(self: _Cls, resolver: Resolver, existing_object_id: Optional[str]):
             request = api_pb2.ClassGetRequest(
                 app_name=app_name,
                 object_tag=name,
-                namespace=namespace,
+                namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
                 environment_name=_environment_name,
                 only_class_function=True,
             )
@@ -852,11 +852,11 @@ More information on class parameterization can be found here: https://modal.com/
             " It can be replaced with `modal.Cls.from_name`."
             "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
         )
-        namespace = warn_if_passing_namespace(namespace, "modal.Cls")
+        warn_if_passing_namespace(namespace, "modal.Cls")
         obj = _Cls.from_name(
             app_name,
             name,
-            namespace=namespace,
+            namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
             environment_name=environment_name,
         )
         if client is None:

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -190,7 +190,6 @@ class _Dict(_Object, type_prefix="di"):
         obj = _Dict.from_name(
             name,
             data=data,
-            namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
             environment_name=environment_name,
             create_if_missing=create_if_missing,
         )

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -135,7 +135,7 @@ class _Dict(_Object, type_prefix="di"):
         ```
         """
         check_object_name(name, "Dict")
-        warn_if_passing_namespace(namespace, "modal.Dict")
+        warn_if_passing_namespace(namespace, "modal.Dict.from_name")
 
         if data:
             deprecation_warning(
@@ -186,7 +186,7 @@ class _Dict(_Object, type_prefix="di"):
             " It can be replaced with `modal.Dict.from_name`."
             "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
         )
-        warn_if_passing_namespace(namespace, "modal.Dict")
+        warn_if_passing_namespace(namespace, "modal.Dict.lookup")
         obj = _Dict.from_name(
             name,
             data=data,

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -117,9 +117,9 @@ class _Dict(_Object, type_prefix="di"):
     @staticmethod
     def from_name(
         name: str,
-        data: Optional[dict] = None,  # DEPRECATED
+        data: Optional[dict] = None,  # DEPRECATED, mdmd:line-hidden
         *,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
     ) -> "_Dict":
@@ -162,7 +162,7 @@ class _Dict(_Object, type_prefix="di"):
     async def lookup(
         name: str,
         data: Optional[dict] = None,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -11,7 +11,7 @@ from ._object import EPHEMERAL_OBJECT_HEARTBEAT_SLEEP, _get_environment_name, _O
 from ._resolver import Resolver
 from ._serialization import deserialize, serialize
 from ._utils.async_utils import TaskContext, synchronize_api
-from ._utils.deprecation import _ARGUMENT_NOT_PASSED, deprecation_warning, warn_if_passing_namespace
+from ._utils.deprecation import deprecation_warning, warn_if_passing_namespace
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from .client import _Client
@@ -119,7 +119,7 @@ class _Dict(_Object, type_prefix="di"):
         name: str,
         data: Optional[dict] = None,  # DEPRECATED, mdmd:line-hidden
         *,
-        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
+        namespace=None,  # mdmd:line-hidden
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
     ) -> "_Dict":
@@ -162,7 +162,7 @@ class _Dict(_Object, type_prefix="di"):
     async def lookup(
         name: str,
         data: Optional[dict] = None,
-        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
+        namespace=None,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -11,7 +11,7 @@ from ._object import EPHEMERAL_OBJECT_HEARTBEAT_SLEEP, _get_environment_name, _O
 from ._resolver import Resolver
 from ._serialization import deserialize, serialize
 from ._utils.async_utils import TaskContext, synchronize_api
-from ._utils.deprecation import deprecation_warning
+from ._utils.deprecation import _ARGUMENT_NOT_PASSED, deprecation_warning, warn_if_passing_namespace
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from .client import _Client
@@ -119,7 +119,7 @@ class _Dict(_Object, type_prefix="di"):
         name: str,
         data: Optional[dict] = None,  # DEPRECATED
         *,
-        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        namespace=_ARGUMENT_NOT_PASSED,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
     ) -> "_Dict":
@@ -135,6 +135,7 @@ class _Dict(_Object, type_prefix="di"):
         ```
         """
         check_object_name(name, "Dict")
+        namespace = warn_if_passing_namespace(namespace, "modal.Dict")
 
         if data:
             deprecation_warning(
@@ -161,7 +162,7 @@ class _Dict(_Object, type_prefix="di"):
     async def lookup(
         name: str,
         data: Optional[dict] = None,
-        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        namespace=_ARGUMENT_NOT_PASSED,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
@@ -185,6 +186,7 @@ class _Dict(_Object, type_prefix="di"):
             " It can be replaced with `modal.Dict.from_name`."
             "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
         )
+        namespace = warn_if_passing_namespace(namespace, "modal.Dict")
         obj = _Dict.from_name(
             name,
             data=data,

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -147,7 +147,6 @@ class _Dict(_Object, type_prefix="di"):
             serialized = _serialize_dict(data if data is not None else {})
             req = api_pb2.DictGetOrCreateRequest(
                 deployment_name=name,
-                namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
                 environment_name=_get_environment_name(environment_name, resolver),
                 object_creation_type=(api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING if create_if_missing else None),
                 data=serialized,

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -135,7 +135,7 @@ class _Dict(_Object, type_prefix="di"):
         ```
         """
         check_object_name(name, "Dict")
-        namespace = warn_if_passing_namespace(namespace, "modal.Dict")
+        warn_if_passing_namespace(namespace, "modal.Dict")
 
         if data:
             deprecation_warning(
@@ -147,7 +147,7 @@ class _Dict(_Object, type_prefix="di"):
             serialized = _serialize_dict(data if data is not None else {})
             req = api_pb2.DictGetOrCreateRequest(
                 deployment_name=name,
-                namespace=namespace,
+                namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
                 environment_name=_get_environment_name(environment_name, resolver),
                 object_creation_type=(api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING if create_if_missing else None),
                 data=serialized,
@@ -186,11 +186,11 @@ class _Dict(_Object, type_prefix="di"):
             " It can be replaced with `modal.Dict.from_name`."
             "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
         )
-        namespace = warn_if_passing_namespace(namespace, "modal.Dict")
+        warn_if_passing_namespace(namespace, "modal.Dict")
         obj = _Dict.from_name(
             name,
             data=data,
-            namespace=namespace,
+            namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
             environment_name=environment_name,
             create_if_missing=create_if_missing,
         )

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -22,7 +22,7 @@ from ._object import (
 from ._resolver import Resolver
 from ._utils.async_utils import TaskContext, aclosing, async_map, sync_or_async_iter, synchronize_api
 from ._utils.blob_utils import LARGE_FILE_LIMIT, blob_iter, blob_upload_file
-from ._utils.deprecation import deprecation_warning
+from ._utils.deprecation import _ARGUMENT_NOT_PASSED, deprecation_warning, warn_if_passing_namespace
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.hash_utils import get_sha256_hex
 from ._utils.name_utils import check_object_name
@@ -92,7 +92,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
     def from_name(
         name: str,
         *,
-        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        namespace=_ARGUMENT_NOT_PASSED,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
     ) -> "_NetworkFileSystem":
@@ -111,6 +111,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         ```
         """
         check_object_name(name, "NetworkFileSystem")
+        namespace = warn_if_passing_namespace(namespace, "modal.NetworkFileSystem")
 
         async def _load(self: _NetworkFileSystem, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.SharedVolumeGetOrCreateRequest(
@@ -167,7 +168,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
     @staticmethod
     async def lookup(
         name: str,
-        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        namespace=_ARGUMENT_NOT_PASSED,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
@@ -191,6 +192,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
             " It can be replaced with `modal.NetworkFileSystem.from_name`."
             "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
         )
+        namespace = warn_if_passing_namespace(namespace, "modal.NetworkFileSystem")
         obj = _NetworkFileSystem.from_name(
             name, namespace=namespace, environment_name=environment_name, create_if_missing=create_if_missing
         )
@@ -203,12 +205,13 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
     @staticmethod
     async def create_deployed(
         deployment_name: str,
-        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        namespace=_ARGUMENT_NOT_PASSED,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
     ) -> str:
         """mdmd:hidden"""
         check_object_name(deployment_name, "NetworkFileSystem")
+        namespace = warn_if_passing_namespace(namespace, "modal.NetworkFileSystem")
         if client is None:
             client = await _Client.from_env()
         request = api_pb2.SharedVolumeGetOrCreateRequest(

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -195,7 +195,6 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         warn_if_passing_namespace(namespace, "modal.NetworkFileSystem.lookup")
         obj = _NetworkFileSystem.from_name(
             name,
-            namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
             environment_name=environment_name,
             create_if_missing=create_if_missing,
         )

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -92,7 +92,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
     def from_name(
         name: str,
         *,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
     ) -> "_NetworkFileSystem":
@@ -168,7 +168,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
     @staticmethod
     async def lookup(
         name: str,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
@@ -205,7 +205,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
     @staticmethod
     async def create_deployed(
         deployment_name: str,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
     ) -> str:

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -22,7 +22,7 @@ from ._object import (
 from ._resolver import Resolver
 from ._utils.async_utils import TaskContext, aclosing, async_map, sync_or_async_iter, synchronize_api
 from ._utils.blob_utils import LARGE_FILE_LIMIT, blob_iter, blob_upload_file
-from ._utils.deprecation import _ARGUMENT_NOT_PASSED, deprecation_warning, warn_if_passing_namespace
+from ._utils.deprecation import deprecation_warning, warn_if_passing_namespace
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.hash_utils import get_sha256_hex
 from ._utils.name_utils import check_object_name
@@ -92,7 +92,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
     def from_name(
         name: str,
         *,
-        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
+        namespace=None,  # mdmd:line-hidden
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
     ) -> "_NetworkFileSystem":
@@ -168,7 +168,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
     @staticmethod
     async def lookup(
         name: str,
-        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
+        namespace=None,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
@@ -205,7 +205,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
     @staticmethod
     async def create_deployed(
         deployment_name: str,
-        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
+        namespace=None,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
     ) -> str:

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -111,12 +111,12 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         ```
         """
         check_object_name(name, "NetworkFileSystem")
-        namespace = warn_if_passing_namespace(namespace, "modal.NetworkFileSystem")
+        warn_if_passing_namespace(namespace, "modal.NetworkFileSystem")
 
         async def _load(self: _NetworkFileSystem, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.SharedVolumeGetOrCreateRequest(
                 deployment_name=name,
-                namespace=namespace,
+                namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
                 environment_name=_get_environment_name(environment_name, resolver),
                 object_creation_type=(api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING if create_if_missing else None),
             )
@@ -192,9 +192,12 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
             " It can be replaced with `modal.NetworkFileSystem.from_name`."
             "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
         )
-        namespace = warn_if_passing_namespace(namespace, "modal.NetworkFileSystem")
+        warn_if_passing_namespace(namespace, "modal.NetworkFileSystem")
         obj = _NetworkFileSystem.from_name(
-            name, namespace=namespace, environment_name=environment_name, create_if_missing=create_if_missing
+            name,
+            namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+            environment_name=environment_name,
+            create_if_missing=create_if_missing,
         )
         if client is None:
             client = await _Client.from_env()
@@ -211,12 +214,12 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
     ) -> str:
         """mdmd:hidden"""
         check_object_name(deployment_name, "NetworkFileSystem")
-        namespace = warn_if_passing_namespace(namespace, "modal.NetworkFileSystem")
+        warn_if_passing_namespace(namespace, "modal.NetworkFileSystem")
         if client is None:
             client = await _Client.from_env()
         request = api_pb2.SharedVolumeGetOrCreateRequest(
             deployment_name=deployment_name,
-            namespace=namespace,
+            namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
             environment_name=_get_environment_name(environment_name),
             object_creation_type=api_pb2.OBJECT_CREATION_TYPE_CREATE_FAIL_IF_EXISTS,
         )

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -116,7 +116,6 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         async def _load(self: _NetworkFileSystem, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.SharedVolumeGetOrCreateRequest(
                 deployment_name=name,
-                namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
                 environment_name=_get_environment_name(environment_name, resolver),
                 object_creation_type=(api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING if create_if_missing else None),
             )
@@ -218,7 +217,6 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
             client = await _Client.from_env()
         request = api_pb2.SharedVolumeGetOrCreateRequest(
             deployment_name=deployment_name,
-            namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
             environment_name=_get_environment_name(environment_name),
             object_creation_type=api_pb2.OBJECT_CREATION_TYPE_CREATE_FAIL_IF_EXISTS,
         )

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -111,7 +111,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         ```
         """
         check_object_name(name, "NetworkFileSystem")
-        warn_if_passing_namespace(namespace, "modal.NetworkFileSystem")
+        warn_if_passing_namespace(namespace, "modal.NetworkFileSystem.from_name")
 
         async def _load(self: _NetworkFileSystem, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.SharedVolumeGetOrCreateRequest(
@@ -192,7 +192,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
             " It can be replaced with `modal.NetworkFileSystem.from_name`."
             "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
         )
-        warn_if_passing_namespace(namespace, "modal.NetworkFileSystem")
+        warn_if_passing_namespace(namespace, "modal.NetworkFileSystem.lookup")
         obj = _NetworkFileSystem.from_name(
             name,
             namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
@@ -214,7 +214,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
     ) -> str:
         """mdmd:hidden"""
         check_object_name(deployment_name, "NetworkFileSystem")
-        warn_if_passing_namespace(namespace, "modal.NetworkFileSystem")
+        warn_if_passing_namespace(namespace, "modal.NetworkFileSystem.create_deployed")
         if client is None:
             client = await _Client.from_env()
         request = api_pb2.SharedVolumeGetOrCreateRequest(

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -14,7 +14,7 @@ from ._object import EPHEMERAL_OBJECT_HEARTBEAT_SLEEP, _get_environment_name, _O
 from ._resolver import Resolver
 from ._serialization import deserialize, serialize
 from ._utils.async_utils import TaskContext, synchronize_api, warn_if_generator_is_not_consumed
-from ._utils.deprecation import deprecation_warning
+from ._utils.deprecation import _ARGUMENT_NOT_PASSED, deprecation_warning, warn_if_passing_namespace
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from .client import _Client
@@ -148,7 +148,7 @@ class _Queue(_Object, type_prefix="qu"):
     def from_name(
         name: str,
         *,
-        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        namespace=_ARGUMENT_NOT_PASSED,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
     ) -> "_Queue":
@@ -164,6 +164,7 @@ class _Queue(_Object, type_prefix="qu"):
         ```
         """
         check_object_name(name, "Queue")
+        namespace = warn_if_passing_namespace(namespace, "modal.Queue")
 
         async def _load(self: _Queue, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.QueueGetOrCreateRequest(
@@ -180,7 +181,7 @@ class _Queue(_Object, type_prefix="qu"):
     @staticmethod
     async def lookup(
         name: str,
-        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        namespace=_ARGUMENT_NOT_PASSED,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
@@ -204,6 +205,7 @@ class _Queue(_Object, type_prefix="qu"):
             " It can be replaced with `modal.Queue.from_name`."
             "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
         )
+        namespace = warn_if_passing_namespace(namespace, "modal.Queue")
         obj = _Queue.from_name(
             name, namespace=namespace, environment_name=environment_name, create_if_missing=create_if_missing
         )

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -148,7 +148,7 @@ class _Queue(_Object, type_prefix="qu"):
     def from_name(
         name: str,
         *,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
     ) -> "_Queue":
@@ -181,7 +181,7 @@ class _Queue(_Object, type_prefix="qu"):
     @staticmethod
     async def lookup(
         name: str,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -208,7 +208,6 @@ class _Queue(_Object, type_prefix="qu"):
         warn_if_passing_namespace(namespace, "modal.Queue.lookup")
         obj = _Queue.from_name(
             name,
-            namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
             environment_name=environment_name,
             create_if_missing=create_if_missing,
         )

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -169,7 +169,6 @@ class _Queue(_Object, type_prefix="qu"):
         async def _load(self: _Queue, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.QueueGetOrCreateRequest(
                 deployment_name=name,
-                namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
                 environment_name=_get_environment_name(environment_name, resolver),
                 object_creation_type=(api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING if create_if_missing else None),
             )

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -14,7 +14,7 @@ from ._object import EPHEMERAL_OBJECT_HEARTBEAT_SLEEP, _get_environment_name, _O
 from ._resolver import Resolver
 from ._serialization import deserialize, serialize
 from ._utils.async_utils import TaskContext, synchronize_api, warn_if_generator_is_not_consumed
-from ._utils.deprecation import _ARGUMENT_NOT_PASSED, deprecation_warning, warn_if_passing_namespace
+from ._utils.deprecation import deprecation_warning, warn_if_passing_namespace
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from .client import _Client
@@ -148,7 +148,7 @@ class _Queue(_Object, type_prefix="qu"):
     def from_name(
         name: str,
         *,
-        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
+        namespace=None,  # mdmd:line-hidden
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
     ) -> "_Queue":
@@ -181,7 +181,7 @@ class _Queue(_Object, type_prefix="qu"):
     @staticmethod
     async def lookup(
         name: str,
-        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
+        namespace=None,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -164,12 +164,12 @@ class _Queue(_Object, type_prefix="qu"):
         ```
         """
         check_object_name(name, "Queue")
-        namespace = warn_if_passing_namespace(namespace, "modal.Queue")
+        warn_if_passing_namespace(namespace, "modal.Queue")
 
         async def _load(self: _Queue, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.QueueGetOrCreateRequest(
                 deployment_name=name,
-                namespace=namespace,
+                namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
                 environment_name=_get_environment_name(environment_name, resolver),
                 object_creation_type=(api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING if create_if_missing else None),
             )
@@ -205,9 +205,12 @@ class _Queue(_Object, type_prefix="qu"):
             " It can be replaced with `modal.Queue.from_name`."
             "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
         )
-        namespace = warn_if_passing_namespace(namespace, "modal.Queue")
+        warn_if_passing_namespace(namespace, "modal.Queue")
         obj = _Queue.from_name(
-            name, namespace=namespace, environment_name=environment_name, create_if_missing=create_if_missing
+            name,
+            namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+            environment_name=environment_name,
+            create_if_missing=create_if_missing,
         )
         if client is None:
             client = await _Client.from_env()

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -164,7 +164,7 @@ class _Queue(_Object, type_prefix="qu"):
         ```
         """
         check_object_name(name, "Queue")
-        warn_if_passing_namespace(namespace, "modal.Queue")
+        warn_if_passing_namespace(namespace, "modal.Queue.from_name")
 
         async def _load(self: _Queue, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.QueueGetOrCreateRequest(
@@ -205,7 +205,7 @@ class _Queue(_Object, type_prefix="qu"):
             " It can be replaced with `modal.Queue.from_name`."
             "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
         )
-        warn_if_passing_namespace(namespace, "modal.Queue")
+        warn_if_passing_namespace(namespace, "modal.Queue.lookup")
         obj = _Queue.from_name(
             name,
             namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -480,7 +480,7 @@ async def _deploy_app(
     if environment_name is None:
         environment_name = typing.cast(str, config.get("environment"))
 
-    warn_if_passing_namespace(namespace, "deploy_app")
+    warn_if_passing_namespace(namespace, "modal.runner.deploy_app")
 
     name = name or app.name or ""
     if not name:

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -103,7 +103,6 @@ async def _init_local_app_new(
 async def _init_local_app_from_name(
     client: _Client,
     name: str,
-    namespace: Any = None,
     environment_name: str = "",
 ) -> RunningApp:
     # Look up any existing deployment

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -103,7 +103,7 @@ async def _init_local_app_new(
 async def _init_local_app_from_name(
     client: _Client,
     name: str,
-    namespace: "api_pb2.DeploymentNamespace.ValueType",
+    namespace: Any = None,
     environment_name: str = "",
 ) -> RunningApp:
     # Look up any existing deployment
@@ -510,9 +510,7 @@ async def _deploy_app(
     # Get git information to track deployment history
     commit_info_task = asyncio.create_task(get_git_commit_info())
 
-    running_app: RunningApp = await _init_local_app_from_name(
-        client, name, api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, environment_name=environment_name
-    )
+    running_app: RunningApp = await _init_local_app_from_name(client, name, environment_name=environment_name)
 
     async with TaskContext(0) as tc:
         # Start heartbeats loop to keep the client alive

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -26,7 +26,7 @@ from ._pty import get_pty_info
 from ._resolver import Resolver
 from ._traceback import print_server_warnings, traceback_contains_remote_call
 from ._utils.async_utils import TaskContext, gather_cancel_on_exc, synchronize_api
-from ._utils.deprecation import _ARGUMENT_NOT_PASSED, warn_if_passing_namespace
+from ._utils.deprecation import warn_if_passing_namespace
 from ._utils.git_utils import get_git_commit_info
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name, is_valid_tag
@@ -468,7 +468,7 @@ class DeployResult:
 async def _deploy_app(
     app: _App,
     name: Optional[str] = None,
-    namespace: Any = _ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
+    namespace: Any = None,  # mdmd:line-hidden
     client: Optional[_Client] = None,
     environment_name: Optional[str] = None,
     tag: str = "",

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -468,7 +468,7 @@ class DeployResult:
 async def _deploy_app(
     app: _App,
     name: Optional[str] = None,
-    namespace: Any = _ARGUMENT_NOT_PASSED,
+    namespace: Any = _ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
     client: Optional[_Client] = None,
     environment_name: Optional[str] = None,
     tag: str = "",

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -26,6 +26,7 @@ from ._pty import get_pty_info
 from ._resolver import Resolver
 from ._traceback import print_server_warnings, traceback_contains_remote_call
 from ._utils.async_utils import TaskContext, gather_cancel_on_exc, synchronize_api
+from ._utils.deprecation import _ARGUMENT_NOT_PASSED, warn_if_passing_namespace
 from ._utils.git_utils import get_git_commit_info
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name, is_valid_tag
@@ -102,7 +103,7 @@ async def _init_local_app_new(
 async def _init_local_app_from_name(
     client: _Client,
     name: str,
-    namespace: Any,
+    namespace: "api_pb2.DeploymentNamespace.ValueType",
     environment_name: str = "",
 ) -> RunningApp:
     # Look up any existing deployment
@@ -467,7 +468,7 @@ class DeployResult:
 async def _deploy_app(
     app: _App,
     name: Optional[str] = None,
-    namespace: Any = api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+    namespace: Any = _ARGUMENT_NOT_PASSED,
     client: Optional[_Client] = None,
     environment_name: Optional[str] = None,
     tag: str = "",
@@ -478,6 +479,8 @@ async def _deploy_app(
     """
     if environment_name is None:
         environment_name = typing.cast(str, config.get("environment"))
+
+    namespace = warn_if_passing_namespace(namespace, "deploy_app")
 
     name = name or app.name or ""
     if not name:

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -109,7 +109,6 @@ async def _init_local_app_from_name(
     # Look up any existing deployment
     app_req = api_pb2.AppGetByDeploymentNameRequest(
         name=name,
-        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name=environment_name,
     )
     app_resp = await retry_transient_errors(client.stub.AppGetByDeploymentName, app_req)

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -109,7 +109,7 @@ async def _init_local_app_from_name(
     # Look up any existing deployment
     app_req = api_pb2.AppGetByDeploymentNameRequest(
         name=name,
-        namespace=namespace,
+        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         environment_name=environment_name,
     )
     app_resp = await retry_transient_errors(client.stub.AppGetByDeploymentName, app_req)
@@ -480,7 +480,7 @@ async def _deploy_app(
     if environment_name is None:
         environment_name = typing.cast(str, config.get("environment"))
 
-    namespace = warn_if_passing_namespace(namespace, "deploy_app")
+    warn_if_passing_namespace(namespace, "deploy_app")
 
     name = name or app.name or ""
     if not name:
@@ -511,7 +511,7 @@ async def _deploy_app(
     commit_info_task = asyncio.create_task(get_git_commit_info())
 
     running_app: RunningApp = await _init_local_app_from_name(
-        client, name, namespace, environment_name=environment_name
+        client, name, api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, environment_name=environment_name
     )
 
     async with TaskContext(0) as tc:

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -190,7 +190,6 @@ class _Secret(_Object, type_prefix="st"):
         async def _load(self: _Secret, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.SecretGetOrCreateRequest(
                 deployment_name=name,
-                namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
                 environment_name=_get_environment_name(environment_name, resolver),
                 required_keys=required_keys,
             )
@@ -255,7 +254,6 @@ class _Secret(_Object, type_prefix="st"):
             object_creation_type = api_pb2.OBJECT_CREATION_TYPE_CREATE_FAIL_IF_EXISTS
         request = api_pb2.SecretGetOrCreateRequest(
             deployment_name=deployment_name,
-            namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
             environment_name=_get_environment_name(environment_name),
             object_creation_type=object_creation_type,
             env_dict=env_dict,

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -185,7 +185,7 @@ class _Secret(_Object, type_prefix="st"):
            ...
         ```
         """
-        warn_if_passing_namespace(namespace, "modal.Secret")
+        warn_if_passing_namespace(namespace, "modal.Secret.from_name")
 
         async def _load(self: _Secret, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.SecretGetOrCreateRequest(
@@ -221,7 +221,7 @@ class _Secret(_Object, type_prefix="st"):
             "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
         )
 
-        warn_if_passing_namespace(namespace, "modal.Secret")
+        warn_if_passing_namespace(namespace, "modal.Secret.lookup")
 
         obj = _Secret.from_name(
             name,
@@ -245,7 +245,7 @@ class _Secret(_Object, type_prefix="st"):
         overwrite: bool = False,
     ) -> str:
         """mdmd:hidden"""
-        warn_if_passing_namespace(namespace, "modal.Secret")
+        warn_if_passing_namespace(namespace, "modal.Secret.create_deployed")
 
         check_object_name(deployment_name, "Secret")
         if client is None:

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -165,7 +165,7 @@ class _Secret(_Object, type_prefix="st"):
     def from_name(
         name: str,
         *,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         environment_name: Optional[str] = None,
         required_keys: list[
             str
@@ -208,7 +208,7 @@ class _Secret(_Object, type_prefix="st"):
     @staticmethod
     async def lookup(
         name: str,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         required_keys: list[str] = [],
@@ -236,7 +236,7 @@ class _Secret(_Object, type_prefix="st"):
     async def create_deployed(
         deployment_name: str,
         env_dict: dict[str, str],
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         overwrite: bool = False,

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -10,7 +10,7 @@ from ._object import _get_environment_name, _Object
 from ._resolver import Resolver
 from ._runtime.execution_context import is_local
 from ._utils.async_utils import synchronize_api
-from ._utils.deprecation import _ARGUMENT_NOT_PASSED, deprecation_warning, warn_if_passing_namespace
+from ._utils.deprecation import deprecation_warning, warn_if_passing_namespace
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from .client import _Client
@@ -165,7 +165,7 @@ class _Secret(_Object, type_prefix="st"):
     def from_name(
         name: str,
         *,
-        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
+        namespace=None,  # mdmd:line-hidden
         environment_name: Optional[str] = None,
         required_keys: list[
             str
@@ -208,7 +208,7 @@ class _Secret(_Object, type_prefix="st"):
     @staticmethod
     async def lookup(
         name: str,
-        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
+        namespace=None,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         required_keys: list[str] = [],
@@ -236,7 +236,7 @@ class _Secret(_Object, type_prefix="st"):
     async def create_deployed(
         deployment_name: str,
         env_dict: dict[str, str],
-        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
+        namespace=None,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         overwrite: bool = False,

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -185,12 +185,12 @@ class _Secret(_Object, type_prefix="st"):
            ...
         ```
         """
-        namespace = warn_if_passing_namespace(namespace, "modal.Secret")
+        warn_if_passing_namespace(namespace, "modal.Secret")
 
         async def _load(self: _Secret, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.SecretGetOrCreateRequest(
                 deployment_name=name,
-                namespace=namespace,
+                namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
                 environment_name=_get_environment_name(environment_name, resolver),
                 required_keys=required_keys,
             )
@@ -221,10 +221,13 @@ class _Secret(_Object, type_prefix="st"):
             "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
         )
 
-        namespace = warn_if_passing_namespace(namespace, "modal.Secret")
+        warn_if_passing_namespace(namespace, "modal.Secret")
 
         obj = _Secret.from_name(
-            name, namespace=namespace, environment_name=environment_name, required_keys=required_keys
+            name,
+            namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+            environment_name=environment_name,
+            required_keys=required_keys,
         )
         if client is None:
             client = await _Client.from_env()
@@ -242,7 +245,7 @@ class _Secret(_Object, type_prefix="st"):
         overwrite: bool = False,
     ) -> str:
         """mdmd:hidden"""
-        namespace = warn_if_passing_namespace(namespace, "modal.Secret")
+        warn_if_passing_namespace(namespace, "modal.Secret")
 
         check_object_name(deployment_name, "Secret")
         if client is None:
@@ -253,7 +256,7 @@ class _Secret(_Object, type_prefix="st"):
             object_creation_type = api_pb2.OBJECT_CREATION_TYPE_CREATE_FAIL_IF_EXISTS
         request = api_pb2.SecretGetOrCreateRequest(
             deployment_name=deployment_name,
-            namespace=namespace,
+            namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
             environment_name=_get_environment_name(environment_name),
             object_creation_type=object_creation_type,
             env_dict=env_dict,

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -225,7 +225,6 @@ class _Secret(_Object, type_prefix="st"):
 
         obj = _Secret.from_name(
             name,
-            namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
             environment_name=environment_name,
             required_keys=required_keys,
         )

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -10,7 +10,7 @@ from ._object import _get_environment_name, _Object
 from ._resolver import Resolver
 from ._runtime.execution_context import is_local
 from ._utils.async_utils import synchronize_api
-from ._utils.deprecation import deprecation_warning
+from ._utils.deprecation import _ARGUMENT_NOT_PASSED, deprecation_warning, warn_if_passing_namespace
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from .client import _Client
@@ -165,7 +165,7 @@ class _Secret(_Object, type_prefix="st"):
     def from_name(
         name: str,
         *,
-        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        namespace=_ARGUMENT_NOT_PASSED,
         environment_name: Optional[str] = None,
         required_keys: list[
             str
@@ -185,6 +185,7 @@ class _Secret(_Object, type_prefix="st"):
            ...
         ```
         """
+        namespace = warn_if_passing_namespace(namespace, "modal.Secret")
 
         async def _load(self: _Secret, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.SecretGetOrCreateRequest(
@@ -207,7 +208,7 @@ class _Secret(_Object, type_prefix="st"):
     @staticmethod
     async def lookup(
         name: str,
-        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        namespace=_ARGUMENT_NOT_PASSED,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         required_keys: list[str] = [],
@@ -219,6 +220,9 @@ class _Secret(_Object, type_prefix="st"):
             " It can be replaced with `modal.Secret.from_name`."
             "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
         )
+
+        namespace = warn_if_passing_namespace(namespace, "modal.Secret")
+
         obj = _Secret.from_name(
             name, namespace=namespace, environment_name=environment_name, required_keys=required_keys
         )
@@ -232,12 +236,14 @@ class _Secret(_Object, type_prefix="st"):
     async def create_deployed(
         deployment_name: str,
         env_dict: dict[str, str],
-        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        namespace=_ARGUMENT_NOT_PASSED,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         overwrite: bool = False,
     ) -> str:
         """mdmd:hidden"""
+        namespace = warn_if_passing_namespace(namespace, "modal.Secret")
+
         check_object_name(deployment_name, "Secret")
         if client is None:
             client = await _Client.from_env()

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -49,7 +49,7 @@ from ._utils.blob_utils import (
     get_file_upload_spec_from_fileobj,
     get_file_upload_spec_from_path,
 )
-from ._utils.deprecation import deprecation_warning
+from ._utils.deprecation import _ARGUMENT_NOT_PASSED, deprecation_warning, warn_if_passing_namespace
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.http_utils import ClientSessionRegistry
 from ._utils.name_utils import check_object_name
@@ -182,7 +182,7 @@ class _Volume(_Object, type_prefix="vo"):
     def from_name(
         name: str,
         *,
-        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        namespace=_ARGUMENT_NOT_PASSED,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
         version: "typing.Optional[modal_proto.api_pb2.VolumeFsVersion.ValueType]" = None,
@@ -205,6 +205,7 @@ class _Volume(_Object, type_prefix="vo"):
         ```
         """
         check_object_name(name, "Volume")
+        namespace = warn_if_passing_namespace(namespace, "modal.Volume")
 
         async def _load(self: _Volume, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.VolumeGetOrCreateRequest(
@@ -275,7 +276,7 @@ class _Volume(_Object, type_prefix="vo"):
     @staticmethod
     async def lookup(
         name: str,
-        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        namespace=_ARGUMENT_NOT_PASSED,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
@@ -300,6 +301,7 @@ class _Volume(_Object, type_prefix="vo"):
             " It can be replaced with `modal.Volume.from_name`."
             "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
         )
+        namespace = warn_if_passing_namespace(namespace, "modal.Volume")
         obj = _Volume.from_name(
             name,
             namespace=namespace,
@@ -316,13 +318,14 @@ class _Volume(_Object, type_prefix="vo"):
     @staticmethod
     async def create_deployed(
         deployment_name: str,
-        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
+        namespace=_ARGUMENT_NOT_PASSED,
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         version: "typing.Optional[modal_proto.api_pb2.VolumeFsVersion.ValueType]" = None,
     ) -> str:
         """mdmd:hidden"""
         check_object_name(deployment_name, "Volume")
+        namespace = warn_if_passing_namespace(namespace, "modal.Volume")
         if client is None:
             client = await _Client.from_env()
         request = api_pb2.VolumeGetOrCreateRequest(

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -182,7 +182,7 @@ class _Volume(_Object, type_prefix="vo"):
     def from_name(
         name: str,
         *,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
         version: "typing.Optional[modal_proto.api_pb2.VolumeFsVersion.ValueType]" = None,
@@ -276,7 +276,7 @@ class _Volume(_Object, type_prefix="vo"):
     @staticmethod
     async def lookup(
         name: str,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
@@ -318,7 +318,7 @@ class _Volume(_Object, type_prefix="vo"):
     @staticmethod
     async def create_deployed(
         deployment_name: str,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         version: "typing.Optional[modal_proto.api_pb2.VolumeFsVersion.ValueType]" = None,

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -210,7 +210,6 @@ class _Volume(_Object, type_prefix="vo"):
         async def _load(self: _Volume, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.VolumeGetOrCreateRequest(
                 deployment_name=name,
-                namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
                 environment_name=_get_environment_name(environment_name, resolver),
                 object_creation_type=(api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING if create_if_missing else None),
                 version=version,
@@ -329,7 +328,6 @@ class _Volume(_Object, type_prefix="vo"):
             client = await _Client.from_env()
         request = api_pb2.VolumeGetOrCreateRequest(
             deployment_name=deployment_name,
-            namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
             environment_name=_get_environment_name(environment_name),
             object_creation_type=api_pb2.OBJECT_CREATION_TYPE_CREATE_FAIL_IF_EXISTS,
             version=version,

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -49,7 +49,7 @@ from ._utils.blob_utils import (
     get_file_upload_spec_from_fileobj,
     get_file_upload_spec_from_path,
 )
-from ._utils.deprecation import _ARGUMENT_NOT_PASSED, deprecation_warning, warn_if_passing_namespace
+from ._utils.deprecation import deprecation_warning, warn_if_passing_namespace
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.http_utils import ClientSessionRegistry
 from ._utils.name_utils import check_object_name
@@ -182,7 +182,7 @@ class _Volume(_Object, type_prefix="vo"):
     def from_name(
         name: str,
         *,
-        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
+        namespace=None,  # mdmd:line-hidden
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
         version: "typing.Optional[modal_proto.api_pb2.VolumeFsVersion.ValueType]" = None,
@@ -276,7 +276,7 @@ class _Volume(_Object, type_prefix="vo"):
     @staticmethod
     async def lookup(
         name: str,
-        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
+        namespace=None,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
@@ -318,7 +318,7 @@ class _Volume(_Object, type_prefix="vo"):
     @staticmethod
     async def create_deployed(
         deployment_name: str,
-        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
+        namespace=None,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         version: "typing.Optional[modal_proto.api_pb2.VolumeFsVersion.ValueType]" = None,

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -205,7 +205,7 @@ class _Volume(_Object, type_prefix="vo"):
         ```
         """
         check_object_name(name, "Volume")
-        warn_if_passing_namespace(namespace, "modal.Volume")
+        warn_if_passing_namespace(namespace, "modal.Volume.from_name")
 
         async def _load(self: _Volume, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.VolumeGetOrCreateRequest(
@@ -301,7 +301,7 @@ class _Volume(_Object, type_prefix="vo"):
             " It can be replaced with `modal.Volume.from_name`."
             "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
         )
-        warn_if_passing_namespace(namespace, "modal.Volume")
+        warn_if_passing_namespace(namespace, "modal.Volume.lookup")
         obj = _Volume.from_name(
             name,
             namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
@@ -325,7 +325,7 @@ class _Volume(_Object, type_prefix="vo"):
     ) -> str:
         """mdmd:hidden"""
         check_object_name(deployment_name, "Volume")
-        warn_if_passing_namespace(namespace, "modal.Volume")
+        warn_if_passing_namespace(namespace, "modal.Volume.create_deployed")
         if client is None:
             client = await _Client.from_env()
         request = api_pb2.VolumeGetOrCreateRequest(

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -304,7 +304,6 @@ class _Volume(_Object, type_prefix="vo"):
         warn_if_passing_namespace(namespace, "modal.Volume.lookup")
         obj = _Volume.from_name(
             name,
-            namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
             environment_name=environment_name,
             create_if_missing=create_if_missing,
             version=version,

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -205,12 +205,12 @@ class _Volume(_Object, type_prefix="vo"):
         ```
         """
         check_object_name(name, "Volume")
-        namespace = warn_if_passing_namespace(namespace, "modal.Volume")
+        warn_if_passing_namespace(namespace, "modal.Volume")
 
         async def _load(self: _Volume, resolver: Resolver, existing_object_id: Optional[str]):
             req = api_pb2.VolumeGetOrCreateRequest(
                 deployment_name=name,
-                namespace=namespace,
+                namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
                 environment_name=_get_environment_name(environment_name, resolver),
                 object_creation_type=(api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING if create_if_missing else None),
                 version=version,
@@ -301,10 +301,10 @@ class _Volume(_Object, type_prefix="vo"):
             " It can be replaced with `modal.Volume.from_name`."
             "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
         )
-        namespace = warn_if_passing_namespace(namespace, "modal.Volume")
+        warn_if_passing_namespace(namespace, "modal.Volume")
         obj = _Volume.from_name(
             name,
-            namespace=namespace,
+            namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
             environment_name=environment_name,
             create_if_missing=create_if_missing,
             version=version,
@@ -325,12 +325,12 @@ class _Volume(_Object, type_prefix="vo"):
     ) -> str:
         """mdmd:hidden"""
         check_object_name(deployment_name, "Volume")
-        namespace = warn_if_passing_namespace(namespace, "modal.Volume")
+        warn_if_passing_namespace(namespace, "modal.Volume")
         if client is None:
             client = await _Client.from_env()
         request = api_pb2.VolumeGetOrCreateRequest(
             deployment_name=deployment_name,
-            namespace=namespace,
+            namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
             environment_name=_get_environment_name(environment_name),
             object_creation_type=api_pb2.OBJECT_CREATION_TYPE_CREATE_FAIL_IF_EXISTS,
             version=version,

--- a/modal_docs/mdmd/mdmd.py
+++ b/modal_docs/mdmd/mdmd.py
@@ -5,18 +5,20 @@ import inspect
 import warnings
 from enum import Enum, EnumMeta
 from types import ModuleType
-from typing import Callable
+from typing import Callable, Optional
 
 import synchronicity.synchronizer
 
 from .signatures import get_signature
 
 
-def format_docstring(docstring: str):
+def format_docstring(docstring: Optional[str]) -> str:
     if docstring is None:
         docstring = ""
     else:
         docstring = inspect.cleandoc(docstring)
+
+    docstring = "\n".join(l for l in docstring.split("\n") if "mdmd:line-hidden" not in l)
 
     if docstring and not docstring.endswith("\n"):
         docstring += "\n"
@@ -24,8 +26,9 @@ def format_docstring(docstring: str):
     return docstring
 
 
-def function_str(name: str, func):
+def function_str(name: str, func) -> str:
     signature = get_signature(name, func)
+    signature = "\n".join(l for l in signature.split("\n") if "mdmd:line-hidden" not in l)
     decl = f"""```python
 {signature}
 ```\n\n"""

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -301,7 +301,7 @@ message AppCreateResponse {
 
 message AppDeployRequest {
   string app_id = 1 [ (modal.options.audit_target_attr) = true ];
-  DeploymentNamespace namespace = 2;
+  reserved 2; // namespace
   string name = 3;
   string object_entity = 4;
   AppDeployVisibility visibility = 5;
@@ -334,7 +334,7 @@ message AppDeploymentHistoryResponse {
 }
 
 message AppGetByDeploymentNameRequest {
-  DeploymentNamespace namespace = 1;
+  reserved 1; // removed namespace
   string name = 2;
   string environment_name = 4;
 }
@@ -701,7 +701,7 @@ message ClassCreateResponse {
 message ClassGetRequest {
   string app_name = 1;
   string object_tag = 2;
-  DeploymentNamespace namespace = 3;
+  reserved 3; // removed namespace
   string environment_name = 4;
 
   reserved 8; // lookup_published
@@ -1075,7 +1075,7 @@ message DictEntry {
 
 message DictGetOrCreateRequest {
   string deployment_name = 1 [ (modal.options.audit_target_attr) = true ];
-  DeploymentNamespace namespace = 2;
+  reserved 2; // removed namespace
   string environment_name = 3;
   ObjectCreationType object_creation_type = 4;
   repeated DictEntry data = 5;
@@ -1679,7 +1679,7 @@ message FunctionGetOutputsResponse {
 message FunctionGetRequest {
   string app_name = 1;
   string object_tag = 2;
-  DeploymentNamespace namespace = 3;
+  reserved 3; // removed namespace
   string environment_name = 4;
 }
 
@@ -2252,7 +2252,7 @@ message ProxyDeleteRequest {
 
 message ProxyGetOrCreateRequest {
   string deployment_name = 1 [ (modal.options.audit_target_attr) = true ];
-  DeploymentNamespace namespace = 2;
+  reserved 2; // namespace
   string environment_name = 3;
   ObjectCreationType object_creation_type = 4;  // must be UNSPECIFIED
 }
@@ -2305,7 +2305,7 @@ message QueueDeleteRequest {
 
 message QueueGetOrCreateRequest {
   string deployment_name = 1;
-  DeploymentNamespace namespace = 2;
+  reserved 2; // removed namespace
   string environment_name = 3;
   ObjectCreationType object_creation_type = 4;
 }
@@ -2701,7 +2701,7 @@ message SecretDeleteRequest {
 
 message SecretGetOrCreateRequest {
   string deployment_name = 1 [ (modal.options.audit_target_attr) = true ];
-  DeploymentNamespace namespace = 2;
+  reserved 2; // removed namespace
   string environment_name = 3;
   ObjectCreationType object_creation_type = 4;  // Not used atm
   map<string, string> env_dict = 5;
@@ -2748,7 +2748,7 @@ message SharedVolumeGetFileResponse {
 
 message SharedVolumeGetOrCreateRequest {
   string deployment_name = 1 [ (modal.options.audit_target_attr) = true ];
-  DeploymentNamespace namespace = 2;
+  reserved 2; // removed namespace
   string environment_name = 3;
   ObjectCreationType object_creation_type = 4;
   string app_id = 5;  // only used with OBJECT_CREATION_TYPE_ANONYMOUS_OWNED_BY_APP
@@ -3028,7 +3028,7 @@ message VolumeGetFileResponse {
 
 message VolumeGetOrCreateRequest {
   string deployment_name = 1 [ (modal.options.audit_target_attr) = true ];
-  DeploymentNamespace namespace = 2;
+  reserved 2; // removed namespace
   string environment_name = 3;
   ObjectCreationType object_creation_type = 4;
   string app_id = 5;  // only used with OBJECT_CREATION_TYPE_ANONYMOUS_OWNED_BY_APP

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -1052,7 +1052,7 @@ def test_dict_create_list_delete(servicer, server_url_env, set_env_client):
 
 def test_dict_show_get_clear(servicer, server_url_env, set_env_client):
     # Kind of hacky to be modifying the attributes on the servicer like this
-    key = ("baz-dict", api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, os.environ.get("MODAL_ENVIRONMENT", "main"))
+    key = ("baz-dict", os.environ.get("MODAL_ENVIRONMENT", "main"))
     dict_id = "di-abc123"
     servicer.deployed_dicts[key] = dict_id
     servicer.dicts[dict_id] = {dumps("a"): dumps(123), dumps("b"): dumps("blah")}
@@ -1098,7 +1098,7 @@ def test_queue_create_list_delete(servicer, server_url_env, set_env_client):
 def test_queue_peek_len_clear(servicer, server_url_env, set_env_client):
     # Kind of hacky to be modifying the attributes on the servicer like this
     name = "queue-who"
-    key = (name, api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, os.environ.get("MODAL_ENVIRONMENT", "main"))
+    key = (name, os.environ.get("MODAL_ENVIRONMENT", "main"))
     queue_id = "qu-abc123"
     servicer.deployed_queues[key] = queue_id
     servicer.queue = {b"": [dumps("a"), dumps("b"), dumps("c")], b"alt": [dumps("x"), dumps("y")]}

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -21,7 +21,7 @@ from modal._serialization import deserialize, deserialize_params, serialize
 from modal._utils.async_utils import synchronizer
 from modal._utils.function_utils import FunctionInfo
 from modal.cls import _ServiceOptions
-from modal.exception import DeprecationError, ExecutionError, InvalidError, NotFoundError, PendingDeprecationError
+from modal.exception import DeprecationError, ExecutionError, InvalidError, NotFoundError
 from modal.partial_function import (
     PartialFunction,
     asgi_app,
@@ -1350,9 +1350,7 @@ def test_parameter_inheritance(client):
 
 def test_cls_namespace_deprecated(servicer, client):
     # Test from_name with namespace parameter warns
-    with pytest.warns(
-        PendingDeprecationError, match="The `namespace` parameter for `modal.Cls.from_name` is deprecated"
-    ):
+    with pytest.warns(DeprecationError, match="The `namespace` parameter for `modal.Cls.from_name` is deprecated"):
         Cls.from_name("test-app", "test-cls", namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE)
 
     # Test that from_name without namespace parameter doesn't warn about namespace

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -1350,7 +1350,9 @@ def test_parameter_inheritance(client):
 
 def test_cls_namespace_deprecated(servicer, client):
     # Test from_name with namespace parameter warns
-    with pytest.warns(PendingDeprecationError, match="The `namespace` parameter for `modal.Cls` is deprecated"):
+    with pytest.warns(
+        PendingDeprecationError, match="The `namespace` parameter for `modal.Cls.from_name` is deprecated"
+    ):
         Cls.from_name("test-app", "test-cls", namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE)
 
     # Test that from_name without namespace parameter doesn't warn about namespace

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -846,7 +846,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def DictGetOrCreate(self, stream):
         request: api_pb2.DictGetOrCreateRequest = await stream.recv_message()
-        k = (request.deployment_name, request.namespace, request.environment_name)
+        k = (request.deployment_name, request.environment_name)
         if k in self.deployed_dicts:
             dict_id = self.deployed_dicts[k]
         elif request.object_creation_type == api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING:
@@ -888,7 +888,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
     async def DictList(self, stream):
         dicts = [
             api_pb2.DictListResponse.DictInfo(name=name, created_at=1)
-            for name, _, _ in self.deployed_dicts
+            for name, _ in self.deployed_dicts
             if name in self.deployed_apps
         ]
         await stream.send_message(api_pb2.DictListResponse(dicts=dicts))
@@ -1492,7 +1492,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def QueueGetOrCreate(self, stream):
         request: api_pb2.QueueGetOrCreateRequest = await stream.recv_message()
-        k = (request.deployment_name, request.namespace, request.environment_name)
+        k = (request.deployment_name, request.environment_name)
         if k in self.deployed_queues:
             queue_id = self.deployed_queues[k]
         elif request.object_creation_type == api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING:
@@ -1549,7 +1549,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         # So there is a mismatch and I am not implementing a mock for the num_partitions / total_size
         queues = [
             api_pb2.QueueListResponse.QueueInfo(name=name, created_at=1)
-            for name, _, _ in self.deployed_queues
+            for name, _ in self.deployed_queues
             if name in self.deployed_apps
         ]
         await stream.send_message(api_pb2.QueueListResponse(queues=queues))
@@ -1710,7 +1710,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def SecretGetOrCreate(self, stream):
         request: api_pb2.SecretGetOrCreateRequest = await stream.recv_message()
-        k = (request.deployment_name, request.namespace, request.environment_name)
+        k = (request.deployment_name, request.environment_name)
         if request.object_creation_type == api_pb2.OBJECT_CREATION_TYPE_ANONYMOUS_OWNED_BY_APP:
             secret_id = "st-" + str(len(self.secrets))
             self.secrets[secret_id] = request.env_dict
@@ -1740,7 +1740,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
     async def SecretList(self, stream):
         await stream.recv_message()
         # Note: being lazy and not implementing the env filtering
-        items = [api_pb2.SecretListItem(label=name) for name, _, env in self.deployed_secrets]
+        items = [api_pb2.SecretListItem(label=name) for name, env in self.deployed_secrets]
         await stream.send_message(api_pb2.SecretListResponse(items=items))
 
     ### Snapshot
@@ -1759,7 +1759,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def SharedVolumeGetOrCreate(self, stream):
         request: api_pb2.SharedVolumeGetOrCreateRequest = await stream.recv_message()
-        k = (request.deployment_name, request.namespace, request.environment_name)
+        k = (request.deployment_name, request.environment_name)
         if request.object_creation_type == api_pb2.OBJECT_CREATION_TYPE_UNSPECIFIED:
             if k not in self.deployed_nfss:
                 if k in self.deployed_volumes:
@@ -1794,7 +1794,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
     async def SharedVolumeList(self, stream):
         req = await stream.recv_message()
         items = []
-        for (name, _, env_name), volume_id in self.deployed_nfss.items():
+        for (name, env_name), volume_id in self.deployed_nfss.items():
             if env_name != req.environment_name:
                 continue
             items.append(api_pb2.SharedVolumeListItem(label=name, shared_volume_id=volume_id, created_at=1))
@@ -1870,7 +1870,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def VolumeGetOrCreate(self, stream):
         request: api_pb2.VolumeGetOrCreateRequest = await stream.recv_message()
-        k = (request.deployment_name, request.namespace, request.environment_name)
+        k = (request.deployment_name, request.environment_name)
         if request.object_creation_type == api_pb2.OBJECT_CREATION_TYPE_UNSPECIFIED:
             if k not in self.deployed_volumes:
                 raise GRPCError(Status.NOT_FOUND, f"Volume {k} not found")
@@ -1900,7 +1900,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
     async def VolumeList(self, stream):
         req = await stream.recv_message()
         items = []
-        for (name, _, env_name), volume_id in self.deployed_volumes.items():
+        for (name, env_name), volume_id in self.deployed_volumes.items():
             if env_name != req.environment_name:
                 continue
             items.append(api_pb2.VolumeListItem(label=name, volume_id=volume_id, created_at=1))

--- a/test/dict_test.py
+++ b/test/dict_test.py
@@ -3,7 +3,7 @@ import pytest
 import time
 
 from modal import Dict
-from modal.exception import InvalidError, NotFoundError, PendingDeprecationError
+from modal.exception import DeprecationError, InvalidError, NotFoundError
 from modal_proto import api_pb2
 
 
@@ -76,7 +76,7 @@ def test_dict_put_skip_if_exists(client):
 def test_dict_namespace_deprecated(servicer, client):
     # Test from_name with namespace parameter warns
     with pytest.warns(
-        PendingDeprecationError,
+        DeprecationError,
         match="The `namespace` parameter for `modal.Dict.from_name` is deprecated",
     ):
         Dict.from_name("test-dict", namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE)

--- a/test/dict_test.py
+++ b/test/dict_test.py
@@ -75,7 +75,10 @@ def test_dict_put_skip_if_exists(client):
 
 def test_dict_namespace_deprecated(servicer, client):
     # Test from_name with namespace parameter warns
-    with pytest.warns(PendingDeprecationError, match="The `namespace` parameter for `modal.Dict` is deprecated"):
+    with pytest.warns(
+        PendingDeprecationError,
+        match="The `namespace` parameter for `modal.Dict.from_name` is deprecated",
+    ):
         Dict.from_name("test-dict", namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE)
 
     # Test that from_name without namespace parameter doesn't warn about namespace

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -15,7 +15,7 @@ import modal
 from modal import App, Image, NetworkFileSystem, Proxy, asgi_app, batched, fastapi_endpoint
 from modal._utils.async_utils import synchronize_api
 from modal._vendor import cloudpickle
-from modal.exception import DeprecationError, ExecutionError, InvalidError, NotFoundError, PendingDeprecationError
+from modal.exception import DeprecationError, ExecutionError, InvalidError, NotFoundError
 from modal.functions import Function, FunctionCall
 from modal.runner import deploy_app
 from modal_proto import api_pb2
@@ -1430,7 +1430,7 @@ def test_restrict_modal_access(client, servicer):
 def test_function_namespace_deprecated(servicer, client):
     # Test from_name with namespace parameter warns
     with pytest.warns(
-        PendingDeprecationError,
+        DeprecationError,
         match="The `namespace` parameter for `modal.Function.from_name` is deprecated",
     ):
         Function.from_name("test-app", "test-function", namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE)

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -1429,7 +1429,10 @@ def test_restrict_modal_access(client, servicer):
 
 def test_function_namespace_deprecated(servicer, client):
     # Test from_name with namespace parameter warns
-    with pytest.warns(PendingDeprecationError, match="The `namespace` parameter for `modal.Function` is deprecated"):
+    with pytest.warns(
+        PendingDeprecationError,
+        match="The `namespace` parameter for `modal.Function.from_name` is deprecated",
+    ):
         Function.from_name("test-app", "test-function", namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE)
 
     # Test that from_name without namespace parameter doesn't warn about namespace

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -15,7 +15,7 @@ import modal
 from modal import App, Image, NetworkFileSystem, Proxy, asgi_app, batched, fastapi_endpoint
 from modal._utils.async_utils import synchronize_api
 from modal._vendor import cloudpickle
-from modal.exception import DeprecationError, ExecutionError, InvalidError, NotFoundError
+from modal.exception import DeprecationError, ExecutionError, InvalidError, NotFoundError, PendingDeprecationError
 from modal.functions import Function, FunctionCall
 from modal.runner import deploy_app
 from modal_proto import api_pb2
@@ -1425,3 +1425,19 @@ def test_restrict_modal_access(client, servicer):
             pass
 
     assert ctx.get_requests("FunctionCreate")[0].function.untrusted == False
+
+
+def test_function_namespace_deprecated(servicer, client):
+    # Test from_name with namespace parameter warns
+    with pytest.warns(PendingDeprecationError, match="The `namespace` parameter for `modal.Function` is deprecated"):
+        Function.from_name("test-app", "test-function", namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE)
+
+    # Test that from_name without namespace parameter doesn't warn about namespace
+    import warnings
+
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        Function.from_name("test-app", "test-function")
+    # Filter out any unrelated warnings
+    namespace_warnings = [w for w in record if "namespace" in str(w.message).lower()]
+    assert len(namespace_warnings) == 0

--- a/test/mdmd_test.py
+++ b/test/mdmd_test.py
@@ -54,6 +54,25 @@ def foo(a: str, *args, **kwargs):
     )
 
 
+def test_complex_function_signature_with_line_hidden():
+    def foo(
+        a: str,
+        *args,  # mdmd:line-hidden
+        **kwargs,
+    ):
+        pass
+
+    assert (
+        mdmd.function_str("foo", foo)
+        == """```python
+def foo(
+    a: str,
+    **kwargs,
+):
+```\n\n"""
+    )
+
+
 def test_function_has_docstring():
     def foo():
         """short description
@@ -87,6 +106,33 @@ class Foo(object)
 ```
 
 The all important Foo
+
+### bar
+
+```python
+def bar(self, baz: str):
+```
+
+Bars the foo with the baz
+"""
+    )
+
+
+def test_simple_class_with_docstring_with_line_hidden():
+    class Foo:
+        """The all important Foo mdmd:line-hidden"""
+
+        def bar(self, baz: str):
+            """Bars the foo with the baz
+
+            This won't be included mdmd:line-hidden
+            """
+
+    assert (
+        mdmd.class_str("Foo", Foo)
+        == """```python
+class Foo(object)
+```
 
 ### bar
 

--- a/test/network_file_system_test.py
+++ b/test/network_file_system_test.py
@@ -5,7 +5,7 @@ from io import BytesIO
 from unittest import mock
 
 import modal
-from modal.exception import InvalidError, NotFoundError, PendingDeprecationError
+from modal.exception import DeprecationError, InvalidError, NotFoundError
 from modal_proto import api_pb2
 
 
@@ -167,7 +167,7 @@ def test_attempt_mount_volume(client, servicer):
 def test_network_file_system_namespace_deprecated(servicer, client):
     # Test from_name with namespace parameter warns
     with pytest.warns(
-        PendingDeprecationError, match="The `namespace` parameter for `modal.NetworkFileSystem.from_name` is deprecated"
+        DeprecationError, match="The `namespace` parameter for `modal.NetworkFileSystem.from_name` is deprecated"
     ):
         modal.NetworkFileSystem.from_name("test-nfs", namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE)
 

--- a/test/network_file_system_test.py
+++ b/test/network_file_system_test.py
@@ -167,7 +167,7 @@ def test_attempt_mount_volume(client, servicer):
 def test_network_file_system_namespace_deprecated(servicer, client):
     # Test from_name with namespace parameter warns
     with pytest.warns(
-        PendingDeprecationError, match="The `namespace` parameter for `modal.NetworkFileSystem` is deprecated"
+        PendingDeprecationError, match="The `namespace` parameter for `modal.NetworkFileSystem.from_name` is deprecated"
     ):
         modal.NetworkFileSystem.from_name("test-nfs", namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE)
 

--- a/test/network_file_system_test.py
+++ b/test/network_file_system_test.py
@@ -5,7 +5,8 @@ from io import BytesIO
 from unittest import mock
 
 import modal
-from modal.exception import InvalidError, NotFoundError
+from modal.exception import InvalidError, NotFoundError, PendingDeprecationError
+from modal_proto import api_pb2
 
 
 def dummy():
@@ -161,3 +162,21 @@ def test_attempt_mount_volume(client, servicer):
     with pytest.raises(InvalidError, match="already exists as a Volume"):
         with app.run(client=client):
             f.remote()
+
+
+def test_network_file_system_namespace_deprecated(servicer, client):
+    # Test from_name with namespace parameter warns
+    with pytest.warns(
+        PendingDeprecationError, match="The `namespace` parameter for `modal.NetworkFileSystem` is deprecated"
+    ):
+        modal.NetworkFileSystem.from_name("test-nfs", namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE)
+
+    # Test that from_name without namespace parameter doesn't warn about namespace
+    import warnings
+
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        modal.NetworkFileSystem.from_name("test-nfs")
+    # Filter out any unrelated warnings
+    namespace_warnings = [w for w in record if "namespace" in str(w.message).lower()]
+    assert len(namespace_warnings) == 0

--- a/test/queue_test.py
+++ b/test/queue_test.py
@@ -4,7 +4,7 @@ import queue
 import time
 
 from modal import Queue
-from modal.exception import InvalidError, NotFoundError, PendingDeprecationError
+from modal.exception import DeprecationError, InvalidError, NotFoundError
 from modal_proto import api_pb2
 
 from .supports.skip import skip_macos, skip_windows
@@ -125,7 +125,7 @@ def test_invalid_name(name):
 def test_queue_namespace_deprecated(servicer, client):
     # Test from_name with namespace parameter warns
     with pytest.warns(
-        PendingDeprecationError,
+        DeprecationError,
         match="The `namespace` parameter for `modal.Queue.from_name` is deprecated",
     ):
         Queue.from_name("test-queue", namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE)

--- a/test/queue_test.py
+++ b/test/queue_test.py
@@ -124,7 +124,10 @@ def test_invalid_name(name):
 
 def test_queue_namespace_deprecated(servicer, client):
     # Test from_name with namespace parameter warns
-    with pytest.warns(PendingDeprecationError, match="The `namespace` parameter for `modal.Queue` is deprecated"):
+    with pytest.warns(
+        PendingDeprecationError,
+        match="The `namespace` parameter for `modal.Queue.from_name` is deprecated",
+    ):
         Queue.from_name("test-queue", namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE)
 
     # Test that from_name without namespace parameter doesn't warn about namespace

--- a/test/runner_test.py
+++ b/test/runner_test.py
@@ -8,7 +8,7 @@ from unittest import mock
 
 import modal
 from modal.client import Client
-from modal.exception import AuthError, PendingDeprecationError
+from modal.exception import AuthError, DeprecationError
 from modal.runner import deploy_app, run_app
 from modal_proto import api_pb2
 
@@ -150,7 +150,7 @@ def test_deploy_app_namespace_deprecated(servicer, client):
     app = modal.App("test-app")
 
     with pytest.warns(
-        PendingDeprecationError,
+        DeprecationError,
         match="The `namespace` parameter for `modal.runner.deploy_app` is deprecated",
     ):
         deploy_app(app, name="test-deploy", namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, client=client)

--- a/test/runner_test.py
+++ b/test/runner_test.py
@@ -149,7 +149,10 @@ def test_deploy_app_namespace_deprecated(servicer, client):
     # Test deploy_app with namespace parameter warns
     app = modal.App("test-app")
 
-    with pytest.warns(PendingDeprecationError, match="The `namespace` parameter for `deploy_app` is deprecated"):
+    with pytest.warns(
+        PendingDeprecationError,
+        match="The `namespace` parameter for `modal.runner.deploy_app` is deprecated",
+    ):
         deploy_app(app, name="test-deploy", namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, client=client)
 
     # Test that deploy_app without namespace parameter doesn't warn about namespace

--- a/test/runner_test.py
+++ b/test/runner_test.py
@@ -8,7 +8,7 @@ from unittest import mock
 
 import modal
 from modal.client import Client
-from modal.exception import AuthError
+from modal.exception import AuthError, PendingDeprecationError
 from modal.runner import deploy_app, run_app
 from modal_proto import api_pb2
 
@@ -143,3 +143,21 @@ async def test_mid_build_modifications(servicer, client, tmp_path, monkeypatch, 
     with handler_assertion:
         async with app.run.aio(client=client):
             ...
+
+
+def test_deploy_app_namespace_deprecated(servicer, client):
+    # Test deploy_app with namespace parameter warns
+    app = modal.App("test-app")
+
+    with pytest.warns(PendingDeprecationError, match="The `namespace` parameter for `deploy_app` is deprecated"):
+        deploy_app(app, name="test-deploy", namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, client=client)
+
+    # Test that deploy_app without namespace parameter doesn't warn about namespace
+    import warnings
+
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        deploy_app(app, name="test-deploy", client=client)
+    # Filter out any unrelated warnings
+    namespace_warnings = [w for w in record if "namespace" in str(w.message).lower()]
+    assert len(namespace_warnings) == 0

--- a/test/secret_test.py
+++ b/test/secret_test.py
@@ -90,10 +90,16 @@ def test_secret_from_name(servicer, client):
 
 
 def test_secret_namespace_deprecated(servicer, client):
-    with pytest.warns(PendingDeprecationError, match="The `namespace` parameter for `modal.Secret` is deprecated"):
+    with pytest.warns(
+        PendingDeprecationError,
+        match="The `namespace` parameter for `modal.Secret.from_name` is deprecated",
+    ):
         Secret.from_name("my-secret", namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE)
 
-    with pytest.warns(PendingDeprecationError, match="The `namespace` parameter for `modal.Secret` is deprecated"):
+    with pytest.warns(
+        PendingDeprecationError,
+        match="The `namespace` parameter for `modal.Secret.create_deployed` is deprecated",
+    ):
         Secret.create_deployed(
             "my-secret", {"FOO": "123"}, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, client=client
         )

--- a/test/secret_test.py
+++ b/test/secret_test.py
@@ -5,7 +5,7 @@ import tempfile
 from unittest import mock
 
 from modal import App, Secret
-from modal.exception import DeprecationError, InvalidError, PendingDeprecationError
+from modal.exception import DeprecationError, InvalidError
 from modal_proto import api_pb2
 
 from .supports.skip import skip_old_py
@@ -91,13 +91,13 @@ def test_secret_from_name(servicer, client):
 
 def test_secret_namespace_deprecated(servicer, client):
     with pytest.warns(
-        PendingDeprecationError,
+        DeprecationError,
         match="The `namespace` parameter for `modal.Secret.from_name` is deprecated",
     ):
         Secret.from_name("my-secret", namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE)
 
     with pytest.warns(
-        PendingDeprecationError,
+        DeprecationError,
         match="The `namespace` parameter for `modal.Secret.create_deployed` is deprecated",
     ):
         Secret.create_deployed(
@@ -109,4 +109,3 @@ def test_secret_namespace_deprecated(servicer, client):
     # Should warn about both the deprecated lookup method and the deprecated namespace parameter
     assert len(record) >= 2
     assert any(isinstance(w.message, DeprecationError) for w in record)
-    assert any(isinstance(w.message, PendingDeprecationError) for w in record)

--- a/test/secret_test.py
+++ b/test/secret_test.py
@@ -5,7 +5,8 @@ import tempfile
 from unittest import mock
 
 from modal import App, Secret
-from modal.exception import InvalidError
+from modal.exception import DeprecationError, InvalidError, PendingDeprecationError
+from modal_proto import api_pb2
 
 from .supports.skip import skip_old_py
 
@@ -86,3 +87,20 @@ def test_secret_from_name(servicer, client):
     app.function(secrets=[secret])(dummy)
     with app.run(client=client):
         assert secret.object_id == secret_id
+
+
+def test_secret_namespace_deprecated(servicer, client):
+    with pytest.warns(PendingDeprecationError, match="The `namespace` parameter for `modal.Secret` is deprecated"):
+        Secret.from_name("my-secret", namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE)
+
+    with pytest.warns(PendingDeprecationError, match="The `namespace` parameter for `modal.Secret` is deprecated"):
+        Secret.create_deployed(
+            "my-secret", {"FOO": "123"}, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, client=client
+        )
+
+    with pytest.warns() as record:
+        Secret.lookup("my-secret", namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, client=client)
+    # Should warn about both the deprecated lookup method and the deprecated namespace parameter
+    assert len(record) >= 2
+    assert any(isinstance(w.message, DeprecationError) for w in record)
+    assert any(isinstance(w.message, PendingDeprecationError) for w in record)

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -13,7 +13,7 @@ from unittest import mock
 
 import modal
 from modal._utils.blob_utils import BLOCK_SIZE
-from modal.exception import InvalidError, NotFoundError, PendingDeprecationError, VolumeUploadTimeoutError
+from modal.exception import DeprecationError, InvalidError, NotFoundError, VolumeUploadTimeoutError
 from modal.volume import _open_files_error_annotation
 from modal_proto import api_pb2
 
@@ -544,7 +544,7 @@ def test_lock_is_py39_safe(set_env_client):
 def test_volume_namespace_deprecated(servicer, client):
     # Test from_name with namespace parameter warns
     with pytest.warns(
-        PendingDeprecationError,
+        DeprecationError,
         match="The `namespace` parameter for `modal.Volume.from_name` is deprecated",
     ):
         modal.Volume.from_name("test-volume", namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE)

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -13,7 +13,7 @@ from unittest import mock
 
 import modal
 from modal._utils.blob_utils import BLOCK_SIZE
-from modal.exception import InvalidError, NotFoundError, VolumeUploadTimeoutError
+from modal.exception import InvalidError, NotFoundError, PendingDeprecationError, VolumeUploadTimeoutError
 from modal.volume import _open_files_error_annotation
 from modal_proto import api_pb2
 
@@ -539,3 +539,19 @@ def unset_main_thread_event_loop():
 def test_lock_is_py39_safe(set_env_client):
     vol = modal.Volume.from_name("my_vol", create_if_missing=True)
     vol.reload()
+
+
+def test_volume_namespace_deprecated(servicer, client):
+    # Test from_name with namespace parameter warns
+    with pytest.warns(PendingDeprecationError, match="The `namespace` parameter for `modal.Volume` is deprecated"):
+        modal.Volume.from_name("test-volume", namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE)
+
+    # Test that from_name without namespace parameter doesn't warn about namespace
+    import warnings
+
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        modal.Volume.from_name("test-volume")
+    # Filter out any unrelated warnings
+    namespace_warnings = [w for w in record if "namespace" in str(w.message).lower()]
+    assert len(namespace_warnings) == 0

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -543,7 +543,10 @@ def test_lock_is_py39_safe(set_env_client):
 
 def test_volume_namespace_deprecated(servicer, client):
     # Test from_name with namespace parameter warns
-    with pytest.warns(PendingDeprecationError, match="The `namespace` parameter for `modal.Volume` is deprecated"):
+    with pytest.warns(
+        PendingDeprecationError,
+        match="The `namespace` parameter for `modal.Volume.from_name` is deprecated",
+    ):
         modal.Volume.from_name("test-volume", namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE)
 
     # Test that from_name without namespace parameter doesn't warn about namespace


### PR DESCRIPTION
## Describe your changes

Part of a larger project (CLI-335) to remove `DeploymentNamespace` from RPCs.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


</details>

## Changelog

- Deprecated the `namespace` parameter on `Secret`, `Function`, `Cls`, `Dict`, `Queue`, `Volume`, `NetworkFileSystem`, and `deploy_app`.