### PR TITLE
Pass through RDMA requests to functions in a class

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -931,13 +931,16 @@ class _App:
 
                 if wrapped_cls.flags & _PartialFunctionFlags.CLUSTERED:
                     cluster_size = wrapped_cls.params.cluster_size
+                    rdma = wrapped_cls.params.rdma
                 else:
                     cluster_size = None
+                    rdma = None
             else:
                 user_cls = wrapped_cls
                 max_concurrent_inputs = allow_concurrent_inputs
                 target_concurrent_inputs = None
                 cluster_size = None
+                rdma = None
             if not inspect.isclass(user_cls):
                 raise TypeError("The @app.cls decorator must be used on a class.")
 
@@ -1007,6 +1010,7 @@ class _App:
                 scheduler_placement=scheduler_placement,
                 i6pn_enabled=i6pn_enabled,
                 cluster_size=cluster_size,
+                rdma=rdma,
                 include_source=include_source if include_source is not None else self._include_source_default,
                 experimental_options={k: str(v) for k, v in (experimental_options or {}).items()},
                 _experimental_proxy_ip=_experimental_proxy_ip,

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -1341,6 +1341,7 @@ def test_clustered_cls(client, servicer):
         class_function = servicer.function_by_name("ClusteredClass.*")
         assert class_function._experimental_group_size == 3
         assert class_function.i6pn_enabled is True  # clustered implies i6pn
+        assert class_function.resources.rdma == 1
 
         obj = ClusteredClass()
         assert hasattr(obj, "run_task")
@@ -1348,6 +1349,7 @@ def test_clustered_cls(client, servicer):
         regular_function = servicer.function_by_name("RegularClass.*")
         assert regular_function._experimental_group_size == 0  # or not set
         assert regular_function.i6pn_enabled is False
+        assert regular_function.resources.rdma == 0
 
 
 invalid_clustered_app = App()


### PR DESCRIPTION
## Describe your changes

- Enable class-based multinode functions to use RDMA.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.



</details>

## Changelog

- Allow multi-node Class-based functions to use RDMA