### PR TITLE
Cyril/add back attempt token

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1487,7 +1487,7 @@ message FunctionCallCancelRequest {
 message FunctionCallGetDataRequest {
   string function_call_id = 1;
   uint64 last_index = 2;
-  reserved 3; // attempt_token
+  optional string attempt_token = 3;
 }
 
 message FunctionCallInfo {


### PR DESCRIPTION
Add it back because otherwise we have no way of communicating to the input plane what function call id we wish to get an output from.