### PR TITLE
Added client side support for image build_args

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -497,6 +497,7 @@ class _Image(_Object, type_prefix="im"):
         image_registry_config: Optional[_ImageRegistryConfig] = None,
         context_mount_function: Optional[Callable[[], Optional[_Mount]]] = None,
         force_build: bool = False,
+        build_args: dict[str, str] = {},
         # For internal use only.
         _namespace: "api_pb2.DeploymentNamespace.ValueType" = api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
         _do_assert_no_mount_layers: bool = True,
@@ -613,6 +614,7 @@ class _Image(_Object, type_prefix="im"):
                 runtime=config.get("function_runtime"),
                 runtime_debug=config.get("function_runtime_debug"),
                 build_function=_build_function,
+                build_args=build_args,
             )
 
             req = api_pb2.ImageGetOrCreateRequest(
@@ -1716,6 +1718,7 @@ class _Image(_Object, type_prefix="im"):
         secrets: Sequence[_Secret] = [],
         gpu: GPU_T = None,
         add_python: Optional[str] = None,
+        build_args: dict[str, str] = {},
         ignore: Union[Sequence[str], Callable[[Path], bool]] = AUTO_DOCKERIGNORE,
     ) -> "_Image":
         """Build a Modal image from a local Dockerfile.
@@ -1789,6 +1792,7 @@ class _Image(_Object, type_prefix="im"):
             ),
             gpu_config=gpu_config,
             secrets=secrets,
+            build_args=build_args,
         )
 
         # --- Now add in the modal dependencies, and, optionally a Python distribution


### PR DESCRIPTION
Added client side support for image build_args (equivalent of [--build-arg](https://docs.docker.com/reference/cli/docker/buildx/build/#build-arg))

[[WRK-932]](https://linear.app/modal-labs/issue/WRK-932/support-build-arg-in-builderrs)

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

- allows setting build-time variables for images created from Dockerfiles
- can pass in build_args map as an argument passed into `Image.from_dockerfile()`
- ex: Having the image be built from `alpine:latest` base image, instead of the default of `alpine:3`
```
ARG IMAGE_VERSION=3
FROM alpine:${IMAGE_VERSION}
```
```python
dockerfile_image = Image.from_dockerfile(dockerfile_path, build_args={"IMAGE_VERSION": "latest"}
```