### PR TITLE
reload_volumes() accepts volume_ids

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -538,13 +538,17 @@ class _Sandbox(_Object, type_prefix="sb"):
 
         return self._tunnels
 
-    async def reload_volumes(self) -> None:
-        """Reload all Volumes mounted in the Sandbox."""
+    async def reload_volumes(self, volume_ids: list[str] | None = None) -> None:
+        """Reloads volumes mounted in the Sandbox.
+
+        If `volume_ids` is provided, only reloads the specified volumes, otherwise reloads all volumes.
+        """
         task_id = await self._get_task_id()
         await retry_transient_errors(
             self._client.stub.ContainerReloadVolumes,
             api_pb2.ContainerReloadVolumesRequest(
                 task_id=task_id,
+                volume_ids=volume_ids,
             ),
         )
 

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -538,12 +538,13 @@ class _Sandbox(_Object, type_prefix="sb"):
 
         return self._tunnels
 
-    async def reload_volumes(self, volume_ids: list[str] | None = None) -> None:
+    async def reload_volumes(self, volumes: list[_Volume] | None = None) -> None:
         """Reloads volumes mounted in the Sandbox.
 
-        If `volume_ids` is provided, only reloads the specified volumes, otherwise reloads all volumes.
+        If `volumes` is provided, only reloads the specified volumes, otherwise reloads all volumes.
         """
         task_id = await self._get_task_id()
+        volume_ids = [volume.object_id for volume in volumes] if volumes else None
         await retry_transient_errors(
             self._client.stub.ContainerReloadVolumes,
             api_pb2.ContainerReloadVolumesRequest(

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1017,6 +1017,7 @@ message ContainerLogRequest {
 
 message ContainerReloadVolumesRequest {
   string task_id = 1;
+  repeated string volume_ids = 2;
 }
 
 message ContainerReloadVolumesResponse { }


### PR DESCRIPTION
## Describe your changes
Adds optional `volume_ids` to `modal.Sandbox.reload_volumes`
- PRD-957

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [X] Client+Server: this change is compatible with old servers
- [X] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

---

</details>

## Changelog

* `modal.Sandbox.reload_volumes` accepts `volume_ids` to reload specific volumes. All volumes are reloaded if not specified.