### PR TITLE
Added container exec timeout logic

### DIFF
--- a/modal/container_process.py
+++ b/modal/container_process.py
@@ -131,7 +131,7 @@ class _ContainerProcess(Generic[T]):
                 timeout = self._exec_deadline - time.monotonic()
                 if timeout <= 0:
                     raise TimeoutError()
-                self._returncode = await asyncio.wait_for(self._wait_for_completion(), timeout=timeout)
+            self._returncode = await asyncio.wait_for(self._wait_for_completion(), timeout=timeout)
         except (asyncio.TimeoutError, TimeoutError):
             self._returncode = -1
         return self._returncode

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -2,6 +2,7 @@
 import asyncio
 import os
 from collections.abc import AsyncGenerator, Sequence
+from datetime import datetime
 from typing import TYPE_CHECKING, AsyncIterator, Literal, Optional, Union, overload
 
 if TYPE_CHECKING:
@@ -655,7 +656,16 @@ class _Sandbox(_Object, type_prefix="sb"):
         )
         resp = await retry_transient_errors(self._client.stub.ContainerExec, req)
         by_line = bufsize == 1
-        return _ContainerProcess(resp.exec_id, self._client, stdout=stdout, stderr=stderr, text=text, by_line=by_line)
+        return _ContainerProcess(
+            resp.exec_id,
+            self._client,
+            stdout=stdout,
+            stderr=stderr,
+            text=text,
+            timeout_secs=timeout,
+            exec_start=datetime.now(),
+            by_line=by_line,
+        )
 
     async def _experimental_snapshot(self) -> _SandboxSnapshot:
         await self._get_task_id()

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -660,7 +660,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         )
         resp = await retry_transient_errors(self._client.stub.ContainerExec, req)
         by_line = bufsize == 1
-        exec_deadline = time.monotonic() + timeout + CONTAINER_EXEC_TIMEOUT_BUFFER if timeout else None
+        exec_deadline = time.monotonic() + int(timeout) + CONTAINER_EXEC_TIMEOUT_BUFFER if timeout else None
         return _ContainerProcess(
             resp.exec_id,
             self._client,

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -52,7 +52,7 @@ ARG_MAX_BYTES = 2**16
 
 
 # This buffer extends the user-supplied timeout on ContainerExec-related RPCs. This was introduced to
-# (hopefully) allow any in-flight status codes/IO data to reach the client before the stream is closed.
+# give any in-flight status codes/IO data more time to reach the client before the stream is closed.
 CONTAINER_EXEC_TIMEOUT_BUFFER = 5
 if TYPE_CHECKING:
     import modal.app

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -1,8 +1,8 @@
 # Copyright Modal Labs 2022
 import asyncio
 import os
+import time
 from collections.abc import AsyncGenerator, Sequence
-from datetime import datetime
 from typing import TYPE_CHECKING, AsyncIterator, Literal, Optional, Union, overload
 
 if TYPE_CHECKING:
@@ -656,14 +656,14 @@ class _Sandbox(_Object, type_prefix="sb"):
         )
         resp = await retry_transient_errors(self._client.stub.ContainerExec, req)
         by_line = bufsize == 1
+        exec_deadline = time.monotonic() + timeout if timeout else None
         return _ContainerProcess(
             resp.exec_id,
             self._client,
             stdout=stdout,
             stderr=stderr,
             text=text,
-            timeout_secs=timeout,
-            exec_start=datetime.now(),
+            exec_deadline=exec_deadline,
             by_line=by_line,
         )
 

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -51,11 +51,9 @@ _default_image: _Image = _Image.debian_slim()
 ARG_MAX_BYTES = 2**16
 
 
-# A user-supplied timeout of n seconds on a ContainerExec will be extended by this buffer.
-# This is introduced to minimize the effects of a race condition between the Sandbox.exec timeout
-# handler on the client side and the receiving of server RPCs carrying status codes or IO data.
+# This buffer extends the user-supplied timeout on ContainerExec-related RPCs. This was introduced to
+# (hopefully) allow any in-flight status codes/IO data to reach the client before the stream is closed.
 CONTAINER_EXEC_TIMEOUT_BUFFER = 5
-
 if TYPE_CHECKING:
     import modal.app
 

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -315,7 +315,7 @@ def test_sandbox_exec_wait(app, servicer):
 def test_sandbox_exec_wait_timeout(app, servicer):
     sb = Sandbox.create("sleep", "infinity", app=app)
 
-    cp = sb.exec("sleep", "inf", timeout=1)
+    cp = sb.exec("sleep", "999", timeout=1)
     t0 = time.monotonic()
     assert cp.wait() == -1
     assert 1 < time.monotonic() - t0 <= 1.2
@@ -326,7 +326,7 @@ def test_sandbox_exec_wait_timeout(app, servicer):
 def test_sandbox_exec_poll_timeout(app, servicer):
     sb = Sandbox.create("sleep", "infinity", app=app)
 
-    cp = sb.exec("sleep", "inf", timeout=1)
+    cp = sb.exec("sleep", "999", timeout=1)
     assert not cp.poll()
     time.sleep(1.2)
     assert cp.poll() == -1

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -310,6 +310,25 @@ def test_sandbox_exec_wait(app, servicer):
 
 
 @skip_non_subprocess
+def test_sandbox_exec_wait_timeout(app, servicer):
+    sb = Sandbox.create("sleep", "infinity", app=app)
+
+    cp = sb.exec("sleep", "20", timeout=3)
+    t0 = time.monotonic()
+    assert cp.wait() == -1
+    assert 3 <= time.monotonic() - t0 <= 3 + 0.2
+
+
+@skip_non_subprocess
+def test_sandbox_exec_poll_timeout(app, servicer):
+    sb = Sandbox.create("sleep", "infinity", app=app)
+
+    cp = sb.exec("sleep", "10", timeout=3)
+    time.sleep(5)
+    assert cp.poll() == -1
+
+
+@skip_non_subprocess
 def test_sandbox_create_and_exec_with_bad_args(app, servicer):
     too_big = 130_000
     single_arg_size = too_big // 10

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -313,18 +313,19 @@ def test_sandbox_exec_wait(app, servicer):
 def test_sandbox_exec_wait_timeout(app, servicer):
     sb = Sandbox.create("sleep", "infinity", app=app)
 
-    cp = sb.exec("sleep", "20", timeout=3)
+    cp = sb.exec("sleep", "inf", timeout=1)
     t0 = time.monotonic()
     assert cp.wait() == -1
-    assert 3 <= time.monotonic() - t0 <= 3 + 0.2
+    assert 1 < time.monotonic() - t0 <= 1.2
 
 
 @skip_non_subprocess
 def test_sandbox_exec_poll_timeout(app, servicer):
     sb = Sandbox.create("sleep", "infinity", app=app)
 
-    cp = sb.exec("sleep", "10", timeout=3)
-    time.sleep(5)
+    cp = sb.exec("sleep", "inf", timeout=1)
+    assert not cp.poll()
+    time.sleep(1.2)
     assert cp.poll() == -1
 
 

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -4,6 +4,7 @@ import hashlib
 import pytest
 import time
 from pathlib import Path
+from unittest import mock
 
 from modal import App, Image, NetworkFileSystem, Proxy, Sandbox, SandboxSnapshot, Secret, Volume
 from modal.exception import InvalidError
@@ -309,6 +310,7 @@ def test_sandbox_exec_wait(app, servicer):
     assert cp.poll() == 42
 
 
+@mock.patch("modal.sandbox.CONTAINER_EXEC_TIMEOUT_BUFFER", 0)
 @skip_non_subprocess
 def test_sandbox_exec_wait_timeout(app, servicer):
     sb = Sandbox.create("sleep", "infinity", app=app)
@@ -319,6 +321,7 @@ def test_sandbox_exec_wait_timeout(app, servicer):
     assert 1 < time.monotonic() - t0 <= 1.2
 
 
+@mock.patch("modal.sandbox.CONTAINER_EXEC_TIMEOUT_BUFFER", 0)
 @skip_non_subprocess
 def test_sandbox_exec_poll_timeout(app, servicer):
     sb = Sandbox.create("sleep", "infinity", app=app)


### PR DESCRIPTION
Introduce a client-side timer to ensure that the Sandbox.exec timeout parameter is respected. The timer begins right after `ContainerExecRequest` is sent to the server, and is checked within Sandbox `.wait` and `.poll` right before the `ContainerExecWaitRequest` RPC.

Context:
* User was experiencing sandbox exec hanging indefinitely ([context](https://modal-com.slack.com/archives/C07JNJMJPQC/p1751923161013099))
* See design discussion [here](https://modal-com.slack.com/archives/C07JNJMJPQC/p1752077999250329)

## Changelog
* Fixes a bug where the specified timeout for a `Sandbox.exec` is not respected by `wait()` or `poll()`.