### PR TITLE
Allow Modal Cls functions to get i6pn addresses

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -863,6 +863,7 @@ class _App:
         # Limits the number of inputs a container handles before shutting down.
         # Use `max_inputs = 1` for single-use containers.
         max_inputs: Optional[int] = None,
+        i6pn: Optional[bool] = None,  # Whether to enable IPv6 container networking within the region.
         include_source: Optional[bool] = None,  # When `False`, don't automatically add the App source to the container.
         experimental_options: Optional[dict[str, Any]] = None,
         # Parameters below here are experimental. Use with caution!
@@ -977,6 +978,7 @@ class _App:
                 restrict_modal_access=restrict_modal_access,
                 max_inputs=max_inputs,
                 scheduler_placement=scheduler_placement,
+                i6pn_enabled=i6pn or False,
                 include_source=include_source if include_source is not None else self._include_source_default,
                 experimental_options={k: str(v) for k, v in (experimental_options or {}).items()},
                 _experimental_proxy_ip=_experimental_proxy_ip,


### PR DESCRIPTION
## Describe your changes

This extends i6pn support to Cls so users with lifecycle hooks can use i6pn.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [x] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [x] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

- Allows i6pn configuration for Modal Classes