### PR TITLE
raise an AlreadyExistsError when sandbox already exists with given name

### DIFF
--- a/modal/exception.py
+++ b/modal/exception.py
@@ -26,6 +26,10 @@ class Error(Exception):
     """
 
 
+class AlreadyExistsError(Error):
+    """Raised when a resource creation conflicts with an existing resource."""
+
+
 class RemoteError(Error):
     """Raised when an error occurs on the Modal server."""
 


### PR DESCRIPTION
## Describe your changes

This updates the `Sandbox.create()` to throw a ` modal.exception.AlreadyExistsError` when Sandbox creation fails due to another running Sandbox already holding the given name.