### PR TITLE
Make Function.from_name repr have string arguments

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1282,7 +1282,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
 
             self._hydrate(response.function_id, resolver.client, response.handle_metadata)
 
-        rep = f"Function.from_name({app_name}, {name})"
+        rep = f"Function.from_name('{app_name}', '{name}')"
         return cls._from_loader(_load_remote, rep, is_another_app=True, hydrate_lazily=True)
 
     @classmethod


### PR DESCRIPTION
Noticed this minor blemish:

```python
$ python from_name_oops.py
Cls.from_name('synthetic-traffic', 'Server')
Function.from_name(synthetic-traffic, trigger)
```