### PR TITLE
filesystem snapshot protobuf changes

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2718,15 +2718,8 @@ message SandboxSnapshotFsAsyncGetRequest {
   float timeout = 2;
 }
 
-message SandboxSnapshotFsAsyncGetResponse {
-  string image_id = 1;
-  GenericResult result = 2;
-  ImageMetadata image_metadata = 3;
-}
-
 message SandboxSnapshotFsAsyncRequest {
   string sandbox_id = 1;
-  float timeout = 2;
 }
 
 message SandboxSnapshotFsAsyncResponse {
@@ -3562,7 +3555,7 @@ service ModalClient {
   rpc SandboxSnapshot(SandboxSnapshotRequest) returns (SandboxSnapshotResponse);
   rpc SandboxSnapshotFs(SandboxSnapshotFsRequest) returns (SandboxSnapshotFsResponse);
   rpc SandboxSnapshotFsAsync(SandboxSnapshotFsAsyncRequest) returns (SandboxSnapshotFsAsyncResponse);
-  rpc SandboxSnapshotFsAsyncGet(SandboxSnapshotFsAsyncGetRequest) returns (SandboxSnapshotFsAsyncGetResponse);
+  rpc SandboxSnapshotFsAsyncGet(SandboxSnapshotFsAsyncGetRequest) returns (SandboxSnapshotFsResponse);
   rpc SandboxSnapshotGet(SandboxSnapshotGetRequest) returns (SandboxSnapshotGetResponse);
   rpc SandboxSnapshotWait(SandboxSnapshotWaitRequest) returns (SandboxSnapshotWaitResponse);
   rpc SandboxStdinWrite(SandboxStdinWriteRequest) returns (SandboxStdinWriteResponse);


### PR DESCRIPTION
## Describe your changes

Protobuf changes that came up while implementing server-side support for async.

- Removes `SandboxSnapshotFsAsyncGetResponse`, instead re-using `SandboxSnapshotFsResponse`.
- Removes `timeout` from `SandboxSnapshotFsAsyncRequest`, since it returns (almost) immediately and the desired semantics of a timeout are unclear.

<details> <summary>Checklists</summary>

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

This PR contains proto changes that would be unsafe if the protobufs had already been used, but because the have not yet been used, they are safe.
