### PR TITLE
Increase timeout on fork tests

### DIFF
--- a/test/fork_test.py
+++ b/test/fork_test.py
@@ -12,7 +12,7 @@ from test.supports.skip import skip_windows
 )
 def test_process_fork(supports_dir, server_url_env, token_env, test_case):
     output = subprocess.check_output(
-        [sys.executable, supports_dir / "forking.py", test_case], timeout=2, encoding="utf8"
+        [sys.executable, supports_dir / "forking.py", test_case], timeout=4, encoding="utf8"
     )
 
     success_pids = {int(x) for x in output.split()}


### PR DESCRIPTION
These tests are flaking often with a TimeoutError, especially on the MacOS-13 build.

I'm guessing that just doubling the timeout will cut down on flakes substantially but @thecodingwizard  would appreciate if you can give it a little thought whether there's a deeper issue here.

Closes SVC-808