### PR TITLE
add GENERIC_STATUS_IDLE_TIMEOUT variant for GenericStatus

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1976,6 +1976,8 @@ message GenericResult {  // Used for both tasks and function outputs
     // Terminates the function and all remaining inputs.
     GENERIC_STATUS_INIT_FAILURE = 5;
     GENERIC_STATUS_INTERNAL_FAILURE = 6;
+    // Used when sandboxes are terminated due to idle_timeout
+    GENERIC_STATUS_IDLE_TIMEOUT = 7;
   }
 
   GenericStatus status = 1; // Status of the task or function output.


### PR DESCRIPTION
## Describe your changes

We want to differentiate between sandboxes that hit their lifetime limit (i.e. `timeout` param), those that were explicitly terminated by the user, and those that were terminated due to hitting an idle timeout. This new `GenericStatus` variant makes that possible.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself
- [x] Client+Server: this change is compatible with old servers

There are a few places on the server where we may need to update some code for this new variant. There's a PR for those changes [here](https://github.com/modal-labs/modal/pull/25917).

Note that running servers should not encounter this new variant until we actually release the `idle_timeout` client, but `cargo build`s may fail until we add support for the new variant.
---

</details>