### PR TITLE
Improve most Object subclass reprs

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1276,7 +1276,8 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
 
             self._hydrate(response.function_id, resolver.client, response.handle_metadata)
 
-        rep = f"Function.from_name('{app_name}', '{name}')"
+        environment_rep = f", environment_name={environment_name!r}" if environment_name else ""
+        rep = f"modal.Function.from_name('{app_name}', '{name}'{environment_rep})"
         return cls._from_loader(_load_remote, rep, is_another_app=True, hydrate_lazily=True)
 
     @classmethod

--- a/modal/_object.py
+++ b/modal/_object.py
@@ -192,8 +192,19 @@ class _Object:
         return cls._get_type_from_id(object_id) == cls
 
     @classmethod
+    def _repr(cls, name: str, environment_name: Optional[str] = None) -> str:
+        public_cls = cls.__name__.strip("_")
+        environment_repr = f", environment_name={environment_name!r}" if environment_name else ""
+        return f"modal.{public_cls}.from_name({name!r}{environment_repr})"
+
+    @classmethod
     def _new_hydrated(
-        cls, object_id: str, client: _Client, handle_metadata: Optional[Message], is_another_app: bool = False
+        cls,
+        object_id: str,
+        client: _Client,
+        handle_metadata: Optional[Message],
+        is_another_app: bool = False,
+        rep: Optional[str] = None,
     ) -> Self:
         obj_cls: type[Self]
         if cls._type_prefix is not None:
@@ -210,7 +221,7 @@ class _Object:
 
         # Instantiate provider
         obj = _Object.__new__(obj_cls)
-        rep = f"Object({object_id})"  # TODO(erikbern): dumb
+        rep = rep or f"modal.{obj_cls.__name__.strip('_')}.from_id({object_id!r})"
         obj._init(rep, is_another_app=is_another_app)
         obj._hydrate(object_id, client, handle_metadata)
 

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -657,7 +657,8 @@ More information on class parameterization can be found here: https://modal.com/
             await resolver.load(self._class_service_function)
             self._hydrate(response.class_id, resolver.client, response.handle_metadata)
 
-        rep = f"Cls.from_name({app_name!r}, {name!r})"
+        environment_rep = f", environment_name={environment_name!r}" if environment_name else ""
+        rep = f"Cls.from_name({app_name!r}, {name!r}{environment_rep})"
         cls = cls._from_loader(_load_remote, rep, is_another_app=True, hydrate_lazily=True)
 
         class_service_name = f"{name}.*"  # special name of the base service function for the class

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -261,7 +261,13 @@ class _Dict(_Object, type_prefix="di"):
         async with TaskContext() as tc:
             request = api_pb2.DictHeartbeatRequest(dict_id=response.dict_id)
             tc.infinite_loop(lambda: client.stub.DictHeartbeat(request), sleep=_heartbeat_sleep)
-            yield cls._new_hydrated(response.dict_id, client, response.metadata, is_another_app=True)
+            yield cls._new_hydrated(
+                response.dict_id,
+                client,
+                response.metadata,
+                is_another_app=True,
+                rep="modal.Dict.ephemeral()",
+            )
 
     @staticmethod
     def from_name(

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -101,7 +101,16 @@ class _DictManager:
                 break
             finished = await retrieve_page(items[-1].metadata.creation_info.created_at)
 
-        dicts = [_Dict._new_hydrated(item.dict_id, client, item.metadata, is_another_app=True) for item in items]
+        dicts = [
+            _Dict._new_hydrated(
+                item.dict_id,
+                client,
+                item.metadata,
+                is_another_app=True,
+                rep=_Dict._repr(item.name, environment_name),
+            )
+            for item in items
+        ]
         return dicts[:max_objects] if max_objects is not None else dicts
 
     @staticmethod
@@ -295,7 +304,8 @@ class _Dict(_Object, type_prefix="di"):
             logger.debug(f"Created dict with id {response.dict_id}")
             self._hydrate(response.dict_id, resolver.client, response.metadata)
 
-        return _Dict._from_loader(_load, "Dict()", is_another_app=True, hydrate_lazily=True, name=name)
+        rep = _Dict._repr(name, environment_name)
+        return _Dict._from_loader(_load, rep, is_another_app=True, hydrate_lazily=True, name=name)
 
     @staticmethod
     async def lookup(

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -161,7 +161,13 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         async with TaskContext() as tc:
             request = api_pb2.SharedVolumeHeartbeatRequest(shared_volume_id=response.shared_volume_id)
             tc.infinite_loop(lambda: client.stub.SharedVolumeHeartbeat(request), sleep=_heartbeat_sleep)
-            yield cls._new_hydrated(response.shared_volume_id, client, None, is_another_app=True)
+            yield cls._new_hydrated(
+                response.shared_volume_id,
+                client,
+                None,
+                is_another_app=True,
+                rep="modal.NetworkFileSystem.ephemeral()",
+            )
 
     @staticmethod
     async def lookup(

--- a/modal/proxy.py
+++ b/modal/proxy.py
@@ -36,7 +36,8 @@ class _Proxy(_Object, type_prefix="pr"):
             response: api_pb2.ProxyGetResponse = await resolver.client.stub.ProxyGet(req)
             self._hydrate(response.proxy.proxy_id, resolver.client, None)
 
-        return _Proxy._from_loader(_load, "Proxy()", is_another_app=True)
+        rep = _Proxy._repr(name, environment_name)
+        return _Proxy._from_loader(_load, rep, is_another_app=True)
 
 
 Proxy = synchronize_api(_Proxy, target_module=__name__)

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -99,7 +99,16 @@ class _QueueManager:
                 break
             finished = await retrieve_page(items[-1].metadata.creation_info.created_at)
 
-        queues = [_Queue._new_hydrated(item.queue_id, client, item.metadata, is_another_app=True) for item in items]
+        queues = [
+            _Queue._new_hydrated(
+                item.queue_id,
+                client,
+                item.metadata,
+                is_another_app=True,
+                rep=_Queue._repr(item.name, environment_name),
+            )
+            for item in items
+        ]
         return queues[:max_objects] if max_objects is not None else queues
 
     @staticmethod
@@ -314,7 +323,8 @@ class _Queue(_Object, type_prefix="qu"):
             response = await resolver.client.stub.QueueGetOrCreate(req)
             self._hydrate(response.queue_id, resolver.client, response.metadata)
 
-        return _Queue._from_loader(_load, "Queue()", is_another_app=True, hydrate_lazily=True, name=name)
+        rep = _Queue._repr(name, environment_name)
+        return _Queue._from_loader(_load, rep, is_another_app=True, hydrate_lazily=True, name=name)
 
     @staticmethod
     async def lookup(

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -91,7 +91,16 @@ class _SecretManager:
                 break
             finished = await retrieve_page(items[-1].metadata.creation_info.created_at)
 
-        secrets = [_Secret._new_hydrated(item.secret_id, client, item.metadata, is_another_app=True) for item in items]
+        secrets = [
+            _Secret._new_hydrated(
+                item.secret_id,
+                client,
+                item.metadata,
+                is_another_app=True,
+                rep=_Secret._repr(item.label, environment_name),
+            )
+            for item in items
+        ]
         return secrets[:max_objects] if max_objects is not None else secrets
 
     @staticmethod
@@ -334,7 +343,8 @@ class _Secret(_Object, type_prefix="st"):
                     raise
             self._hydrate(response.secret_id, resolver.client, response.metadata)
 
-        return _Secret._from_loader(_load, "Secret()", hydrate_lazily=True, name=name)
+        rep = _Secret._repr(name, environment_name)
+        return _Secret._from_loader(_load, rep, hydrate_lazily=True, name=name)
 
     @staticmethod
     async def lookup(

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -408,7 +408,13 @@ class _Volume(_Object, type_prefix="vo"):
         async with TaskContext() as tc:
             request = api_pb2.VolumeHeartbeatRequest(volume_id=response.volume_id)
             tc.infinite_loop(lambda: client.stub.VolumeHeartbeat(request), sleep=_heartbeat_sleep)
-            yield cls._new_hydrated(response.volume_id, client, response.metadata, is_another_app=True)
+            yield cls._new_hydrated(
+                response.volume_id,
+                client,
+                response.metadata,
+                is_another_app=True,
+                rep="modal.Volume.ephemeral()",
+            )
 
     @staticmethod
     async def lookup(

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -168,7 +168,16 @@ class _VolumeManager:
                 break
             finished = await retrieve_page(items[-1].metadata.creation_info.created_at)
 
-        volumes = [_Volume._new_hydrated(item.volume_id, client, item.metadata, is_another_app=True) for item in items]
+        volumes = [
+            _Volume._new_hydrated(
+                item.volume_id,
+                client,
+                item.metadata,
+                is_another_app=True,
+                rep=_Volume._repr(item.label, environment_name),
+            )
+            for item in items
+        ]
         return volumes[:max_objects] if max_objects is not None else volumes
 
     @staticmethod
@@ -362,7 +371,8 @@ class _Volume(_Object, type_prefix="vo"):
             response = await resolver.client.stub.VolumeGetOrCreate(req)
             self._hydrate(response.volume_id, resolver.client, response.metadata)
 
-        return _Volume._from_loader(_load, "Volume()", hydrate_lazily=True, name=name)
+        rep = _Volume._repr(name, environment_name)
+        return _Volume._from_loader(_load, rep, hydrate_lazily=True, name=name)
 
     @classmethod
     @asynccontextmanager


### PR DESCRIPTION
## Describe your changes

This improves the way we provide reprs for our Object types.

Currently we have a mix of things that are not [strictly valid reprs](https://docs.python.org/3/reference/datamodel.html#object.__repr__) in the sense that they can
> be used to recreate an object with the same value (given an appropriate environment)

Now we generally speaking will try to represent an Object with how it could be instantiated via its `.from_name()` constructor, including accounting for the environment name (but _not_ any `create_if_missing` value or any other configuration that's snuck into that type's `.from_name()`):

```python
In [1]: import modal

In [2]: modal.Dict.from_name("a-dict")
Out[2]: modal.Dict.from_name('a-dict')

In [3]: modal.Dict.from_name("a-dict", environment_name="dev")
Out[3]: modal.Dict.from_name('a-dict', environment_name='dev')

In [4]: modal.Volume.objects.list()
Out[4]:
[modal.Volume.from_name('hf-hub-cache'),
 modal.Volume.from_name('train-data'),
 modal.Volume.from_name('test-build-enter-volume'),
 ...
 modal.Volume.from_name('test-vol')]
```

I do wonder if we'd like to also have a "richer" str representation of objects that makes the result of printing `modal.Dict.object.list()` look closer to e.g. the `modal dict list` output (in terms of showing useful metadata, not in terms of the tabular formatting) but this seems to be what we were previously aiming for, but not quite achieving, with the default reprs.

Closes SDK-545
Supersedes #3248 