### PR TITLE
Set force_jupyter=False on rich Console objects

### DIFF
--- a/modal/__main__.py
+++ b/modal/__main__.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
 import sys
 
+from ._output import make_console
 from ._traceback import reduce_traceback_to_user_code
 from .cli._traceback import highlight_modal_warnings, setup_rich_traceback
 from .cli.entry_point import entrypoint_cli
@@ -35,7 +36,6 @@ def main():
             raise
 
         from grpclib import GRPCError, Status
-        from rich.console import Console
         from rich.panel import Panel
         from rich.text import Text
 
@@ -68,7 +68,7 @@ def main():
             if notes := getattr(exc, "__notes__", []):
                 content = f"{content}\n\nNote: {' '.join(notes)}"
 
-        console = Console(stderr=True)
+        console = make_console(stderr=True)
         panel = Panel(Text(content), title=title, title_align="left", border_style="red")
         console.print(panel, highlight=False)
         sys.exit(1)

--- a/modal/_output.py
+++ b/modal/_output.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import functools
-import io
 import platform
 import re
 import socket
@@ -44,6 +43,16 @@ if platform.system() == "Windows":
     default_spinner = "line"
 else:
     default_spinner = "dots"
+
+
+def make_console(*, stderr: bool = False, highlight: bool = True) -> Console:
+    """Create a rich Console tuned for Modal CLI output."""
+    return Console(
+        stderr=stderr,
+        highlight=highlight,
+        # CLI does not work with auto-detected Jupyter HTML display_data.
+        force_jupyter=False,
+    )
 
 
 class FunctionQueuingColumn(ProgressColumn):
@@ -147,12 +156,11 @@ class OutputManager:
     def __init__(
         self,
         *,
-        stdout: io.TextIOWrapper | None = None,
         status_spinner_text: str = "Running app...",
         show_timestamps: bool = False,
     ):
-        self._stdout = stdout or sys.stdout
-        self._console = Console(file=stdout, highlight=False)
+        self._stdout = sys.stdout
+        self._console = make_console(highlight=False)
         self._task_states = {}
         self._task_progress_items = {}
         self._current_render_group = None

--- a/modal/cli/_traceback.py
+++ b/modal/cli/_traceback.py
@@ -6,7 +6,7 @@ import re
 import warnings
 from typing import Optional
 
-from rich.console import Console, RenderResult, group
+from rich.console import RenderResult, group
 from rich.panel import Panel
 from rich.syntax import Syntax
 from rich.text import Text
@@ -166,6 +166,8 @@ def highlight_modal_warnings() -> None:
     base_showwarning = warnings.showwarning
 
     def showwarning(warning, category, filename, lineno, file=None, line=None):
+        from .._output import make_console
+
         if issubclass(category, (DeprecationError, PendingDeprecationError, ServerWarning)):
             content = str(warning)
             if re.match(r"^\d{4}-\d{2}-\d{2}", content):
@@ -193,7 +195,7 @@ def highlight_modal_warnings() -> None:
                 title=title,
                 title_align="left",
             )
-            Console().print(panel)
+            make_console().print(panel)
         else:
             base_showwarning(warning, category, filename, lineno, file=None, line=None)
 

--- a/modal/cli/cluster.py
+++ b/modal/cli/cluster.py
@@ -2,10 +2,10 @@
 from typing import Optional, Union
 
 import typer
-from rich.console import Console
 from rich.text import Text
 
 from modal._object import _get_environment_name
+from modal._output import make_console
 from modal._pty import get_pty_info
 from modal._utils.async_utils import synchronizer
 from modal._utils.time_utils import timestamp_to_local
@@ -62,7 +62,7 @@ async def shell(
     if len(res.cluster.task_ids) <= rank:
         raise typer.Abort(f"No node with rank {rank} in cluster {cluster_id}")
     task_id = res.cluster.task_ids[rank]
-    console = Console()
+    console = make_console()
     is_main = "(main)" if rank == 0 else ""
     console.print(
         f"Opening shell to node {rank} {is_main} of cluster {cluster_id} (container {task_id})", style="green"

--- a/modal/cli/config.py
+++ b/modal/cli/config.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 import typer
-from rich.console import Console
 
+from modal._output import make_console
 from modal.config import _profile, _store_user_config, config
 from modal.environments import Environment
 
@@ -24,7 +24,7 @@ def show(redact: bool = typer.Option(True, help="Redact the `token_secret` value
     if redact and config_dict.get("token_secret"):
         config_dict["token_secret"] = "***"
 
-    console = Console()
+    console = make_console()
     console.print(config_dict)
 
 

--- a/modal/cli/dict.py
+++ b/modal/cli/dict.py
@@ -2,9 +2,9 @@
 from typing import Optional
 
 import typer
-from rich.console import Console
 from typer import Argument, Option, Typer
 
+from modal._output import make_console
 from modal._resolver import Resolver
 from modal._utils.async_utils import synchronizer
 from modal._utils.grpc_utils import retry_transient_errors
@@ -85,7 +85,7 @@ async def get(name: str, key: str, *, env: Optional[str] = ENV_OPTION):
     Note: When using the CLI, keys are always interpreted as having a string type.
     """
     d = _Dict.from_name(name, environment_name=env)
-    console = Console()
+    console = make_console()
     val = await d.get(key)
     console.print(val)
 

--- a/modal/cli/entry_point.py
+++ b/modal/cli/entry_point.py
@@ -3,9 +3,9 @@ import subprocess
 from typing import Optional
 
 import typer
-from rich.console import Console
 from rich.rule import Rule
 
+from modal._output import make_console
 from modal._utils.async_utils import synchronizer
 
 from . import run
@@ -71,7 +71,7 @@ def check_path():
             "You may need to give it permissions or use `[white]python -m modal[/white]` as a workaround.[/red]\n"
         )
     text += f"See more information here:\n\n[link={url}]{url}[/link]\n"
-    console = Console()
+    console = make_console()
     console.print(text)
     console.print(Rule(style="white"))
 

--- a/modal/cli/import_refs.py
+++ b/modal/cli/import_refs.py
@@ -19,9 +19,9 @@ from pathlib import Path
 from typing import Optional, Union, cast
 
 import click
-from rich.console import Console
 from rich.markdown import Markdown
 
+from modal._output import make_console
 from modal._utils.deprecation import deprecation_warning
 from modal.app import App, LocalEntrypoint
 from modal.cls import Cls
@@ -258,7 +258,7 @@ def import_app_from_ref(import_ref: ImportRef, base_cmd: str = "") -> App:
     app = getattr(module, object_path)
 
     if app is None:
-        error_console = Console(stderr=True)
+        error_console = make_console(stderr=True)
         error_console.print(f"[bold red]Could not find Modal app '{object_path}' in {import_path}.[/bold red]")
 
         if not object_path:
@@ -282,7 +282,7 @@ def import_app_from_ref(import_ref: ImportRef, base_cmd: str = "") -> App:
 def _show_function_ref_help(app_ref: ImportRef, base_cmd: str) -> None:
     object_path = app_ref.object_path
     import_path = app_ref.file_or_module
-    error_console = Console(stderr=True)
+    error_console = make_console(stderr=True)
     if object_path:
         error_console.print(
             f"[bold red]Could not find Modal function or local entrypoint"

--- a/modal/cli/profile.py
+++ b/modal/cli/profile.py
@@ -5,10 +5,10 @@ import os
 from typing import Optional
 
 import typer
-from rich.console import Console
 from rich.json import JSON
 from rich.table import Table
 
+from modal._output import make_console
 from modal._utils.async_utils import synchronizer
 from modal.config import Config, _lookup_workspace, _profile, config_profiles, config_set_active_profile
 from modal.exception import AuthError
@@ -69,7 +69,7 @@ async def list_(json: Optional[bool] = False):
         except AuthError:
             env_based_workspace = "Unknown (authentication failure)"
 
-    console = Console()
+    console = make_console()
     highlight = "bold green" if env_based_workspace is None else "yellow"
     if json:
         json_data = []

--- a/modal/cli/queues.py
+++ b/modal/cli/queues.py
@@ -2,9 +2,9 @@
 from typing import Optional
 
 import typer
-from rich.console import Console
 from typer import Argument, Option, Typer
 
+from modal._output import make_console
 from modal._resolver import Resolver
 from modal._utils.async_utils import synchronizer
 from modal._utils.grpc_utils import retry_transient_errors
@@ -108,7 +108,7 @@ async def peek(
 ):
     """Print the next N items in the queue or queue partition (without removal)."""
     q = _Queue.from_name(name, environment_name=env)
-    console = Console()
+    console = make_console()
     i = 0
     async for item in q.iterate(partition=partition):
         console.print(item)
@@ -128,5 +128,5 @@ async def len(
 ):
     """Print the length of a queue partition or the total length of all partitions."""
     q = _Queue.from_name(name, environment_name=env)
-    console = Console()
+    console = make_console()
     console.print(await q.len(partition=partition, total=total))

--- a/modal/cli/secret.py
+++ b/modal/cli/secret.py
@@ -9,10 +9,10 @@ from typing import Optional
 
 import click
 import typer
-from rich.console import Console
 from rich.syntax import Syntax
 from typer import Argument
 
+from modal._output import make_console
 from modal._utils.async_utils import synchronizer
 from modal._utils.grpc_utils import retry_transient_errors
 from modal._utils.time_utils import timestamp_to_local
@@ -117,7 +117,7 @@ modal secret create my-credentials username=john password="$PASSWORD"
     await _Secret.create_deployed(secret_name, env_dict, overwrite=force)
 
     # Print code sample
-    console = Console()
+    console = make_console()
     env_var_code = "\n    ".join(f'os.getenv("{name}")' for name in env_dict.keys()) if env_dict else "..."
     example_code = f"""
 @app.function(secrets=[modal.Secret.from_name("{secret_name}")])

--- a/modal/cli/utils.py
+++ b/modal/cli/utils.py
@@ -7,13 +7,12 @@ from typing import Optional, Union
 import typer
 from click import UsageError
 from grpclib import GRPCError, Status
-from rich.console import Console
 from rich.table import Column, Table
 from rich.text import Text
 
 from modal_proto import api_pb2
 
-from .._output import OutputManager, get_app_logs_loop
+from .._output import OutputManager, get_app_logs_loop, make_console
 from .._utils.async_utils import synchronizer
 from ..client import _Client
 from ..environments import ensure_env
@@ -66,7 +65,7 @@ def _plain(text: Union[Text, str]) -> str:
 
 
 def is_tty() -> bool:
-    return Console().is_terminal
+    return make_console().is_terminal
 
 
 def display_table(
@@ -78,7 +77,7 @@ def display_table(
     def col_to_str(col: Union[Column, str]) -> str:
         return str(col.header) if isinstance(col, Column) else col
 
-    console = Console()
+    console = make_console()
     if json:
         json_data = [{col_to_str(col): _plain(row[i]) for i, col in enumerate(columns)} for row in rows]
         console.print_json(dumps(json_data))

--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -7,12 +7,11 @@ from typing import Optional
 import typer
 from click import UsageError
 from grpclib import GRPCError, Status
-from rich.console import Console
 from rich.syntax import Syntax
 from typer import Argument, Option, Typer
 
 import modal
-from modal._output import OutputManager, ProgressHandler
+from modal._output import OutputManager, ProgressHandler, make_console
 from modal._utils.async_utils import synchronizer
 from modal._utils.grpc_utils import retry_transient_errors
 from modal._utils.time_utils import timestamp_to_local
@@ -64,7 +63,7 @@ def some_func():
     os.listdir("/my_vol")
 """
 
-    console = Console()
+    console = make_console()
     console.print(f"Created Volume '{name}' in environment '{env_name}'. \n\nCode example:\n")
     usage = Syntax(usage_code, "python")
     console.print(usage)
@@ -96,7 +95,7 @@ async def get(
     ensure_env(env)
     destination = Path(local_destination)
     volume = _Volume.from_name(volume_name, environment_name=env)
-    console = Console()
+    console = make_console()
     progress_handler = ProgressHandler(type="download", console=console)
     with progress_handler.live:
         await _volume_download(volume, remote_path, destination, force, progress_cb=progress_handler.progress)
@@ -197,7 +196,7 @@ async def put(
 
     if remote_path.endswith("/"):
         remote_path = remote_path + os.path.basename(local_path)
-    console = Console()
+    console = make_console()
     progress_handler = ProgressHandler(type="upload", console=console)
 
     if Path(local_path).is_dir():
@@ -245,7 +244,7 @@ async def rm(
 ):
     ensure_env(env)
     volume = _Volume.from_name(volume_name, environment_name=env)
-    console = Console()
+    console = make_console()
     try:
         await volume.remove_file(remote_path, recursive=recursive)
         console.print(OutputManager.step_completed(f"{remote_path} was deleted successfully!"))

--- a/modal/container_process.py
+++ b/modal/container_process.py
@@ -6,6 +6,7 @@ from typing import Generic, Optional, TypeVar
 
 from modal_proto import api_pb2
 
+from ._output import make_console
 from ._utils.async_utils import TaskContext, synchronize_api
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.shell_utils import stream_from_stdin, write_to_fd
@@ -144,9 +145,7 @@ class _ContainerProcess(Generic[T]):
             print("interactive exec is not currently supported on Windows.")
             return
 
-        from rich.console import Console
-
-        console = Console()
+        console = make_console()
 
         connecting_status = console.status("Connecting...")
         connecting_status.start()

--- a/modal/token_flow.py
+++ b/modal/token_flow.py
@@ -6,11 +6,11 @@ from collections.abc import AsyncGenerator
 from typing import Optional
 
 import aiohttp.web
-from rich.console import Console
 from synchronicity.async_wrap import asynccontextmanager
 
 from modal_proto import api_pb2
 
+from ._output import make_console
 from ._utils.async_utils import synchronize_api
 from ._utils.http_utils import run_temporary_http_server
 from .client import _Client
@@ -76,7 +76,7 @@ async def _new_token(
 ):
     server_url = config.get("server_url", profile=profile)
 
-    console = Console()
+    console = make_console()
 
     result: Optional[api_pb2.TokenFlowWaitResponse] = None
     async with _Client.anonymous(server_url) as client:
@@ -133,7 +133,7 @@ async def _set_token(
 ):
     # TODO add server_url as a parameter for verification?
     server_url = config.get("server_url", profile=profile)
-    console = Console()
+    console = make_console()
     if verify:
         console.print(f"Verifying token against [blue]{server_url}[/blue]")
         await _Client.verify(server_url, (token_id, token_secret))


### PR DESCRIPTION
Rich's autodetection of Jupyter is a bit aggressive and changes the way interactive CLI outputs are displayed in notebooks, causing problems while rendering. It appears that just using the terminal output mode is better, and the only way to do this seems to be by "disabling" Jupyter with `force_jupyter=False`.

## Describe your changes

Resolves PRD-1096



https://github.com/user-attachments/assets/92e3da73-5355-49cc-800e-f4d8ead68724

