### PR TITLE
Warn when non-python files are included in auto-mounted function source package

### DIFF
--- a/modal/_utils/function_utils.py
+++ b/modal/_utils/function_utils.py
@@ -343,7 +343,7 @@ class FunctionInfo:
                         file_list += f"\n...(and {num_files - 3} others)"
                     deprecation_warning(
                         (2025, 6, 7),
-                        f"There are non-python files in function package mount for `{self.function_name}`.\n"
+                        f"There are non-python files in Function package for `{self.function_name}`.\n"
                         "Starting in Modal 1.2, these will no longer be included by default and will need to be "
                         "included through Image.add_local_file or similar:\n"
                         f"{file_list}\n\n",


### PR DESCRIPTION
This was originally intended to go into 1.0 but ended up not getting in :(

Need to figure out a good way for user to mute this warning (and add that technique as a suggestion in the deprecation warning)
* Just adding the files with .add_local will note mute it (messy to implement that, and you don't always *want* to include all the files)
* Setting include_source=False will mute it, but will also require the package to be explicitly mounted on the image - maybe this is acceptable? (e.g. `image = some_image.add_local_python_source("mypak")`)
* Adding an env var feels too blunt since it would mute the same warning for other functions/apps making it hide potential bugs for the eventual 1.2 upgrade
* Adding another @function decorator option similar to `include_source` for changing this particular mount behavior is an option, but an ugly one

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

This should be included in the minor release 1.1.

---

</details>

## Changelog

* Adds a deprecation warning if a function sourced in "module mode" (`modal deploy -m`) would include non-python files. Starting in Modal 1.2, Modal will no longer include non-python files in the automatically added package, and those would have to be explicitly included using `Image.add_local_file()` etc.