### PR TITLE
Adds Image.build to eagerly build an image

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -880,6 +880,7 @@ class _Image(_Object, type_prefix="im"):
         with app.run(), modal.enable_output():
             image.build(app)
 
+        # Use this object_id with `Image.from_id` to use the built image in a sandbox or function.
         print(image.object_id)
         ```
         """

--- a/modal/image.py
+++ b/modal/image.py
@@ -868,6 +868,31 @@ class _Image(_Object, type_prefix="im"):
 
         return obj
 
+    async def build(self, app: "modal.app._App") -> "_Image":
+        """Eagerly build an image.
+
+        **Examples**
+
+        ```python
+        image = modal.Image.debian_slim().uv_pip_install("scipy", "numpy")
+
+        app = modal.App("build-image")
+        with app.run(), modal.enable_output():
+            image.build(app)
+
+        print(image.object_id)
+        ```
+        """
+        if app.app_id is None:
+            raise InvalidError("App has not been initialized yet. Run with `with app.run()`.")
+
+        app_id = app.app_id
+        app_client = app._client or await _Client.from_env()
+
+        resolver = Resolver(app_client, app_id=app_id)
+        await resolver.load(self)
+        return self
+
     def pip_install(
         self,
         *packages: Union[str, list[str]],  # A list of Python packages, eg. ["numpy", "matplotlib>=3.5.0"]

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -2267,3 +2267,14 @@ def test_raw_registry_image(servicer, client):
 def test_hydration_refusal():
     with pytest.raises(ExecutionError, match="Images cannot currently be hydrated on demand"):
         Image.debian_slim().hydrate()
+
+
+def test_build(servicer, client):
+    image = modal.Image.debian_slim().uv_pip_install("scipy", "numpy")
+
+    app = App()
+    with servicer.intercept() as ctx:
+        with app.run(client=client):
+            image.build(app)
+
+    assert len(ctx.get_requests("ImageGetOrCreate")) == 2


### PR DESCRIPTION
## Describe your changes

Although, eagerly building an image requires an app, I still think it's useful. In a future, where an app is not required, we can make the app kwarg optional.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->

- Adds `image.build` to eagerly build an image:
 
```python
image = modal.Image.debian_slim().uv_pip_install("scipy", "numpy")
app = modal.App("build-image")
with app.run(), modal.enable_output():
    image.build(app)

# Use this object_id with `Image.from_id` to use the built image in a sandbox or function.
print(image.object_id)
```