### PR TITLE
Add IPv4 field to TaskClusterHello  proto

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2919,6 +2919,7 @@ message TaskClusterHelloResponse {
   uint32 cluster_rank = 2;
   // All IP addresses in cluster, ordered by cluster rank
   repeated string container_ips = 3;
+  repeated string ipv4_ips = 4;
 }
 
 message TaskCurrentInputsResponse {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2917,9 +2917,9 @@ message TaskClusterHelloRequest {
 message TaskClusterHelloResponse {
   string cluster_id = 1;
   uint32 cluster_rank = 2;
-  // All IP addresses in cluster, ordered by cluster rank
+  // All IPv6 addresses in cluster, ordered by cluster rank
   repeated string container_ips = 3;
-  repeated string ipv4_ips = 4;
+  repeated string container_ipv4_ips = 4;
 }
 
 message TaskCurrentInputsResponse {


### PR DESCRIPTION
## Describe your changes

This PR adds support for IPv4 IPs in the TaskClusterHello response so we can inform the client of its V4 IP instead of users having to configure it.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


</details>
