### PR TITLE
Add `.objects.delete()` API

### DIFF
--- a/modal/cli/dict.py
+++ b/modal/cli/dict.py
@@ -63,17 +63,21 @@ async def clear(name: str, *, yes: bool = YES_OPTION, env: Optional[str] = ENV_O
 
 @dict_cli.command(name="delete", rich_help_panel="Management")
 @synchronizer.create_blocking
-async def delete(name: str, *, yes: bool = YES_OPTION, env: Optional[str] = ENV_OPTION):
+async def delete(
+    name: str,
+    *,
+    allow_missing: bool = Option(False, "--allow-missing", help="Don't error if the Dict doesn't exist."),
+    yes: bool = YES_OPTION,
+    env: Optional[str] = ENV_OPTION,
+):
     """Delete a named Dict and all of its data."""
-    # Lookup first so we validate the name before asking for confirmation
-    await _Dict.from_name(name, environment_name=env).hydrate()
     if not yes:
         typer.confirm(
             f"Are you sure you want to irrevocably delete the modal.Dict '{name}'?",
             default=False,
             abort=True,
         )
-    await _Dict.objects.delete(name, environment_name=env)
+    await _Dict.objects.delete(name, environment_name=env, allow_missing=allow_missing)
 
 
 @dict_cli.command(name="get", rich_help_panel="Inspection")

--- a/modal/cli/dict.py
+++ b/modal/cli/dict.py
@@ -65,7 +65,7 @@ async def clear(name: str, *, yes: bool = YES_OPTION, env: Optional[str] = ENV_O
 @synchronizer.create_blocking
 async def delete(name: str, *, yes: bool = YES_OPTION, env: Optional[str] = ENV_OPTION):
     """Delete a named Dict and all of its data."""
-    # Lookup first to validate the name, even though delete is a staticmethod
+    # Lookup first so we validate the name before asking for confirmation
     await _Dict.from_name(name, environment_name=env).hydrate()
     if not yes:
         typer.confirm(
@@ -73,7 +73,7 @@ async def delete(name: str, *, yes: bool = YES_OPTION, env: Optional[str] = ENV_
             default=False,
             abort=True,
         )
-    await _Dict.delete(name, environment_name=env)
+    await _Dict.objects.delete(name, environment_name=env)
 
 
 @dict_cli.command(name="get", rich_help_panel="Inspection")

--- a/modal/cli/queues.py
+++ b/modal/cli/queues.py
@@ -45,17 +45,22 @@ async def create(name: str, *, env: Optional[str] = ENV_OPTION):
 
 @queue_cli.command(name="delete", rich_help_panel="Management")
 @synchronizer.create_blocking
-async def delete(name: str, *, yes: bool = YES_OPTION, env: Optional[str] = ENV_OPTION):
+async def delete(
+    name: str,
+    *,
+    allow_missing: bool = Option(False, "--allow-missing", help="Don't error if the Queue doesn't exist."),
+    yes: bool = YES_OPTION,
+    env: Optional[str] = ENV_OPTION,
+):
     """Delete a named Queue and all of its data."""
-    # Lookup first so we validate the name before asking for confirmation
-    await _Queue.from_name(name, environment_name=env).hydrate()
+    env = ensure_env(env)
     if not yes:
         typer.confirm(
             f"Are you sure you want to irrevocably delete the modal.Queue '{name}'?",
             default=False,
             abort=True,
         )
-    await _Queue.objects.delete(name, environment_name=env)
+    await _Queue.objects.delete(name, environment_name=env, allow_missing=allow_missing)
 
 
 @queue_cli.command(name="list", rich_help_panel="Management")

--- a/modal/cli/queues.py
+++ b/modal/cli/queues.py
@@ -47,7 +47,7 @@ async def create(name: str, *, env: Optional[str] = ENV_OPTION):
 @synchronizer.create_blocking
 async def delete(name: str, *, yes: bool = YES_OPTION, env: Optional[str] = ENV_OPTION):
     """Delete a named Queue and all of its data."""
-    # Lookup first to validate the name, even though delete is a staticmethod
+    # Lookup first so we validate the name before asking for confirmation
     await _Queue.from_name(name, environment_name=env).hydrate()
     if not yes:
         typer.confirm(
@@ -55,7 +55,7 @@ async def delete(name: str, *, yes: bool = YES_OPTION, env: Optional[str] = ENV_
             default=False,
             abort=True,
         )
-    await _Queue.delete(name, environment_name=env)
+    await _Queue.objects.delete(name, environment_name=env)
 
 
 @queue_cli.command(name="list", rich_help_panel="Management")

--- a/modal/cli/secret.py
+++ b/modal/cli/secret.py
@@ -165,19 +165,17 @@ async def delete(
     yes: bool = YES_OPTION,
     env: Optional[str] = ENV_OPTION,
 ):
-    """TODO"""
+    """Delete a named secret."""
     env = ensure_env(env)
-    secret = await _Secret.from_name(secret_name, environment_name=env).hydrate()
+    # Lookup first so we validate the name before asking for confirmation
+    await _Secret.from_name(secret_name, environment_name=env).hydrate()
     if not yes:
         typer.confirm(
             f"Are you sure you want to irrevocably delete the modal.Secret '{secret_name}'?",
             default=False,
             abort=True,
         )
-    client = await _Client.from_env()
-
-    # TODO: replace with API on `modal.Secret` when we add it
-    await client.stub.SecretDelete(api_pb2.SecretDeleteRequest(secret_id=secret.object_id))
+    await _Secret.objects.delete(secret_name, environment_name=env)
 
 
 def get_text_from_editor(key) -> str:

--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -283,7 +283,7 @@ async def delete(
     yes: bool = YES_OPTION,
     env: Optional[str] = ENV_OPTION,
 ):
-    # Lookup first to validate the name, even though delete is a staticmethod
+    # Lookup first so we validate the name before asking for confirmation
     await _Volume.from_name(volume_name, environment_name=env).hydrate()
     if not yes:
         typer.confirm(
@@ -292,7 +292,7 @@ async def delete(
             abort=True,
         )
 
-    await _Volume.delete(volume_name, environment_name=env)
+    await _Volume.objects.delete(volume_name, environment_name=env)
 
 
 @volume_cli.command(

--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -274,25 +274,26 @@ async def cp(
 
 @volume_cli.command(
     name="delete",
-    help="Delete a named, persistent modal.Volume.",
+    help="Delete a named Volume and all of its data.",
     rich_help_panel="Management",
 )
 @synchronizer.create_blocking
 async def delete(
-    volume_name: str = Argument(help="Name of the modal.Volume to be deleted. Case sensitive"),
+    name: str = Argument(help="Name of the modal.Volume to be deleted. Case sensitive"),
+    *,
+    allow_missing: bool = Option(False, "--allow-missing", help="Don't error if the Volume doesn't exist."),
     yes: bool = YES_OPTION,
     env: Optional[str] = ENV_OPTION,
 ):
-    # Lookup first so we validate the name before asking for confirmation
-    await _Volume.from_name(volume_name, environment_name=env).hydrate()
+    env = ensure_env(env)
     if not yes:
         typer.confirm(
-            f"Are you sure you want to irrevocably delete the modal.Volume '{volume_name}'?",
+            f"Are you sure you want to irrevocably delete the modal.Volume '{name}'?",
             default=False,
             abort=True,
         )
 
-    await _Volume.objects.delete(volume_name, environment_name=env)
+    await _Volume.objects.delete(name, environment_name=env, allow_missing=allow_missing)
 
 
 @volume_cli.command(

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -113,17 +113,18 @@ class _DictManager:
     ):
         """Delete a named Dict.
 
-        Warning: Deleting is irreversible and will affect any Apps currently using the Dict.
+        Warning: This deletes an *entire Dict*, not just a specific key.
+        Deletion is irreversible and will affect any Apps currently using the Dict.
 
         **Examples:**
 
-        ```python
+        ```python notest
         await modal.Dict.objects.delete("my-dict")
         ```
 
         Dicts will be deleted from the active environment, or another one can be specified:
 
-        ```python
+        ```python notest
         await modal.Dict.objects.delete("my-dict", environment_name="dev")
         ```
         """
@@ -338,10 +339,18 @@ class _Dict(_Object, type_prefix="di"):
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
     ):
-        # TODO deprecate or at least warn!
-        obj = await _Dict.from_name(name, environment_name=environment_name).hydrate(client)
-        req = api_pb2.DictDeleteRequest(dict_id=obj.object_id)
-        await retry_transient_errors(obj._client.stub.DictDelete, req)
+        """mdmd:hidden
+        Delete a named Dict object.
+
+        Warning: This deletes an *entire Dict*, not just a specific key.
+        Deletion is irreversible and will affect any Apps currently using the Dict.
+
+        DEPRECATED: This method is deprecated; we recommend using `modal.Dict.objects.delete` instead.
+        """
+        deprecation_warning(
+            (2025, 8, 6), "`modal.Dict.delete` is deprecated; we recommend using `modal.Dict.objects.delete` instead."
+        )
+        await _Dict.objects.delete(name, environment_name=environment_name, client=client)
 
     @live_method
     async def info(self) -> DictInfo:

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -102,6 +102,31 @@ class _QueueManager:
         queues = [_Queue._new_hydrated(item.queue_id, client, item.metadata, is_another_app=True) for item in items]
         return queues[:max_objects] if max_objects is not None else queues
 
+    @staticmethod
+    async def delete(
+        name: str,  # Name of the Queue to delete
+        *,
+        environment_name: Optional[str] = None,  # Uses active environment if not specified
+        client: Optional[_Client] = None,  # Optional client with Modal credentials
+    ):
+        """Delete a named Queue.
+
+        **Examples:**
+
+        ```python
+        await modal.Queue.objects.delete("my-queue")
+        ```
+
+        Queues will be deleted from the active environment, or another one can be specified:
+
+        ```python
+        await modal.Queue.objects.delete("my-queue", environment_name="dev")
+        ```
+        """
+        obj = await _Queue.from_name(name, environment_name=environment_name).hydrate(client)
+        req = api_pb2.QueueDeleteRequest(queue_id=obj.object_id)
+        await retry_transient_errors(obj._client.stub.QueueDelete, req)
+
 
 QueueManager = synchronize_api(_QueueManager)
 
@@ -323,6 +348,7 @@ class _Queue(_Object, type_prefix="qu"):
 
     @staticmethod
     async def delete(name: str, *, client: Optional[_Client] = None, environment_name: Optional[str] = None):
+        # TODO deprecate or at least warn!
         obj = await _Queue.from_name(name, environment_name=environment_name).hydrate(client)
         req = api_pb2.QueueDeleteRequest(queue_id=obj.object_id)
         await retry_transient_errors(obj._client.stub.QueueDelete, req)

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -111,15 +111,18 @@ class _QueueManager:
     ):
         """Delete a named Queue.
 
+        Warning: This deletes an *entire Queue*, not just a specific entry or partition.
+        Deletion is irreversible and will affect any Apps currently using the Queue.
+
         **Examples:**
 
-        ```python
+        ```python notest
         await modal.Queue.objects.delete("my-queue")
         ```
 
         Queues will be deleted from the active environment, or another one can be specified:
 
-        ```python
+        ```python notest
         await modal.Queue.objects.delete("my-queue", environment_name="dev")
         ```
         """
@@ -348,10 +351,20 @@ class _Queue(_Object, type_prefix="qu"):
 
     @staticmethod
     async def delete(name: str, *, client: Optional[_Client] = None, environment_name: Optional[str] = None):
-        # TODO deprecate or at least warn!
-        obj = await _Queue.from_name(name, environment_name=environment_name).hydrate(client)
-        req = api_pb2.QueueDeleteRequest(queue_id=obj.object_id)
-        await retry_transient_errors(obj._client.stub.QueueDelete, req)
+        """mdmd:hidden
+        Delete a named Queue.
+
+        Warning: This deletes an *entire Queue*, not just a specific entry or partition.
+        Deletion is irreversible and will affect any Apps currently using the Queue.
+
+        DEPRECATED: This method is deprecated; we recommend using `modal.Queue.objects.delete` instead.
+
+        """
+        deprecation_warning(
+            (2025, 8, 6),
+            "`modal.Queue.delete` is deprecated; we recommend using `modal.Queue.objects.delete` instead.",
+        )
+        await _Queue.objects.delete(name, environment_name=environment_name, client=client)
 
     @live_method
     async def info(self) -> QueueInfo:

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -94,6 +94,31 @@ class _SecretManager:
         secrets = [_Secret._new_hydrated(item.secret_id, client, item.metadata, is_another_app=True) for item in items]
         return secrets[:max_objects] if max_objects is not None else secrets
 
+    @staticmethod
+    async def delete(
+        name: str,  # Name of the Secret to delete
+        *,
+        environment_name: Optional[str] = None,  # Uses active environment if not specified
+        client: Optional[_Client] = None,  # Optional client with Modal credentials
+    ):
+        """Delete a named Secret.
+
+        **Examples:**
+
+        ```python
+        await modal.Secret.objects.delete("my-secret")
+        ```
+
+        Secrets will be deleted from the active environment, or another one can be specified:
+
+        ```python
+        await modal.Secret.objects.delete("my-secret", environment_name="dev")
+        ```
+        """
+        obj = await _Secret.from_name(name, environment_name=environment_name).hydrate(client)
+        req = api_pb2.SecretDeleteRequest(secret_id=obj.object_id)
+        await retry_transient_errors(obj._client.stub.SecretDelete, req)
+
 
 SecretManager = synchronize_api(_SecretManager)
 

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -103,15 +103,17 @@ class _SecretManager:
     ):
         """Delete a named Secret.
 
+        Warning: Deletion is irreversible and will affect any Apps currently using the Secret.
+
         **Examples:**
 
-        ```python
+        ```python notest
         await modal.Secret.objects.delete("my-secret")
         ```
 
         Secrets will be deleted from the active environment, or another one can be specified:
 
-        ```python
+        ```python notest
         await modal.Secret.objects.delete("my-secret", environment_name="dev")
         ```
         """

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -180,15 +180,18 @@ class _VolumeManager:
     ):
         """Delete a named Volume.
 
+        Warning: This deletes an *entire Volume*, not just a specific file.
+        Deletion is irreversible and will affect any Apps currently using the Volume.
+
         **Examples:**
 
-        ```python
+        ```python notest
         await modal.Volume.objects.delete("my-volume")
         ```
 
         Volumes will be deleted from the active environment, or another one can be specified:
 
-        ```python
+        ```python notest
         await modal.Volume.objects.delete("my-volume", environment_name="dev")
         ```
         """
@@ -744,10 +747,20 @@ class _Volume(_Object, type_prefix="vo"):
 
     @staticmethod
     async def delete(name: str, client: Optional[_Client] = None, environment_name: Optional[str] = None):
-        # TODO deprecate or at least warn!
-        obj = await _Volume.from_name(name, environment_name=environment_name).hydrate(client)
-        req = api_pb2.VolumeDeleteRequest(volume_id=obj.object_id)
-        await retry_transient_errors(obj._client.stub.VolumeDelete, req)
+        """mdmd:hidden
+        Delete a named Volume.
+
+        Warning: This deletes an *entire Volume*, not just a specific file.
+        Deletion is irreversible and will affect any Apps currently using the Volume.
+
+        DEPRECATED: This method is deprecated; we recommend using `modal.Volume.objects.delete` instead.
+
+        """
+        deprecation_warning(
+            (2025, 8, 6),
+            "`modal.Volume.delete` is deprecated; we recommend using `modal.Volume.objects.delete` instead.",
+        )
+        await _Volume.objects.delete(name, environment_name=environment_name, client=client)
 
     @staticmethod
     async def rename(

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -171,6 +171,31 @@ class _VolumeManager:
         volumes = [_Volume._new_hydrated(item.volume_id, client, item.metadata, is_another_app=True) for item in items]
         return volumes[:max_objects] if max_objects is not None else volumes
 
+    @staticmethod
+    async def delete(
+        name: str,  # Name of the Volume to delete
+        *,
+        environment_name: Optional[str] = None,  # Uses active environment if not specified
+        client: Optional[_Client] = None,  # Optional client with Modal credentials
+    ):
+        """Delete a named Volume.
+
+        **Examples:**
+
+        ```python
+        await modal.Volume.objects.delete("my-volume")
+        ```
+
+        Volumes will be deleted from the active environment, or another one can be specified:
+
+        ```python
+        await modal.Volume.objects.delete("my-volume", environment_name="dev")
+        ```
+        """
+        obj = await _Volume.from_name(name, environment_name=environment_name).hydrate(client)
+        req = api_pb2.VolumeDeleteRequest(volume_id=obj.object_id)
+        await retry_transient_errors(obj._client.stub.VolumeDelete, req)
+
 
 VolumeManager = synchronize_api(_VolumeManager)
 
@@ -719,6 +744,7 @@ class _Volume(_Object, type_prefix="vo"):
 
     @staticmethod
     async def delete(name: str, client: Optional[_Client] = None, environment_name: Optional[str] = None):
+        # TODO deprecate or at least warn!
         obj = await _Volume.from_name(name, environment_name=environment_name).hydrate(client)
         req = api_pb2.VolumeDeleteRequest(volume_id=obj.object_id)
         await retry_transient_errors(obj._client.stub.VolumeDelete, req)

--- a/test/dict_test.py
+++ b/test/dict_test.py
@@ -37,9 +37,10 @@ def test_dict_named(servicer, client):
     d["foo"] = None
     assert d["foo"] is None
 
-    Dict.delete("my-amazing-dict", client=client)
+    Dict.objects.delete("my-amazing-dict", client=client)
     with pytest.raises(NotFoundError):
         Dict.from_name("my-amazing-dict").hydrate(client)
+    Dict.objects.delete("my-amazing-dict", client=client, allow_missing=True)
 
 
 def test_dict_ephemeral(servicer, client):

--- a/test/queue_test.py
+++ b/test/queue_test.py
@@ -38,9 +38,10 @@ def test_queue_named(servicer, client):
     assert 1.0 < time.time() - t0 < 2.0
     assert [v for v in q.iterate(item_poll_timeout=0.0)] == [1, 2, 3]
 
-    Queue.delete("some-random-queue", client=client)
+    Queue.objects.delete("some-random-queue", client=client)
     with pytest.raises(NotFoundError):
         Queue.from_name("some-random-queue").hydrate(client)
+    Queue.objects.delete("some-random-queue", client=client, allow_missing=True)
 
 
 def test_queue_ephemeral(servicer, client):

--- a/test/secret_test.py
+++ b/test/secret_test.py
@@ -7,7 +7,7 @@ import time
 from unittest import mock
 
 from modal import App, Secret
-from modal.exception import DeprecationError, InvalidError
+from modal.exception import DeprecationError, InvalidError, NotFoundError
 from modal_proto import api_pb2
 
 from .supports.skip import skip_old_py
@@ -96,6 +96,11 @@ def test_secret_from_name(servicer, client):
     app.function(secrets=[secret])(dummy)
     with app.run(client=client):
         assert secret.object_id == secret_id
+
+    Secret.objects.delete("my-secret", client=client)
+    with pytest.raises(NotFoundError):
+        Secret.from_name("my-secret").hydrate(client)
+    Secret.objects.delete("my-secret", client=client, allow_missing=True)
 
 
 def test_secret_namespace_deprecated(servicer, client):

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -451,9 +451,8 @@ async def test_volume_copy_2(client, tmp_path, servicer, version):
     assert returned_file_data[Path("test_dir/file2.txt")].data == b"test copy"
 
 
-@pytest.mark.parametrize("delete_as_instance_method", [True, False])
 @pytest.mark.parametrize("version", VERSIONS)
-def test_persisted(servicer, client, delete_as_instance_method, version):
+def test_from_name(servicer, client, version):
     # Lookup should fail since it doesn't exist
     with pytest.raises(NotFoundError):
         modal.Volume.from_name("xyz", version=version).hydrate(client)
@@ -464,12 +463,11 @@ def test_persisted(servicer, client, delete_as_instance_method, version):
     # Lookup should succeed now
     modal.Volume.from_name("xyz", version=version).hydrate(client)
 
-    # Delete it
-    modal.Volume.delete("xyz", client=client)
-
+    modal.Volume.objects.delete("xyz", client=client)
     # Lookup should fail again
     with pytest.raises(NotFoundError):
         modal.Volume.from_name("xyz", version=version).hydrate(client)
+    modal.Volume.objects.delete("xyz", client=client, allow_missing=True)
 
 
 def test_ephemeral(servicer, client):


### PR DESCRIPTION
## Describe your changes

- Closes SDK-548

## Changelog

- Added `.objects.delete()` methods
- Deprecated existing `.delete()` static methods due to risks of confusion with content deletion operations.