### PR TITLE
reliability: _get_task_id not retried

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -578,7 +578,9 @@ class _Sandbox(_Object, type_prefix="sb"):
 
     async def _get_task_id(self) -> str:
         while not self._task_id:
-            resp = await self._client.stub.SandboxGetTaskId(api_pb2.SandboxGetTaskIdRequest(sandbox_id=self.object_id))
+            resp = await retry_transient_errors(
+                self._client.stub.SandboxGetTaskId, api_pb2.SandboxGetTaskIdRequest(sandbox_id=self.object_id)
+            )
             self._task_id = resp.task_id
             if not self._task_id:
                 await asyncio.sleep(0.5)


### PR DESCRIPTION
## Describe your changes

Over the past week about 3.3% of our Sandbox HFM errors are: `error_message="StreamTerminatedError('Stream reset by remote party, error_code: 0')"`. Looking at the code executed and the relevant RPCs, I think this is the cause. 

Being optimistic that a different error wouldn't have happened, fixing this gives us an `100 - 99.883 * 0.0337 = 0.00394%` boost 😄. 

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

