### PR TITLE
Adds `enable_gpu_snapshot` to proto definition

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1444,6 +1444,8 @@ message Function {
 
   repeated string flash_service_urls = 83;
   string flash_service_label = 84;
+
+  bool enable_gpu_snapshot = 84; // GPU memory snapshotting (alpha)
 }
 
 message FunctionAsyncInvokeRequest {


### PR DESCRIPTION
We are moving GPU memory snapshots from experimental to alpha. I am renaming the flag from `_experimental_enable_gpu_snapshot` to `enable_gpu_snapshot` to promote the interface. I am first making a proto change to add backend support and will update the client interface after. 