### PR TITLE
Expose version= in modal.Volume.objects.create

### DIFF
--- a/modal/volume.py
+++ b/modal/volume.py
@@ -120,6 +120,7 @@ class _VolumeManager:
     async def create(
         name: str,  # Name to use for the new Volume
         *,
+        version: Optional[int] = None,  # Experimental: Configure the backend VolumeFS version
         allow_existing: bool = False,  # If True, no-op when the Volume already exists
         environment_name: Optional[str] = None,  # Uses active environment if not specified
         client: Optional[_Client] = None,  # Optional client with Modal credentials
@@ -154,10 +155,15 @@ class _VolumeManager:
             if allow_existing
             else api_pb2.OBJECT_CREATION_TYPE_CREATE_FAIL_IF_EXISTS
         )
+
+        if version is not None and version not in {1, 2}:
+            raise InvalidError("VolumeFS version must be either 1 or 2")
+
         req = api_pb2.VolumeGetOrCreateRequest(
             deployment_name=name,
             environment_name=_get_environment_name(environment_name),
             object_creation_type=object_creation_type,
+            version=version,
         )
         try:
             await retry_transient_errors(client.stub.VolumeGetOrCreate, req)

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -628,3 +628,13 @@ def test_volume_create(servicer, client):
     with pytest.raises(AlreadyExistsError):
         modal.Volume.objects.create(name="test-volume-create", client=client)
     modal.Volume.objects.create(name="test-volume-create", allow_existing=True, client=client)
+
+
+def test_volume_create_version(servicer, client):
+    for version in [1, 2]:
+        modal.Volume.objects.create(name=f"should-be-v{version}", version=version, client=client)
+        vol_id = servicer.deployed_volumes[(f"should-be-v{version}", "main")]
+        assert servicer.volumes[vol_id].version == version
+
+    with pytest.raises(InvalidError, match="VolumeFS version must be either 1 or 2"):
+        modal.Volume.objects.create(name="should-be-v3", version=3, client=client)


### PR DESCRIPTION
Brings `modal.Volume.objects.create()` to parity with the `modal volume create` CLI.

Would sort of have preferred we didn't need to expose this semi-internal / transient configuration option in the public API (maybe we should have `experimental_options` everywhere?)