### PR TITLE
Fix error message with serialized=True

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -731,7 +731,7 @@ class _App:
                         dedent(
                             """
                             The `@app.function` decorator must apply to functions in global scope,
-                            unless `serialize=True` is set.
+                            unless `serialized=True` is set.
                             If trying to apply additional decorators, they may need to use `functools.wraps`.
                             """
                         )


### PR DESCRIPTION
## Describe your changes

- Fixes error message for API to use `serialized=True`.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>
