### PR TITLE
[WRK-1102] Calling read more than once on sandbox exec StreamReader fails

### DIFF
--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -287,10 +287,10 @@ class _StreamReader(Generic[T]):
                     if skip_empty_messages and message == b"":
                         continue
 
-                    yield message
                     if message is None:
                         completed = True
                         self.eof = True
+                    yield message
 
             except (GRPCError, StreamTerminatedError) as exc:
                 if retries_remaining > 0:

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -345,6 +345,16 @@ def test_sandbox_exec_output_timeout(app, servicer):
 
 
 @skip_non_subprocess
+def test_sandbox_exec_output_double_read(app, servicer):
+    sb = Sandbox.create("sleep", "infinity", app=app)
+
+    cp = sb.exec("sh", "-c", "echo hi")
+    assert cp.stdout.read() == "hi\n"
+    assert cp.stdout.read() == ""
+    assert cp.wait() == 0
+
+
+@skip_non_subprocess
 def test_sandbox_create_and_exec_with_bad_args(app, servicer):
     too_big = 130_000
     single_arg_size = too_big // 10


### PR DESCRIPTION
When `StreamReader.eof=True`, successive reads with no new data will return empty string, which is expected. However, `eof=True` was not being set properly. Moving the yield below the None check ensures that the check always runs. The bug is that the `_get_logs` iterator gets canceled => code after yield does not run since the generator is canceled.