### PR TITLE
Delete redundant input plane retry unit tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -318,8 +318,6 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.port = port
         # AttemptAwait will return a failure until this is 0. It is decremented by 1 each time AttemptAwait is called.
         self.attempt_await_failures_remaining = 0
-        # Number of times AttemptRetry has been called.
-        self.attempted_retries = 0
         # Value returned by AuthTokenGet
         self.auth_token = jwt.encode({"exp": int(time.time()) + 3600}, "my-secret-key", algorithm="HS256")
         self.auth_tokens_generated = 0
@@ -2373,7 +2371,6 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.n_inputs += 1
         self.add_function_call_input(function_call_id, request.input, input_id, 0)
 
-        self.attempted_retries += 1
         await stream.send_message(api_pb2.AttemptRetryResponse(attempt_token=request.attempt_token))
 
     async def MapStartOrContinue(self, stream):

--- a/test/function_retry_test.py
+++ b/test/function_retry_test.py
@@ -68,7 +68,6 @@ def fetch_input_plane_request_counts(ctx):
 def setup_app_and_function_inputplane(servicer):
     app = App()
     servicer.function_body(counting_function)
-    # Custom retries are not supported for inputplane functions yet.
     f = app.function(experimental_options={"input_plane_region": "us-east"}, retries=modal.Retries(max_retries=3))(
         counting_function
     )


### PR DESCRIPTION
`test/function_retry_test.py:test_map_all_retries_fail_raises_error_inputplane` covers the same case as `test/input_plane_test.py:test_no_user_retry_policy`.

`test/function_retry_test.py:test_map_failures_followed_by_success_inputplane` covers the same case as `test/input_plane_test.py:test_user_retry_policy`.

Remove unnecessary attribute and outdated comments too.
