### PR TITLE
Add cloud_provider_str to FunctionOptions proto

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1824,6 +1824,7 @@ message FunctionOptions {
   optional uint32 batch_max_size = 15;
   optional uint64 batch_linger_ms = 16;
   optional SchedulerPlacement scheduler_placement = 17;
+  optional string cloud_provider_str = 18;
 }
 
 message FunctionPrecreateRequest {


### PR DESCRIPTION
## Describe your changes

- Adds `cloud_provider_str` to FunctionOptions

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>