### PR TITLE
Add FlashContainerList RPC

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1246,8 +1246,21 @@ message FlashContainerDeregisterRequest {
   string service_name = 1;
 }
 
+message FlashContainerListRequest {
+  string function_id = 1;
+}
+
+message FlashContainerListResponse {
+  message Container {
+    string task_id = 1;
+    string host = 2;
+    uint32 port = 3;
+  }
+  repeated Container containers = 1;
+}
+
 message FlashContainerRegisterRequest {
-  string service_name = 1;
+  string service_name = 1;  // not used?
   uint32 priority = 2;
   uint32 weight = 3;
   string host = 4;
@@ -3294,6 +3307,7 @@ service ModalClient {
 
   // Modal Flash (experimental)
   rpc FlashContainerDeregister(FlashContainerDeregisterRequest) returns (google.protobuf.Empty);
+  rpc FlashContainerList(FlashContainerListRequest) returns (FlashContainerListResponse);
   rpc FlashContainerRegister(FlashContainerRegisterRequest) returns (FlashContainerRegisterResponse);
 
   // Functions


### PR DESCRIPTION
The FlashContainerList RPC lists all Modal Flash containers for the Modal Flash endpoint associated with a particular function ID. We will need this for autoscaling.

I am not sure if it makes the most sense to look up flash containers by function ID. We can revisit this in the future. I kept it this way for now because we need to somehow figure out which Flash region to query.