### PR TITLE
Flip MODAL_FUNCTION_SCHEMAS to True

### DIFF
--- a/modal/_serialization.py
+++ b/modal/_serialization.py
@@ -14,7 +14,7 @@ from modal_proto import api_pb2
 from ._object import _Object
 from ._type_manager import parameter_serde_registry, schema_registry
 from ._vendor import cloudpickle
-from .config import config, logger
+from .config import logger
 from .exception import DeserializationError, ExecutionError, InvalidError
 from .object import Object
 
@@ -555,7 +555,7 @@ def get_callable_schema(
     callable: typing.Callable, *, is_web_endpoint: bool, ignore_first_argument: bool = False
 ) -> typing.Optional[api_pb2.FunctionSchema]:
     # ignore_first_argument can be used in case of unbound methods where we want to ignore the first (self) argument
-    if is_web_endpoint or not config.get("function_schemas"):
+    if is_web_endpoint:
         # we don't support schemas on web endpoints for now
         return None
 

--- a/modal/_serialization.py
+++ b/modal/_serialization.py
@@ -559,7 +559,12 @@ def get_callable_schema(
         # we don't support schemas on web endpoints for now
         return None
 
-    sig = inspect.signature(callable)
+    try:
+        sig = inspect.signature(callable)
+    except Exception as e:
+        logger.debug(f"Error getting signature for function {callable}", exc_info=e)
+        return None
+
     # TODO: treat no return value annotation as None return?
     return_type_proto = schema_registry.get_proto_generic_type(sig.return_annotation)
     arguments = []

--- a/modal/config.py
+++ b/modal/config.py
@@ -238,7 +238,7 @@ _SETTINGS = {
     "strict_parameters": _Setting(False, transform=_to_boolean),  # For internal/experimental use
     "snapshot_debug": _Setting(False, transform=_to_boolean),
     "cuda_checkpoint_path": _Setting("/__modal/.bin/cuda-checkpoint"),  # Used for snapshotting GPU memory.
-    "function_schemas": _Setting(False, transform=_to_boolean),
+    "function_schemas": _Setting(True, transform=_to_boolean),
     "build_validation": _Setting("error", transform=_check_value(["error", "warn", "ignore"])),
 }
 

--- a/modal/config.py
+++ b/modal/config.py
@@ -238,7 +238,6 @@ _SETTINGS = {
     "strict_parameters": _Setting(False, transform=_to_boolean),  # For internal/experimental use
     "snapshot_debug": _Setting(False, transform=_to_boolean),
     "cuda_checkpoint_path": _Setting("/__modal/.bin/cuda-checkpoint"),  # Used for snapshotting GPU memory.
-    "function_schemas": _Setting(True, transform=_to_boolean),
     "build_validation": _Setting("error", transform=_check_value(["error", "warn", "ignore"])),
 }
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1431,7 +1431,7 @@ message Function {
   bool _experimental_enable_gpu_snapshot = 78; // Experimental support for GPU snapshotting
 
   AutoscalerSettings autoscaler_settings = 79;  // Bundle of parameters related to autoscaling
-  FunctionSchema function_schema = 80;
+  FunctionSchema function_schema = 80; // Function schema, may be missing: client doesn't block deployment if it fails to get it
 
   // For server-side experimental functionality. Prefer using this over individual _experimental_* fields.
   // Note the value type as string. Internally we'll coerce all values to string with str().

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -92,10 +92,38 @@ def test_run_class(client, servicer):
         "bar": api_pb2.MethodDefinition(
             function_name="Foo.bar",
             function_type=api_pb2.Function.FunctionType.FUNCTION_TYPE_FUNCTION,
+            function_schema=api_pb2.FunctionSchema(
+                schema_type=api_pb2.FunctionSchema.FunctionSchemaType.FUNCTION_SCHEMA_V1,
+                arguments=[
+                    api_pb2.ClassParameterSpec(
+                        name="x",
+                        full_type=api_pb2.GenericPayloadType(
+                            base_type=api_pb2.ParameterType.PARAM_TYPE_INT,
+                        ),
+                    )
+                ],
+                return_type=api_pb2.GenericPayloadType(
+                    base_type=api_pb2.ParameterType.PARAM_TYPE_UNKNOWN,
+                ),
+            ),
         ),
         "baz": api_pb2.MethodDefinition(
             function_name="Foo.baz",
             function_type=api_pb2.Function.FunctionType.FUNCTION_TYPE_FUNCTION,
+            function_schema=api_pb2.FunctionSchema(
+                schema_type=api_pb2.FunctionSchema.FunctionSchemaType.FUNCTION_SCHEMA_V1,
+                arguments=[
+                    api_pb2.ClassParameterSpec(
+                        name="y",
+                        full_type=api_pb2.GenericPayloadType(
+                            base_type=api_pb2.ParameterType.PARAM_TYPE_INT,
+                        ),
+                    )
+                ],
+                return_type=api_pb2.GenericPayloadType(
+                    base_type=api_pb2.ParameterType.PARAM_TYPE_UNKNOWN,
+                ),
+            ),
         ),
     }
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2441,6 +2441,7 @@ async def client(servicer, credentials):
     with Client(servicer.client_addr, api_pb2.CLIENT_TYPE_CLIENT, credentials) as client:
         yield client
 
+
 @pytest_asyncio.fixture(scope="function")
 async def container_client(servicer):
     async with Client(servicer.container_addr, api_pb2.CLIENT_TYPE_CONTAINER, None) as client:
@@ -2657,8 +2658,3 @@ def tmp_cwd(tmp_path, monkeypatch):
     with monkeypatch.context() as m:
         m.chdir(tmp_path)
         yield
-
-
-@pytest.fixture()
-def record_function_schemas(monkeypatch):
-    monkeypatch.setenv("MODAL_FUNCTION_SCHEMAS", "1")

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -1270,7 +1270,7 @@ def test_concurrency_config_migration(client, servicer):
             raise RuntimeError(f"Unexpected function name: {request.function.function_name}")
 
 
-@pytest.mark.usefixtures("record_function_schemas", "set_env_client")
+@pytest.mark.usefixtures("set_env_client")
 def test_function_schema_recording(client, servicer):
     app = App("app")
 
@@ -1302,7 +1302,7 @@ def test_function_schema_recording(client, servicer):
     assert Function.from_name("app", "f")._get_schema() == expected_schema
 
 
-@pytest.mark.usefixtures("record_function_schemas", "set_env_client")
+@pytest.mark.usefixtures("set_env_client")
 def test_function_schema_excludes_web_endpoints(client, servicer):
     # for now we exclude web endpoints since they don't use straight-forward arguments
     # in the same way as regular modal functions
@@ -1317,7 +1317,7 @@ def test_function_schema_excludes_web_endpoints(client, servicer):
     assert schema.schema_type == api_pb2.FunctionSchema.FUNCTION_SCHEMA_UNSPECIFIED
 
 
-@pytest.mark.usefixtures("record_function_schemas", "set_env_client")
+@pytest.mark.usefixtures("set_env_client")
 def test_class_schema_recording(client, servicer):
     app = App("app")
 
@@ -1445,6 +1445,7 @@ def test_function_namespace_deprecated(servicer, client):
     namespace_warnings = [w for w in record if "namespace" in str(w.message).lower()]
     assert len(namespace_warnings) == 0
 
+
 # These test and the two below it pass on their own but fail with this error when all the tests are run:
 # `modal.exception.NotFoundError: Volume ('my-vol', 'main') not found`
 # So there's some interaction happening that needs to be fixed.
@@ -1458,6 +1459,7 @@ def test_input_above_limit_does_blob_upload(client, servicer, blob_server):
         assert len(servicer.cleared_function_calls) == 1
     assert len(blobs) == 1
 
+
 @pytest.mark.skip()
 def test_input_above_limit_does_not_blob_upload(client, servicer, blob_server):
     # Setting max_object_size_bytes to 1000 should cause input to not be blob uploaded
@@ -1467,6 +1469,7 @@ def test_input_above_limit_does_not_blob_upload(client, servicer, blob_server):
         assert foo.remote(2, 4) == 20
         assert len(servicer.cleared_function_calls) == 1
     assert len(blobs) == 0
+
 
 @pytest.mark.skip()
 def test_unset_input_limit_does_not_blob_upload(client, servicer, blob_server):

--- a/test/serialization_test.py
+++ b/test/serialization_test.py
@@ -125,7 +125,7 @@ def test_non_implemented_proto_type():
         parameter_serde_registry.decode(api_pb2.ClassParameterValue(type=1000))  # type: ignore
 
 
-def test_schema_extraction_unknown(record_function_schemas):
+def test_schema_extraction_unknown():
     def with_empty(a): ...
 
     def with_any(a: typing.Any): ...
@@ -198,7 +198,6 @@ def test_schema_extraction_bytes():
     )
 
 
-@pytest.mark.usefixtures("record_function_schemas")
 def test_schema_extraction_list():
     def new_f(simple_list: list[int]): ...
     def old_f(simple_list: typing.List[int]): ...
@@ -215,7 +214,6 @@ def test_schema_extraction_list():
         )
 
 
-@pytest.mark.usefixtures("record_function_schemas")
 def test_schema_extraction_nested_list():
     def f(nested_list: list[list[bytes]]): ...
 
@@ -235,7 +233,6 @@ def test_schema_extraction_nested_list():
     )
 
 
-@pytest.mark.usefixtures("record_function_schemas")
 def test_schema_extraction_nested_dict():
     def f(nested_dict: dict[str, dict[str, bytes]] = {}): ...
 
@@ -261,7 +258,6 @@ def test_schema_extraction_nested_dict():
     )
 
 
-@pytest.mark.usefixtures("record_function_schemas")
 def test_schema_extraction_dict_with_non_str_key_is_unknown():
     def f(dct: dict): ...
 


### PR DESCRIPTION
Flip the flag to True so that we can ship UIs for functions later.

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
