### PR TITLE
Enforce timeouts on sandbox `StreamReader` operations

### DIFF
--- a/modal/container_process.py
+++ b/modal/container_process.py
@@ -50,6 +50,7 @@ class _ContainerProcess(Generic[T]):
             stream_type=stdout,
             text=text,
             by_line=by_line,
+            deadline=exec_deadline,
         )
         self._stderr = _StreamReader[T](
             api_pb2.FILE_DESCRIPTOR_STDERR,
@@ -59,6 +60,7 @@ class _ContainerProcess(Generic[T]):
             stream_type=stderr,
             text=text,
             by_line=by_line,
+            deadline=exec_deadline,
         )
         self._stdin = _StreamWriter(process_id, "container_process", self._client)
 

--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -1,7 +1,6 @@
 # Copyright Modal Labs 2022
 import asyncio
 import time
-from asyncio import timeout as asyncio_timeout
 from collections.abc import AsyncGenerator, AsyncIterator
 from typing import (
     TYPE_CHECKING,
@@ -62,17 +61,22 @@ async def _container_process_logs_iterator(
         last_batch_index=last_index,
     )
 
-    timeout = max(deadline - time.monotonic(), 0.0) if deadline else None
-    try:
-        async with asyncio_timeout(timeout):
-            async for batch in client.stub.ContainerExecGetOutput.unary_stream(req):
-                if batch.HasField("exit_code"):
-                    yield None, batch.batch_index
-                    return
-                for item in batch.items:
-                    yield item.message_bytes, batch.batch_index
-    except asyncio.TimeoutError:
-        yield None, -1
+    stream = client.stub.ContainerExecGetOutput.unary_stream(req)
+    while True:
+        # Check deadline before attempting to receive the next batch
+        try:
+            remaining = (deadline - time.monotonic()) if deadline else None
+            batch = await asyncio.wait_for(stream.__anext__(), timeout=remaining)
+        except asyncio.TimeoutError:
+            yield None, -1
+            break
+        except StopAsyncIteration:
+            break
+        if batch.HasField("exit_code"):
+            yield None, batch.batch_index
+            break
+        for item in batch.items:
+            yield item.message_bytes, batch.batch_index
 
 
 T = TypeVar("T", str, bytes)

--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -1,5 +1,6 @@
 # Copyright Modal Labs 2022
 import asyncio
+import time
 from collections.abc import AsyncGenerator, AsyncIterator
 from typing import (
     TYPE_CHECKING,
@@ -50,6 +51,7 @@ async def _container_process_logs_iterator(
     file_descriptor: "api_pb2.FileDescriptor.ValueType",
     client: _Client,
     last_index: int,
+    deadline: Optional[float] = None,
 ) -> AsyncGenerator[tuple[Optional[bytes], int], None]:
     req = api_pb2.ContainerExecGetOutputRequest(
         exec_id=process_id,
@@ -58,7 +60,20 @@ async def _container_process_logs_iterator(
         get_raw_bytes=True,
         last_batch_index=last_index,
     )
-    async for batch in client.stub.ContainerExecGetOutput.unary_stream(req):
+    # Create the stream once and then pull batches manually so we can wrap
+    # each receive in `asyncio.wait_for`, guaranteeing the deadline.
+    stream = client.stub.ContainerExecGetOutput.unary_stream(req)
+    while True:
+        # Check deadline before attempting to receive the next batch
+        try:
+            remaining = (deadline - time.monotonic()) if deadline else None
+            batch = await asyncio.wait_for(stream.__anext__(), timeout=remaining)
+        except asyncio.TimeoutError:
+            yield None, -1
+            break
+        except StopAsyncIteration:
+            break
+
         if batch.HasField("exit_code"):
             yield None, batch.batch_index
             break
@@ -102,6 +117,7 @@ class _StreamReader(Generic[T]):
         stream_type: StreamType = StreamType.PIPE,
         text: bool = True,
         by_line: bool = False,
+        deadline: Optional[float] = None,
     ) -> None:
         """mdmd:hidden"""
         self._file_descriptor = file_descriptor
@@ -111,6 +127,7 @@ class _StreamReader(Generic[T]):
         self._stream = None
         self._last_entry_id: str = ""
         self._line_buffer = b""
+        self._deadline = deadline
 
         # Sandbox logs are streamed to the client as strings, so StreamReaders reading
         # them must have text mode enabled.
@@ -187,11 +204,12 @@ class _StreamReader(Generic[T]):
         retries_remaining = 10
         last_index = 0
         while not completed:
+            if self._deadline and time.monotonic() >= self._deadline:
+                break
             try:
                 iterator = _container_process_logs_iterator(
-                    self._object_id, self._file_descriptor, self._client, last_index
+                    self._object_id, self._file_descriptor, self._client, last_index, self._deadline
                 )
-
                 async for message, batch_index in iterator:
                     if self._stream_type == StreamType.STDOUT and message:
                         print(message.decode("utf-8"), end="")

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -30,7 +30,7 @@ from .exception import ExecutionError, InvalidError, SandboxTerminatedError, San
 from .file_io import FileWatchEvent, FileWatchEventType, _FileIO
 from .gpu import GPU_T
 from .image import _Image
-from .io_streams import StreamReader, StreamWriter, _StreamReader, _StreamWriter
+from .io_streams import CONTAINER_EXEC_TIMEOUT_BUFFER, StreamReader, StreamWriter, _StreamReader, _StreamWriter
 from .network_file_system import _NetworkFileSystem, network_file_system_mount_protos
 from .proxy import _Proxy
 from .scheduler_placement import SchedulerPlacement
@@ -49,11 +49,6 @@ _default_image: _Image = _Image.debian_slim()
 # We need some bytes of overhead for the rest of the command line besides the args,
 # e.g. 'runsc exec ...'. So we use 2**16 as the limit.
 ARG_MAX_BYTES = 2**16
-
-
-# This buffer extends the user-supplied timeout on ContainerExec-related RPCs. This was introduced to
-# give any in-flight status codes/IO data more time to reach the client before the stream is closed.
-CONTAINER_EXEC_TIMEOUT_BUFFER = 5
 
 
 if TYPE_CHECKING:

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -54,6 +54,8 @@ ARG_MAX_BYTES = 2**16
 # This buffer extends the user-supplied timeout on ContainerExec-related RPCs. This was introduced to
 # give any in-flight status codes/IO data more time to reach the client before the stream is closed.
 CONTAINER_EXEC_TIMEOUT_BUFFER = 5
+
+
 if TYPE_CHECKING:
     import modal.app
 

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -30,7 +30,7 @@ from .exception import ExecutionError, InvalidError, SandboxTerminatedError, San
 from .file_io import FileWatchEvent, FileWatchEventType, _FileIO
 from .gpu import GPU_T
 from .image import _Image
-from .io_streams import CONTAINER_EXEC_TIMEOUT_BUFFER, StreamReader, StreamWriter, _StreamReader, _StreamWriter
+from .io_streams import StreamReader, StreamWriter, _StreamReader, _StreamWriter
 from .network_file_system import _NetworkFileSystem, network_file_system_mount_protos
 from .proxy import _Proxy
 from .scheduler_placement import SchedulerPlacement
@@ -49,6 +49,10 @@ _default_image: _Image = _Image.debian_slim()
 # We need some bytes of overhead for the rest of the command line besides the args,
 # e.g. 'runsc exec ...'. So we use 2**16 as the limit.
 ARG_MAX_BYTES = 2**16
+
+# This buffer extends the user-supplied timeout on ContainerExec-related RPCs. This was introduced to
+# give any in-flight status codes/IO data more time to reach the client before the stream is closed.
+CONTAINER_EXEC_TIMEOUT_BUFFER = 5
 
 
 if TYPE_CHECKING:

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -332,6 +332,20 @@ def test_sandbox_exec_poll_timeout(app, servicer):
     assert cp.poll() == -1
 
 
+@mock.patch("modal.sandbox.CONTAINER_EXEC_TIMEOUT_BUFFER", 1)
+@skip_non_subprocess
+def test_sandbox_exec_output_timeout(app, servicer):
+    sb = Sandbox.create("sleep", "infinity", app=app)
+
+    cp = sb.exec("sh", "-c", "c=1; while true; do echo $c; sleep 1; c=$((c+1)); done", timeout=1)
+    t1 = time.monotonic()
+    # Assert that 2 is received, despite the message being sent at/after the 1s timeout
+    assert cp.stdout.read() == "1\n2\n"
+    # Assert that it is received within the buffer window
+    assert 2 < time.monotonic() - t1 < 2.1
+    assert cp.wait() == -1
+
+
 @skip_non_subprocess
 def test_sandbox_create_and_exec_with_bad_args(app, servicer):
     too_big = 130_000

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -332,17 +332,15 @@ def test_sandbox_exec_poll_timeout(app, servicer):
     assert cp.poll() == -1
 
 
-@mock.patch("modal.sandbox.CONTAINER_EXEC_TIMEOUT_BUFFER", 1)
+@mock.patch("modal.sandbox.CONTAINER_EXEC_TIMEOUT_BUFFER", 0)
 @skip_non_subprocess
 def test_sandbox_exec_output_timeout(app, servicer):
     sb = Sandbox.create("sleep", "infinity", app=app)
 
-    cp = sb.exec("sh", "-c", "c=1; while true; do echo $c; sleep 1; c=$((c+1)); done", timeout=1)
+    cp = sb.exec("sh", "-c", "echo hi; sleep 999", timeout=1)
     t1 = time.monotonic()
-    # Assert that 2 is received, despite the message being sent at/after the 1s timeout
-    assert cp.stdout.read() == "1\n2\n"
-    # Assert that it is received within the buffer window
-    assert 2 < time.monotonic() - t1 < 2.1
+    assert cp.stdout.read() == "hi\n"
+    assert 1 < time.monotonic() - t1 < 2.0
     assert cp.wait() == -1
 
 


### PR DESCRIPTION
Enforce a timeout (`deadline`) on `StreamReader` consumption. This is introduced since `.read()` and `async for` consumption can currently hang indefinitely. The buffer (`CONTAINER_EXEC_TIMEOUT_BUFFER`) is used so that in-flight `ContainerExecGetOutput` RPCs are given a bit more time to reach the client after a timeout.

Impl detail: in `_container_process_logs_iterator`, I create the stream once and then break the `async for` into a `while` with manual `.__next__()` consumption of the iterator. This makes it easier to ensure that the timeout is not exceeded while stepping through the iterator.