### PR TITLE
Enable hiding deprecated function arguments

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1222,7 +1222,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         cls,
         app_name: str,
         name: str,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         environment_name: Optional[str] = None,
     ):
         # internal function lookup implementation that allows lookup of class "service functions"
@@ -1259,7 +1259,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         app_name: str,
         name: str,
         *,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         environment_name: Optional[str] = None,
     ) -> "_Function":
         """Reference a Function from a deployed App by its name.
@@ -1290,7 +1290,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
     async def lookup(
         app_name: str,
         name: str,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
     ) -> "_Function":

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -617,7 +617,7 @@ More information on class parameterization can be found here: https://modal.com/
         app_name: str,
         name: str,
         *,
-        namespace: Any = _ARGUMENT_NOT_PASSED,
+        namespace: Any = _ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         environment_name: Optional[str] = None,
     ) -> "_Cls":
         """Reference a Cls from a deployed App by its name.
@@ -829,7 +829,7 @@ More information on class parameterization can be found here: https://modal.com/
     async def lookup(
         app_name: str,
         name: str,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
     ) -> "_Cls":

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -117,9 +117,9 @@ class _Dict(_Object, type_prefix="di"):
     @staticmethod
     def from_name(
         name: str,
-        data: Optional[dict] = None,  # DEPRECATED
+        data: Optional[dict] = None,  # DEPRECATED, mdmd:line-hidden
         *,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
     ) -> "_Dict":
@@ -162,7 +162,7 @@ class _Dict(_Object, type_prefix="di"):
     async def lookup(
         name: str,
         data: Optional[dict] = None,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -92,7 +92,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
     def from_name(
         name: str,
         *,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
     ) -> "_NetworkFileSystem":
@@ -168,7 +168,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
     @staticmethod
     async def lookup(
         name: str,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
@@ -205,7 +205,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
     @staticmethod
     async def create_deployed(
         deployment_name: str,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
     ) -> str:

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -148,7 +148,7 @@ class _Queue(_Object, type_prefix="qu"):
     def from_name(
         name: str,
         *,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
     ) -> "_Queue":
@@ -181,7 +181,7 @@ class _Queue(_Object, type_prefix="qu"):
     @staticmethod
     async def lookup(
         name: str,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -468,7 +468,7 @@ class DeployResult:
 async def _deploy_app(
     app: _App,
     name: Optional[str] = None,
-    namespace: Any = _ARGUMENT_NOT_PASSED,
+    namespace: Any = _ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
     client: Optional[_Client] = None,
     environment_name: Optional[str] = None,
     tag: str = "",

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -165,7 +165,7 @@ class _Secret(_Object, type_prefix="st"):
     def from_name(
         name: str,
         *,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         environment_name: Optional[str] = None,
         required_keys: list[
             str
@@ -208,7 +208,7 @@ class _Secret(_Object, type_prefix="st"):
     @staticmethod
     async def lookup(
         name: str,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         required_keys: list[str] = [],
@@ -236,7 +236,7 @@ class _Secret(_Object, type_prefix="st"):
     async def create_deployed(
         deployment_name: str,
         env_dict: dict[str, str],
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         overwrite: bool = False,

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -154,7 +154,7 @@ class _Volume(_Object, type_prefix="vo"):
     def from_name(
         name: str,
         *,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
         version: "typing.Optional[modal_proto.api_pb2.VolumeFsVersion.ValueType]" = None,
@@ -248,7 +248,7 @@ class _Volume(_Object, type_prefix="vo"):
     @staticmethod
     async def lookup(
         name: str,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         create_if_missing: bool = False,
@@ -290,7 +290,7 @@ class _Volume(_Object, type_prefix="vo"):
     @staticmethod
     async def create_deployed(
         deployment_name: str,
-        namespace=_ARGUMENT_NOT_PASSED,
+        namespace=_ARGUMENT_NOT_PASSED,  # mdmd:line-hidden
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         version: "typing.Optional[modal_proto.api_pb2.VolumeFsVersion.ValueType]" = None,

--- a/modal_docs/mdmd/mdmd.py
+++ b/modal_docs/mdmd/mdmd.py
@@ -5,18 +5,20 @@ import inspect
 import warnings
 from enum import Enum, EnumMeta
 from types import ModuleType
-from typing import Callable
+from typing import Callable, Optional
 
 import synchronicity.synchronizer
 
 from .signatures import get_signature
 
 
-def format_docstring(docstring: str):
+def format_docstring(docstring: Optional[str]) -> str:
     if docstring is None:
         docstring = ""
     else:
         docstring = inspect.cleandoc(docstring)
+
+    docstring = "\n".join(l for l in docstring.split("\n") if "mdmd:line-hidden" not in l)
 
     if docstring and not docstring.endswith("\n"):
         docstring += "\n"
@@ -24,8 +26,9 @@ def format_docstring(docstring: str):
     return docstring
 
 
-def function_str(name: str, func):
+def function_str(name: str, func) -> str:
     signature = get_signature(name, func)
+    signature = "\n".join(l for l in signature.split("\n") if "mdmd:line-hidden" not in l)
     decl = f"""```python
 {signature}
 ```\n\n"""

--- a/test/mdmd_test.py
+++ b/test/mdmd_test.py
@@ -54,6 +54,25 @@ def foo(a: str, *args, **kwargs):
     )
 
 
+def test_complex_function_signature_with_line_hidden():
+    def foo(
+        a: str,
+        *args,  # mdmd:line-hidden
+        **kwargs,
+    ):
+        pass
+
+    assert (
+        mdmd.function_str("foo", foo)
+        == """```python
+def foo(
+    a: str,
+    **kwargs,
+):
+```\n\n"""
+    )
+
+
 def test_function_has_docstring():
     def foo():
         """short description
@@ -87,6 +106,33 @@ class Foo(object)
 ```
 
 The all important Foo
+
+### bar
+
+```python
+def bar(self, baz: str):
+```
+
+Bars the foo with the baz
+"""
+    )
+
+
+def test_simple_class_with_docstring_with_line_hidden():
+    class Foo:
+        """The all important Foo mdmd:line-hidden"""
+
+        def bar(self, baz: str):
+            """Bars the foo with the baz
+
+            This won't be included mdmd:line-hidden
+            """
+
+    assert (
+        mdmd.class_str("Foo", Foo)
+        == """```python
+class Foo(object)
+```
 
 ### bar
 


### PR DESCRIPTION
The diff in generated docs:

```diff
> diff -r reference_docs_output reference_docs_output-with-hidden/
diff --color=auto -r reference_docs_output/modal.Cls.md reference_docs_output-with-hidden/modal.Cls.md
35d34
<     namespace: Any = _ARGUMENT_NOT_PASSED,
diff --color=auto -r reference_docs_output/modal.Dict.md reference_docs_output-with-hidden/modal.Dict.md
94d93
<     data: Optional[dict] = None,  # DEPRECATED
96d94
<     namespace=_ARGUMENT_NOT_PASSED,
diff --color=auto -r reference_docs_output/modal.Function.md reference_docs_output-with-hidden/modal.Function.md
71d70
<     namespace=_ARGUMENT_NOT_PASSED,
diff --color=auto -r reference_docs_output/modal.NetworkFileSystem.md reference_docs_output-with-hidden/modal.NetworkFileSystem.md
63d62
<     namespace=_ARGUMENT_NOT_PASSED,
diff --color=auto -r reference_docs_output/modal.Queue.md reference_docs_output-with-hidden/modal.Queue.md
132d131
<     namespace=_ARGUMENT_NOT_PASSED,
diff --color=auto -r reference_docs_output/modal.Secret.md reference_docs_output-with-hidden/modal.Secret.md
96d95
<     namespace=_ARGUMENT_NOT_PASSED,
diff --color=auto -r reference_docs_output/modal.Volume.md reference_docs_output-with-hidden/modal.Volume.md
67d66
<     namespace=_ARGUMENT_NOT_PASSED,
```
