### PR TITLE
Added protobuf definition for image build args

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1920,6 +1920,9 @@ message Image {
   bool runtime_debug = 20;
 
   BuildFunction build_function = 21;
+
+  // Build arguments for the image (--build-arg) for ARG substitution in Dockerfile.
+  map<string, string> build_args = 22;
 }
 
 message ImageContextFile {


### PR DESCRIPTION
Addition protobuf to support image build_args (equivalent of [--build-arg](https://docs.docker.com/reference/cli/docker/buildx/build/#build-arg))

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [X] Client+Server: this change is compatible with old servers
- [X] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

- added `build_args` to `Image` in api.proto
