### PR TITLE
Update micromamba base image tag for next builder version

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -1450,8 +1450,7 @@ class _Image(_Object, type_prefix="im"):
                 python_version = "3.9"  # Backcompat for old hardcoded default param
             validated_python_version = _validate_python_version(python_version, version)
             micromamba_version = _base_image_config("micromamba", version)
-            debian_codename = _base_image_config("debian", version)
-            tag = f"mambaorg/micromamba:{micromamba_version}-{debian_codename}-slim"
+            tag = f"mambaorg/micromamba:{micromamba_version}"
             setup_commands = [
                 'SHELL ["/usr/local/bin/_dockerfile_shell.sh"]',
                 "ENV MAMBA_DOCKERFILE_ACTIVATE=1",

--- a/modal/requirements/base-images.json
+++ b/modal/requirements/base-images.json
@@ -34,10 +34,10 @@
         ]
     },
     "micromamba": {
-        "PREVIEW": "2.1.1",
-        "2024.10": "1.5.10",
-        "2024.04": "1.5.8",
-        "2023.12": "1.3.1"
+        "PREVIEW": "2.1.1-debian12-slim",
+        "2024.10": "1.5.10-bookworm-slim",
+        "2024.04": "1.5.8-bookworm-slim",
+        "2023.12": "1.3.1-bullseye-slim"
     },
     "package_tools": {
         "PREVIEW": "pip wheel uv",


### PR DESCRIPTION
The [micromamba docker images](https://hub.docker.com/r/mambaorg/micromamba) appear to have changed their naming scheme since the last image builder update. Previously they used Debian "codenames" but more recent tags have numeric debian versions. That means we need to change the way we store versioned micromamba base images.

Closes CLI-459