### PR TITLE
Adds `modal.Sandbox.reload_volumes` method

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -538,6 +538,16 @@ class _Sandbox(_Object, type_prefix="sb"):
 
         return self._tunnels
 
+    async def reload_volumes(self) -> None:
+        """Reload all Volumes mounted in the Sandbox."""
+        task_id = await self._get_task_id()
+        await retry_transient_errors(
+            self._client.stub.ContainerReloadVolumes,
+            api_pb2.ContainerReloadVolumesRequest(
+                task_id=task_id,
+            ),
+        )
+
     async def terminate(self) -> None:
         """Terminate Sandbox execution.
 


### PR DESCRIPTION
## Describe your changes

- Part of SPR-137 

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers

---

</details>

## Changelog

* Added a [`modal.Sandbox.reload_volumes`](https://modal.com/docs/reference/modal.Sandbox#reload_volumes) method, which triggers a reload of all volumes currently mounted inside a Sandbox, allowing sandboxes to sync any concurrent updates to Volumes they have mounted.