### PR TITLE
Add is_managed to EnvironmentListItem

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1236,6 +1236,7 @@ message EnvironmentListItem {
   double created_at = 3;
   bool default = 4;
   bool is_managed = 5;
+  string environment_id = 6;
 }
 
 message EnvironmentListResponse {

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1235,6 +1235,7 @@ message EnvironmentListItem {
   string webhook_suffix = 2;
   double created_at = 3;
   bool default = 4;
+  bool is_managed = 5;
 }
 
 message EnvironmentListResponse {


### PR DESCRIPTION
We'll update `EnvironmentList` so that web calls it as well for the environment picker on the /settings page: https://github.com/modal-labs/modal/blob/77bc45ed4dfaa7391edfd34d1764ce34a40c582a/server/modal_server/objects/environment.py#L156