### PR TITLE
Increase concurrency of blob uploads/downloads

### DIFF
--- a/modal/_utils/blob_utils.py
+++ b/modal/_utils/blob_utils.py
@@ -46,7 +46,7 @@ MAX_ASYNC_OBJECT_SIZE_BYTES = 8 * 1024  # 8 KiB
 LARGE_FILE_LIMIT = 4 * 1024 * 1024  # 4 MiB
 
 # Max parallelism during map calls
-BLOB_MAX_PARALLELISM = 10
+BLOB_MAX_PARALLELISM = 20
 
 # read ~16MiB chunks by default
 DEFAULT_SEGMENT_CHUNK_SIZE = 2**24


### PR DESCRIPTION
This increases the concurrency with which we upload and download blobs from 10 to 20. 

This is in response to a user issue where the overall runtime of a map operation was limited by the speed of blob downloads. The server will reject requests if it has more than 100 outputs waiting to be consumed. In this case, the rate at which inputs were sent and processed was much higher than the rate the large outputs could be downloaded. The quicker we download outputs, the quicker we can send more inputs.

Trying out the change on my dev box, the total runtime of [this starmap script](https://gist.github.com/rculbertson/3b0e9e18ffd80f4881ddccf4f49a38db) went from ~4 min to ~2 min. 

This will have a positive impact only if you have enough bandwidth of course. Running the same script on my laptop, I saw no performance bump because I'm already at my max throughput apparently.

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
