### PR TITLE
Add `.objects.create` methods

### DIFF
--- a/modal/queue.py
+++ b/modal/queue.py
@@ -29,7 +29,7 @@ from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from ._utils.time_utils import as_timestamp, timestamp_to_localized_dt
 from .client import _Client
-from .exception import InvalidError, NotFoundError, RequestSizeError
+from .exception import AlreadyExistsError, InvalidError, NotFoundError, RequestSizeError
 
 
 @dataclass
@@ -48,9 +48,62 @@ class _QueueManager:
     """Namespace with methods for managing named Queue objects."""
 
     @staticmethod
+    async def create(
+        name: str,  # Name to use for the new Queue
+        *,
+        allow_existing: bool = False,  # If True, no-op when the Queue already exists
+        environment_name: Optional[str] = None,  # Uses active environment if not specified
+        client: Optional[_Client] = None,  # Optional client with Modal credentials
+    ) -> None:
+        """Create a new Queue object.
+
+        **Examples:**
+
+        ```python notest
+        modal.Queue.objects.create("my-queue")
+        ```
+
+        Queues will be created in the active environment, or another one can be specified:
+
+        ```python notest
+        modal.Queue.objects.create("my-queue", environment_name="dev")
+        ```
+
+        By default, an error will be raised if the Queue already exists, but passing
+        `allow_existing=True` will make the creation attempt a no-op in this case.
+
+        ```python notest
+        modal.Queue.objects.create("my-queue", allow_existing=True)
+        ```
+
+        Note that this method does not return a local instance of the Queue. You can use
+        `modal.Queue.from_name` to perform a lookup after creation.
+
+        """
+        client = await _Client.from_env() if client is None else client
+        object_creation_type = (
+            api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING
+            if allow_existing
+            else api_pb2.OBJECT_CREATION_TYPE_CREATE_FAIL_IF_EXISTS
+        )
+        req = api_pb2.QueueGetOrCreateRequest(
+            deployment_name=name,
+            environment_name=_get_environment_name(environment_name),
+            object_creation_type=object_creation_type,
+        )
+        try:
+            await retry_transient_errors(client.stub.QueueGetOrCreate, req)
+        except GRPCError as exc:
+            if exc.status == Status.ALREADY_EXISTS:
+                if not allow_existing:
+                    raise AlreadyExistsError(exc.message)
+            else:
+                raise
+
+    @staticmethod
     async def list(
         *,
-        max_objects: Optional[int] = None,  # Limit requests to this size
+        max_objects: Optional[int] = None,  # Limit results to this size
         created_before: Optional[Union[datetime, str]] = None,  # Limit based on creation date
         environment_name: str = "",  # Uses active environment if not specified
         client: Optional[_Client] = None,  # Optional client with Modal credentials
@@ -87,7 +140,9 @@ class _QueueManager:
         async def retrieve_page(created_before: float) -> bool:
             max_page_size = 100 if max_objects is None else min(100, max_objects - len(items))
             pagination = api_pb2.ListPagination(max_objects=max_page_size, created_before=created_before)
-            req = api_pb2.QueueListRequest(environment_name=environment_name, pagination=pagination)
+            req = api_pb2.QueueListRequest(
+                environment_name=_get_environment_name(environment_name), pagination=pagination
+            )
             resp = await retry_transient_errors(client.stub.QueueList, req)
             items.extend(resp.queues)
             finished = (len(resp.queues) < max_page_size) or (max_objects is not None and len(items) >= max_objects)

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -19,7 +19,7 @@ from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from ._utils.time_utils import as_timestamp, timestamp_to_localized_dt
 from .client import _Client
-from .exception import InvalidError, NotFoundError
+from .exception import AlreadyExistsError, InvalidError, NotFoundError
 
 ENV_DICT_WRONG_TYPE_ERR = "the env_dict argument to Secret has to be a dict[str, Union[str, None]]"
 
@@ -38,6 +38,63 @@ class SecretInfo:
 
 class _SecretManager:
     """Namespace with methods for managing named Secret objects."""
+
+    @staticmethod
+    async def create(
+        name: str,  # Name to use for the new Secret
+        env_dict: dict[str, str],  # Dictionary of environment variables to set in the Secret
+        *,
+        allow_existing: bool = False,  # If True, no-op when the Secret already exists
+        environment_name: Optional[str] = None,  # Uses active environment if not specified
+        client: Optional[_Client] = None,  # Optional client with Modal credentials
+    ) -> None:
+        """Create a new Secret object.
+
+        **Examples:**
+
+        ```python notest
+        env_dict = {"FOO": "bar"}
+        modal.Secret.objects.create("my-secret", env_dict)
+        ```
+
+        Secrets will be created in the active environment, or another one can be specified:
+
+        ```python notest
+        modal.Secret.objects.create("my-secret", env_dict, environment_name="dev")
+        ```
+
+        By default, an error will be raised if the Secret already exists, but passing
+        `allow_existing=True` will make the creation attempt a no-op in this case.
+        If the `env_dict` data differs from the existing Secret, it will be ignored.
+
+        ```python notest
+        modal.Secret.objects.create("my-secret", env_dict, allow_existing=True)
+        ```
+
+        Note that this method does not return a local instance of the Secret. You can use
+        `modal.Secret.from_name` to perform a lookup after creation.
+
+        """
+        client = await _Client.from_env() if client is None else client
+        object_creation_type = (
+            api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING
+            if allow_existing
+            else api_pb2.OBJECT_CREATION_TYPE_CREATE_FAIL_IF_EXISTS
+        )
+        req = api_pb2.SecretGetOrCreateRequest(
+            deployment_name=name,
+            environment_name=_get_environment_name(environment_name),
+            object_creation_type=object_creation_type,
+            env_dict=env_dict,
+        )
+        try:
+            await retry_transient_errors(client.stub.SecretGetOrCreate, req)
+        except GRPCError as exc:
+            if exc.status == Status.ALREADY_EXISTS:
+                if not allow_existing:
+                    raise AlreadyExistsError(exc.message)
+            else:
+                raise
 
     @staticmethod
     async def list(
@@ -79,7 +136,9 @@ class _SecretManager:
         async def retrieve_page(created_before: float) -> bool:
             max_page_size = 100 if max_objects is None else min(100, max_objects - len(items))
             pagination = api_pb2.ListPagination(max_objects=max_page_size, created_before=created_before)
-            req = api_pb2.SecretListRequest(environment_name=environment_name, pagination=pagination)
+            req = api_pb2.SecretListRequest(
+                environment_name=_get_environment_name(environment_name), pagination=pagination
+            )
             resp = await retry_transient_errors(client.stub.SecretList, req)
             items.extend(resp.items)
             finished = (len(resp.items) < max_page_size) or (max_objects is not None and len(items) >= max_objects)

--- a/test/dict_test.py
+++ b/test/dict_test.py
@@ -4,7 +4,7 @@ import sys
 import time
 
 from modal import Dict
-from modal.exception import DeprecationError, InvalidError, NotFoundError
+from modal.exception import AlreadyExistsError, DeprecationError, InvalidError, NotFoundError
 from modal_proto import api_pb2
 
 
@@ -117,3 +117,11 @@ def test_dict_list(servicer, client):
 
     dict_list = Dict.objects.list(max_objects=2, client=client)
     assert len(dict_list) == 2
+
+
+def test_dict_create(servicer, client):
+    Dict.objects.create(name="test-dict-create", client=client)
+    Dict.from_name("test-dict-create").hydrate(client)
+    with pytest.raises(AlreadyExistsError):
+        Dict.objects.create(name="test-dict-create", client=client)
+    Dict.objects.create(name="test-dict-create", allow_existing=True, client=client)

--- a/test/queue_test.py
+++ b/test/queue_test.py
@@ -5,7 +5,7 @@ import sys
 import time
 
 from modal import Queue
-from modal.exception import DeprecationError, InvalidError, NotFoundError
+from modal.exception import AlreadyExistsError, DeprecationError, InvalidError, NotFoundError
 from modal_proto import api_pb2
 
 from .supports.skip import skip_macos, skip_windows
@@ -165,3 +165,11 @@ def test_queue_list(servicer, client):
 
     queue_list = Queue.objects.list(max_objects=2, client=client)
     assert len(queue_list) == 2
+
+
+def test_queue_create(servicer, client):
+    Queue.objects.create(name="test-queue-create", client=client)
+    Queue.from_name("test-queue-create").hydrate(client)
+    with pytest.raises(AlreadyExistsError):
+        Queue.objects.create(name="test-queue-create", client=client)
+    Queue.objects.create(name="test-queue-create", allow_existing=True, client=client)

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -13,7 +13,7 @@ from unittest import mock
 
 import modal
 from modal._utils.blob_utils import BLOCK_SIZE
-from modal.exception import DeprecationError, InvalidError, NotFoundError, VolumeUploadTimeoutError
+from modal.exception import AlreadyExistsError, DeprecationError, InvalidError, NotFoundError, VolumeUploadTimeoutError
 from modal.volume import _open_files_error_annotation
 from modal_proto import api_pb2
 
@@ -588,3 +588,11 @@ def test_volume_list(servicer, client):
 
     volume_list = modal.Volume.objects.list(max_objects=2, client=client)
     assert len(volume_list) == 2
+
+
+def test_volume_create(servicer, client):
+    modal.Volume.objects.create(name="test-volume-create", client=client)
+    modal.Volume.from_name("test-volume-create").hydrate(client)
+    with pytest.raises(AlreadyExistsError):
+        modal.Volume.objects.create(name="test-volume-create", client=client)
+    modal.Volume.objects.create(name="test-volume-create", allow_existing=True, client=client)


### PR DESCRIPTION
## Describe your changes

- Closes SDK-549

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

- Added `.objects.create()` methods