### PR TITLE
Measure Throughput Instead

### DIFF
--- a/modal/_utils/function_utils.py
+++ b/modal/_utils/function_utils.py
@@ -550,7 +550,7 @@ async def _create_input(
     args_serialized = serialize((args, kwargs))
 
     if should_upload(len(args_serialized), max_object_size_bytes, function_call_invocation_type):
-        args_blob_id, r2_failed, r2_latency_ms = await blob_upload_with_r2_failure_info(args_serialized, stub)
+        args_blob_id, r2_failed, r2_throughput_bytes_s = await blob_upload_with_r2_failure_info(args_serialized, stub)
         return api_pb2.FunctionPutInputsItem(
             input=api_pb2.FunctionInput(
                 args_blob_id=args_blob_id,
@@ -559,7 +559,7 @@ async def _create_input(
             ),
             idx=idx,
             r2_failed=r2_failed,
-            r2_latency_ms=r2_latency_ms,
+            r2_throughput_bytes_s=r2_throughput_bytes_s,
         )
     else:
         return api_pb2.FunctionPutInputsItem(

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1801,7 +1801,8 @@ message FunctionPutInputsItem {
   int32 idx = 1;
   FunctionInput input = 2;
   bool r2_failed = 3;
-  uint64 r2_latency_ms = 4;
+  reserved 4; // r2_latency_ms
+  uint64 r2_throughput_bytes_s = 5;
 }
 
 message FunctionPutInputsRequest {


### PR DESCRIPTION
This provides a way for the client to signal R2's health.