### PR TITLE
Allow Cls to be clustered

### DIFF
--- a/modal/_partial_function.py
+++ b/modal/_partial_function.py
@@ -836,7 +836,12 @@ def _concurrent(
 
 
 # NOTE: clustered is currently exposed through modal.experimental, not the top-level namespace
-def _clustered(size: int, broadcast: bool = True, rdma: bool = False):
+def _clustered(
+    size: int, broadcast: bool = True, rdma: bool = False
+) -> Callable[
+    [Union[Callable[P, ReturnType], _PartialFunction[P, ReturnType, ReturnType]]],
+    _PartialFunction[P, ReturnType, ReturnType],
+]:
     """Provision clusters of colocated and networked containers for the Function.
 
     Parameters:

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 from typing_extensions import assert_type
 
+import modal.experimental
 import modal.partial_function
 from modal import App, Cls, Function, Image, Volume, enter, exit, method
 from modal._partial_function import (
@@ -1287,3 +1288,55 @@ def test_cls_namespace_deprecated(servicer, client):
     # Filter out any unrelated warnings
     namespace_warnings = [w for w in record if "namespace" in str(w.message).lower()]
     assert len(namespace_warnings) == 0
+
+
+clustered_app = App()
+
+
+def test_clustered_cls(client, servicer):
+    @clustered_app.cls(serialized=True)
+    @modal.experimental.clustered(size=3, rdma=True)  # type: ignore
+    class ClusteredClass:
+        @method()
+        def run_task(self, x):
+            return x * 2
+
+    @clustered_app.cls(serialized=True)
+    class RegularClass:
+        @method()
+        def regular_method(self, x):
+            return x * 4
+
+    with clustered_app.run(client=client):
+        assert len(servicer.app_functions) == 2
+
+        class_function = servicer.function_by_name("ClusteredClass.*")
+        assert class_function._experimental_group_size == 3
+        assert class_function.i6pn_enabled is True  # clustered implies i6pn
+
+        obj = ClusteredClass()
+        assert hasattr(obj, "run_task")
+
+        regular_function = servicer.function_by_name("RegularClass.*")
+        assert regular_function._experimental_group_size == 0  # or not set
+        assert regular_function.i6pn_enabled is False
+
+
+invalid_clustered_app = App()
+
+
+def test_clustered_cls_with_multiple_methods(client, servicer):
+    with pytest.raises(
+        InvalidError, match="Modal class ClusteredClassMixed cannot have multiple methods when clustered."
+    ):
+
+        @invalid_clustered_app.cls(serialized=True)
+        @modal.experimental.clustered(size=2)  # type: ignore
+        class ClusteredClassMixed:
+            @method()
+            def clustered_method(self, x):
+                return x * 3
+
+            @method()
+            def second_clustered_method(self, x):
+                return x * 3


### PR DESCRIPTION
## Describe your changes

- Allows Cls to be grouped in a clustered function

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

- Adds `modal.experimental.clustered` support to `modal.Cls`
