### PR TITLE
Localize timestamps in object info

### DIFF
--- a/modal/_output.py
+++ b/modal/_output.py
@@ -31,7 +31,7 @@ from rich.progress import (
 from rich.spinner import Spinner
 from rich.text import Text
 
-from modal._utils.time_utils import timestamp_to_local
+from modal._utils.time_utils import timestamp_to_localized_str
 from modal_proto import api_pb2
 
 from ._utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES, retry_transient_errors
@@ -91,7 +91,7 @@ class LineBufferedOutput:
 
         if self._show_timestamps:
             for i in range(0, len(chunks) - 1, 2):
-                chunks[i] = f"{timestamp_to_local(log.timestamp)} {chunks[i]}"
+                chunks[i] = f"{timestamp_to_localized_str(log.timestamp)} {chunks[i]}"
 
         completed_lines = "".join(chunks[:-1])
         remainder = chunks[-1]

--- a/modal/_utils/time_utils.py
+++ b/modal/_utils/time_utils.py
@@ -3,13 +3,17 @@ from datetime import datetime
 from typing import Optional
 
 
-def timestamp_to_local(ts: float, isotz: bool = True) -> Optional[str]:
+def timestamp_to_localized_dt(ts: float) -> datetime:
+    locale_tz = datetime.now().astimezone().tzinfo
+    return datetime.fromtimestamp(ts, tz=locale_tz)
+
+
+def timestamp_to_localized_str(ts: float, isotz: bool = True) -> Optional[str]:
     if ts > 0:
-        locale_tz = datetime.now().astimezone().tzinfo
-        dt = datetime.fromtimestamp(ts, tz=locale_tz)
+        dt = timestamp_to_localized_dt(ts)
         if isotz:
             return dt.isoformat(sep=" ", timespec="seconds")
         else:
-            return f"{datetime.strftime(dt, '%Y-%m-%d %H:%M')} {locale_tz.tzname(dt)}"
+            return f"{dt:%Y-%m-%d %H:%M %Z}"
     else:
         return None

--- a/modal/cli/app.py
+++ b/modal/cli/app.py
@@ -15,7 +15,7 @@ from modal.client import _Client
 from modal.environments import ensure_env
 from modal_proto import api_pb2
 
-from .._utils.time_utils import timestamp_to_local
+from .._utils.time_utils import timestamp_to_localized_str
 from .utils import ENV_OPTION, display_table, get_app_id_from_name, stream_app_logs
 
 APP_IDENTIFIER = Argument("", help="App name or ID")
@@ -71,8 +71,8 @@ async def list_(env: Optional[str] = ENV_OPTION, json: bool = False):
                 app_stats.description,
                 state,
                 str(app_stats.n_running_tasks),
-                timestamp_to_local(app_stats.created_at, json),
-                timestamp_to_local(app_stats.stopped_at, json),
+                timestamp_to_localized_str(app_stats.created_at, json),
+                timestamp_to_localized_str(app_stats.stopped_at, json),
             ]
         )
 
@@ -217,7 +217,7 @@ async def history(
 
         row = [
             Text(f"v{app_stats.version}", style=style),
-            Text(timestamp_to_local(app_stats.deployed_at, json), style=style),
+            Text(timestamp_to_localized_str(app_stats.deployed_at, json), style=style),
             Text(app_stats.client_version, style=style),
             Text(app_stats.deployed_by, style=style),
         ]

--- a/modal/cli/cluster.py
+++ b/modal/cli/cluster.py
@@ -8,7 +8,7 @@ from modal._object import _get_environment_name
 from modal._output import make_console
 from modal._pty import get_pty_info
 from modal._utils.async_utils import synchronizer
-from modal._utils.time_utils import timestamp_to_local
+from modal._utils.time_utils import timestamp_to_localized_str
 from modal.cli.utils import ENV_OPTION, display_table, is_tty
 from modal.client import _Client
 from modal.config import config
@@ -42,7 +42,7 @@ async def list_(env: Optional[str] = ENV_OPTION, json: bool = False):
             [
                 c.cluster_id,
                 c.app_id,
-                timestamp_to_local(c.started_at, json) if c.started_at else "Pending",
+                timestamp_to_localized_str(c.started_at, json) if c.started_at else "Pending",
                 str(len(c.task_ids)),
             ]
         )

--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -8,7 +8,7 @@ from modal._object import _get_environment_name
 from modal._pty import get_pty_info
 from modal._utils.async_utils import synchronizer
 from modal._utils.grpc_utils import retry_transient_errors
-from modal._utils.time_utils import timestamp_to_local
+from modal._utils.time_utils import timestamp_to_localized_str
 from modal.cli.utils import ENV_OPTION, display_table, is_tty, stream_app_logs
 from modal.client import _Client
 from modal.config import config
@@ -40,7 +40,7 @@ async def list_(env: Optional[str] = ENV_OPTION, json: bool = False):
                 task_stats.task_id,
                 task_stats.app_id,
                 task_stats.app_description,
-                timestamp_to_local(task_stats.started_at, json) if task_stats.started_at else "Pending",
+                timestamp_to_localized_str(task_stats.started_at, json) if task_stats.started_at else "Pending",
             ]
         )
 

--- a/modal/cli/dict.py
+++ b/modal/cli/dict.py
@@ -8,7 +8,7 @@ from modal._output import make_console
 from modal._resolver import Resolver
 from modal._utils.async_utils import synchronizer
 from modal._utils.grpc_utils import retry_transient_errors
-from modal._utils.time_utils import timestamp_to_local
+from modal._utils.time_utils import timestamp_to_localized_str
 from modal.cli.utils import ENV_OPTION, YES_OPTION, display_table
 from modal.client import _Client
 from modal.dict import _Dict
@@ -44,7 +44,7 @@ async def list_(*, json: bool = False, env: Optional[str] = ENV_OPTION):
     request = api_pb2.DictListRequest(environment_name=env)
     response = await retry_transient_errors(client.stub.DictList, request)
 
-    rows = [(d.name, timestamp_to_local(d.created_at, json)) for d in response.dicts]
+    rows = [(d.name, timestamp_to_localized_str(d.created_at, json)) for d in response.dicts]
     display_table(["Name", "Created at"], rows, json)
 
 

--- a/modal/cli/network_file_system.py
+++ b/modal/cli/network_file_system.py
@@ -16,7 +16,7 @@ from modal._location import display_location
 from modal._output import OutputManager, ProgressHandler, make_console
 from modal._utils.async_utils import synchronizer
 from modal._utils.grpc_utils import retry_transient_errors
-from modal._utils.time_utils import timestamp_to_local
+from modal._utils.time_utils import timestamp_to_localized_str
 from modal.cli._download import _volume_download
 from modal.cli.utils import ENV_OPTION, YES_OPTION, display_table
 from modal.client import _Client
@@ -44,7 +44,7 @@ async def list_(env: Optional[str] = ENV_OPTION, json: Optional[bool] = False):
             [
                 item.label,
                 display_location(item.cloud_provider),
-                timestamp_to_local(item.created_at, json),
+                timestamp_to_localized_str(item.created_at, json),
             ]
         )
     display_table(column_names, rows, json, title=f"Shared Volumes{env_part}")

--- a/modal/cli/queues.py
+++ b/modal/cli/queues.py
@@ -8,7 +8,7 @@ from modal._output import make_console
 from modal._resolver import Resolver
 from modal._utils.async_utils import synchronizer
 from modal._utils.grpc_utils import retry_transient_errors
-from modal._utils.time_utils import timestamp_to_local
+from modal._utils.time_utils import timestamp_to_localized_str
 from modal.cli.utils import ENV_OPTION, YES_OPTION, display_table
 from modal.client import _Client
 from modal.environments import ensure_env
@@ -71,7 +71,7 @@ async def list_(*, json: bool = False, env: Optional[str] = ENV_OPTION):
     rows = [
         (
             q.name,
-            timestamp_to_local(q.created_at, json),
+            timestamp_to_localized_str(q.created_at, json),
             str(q.num_partitions),
             str(q.total_size) if q.total_size <= max_total_size else f">{max_total_size}",
         )

--- a/modal/cli/secret.py
+++ b/modal/cli/secret.py
@@ -15,7 +15,7 @@ from typer import Argument
 from modal._output import make_console
 from modal._utils.async_utils import synchronizer
 from modal._utils.grpc_utils import retry_transient_errors
-from modal._utils.time_utils import timestamp_to_local
+from modal._utils.time_utils import timestamp_to_localized_str
 from modal.cli.utils import ENV_OPTION, YES_OPTION, display_table
 from modal.client import _Client
 from modal.environments import ensure_env
@@ -38,8 +38,8 @@ async def list_(env: Optional[str] = ENV_OPTION, json: bool = False):
         rows.append(
             [
                 item.label,
-                timestamp_to_local(item.created_at, json),
-                timestamp_to_local(item.last_used_at, json) if item.last_used_at else "-",
+                timestamp_to_localized_str(item.created_at, json),
+                timestamp_to_localized_str(item.last_used_at, json) if item.last_used_at else "-",
             ]
         )
 

--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -14,7 +14,7 @@ import modal
 from modal._output import OutputManager, ProgressHandler, make_console
 from modal._utils.async_utils import synchronizer
 from modal._utils.grpc_utils import retry_transient_errors
-from modal._utils.time_utils import timestamp_to_local
+from modal._utils.time_utils import timestamp_to_localized_str
 from modal.cli._download import _volume_download
 from modal.cli.utils import ENV_OPTION, YES_OPTION, display_table
 from modal.client import _Client
@@ -116,7 +116,7 @@ async def list_(env: Optional[str] = ENV_OPTION, json: Optional[bool] = False):
     column_names = ["Name", "Created at"]
     rows = []
     for item in response.items:
-        rows.append([item.label, timestamp_to_local(item.created_at, json)])
+        rows.append([item.label, timestamp_to_localized_str(item.created_at, json)])
     display_table(column_names, rows, json, title=f"Volumes{env_part}")
 
 
@@ -163,7 +163,7 @@ async def ls(
                 (
                     entry.path.encode("unicode_escape").decode("utf-8"),
                     filetype,
-                    timestamp_to_local(entry.mtime, False),
+                    timestamp_to_localized_str(entry.mtime, False),
                     humanize_filesize(entry.size),
                 )
             )

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -17,6 +17,7 @@ from ._utils.async_utils import TaskContext, synchronize_api
 from ._utils.deprecation import deprecation_warning, warn_if_passing_namespace
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
+from ._utils.time_utils import timestamp_to_localized_dt
 from .client import _Client
 from .config import logger
 from .exception import RequestSizeError
@@ -248,7 +249,7 @@ class _Dict(_Object, type_prefix="di"):
         creation_info = metadata.creation_info
         return DictInfo(
             name=metadata.name or None,
-            created_at=datetime.fromtimestamp(creation_info.created_at),
+            created_at=timestamp_to_localized_dt(creation_info.created_at),
             created_by=creation_info.created_by or None,
         )
 

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -20,6 +20,7 @@ from ._utils.async_utils import TaskContext, synchronize_api, warn_if_generator_
 from ._utils.deprecation import deprecation_warning, warn_if_passing_namespace
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
+from ._utils.time_utils import timestamp_to_localized_dt
 from .client import _Client
 from .exception import InvalidError, RequestSizeError
 
@@ -260,7 +261,7 @@ class _Queue(_Object, type_prefix="qu"):
         creation_info = metadata.creation_info
         return QueueInfo(
             name=metadata.name or None,
-            created_at=datetime.fromtimestamp(creation_info.created_at),
+            created_at=timestamp_to_localized_dt(creation_info.created_at),
             created_by=creation_info.created_by or None,
         )
 

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -16,6 +16,7 @@ from ._utils.async_utils import synchronize_api
 from ._utils.deprecation import deprecation_warning, warn_if_passing_namespace
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
+from ._utils.time_utils import timestamp_to_localized_dt
 from .client import _Client
 from .exception import InvalidError, NotFoundError
 
@@ -299,7 +300,7 @@ class _Secret(_Object, type_prefix="st"):
         creation_info = metadata.creation_info
         return SecretInfo(
             name=metadata.name or None,
-            created_at=datetime.fromtimestamp(creation_info.created_at),
+            created_at=timestamp_to_localized_dt(creation_info.created_at),
             created_by=creation_info.created_by or None,
         )
 

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -55,6 +55,7 @@ from ._utils.deprecation import deprecation_warning, warn_if_passing_namespace
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.http_utils import ClientSessionRegistry
 from ._utils.name_utils import check_object_name
+from ._utils.time_utils import timestamp_to_localized_dt
 from .client import _Client
 from .config import logger
 
@@ -364,7 +365,7 @@ class _Volume(_Object, type_prefix="vo"):
         creation_info = metadata.creation_info
         return VolumeInfo(
             name=metadata.name or None,
-            created_at=datetime.fromtimestamp(creation_info.created_at) if creation_info.created_at else None,
+            created_at=timestamp_to_localized_dt(creation_info.created_at),
             created_by=creation_info.created_by or None,
         )
 


### PR DESCRIPTION
Follow-on to #3393 making the `created_at` metadata a localized datetime, which matches what we currently do in the UI and CLI