### PR TITLE
Add read-only to volumes

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -833,6 +833,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                         mount_path=path,
                         volume_id=volume.object_id,
                         allow_background_commits=True,
+                        read_only=volume.read_only,
                     )
                     for path, volume in validated_volumes_no_cloud_buckets
                 ]
@@ -1086,6 +1087,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                         mount_path=path,
                         volume_id=volume.object_id,
                         allow_background_commits=True,
+                        read_only=volume.read_only,
                     )
                     for path, volume in options.validated_volumes
                 ]

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -833,7 +833,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                         mount_path=path,
                         volume_id=volume.object_id,
                         allow_background_commits=True,
-                        read_only=volume.read_only,
+                        read_only=volume._read_only,
                     )
                     for path, volume in validated_volumes_no_cloud_buckets
                 ]
@@ -1087,7 +1087,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                         mount_path=path,
                         volume_id=volume.object_id,
                         allow_background_commits=True,
-                        read_only=volume.read_only,
+                        read_only=volume._read_only,
                     )
                     for path, volume in options.validated_volumes
                 ]

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -151,7 +151,7 @@ class _Sandbox(_Object, type_prefix="sb"):
                     mount_path=path,
                     volume_id=volume.object_id,
                     allow_background_commits=True,
-                    read_only=volume.read_only,
+                    read_only=volume._read_only,
                 )
                 for path, volume in validated_volumes
             ]

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -151,6 +151,7 @@ class _Sandbox(_Object, type_prefix="sb"):
                     mount_path=path,
                     volume_id=volume.object_id,
                     allow_background_commits=True,
+                    read_only=volume.read_only,
                 )
                 for path, volume in validated_volumes
             ]

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -142,9 +142,16 @@ class _Volume(_Object, type_prefix="vo"):
     def read_only(self) -> bool:
         return self._read_only
 
-    def with_read_only(self) -> "_Volume":
+    def with_options(
+        self,
+        *,
+        read_only: Optional[bool] = None,  # Configure Volume to be read-only.
+    ) -> "_Volume":
+        """Configure Volume to mount as read-only"""
+        if read_only is None:
+            return self
         volume = deepcopy(self)
-        volume._read_only = True
+        volume._read_only = read_only
         return volume
 
     async def _get_lock(self):

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -137,7 +137,7 @@ class _Volume(_Object, type_prefix="vo"):
     _metadata: "typing.Optional[api_pb2.VolumeMetadata]"
     _read_only: bool = False
 
-    def as_read_only(self) -> "_Volume":
+    def read_only(self) -> "_Volume":
         """Configure Volume to mount as read-only.
 
         **Example**

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -155,9 +155,6 @@ class _Volume(_Object, type_prefix="vo"):
 
         The Volume is mounted as a read-only volume in a function. Any file system write operation into the
         mounted volume will result in an error.
-
-        Volume methods such as `batch_upload`, `copy_files`, or `remove_file` will still work for
-        writing data into the volume.
         """
 
         async def _load(new_volume: _Volume, resolver: Resolver, existing_object_id: Optional[str]):

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -164,7 +164,7 @@ class _Volume(_Object, type_prefix="vo"):
             new_volume._initialize_from_other(self)
             new_volume._read_only = True
 
-        obj = _Volume._from_loader(_load, "Volume.read_only()", hydrate_lazily=True, deps=lambda: [self])
+        obj = _Volume._from_loader(_load, "Volume()", hydrate_lazily=True, deps=lambda: [self])
         return obj
 
     async def _get_lock(self):

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -526,6 +526,9 @@ class _Volume(_Object, type_prefix="vo"):
     @live_method
     async def remove_file(self, path: str, recursive: bool = False) -> None:
         """Remove a file or directory from a volume."""
+        if self._read_only:
+            raise InvalidError("Read-only Volume can not be written to")
+
         if self._is_v1:
             req = api_pb2.VolumeRemoveFileRequest(volume_id=self.object_id, path=path, recursive=recursive)
             await retry_transient_errors(self._client.stub.VolumeRemoveFile, req)
@@ -558,6 +561,9 @@ class _Volume(_Object, type_prefix="vo"):
         like `os.rename()` and then `commit()` the volume. The `copy_files()` method is useful when you don't have
         the volume mounted as a filesystem, e.g. when running a script on your local computer.
         """
+        if self._read_only:
+            raise InvalidError("Read-only Volume can not be written to")
+
         if self._is_v1:
             if recursive:
                 raise ValueError("`recursive` is not supported for V1 volumes")
@@ -591,6 +597,9 @@ class _Volume(_Object, type_prefix="vo"):
             batch.put_file(io.BytesIO(b"some data"), "/foobar")
         ```
         """
+        if self._read_only:
+            raise InvalidError("Read-only Volume can not be written to")
+
         return _AbstractVolumeUploadContextManager.resolve(
             self._metadata.version, self.object_id, self._client, force=force
         )

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -147,7 +147,7 @@ class _Volume(_Object, type_prefix="vo"):
 
         volume = modal.Volume.from_name("my-volume", create_if_missing=True)
 
-        @app.function(volumes={"/mnt/items": volume.as_read_only()})
+        @app.function(volumes={"/mnt/items": volume.read_only()})
         def f():
             with open("/mnt/items/my-file.txt") as f:
                 return f.read()

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -220,8 +220,7 @@ class _Volume(_Object, type_prefix="vo"):
             response = await resolver.client.stub.VolumeGetOrCreate(req)
             self._hydrate(response.volume_id, resolver.client, response.metadata)
 
-        obj = _Volume._from_loader(_load, "Volume()", hydrate_lazily=True)
-        return obj
+        return _Volume._from_loader(_load, "Volume()", hydrate_lazily=True)
 
     def _hydrate_metadata(self, metadata: Optional[Message]):
         if metadata and isinstance(metadata, api_pb2.VolumeMetadata):

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -137,7 +137,7 @@ class _Volume(_Object, type_prefix="vo"):
     _metadata: "typing.Optional[api_pb2.VolumeMetadata]"
     _read_only: bool = False
 
-    def read_only(self) -> "_Volume":
+    def as_read_only(self) -> "_Volume":
         """Configure Volume to mount as read-only.
 
         **Example**
@@ -147,7 +147,7 @@ class _Volume(_Object, type_prefix="vo"):
 
         volume = modal.Volume.from_name("my-volume", create_if_missing=True)
 
-        @app.function(volumes={"/mnt/items": volume.read_only()})
+        @app.function(volumes={"/mnt/items": volume.as_read_only()})
         def f():
             with open("/mnt/items/my-file.txt") as f:
                 return f.read()

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -180,7 +180,10 @@ def test_class_multiple_dynamic_parameterization_methods(client, servicer):
 
 @pytest.mark.parametrize("read_only", [True, False])
 def test_class_multiple_with_options_calls(client, servicer, read_only):
-    weights_volume = Volume.from_name("weights", create_if_missing=True).with_options(read_only=read_only)
+    weights_volume = Volume.from_name("weights", create_if_missing=True)
+
+    if read_only:
+        weights_volume = weights_volume.read_only()
     foo = (
         Foo.with_options(  # type: ignore
             gpu="A10:4",

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -180,6 +180,9 @@ def test_class_multiple_dynamic_parameterization_methods(client, servicer):
 
 @pytest.mark.parametrize("read_only", [True, False])
 def test_class_multiple_with_options_calls(client, servicer, read_only):
+    weights_volume = Volume.from_name("weights", create_if_missing=True)
+    if read_only:
+        weights_volume = weights_volume.with_read_only()
     foo = (
         Foo.with_options(  # type: ignore
             gpu="A10:4",
@@ -192,7 +195,7 @@ def test_class_multiple_with_options_calls(client, servicer, read_only):
             gpu="A100",
             memory=2048,
             max_containers=10,
-            volumes={"/weights": Volume.from_name("weights", create_if_missing=True, read_only=read_only)},
+            volumes={"/weights": weights_volume},
         )()  # type: ignore
     )
 

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -181,8 +181,6 @@ def test_class_multiple_dynamic_parameterization_methods(client, servicer):
 @pytest.mark.parametrize("read_only", [True, False])
 def test_class_multiple_with_options_calls(client, servicer, read_only):
     weights_volume = Volume.from_name("weights", create_if_missing=True).with_options(read_only=read_only)
-    if read_only:
-        weights_volume = weights_volume.with_read_only()
     foo = (
         Foo.with_options(  # type: ignore
             gpu="A10:4",

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -178,7 +178,8 @@ def test_class_multiple_dynamic_parameterization_methods(client, servicer):
     assert res == 4
 
 
-def test_class_multiple_with_options_calls(client, servicer):
+@pytest.mark.parametrize("read_only", [True, False])
+def test_class_multiple_with_options_calls(client, servicer, read_only):
     foo = (
         Foo.with_options(  # type: ignore
             gpu="A10:4",
@@ -191,7 +192,7 @@ def test_class_multiple_with_options_calls(client, servicer):
             gpu="A100",
             memory=2048,
             max_containers=10,
-            volumes={"/weights": Volume.from_name("weights", create_if_missing=True)},
+            volumes={"/weights": Volume.from_name("weights", create_if_missing=True, read_only=read_only)},
         )()  # type: ignore
     )
 
@@ -208,6 +209,7 @@ def test_class_multiple_with_options_calls(client, servicer):
             assert function_bind_params.function_options.concurrency_limit == 10
             assert len(function_bind_params.function_options.volume_mounts) == 1
             assert function_bind_params.function_options.volume_mounts[0].mount_path == "/weights"
+            assert function_bind_params.function_options.volume_mounts[0].read_only == read_only
 
 
 def test_with_options_from_name(servicer):

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -180,7 +180,7 @@ def test_class_multiple_dynamic_parameterization_methods(client, servicer):
 
 @pytest.mark.parametrize("read_only", [True, False])
 def test_class_multiple_with_options_calls(client, servicer, read_only):
-    weights_volume = Volume.from_name("weights", create_if_missing=True)
+    weights_volume = Volume.from_name("weights", create_if_missing=True).with_options(read_only=read_only)
     if read_only:
         weights_volume = weights_volume.with_read_only()
     foo = (

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -183,7 +183,7 @@ def test_class_multiple_with_options_calls(client, servicer, read_only):
     weights_volume = Volume.from_name("weights", create_if_missing=True)
 
     if read_only:
-        weights_volume = weights_volume.read_only()
+        weights_volume = weights_volume.as_read_only()
     foo = (
         Foo.with_options(  # type: ignore
             gpu="A10:4",

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -183,7 +183,7 @@ def test_class_multiple_with_options_calls(client, servicer, read_only):
     weights_volume = Volume.from_name("weights", create_if_missing=True)
 
     if read_only:
-        weights_volume = weights_volume.as_read_only()
+        weights_volume = weights_volume.read_only()
     foo = (
         Foo.with_options(  # type: ignore
             gpu="A10:4",

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -529,7 +529,11 @@ def test_sandbox_list_sets_correct_returncode_for_stopped(client, servicer):
 @pytest.mark.parametrize("read_only", [True, False])
 @skip_non_subprocess
 def test_sandbox_volume(app, servicer, read_only):
-    volume = Volume.from_name("my-volume", create_if_missing=True).with_options(read_only=read_only)
+    volume = Volume.from_name("my-volume", create_if_missing=True)
+
+    if read_only:
+        volume = volume.read_only()
+
     with servicer.intercept() as ctx:
         Sandbox.create(
             "bash",

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -532,7 +532,7 @@ def test_sandbox_volume(app, servicer, read_only):
     volume = Volume.from_name("my-volume", create_if_missing=True)
 
     if read_only:
-        volume = volume.read_only()
+        volume = volume.as_read_only()
 
     with servicer.intercept() as ctx:
         Sandbox.create(

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -529,7 +529,9 @@ def test_sandbox_list_sets_correct_returncode_for_stopped(client, servicer):
 @pytest.mark.parametrize("read_only", [True, False])
 @skip_non_subprocess
 def test_sandbox_volume(app, servicer, read_only):
-    volume = Volume.from_name("my-volume", create_if_missing=True, read_only=read_only)
+    volume = Volume.from_name("my-volume", create_if_missing=True)
+    if read_only:
+        volume = volume.with_read_only()
     with servicer.intercept() as ctx:
         Sandbox.create(
             "bash",

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -5,7 +5,7 @@ import pytest
 import time
 from pathlib import Path
 
-from modal import App, Image, NetworkFileSystem, Proxy, Sandbox, SandboxSnapshot, Secret
+from modal import App, Image, NetworkFileSystem, Proxy, Sandbox, SandboxSnapshot, Secret, Volume
 from modal.exception import InvalidError
 from modal.stream_type import StreamType
 from modal_proto import api_pb2
@@ -524,3 +524,20 @@ def test_sandbox_list_sets_correct_returncode_for_stopped(client, servicer):
         )  # list will loop for older sandboxes until no more arrive
         (list_result,) = list(Sandbox.list(client=client))
     assert list_result.returncode == 0
+
+
+@pytest.mark.parametrize("read_only", [True, False])
+@skip_non_subprocess
+def test_sandbox_volume(app, servicer, read_only):
+    volume = Volume.from_name("my-volume", create_if_missing=True, read_only=read_only)
+    with servicer.intercept() as ctx:
+        Sandbox.create(
+            "bash",
+            "-c",
+            "echo bye >&2 && sleep 1 && echo hi && exit 42",
+            timeout=600,
+            app=app,
+            volumes={"/mnt": volume},
+        )
+        req = ctx.pop_request("SandboxCreate")
+        assert req.definition.volume_mounts[0].read_only == read_only

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -532,7 +532,7 @@ def test_sandbox_volume(app, servicer, read_only):
     volume = Volume.from_name("my-volume", create_if_missing=True)
 
     if read_only:
-        volume = volume.as_read_only()
+        volume = volume.read_only()
 
     with servicer.intercept() as ctx:
         Sandbox.create(

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -529,9 +529,7 @@ def test_sandbox_list_sets_correct_returncode_for_stopped(client, servicer):
 @pytest.mark.parametrize("read_only", [True, False])
 @skip_non_subprocess
 def test_sandbox_volume(app, servicer, read_only):
-    volume = Volume.from_name("my-volume", create_if_missing=True)
-    if read_only:
-        volume = volume.with_read_only()
+    volume = Volume.from_name("my-volume", create_if_missing=True).with_options(read_only=read_only)
     with servicer.intercept() as ctx:
         Sandbox.create(
             "bash",

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -34,7 +34,7 @@ def test_volume_mount(client, servicer, version, read_only):
 
     vol = modal.Volume.from_name("xyz", create_if_missing=True, version=version)
     if read_only:
-        vol = vol.read_only()
+        vol = vol.as_read_only()
 
     _ = app.function(volumes={"/root/foo": vol})(dummy)
 

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -34,7 +34,7 @@ def test_volume_mount(client, servicer, version, read_only):
 
     vol = modal.Volume.from_name("xyz", create_if_missing=True, version=version)
     if read_only:
-        vol = vol.as_read_only()
+        vol = vol.read_only()
 
     _ = app.function(volumes={"/root/foo": vol})(dummy)
 
@@ -60,7 +60,7 @@ def test_volume_bad_paths():
 
 def test_volume_mount_read_only_error(client, servicer):
     app = modal.App()
-    read_only_vol = modal.Volume.from_name("xyz", create_if_missing=True).as_read_only()
+    read_only_vol = modal.Volume.from_name("xyz", create_if_missing=True).read_only()
 
     def batch_upload():
         read_only_vol.batch_upload()

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -58,29 +58,18 @@ def test_volume_bad_paths():
         app.function(volumes={"/tmp/": vol})(dummy)
 
 
-def test_volume_mount_read_only_error(client, servicer):
-    app = modal.App()
+def test_volume_mount_read_only_error(client):
     read_only_vol = modal.Volume.from_name("xyz", create_if_missing=True).read_only()
+    read_only_vol_hydrated = read_only_vol.hydrate(client)
 
-    def batch_upload():
-        read_only_vol.batch_upload()
+    with pytest.raises(InvalidError):
+        read_only_vol_hydrated.batch_upload()
 
-    def remove_file():
-        read_only_vol.remove_file("file1.txt")
+    with pytest.raises(InvalidError):
+        read_only_vol_hydrated.remove_file("file1.txt")
 
-    def copy_files():
-        read_only_vol.copy_files(["file1.txt"], "bar2")
-
-    with servicer.intercept():
-        with app.run(client=client):
-            with pytest.raises(InvalidError):
-                app.function()(batch_upload)
-
-            with pytest.raises(InvalidError):
-                app.function()(remove_file)
-
-            with pytest.raises(InvalidError):
-                app.function()(copy_files)
+    with pytest.raises(InvalidError):
+        read_only_vol_hydrated.copy_files(["file1.txt"], "bar2")
 
 
 def test_volume_duplicate_mount():

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -58,6 +58,19 @@ def test_volume_bad_paths():
         app.function(volumes={"/tmp/": vol})(dummy)
 
 
+def test_volume_mount_read_only_error():
+    read_only_vol = modal.Volume.from_name("xyz", create_if_missing=True).as_read_only()
+
+    with pytest.raises(InvalidError):
+        read_only_vol.batch_upload()
+
+    with pytest.raises(InvalidError):
+        read_only_vol.copy_files(["file1.txt"], "bar2")
+
+    with pytest.raises(InvalidError):
+        read_only_vol.remove_file("file1.txt")
+
+
 def test_volume_duplicate_mount():
     app = modal.App()
     vol = modal.Volume.from_name("xyz")

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -31,7 +31,9 @@ def dummy():
 @pytest.mark.parametrize("version", VERSIONS)
 def test_volume_mount(client, servicer, version, read_only):
     app = modal.App()
-    vol = modal.Volume.from_name("xyz", create_if_missing=True, version=version, read_only=read_only)
+    vol = modal.Volume.from_name("xyz", create_if_missing=True, version=version)
+    if read_only:
+        vol = vol.with_read_only()
 
     _ = app.function(volumes={"/root/foo": vol})(dummy)
 

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -58,17 +58,29 @@ def test_volume_bad_paths():
         app.function(volumes={"/tmp/": vol})(dummy)
 
 
-def test_volume_mount_read_only_error():
+def test_volume_mount_read_only_error(client, servicer):
+    app = modal.App()
     read_only_vol = modal.Volume.from_name("xyz", create_if_missing=True).as_read_only()
 
-    with pytest.raises(InvalidError):
+    def batch_upload():
         read_only_vol.batch_upload()
 
-    with pytest.raises(InvalidError):
+    def remove_file():
+        read_only_vol.remove_file("file1.txt")
+
+    def copy_files():
         read_only_vol.copy_files(["file1.txt"], "bar2")
 
-    with pytest.raises(InvalidError):
-        read_only_vol.remove_file("file1.txt")
+    with servicer.intercept():
+        with app.run(client=client):
+            with pytest.raises(InvalidError):
+                app.function()(batch_upload)
+
+            with pytest.raises(InvalidError):
+                app.function()(remove_file)
+
+            with pytest.raises(InvalidError):
+                app.function()(copy_files)
 
 
 def test_volume_duplicate_mount():

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -31,9 +31,7 @@ def dummy():
 @pytest.mark.parametrize("version", VERSIONS)
 def test_volume_mount(client, servicer, version, read_only):
     app = modal.App()
-    vol = modal.Volume.from_name("xyz", create_if_missing=True, version=version)
-    if read_only:
-        vol = vol.with_read_only()
+    vol = modal.Volume.from_name("xyz", create_if_missing=True, version=version).with_options(read_only=read_only)
 
     _ = app.function(volumes={"/root/foo": vol})(dummy)
 

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -31,7 +31,10 @@ def dummy():
 @pytest.mark.parametrize("version", VERSIONS)
 def test_volume_mount(client, servicer, version, read_only):
     app = modal.App()
-    vol = modal.Volume.from_name("xyz", create_if_missing=True, version=version).with_options(read_only=read_only)
+
+    vol = modal.Volume.from_name("xyz", create_if_missing=True, version=version)
+    if read_only:
+        vol = vol.read_only()
 
     _ = app.function(volumes={"/root/foo": vol})(dummy)
 


### PR DESCRIPTION
## Describe your changes

Closes https://linear.app/modal-labs/issue/CLI-273/support-read-only-volumes

This PR adds `Volume.with_options` to be consistent with `Cls.with_options`. Note that if a `Volume` is mounted as read only any writes to the volume would raise an OSError:

```python
import modal

app = modal.App("read_only")
volume = modal.Volume.from_name("polars-volume")


@app.function(volumes={"/mnt/polars": volume.with_options(read_only=True)})
def main():
    with open("/mnt/polars/modal_here.txt", "w") as f:
        f.write("this is some text")
```

The above will raise `OSError: [Errno 30] Read-only file system: '/mnt/polars/modal_here.txt'`.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->

- Add `read_only` to Volume, which makes the volume read only.
 
```python
volume = modal.Volume.from_name("my-data-volume", read_only=True)
```