### PR TITLE
volume: Strip trailing zeroes from each block when uploading

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2223,13 +2223,14 @@ class MockClientServicer(api_grpc.ModalClientBase):
                     valid_put_response = False
 
                 if block_data is not None and valid_put_response:
-                    # If this is not the last block, it needs to have size BLOCK_SIZE
-                    if block_index + 1 < len(file.blocks):
-                        assert len(block_data) == BLOCK_SIZE
-                    # If this is the last block, it must be at most BLOCK_SIZE
-                    if block_index + 1 == len(file.blocks):
-                        assert len(block_data) <= BLOCK_SIZE
-                    blocks.append(block_data)
+                    assert len(block_data) <= BLOCK_SIZE
+
+                    if block_index == len(file.blocks) - 1:
+                        expanded_data = block_data.ljust(file.size % BLOCK_SIZE, b"\0")
+                    else:
+                        expanded_data = block_data.ljust(BLOCK_SIZE, b"\0")
+
+                    blocks.append(expanded_data)
                 else:
                     missing_block = api_pb2.VolumePutFiles2Response.MissingBlock(
                         file_index=file_index,


### PR DESCRIPTION
## Describe your changes

We now internally store blocks in a more compact format by stripping trailing zeroes from each block. To reduce the number of bytes transferred over the network, and to aid in block de-duplication (which uses the content SHA256 checksum of each block), we can strip the trailing zeroes already client-side to speed up file transfers significantly.

The alternative to this would involve a lot of backend changes, since we would then instead need to track the stripped and un-stripped digest of every block when de-duplicating blocks.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
