### PR TITLE
tweak sandbox-name-related protobuf defs

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2534,6 +2534,7 @@ message SandboxCreateResponse {
 message SandboxGetFromNameRequest {
   string sandbox_name = 1;
   string environment_name = 2;
+  string app_name = 3;
 }
 
 message SandboxGetFromNameResponse {
@@ -2608,6 +2609,7 @@ message SandboxListResponse {
 
 message SandboxRestoreRequest {
   string snapshot_id = 1;
+  string sandbox_name = 2;
 }
 
 message SandboxRestoreResponse {


### PR DESCRIPTION
After more discussion on the Sandbox Names project, we've decided to slightly change the `Sandbox.from_name()` function to take an `app_name`. We've also decided to allow sandboxes restored from snapshots to take an optional `name` override. This PR updates those two definitions.