### PR TITLE
Add 1.0 H2 header in Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ Finally, this release introduces a small number of deprecations and potentially-
 - We're deprecating the `environment_name` parameter in `modal.Sandbox.create()`. A Sandbox's environment association will now be determined by its parent App. This should have no user-facing effects.
 - We've deprecated the `namespace` parameter in the `.from_name` methods of `Function`, `Cls`, `Dict`, `Queue`, `Volume`, `NetworkFileSystem`, and `Secret`, along with `modal.runner.deploy_app`. These object types do not have a concept of distinct namespaces.
 
+## 1.0
+
 ### 1.0.5 (2025-06-27)
 
 - Added a [`modal.Volume.read_only`](/docs/reference/modal.Volume#read_only) method, which will configure a Volume instance to disallow writes:


### PR DESCRIPTION
Noticed it would be nice to have this:

<img width="256" height="499" alt="image" src="https://github.com/user-attachments/assets/e9d43e63-0309-4a2b-86e6-1d89ab4759fc" />
