### PR TITLE
update SandboxRestoreRequest protobuf to support a null value for the sandbox name

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2609,8 +2609,15 @@ message SandboxListResponse {
 }
 
 message SandboxRestoreRequest {
+  enum SandboxNameOverrideType {
+    SANDBOX_NAME_OVERRIDE_TYPE_UNSPECIFIED = 0;
+    SANDBOX_NAME_OVERRIDE_TYPE_NONE = 1;
+    SANDBOX_NAME_OVERRIDE_TYPE_STRING = 2;
+  }
+
   string snapshot_id = 1;
-  string sandbox_name = 2;
+  string sandbox_name_override = 2;
+  SandboxNameOverrideType sandbox_name_override_type = 3;
 }
 
 message SandboxRestoreResponse {


### PR DESCRIPTION
While working on the [Sandbox Names](https://www.notion.so/modal-com/Sandbox-Names-n-e-Keys-Locks-21b1e7f16949802b86a4eec4cfa9f204) project, we've had to decide on the desired behavior when restoring from a sandbox snapshot. So far we've landed on having the new sandboxes use the same name as the original snapshotted sandbox by default, but allowing a user to override that configuration for the new sandbox if desired. That means that there are three possible configurations here: (1) use the original sandbox's name value (either string or null), (2) don't give the new sandbox a name at all (set its name to null), or (3) use the provided string as the sandbox name.

I'll wait to implement this with the other logic changes in a separate PR, but I imagine I'd do something like this to differentiate between these three states on the Python side:

```py
_NO_SANDBOX_OVERRIDE = NoSandboxOverride()

def from_snapshot(snapshot, sandbox_name: Optional[str] = _NO_SANDBOX_OVERRIDE):
    if sandbox_name is _NO_SANDBOX_OVERRIDE:
        # use default behavior
    elif sandbox_name is None:
        # do not give the new sandbox a name
    else:
        # give the sandbox the provided name
```

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [X] Client+Server: this change is compatible with old servers
- [X] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

</details>