### PR TITLE
Add Authentication String To FunctionBindParams

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1484,6 +1484,7 @@ message FunctionBindParamsRequest {
   bytes serialized_params = 2;
   FunctionOptions function_options = 3;
   string environment_name = 4;
+  string auth_secret = 5; // Only used for the input plane.
 }
 
 message FunctionBindParamsResponse {


### PR DESCRIPTION
This is only used by the input-plane, which unfortunately is forced to use a public facing API to communicate with the control plane.