### PR TITLE
Expose resource metadata through `.name` and `.info`

### DIFF
--- a/modal/_object.py
+++ b/modal/_object.py
@@ -48,6 +48,10 @@ class _Object:
     _is_hydrated: bool
     _is_rehydrated: bool
 
+    # Not all object subclasses have a meaningful "name" concept
+    # So whether they expose this is a matter of having a name property
+    _name: Optional[str]
+
     @classmethod
     def __init_subclass__(cls, type_prefix: Optional[str] = None):
         super().__init_subclass__()
@@ -68,6 +72,7 @@ class _Object:
         hydrate_lazily: bool = False,
         deps: Optional[Callable[..., Sequence["_Object"]]] = None,
         deduplication_key: Optional[Callable[[], Awaitable[Hashable]]] = None,
+        name: Optional[str] = None,
     ):
         self._local_uuid = str(uuid.uuid4())
         self._load = load
@@ -82,6 +87,8 @@ class _Object:
         self._client = None
         self._is_hydrated = False
         self._is_rehydrated = False
+
+        self._name = name
 
         self._initialize_from_empty()
 
@@ -163,10 +170,11 @@ class _Object:
         hydrate_lazily: bool = False,
         deps: Optional[Callable[..., Sequence["_Object"]]] = None,
         deduplication_key: Optional[Callable[[], Awaitable[Hashable]]] = None,
+        name: Optional[str] = None,
     ):
         # TODO(erikbern): flip the order of the two first arguments
         obj = _Object.__new__(cls)
-        obj._init(rep, load, is_another_app, preload, hydrate_lazily, deps, deduplication_key)
+        obj._init(rep, load, is_another_app, preload, hydrate_lazily, deps, deduplication_key, name)
         return obj
 
     @staticmethod

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -95,6 +95,7 @@ class _Dict(_Object, type_prefix="di"):
 
     def _hydrate_metadata(self, metadata: Optional[Message]):
         if metadata:
+            assert isinstance(metadata, api_pb2.DictMetadata)
             self._metadata = metadata
             self._name = metadata.name
 

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -33,9 +33,9 @@ class DictInfo:
     # This dataclass should be limited to information that is unchanging over the lifetime of the Dict,
     # since it is transmitted from the server when the object is hydrated and could be stale when accessed.
 
-    name: Optional[str] = None
-    created_at: Optional[datetime] = None
-    created_by: Optional[str] = None
+    name: Optional[str]
+    created_at: datetime
+    created_by: Optional[str]
 
 
 class _Dict(_Object, type_prefix="di"):
@@ -248,7 +248,7 @@ class _Dict(_Object, type_prefix="di"):
         creation_info = metadata.creation_info
         return DictInfo(
             name=metadata.name or None,
-            created_at=datetime.fromtimestamp(creation_info.created_at) if creation_info.created_at else None,
+            created_at=datetime.fromtimestamp(creation_info.created_at),
             created_by=creation_info.created_by or None,
         )
 

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -1,7 +1,10 @@
 # Copyright Modal Labs 2022
 from collections.abc import AsyncIterator, Mapping
+from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, Optional
 
+from google.protobuf.message import Message
 from grpclib import GRPCError
 from synchronicity.async_wrap import asynccontextmanager
 
@@ -21,6 +24,18 @@ from .exception import RequestSizeError
 
 def _serialize_dict(data):
     return [api_pb2.DictEntry(key=serialize(k), value=serialize(v)) for k, v in data.items()]
+
+
+@dataclass
+class DictInfo:
+    """Information about the Dict object."""
+
+    # This dataclass should be limited to information that is unchanging over the lifetime of the Dict,
+    # since it is transmitted from the server when the object is hydrated and could be stale when accessed.
+
+    name: Optional[str] = None
+    created_at: Optional[datetime] = None
+    created_by: Optional[str] = None
 
 
 class _Dict(_Object, type_prefix="di"):
@@ -65,11 +80,27 @@ class _Dict(_Object, type_prefix="di"):
     For more examples, see the [guide](https://modal.com/docs/guide/dicts-and-queues#modal-dicts).
     """
 
+    _name: Optional[str] = None
+    _metadata: Optional[api_pb2.DictMetadata] = None
+
     def __init__(self, data={}):
         """mdmd:hidden"""
         raise RuntimeError(
             "`Dict(...)` constructor is not allowed. Please use `Dict.from_name` or `Dict.ephemeral` instead"
         )
+
+    @property
+    def name(self) -> Optional[str]:
+        return self._name
+
+    def _hydrate_metadata(self, metadata: Optional[Message]):
+        if metadata:
+            self._metadata = metadata
+            self._name = metadata.name
+
+    def _get_metadata(self) -> api_pb2.DictMetadata:
+        assert self._metadata
+        return self._metadata
 
     @classmethod
     @asynccontextmanager
@@ -112,7 +143,7 @@ class _Dict(_Object, type_prefix="di"):
         async with TaskContext() as tc:
             request = api_pb2.DictHeartbeatRequest(dict_id=response.dict_id)
             tc.infinite_loop(lambda: client.stub.DictHeartbeat(request), sleep=_heartbeat_sleep)
-            yield cls._new_hydrated(response.dict_id, client, None, is_another_app=True)
+            yield cls._new_hydrated(response.dict_id, client, response.metadata, is_another_app=True)
 
     @staticmethod
     def from_name(
@@ -155,7 +186,7 @@ class _Dict(_Object, type_prefix="di"):
             logger.debug(f"Created dict with id {response.dict_id}")
             self._hydrate(response.dict_id, resolver.client, response.metadata)
 
-        return _Dict._from_loader(_load, "Dict()", is_another_app=True, hydrate_lazily=True)
+        return _Dict._from_loader(_load, "Dict()", is_another_app=True, hydrate_lazily=True, name=name)
 
     @staticmethod
     async def lookup(
@@ -208,6 +239,17 @@ class _Dict(_Object, type_prefix="di"):
         obj = await _Dict.from_name(name, environment_name=environment_name).hydrate(client)
         req = api_pb2.DictDeleteRequest(dict_id=obj.object_id)
         await retry_transient_errors(obj._client.stub.DictDelete, req)
+
+    @live_method
+    async def info(self) -> DictInfo:
+        """Return information about the Dict object."""
+        metadata = self._get_metadata()
+        creation_info = metadata.creation_info
+        return DictInfo(
+            name=metadata.name or None,
+            created_at=datetime.fromtimestamp(creation_info.created_at) if creation_info.created_at else None,
+            created_by=creation_info.created_by or None,
+        )
 
     @live_method
     async def clear(self) -> None:

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -121,6 +121,7 @@ class _Queue(_Object, type_prefix="qu"):
 
     def _hydrate_metadata(self, metadata: Optional[Message]):
         if metadata:
+            assert isinstance(metadata, api_pb2.QueueMetadata)
             self._metadata = metadata
             self._name = metadata.name
 

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -31,9 +31,9 @@ class QueueInfo:
     # This dataclass should be limited to information that is unchanging over the lifetime of the Queue,
     # since it is transmitted from the server when the object is hydrated and could be stale when accessed.
 
-    name: Optional[str] = None
-    created_at: Optional[datetime] = None
-    created_by: Optional[str] = None
+    name: Optional[str]
+    created_at: datetime
+    created_by: Optional[str]
 
 
 class _Queue(_Object, type_prefix="qu"):
@@ -260,7 +260,7 @@ class _Queue(_Object, type_prefix="qu"):
         creation_info = metadata.creation_info
         return QueueInfo(
             name=metadata.name or None,
-            created_at=datetime.fromtimestamp(creation_info.created_at) if creation_info.created_at else None,
+            created_at=datetime.fromtimestamp(creation_info.created_at),
             created_by=creation_info.created_by or None,
         )
 

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -1,12 +1,15 @@
 # Copyright Modal Labs 2022
 import os
+from dataclasses import dataclass
+from datetime import datetime
 from typing import Optional, Union
 
+from google.protobuf.message import Message
 from grpclib import GRPCError, Status
 
 from modal_proto import api_pb2
 
-from ._object import _get_environment_name, _Object
+from ._object import _get_environment_name, _Object, live_method
 from ._resolver import Resolver
 from ._runtime.execution_context import is_local
 from ._utils.async_utils import synchronize_api
@@ -19,6 +22,18 @@ from .exception import InvalidError, NotFoundError
 ENV_DICT_WRONG_TYPE_ERR = "the env_dict argument to Secret has to be a dict[str, Union[str, None]]"
 
 
+@dataclass
+class SecretInfo:
+    """Information about the Secret object."""
+
+    # This dataclass should be limited to information that is unchanging over the lifetime of the Secret,
+    # since it is transmitted from the server when the object is hydrated and could be stale when accessed.
+
+    name: Optional[str] = None
+    created_at: Optional[datetime] = None
+    created_by: Optional[str] = None
+
+
 class _Secret(_Object, type_prefix="st"):
     """Secrets provide a dictionary of environment variables for images.
 
@@ -28,6 +43,21 @@ class _Secret(_Object, type_prefix="st"):
 
     See [the secrets guide page](https://modal.com/docs/guide/secrets) for more information.
     """
+
+    _metadata: Optional[api_pb2.SecretMetadata] = None
+
+    @property
+    def name(self) -> Optional[str]:
+        return self._name
+
+    def _hydrate_metadata(self, metadata: Optional[Message]):
+        if metadata:
+            self._metadata = metadata
+            self._name = metadata.name
+
+    def _get_metadata(self) -> api_pb2.SecretMetadata:
+        assert self._metadata
+        return self._metadata
 
     @staticmethod
     def from_dict(
@@ -202,7 +232,7 @@ class _Secret(_Object, type_prefix="st"):
                     raise
             self._hydrate(response.secret_id, resolver.client, response.metadata)
 
-        return _Secret._from_loader(_load, "Secret()", hydrate_lazily=True)
+        return _Secret._from_loader(_load, "Secret()", hydrate_lazily=True, name=name)
 
     @staticmethod
     async def lookup(
@@ -260,6 +290,17 @@ class _Secret(_Object, type_prefix="st"):
         )
         resp = await retry_transient_errors(client.stub.SecretGetOrCreate, request)
         return resp.secret_id
+
+    @live_method
+    async def info(self) -> SecretInfo:
+        """Return information about the Secret object."""
+        metadata = self._get_metadata()
+        creation_info = metadata.creation_info
+        return SecretInfo(
+            name=metadata.name or None,
+            created_at=datetime.fromtimestamp(creation_info.created_at) if creation_info.created_at else None,
+            created_by=creation_info.created_by or None,
+        )
 
 
 Secret = synchronize_api(_Secret)

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -52,6 +52,7 @@ class _Secret(_Object, type_prefix="st"):
 
     def _hydrate_metadata(self, metadata: Optional[Message]):
         if metadata:
+            assert isinstance(metadata, api_pb2.SecretMetadata)
             self._metadata = metadata
             self._name = metadata.name
 

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -29,9 +29,9 @@ class SecretInfo:
     # This dataclass should be limited to information that is unchanging over the lifetime of the Secret,
     # since it is transmitted from the server when the object is hydrated and could be stale when accessed.
 
-    name: Optional[str] = None
-    created_at: Optional[datetime] = None
-    created_by: Optional[str] = None
+    name: Optional[str]
+    created_at: datetime
+    created_by: Optional[str]
 
 
 class _Secret(_Object, type_prefix="st"):
@@ -299,7 +299,7 @@ class _Secret(_Object, type_prefix="st"):
         creation_info = metadata.creation_info
         return SecretInfo(
             name=metadata.name or None,
-            created_at=datetime.fromtimestamp(creation_info.created_at) if creation_info.created_at else None,
+            created_at=datetime.fromtimestamp(creation_info.created_at),
             created_by=creation_info.created_by or None,
         )
 

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -185,11 +185,10 @@ class _Volume(_Object, type_prefix="vo"):
         return self._name
 
     def _hydrate_metadata(self, metadata: Optional[Message]):
-        if metadata and isinstance(metadata, api_pb2.VolumeMetadata):
+        if metadata:
+            assert isinstance(metadata, api_pb2.VolumeMetadata)
             self._metadata = metadata
             self._name = metadata.name
-        else:
-            raise TypeError("_hydrate_metadata() requires an `api_pb2.VolumeMetadata` to determine volume version")
 
     def _get_metadata(self) -> Optional[Message]:
         return self._metadata

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -100,9 +100,9 @@ class VolumeInfo:
     # This dataclass should be limited to information that is unchanging over the lifetime of the Volume,
     # since it is transmitted from the server when the object is hydrated and could be stale when accessed.
 
-    name: Optional[str] = None
-    created_at: Optional[datetime] = None
-    created_by: Optional[str] = None
+    name: Optional[str]
+    created_at: datetime
+    created_by: Optional[str]
 
 
 class _Volume(_Object, type_prefix="vo"):

--- a/test/dict_test.py
+++ b/test/dict_test.py
@@ -7,8 +7,16 @@ from modal.exception import DeprecationError, InvalidError, NotFoundError
 from modal_proto import api_pb2
 
 
-def test_dict_app(servicer, client):
-    d = Dict.from_name("my-amazing-dict", create_if_missing=True).hydrate(client)
+def test_dict_named(servicer, client):
+    name = "my-amazing-dict"
+    d = Dict.from_name(name, create_if_missing=True)
+    assert d.name == name
+
+    d.hydrate(client)
+    info = d.info()
+    assert info.name == name
+    assert info.created_by == servicer.default_username
+
     d["xyz"] = 123
     d["foo"] = 42
     d["foo"] += 5

--- a/test/queue_test.py
+++ b/test/queue_test.py
@@ -10,9 +10,18 @@ from modal_proto import api_pb2
 from .supports.skip import skip_macos, skip_windows
 
 
-def test_queue(servicer, client):
-    q = Queue.from_name("some-random-queue", create_if_missing=True).hydrate(client)
+def test_queue_named(servicer, client):
+    name = "some-random-queue"
+    q = Queue.from_name(name, create_if_missing=True)
     assert isinstance(q, Queue)
+    assert q.name == name
+
+    q.hydrate(client)
+
+    info = q.info()
+    assert info.name == name
+    assert info.created_by == servicer.default_username
+
     assert q.len() == 0
     q.put(42)
     assert q.len() == 1

--- a/test/secret_test.py
+++ b/test/secret_test.py
@@ -110,3 +110,9 @@ def test_secret_namespace_deprecated(servicer, client):
         Secret.create_deployed(
             "my-secret", {"FOO": "123"}, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, client=client
         )
+
+    with pytest.warns() as record:
+        Secret.lookup("my-secret", namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, client=client)
+    # Should warn about both the deprecated lookup method and the deprecated namespace parameter
+    assert len(record) >= 2
+    assert any(isinstance(w.message, DeprecationError) for w in record)

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -27,6 +27,17 @@ def dummy():
     pass
 
 
+def test_volume_info(servicer, client):
+    name = "super-important-data"
+    vol = modal.Volume.from_name(name, create_if_missing=True)
+    assert vol.name == name
+
+    vol.hydrate(client)
+    info = vol.info()
+    assert info.name == name
+    assert info.created_by == servicer.default_username
+
+
 @pytest.mark.parametrize("read_only", [True, False])
 @pytest.mark.parametrize("version", VERSIONS)
 def test_volume_mount(client, servicer, version, read_only):


### PR DESCRIPTION
## Describe your changes

- Closes SDK-538, see also [ideation doc](https://www.notion.so/modal-com/Emergent-issues-around-object-metadata-21c1e7f1694980b38d6dd33744ec6aac)
- Depends on https://github.com/modal-labs/modal/pull/25030



<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

- Added a `.name` property and a `.info()` method to `modal.Dict`, `modal.Queue`, `modal.Volume`, and `modal.Secret` objects.