### PR TITLE
[Input-Plane Parameterized Webendpoints](11) Add Input Plane Server URL To ContainerIOManager

### DIFF
--- a/modal/_runtime/container_io_manager.py
+++ b/modal/_runtime/container_io_manager.py
@@ -300,11 +300,7 @@ class _ContainerIOManager:
         self.function_def = container_args.function_def
         self.checkpoint_id = container_args.checkpoint_id or None
 
-        # We could also have the worker pass this in explicitly.
-        self.input_plane_server_url = None
-        for obj in container_args.app_layout.objects:
-            if obj.object_id == self.function_id:
-                self.input_plane_server_url = obj.function_handle_metadata.input_plane_url
+        self.input_plane_server_url = container_args.input_plane_server_url
 
         self.calls_completed = 0
         self.total_user_time = 0.0


### PR DESCRIPTION
Note that this field won't be set on all workers until about 1 day has passed, we should probably wait until Friday to avoid breaking web endpoints.