### PR TITLE
Adds cbor2 dependency to PREVIEW image builder

### DIFF
--- a/modal/builder/PREVIEW.txt
+++ b/modal/builder/PREVIEW.txt
@@ -15,3 +15,4 @@ propcache==0.3.1
 protobuf==6.31.1
 typing_extensions==4.13.2
 yarl==1.20.0
+cbor2==5.7.0


### PR DESCRIPTION
I intend to manually publish a new version of the preview mounts once this is merged.

If subsequent testing shows it works, the intention is to patch the 2025.06 image builder to include cbor2 as well, since it's a relatively safe thing to do and would unlock cbor2 functionality on new clients without having to wait for/switch to a future image builder version.

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
