### PR TITLE
Edit proto for filter by sandbox ID

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -360,6 +360,7 @@ message AppGetLogsRequest {
   string task_id = 7;
   string function_call_id = 9;
   FileDescriptor file_descriptor = 8;
+  string sandbox_id = 10;
 }
 
 message AppGetObjectsItem {


### PR DESCRIPTION
## Describe your changes

- Part of Linear issue PRD-926
- Add `sandbox_id` field to `AppGetLogsRequest` proto message
- Enables filtering logs by sandbox_id in relevant log RPCs