### PR TITLE
Show message about Notebooks in launch jupyter

### DIFF
--- a/modal/cli/launch.py
+++ b/modal/cli/launch.py
@@ -67,7 +67,8 @@ def jupyter(
     console.print(
         rich.panel.Panel(
             (
-                "[underline]Try Modal Notebooks! [link=https://modal.com/notebooks]modal.com/notebooks[/link][/underline]\n"
+                "[link=https://modal.com/notebooks]Try Modal Notebooks! "
+                "modal.com/notebooks[/link]\n"
                 "Notebooks have a new UI, saved content, real-time collaboration and more."
             ),
         ),

--- a/modal/cli/launch.py
+++ b/modal/cli/launch.py
@@ -6,8 +6,10 @@ import os
 from pathlib import Path
 from typing import Any, Optional
 
+import rich.panel
 from typer import Typer
 
+from .._output import make_console
 from ..exception import _CliUserExecutionError
 from ..output import enable_output
 from ..runner import run_app
@@ -61,6 +63,16 @@ def jupyter(
     volume: Optional[str] = None,  # Attach a persisted `modal.Volume` by name (creating if missing).
     detach: bool = False,  # Run the app in "detached" mode to persist after local client disconnects
 ):
+    console = make_console()
+    console.print(
+        rich.panel.Panel(
+            (
+                "[underline]Try Modal Notebooks! [link=https://modal.com/notebooks]modal.com/notebooks[/link][/underline]\n"
+                "Notebooks have a new UI, saved content, real-time collaboration and more."
+            ),
+        ),
+        style="bold cyan",
+    )
     args = {
         "cpu": cpu,
         "memory": memory,


### PR DESCRIPTION
This is just an informational message for now, but I'd like to help integrate this better into notebooks in the future, for example by having a CLI command similar to `modal launch jupyter` pointing at an app to launch a Modal Notebook in that app's configuration instead.

<img width="625" height="129" alt="image" src="https://github.com/user-attachments/assets/e96e22a8-95e5-411b-bd29-35c1907e51da" />
