### PR TITLE
[SpawnMapV2](1) Introduce Experimental Spawn Map To The API

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -71,6 +71,8 @@ from .mount import _get_client_mount, _Mount
 from .network_file_system import _NetworkFileSystem, network_file_system_mount_protos
 from .output import _get_output_manager
 from .parallel_map import (
+    _experimental_spawn_map_async,
+    _experimental_spawn_map_sync,
     _for_each_async,
     _for_each_sync,
     _map_async,
@@ -78,6 +80,7 @@ from .parallel_map import (
     _map_invocation_inputplane,
     _map_sync,
     _spawn_map_async,
+    _spawn_map_invocation,
     _spawn_map_sync,
     _starmap_async,
     _starmap_sync,
@@ -1543,6 +1546,19 @@ Use the `Function.get_web_url()` method instead.
                 async for item in stream:
                     yield item
 
+    @live_method
+    async def _spawn_map(self, input_queue: _SynchronizedQueue) -> "_FunctionCall":
+        self._check_no_web_url("map")
+        if self._is_generator:
+            raise InvalidError("A generator function cannot be called with `.spawn_map(...)`.")
+
+        assert self._function_name
+        return await _spawn_map_invocation(
+            self,
+            input_queue,
+            self.client,
+        )
+
     async def _call_function(self, args, kwargs) -> ReturnType:
         invocation: Union[_Invocation, _InputPlaneInvocation]
         if self._input_plane_url:
@@ -1789,6 +1805,7 @@ Use the `Function.get_web_url()` method instead.
     starmap = MethodWithAio(_starmap_sync, _starmap_async, synchronizer)
     for_each = MethodWithAio(_for_each_sync, _for_each_async, synchronizer)
     spawn_map = MethodWithAio(_spawn_map_sync, _spawn_map_async, synchronizer)
+    experimental_spawn_map = MethodWithAio(_experimental_spawn_map_sync, _experimental_spawn_map_async, synchronizer)
 
 
 class _FunctionCall(typing.Generic[ReturnType], _Object, type_prefix="fc"):

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1547,17 +1547,19 @@ Use the `Function.get_web_url()` method instead.
                     yield item
 
     @live_method
-    async def _spawn_map(self, input_queue: _SynchronizedQueue) -> "_FunctionCall":
+    async def _spawn_map(self, input_queue: _SynchronizedQueue) -> "_FunctionCall[ReturnType]":
         self._check_no_web_url("spawn_map")
         if self._is_generator:
             raise InvalidError("A generator function cannot be called with `.spawn_map(...)`.")
 
         assert self._function_name
-        return await _spawn_map_invocation(
+        function_call_id = await _spawn_map_invocation(
             self,
             input_queue,
             self.client,
         )
+        fc: _FunctionCall[ReturnType] = _FunctionCall._new_hydrated(function_call_id, self.client, None)
+        return fc
 
     async def _call_function(self, args, kwargs) -> ReturnType:
         invocation: Union[_Invocation, _InputPlaneInvocation]

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1548,7 +1548,7 @@ Use the `Function.get_web_url()` method instead.
 
     @live_method
     async def _spawn_map(self, input_queue: _SynchronizedQueue) -> "_FunctionCall":
-        self._check_no_web_url("map")
+        self._check_no_web_url("spawn_map")
         if self._is_generator:
             raise InvalidError("A generator function cannot be called with `.spawn_map(...)`.")
 

--- a/modal/parallel_map.py
+++ b/modal/parallel_map.py
@@ -260,6 +260,89 @@ class SyncInputPumper(InputPumper):
         yield
 
 
+class AsyncInputPumper(InputPumper):
+    def __init__(
+        self,
+        client: "modal.client._Client",
+        *,
+        input_queue: asyncio.Queue,
+        function: "modal.functions._Function",
+        function_call_id: str,
+    ):
+        super().__init__(client, input_queue=input_queue, function=function, function_call_id=function_call_id)
+
+
+async def _spawn_map_invocation(
+    function: "modal.functions._Function", raw_input_queue: _SynchronizedQueue, client: "modal.client._Client"
+) -> "modal.functions._FunctionCall":
+    assert client.stub
+    request = api_pb2.FunctionMapRequest(
+        function_id=function.object_id,
+        parent_input_id=current_input_id() or "",
+        function_call_type=api_pb2.FUNCTION_CALL_TYPE_MAP,
+        function_call_invocation_type=api_pb2.FUNCTION_CALL_INVOCATION_TYPE_ASYNC,
+    )
+    response: api_pb2.FunctionMapResponse = await retry_transient_errors(client.stub.FunctionMap, request)
+    function_call_id = response.function_call_id
+
+    have_all_inputs = False
+    inputs_created = 0
+
+    def set_inputs_created(set_inputs_created):
+        nonlocal inputs_created
+        assert set_inputs_created is None or set_inputs_created > inputs_created
+        inputs_created = set_inputs_created
+
+    def set_have_all_inputs():
+        nonlocal have_all_inputs
+        have_all_inputs = True
+
+    input_queue: asyncio.Queue[api_pb2.FunctionPutInputsItem | None] = asyncio.Queue()
+    input_preprocessor = InputPreprocessor(
+        client=client,
+        raw_input_queue=raw_input_queue,
+        processed_input_queue=input_queue,
+        function=function,
+        created_callback=set_inputs_created,
+        done_callback=set_have_all_inputs,
+    )
+
+    input_pumper = AsyncInputPumper(
+        client=client,
+        input_queue=input_queue,
+        function=function,
+        function_call_id=function_call_id,
+    )
+
+    def log_stats():
+        logger.debug(
+            f"have_all_inputs={have_all_inputs} inputs_created={inputs_created} inputs_sent={input_pumper.inputs_sent} "
+        )
+
+    async def log_task():
+        while True:
+            log_stats()
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                # Log final stats before exiting
+                log_stats()
+                break
+
+    async def consume_generator(gen):
+        async for _ in gen:
+            pass
+
+    log_debug_stats_task = asyncio.create_task(log_task())
+    await asyncio.gather(
+        consume_generator(input_preprocessor.drain_input_generator()),
+        consume_generator(input_pumper.pump_inputs()),
+    )
+    log_debug_stats_task.cancel()
+    await log_debug_stats_task
+    return await modal.functions._FunctionCall.from_id(function_call_id, client)
+
+
 async def _map_invocation(
     function: "modal.functions._Function",
     raw_input_queue: _SynchronizedQueue,
@@ -1060,6 +1143,54 @@ def _map_sync(
         nested_async_message=(
             "You can't iter(Function.map()) from an async function. Use async for ... in Function.map.aio() instead."
         ),
+    )
+
+
+async def _experimental_spawn_map_async(self, *input_iterators, kwargs={}) -> "modal.functions._FunctionCall":
+    async_input_gen = async_zip(*[sync_or_async_iter(it) for it in input_iterators])
+    return await _spawn_map_helper(self, async_input_gen, kwargs)
+
+
+async def _spawn_map_helper(
+    self: "modal.functions.Function", async_input_gen, kwargs={}
+) -> "modal.functions._FunctionCall":
+    raw_input_queue: Any = SynchronizedQueue()  # type: ignore
+    await raw_input_queue.init.aio()
+
+    async def feed_queue():
+        async with aclosing(async_input_gen) as streamer:
+            async for args in streamer:
+                await raw_input_queue.put.aio((args, kwargs))
+        await raw_input_queue.put.aio(None)  # end-of-input sentinel
+
+    fc, _ = await asyncio.gather(self._spawn_map.aio(raw_input_queue), feed_queue())
+    return fc
+
+
+def _experimental_spawn_map_sync(self, *input_iterators, kwargs={}) -> "modal.functions._FunctionCall":
+    """Spawn parallel execution over a set of inputs, exiting as soon as the inputs are created (without waiting
+    for the map to complete).
+
+    Takes one iterator argument per argument in the function being mapped over.
+
+    Example:
+    ```python
+    @app.function()
+    def my_func(a):
+        return a ** 2
+
+
+    @app.local_entrypoint()
+    def main():
+        fc = my_func.spawn_map([1, 2, 3, 4])
+    ```
+
+    Returns a FunctionCall object that can be used to retrieve results
+    """
+
+    return run_coroutine_in_temporary_event_loop(
+        _experimental_spawn_map_async(self, *input_iterators, kwargs=kwargs),
+        "You can't run Function.spawn_map() from an async function. Use Function.spawn_map.aio() instead.",
     )
 
 

--- a/modal/parallel_map.py
+++ b/modal/parallel_map.py
@@ -274,7 +274,7 @@ class AsyncInputPumper(InputPumper):
 
 async def _spawn_map_invocation(
     function: "modal.functions._Function", raw_input_queue: _SynchronizedQueue, client: "modal.client._Client"
-) -> "modal.functions._FunctionCall":
+) -> str:
     assert client.stub
     request = api_pb2.FunctionMapRequest(
         function_id=function.object_id,
@@ -340,7 +340,7 @@ async def _spawn_map_invocation(
     )
     log_debug_stats_task.cancel()
     await log_debug_stats_task
-    return await modal.functions._FunctionCall.from_id(function_call_id, client)
+    return function_call_id
 
 
 async def _map_invocation(

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -1203,11 +1203,12 @@ def test_experimental_spawn_map_sync(client, servicer):
     dummy_function = app.function()(dummy)
     with servicer.intercept() as ctx:
         with app.run(client=client):
-            dummy_function.experimental_spawn_map([1, 2, 3])
+            fc = dummy_function.experimental_spawn_map([1, 2, 3])
 
         # Verify the correct invocation type was used
         function_put_inputs = ctx.pop_request("FunctionPutInputs")
         assert function_put_inputs is not None
+        assert type(fc) is modal.FunctionCall
 
 
 def test_warn_on_local_volume_mount(client, servicer):

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -1199,6 +1199,17 @@ def test_spawn_map_sync(client, servicer):
         assert deserialize(function_map.pipelined_inputs[0].input.args, client) == ((1,), {})
 
 
+def test_experimental_spawn_map_sync(client, servicer):
+    dummy_function = app.function()(dummy)
+    with servicer.intercept() as ctx:
+        with app.run(client=client):
+            dummy_function.experimental_spawn_map([1, 2, 3])
+
+        # Verify the correct invocation type was used
+        function_put_inputs = ctx.pop_request("FunctionPutInputs")
+        assert function_put_inputs is not None
+
+
 def test_warn_on_local_volume_mount(client, servicer):
     vol = modal.Volume.from_name("my-vol")
     dummy_function = app.function(volumes={"/foo": vol})(dummy)


### PR DESCRIPTION
This PR introduces `experimental_spawn_map` which is equivalent to `spawn_map` except in the backend it is a single function call invocation. It also return a `FunctionCall` handler instead of `None`. Follow-up PRs will add more functionality to the `FunctionCall` handler such as `.get(index)` and an iterator. 