### PR TITLE
Adds `Dict.objects`

### DIFF
--- a/modal/dict.py
+++ b/modal/dict.py
@@ -25,6 +25,8 @@ def _serialize_dict(data):
 
 
 class _DictObjectNamespaceAsync:
+    """Namespace for managing Dict objects."""
+
     async def list(
         self,
         environment_name: Optional[str] = None,
@@ -108,6 +110,19 @@ class _Dict(_Object, type_prefix="di"):
 
     @classproperty
     def objects(cls):
+        """Namespace for managing Dict objects.
+
+        Usage:
+        ```python
+        from modal import Dict
+
+        all_dicts = Dict.objects.list()
+
+        d = modal.Dict.from_name("my-dict", create_if_missing=True)
+        Dict.objects.delete("my-dict")
+        ```
+
+        """
         return _dict_object_namespace
 
     @classmethod

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -394,6 +394,8 @@ class _Dict(_Object, type_prefix="di"):
         async for resp in self._client.stub.DictContents.unary_stream(req):
             yield (deserialize(resp.key, self._client), deserialize(resp.value, self._client))
 
+    objects = _dict_object_namespace
 
-Dict = synchronize_api(_Dict)
-setattr(Dict, "objects", _dict_object_namespace)
+
+# Dict = synchronize_api(_Dict)
+# setattr(Dict, "objects", _dict_object_namespace)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "grpclib==0.4.7",
     "protobuf>=3.19,<7.0,!=4.24.0",
     "rich>=12.0.0",
-    "synchronicity~=0.9.15",
+    "synchronicity~=0.10.0",
     "toml",
     "typer>=0.9",
     "types-certifi",


### PR DESCRIPTION
## Describe your changes

Toward https://linear.app/modal-labs/issue/CLI-428/python-client-api-for-object-management

This PR adds `Dict.objects` to introduce the objects management 

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->

- Introduces `Dict.objects` namespace to manage Dict objects:

```python
from modal import Dict
all_dicts = Dict.objects.list()
d = Dict.from_name("my-dict", create_if_missing=True)
Dict.objects.delete("my-dict")
```