### PR TITLE
fix: remove outdated Attempt RPC comments

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -3416,8 +3416,6 @@ service ModalClient {
   rpc AppStop(AppStopRequest) returns (google.protobuf.Empty);
 
   // Input Plane
-  // These RPCs are experimental, not deployed to production, and can be changed / removed
-  // without needing to worry about backwards compatibility.
   rpc AttemptAwait(AttemptAwaitRequest) returns (AttemptAwaitResponse);
   rpc AttemptRetry(AttemptRetryRequest) returns (AttemptRetryResponse);
   rpc AttemptStart(AttemptStartRequest) returns (AttemptStartResponse);


### PR DESCRIPTION
about clients not using them in production.
Clients do use them in production.