### PR TITLE
Add flash_get_containers function

### DIFF
--- a/modal/experimental/__init__.py
+++ b/modal/experimental/__init__.py
@@ -20,7 +20,7 @@ from ..cls import _Cls, _Obj
 from ..exception import InvalidError
 from ..image import DockerfileSpec, ImageBuilderVersion, _Image, _ImageRegistryConfig
 from ..secret import _Secret
-from .flash import flash_forward, flash_prometheus_autoscaler  # noqa: F401
+from .flash import flash_forward, flash_get_containers, flash_prometheus_autoscaler  # noqa: F401
 
 
 def stop_fetching_inputs():


### PR DESCRIPTION
Adds an experimental function to get all flash containers based on app name and class name.

This is useful for setting up Prometheus + vLLM (the Prometheus container needs to get a list of vLLM instances).