### PR TITLE
Remove outdated `MapStartOrContinueResponse` comment

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2167,7 +2167,7 @@ message MapStartOrContinueResponse {
   string function_call_id = 2;
   uint32 max_inputs_outstanding = 3;
   repeated string attempt_tokens = 4;
-  FunctionRetryPolicy retry_policy = 5; // TODO(ben-okeefe): Not currently used
+  FunctionRetryPolicy retry_policy = 5;
 }
 
 message MethodDefinition {


### PR DESCRIPTION
`ClientServer.MapStartOrContinue()` now sets
`MapStartOrContinueResponse.RetryPolicy`.