### PR TITLE
Pass put_data_out through input-plane from containers

### DIFF
--- a/modal/_runtime/container_io_manager.py
+++ b/modal/_runtime/container_io_manager.py
@@ -511,7 +511,12 @@ class _ContainerIOManager:
                 chunk.data = message_bytes
             data_chunks.append(chunk)
 
-        req = api_pb2.FunctionCallPutDataRequest(function_call_id=function_call_id, data_chunks=data_chunks)
+        attempt_token = await self._client._auth_token_manager.get_token()
+        req = api_pb2.FunctionCallPutDataRequest(
+            function_call_id=function_call_id,
+            data_chunks=data_chunks,
+            attempt_token=attempt_token,
+        )
 
         if self.input_plane_server_url:
             stub = await self._client.get_stub(self.input_plane_server_url)


### PR DESCRIPTION
This uses the same mechanism a `.remote()` request on an input-plane container uses, namely it doesn't write into the Unix Domain Socket and completely bypasses the worker.

This isn't the only approach (ideally our requests should get routed to the worker, like most of our gRPCs), but I think it's fine to do that in a follow-up if necessary.