### PR TITLE
Hide some internal parameters from the API docs

### DIFF
--- a/modal/_partial_function.py
+++ b/modal/_partial_function.py
@@ -282,7 +282,7 @@ class _MethodDecoratorType:
 
 # TODO(elias): fix support for coroutine type unwrapping for methods (static typing)
 def _method(
-    _warn_parentheses_missing=None,
+    _warn_parentheses_missing=None,  # mdmd:line-hidden
     *,
     # Set this to True if it's a non-generator function returning
     # a [sync/async] generator object
@@ -337,7 +337,7 @@ def _parse_custom_domains(custom_domains: Optional[Iterable[str]] = None) -> lis
 
 
 def _fastapi_endpoint(
-    _warn_parentheses_missing=None,
+    _warn_parentheses_missing=None,  # mdmd:line-hidden
     *,
     method: str = "GET",  # REST method for the created endpoint.
     label: Optional[str] = None,  # Label for created endpoint. Final subdomain will be <workspace>--<label>.modal.run.
@@ -400,7 +400,7 @@ def _fastapi_endpoint(
 
 
 def _web_endpoint(
-    _warn_parentheses_missing=None,
+    _warn_parentheses_missing=None,  # mdmd:line-hidden
     *,
     method: str = "GET",  # REST method for the created endpoint.
     label: Optional[str] = None,  # Label for created endpoint. Final subdomain will be <workspace>--<label>.modal.run.
@@ -468,7 +468,7 @@ def _web_endpoint(
 
 
 def _asgi_app(
-    _warn_parentheses_missing=None,
+    _warn_parentheses_missing=None,  # mdmd:line-hidden
     *,
     label: Optional[str] = None,  # Label for created endpoint. Final subdomain will be <workspace>--<label>.modal.run.
     custom_domains: Optional[Iterable[str]] = None,  # Deploy this endpoint on a custom domain.
@@ -525,7 +525,7 @@ def _asgi_app(
 
 
 def _wsgi_app(
-    _warn_parentheses_missing=None,
+    _warn_parentheses_missing=None,  # mdmd:line-hidden
     *,
     label: Optional[str] = None,  # Label for created endpoint. Final subdomain will be <workspace>--<label>.modal.run.
     custom_domains: Optional[Iterable[str]] = None,  # Deploy this endpoint on a custom domain.
@@ -645,7 +645,7 @@ def _web_server(
 
 
 def _enter(
-    _warn_parentheses_missing=None,
+    _warn_parentheses_missing=None,  # mdmd:line-hidden
     *,
     snap: bool = False,
 ) -> Callable[[Union[_PartialFunction, NullaryMethod]], _PartialFunction]:
@@ -696,7 +696,7 @@ def _exit(_warn_parentheses_missing=None) -> Callable[[NullaryMethod], _PartialF
 
 
 def _batched(
-    _warn_parentheses_missing=None,
+    _warn_parentheses_missing=None,  # mdmd:line-hidden
     *,
     max_batch_size: int,
     wait_ms: int,
@@ -758,7 +758,7 @@ def _batched(
 
 
 def _concurrent(
-    _warn_parentheses_missing=None,
+    _warn_parentheses_missing=None,  # mdmd:line-hidden
     *,
     max_inputs: int,  # Hard limit on each container's input concurrency
     target_inputs: Optional[int] = None,  # Input concurrency that Modal's autoscaler should target

--- a/modal/app.py
+++ b/modal/app.py
@@ -612,7 +612,7 @@ class _App:
     @warn_on_renamed_autoscaler_settings
     def function(
         self,
-        _warn_parentheses_missing: Any = None,
+        _warn_parentheses_missing=None,  # mdmd:line-hidden
         *,
         image: Optional[_Image] = None,  # The image to run as the container for the function
         schedule: Optional[Schedule] = None,  # An optional Modal Schedule for the function
@@ -841,7 +841,7 @@ class _App:
     @warn_on_renamed_autoscaler_settings
     def cls(
         self,
-        _warn_parentheses_missing: Optional[bool] = None,
+        _warn_parentheses_missing=None,  # mdmd:line-hidden
         *,
         image: Optional[_Image] = None,  # The image to run as the container for the function
         secrets: Sequence[_Secret] = (),  # Optional Modal Secret objects with environment variables for the container

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -227,7 +227,7 @@ class _Dict(_Object, type_prefix="di"):
         data: Optional[dict] = None,  # DEPRECATED
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
-        _heartbeat_sleep: float = EPHEMERAL_OBJECT_HEARTBEAT_SLEEP,
+        _heartbeat_sleep: float = EPHEMERAL_OBJECT_HEARTBEAT_SLEEP,  # mdmd:line-hidden
     ) -> AsyncIterator["_Dict"]:
         """Creates a new ephemeral Dict within a context manager:
 

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -136,7 +136,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         cls: type["_NetworkFileSystem"],
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
-        _heartbeat_sleep: float = EPHEMERAL_OBJECT_HEARTBEAT_SLEEP,
+        _heartbeat_sleep: float = EPHEMERAL_OBJECT_HEARTBEAT_SLEEP,  # mdmd:line-hidden
     ) -> AsyncIterator["_NetworkFileSystem"]:
         """Creates a new ephemeral network filesystem within a context manager:
 

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -263,7 +263,7 @@ class _Queue(_Object, type_prefix="qu"):
         cls: type["_Queue"],
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
-        _heartbeat_sleep: float = EPHEMERAL_OBJECT_HEARTBEAT_SLEEP,
+        _heartbeat_sleep: float = EPHEMERAL_OBJECT_HEARTBEAT_SLEEP,  # mdmd:line-hidden
     ) -> AsyncIterator["_Queue"]:
         """Creates a new ephemeral queue within a context manager:
 

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -381,7 +381,7 @@ class _Volume(_Object, type_prefix="vo"):
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,
         version: "typing.Optional[modal_proto.api_pb2.VolumeFsVersion.ValueType]" = None,
-        _heartbeat_sleep: float = EPHEMERAL_OBJECT_HEARTBEAT_SLEEP,
+        _heartbeat_sleep: float = EPHEMERAL_OBJECT_HEARTBEAT_SLEEP,  # mdmd:line-hidden
     ) -> AsyncGenerator["_Volume", None]:
         """Creates a new ephemeral volume within a context manager:
 


### PR DESCRIPTION
Just a quick driveby to leverage the nice `mdmd:line-hidden` that @ehdr added a little while back.