### PR TITLE
Fix flaky `io_streams` test

### DIFF
--- a/test/io_streams_test.py
+++ b/test/io_streams_test.py
@@ -287,30 +287,31 @@ async def test_stream_reader_container_process_retry(servicer, client):
 
 
 @pytest.mark.asyncio
-@pytest.mark.flaky(max_runs=3)  # TODO(matt-n) Fix test to avoid flaking in CI
 async def test_stream_reader_timeout(servicer, client):
     """Test that StreamReader stops reading messages after the given deadline, and that
     messages are received within the deadline"""
+
     time_first_send = 0.0
 
     async def container_exec_get_output(servicer, stream):
         nonlocal time_first_send
         await stream.recv_message()
-        time_first_send = time.monotonic()
         # Send three messages, third one heavily delayed
         for i in range(3):
+            if i == 2:
+                await asyncio.sleep(3)
             await stream.send_message(
                 api_pb2.RuntimeOutputBatch(
                     batch_index=i,
                     items=[api_pb2.RuntimeOutputMessage(message_bytes=f"msg{i}\n".encode())],
                 )
             )
-            await asyncio.sleep(1 if i <= 1 else 2)
+            if i == 0:
+                time_first_send = time.monotonic()
         await stream.send_message(api_pb2.RuntimeOutputBatch(exit_code=0))
 
     with servicer.intercept() as ctx:
         ctx.set_responder("ContainerExecGetOutput", container_exec_get_output)
-
         with enable_output():
             stdout: StreamReader[str] = StreamReader(
                 file_descriptor=api_pb2.FILE_DESCRIPTOR_STDOUT,
@@ -320,18 +321,9 @@ async def test_stream_reader_timeout(servicer, client):
                 by_line=True,
                 deadline=time.monotonic() + 2,  # use a 2-second timeout
             )
-
             output: list[str] = []
-            expected_times = [
-                (0, 1.5),  # message 0: between 0 and 1.5s
-                (1, 2.0),  # message 1: between 1 and 2
-            ]
             async for line in stdout:
-                elapsed = time.monotonic() - time_first_send
-                min_time, max_time = expected_times[len(output)]
-                assert min_time < elapsed < max_time
                 output.append(line)
-
             # message 3 should not be received, due to the timeout
             assert output == [f"msg{i}\n" for i in range(2)]
-            assert time.monotonic() - time_first_send <= 3
+            assert time.monotonic() - time_first_send <= 4


### PR DESCRIPTION
Asserting that the messages arrive within a tight time window is not important behavior to test and just leads to flakes. Also refactored the test to remove unnecessary sleeps, and added a 1s buffer on the last assertion in case of slow CI workers. This should fix flakes (unless a CI worker is really slow) and it also makes the test 2x faster.

Re https://github.com/modal-labs/modal-client/pull/3356