### PR TITLE
Add developing instructions

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,32 @@
+# Developing `modal-client`
+
+Check out the repo:
+
+```bash
+git clone https://github.com/modal-labs/modal-client.git
+cd modal-client
+```
+
+Create a virtual environment:
+
+```bash
+uv venv
+source .venv/bin/activate
+uv pip install -e .
+uv pip install -r requirements.dev.txt
+```
+
+Build protobufs:
+
+```bash
+inv protoc type-stubs
+```
+
+`inv` refers to [Invoke](https://www.pyinvoke.org/), a Python CLI task runner.
+
+Run modal:
+
+```bash
+source .venv/bin/activate
+modal
+```


### PR DESCRIPTION
I found it a little tricky to figure out how to go from a repo to a locally-running client. This PR adds a `DEVELOPING.md` with instructions to do that.