### PR TITLE
support Sandbox Names

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -73,13 +73,12 @@ def _validate_exec_args(entrypoint_args: Sequence[str]) -> None:
         )
 
 
-"""
-This is a singleton class that represents the default sandbox name override.
-It is used to indicate that the sandbox name should not be overridden.
-"""
-
-
 class DefaultSandboxNameOverride:
+    """
+    This is a singleton class that represents the default sandbox name override.
+    It is used to indicate that the sandbox name should not be overridden.
+    """
+
     def __repr__(self) -> str:
         return "DefaultSandboxNameOverride"
 

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -74,8 +74,8 @@ def _validate_exec_args(entrypoint_args: Sequence[str]) -> None:
 
 
 class DefaultSandboxNameOverride:
-    """
-    This is a singleton class that represents the default sandbox name override.
+    """A singleton class that represents the default sandbox name override.
+
     It is used to indicate that the sandbox name should not be overridden.
     """
 
@@ -472,10 +472,10 @@ class _Sandbox(_Object, type_prefix="sb"):
         environment_name: Optional[str] = None,
         client: Optional[_Client] = None,
     ) -> "_Sandbox":
-        """Return the running Sandbox in the given app with the given name. Raises an error if no running
-        sandbox is found with the given name.
+        """Get a running Sandbox by name from the given app.
 
-        A Sandbox's name is the `name` argument passed to `Sandbox.create`.
+        Raises an error if no running sandbox is found with the given name. A Sandbox's name
+        is the `name` argument passed to `Sandbox.create`.
         """
         if client is None:
             client = await _Client.from_env()

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -93,6 +93,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         entrypoint_args: Sequence[str],
         image: _Image,
         secrets: Sequence[_Secret],
+        name: Optional[str] = None,
         timeout: Optional[int] = None,
         workdir: Optional[str] = None,
         gpu: GPU_T = None,
@@ -216,6 +217,7 @@ class _Sandbox(_Object, type_prefix="sb"):
                 proxy_id=(proxy.object_id if proxy else None),
                 enable_snapshot=enable_snapshot,
                 verbose=verbose,
+                name=name,
                 experimental_options=experimental_options,
             )
 
@@ -231,6 +233,7 @@ class _Sandbox(_Object, type_prefix="sb"):
     async def create(
         *entrypoint_args: str,
         app: Optional["modal.app._App"] = None,  # Optionally associate the sandbox with an app
+        name: Optional[str] = None,  # Optionally give the sandbox a name. Unique within an app.
         image: Optional[_Image] = None,  # The image to run as the container for the sandbox.
         secrets: Sequence[_Secret] = (),  # Environment variables to inject into the sandbox.
         network_file_systems: dict[Union[str, os.PathLike], _NetworkFileSystem] = {},
@@ -295,6 +298,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         return await _Sandbox._create(
             *entrypoint_args,
             app=app,
+            name=name,
             image=image,
             secrets=secrets,
             network_file_systems=network_file_systems,
@@ -324,6 +328,7 @@ class _Sandbox(_Object, type_prefix="sb"):
     async def _create(
         *entrypoint_args: str,
         app: Optional["modal.app._App"] = None,  # Optionally associate the sandbox with an app
+        name: Optional[str] = None,  # Optionally give the sandbox a name. Unique within an app.
         image: Optional[_Image] = None,  # The image to run as the container for the sandbox.
         secrets: Sequence[_Secret] = (),  # Environment variables to inject into the sandbox.
         mounts: Sequence[_Mount] = (),
@@ -376,6 +381,7 @@ class _Sandbox(_Object, type_prefix="sb"):
             entrypoint_args,
             image=image or _default_image,
             secrets=secrets,
+            name=name,
             timeout=timeout,
             workdir=workdir,
             gpu=gpu,
@@ -442,6 +448,27 @@ class _Sandbox(_Object, type_prefix="sb"):
         )
         self._stdin = StreamWriter(self.object_id, "sandbox", self._client)
         self._result = None
+
+    @staticmethod
+    async def from_name(
+        app_name: str,
+        name: str,
+        *,
+        environment_name: Optional[str] = None,
+        client: Optional[_Client] = None,
+    ) -> "_Sandbox":
+        """Return the running Sandbox in the given app with the given name. Raises an error if no running
+        sandbox is found with the given name.
+
+        A Sandbox's name is the `name` argument passed to `Sandbox.create`.
+        """
+        if client is None:
+            client = await _Client.from_env()
+        env_name = _get_environment_name(environment_name)
+
+        req = api_pb2.SandboxGetFromNameRequest(sandbox_name=name, app_name=app_name, environment_name=env_name)
+        resp = await retry_transient_errors(client.stub.SandboxGetFromName, req)
+        return _Sandbox._new_hydrated(resp.sandbox_id, client, None)
 
     @staticmethod
     async def from_id(sandbox_id: str, client: Optional[_Client] = None) -> "_Sandbox":
@@ -719,10 +746,12 @@ class _Sandbox(_Object, type_prefix="sb"):
         return obj
 
     @staticmethod
-    async def _experimental_from_snapshot(snapshot: _SandboxSnapshot, client: Optional[_Client] = None):
+    async def _experimental_from_snapshot(
+        snapshot: _SandboxSnapshot, client: Optional[_Client] = None, sandbox_name: Optional[str] = None
+    ):
         client = client or await _Client.from_env()
 
-        restore_req = api_pb2.SandboxRestoreRequest(snapshot_id=snapshot.object_id)
+        restore_req = api_pb2.SandboxRestoreRequest(snapshot_id=snapshot.object_id, sandbox_name=sandbox_name)
         restore_resp: api_pb2.SandboxRestoreResponse = await retry_transient_errors(
             client.stub.SandboxRestore, restore_req
         )

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -73,14 +73,15 @@ def _validate_exec_args(entrypoint_args: Sequence[str]) -> None:
         )
 
 
-class DefaultSandboxNameOverride:
+class DefaultSandboxNameOverride(str):
     """A singleton class that represents the default sandbox name override.
 
     It is used to indicate that the sandbox name should not be overridden.
     """
 
     def __repr__(self) -> str:
-        return "DefaultSandboxNameOverride"
+        # NOTE: this must match the instance var name below in order for type stubs to work 😬
+        return "_DEFAULT_SANDBOX_NAME_OVERRIDE"
 
 
 _DEFAULT_SANDBOX_NAME_OVERRIDE = DefaultSandboxNameOverride()
@@ -765,7 +766,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         snapshot: _SandboxSnapshot,
         client: Optional[_Client] = None,
         *,
-        name: Optional[Union[str, type[DefaultSandboxNameOverride]]] = _DEFAULT_SANDBOX_NAME_OVERRIDE,
+        name: Optional[str] = _DEFAULT_SANDBOX_NAME_OVERRIDE,
     ):
         client = client or await _Client.from_env()
 

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -232,7 +232,8 @@ class _Sandbox(_Object, type_prefix="sb"):
     @staticmethod
     async def create(
         *entrypoint_args: str,
-        app: Optional["modal.app._App"] = None,  # Optionally associate the sandbox with an app
+        # Associate the sandbox with an app. Required unless creating from a container.
+        app: Optional["modal.app._App"] = None,
         name: Optional[str] = None,  # Optionally give the sandbox a name. Unique within an app.
         image: Optional[_Image] = None,  # The image to run as the container for the sandbox.
         secrets: Sequence[_Secret] = (),  # Environment variables to inject into the sandbox.
@@ -327,7 +328,8 @@ class _Sandbox(_Object, type_prefix="sb"):
     @staticmethod
     async def _create(
         *entrypoint_args: str,
-        app: Optional["modal.app._App"] = None,  # Optionally associate the sandbox with an app
+        # Associate the sandbox with an app. Required unless creating from a container.
+        app: Optional["modal.app._App"] = None,
         name: Optional[str] = None,  # Optionally give the sandbox a name. Unique within an app.
         image: Optional[_Image] = None,  # The image to run as the container for the sandbox.
         secrets: Sequence[_Secret] = (),  # Environment variables to inject into the sandbox.

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -765,16 +765,16 @@ class _Sandbox(_Object, type_prefix="sb"):
         snapshot: _SandboxSnapshot,
         client: Optional[_Client] = None,
         *,
-        sandbox_name: Optional[Union[str, type[DefaultSandboxNameOverride]]] = _DEFAULT_SANDBOX_NAME_OVERRIDE,
+        name: Optional[Union[str, type[DefaultSandboxNameOverride]]] = _DEFAULT_SANDBOX_NAME_OVERRIDE,
     ):
         client = client or await _Client.from_env()
 
-        if sandbox_name is _DEFAULT_SANDBOX_NAME_OVERRIDE:
+        if name is _DEFAULT_SANDBOX_NAME_OVERRIDE:
             restore_req = api_pb2.SandboxRestoreRequest(
                 snapshot_id=snapshot.object_id,
                 sandbox_name_override_type=api_pb2.SandboxRestoreRequest.SANDBOX_NAME_OVERRIDE_TYPE_UNSPECIFIED,
             )
-        elif sandbox_name is None:
+        elif name is None:
             restore_req = api_pb2.SandboxRestoreRequest(
                 snapshot_id=snapshot.object_id,
                 sandbox_name_override_type=api_pb2.SandboxRestoreRequest.SANDBOX_NAME_OVERRIDE_TYPE_NONE,
@@ -782,7 +782,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         else:
             restore_req = api_pb2.SandboxRestoreRequest(
                 snapshot_id=snapshot.object_id,
-                sandbox_name_override=sandbox_name,
+                sandbox_name_override=name,
                 sandbox_name_override_type=api_pb2.SandboxRestoreRequest.SANDBOX_NAME_OVERRIDE_TYPE_STRING,
             )
 


### PR DESCRIPTION
This PR adds support for Sandbox names by adding a `name` keyword arg to `Sandbox.create()` and a `Sandbox.from_name()` static method. (Note: protobuf defs were updated in a [previous PR](https://github.com/modal-labs/modal-client/pull/3332).)

## Usage

```
app = App.lookup("my-app", create_if_missing=True)
sb = Sandbox.create(app=app, name="my-sandbox")
sb2 = Sandbox.create(app=app, name="my-sandbox") # raises an Error, cannot have more than one running sandbox with the same name in the same environment

# from_name() returns the _running_ sandbox with the given name (in the same environment)
sb2 = Sandbox.from_name("my-app", "my-sandbox")
assert sb.object_id == sb2.object_id

sb.terminate()
sb.wait(raise_on_termination=False)

Sandbox.from_name("my-app", "my-sandbox-name") # raises an Error because no running sandbox has the given name
```

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [X] Client+Server: this change is compatible with old servers
- [X] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Added a `name` parameter to `Sandbox.create()`
- Added a `Sandbox.from_name()` static method.
- Added a `name` parameter to `Sandbox._experimental_from_snapshot()`