### PR TITLE
Fix FunctionCall.from_id not setting client object

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -2015,6 +2015,7 @@ class _FunctionCall(typing.Generic[ReturnType], _Object, type_prefix="fc"):
         fc: _FunctionCall[Any] = _FunctionCall._from_loader(_load, rep, hydrate_lazily=True)
         # We already know the object ID, so we can set it directly
         fc._object_id = function_call_id
+        fc._client = client
         return fc
 
     @staticmethod

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -781,18 +781,23 @@ def test_from_id(client, servicer):
 
     @app.function(serialized=True)
     def foo():
-        pass
+        return 42
 
     deploy_app(app, "dummy", client=client)
 
-    function_id = foo.object_id
-    assert function_id
-
     function_call = foo.spawn()
     assert function_call.object_id
-    # Used in a few examples to construct FunctionCall objects
-    rehydrated_function_call = FunctionCall.from_id(function_call.object_id, client)
-    assert rehydrated_function_call.object_id == function_call.object_id
+
+    # Ensure from_id doesn't do a metadata RPC and .get() works without prior hydration
+    with servicer.intercept() as ctx:
+        fc2 = FunctionCall.from_id(function_call.object_id, client)
+        assert fc2.object_id == function_call.object_id
+        assert fc2.get() == 42
+        # Optional: also ensure get_call_graph works without metadata RPC
+        cg = fc2.get_call_graph()
+        assert cg and cg[0].function_call_id == function_call.object_id
+
+    ctx.assert_no_request("FunctionCallFromId")
 
 
 def test_local_execution_on_web_endpoint(client, servicer):


### PR DESCRIPTION
## Describe your changes

https://github.com/modal-labs/modal-client/pull/3445 changed the logic of `FunctionCall.from_id` to return an un-hydrated `FunctionCall` object, because there is now server-side object metadata (`num_inputs`) that can be set on the `FunctionCall` handle. This `num_inputs` information is only used by the newly introduced `FunctionCall.iter` (and `FunctionCall.num_inputs`). Previously, `FunctionCall.from_id` would use `_FunctionCall._new_hydrated` so it would return a hydrated `FunctionCall` object with `_client` set. Methods like `.get()`, `.get_call_graph()`, etc. depend on `_client` being set. With the change, we forgot to manually set `_client` on the `FunctionCall` in `from_id`.

Discussed this fix with @mwaskom. We are getting this bug fix in quickly for now but want to discuss further and hopefully move towards a cleaner state where an Object is only either hydrated (ID+server side metadata present) or not.

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

Fixes a bug introduced in `1.1.2` which causes invocation of `FunctionCall.get`, `FunctionCall.get_call_graph`, `FunctionCall.cancel`, and `FunctionCall.gather` to fail when the `FunctionCall` object is retrieved via `FunctionCall.from_id`.
