### PR TITLE
Disable FileIO doctests

### DIFF
--- a/modal/file_io.py
+++ b/modal/file_io.py
@@ -128,7 +128,7 @@ class _FileIO(Generic[T]):
 
     **Usage**
 
-    ```python
+    ```python notest
     import modal
 
     app = modal.App.lookup("my-app", create_if_missing=True)

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -296,8 +296,9 @@ class _Sandbox(_Object, type_prefix="sb"):
         environment_name: Optional[str] = None,  # *DEPRECATED* Optionally override the default environment
     ) -> "_Sandbox":
         """
-        Create a new Sandbox to run untrusted, arbitrary code. The Sandbox's corresponding container
-        will be created asynchronously.
+        Create a new Sandbox to run untrusted, arbitrary code.
+
+        The Sandbox's corresponding container will be created asynchronously.
 
         **Usage**
 


### PR DESCRIPTION
I don't like doing this, but these flake too often, and the FileIO API is "in alpha".