### PR TITLE
Refactor _run_app into composable functions

### DIFF
--- a/modal/runner.py
+++ b/modal/runner.py
@@ -11,7 +11,7 @@ import time
 import typing
 from collections.abc import AsyncGenerator
 from multiprocessing.synchronize import Event
-from typing import TYPE_CHECKING, Any, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, Optional, Protocol, TypeVar
 
 from grpclib import GRPCError, Status
 from synchronicity.async_wrap import asynccontextmanager
@@ -256,16 +256,77 @@ async def _status_based_disconnect(client: _Client, app_id: str, exc_info: Optio
     await _disconnect(client, app_id, reason, exc_str)
 
 
+class InterruptHandler(Protocol):
+    """mdmd:hidden"""
+    @asynccontextmanager
+    async def __call__(self) -> AsyncGenerator[None, None]:
+        """Handle an interrupt event."""
+        yield
+
+
 @asynccontextmanager
-async def _run_app(
+async def _null_interrupt_handler() -> AsyncGenerator[None, None]:
+    """mdmd:hidden"""
+    yield
+
+
+@asynccontextmanager
+async def _disconnect_on_error(
+    client: _Client,
+    app_id: str,
+    *,
+    on_interrupt: Optional[InterruptHandler] = None,
+) -> AsyncGenerator[None, None]:
+    """Disconnect from the app on any error."""
+    if on_interrupt is None:
+        on_interrupt = _null_interrupt_handler
+
+    try:
+        yield
+    except asyncio.CancelledError as e:
+        # typically happens on sigint/ctrl-C during setup (the KeyboardInterrupt happens in the main thread)
+        async with on_interrupt():
+            await _status_based_disconnect(client, app_id, e)
+        raise
+    except KeyboardInterrupt as e:
+        # typically happens if sigint comes in during user code execution
+        async with on_interrupt():
+            await _status_based_disconnect(client, app_id, e)
+        return
+    except BaseException as e:
+        await _status_based_disconnect(client, app_id, e)
+        raise
+
+
+def _app_state_for(detach: bool):
+    """mdmd:hidden"""
+    return api_pb2.APP_STATE_DETACHED if detach else api_pb2.APP_STATE_EPHEMERAL
+
+
+@dataclasses.dataclass
+class RunContext:
+    running_app: RunningApp
+    client: _Client
+    environment_name: str
+    detach: bool
+    task_context: TaskContext
+
+    @property
+    def app_id(self) -> str:
+        return self.running_app.app_id
+
+
+@asynccontextmanager
+async def _run_app_init(
     app: _App,
     *,
     client: Optional[_Client] = None,
     detach: bool = False,
     environment_name: Optional[str] = None,
     interactive: bool = False,
-) -> AsyncGenerator[_App, None]:
-    """mdmd:hidden"""
+    grace: Optional[float] = None,
+) -> AsyncGenerator[RunContext, None]:
+    """Run app, step 1: initialize a running app."""
     if environment_name is None:
         environment_name = typing.cast(str, config.get("environment"))
 
@@ -291,23 +352,15 @@ async def _run_app(
     if client is None:
         client = await _Client.from_env()
 
-    app_state = api_pb2.APP_STATE_DETACHED if detach else api_pb2.APP_STATE_EPHEMERAL
-
-    output_mgr = _get_output_manager()
-    if interactive and output_mgr is None:
-        msg = "Interactive mode requires output to be enabled. (Use the the `modal.enable_output()` context manager.)"
-        raise InvalidError(msg)
-
     running_app: RunningApp = await _init_local_app_new(
         client,
         app.description or "",
         environment_name=environment_name or "",
-        app_state=app_state,
+        app_state=_app_state_for(detach),
         interactive=interactive,
     )
 
-    logs_timeout = config["logs_timeout"]
-    async with app._set_local_app(client, running_app), TaskContext(grace=logs_timeout) as tc:
+    async with app._set_local_app(client, running_app), TaskContext(grace=grace) as tc:
         # Start heartbeats loop to keep the client alive
         # we don't log heartbeat exceptions in detached mode
         # as losing the local connection will not affect the running app
@@ -315,7 +368,53 @@ async def _run_app(
             return _heartbeat(client, running_app.app_id)
 
         heartbeat_loop = tc.infinite_loop(heartbeat, sleep=HEARTBEAT_INTERVAL, log_exception=not detach)
+
+        yield RunContext(
+            running_app=running_app,
+            client=client,
+            environment_name=environment_name,
+            detach=detach,
+            task_context=tc,
+        )
+
+        # successful completion!
+        heartbeat_loop.cancel()
+        await _status_based_disconnect(client, running_app.app_id, exc_info=None)
+
+
+async def _run_app_create(app: _App, ctx: RunContext):
+    """Run app, step 2: create objects and publish."""
+    await _create_all_objects(ctx.client, ctx.running_app, app._functions, app._classes, ctx.environment_name)
+    await _publish_app(ctx.client, ctx.running_app, _app_state_for(ctx.detach), app._functions, app._classes)
+
+
+@asynccontextmanager
+async def _run_app(
+    app: _App,
+    *,
+    client: Optional[_Client] = None,
+    detach: bool = False,
+    environment_name: Optional[str] = None,
+    interactive: bool = False,
+) -> AsyncGenerator[_App, None]:
+    """mdmd:hidden"""
+    output_mgr = _get_output_manager()
+    if interactive and output_mgr is None:
+        msg = "Interactive mode requires output to be enabled. (Use the the `modal.enable_output()` context manager.)"
+        raise InvalidError(msg)
+
+    logs_timeout = config["logs_timeout"]
+
+    async with _run_app_init(
+        app,
+        client=client,
+        detach=detach,
+        environment_name=environment_name,
+        interactive=interactive,
+        grace=logs_timeout,
+    ) as ctx:
         logs_loop: Optional[asyncio.Task] = None
+        running_app = ctx.running_app
 
         if output_mgr is not None:
             # Defer import so this module is rich-safe
@@ -332,45 +431,24 @@ async def _run_app(
 
             # Start logs loop
 
-            logs_loop = tc.create_task(
-                get_app_logs_loop(client, output_mgr, app_id=running_app.app_id, app_logs_url=running_app.app_logs_url)
+            logs_loop = ctx.task_context.create_task(
+                get_app_logs_loop(ctx.client, output_mgr, app_id=ctx.app_id, app_logs_url=running_app.app_logs_url)
             )
 
-        try:
-            # Create all members
-            await _create_all_objects(client, running_app, app._functions, app._classes, environment_name)
-
-            # Publish the app
-            await _publish_app(client, running_app, app_state, app._functions, app._classes)
-        except asyncio.CancelledError as e:
+        @asynccontextmanager
+        async def on_cancel():
             # this typically happens on sigint/ctrl-C during setup (the KeyboardInterrupt happens in the main thread)
             if output_mgr := _get_output_manager():
                 output_mgr.print("Aborting app initialization...\n")
+            yield  # Allow disconnect to happen
 
-            await _status_based_disconnect(client, running_app.app_id, e)
-            raise
-        except BaseException as e:
-            await _status_based_disconnect(client, running_app.app_id, e)
-            raise
+        async with _disconnect_on_error(ctx.client, ctx.app_id, on_interrupt=on_cancel):
+            await _run_app_create(app, ctx)
 
-        try:
-            # Show logs from dynamically created images.
-            # TODO: better way to do this
-            if output_mgr := _get_output_manager():
-                output_mgr.enable_image_logs()
+        if detach:
 
-            # Yield to context
-            if output_mgr := _get_output_manager():
-                with output_mgr.show_status_spinner():
-                    yield app
-            else:
-                yield app
-            # successful completion!
-            heartbeat_loop.cancel()
-            await _status_based_disconnect(client, running_app.app_id, exc_info=None)
-        except KeyboardInterrupt as e:
-            # this happens only if sigint comes in during the yield block above
-            if detach:
+            @asynccontextmanager
+            async def on_interrupt():
                 if output_mgr := _get_output_manager():
                     output_mgr.print(output_mgr.step_completed("Shutting down Modal client."))
                     output_mgr.print(
@@ -380,13 +458,17 @@ async def _run_app(
                     )
                 if logs_loop:
                     logs_loop.cancel()
-                await _status_based_disconnect(client, running_app.app_id, e)
-            else:
+                yield  # Allow disconnect to happen
+
+        else:
+
+            @asynccontextmanager
+            async def on_interrupt():
                 if output_mgr := _get_output_manager():
                     output_mgr.print(
                         "Disconnecting from Modal - This will terminate your Modal app in a few seconds.\n"
                     )
-                await _status_based_disconnect(client, running_app.app_id, e)
+                yield  # Allow disconnect to happen
                 if logs_loop:
                     try:
                         await asyncio.wait_for(logs_loop, timeout=logs_timeout)
@@ -400,11 +482,19 @@ async def _run_app(
                             f"[grey70]View run at [underline]{running_app.app_page_url}[/underline][/grey70]"
                         )
                     )
-            return
-        except BaseException as e:
-            logger.info("Exception during app run")
-            await _status_based_disconnect(client, running_app.app_id, e)
-            raise
+
+        async with _disconnect_on_error(ctx.client, ctx.app_id, on_interrupt=on_interrupt):
+            # Show logs from dynamically created images.
+            # TODO: better way to do this
+            if output_mgr := _get_output_manager():
+                output_mgr.enable_image_logs()
+
+            # Yield to context
+            if output_mgr := _get_output_manager():
+                with output_mgr.show_status_spinner():
+                    yield app
+            else:
+                yield app
 
         # wait for logs gracefully, even though the task context would do the same
         # this allows us to log a more specific warning in case the app doesn't


### PR DESCRIPTION
## Describe your changes

This PR refactors the monolithic `_run_app` function into reusable components. The motivation is to decouple output management from core app lifecycle operations, to allow custom output implementations.

- [x] Modularized `_run_app` into three parts:
    - `_run_app_init`, which creates the `RunningApp`
    - `_run_app_create`, which calls `_create_all_objects` and `_publish_app`
    - `_disconnect_on_error`, which encapsulates error handling
- [ ] Add lifecycle hooks (callbacks) to allow complete separation of `OutputManager` from `_run_app`
- [x] Preserved behavior of `OutputManager`

It's hard to tell from the patch, but the core of the function is now this:

```python
@asynccontextmanager
async def _run_app(
    app: _App,
    *,
    client: Optional[_Client] = None,
    detach: bool = False,
    environment_name: Optional[str] = None,
) -> AsyncGenerator[_App, None]:
    grace = config['logs_timeout']

    async with _run_app_init(app, client, detach, environment_name, grace) as ctx:
        async with _disconnect_on_error(ctx.client, ctx.app_id):
            await _run_app_create(app, ctx)
            yield app
```

Next steps, to allow custom output management:
1. Make `_App._logs()` public, and have it include metadata (such as the file descriptor and task state).
2. Extract `OutputManager` from `_run_app`, by either:
    - Make `_run_app_init`, `_disconnect_on_error`, and `_run_app_create` public, so users can compose their own `run_app` variant, _or_
    - Add lifecycle hooks to the simplified function (shown above), and make an adaptor for `OutputManager` to use those

Unlike the current `App.run()` context manager, which doesn't yield until the containers have been build, this would allow the user to start tailing logs as soon as the `RunningApp` has been created.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

No protobuf changes.

---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
