### PR TITLE
Mark Nfs as deprecated in the docs

### DIFF
--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -55,6 +55,8 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
     By attaching this file system as a mount to one or more functions, they can
     share and persist data with each other.
 
+    **Note: `NetworkFileSystem` has been deprecated and will be removed.**
+
     **Usage**
 
     ```python


### PR DESCRIPTION
We are working on deprecating Nfs and want to actively discourage using it.

## Describe your changes

- _FS-265._

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
