### PR TITLE
add an idle_timeout param for Sandbox.create()

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -259,7 +259,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         image: Optional[_Image] = None,  # The image to run as the container for the sandbox.
         secrets: Sequence[_Secret] = (),  # Environment variables to inject into the sandbox.
         network_file_systems: dict[Union[str, os.PathLike], _NetworkFileSystem] = {},
-        timeout: int = 300,  # Maximum execution time of the sandbox in seconds.
+        timeout: int = 300,  # Maximum lifetime of the sandbox in seconds.
         # The amount of time in seconds that a sandbox can be idle before being terminated.
         idle_timeout: Optional[int] = None,
         workdir: Optional[str] = None,  # Working directory of the sandbox.
@@ -360,7 +360,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         secrets: Sequence[_Secret] = (),  # Environment variables to inject into the sandbox.
         mounts: Sequence[_Mount] = (),
         network_file_systems: dict[Union[str, os.PathLike], _NetworkFileSystem] = {},
-        timeout: int = 300,  # Maximum execution time of the sandbox in seconds.
+        timeout: int = 300,  # Maximum lifetime of the sandbox in seconds.
         # The amount of time in seconds that a sandbox can be idle before being terminated.
         idle_timeout: Optional[int] = None,
         workdir: Optional[str] = None,  # Working directory of the sandbox.


### PR DESCRIPTION
## Describe your changes

Adds an `idle_timeout` param to `Sandbox.create()`. See design doc for this feature [here](https://www.notion.so/modal-com/Sandbox-Idle-Timeouts-2491e7f1694980208ccde60da0e8622e?source=copy_link).

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [X] Client+Server: this change is compatible with old servers
- [X] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

</details>

## Changelog

- Added an `idle_timeout` param to `Sandbox.create()` which, when provided, will have the sandbox terminate after `idle_timeout` seconds of idleness.