### PR TITLE
deprecate environment_name from Sandbox.create()

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -228,7 +228,6 @@ class _Sandbox(_Object, type_prefix="sb"):
     async def create(
         *entrypoint_args: str,
         app: Optional["modal.app._App"] = None,  # Optionally associate the sandbox with an app
-        environment_name: Optional[str] = None,  # *DEPRECATED* Optionally override the default environment
         image: Optional[_Image] = None,  # The image to run as the container for the sandbox.
         secrets: Sequence[_Secret] = (),  # Environment variables to inject into the sandbox.
         network_file_systems: dict[Union[str, os.PathLike], _NetworkFileSystem] = {},
@@ -267,6 +266,7 @@ class _Sandbox(_Object, type_prefix="sb"):
             SchedulerPlacement
         ] = None,  # Experimental controls over fine-grained scheduling (alpha).
         client: Optional[_Client] = None,
+        environment_name: Optional[str] = None,  # *DEPRECATED* Optionally override the default environment
     ) -> "_Sandbox":
         """
         Create a new Sandbox to run untrusted, arbitrary code. The Sandbox's corresponding container

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -365,7 +365,7 @@ class _Sandbox(_Object, type_prefix="sb"):
             deprecation_warning(
                 (2025, 7, 16),
                 "Passing `environment_name` to `Sandbox.create` is deprecated and will be removed in a future release.",
-                "A sandbox's environment is now determined by the app it is associated with.",
+                "A sandbox's environment will then be determined by the app it is associated with.",
             )
 
         environment_name = _get_environment_name(environment_name)

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -21,6 +21,7 @@ from ._object import _get_environment_name, _Object
 from ._resolver import Resolver
 from ._resources import convert_fn_config_to_resources_config
 from ._utils.async_utils import TaskContext, synchronize_api
+from ._utils.deprecation import deprecation_warning
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.mount_utils import validate_network_file_systems, validate_volumes
 from .client import _Client
@@ -230,7 +231,7 @@ class _Sandbox(_Object, type_prefix="sb"):
     async def create(
         *entrypoint_args: str,
         app: Optional["modal.app._App"] = None,  # Optionally associate the sandbox with an app
-        environment_name: Optional[str] = None,  # Optionally override the default environment
+        environment_name: Optional[str] = None,  # *DEPRECATED* Optionally override the default environment
         image: Optional[_Image] = None,  # The image to run as the container for the sandbox.
         secrets: Sequence[_Secret] = (),  # Environment variables to inject into the sandbox.
         network_file_systems: dict[Union[str, os.PathLike], _NetworkFileSystem] = {},
@@ -315,7 +316,7 @@ class _Sandbox(_Object, type_prefix="sb"):
     async def _create(
         *entrypoint_args: str,
         app: Optional["modal.app._App"] = None,  # Optionally associate the sandbox with an app
-        environment_name: Optional[str] = None,  # Optionally override the default environment
+        environment_name: Optional[str] = None,  # *DEPRECATED* Optionally override the default environment
         image: Optional[_Image] = None,  # The image to run as the container for the sandbox.
         secrets: Sequence[_Secret] = (),  # Environment variables to inject into the sandbox.
         mounts: Sequence[_Mount] = (),
@@ -359,6 +360,13 @@ class _Sandbox(_Object, type_prefix="sb"):
         # `mounts` is currently only used by modal shell (cli) to provide a function's mounts to the
         # sandbox that runs the shell session
         from .app import _App
+
+        if environment_name is not None:
+            deprecation_warning(
+                (2025, 7, 16),
+                "Passing `environment_name` to `Sandbox.create` is deprecated and will be removed in a future release.",
+                "A sandbox's environment is now determined by the app it is associated with.",
+            )
 
         environment_name = _get_environment_name(environment_name)
 

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -216,7 +216,6 @@ class _Sandbox(_Object, type_prefix="sb"):
                 verbose=verbose,
             )
 
-            # Note - `resolver.app_id` will be `None` for app-less sandboxes
             create_req = api_pb2.SandboxCreateRequest(app_id=resolver.app_id, definition=definition)
             create_resp = await retry_transient_errors(resolver.client.stub.SandboxCreate, create_req)
 

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -217,9 +217,7 @@ class _Sandbox(_Object, type_prefix="sb"):
             )
 
             # Note - `resolver.app_id` will be `None` for app-less sandboxes
-            create_req = api_pb2.SandboxCreateRequest(
-                app_id=resolver.app_id, definition=definition, environment_name=resolver.environment_name
-            )
+            create_req = api_pb2.SandboxCreateRequest(app_id=resolver.app_id, definition=definition)
             create_resp = await retry_transient_errors(resolver.client.stub.SandboxCreate, create_req)
 
             sandbox_id = create_resp.sandbox_id
@@ -284,10 +282,16 @@ class _Sandbox(_Object, type_prefix="sb"):
         sandbox.wait()
         ```
         """
+        if environment_name is not None:
+            deprecation_warning(
+                (2025, 7, 16),
+                "Passing `environment_name` to `Sandbox.create` is deprecated and will be removed in a future release.",
+                "A sandbox's environment is determined by the app it is associated with.",
+            )
+
         return await _Sandbox._create(
             *entrypoint_args,
             app=app,
-            environment_name=environment_name,
             image=image,
             secrets=secrets,
             network_file_systems=network_file_systems,
@@ -316,7 +320,6 @@ class _Sandbox(_Object, type_prefix="sb"):
     async def _create(
         *entrypoint_args: str,
         app: Optional["modal.app._App"] = None,  # Optionally associate the sandbox with an app
-        environment_name: Optional[str] = None,  # *DEPRECATED* Optionally override the default environment
         image: Optional[_Image] = None,  # The image to run as the container for the sandbox.
         secrets: Sequence[_Secret] = (),  # Environment variables to inject into the sandbox.
         mounts: Sequence[_Mount] = (),
@@ -360,15 +363,6 @@ class _Sandbox(_Object, type_prefix="sb"):
         # `mounts` is currently only used by modal shell (cli) to provide a function's mounts to the
         # sandbox that runs the shell session
         from .app import _App
-
-        if environment_name is not None:
-            deprecation_warning(
-                (2025, 7, 16),
-                "Passing `environment_name` to `Sandbox.create` is deprecated and will be removed in a future release.",
-                "A sandbox's environment will then be determined by the app it is associated with.",
-            )
-
-        environment_name = _get_environment_name(environment_name)
 
         _validate_exec_args(entrypoint_args)
 
@@ -429,7 +423,7 @@ class _Sandbox(_Object, type_prefix="sb"):
 
         client = client or app_client or await _Client.from_env()
 
-        resolver = Resolver(client, environment_name=environment_name, app_id=app_id)
+        resolver = Resolver(client, app_id=app_id)
         await resolver.load(obj)
         return obj
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2524,7 +2524,7 @@ message Sandbox {
 message SandboxCreateRequest {
   string app_id = 1 [ (modal.options.audit_target_attr) = true ];
   Sandbox definition = 2;
-  string environment_name = 3;
+  string environment_name = 3; // *DEPRECATED* 7/16/2025
 }
 
 message SandboxCreateResponse {


### PR DESCRIPTION
## Describe your changes

Linear issue: [CLI-504](https://linear.app/modal-labs/issue/CLI-504/sandbox-environment-membership-is-ambiguous)

Consider the following code:

```py
app = modal.App("sandbox-wtf")
with modal.enable_output(), app.run(environment_name="main"):
    sb = modal.Sandbox.create(app=app, environment_name="dev")
```

It's unclear which environment the sandbox should belong to. As it turns out, the sandbox will be created in the `dev` environment, but it will be grouped with the sandboxes under the `main` environment in the UI. Other App dependents (Function, Cls, etc) don't have this problem as they have no independent way to specify an environment. Let's deprecate the `environment_name` arg from `Sandbox.create()`.