### PR TITLE
Adds an Index Field FunctionGetOutputs Protobuf

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1690,6 +1690,7 @@ message FunctionGetOutputsRequest {
   double requested_at = 8; // Used for waypoints.
   // The jwts the client expects the server to be processing. This is optional and used for sync inputs only.
   repeated string input_jwts = 9;
+  optional int32 start_idx = 10; // for async batch requests. this indicates which index to start from.
 }
 
 message FunctionGetOutputsResponse {


### PR DESCRIPTION
This field is needed for supporting queries like `.get()` on a SpawnMap Handler.