### PR TITLE
add idle_timeout_secs field to Sandbox protobuf def

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2635,6 +2635,9 @@ message Sandbox {
   map<string, bool> experimental_options = 31;
 
   repeated string preload_path_prefixes = 32; // Internal use only.
+
+  // Optional idle timeout in seconds. If set, the sandbox will be terminated after being idle for this duration.
+  optional uint32 idle_timeout_secs = 33;
 }
 
 message SandboxCreateRequest {


### PR DESCRIPTION
## Describe your changes

This adds an `idle_timeout_secs` field to the Sandbox protobuf definition in advance of the [Sandbox Idle Timeouts](https://www.notion.so/modal-com/Sandbox-Idle-Timeouts-2491e7f1694980208ccde60da0e8622e?source=copy_link) work.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [X] Client+Server: this change is compatible with old servers
- [X] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

</details>