### PR TITLE
add support for key not found

### DIFF
--- a/modal/dict.py
+++ b/modal/dict.py
@@ -309,7 +309,7 @@ class _Dict(_Object, type_prefix="di"):
         """Remove a key from the Dict, returning the value if it exists."""
         req = api_pb2.DictPopRequest(dict_id=self.object_id, key=serialize(key))
         resp = await retry_transient_errors(self._client.stub.DictPop, req)
-        if not resp.found:
+        if not resp or not resp.found:
             raise KeyError(f"{key} not in dict {self.object_id}")
         return deserialize(resp.value, self._client)
 


### PR DESCRIPTION
## Describe your changes
if the key is not found, the server side returns None (according to type definition)
add support for handling that case on client side

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ x] Client+Server: this change is compatible with old servers
- [ x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

</details>

## Changelog
- Improve error handling for DictPop on nonexistent keys
