### PR TITLE
[SpawnMapV2](0) Refactor Map

### DIFF
--- a/modal/parallel_map.py
+++ b/modal/parallel_map.py
@@ -88,8 +88,7 @@ if typing.TYPE_CHECKING:
 
 class InputPreprocessor:
     """
-    Consumes unregistered, user provided inputs from a raw-input queue
-    Registers each of them with the control-plane, and puts them in a processed-input queue.
+    Constructs FunctionPutInputsItem objects from the raw-input queue, and puts them in the processed-input queue.
     """
 
     def __init__(

--- a/modal/parallel_map.py
+++ b/modal/parallel_map.py
@@ -86,6 +86,162 @@ if typing.TYPE_CHECKING:
     import modal.functions
 
 
+class InputPreprocessor:
+    """
+    Preprocesses inputs to be sent to the server.
+    """
+
+    def __init__(
+        self,
+        client: "modal.client._Client",
+        *,
+        raw_input_queue: _SynchronizedQueue,
+        processed_input_queue: asyncio.Queue,
+        function: "modal.functions._Function",
+        created_callback: Optional[Callable[[int], None]],
+        done_callback: Optional[Callable[[int], None]],
+    ):
+        self.client = client
+        self.function = function
+        self.inputs_created = 0
+        self.raw_input_queue = raw_input_queue
+        self.processed_input_queue = processed_input_queue
+        self.processed_all_inputs = False
+        self.created_callback = created_callback
+        self.done_callback = done_callback
+
+    async def input_iter(self):
+        while 1:
+            raw_input = await self.raw_input_queue.get()
+            if raw_input is None:  # end of input sentinel
+                break
+            yield raw_input  # args, kwargs
+
+    def create_input(self):
+        async def create_input_inner(argskwargs):
+            idx = self.inputs_created
+            self.inputs_created += 1
+            self.created_callback(self.inputs_created)
+            (args, kwargs) = argskwargs
+            return await _create_input(
+                args,
+                kwargs,
+                self.client.stub,
+                max_object_size_bytes=self.function._max_object_size_bytes,
+                idx=idx,
+                method_name=self.function._use_method_name,
+            )
+
+        return create_input_inner
+
+    async def drain_input_generator(self):
+        # Parallelize uploading blobs
+        async with aclosing(
+            async_map_ordered(self.input_iter(), self.create_input(), concurrency=BLOB_MAX_PARALLELISM)
+        ) as streamer:
+            async for item in streamer:
+                await self.processed_input_queue.put(item)
+
+        # close queue iterator
+        await self.processed_input_queue.put(None)
+        self.processed_all_inputs = True
+        if self.done_callback is not None:
+            self.done_callback(self.inputs_created)
+        yield
+
+
+class InputPumper:
+    """
+    Pumps inputs to the server.
+    """
+
+    def __init__(
+        self,
+        client: "modal.client._Client",
+        *,
+        input_queue: asyncio.Queue,
+        retry_queue: TimestampPriorityQueue,
+        function: "modal.functions._Function",
+        map_items_manager: "_MapItemsManager",
+        function_call_jwt: str,
+        function_call_id: str,
+    ):
+        self.client = client
+        self.function = function
+        self.map_items_manager = map_items_manager
+        self.retry_queue = retry_queue
+        self.input_queue = input_queue
+        self.inputs_sent = 0
+        self.inputs_retried = 0
+        self.function_call_jwt = function_call_jwt
+        self.function_call_id = function_call_id
+
+    async def pump_inputs(self):
+        assert self.client.stub
+        async for items in queue_batch_iterator(self.input_queue, max_batch_size=MAP_INVOCATION_CHUNK_SIZE):
+            # Add items to the manager. Their state will be SENDING.
+            await self.map_items_manager.add_items(items)
+            request = api_pb2.FunctionPutInputsRequest(
+                function_id=self.function.object_id,
+                inputs=items,
+                function_call_id=self.function_call_id,
+            )
+            logger.debug(
+                f"Pushing {len(items)} inputs to server. Num queued inputs awaiting"
+                f" push is {self.input_queue.qsize()}. "
+            )
+
+            resp = await self.send_inputs(self.client.stub.FunctionPutInputs, request)
+            self.inputs_sent += len(items)
+            # Change item state to WAITING_FOR_OUTPUT, and set the input_id and input_jwt which are in the response.
+            self.map_items_manager.handle_put_inputs_response(resp.inputs)
+            logger.debug(
+                f"Successfully pushed {len(items)} inputs to server. "
+                f"Num queued inputs awaiting push is {self.input_queue.qsize()}."
+            )
+        yield
+
+    async def retry_inputs(self):
+        async for retriable_idxs in queue_batch_iterator(self.retry_queue, max_batch_size=MAP_INVOCATION_CHUNK_SIZE):
+            # For each index, use the context in the manager to create a FunctionRetryInputsItem.
+            # This will also update the context state to RETRYING.
+            inputs: list[api_pb2.FunctionRetryInputsItem] = await self.map_items_manager.prepare_items_for_retry(
+                retriable_idxs
+            )
+            request = api_pb2.FunctionRetryInputsRequest(
+                function_call_jwt=self.function_call_jwt,
+                inputs=inputs,
+            )
+            resp = await self.send_inputs(self.client.stub.FunctionRetryInputs, request)
+            # Update the state to WAITING_FOR_OUTPUT, and update the input_jwt in the context
+            # to the new value in the response.
+            self.map_items_manager.handle_retry_response(resp.input_jwts)
+            logger.debug(f"Successfully pushed retry for {len(inputs)} to server.")
+            self.inputs_retried += len(inputs)
+        yield
+
+    async def send_inputs(
+        self,
+        fn: "modal.client.UnaryUnaryWrapper",
+        request: typing.Union[api_pb2.FunctionPutInputsRequest, api_pb2.FunctionRetryInputsRequest],
+    ) -> typing.Union[api_pb2.FunctionPutInputsResponse, api_pb2.FunctionRetryInputsResponse]:
+        # with 8 retries we log the warning below about every 30 seconds which isn't too spammy.
+        retry_warning_message = RetryWarningMessage(
+            message=f"Warning: map progress for function {self.function._function_name} is limited."
+            " Common bottlenecks include slow iteration over results, or function backlogs.",
+            warning_interval=8,
+            errors_to_warn_for=[Status.RESOURCE_EXHAUSTED],
+        )
+        return await retry_transient_errors(
+            fn,
+            request,
+            max_retries=None,
+            max_delay=PUMP_INPUTS_MAX_RETRY_DELAY,
+            additional_status_codes=[Status.RESOURCE_EXHAUSTED],
+            retry_warning_message=retry_warning_message,
+        )
+
+
 async def _map_invocation(
     function: "modal.functions._Function",
     raw_input_queue: _SynchronizedQueue,
@@ -117,8 +273,6 @@ async def _map_invocation(
     have_all_inputs = False
     map_done_event = asyncio.Event()
     inputs_created = 0
-    inputs_sent = 0
-    inputs_retried = 0
     outputs_completed = 0
     outputs_received = 0
     retried_outputs = 0
@@ -135,25 +289,24 @@ async def _map_invocation(
         retry_policy, function_call_invocation_type, retry_queue, sync_client_retries_enabled, max_inputs_outstanding
     )
 
-    async def create_input(argskwargs):
-        idx = inputs_created
-        update_state(set_inputs_created=inputs_created + 1)
-        (args, kwargs) = argskwargs
-        return await _create_input(
-            args,
-            kwargs,
-            client.stub,
-            max_object_size_bytes=function._max_object_size_bytes,
-            idx=idx,
-            method_name=function._use_method_name,
-        )
+    input_preprocessor = InputPreprocessor(
+        client=client,
+        raw_input_queue=raw_input_queue,
+        processed_input_queue=input_queue,
+        function=function,
+        created_callback=lambda x: update_state(set_inputs_created=x),
+        done_callback=lambda _: update_state(set_have_all_inputs=True),
+    )
 
-    async def input_iter():
-        while 1:
-            raw_input = await raw_input_queue.get()
-            if raw_input is None:  # end of input sentinel
-                break
-            yield raw_input  # args, kwargs
+    input_pumper = InputPumper(
+        client=client,
+        input_queue=input_queue,
+        retry_queue=retry_queue,
+        function=function,
+        map_items_manager=map_items_manager,
+        function_call_jwt=function_call_jwt,
+        function_call_id=function_call_id,
+    )
 
     def update_state(set_have_all_inputs=None, set_inputs_created=None, set_outputs_completed=None):
         # This should be the only method that needs nonlocal of the following vars
@@ -174,84 +327,6 @@ async def _map_invocation(
         if have_all_inputs and outputs_completed >= inputs_created:
             # map is done
             map_done_event.set()
-
-    async def drain_input_generator():
-        # Parallelize uploading blobs
-        async with aclosing(
-            async_map_ordered(input_iter(), create_input, concurrency=BLOB_MAX_PARALLELISM)
-        ) as streamer:
-            async for item in streamer:
-                await input_queue.put(item)
-
-        # close queue iterator
-        await input_queue.put(None)
-        update_state(set_have_all_inputs=True)
-        yield
-
-    async def pump_inputs():
-        assert client.stub
-        nonlocal inputs_sent
-        async for items in queue_batch_iterator(input_queue, max_batch_size=MAP_INVOCATION_CHUNK_SIZE):
-            # Add items to the manager. Their state will be SENDING.
-            await map_items_manager.add_items(items)
-            request = api_pb2.FunctionPutInputsRequest(
-                function_id=function.object_id,
-                inputs=items,
-                function_call_id=function_call_id,
-            )
-            logger.debug(
-                f"Pushing {len(items)} inputs to server. Num queued inputs awaiting push is {input_queue.qsize()}."
-            )
-
-            resp = await send_inputs(client.stub.FunctionPutInputs, request)
-            inputs_sent += len(items)
-            # Change item state to WAITING_FOR_OUTPUT, and set the input_id and input_jwt which are in the response.
-            map_items_manager.handle_put_inputs_response(resp.inputs)
-            logger.debug(
-                f"Successfully pushed {len(items)} inputs to server. "
-                f"Num queued inputs awaiting push is {input_queue.qsize()}."
-            )
-        yield
-
-    async def retry_inputs():
-        nonlocal inputs_retried
-        async for retriable_idxs in queue_batch_iterator(retry_queue, max_batch_size=MAP_INVOCATION_CHUNK_SIZE):
-            # For each index, use the context in the manager to create a FunctionRetryInputsItem.
-            # This will also update the context state to RETRYING.
-            inputs: list[api_pb2.FunctionRetryInputsItem] = await map_items_manager.prepare_items_for_retry(
-                retriable_idxs
-            )
-            request = api_pb2.FunctionRetryInputsRequest(
-                function_call_jwt=function_call_jwt,
-                inputs=inputs,
-            )
-            resp = await send_inputs(client.stub.FunctionRetryInputs, request)
-            # Update the state to WAITING_FOR_OUTPUT, and update the input_jwt in the context
-            # to the new value in the response.
-            map_items_manager.handle_retry_response(resp.input_jwts)
-            logger.debug(f"Successfully pushed retry for {len(inputs)} to server.")
-            inputs_retried += len(inputs)
-        yield
-
-    async def send_inputs(
-        fn: "modal.client.UnaryUnaryWrapper",
-        request: typing.Union[api_pb2.FunctionPutInputsRequest, api_pb2.FunctionRetryInputsRequest],
-    ) -> typing.Union[api_pb2.FunctionPutInputsResponse, api_pb2.FunctionRetryInputsResponse]:
-        # with 8 retries we log the warning below about every 30 seconds which isn't too spammy.
-        retry_warning_message = RetryWarningMessage(
-            message=f"Warning: map progress for function {function._function_name} is limited."
-            " Common bottlenecks include slow iteration over results, or function backlogs.",
-            warning_interval=8,
-            errors_to_warn_for=[Status.RESOURCE_EXHAUSTED],
-        )
-        return await retry_transient_errors(
-            fn,
-            request,
-            max_retries=None,
-            max_delay=PUMP_INPUTS_MAX_RETRY_DELAY,
-            additional_status_codes=[Status.RESOURCE_EXHAUSTED],
-            retry_warning_message=retry_warning_message,
-        )
 
     async def get_all_outputs():
         assert client.stub
@@ -395,8 +470,11 @@ async def _map_invocation(
         def log_stats():
             logger.debug(
                 f"Map stats: sync_client_retries_enabled={sync_client_retries_enabled} "
-                f"have_all_inputs={have_all_inputs} inputs_created={inputs_created} input_sent={inputs_sent} "
-                f"inputs_retried={inputs_retried} outputs_received={outputs_received} "
+                f"have_all_inputs={input_preprocessor.processed_all_inputs} "
+                f"inputs_created={input_preprocessor.inputs_created} "
+                f"input_sent={input_pumper.inputs_sent} "
+                f"inputs_retried={input_pumper.inputs_retried} "
+                f"outputs_received={outputs_received} "
                 f"successful_completions={successful_completions} failed_completions={failed_completions} "
                 f"no_context_duplicates={no_context_duplicates} old_retry_duplicates={stale_retry_duplicates} "
                 f"already_complete_duplicates={already_complete_duplicates} "
@@ -415,7 +493,12 @@ async def _map_invocation(
 
     log_debug_stats_task = asyncio.create_task(log_debug_stats())
     async with aclosing(
-        async_merge(drain_input_generator(), pump_inputs(), poll_outputs(), retry_inputs())
+        async_merge(
+            input_preprocessor.drain_input_generator(),
+            input_pumper.pump_inputs(),
+            input_pumper.retry_inputs(),
+            poll_outputs(),
+        )
     ) as streamer:
         async for response in streamer:
             if response is not None:  # type: ignore[unreachable]


### PR DESCRIPTION
This is a relatively small refactor which just groups related functionality into classes. This refactor is necessary because
1. The Map Code is a mess
2. The map logic should be re-usable, especially with the soon-to-arrive introduction of `Spawn-Map` v2.