### PR TITLE
Show experimental warning when using any `modal launch` command

### DIFF
--- a/modal/cli/launch.py
+++ b/modal/cli/launch.py
@@ -21,9 +21,10 @@ from .import_refs import ImportRef, _get_runnable_app, import_file_or_module
 launch_cli = Typer(
     name="launch",
     no_args_is_help=True,
+    rich_markup_mode="markdown",
     help="""
     Open a serverless app instance on Modal.
-    >⚠️  modal launch is experimental and may change in the future.
+    >⚠️  `modal launch` is **experimental** and may change in the future.
     """,
 )
 


### PR DESCRIPTION
## Describe your changes

This PR shows experimental warning when using any `modal launch` command.

From `modal launch`'s help:

![Screenshot 2025-08-08 at 11 29 39 AM](https://github.com/user-attachments/assets/ebc24103-bf43-4466-a0e0-5718e516fdfd)

When actually launching:

![Screenshot 2025-08-08 at 11 29 10 AM](https://github.com/user-attachments/assets/6109c8e9-950c-443a-9e82-2b2899b91c2c)


<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>