### PR TITLE
Make FilePatternMatcher.can_prune_directories handle delayed init

### DIFF
--- a/modal/file_pattern_matcher.py
+++ b/modal/file_pattern_matcher.py
@@ -202,6 +202,8 @@ class FilePatternMatcher(_AbstractPatternMatcher):
         without missing any files that should be included. This is for example not
         safe when we have inverted/negated ignore patterns (e.g. "!**/*.py").
         """
+        if self._delayed_init:
+            self._delayed_init()
         return not any(pattern.exclusion for pattern in self.patterns)
 
     def __call__(self, file_path: Path) -> bool:

--- a/modal/file_pattern_matcher.py
+++ b/modal/file_pattern_matcher.py
@@ -11,6 +11,7 @@ then asking it whether file paths match any of its patterns.
 
 import os
 from abc import abstractmethod
+from functools import cached_property
 from pathlib import Path
 from typing import Callable, Optional, Sequence, Union
 
@@ -99,11 +100,11 @@ class FilePatternMatcher(_AbstractPatternMatcher):
     ```
     """
 
-    patterns: list[Pattern]
-    _delayed_init: Callable[[], None] = None
+    _file_path: Optional[Union[str, Path]]
+    _pattern_strings: Optional[Sequence[str]]
 
-    def _set_patterns(self, patterns: Sequence[str]) -> None:
-        self.patterns = []
+    def _parse_patterns(self, patterns: Sequence[str]) -> list[Pattern]:
+        parsed_patterns = []
         for pattern in list(patterns):
             pattern = pattern.strip().strip(os.path.sep)
             if not pattern:
@@ -118,7 +119,8 @@ class FilePatternMatcher(_AbstractPatternMatcher):
             # In Python, we can proceed without explicit syntax checking
             new_pattern.cleaned_pattern = pattern
             new_pattern.dirs = pattern.split(os.path.sep)
-            self.patterns.append(new_pattern)
+            parsed_patterns.append(new_pattern)
+        return parsed_patterns
 
     def __init__(self, *pattern: str) -> None:
         """Initialize a new FilePatternMatcher instance.
@@ -129,7 +131,8 @@ class FilePatternMatcher(_AbstractPatternMatcher):
         Raises:
             ValueError: If an illegal exclusion pattern is provided.
         """
-        self._set_patterns(pattern)
+        self._pattern_strings = pattern
+        self._file_path = None
 
     @classmethod
     def from_file(cls, file_path: Union[str, Path]) -> "FilePatternMatcher":
@@ -148,14 +151,10 @@ class FilePatternMatcher(_AbstractPatternMatcher):
         ```
 
         """
-        uninitialized = cls.__new__(cls)
-
-        def _delayed_init():
-            uninitialized._set_patterns(Path(file_path).read_text("utf8").splitlines())
-            uninitialized._delayed_init = None
-
-        uninitialized._delayed_init = _delayed_init
-        return uninitialized
+        instance = cls.__new__(cls)
+        instance._file_path = file_path
+        instance._pattern_strings = None
+        return instance
 
     def _matches(self, file_path: str) -> bool:
         """Check if the file path or any of its parent directories match the patterns.
@@ -194,6 +193,18 @@ class FilePatternMatcher(_AbstractPatternMatcher):
 
         return matched
 
+    @cached_property
+    def patterns(self) -> list[Pattern]:
+        """Get the patterns, loading from file if necessary."""
+        if self._file_path is not None:
+            # Lazy load from file
+            pattern_strings = Path(self._file_path).read_text("utf8").splitlines()
+        else:
+            # Use patterns provided in __init__
+            pattern_strings = list(self._pattern_strings)
+
+        return self._parse_patterns(pattern_strings)
+
     def can_prune_directories(self) -> bool:
         """
         Returns True if this pattern matcher allows safe early directory pruning.
@@ -202,13 +213,9 @@ class FilePatternMatcher(_AbstractPatternMatcher):
         without missing any files that should be included. This is for example not
         safe when we have inverted/negated ignore patterns (e.g. "!**/*.py").
         """
-        if self._delayed_init:
-            self._delayed_init()
         return not any(pattern.exclusion for pattern in self.patterns)
 
     def __call__(self, file_path: Path) -> bool:
-        if self._delayed_init:
-            self._delayed_init()
         return self._matches(str(file_path))
 
 

--- a/test/file_pattern_matcher_test.py
+++ b/test/file_pattern_matcher_test.py
@@ -350,6 +350,7 @@ def test_from_file(as_type):
     ignore_file.write_text("**/*.txt")
 
     lff = FilePatternMatcher.from_file(as_type(ignore_file))
+    assert lff.can_prune_directories()
     assert lff(Path("top/data.txt"))
     assert not lff(Path("top/data.py"))
 
@@ -371,15 +372,3 @@ def test_can_prune_directories(patterns, expected):
 def test_can_prune_directories_negated():
     matcher_negated = ~FilePatternMatcher("*.py")
     assert matcher_negated.can_prune_directories() is False
-
-
-@pytest.mark.usefixtures("tmp_cwd")
-def test_can_prune_directories_delayed_init():
-    """Test that can_prune_directories works correctly when using from_file with delayed initialization."""
-
-    ignore_file = Path(".gitignore")
-    ignore_file.write_text("*.tmp\nnode_modules\ndist/**")
-
-    matcher = FilePatternMatcher.from_file(ignore_file)
-
-    assert matcher.can_prune_directories()

--- a/test/file_pattern_matcher_test.py
+++ b/test/file_pattern_matcher_test.py
@@ -371,3 +371,15 @@ def test_can_prune_directories(patterns, expected):
 def test_can_prune_directories_negated():
     matcher_negated = ~FilePatternMatcher("*.py")
     assert matcher_negated.can_prune_directories() is False
+
+
+@pytest.mark.usefixtures("tmp_cwd")
+def test_can_prune_directories_delayed_init():
+    """Test that can_prune_directories works correctly when using from_file with delayed initialization."""
+
+    ignore_file = Path(".gitignore")
+    ignore_file.write_text("*.tmp\nnode_modules\ndist/**")
+
+    matcher = FilePatternMatcher.from_file(ignore_file)
+
+    assert matcher.can_prune_directories()


### PR DESCRIPTION
This fixes issue #3381 / SDK-535.

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Fixed a bug that would cause e.g. some image builds to fail with `'FilePatternMatcher' object has no attribute 'patterns'` when using a `FilePatternMatcher.from_file` ignore pattern.

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
