### PR TITLE
Add basic experimental public interface for getting App layout

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -508,22 +508,38 @@ class _App:
 
     @property
     def registered_functions(self) -> dict[str, _Function]:
-        """All modal.Function objects registered on the app."""
+        """All modal.Function objects registered on the app.
+
+        Note: this property is populated only during the build phase, and it is not
+        expected to work when a deplyoed App has been retrieved via `modal.App.lookup`.
+        """
         return self._functions
 
     @property
     def registered_classes(self) -> dict[str, _Cls]:
-        """All modal.Cls objects registered on the app."""
+        """All modal.Cls objects registered on the app.
+
+        Note: this property is populated only during the build phase, and it is not
+        expected to work when a deplyoed App has been retrieved via `modal.App.lookup`.
+        """
         return self._classes
 
     @property
     def registered_entrypoints(self) -> dict[str, _LocalEntrypoint]:
-        """All local CLI entrypoints registered on the app."""
+        """All local CLI entrypoints registered on the app.
+
+        Note: this property is populated only during the build phase, and it is not
+        expected to work when a deplyoed App has been retrieved via `modal.App.lookup`.
+        """
         return self._local_entrypoints
 
     @property
     def registered_web_endpoints(self) -> list[str]:
-        """Names of web endpoint (ie. webhook) functions registered on the app."""
+        """Names of web endpoint (ie. webhook) functions registered on the app.
+
+        Note: this property is populated only during the build phase, and it is not
+        expected to work when a deplyoed App has been retrieved via `modal.App.lookup`.
+        """
         return self._web_endpoints
 
     def local_entrypoint(

--- a/test/experimental_test.py
+++ b/test/experimental_test.py
@@ -4,7 +4,6 @@ from typing import Union, cast
 
 import modal
 import modal.experimental
-import modal.runner
 from modal.exception import DeprecationError
 
 app = modal.App(include_source=False)
@@ -53,7 +52,7 @@ def test_update_autoscaler(client, servicer, which):
 
 @pytest.mark.parametrize("which", ["function", "cls"])
 def test_update_autoscaler_after_lookup(client, servicer, which):
-    modal.runner.deploy_app(app, name="test", client=client)
+    app.deploy(name="test", client=client)
 
     overrides = {
         "min_containers": 1,
@@ -81,3 +80,11 @@ def test_update_autoscaler_after_lookup(client, servicer, which):
     assert settings.max_containers == overrides["max_containers"]
     assert settings.buffer_containers == overrides["buffer_containers"]
     assert settings.scaledown_window == overrides["scaledown_window"]
+
+
+def test_app_get_objects(client, servicer):
+    app.deploy(name="test", environment_name="dev", client=client)
+    res = modal.experimental.get_app_objects("test", environment_name="dev", client=client)
+    assert res.keys() == {"C", "f"}
+    assert isinstance(res["C"], modal.Cls)
+    assert isinstance(res["f"], modal.Function)


### PR DESCRIPTION
This is a useful feature to expose, but there are some complicated reasons why we can't implement the desired stable API right now, so this adds it as an experimental function with a provisional API:

```python
>>> modal.experimental.get_app_objects("my-app")
{"MyClass": modal.Cls.from_name("my-app", "MyClass"), "f": modal.Function.from_name("my-app", "f")}
```

Closes CLI-501
