### PR TITLE
Integrate container IPs into clusterinfo

### DIFF
--- a/modal/_clustered_functions.py
+++ b/modal/_clustered_functions.py
@@ -37,25 +37,6 @@ async def _initialize_clustered_function(client: _Client, task_id: str, world_si
         """Returns the ipv6 address assigned to this container."""
         return socket.getaddrinfo("i6pn.modal.local", None, socket.AF_INET6)[0][4][0]
 
-    def get_container_ipv4():
-        """Returns the ipv4 address assigned to this container."""
-        try:
-            # Try to get IPv4 address through hostname resolution
-            hostname = socket.gethostname()
-            return socket.gethostbyname(hostname)
-        except (socket.gaierror, OSError):
-            # Fall back to getting the default route interface address
-            try:
-                # Create a socket to determine which interface would be used for external connections
-                s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-                s.connect(("8.8.8.8", 80))  # Connect to a public DNS server
-                ipv4_address = s.getsockname()[0]
-                s.close()
-                return ipv4_address
-            except Exception:
-                # If all else fails, return localhost
-                return "127.0.0.1"
-
     hostname = socket.gethostname()
     container_ip = get_i6pn()
 
@@ -92,11 +73,10 @@ async def _initialize_clustered_function(client: _Client, task_id: str, world_si
             container_ipv4_ips=resp.container_ipv4_ips,
         )
     else:
-        container_ipv4 = get_container_ipv4()
         cluster_info = ClusterInfo(
             rank=0,
             container_ips=[container_ip],
-            container_ipv4_ips=[container_ipv4],
+            container_ipv4_ips=[],  # No IPv4 IPs for single-node
         )
 
 

--- a/modal/_clustered_functions.py
+++ b/modal/_clustered_functions.py
@@ -16,7 +16,6 @@ class ClusterInfo:
     rank: int
     container_ips: list[str]
     container_ipv4_ips: list[str]
-    error: Optional[str] = None
 
 
 cluster_info: Optional[ClusterInfo] = None
@@ -39,17 +38,7 @@ async def _initialize_clustered_function(client: _Client, task_id: str, world_si
         return socket.getaddrinfo("i6pn.modal.local", None, socket.AF_INET6)[0][4][0]
 
     hostname = socket.gethostname()
-    
-    try:
-        container_ip = get_i6pn()
-    except Exception:
-        cluster_info = ClusterInfo(
-            rank=0,
-            container_ips=[],
-            container_ipv4_ips=[],
-            error="Failed to initialize cluster networking"
-        )
-        return
+    container_ip = get_i6pn()
 
     # nccl's default host ID is $(hostname)$(cat /proc/sys/kernel/random/boot_id).
     # on runc, if two i6pn-linked containers get scheduled on the same worker,
@@ -71,26 +60,18 @@ async def _initialize_clustered_function(client: _Client, task_id: str, world_si
         os.environ["NCCL_NSOCKS_PERTHREAD"] = "1"
 
     if world_size > 1:
-        try:
-            resp: api_pb2.TaskClusterHelloResponse = await retry_transient_errors(
-                client.stub.TaskClusterHello,
-                api_pb2.TaskClusterHelloRequest(
-                    task_id=task_id,
-                    container_ip=container_ip,
-                ),
-            )
-            cluster_info = ClusterInfo(
-                rank=resp.cluster_rank,
-                container_ips=resp.container_ips,
-                container_ipv4_ips=resp.container_ipv4_ips,
-            )
-        except Exception:
-            cluster_info = ClusterInfo(
-                rank=0,
-                container_ips=[container_ip],
-                container_ipv4_ips=[],
-                error="Failed to initialize cluster networking"
-            )
+        resp: api_pb2.TaskClusterHelloResponse = await retry_transient_errors(
+            client.stub.TaskClusterHello,
+            api_pb2.TaskClusterHelloRequest(
+                task_id=task_id,
+                container_ip=container_ip,
+            ),
+        )
+        cluster_info = ClusterInfo(
+            rank=resp.cluster_rank,
+            container_ips=resp.container_ips,
+            container_ipv4_ips=resp.container_ipv4_ips,
+        )
     else:
         cluster_info = ClusterInfo(
             rank=0,


### PR DESCRIPTION
## Describe your changes

- Integrates the `container_ipv4_ips` field into `ClusterInfo`.
- For multi-node clusters, `container_ipv4_ips` is populated from the backend's `TaskClusterHelloResponse`.
- For single-node scenarios, `container_ipv4_ips` is an empty list since the container already has a local V4 IP.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

