### PR TITLE
Move `retry_transient_errors` into the stub generator

### DIFF
--- a/modal/_clustered_functions.py
+++ b/modal/_clustered_functions.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from typing import Optional
 
 from modal._utils.async_utils import synchronize_api
-from modal._utils.grpc_utils import retry_transient_errors
 from modal.client import _Client
 from modal.exception import InvalidError
 from modal_proto import api_pb2
@@ -60,8 +59,7 @@ async def _initialize_clustered_function(client: _Client, task_id: str, world_si
         os.environ["NCCL_NSOCKS_PERTHREAD"] = "1"
 
     if world_size > 1:
-        resp: api_pb2.TaskClusterHelloResponse = await retry_transient_errors(
-            client.stub.TaskClusterHello,
+        resp = await client.stub.TaskClusterHello(
             api_pb2.TaskClusterHelloRequest(
                 task_id=task_id,
                 container_ip=container_ip,

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -53,7 +53,7 @@ from ._utils.function_utils import (
     get_function_type,
     is_async,
 )
-from ._utils.grpc_utils import RetryWarningMessage, retry_transient_errors
+from ._utils.grpc_utils import RetryWarningMessage
 from ._utils.mount_utils import validate_network_file_systems, validate_volumes
 from .call_graph import InputInfo, _reconstruct_call_graph
 from .client import _Client
@@ -167,8 +167,7 @@ class _Invocation:
 
         if from_spawn_map:
             request.from_spawn_map = True
-            response = await retry_transient_errors(
-                client.stub.FunctionMap,
+            response = await client.stub.FunctionMap(
                 request,
                 max_retries=None,
                 max_delay=30.0,
@@ -181,7 +180,7 @@ class _Invocation:
                 additional_status_codes=[Status.RESOURCE_EXHAUSTED],
             )
         else:
-            response = await retry_transient_errors(client.stub.FunctionMap, request)
+            response = await client.stub.FunctionMap(request)
 
         function_call_id = response.function_call_id
         if response.pipelined_inputs:
@@ -201,10 +200,7 @@ class _Invocation:
         request_put = api_pb2.FunctionPutInputsRequest(
             function_id=function_id, inputs=[item], function_call_id=function_call_id
         )
-        inputs_response: api_pb2.FunctionPutInputsResponse = await retry_transient_errors(
-            client.stub.FunctionPutInputs,
-            request_put,
-        )
+        inputs_response: api_pb2.FunctionPutInputsResponse = await client.stub.FunctionPutInputs(request_put)
         processed_inputs = inputs_response.inputs
         if not processed_inputs:
             raise Exception("Could not create function call - the input queue seems to be full")
@@ -246,8 +242,7 @@ class _Invocation:
                 start_idx=index,
                 end_idx=index,
             )
-            response: api_pb2.FunctionGetOutputsResponse = await retry_transient_errors(
-                self.stub.FunctionGetOutputs,
+            response: api_pb2.FunctionGetOutputsResponse = await self.stub.FunctionGetOutputs(
                 request,
                 attempt_timeout=backend_timeout + ATTEMPT_TIMEOUT_GRACE_PERIOD,
             )
@@ -269,10 +264,7 @@ class _Invocation:
 
         item = api_pb2.FunctionRetryInputsItem(input_jwt=ctx.input_jwt, input=ctx.item.input)
         request = api_pb2.FunctionRetryInputsRequest(function_call_jwt=ctx.function_call_jwt, inputs=[item])
-        await retry_transient_errors(
-            self.stub.FunctionRetryInputs,
-            request,
-        )
+        await self.stub.FunctionRetryInputs(request)
 
     async def _get_single_output(self, expected_jwt: Optional[str] = None) -> api_pb2.FunctionGetOutputsItem:
         # waits indefinitely for a single result for the function, and clear the outputs buffer after
@@ -376,10 +368,8 @@ class _Invocation:
                 start_idx=current_index,
                 end_idx=batch_end_index,
             )
-            response: api_pb2.FunctionGetOutputsResponse = await retry_transient_errors(
-                self.stub.FunctionGetOutputs,
-                request,
-                attempt_timeout=ATTEMPT_TIMEOUT_GRACE_PERIOD,
+            response: api_pb2.FunctionGetOutputsResponse = await self.stub.FunctionGetOutputs(
+                request, attempt_timeout=ATTEMPT_TIMEOUT_GRACE_PERIOD
             )
 
             outputs = list(response.outputs)
@@ -452,7 +442,7 @@ class _InputPlaneInvocation:
         )
 
         metadata = await client.get_input_plane_metadata(input_plane_region)
-        response = await retry_transient_errors(stub.AttemptStart, request, metadata=metadata)
+        response = await stub.AttemptStart(request, metadata=metadata)
         attempt_token = response.attempt_token
 
         return _InputPlaneInvocation(
@@ -472,8 +462,7 @@ class _InputPlaneInvocation:
                 requested_at=time.time(),
             )
             metadata = await self.client.get_input_plane_metadata(self.input_plane_region)
-            await_response: api_pb2.AttemptAwaitResponse = await retry_transient_errors(
-                self.stub.AttemptAwait,
+            await_response: api_pb2.AttemptAwaitResponse = await self.stub.AttemptAwait(
                 await_request,
                 attempt_timeout=OUTPUTS_TIMEOUT + ATTEMPT_TIMEOUT_GRACE_PERIOD,
                 metadata=metadata,
@@ -516,11 +505,7 @@ class _InputPlaneInvocation:
             attempt_token=self.attempt_token,
         )
         # TODO(ryan): Add exponential backoff?
-        retry_response = await retry_transient_errors(
-            self.stub.AttemptRetry,
-            retry_request,
-            metadata=metadata,
-        )
+        retry_response = await self.stub.AttemptRetry(retry_request, metadata=metadata)
         return retry_response.attempt_token
 
     async def run_generator(self):
@@ -875,7 +860,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
             elif webhook_config:
                 req.webhook_config.CopyFrom(webhook_config)
 
-            response = await retry_transient_errors(resolver.client.stub.FunctionPrecreate, req)
+            response = await resolver.client.stub.FunctionPrecreate(req)
             self._hydrate(response.function_id, resolver.client, response.handle_metadata)
 
         async def _load(self: _Function, resolver: Resolver, existing_object_id: Optional[str]):
@@ -1077,9 +1062,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                     existing_function_id=existing_object_id or "",
                 )
                 try:
-                    response: api_pb2.FunctionCreateResponse = await retry_transient_errors(
-                        resolver.client.stub.FunctionCreate, request
-                    )
+                    response: api_pb2.FunctionCreateResponse = await resolver.client.stub.FunctionCreate(request)
                 except GRPCError as exc:
                     if exc.status == Status.INVALID_ARGUMENT:
                         raise InvalidError(exc.message)
@@ -1214,7 +1197,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                 or "",  # TODO: investigate shouldn't environment name always be specified here?
             )
 
-            response = await retry_transient_errors(parent._client.stub.FunctionBindParams, req)
+            response = await parent._client.stub.FunctionBindParams(req)
             param_bound_func._hydrate(response.bound_function_id, parent._client, response.handle_metadata)
 
         def _deps():
@@ -1274,7 +1257,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
             scaledown_window=scaledown_window,
         )
         request = api_pb2.FunctionUpdateSchedulingParamsRequest(function_id=self.object_id, settings=settings)
-        await retry_transient_errors(self.client.stub.FunctionUpdateSchedulingParams, request)
+        await self.client.stub.FunctionUpdateSchedulingParams(request)
 
         # One idea would be for FunctionUpdateScheduleParams to return the current (coalesced) settings
         # and then we could return them here (would need some ad hoc dataclass, which I don't love)
@@ -1334,7 +1317,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                 environment_name=_get_environment_name(environment_name, resolver) or "",
             )
             try:
-                response = await retry_transient_errors(resolver.client.stub.FunctionGet, request)
+                response = await resolver.client.stub.FunctionGet(request)
             except NotFoundError as exc:
                 # refine the error message
                 env_context = f" (in the '{environment_name}' environment)" if environment_name else ""
@@ -1857,8 +1840,7 @@ Use the `Function.get_web_url()` method instead.
     @live_method
     async def get_current_stats(self) -> FunctionStats:
         """Return a `FunctionStats` object describing the current function's queue and runner counts."""
-        resp = await retry_transient_errors(
-            self.client.stub.FunctionGetCurrentStats,
+        resp = await self.client.stub.FunctionGetCurrentStats(
             api_pb2.FunctionGetCurrentStatsRequest(function_id=self.object_id),
             total_timeout=10.0,
         )
@@ -1963,7 +1945,7 @@ class _FunctionCall(typing.Generic[ReturnType], _Object, type_prefix="fc"):
         """
         assert self._client and self._client.stub
         request = api_pb2.FunctionGetCallGraphRequest(function_call_id=self.object_id)
-        response = await retry_transient_errors(self._client.stub.FunctionGetCallGraph, request)
+        response = await self._client.stub.FunctionGetCallGraph(request)
         return _reconstruct_call_graph(response)
 
     async def cancel(
@@ -1981,7 +1963,7 @@ class _FunctionCall(typing.Generic[ReturnType], _Object, type_prefix="fc"):
             function_call_id=self.object_id, terminate_containers=terminate_containers
         )
         assert self._client and self._client.stub
-        await retry_transient_errors(self._client.stub.FunctionCallCancel, request)
+        await self._client.stub.FunctionCallCancel(request)
 
     @staticmethod
     async def from_id(function_call_id: str, client: Optional[_Client] = None) -> "_FunctionCall[Any]":
@@ -2008,7 +1990,7 @@ class _FunctionCall(typing.Generic[ReturnType], _Object, type_prefix="fc"):
 
         async def _load(self: _FunctionCall, resolver: Resolver, existing_object_id: Optional[str]):
             request = api_pb2.FunctionCallFromIdRequest(function_call_id=function_call_id)
-            resp = await retry_transient_errors(resolver.client.stub.FunctionCallFromId, request)
+            resp = await resolver.client.stub.FunctionCallFromId(request)
             self._hydrate(function_call_id, resolver.client, resp)
 
         rep = f"FunctionCall.from_id({function_call_id!r})"

--- a/modal/_output.py
+++ b/modal/_output.py
@@ -34,7 +34,7 @@ from rich.text import Text
 from modal._utils.time_utils import timestamp_to_localized_str
 from modal_proto import api_pb2
 
-from ._utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES, retry_transient_errors
+from ._utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES
 from ._utils.shell_utils import stream_from_stdin
 from .client import _Client
 from .config import logger
@@ -489,8 +489,7 @@ async def stream_pty_shell_input(client: _Client, exec_id: str, finish_event: as
     """
 
     async def _handle_input(data: bytes, message_index: int):
-        await retry_transient_errors(
-            client.stub.ContainerExecPutInput,
+        await client.stub.ContainerExecPutInput(
             api_pb2.ContainerExecPutInputRequest(
                 exec_id=exec_id, input=api_pb2.RuntimeInputMessage(message=data, message_index=message_index)
             ),

--- a/modal/_runtime/container_io_manager.py
+++ b/modal/_runtime/container_io_manager.py
@@ -31,7 +31,6 @@ from modal._traceback import extract_traceback, print_exception
 from modal._utils.async_utils import TaskContext, asyncify, synchronize_api, synchronizer
 from modal._utils.blob_utils import MAX_OBJECT_SIZE_BYTES, blob_download, blob_upload
 from modal._utils.function_utils import _stream_function_call_data
-from modal._utils.grpc_utils import retry_transient_errors
 from modal._utils.package_utils import parse_major_minor_version
 from modal.client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, _Client
 from modal.config import config, logger
@@ -410,9 +409,7 @@ class _ContainerIOManager:
                 await self.heartbeat_condition.wait()
 
             request = api_pb2.ContainerHeartbeatRequest(canceled_inputs_return_outputs_v2=True)
-            response = await retry_transient_errors(
-                self._client.stub.ContainerHeartbeat, request, attempt_timeout=HEARTBEAT_TIMEOUT
-            )
+            response = await self._client.stub.ContainerHeartbeat(request, attempt_timeout=HEARTBEAT_TIMEOUT)
 
         if response.HasField("cancel_input_event"):
             # response.cancel_input_event.terminate_containers is never set, the server gets the worker to handle it.
@@ -458,8 +455,7 @@ class _ContainerIOManager:
                     target_concurrency=self._target_concurrency,
                     max_concurrency=self._max_concurrency,
                 )
-                resp = await retry_transient_errors(
-                    self._client.stub.FunctionGetDynamicConcurrency,
+                resp = await self._client.stub.FunctionGetDynamicConcurrency(
                     request,
                     attempt_timeout=DYNAMIC_CONCURRENCY_TIMEOUT_SECS,
                 )
@@ -523,9 +519,9 @@ class _ContainerIOManager:
 
         if self.input_plane_server_url:
             stub = await self._client.get_stub(self.input_plane_server_url)
-            await retry_transient_errors(stub.FunctionCallPutDataOut, req)
+            await stub.FunctionCallPutDataOut(req)
         else:
-            await retry_transient_errors(self._client.stub.FunctionCallPutDataOut, req)
+            await self._client.stub.FunctionCallPutDataOut(req)
 
     @asynccontextmanager
     async def generator_output_sender(
@@ -609,9 +605,7 @@ class _ContainerIOManager:
             try:
                 # If number of active inputs is at max queue size, this will block.
                 iteration += 1
-                response: api_pb2.FunctionGetInputsResponse = await retry_transient_errors(
-                    self._client.stub.FunctionGetInputs, request
-                )
+                response: api_pb2.FunctionGetInputsResponse = await self._client.stub.FunctionGetInputs(request)
 
                 if response.rate_limit_sleep_duration:
                     logger.info(
@@ -701,8 +695,7 @@ class _ContainerIOManager:
         # Limit the batch size to 20 to stay within message size limits and buffer size limits.
         output_batch_size = 20
         for i in range(0, len(outputs), output_batch_size):
-            await retry_transient_errors(
-                self._client.stub.FunctionPutOutputs,
+            await self._client.stub.FunctionPutOutputs(
                 api_pb2.FunctionPutOutputsRequest(outputs=outputs[i : i + output_batch_size]),
                 additional_status_codes=[Status.RESOURCE_EXHAUSTED],
                 max_retries=None,  # Retry indefinitely, trying every 1s.
@@ -762,7 +755,7 @@ class _ContainerIOManager:
             )
 
             req = api_pb2.TaskResultRequest(result=result)
-            await retry_transient_errors(self._client.stub.TaskResult, req)
+            await self._client.stub.TaskResult(req)
 
             # Shut down the task gracefully
             raise UserException()
@@ -973,8 +966,7 @@ class _ContainerIOManager:
         await asyncify(os.sync)()
         results = await asyncio.gather(
             *[
-                retry_transient_errors(
-                    self._client.stub.VolumeCommit,
+                self._client.stub.VolumeCommit(
                     api_pb2.VolumeCommitRequest(volume_id=v_id),
                     max_retries=9,
                     base_delay=0.25,

--- a/modal/_utils/auth_token_manager.py
+++ b/modal/_utils/auth_token_manager.py
@@ -9,7 +9,6 @@ from typing import Any
 from modal.exception import ExecutionError
 from modal_proto import api_pb2, modal_api_grpc
 
-from .grpc_utils import retry_transient_errors
 from .logger import logger
 
 
@@ -66,9 +65,7 @@ class _AuthTokenManager:
             # new token. Once we have a new token, the other coroutines will unblock and return from here.
             if self._token and not self._needs_refresh():
                 return
-            resp: api_pb2.AuthTokenGetResponse = await retry_transient_errors(
-                self._stub.AuthTokenGet, api_pb2.AuthTokenGetRequest()
-            )
+            resp: api_pb2.AuthTokenGetResponse = await self._stub.AuthTokenGet(api_pb2.AuthTokenGetRequest())
             if not resp.token:
                 # Not expected
                 raise ExecutionError(

--- a/modal/_utils/blob_utils.py
+++ b/modal/_utils/blob_utils.py
@@ -27,7 +27,6 @@ from modal_proto.modal_api_grpc import ModalClientModal
 
 from ..exception import ExecutionError
 from .async_utils import TaskContext, retry
-from .grpc_utils import retry_transient_errors
 from .hash_utils import UploadHashes, get_upload_hashes
 from .http_utils import ClientSessionRegistry
 from .logger import logger
@@ -229,7 +228,7 @@ async def _blob_upload(
         content_sha256_base64=upload_hashes.sha256_base64,
         content_length=content_length,
     )
-    resp = await retry_transient_errors(stub.BlobCreate, req)
+    resp = await stub.BlobCreate(req)
 
     if resp.WhichOneof("upload_types_oneof") == "multiparts":
 
@@ -331,7 +330,7 @@ async def blob_download(blob_id: str, stub: ModalClientModal) -> bytes:
     logger.debug(f"Downloading large blob {blob_id}")
     t0 = time.time()
     req = api_pb2.BlobGetRequest(blob_id=blob_id)
-    resp = await retry_transient_errors(stub.BlobGet, req)
+    resp = await stub.BlobGet(req)
     data = await _download_from_url(resp.download_url)
     size_mib = len(data) / 1024 / 1024
     dur_s = max(time.time() - t0, 0.001)  # avoid division by zero
@@ -344,7 +343,7 @@ async def blob_download(blob_id: str, stub: ModalClientModal) -> bytes:
 
 async def blob_iter(blob_id: str, stub: ModalClientModal) -> AsyncIterator[bytes]:
     req = api_pb2.BlobGetRequest(blob_id=blob_id)
-    resp = await retry_transient_errors(stub.BlobGet, req)
+    resp = await stub.BlobGet(req)
     download_url = resp.download_url
     async with ClientSessionRegistry.get_session().get(download_url) as s3_resp:
         # S3 signal to slow down request rate.

--- a/modal/_utils/grpc_utils.py
+++ b/modal/_utils/grpc_utils.py
@@ -271,6 +271,40 @@ async def retry_transient_errors(
             delay = min(delay * delay_factor, max_delay)
 
 
+def _with_retries(fn: "modal.client.UnaryUnaryWrapper[RequestType, ResponseType]"):
+    """Wrap a UnaryUnaryWrapper with retry_transient_errors."""
+
+    async def wrapped(
+        req: RequestType,
+        base_delay: float = 0.1,
+        max_delay: float = 1,
+        delay_factor: float = 2,
+        max_retries: Optional[int] = 3,
+        additional_status_codes: list = [],
+        attempt_timeout: Optional[float] = None,
+        total_timeout: Optional[float] = None,
+        attempt_timeout_floor=2.0,
+        retry_warning_message: Optional[RetryWarningMessage] = None,
+        metadata: list[tuple[str, str]] = [],
+    ) -> ResponseType:
+        return await retry_transient_errors(
+            fn,
+            req,
+            base_delay=base_delay,
+            max_delay=max_delay,
+            delay_factor=delay_factor,
+            max_retries=max_retries,
+            additional_status_codes=additional_status_codes,
+            attempt_timeout=attempt_timeout,
+            total_timeout=total_timeout,
+            attempt_timeout_floor=attempt_timeout_floor,
+            retry_warning_message=retry_warning_message,
+            metadata=metadata,
+        )
+
+    return wrapped
+
+
 def find_free_port() -> int:
     """
     Find a free TCP port, useful for testing.

--- a/modal/app.py
+++ b/modal/app.py
@@ -33,7 +33,6 @@ from ._utils.deprecation import (
     warn_on_renamed_autoscaler_settings,
 )
 from ._utils.function_utils import FunctionInfo, is_global_object, is_method_fn
-from ._utils.grpc_utils import retry_transient_errors
 from ._utils.mount_utils import validate_volumes
 from ._utils.name_utils import check_object_name
 from .client import _Client
@@ -269,7 +268,7 @@ class _App:
             object_creation_type=(api_pb2.OBJECT_CREATION_TYPE_CREATE_IF_MISSING if create_if_missing else None),
         )
 
-        response = await retry_transient_errors(client.stub.AppGetOrCreate, request)
+        response = await client.stub.AppGetOrCreate(request)
 
         app = _App(name)
         app._app_id = response.app_id

--- a/modal/cli/container.py
+++ b/modal/cli/container.py
@@ -7,7 +7,6 @@ from rich.text import Text
 from modal._object import _get_environment_name
 from modal._pty import get_pty_info
 from modal._utils.async_utils import synchronizer
-from modal._utils.grpc_utils import retry_transient_errors
 from modal._utils.time_utils import timestamp_to_localized_str
 from modal.cli.utils import ENV_OPTION, display_table, is_tty, stream_app_logs
 from modal.client import _Client
@@ -95,4 +94,4 @@ async def stop(container_id: str = typer.Argument(help="Container ID")):
     """
     client = await _Client.from_env()
     request = api_pb2.ContainerStopRequest(task_id=container_id)
-    await retry_transient_errors(client.stub.ContainerStop, request)
+    await client.stub.ContainerStop(request)

--- a/modal/cli/network_file_system.py
+++ b/modal/cli/network_file_system.py
@@ -15,7 +15,6 @@ import modal
 from modal._location import display_location
 from modal._output import OutputManager, ProgressHandler, make_console
 from modal._utils.async_utils import synchronizer
-from modal._utils.grpc_utils import retry_transient_errors
 from modal._utils.time_utils import timestamp_to_localized_str
 from modal.cli._download import _volume_download
 from modal.cli.utils import ENV_OPTION, YES_OPTION, display_table
@@ -33,9 +32,7 @@ async def list_(env: Optional[str] = ENV_OPTION, json: Optional[bool] = False):
     env = ensure_env(env)
 
     client = await _Client.from_env()
-    response = await retry_transient_errors(
-        client.stub.SharedVolumeList, api_pb2.SharedVolumeListRequest(environment_name=env)
-    )
+    response = await client.stub.SharedVolumeList(api_pb2.SharedVolumeListRequest(environment_name=env))
     env_part = f" in environment '{env}'" if env else ""
     column_names = ["Name", "Location", "Created at"]
     rows = []

--- a/modal/cli/queues.py
+++ b/modal/cli/queues.py
@@ -8,7 +8,6 @@ from typer import Argument, Option, Typer
 from modal._output import make_console
 from modal._resolver import Resolver
 from modal._utils.async_utils import synchronizer
-from modal._utils.grpc_utils import retry_transient_errors
 from modal._utils.time_utils import timestamp_to_localized_str
 from modal.cli.utils import ENV_OPTION, YES_OPTION, display_table
 from modal.client import _Client
@@ -83,7 +82,7 @@ async def list_(*, json: bool = False, env: Optional[str] = ENV_OPTION):
         max_page_size = 100
         pagination = api_pb2.ListPagination(max_objects=max_page_size, created_before=created_before)
         req = api_pb2.QueueListRequest(environment_name=env, pagination=pagination, total_size_limit=max_total_size)
-        resp = await retry_transient_errors(client.stub.QueueList, req)
+        resp = await client.stub.QueueList(req)
         items.extend(resp.queues)
         return len(resp.queues) < max_page_size
 

--- a/modal/cli/secret.py
+++ b/modal/cli/secret.py
@@ -15,7 +15,6 @@ from typer import Argument, Option
 
 from modal._output import make_console
 from modal._utils.async_utils import synchronizer
-from modal._utils.grpc_utils import retry_transient_errors
 from modal._utils.time_utils import timestamp_to_localized_str
 from modal.cli.utils import ENV_OPTION, YES_OPTION, display_table
 from modal.client import _Client
@@ -44,7 +43,7 @@ async def list_(env: Optional[str] = ENV_OPTION, json: bool = False):
         max_page_size = 100
         pagination = api_pb2.ListPagination(max_objects=max_page_size, created_before=created_before)
         req = api_pb2.SecretListRequest(environment_name=env, pagination=pagination)
-        resp = await retry_transient_errors(client.stub.SecretList, req)
+        resp = await client.stub.SecretList(req)
         items.extend(resp.items)
         return len(resp.items) < max_page_size
 

--- a/modal/client.py
+++ b/modal/client.py
@@ -29,7 +29,7 @@ from ._traceback import print_server_warnings, suppress_tb_frames
 from ._utils import async_utils
 from ._utils.async_utils import TaskContext, synchronize_api
 from ._utils.auth_token_manager import _AuthTokenManager
-from ._utils.grpc_utils import ConnectionManager, retry_transient_errors
+from ._utils.grpc_utils import ConnectionManager
 from .config import _check_config, _is_remote, config, logger
 from .exception import AuthError, ClientClosed, NotFoundError
 
@@ -159,7 +159,7 @@ class _Client:
     async def hello(self):
         """Connect to server and retrieve version information; raise appropriate error for various failures."""
         logger.debug(f"Client ({id(self)}): Starting")
-        resp = await retry_transient_errors(self.stub.ClientHello, empty_pb2.Empty())
+        resp = await self.stub.ClientHello(empty_pb2.Empty())
         print_server_warnings(resp.server_warnings)
 
     async def __aenter__(self):

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -30,7 +30,6 @@ from ._utils.deprecation import (
     warn_if_passing_namespace,
     warn_on_renamed_autoscaler_settings,
 )
-from ._utils.grpc_utils import retry_transient_errors
 from ._utils.mount_utils import validate_volumes
 from .client import _Client
 from .config import config
@@ -644,7 +643,7 @@ More information on class parameterization can be found here: https://modal.com/
                 only_class_function=True,
             )
             try:
-                response = await retry_transient_errors(resolver.client.stub.ClassGet, request)
+                response = await resolver.client.stub.ClassGet(request)
             except NotFoundError as exc:
                 env_context = f" (in the '{environment_name}' environment)" if environment_name else ""
                 raise NotFoundError(

--- a/modal/container_process.py
+++ b/modal/container_process.py
@@ -7,7 +7,6 @@ from typing import Generic, Optional, TypeVar
 from modal_proto import api_pb2
 
 from ._utils.async_utils import TaskContext, synchronize_api
-from ._utils.grpc_utils import retry_transient_errors
 from ._utils.shell_utils import stream_from_stdin, write_to_fd
 from .client import _Client
 from .exception import InteractiveTimeoutError, InvalidError
@@ -105,7 +104,7 @@ class _ContainerProcess(Generic[T]):
             return self._returncode
 
         req = api_pb2.ContainerExecWaitRequest(exec_id=self._process_id, timeout=0)
-        resp: api_pb2.ContainerExecWaitResponse = await retry_transient_errors(self._client.stub.ContainerExecWait, req)
+        resp = await self._client.stub.ContainerExecWait(req)
 
         if resp.completed:
             self._returncode = resp.exit_code
@@ -116,9 +115,7 @@ class _ContainerProcess(Generic[T]):
     async def _wait_for_completion(self) -> int:
         while True:
             req = api_pb2.ContainerExecWaitRequest(exec_id=self._process_id, timeout=10)
-            resp: api_pb2.ContainerExecWaitResponse = await retry_transient_errors(
-                self._client.stub.ContainerExecWait, req
-            )
+            resp = await self._client.stub.ContainerExecWait(req)
             if resp.completed:
                 return resp.exit_code
 

--- a/modal/environments.py
+++ b/modal/environments.py
@@ -12,7 +12,6 @@ from ._object import _Object
 from ._resolver import Resolver
 from ._utils.async_utils import synchronize_api, synchronizer
 from ._utils.deprecation import deprecation_warning
-from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from .client import _Client
 from .config import config, logger
@@ -72,7 +71,7 @@ class _Environment(_Object, type_prefix="en"):
                     else api_pb2.OBJECT_CREATION_TYPE_UNSPECIFIED
                 ),
             )
-            response = await retry_transient_errors(resolver.client.stub.EnvironmentGetOrCreate, request)
+            response = await resolver.client.stub.EnvironmentGetOrCreate(request)
             logger.debug(f"Created environment with id {response.environment_id}")
             self._hydrate(response.environment_id, resolver.client, response.metadata)
 

--- a/modal/experimental/__init__.py
+++ b/modal/experimental/__init__.py
@@ -14,7 +14,6 @@ from .._partial_function import _clustered
 from .._runtime.container_io_manager import _ContainerIOManager
 from .._utils.async_utils import synchronize_api, synchronizer
 from .._utils.deprecation import deprecation_warning
-from .._utils.grpc_utils import retry_transient_errors
 from ..app import _App
 from ..client import _Client
 from ..cls import _Cls, _Obj
@@ -117,7 +116,7 @@ async def get_app_objects(
 
     app = await _App.lookup(app_name, environment_name=environment_name, client=client)
     req = api_pb2.AppGetLayoutRequest(app_id=app.app_id)
-    app_layout_resp = await retry_transient_errors(client.stub.AppGetLayout, req)
+    app_layout_resp = await client.stub.AppGetLayout(req)
 
     app_objects: dict[str, Union[_Function, _Cls]] = {}
 
@@ -385,4 +384,4 @@ async def update_autoscaler(
     await f.hydrate(client=client)
 
     request = api_pb2.FunctionUpdateSchedulingParamsRequest(function_id=f.object_id, settings=settings)
-    await retry_transient_errors(client.stub.FunctionUpdateSchedulingParams, request)
+    await client.stub.FunctionUpdateSchedulingParams(request)

--- a/modal/experimental/flash.py
+++ b/modal/experimental/flash.py
@@ -14,7 +14,6 @@ from modal_proto import api_pb2
 
 from .._tunnel import _forward as _forward_tunnel
 from .._utils.async_utils import synchronize_api, synchronizer
-from .._utils.grpc_utils import retry_transient_errors
 from ..client import _Client
 from ..config import logger
 from ..exception import InvalidError
@@ -71,8 +70,7 @@ class _FlashManager:
 
     async def stop(self):
         self.heartbeat_task.cancel()
-        await retry_transient_errors(
-            self.client.stub.FlashContainerDeregister,
+        await self.client.stub.FlashContainerDeregister(
             api_pb2.FlashContainerDeregisterRequest(),
         )
 
@@ -319,7 +317,7 @@ class _FlashPrometheusAutoscaler:
 
     async def _get_all_containers(self):
         req = api_pb2.FlashContainerListRequest(function_id=self.fn.object_id)
-        resp = await retry_transient_errors(self.client.stub.FlashContainerList, req)
+        resp = await self.client.stub.FlashContainerList(req)
         return resp.containers
 
     def _make_scaling_decision(
@@ -461,5 +459,5 @@ async def flash_get_containers(app_name: str, cls_name: str) -> list[dict[str, A
     assert fn is not None
     await fn.hydrate(client=client)
     req = api_pb2.FlashContainerListRequest(function_id=fn.object_id)
-    resp = await retry_transient_errors(client.stub.FlashContainerList, req)
+    resp = await client.stub.FlashContainerList(req)
     return resp.containers

--- a/modal/image.py
+++ b/modal/image.py
@@ -38,7 +38,7 @@ from ._utils.docker_utils import (
     find_dockerignore_file,
 )
 from ._utils.function_utils import FunctionInfo
-from ._utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES, retry_transient_errors
+from ._utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES
 from .client import _Client
 from .cloud_bucket_mount import _CloudBucketMount
 from .config import config, logger, user_config_path
@@ -631,7 +631,7 @@ class _Image(_Object, type_prefix="im"):
                 allow_global_deployment=os.environ.get("MODAL_IMAGE_ALLOW_GLOBAL_DEPLOYMENT") == "1",
                 ignore_cache=config.get("ignore_cache"),
             )
-            resp = await retry_transient_errors(resolver.client.stub.ImageGetOrCreate, req)
+            resp = await resolver.client.stub.ImageGetOrCreate(req)
             image_id = resp.image_id
             result: api_pb2.GenericResult
             metadata: Optional[api_pb2.ImageMetadata] = None
@@ -860,7 +860,7 @@ class _Image(_Object, type_prefix="im"):
             client = await _Client.from_env()
 
         async def _load(self: _Image, resolver: Resolver, existing_object_id: Optional[str]):
-            resp = await retry_transient_errors(client.stub.ImageFromId, api_pb2.ImageFromIdRequest(image_id=image_id))
+            resp = await client.stub.ImageFromId(api_pb2.ImageFromIdRequest(image_id=image_id))
             self._hydrate(resp.image_id, resolver.client, resp.metadata)
 
         rep = f"Image.from_id({image_id!r})"

--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -19,7 +19,7 @@ from modal.exception import ClientClosed, InvalidError
 from modal_proto import api_pb2
 
 from ._utils.async_utils import synchronize_api
-from ._utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES, retry_transient_errors
+from ._utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES
 from .client import _Client
 from .stream_type import StreamType
 
@@ -442,15 +442,13 @@ class _StreamWriter:
 
         try:
             if self._object_type == "sandbox":
-                await retry_transient_errors(
-                    self._client.stub.SandboxStdinWrite,
+                await self._client.stub.SandboxStdinWrite(
                     api_pb2.SandboxStdinWriteRequest(
                         sandbox_id=self._object_id, index=index, eof=self._is_closed, input=data
                     ),
                 )
             else:
-                await retry_transient_errors(
-                    self._client.stub.ContainerExecPutInput,
+                await self._client.stub.ContainerExecPutInput(
                     api_pb2.ContainerExecPutInputRequest(
                         exec_id=self._object_id,
                         input=api_pb2.RuntimeInputMessage(message=data, message_index=index, eof=self._is_closed),

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -25,7 +25,6 @@ from ._resolver import Resolver
 from ._utils.async_utils import TaskContext, aclosing, async_map, synchronize_api
 from ._utils.blob_utils import FileUploadSpec, blob_upload_file, get_file_upload_spec_from_path
 from ._utils.deprecation import deprecation_warning
-from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from ._utils.package_utils import get_module_mount_info
 from .client import _Client
@@ -575,7 +574,7 @@ class _Mount(_Object, type_prefix="mo"):
 
             request = api_pb2.MountPutFileRequest(sha256_hex=file_spec.sha256_hex)
             accounted_hashes.add(file_spec.sha256_hex)
-            response = await retry_transient_errors(resolver.client.stub.MountPutFile, request, base_delay=1)
+            response = await resolver.client.stub.MountPutFile(request, base_delay=1)
 
             if response.exists:
                 n_finished += 1
@@ -601,7 +600,7 @@ class _Mount(_Object, type_prefix="mo"):
 
             start_time = time.monotonic()
             while time.monotonic() - start_time < MOUNT_PUT_FILE_CLIENT_TIMEOUT:
-                response = await retry_transient_errors(resolver.client.stub.MountPutFile, request2, base_delay=1)
+                response = await resolver.client.stub.MountPutFile(request2, base_delay=1)
                 if response.exists:
                     n_finished += 1
                     return mount_file
@@ -648,7 +647,7 @@ class _Mount(_Object, type_prefix="mo"):
                 environment_name=resolver.environment_name,
             )
 
-        resp = await retry_transient_errors(resolver.client.stub.MountGetOrCreate, req, base_delay=1)
+        resp = await resolver.client.stub.MountGetOrCreate(req, base_delay=1)
         status_row.finish(f"Created mount {message_label}")
 
         logger.debug(f"Uploaded {total_uploads} new files and {total_bytes} bytes in {time.monotonic() - t0}s")

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -22,7 +22,6 @@ from ._resolver import Resolver
 from ._utils.async_utils import TaskContext, aclosing, async_map, sync_or_async_iter, synchronize_api
 from ._utils.blob_utils import LARGE_FILE_LIMIT, blob_iter, blob_upload_file
 from ._utils.deprecation import deprecation_warning, warn_if_passing_namespace
-from ._utils.grpc_utils import retry_transient_errors
 from ._utils.hash_utils import get_sha256_hex
 from ._utils.name_utils import check_object_name
 from .client import _Client
@@ -225,14 +224,14 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
             environment_name=_get_environment_name(environment_name),
             object_creation_type=api_pb2.OBJECT_CREATION_TYPE_CREATE_FAIL_IF_EXISTS,
         )
-        resp = await retry_transient_errors(client.stub.SharedVolumeGetOrCreate, request)
+        resp = await client.stub.SharedVolumeGetOrCreate(request)
         return resp.shared_volume_id
 
     @staticmethod
     async def delete(name: str, client: Optional[_Client] = None, environment_name: Optional[str] = None):
         obj = await _NetworkFileSystem.from_name(name, environment_name=environment_name).hydrate(client)
         req = api_pb2.SharedVolumeDeleteRequest(shared_volume_id=obj.object_id)
-        await retry_transient_errors(obj._client.stub.SharedVolumeDelete, req)
+        await obj._client.stub.SharedVolumeDelete(req)
 
     @live_method
     async def write_file(self, remote_path: str, fp: BinaryIO, progress_cb: Optional[Callable[..., Any]] = None) -> int:
@@ -272,7 +271,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
 
         t0 = time.monotonic()
         while time.monotonic() - t0 < NETWORK_FILE_SYSTEM_PUT_FILE_CLIENT_TIMEOUT:
-            response = await retry_transient_errors(self._client.stub.SharedVolumePutFile, req)
+            response = await self._client.stub.SharedVolumePutFile(req)
             if response.exists:
                 break
         else:
@@ -285,7 +284,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         """Read a file from the network file system"""
         req = api_pb2.SharedVolumeGetFileRequest(shared_volume_id=self.object_id, path=path)
         try:
-            response = await retry_transient_errors(self._client.stub.SharedVolumeGetFile, req)
+            response = await self._client.stub.SharedVolumeGetFile(req)
         except modal.exception.NotFoundError as exc:
             raise FileNotFoundError(exc.args[0])
 
@@ -370,7 +369,7 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
         """Remove a file in a network file system."""
         req = api_pb2.SharedVolumeRemoveFileRequest(shared_volume_id=self.object_id, path=path, recursive=recursive)
         try:
-            await retry_transient_errors(self._client.stub.SharedVolumeRemoveFile, req)
+            await self._client.stub.SharedVolumeRemoveFile(req)
         except modal.exception.NotFoundError as exc:
             raise FileNotFoundError(exc.args[0])
 

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -25,7 +25,6 @@ from ._resolver import Resolver
 from ._serialization import deserialize, serialize
 from ._utils.async_utils import TaskContext, synchronize_api, warn_if_generator_is_not_consumed
 from ._utils.deprecation import deprecation_warning, warn_if_passing_namespace
-from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from ._utils.time_utils import as_timestamp, timestamp_to_localized_dt
 from .client import _Client
@@ -95,7 +94,7 @@ class _QueueManager:
             object_creation_type=object_creation_type,
         )
         try:
-            await retry_transient_errors(client.stub.QueueGetOrCreate, req)
+            await client.stub.QueueGetOrCreate(req)
         except GRPCError as exc:
             if exc.status == Status.ALREADY_EXISTS and not allow_existing:
                 raise AlreadyExistsError(exc.message)
@@ -147,7 +146,7 @@ class _QueueManager:
             req = api_pb2.QueueListRequest(
                 environment_name=_get_environment_name(environment_name), pagination=pagination
             )
-            resp = await retry_transient_errors(client.stub.QueueList, req)
+            resp = await client.stub.QueueList(req)
             items.extend(resp.queues)
             finished = (len(resp.queues) < max_page_size) or (max_objects is not None and len(items) >= max_objects)
             return finished
@@ -205,7 +204,7 @@ class _QueueManager:
                 raise
         else:
             req = api_pb2.QueueDeleteRequest(queue_id=obj.object_id)
-            await retry_transient_errors(obj._client.stub.QueueDelete, req)
+            await obj._client.stub.QueueDelete(req)
 
 
 QueueManager = synchronize_api(_QueueManager)
@@ -463,7 +462,7 @@ class _Queue(_Object, type_prefix="qu"):
             n_values=n_values,
         )
 
-        response = await retry_transient_errors(self._client.stub.QueueGet, request)
+        response = await self._client.stub.QueueGet(request)
         if response.values:
             return [deserialize(value, self._client) for value in response.values]
         else:
@@ -488,7 +487,7 @@ class _Queue(_Object, type_prefix="qu"):
                 n_values=n_values,
             )
 
-            response = await retry_transient_errors(self._client.stub.QueueGet, request)
+            response = await self._client.stub.QueueGet(request)
 
             if response.values:
                 return [deserialize(value, self._client) for value in response.values]
@@ -508,7 +507,7 @@ class _Queue(_Object, type_prefix="qu"):
             partition_key=self.validate_partition_key(partition),
             all_partitions=all,
         )
-        await retry_transient_errors(self._client.stub.QueueClear, request)
+        await self._client.stub.QueueClear(request)
 
     @live_method
     async def get(
@@ -617,8 +616,7 @@ class _Queue(_Object, type_prefix="qu"):
             partition_ttl_seconds=partition_ttl,
         )
         try:
-            await retry_transient_errors(
-                self._client.stub.QueuePut,
+            await self._client.stub.QueuePut(
                 request,
                 # A full queue will return this status.
                 additional_status_codes=[Status.RESOURCE_EXHAUSTED],
@@ -644,7 +642,7 @@ class _Queue(_Object, type_prefix="qu"):
             partition_ttl_seconds=partition_ttl,
         )
         try:
-            await retry_transient_errors(self._client.stub.QueuePut, request)
+            await self._client.stub.QueuePut(request)
         except GRPCError as exc:
             if exc.status == Status.RESOURCE_EXHAUSTED:
                 raise queue.Full(exc.message)
@@ -664,7 +662,7 @@ class _Queue(_Object, type_prefix="qu"):
             partition_key=self.validate_partition_key(partition),
             total=total,
         )
-        response = await retry_transient_errors(self._client.stub.QueueLen, request)
+        response = await self._client.stub.QueueLen(request)
         return response.len
 
     @warn_if_generator_is_not_consumed()
@@ -690,9 +688,7 @@ class _Queue(_Object, type_prefix="qu"):
                 item_poll_timeout=poll_duration,
             )
 
-            response: api_pb2.QueueNextItemsResponse = await retry_transient_errors(
-                self._client.stub.QueueNextItems, request
-            )
+            response: api_pb2.QueueNextItemsResponse = await self._client.stub.QueueNextItems(request)
             if response.items:
                 for item in response.items:
                     yield deserialize(item.value, self._client)

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -28,7 +28,6 @@ from ._traceback import print_server_warnings, traceback_contains_remote_call
 from ._utils.async_utils import TaskContext, gather_cancel_on_exc, synchronize_api
 from ._utils.deprecation import warn_if_passing_namespace
 from ._utils.git_utils import get_git_commit_info
-from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name, is_valid_tag
 from .client import HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, _Client
 from .cls import _Cls
@@ -55,14 +54,14 @@ async def _heartbeat(client: _Client, app_id: str) -> None:
     # TODO(erikbern): we should capture exceptions here
     # * if request fails: destroy the client
     # * if server says the app is gone: print a helpful warning about detaching
-    await retry_transient_errors(client.stub.AppHeartbeat, request, attempt_timeout=HEARTBEAT_TIMEOUT)
+    await client.stub.AppHeartbeat(request, attempt_timeout=HEARTBEAT_TIMEOUT)
 
 
 async def _init_local_app_existing(client: _Client, existing_app_id: str, environment_name: str) -> RunningApp:
     # Get all the objects first
     obj_req = api_pb2.AppGetLayoutRequest(app_id=existing_app_id)
     obj_resp, _ = await gather_cancel_on_exc(
-        retry_transient_errors(client.stub.AppGetLayout, obj_req),
+        client.stub.AppGetLayout(obj_req),
         # Cache the environment associated with the app now as we will use it later
         _get_environment_cached(environment_name, client),
     )
@@ -87,7 +86,7 @@ async def _init_local_app_new(
         app_state=app_state,  # type: ignore
     )
     app_resp, _ = await gather_cancel_on_exc(  # TODO: use TaskGroup?
-        retry_transient_errors(client.stub.AppCreate, app_req),
+        client.stub.AppCreate(app_req),
         # Cache the environment associated with the app now as we will use it later
         _get_environment_cached(environment_name, client),
     )
@@ -110,7 +109,7 @@ async def _init_local_app_from_name(
         name=name,
         environment_name=environment_name,
     )
-    app_resp = await retry_transient_errors(client.stub.AppGetByDeploymentName, app_req)
+    app_resp = await client.stub.AppGetByDeploymentName(app_req)
     existing_app_id = app_resp.app_id or None
 
     # Grab the app
@@ -203,7 +202,7 @@ async def _publish_app(
     )
 
     try:
-        response = await retry_transient_errors(client.stub.AppPublish, request)
+        response = await client.stub.AppPublish(request)
     except GRPCError as exc:
         if exc.status == Status.INVALID_ARGUMENT or exc.status == Status.FAILED_PRECONDITION:
             raise InvalidError(exc.message)
@@ -227,7 +226,7 @@ async def _disconnect(
 
     logger.debug("Sending app disconnect/stop request")
     req_disconnect = api_pb2.AppClientDisconnectRequest(app_id=app_id, reason=reason, exception=exc_str)
-    await retry_transient_errors(client.stub.AppClientDisconnect, req_disconnect)
+    await client.stub.AppClientDisconnect(req_disconnect)
     logger.debug("App disconnected")
 
 
@@ -619,7 +618,7 @@ async def _interactive_shell(
         except InteractiveTimeoutError:
             # Check on status of Sandbox. It may have crashed, causing connection failure.
             req = api_pb2.SandboxWaitRequest(sandbox_id=sandbox._object_id, timeout=0)
-            resp = await retry_transient_errors(sandbox._client.stub.SandboxWait, req)
+            resp = await sandbox._client.stub.SandboxWait(req)
             if resp.result.exception:
                 raise RemoteError(resp.result.exception)
             else:

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -22,7 +22,6 @@ from ._resolver import Resolver
 from ._resources import convert_fn_config_to_resources_config
 from ._utils.async_utils import TaskContext, synchronize_api
 from ._utils.deprecation import deprecation_warning
-from ._utils.grpc_utils import retry_transient_errors
 from ._utils.mount_utils import validate_network_file_systems, validate_volumes
 from .client import _Client
 from .config import config
@@ -237,7 +236,7 @@ class _Sandbox(_Object, type_prefix="sb"):
 
             create_req = api_pb2.SandboxCreateRequest(app_id=resolver.app_id, definition=definition)
             try:
-                create_resp = await retry_transient_errors(resolver.client.stub.SandboxCreate, create_req)
+                create_resp = await resolver.client.stub.SandboxCreate(create_req)
             except GRPCError as exc:
                 if exc.status == Status.ALREADY_EXISTS:
                     raise AlreadyExistsError(exc.message)
@@ -489,7 +488,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         env_name = _get_environment_name(environment_name)
 
         req = api_pb2.SandboxGetFromNameRequest(sandbox_name=name, app_name=app_name, environment_name=env_name)
-        resp = await retry_transient_errors(client.stub.SandboxGetFromName, req)
+        resp = await client.stub.SandboxGetFromName(req)
         return _Sandbox._new_hydrated(resp.sandbox_id, client, None)
 
     @staticmethod
@@ -502,7 +501,7 @@ class _Sandbox(_Object, type_prefix="sb"):
             client = await _Client.from_env()
 
         req = api_pb2.SandboxWaitRequest(sandbox_id=sandbox_id, timeout=0)
-        resp = await retry_transient_errors(client.stub.SandboxWait, req)
+        resp = await client.stub.SandboxWait(req)
 
         obj = _Sandbox._new_hydrated(sandbox_id, client, None)
 
@@ -525,7 +524,7 @@ class _Sandbox(_Object, type_prefix="sb"):
             tags=tags_list,
         )
         try:
-            await retry_transient_errors(client.stub.SandboxTagsSet, req)
+            await client.stub.SandboxTagsSet(req)
         except GRPCError as exc:
             raise InvalidError(exc.message) if exc.status == Status.INVALID_ARGUMENT else exc
 
@@ -537,7 +536,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         """
         await self._get_task_id()  # Ensure the sandbox has started
         req = api_pb2.SandboxSnapshotFsRequest(sandbox_id=self.object_id, timeout=timeout)
-        resp = await retry_transient_errors(self._client.stub.SandboxSnapshotFs, req)
+        resp = await self._client.stub.SandboxSnapshotFs(req)
 
         if resp.result.status != api_pb2.GenericResult.GENERIC_STATUS_SUCCESS:
             raise ExecutionError(resp.result.exception)
@@ -562,7 +561,7 @@ class _Sandbox(_Object, type_prefix="sb"):
 
         while True:
             req = api_pb2.SandboxWaitRequest(sandbox_id=self.object_id, timeout=10)
-            resp = await retry_transient_errors(self._client.stub.SandboxWait, req)
+            resp = await self._client.stub.SandboxWait(req)
             if resp.result.status:
                 self._result = resp.result
 
@@ -587,7 +586,7 @@ class _Sandbox(_Object, type_prefix="sb"):
             return self._tunnels
 
         req = api_pb2.SandboxGetTunnelsRequest(sandbox_id=self.object_id, timeout=timeout)
-        resp = await retry_transient_errors(self._client.stub.SandboxGetTunnels, req)
+        resp = await self._client.stub.SandboxGetTunnels(req)
 
         # If we couldn't get the tunnels in time, report the timeout.
         if resp.result.status == api_pb2.GenericResult.GENERIC_STATUS_TIMEOUT:
@@ -606,8 +605,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         Added in v1.1.0.
         """
         task_id = await self._get_task_id()
-        await retry_transient_errors(
-            self._client.stub.ContainerReloadVolumes,
+        await self._client.stub.ContainerReloadVolumes(
             api_pb2.ContainerReloadVolumesRequest(
                 task_id=task_id,
             ),
@@ -618,9 +616,7 @@ class _Sandbox(_Object, type_prefix="sb"):
 
         This is a no-op if the Sandbox has already finished running."""
 
-        await retry_transient_errors(
-            self._client.stub.SandboxTerminate, api_pb2.SandboxTerminateRequest(sandbox_id=self.object_id)
-        )
+        await self._client.stub.SandboxTerminate(api_pb2.SandboxTerminateRequest(sandbox_id=self.object_id))
 
     async def poll(self) -> Optional[int]:
         """Check if the Sandbox has finished running.
@@ -629,7 +625,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         """
 
         req = api_pb2.SandboxWaitRequest(sandbox_id=self.object_id, timeout=0)
-        resp = await retry_transient_errors(self._client.stub.SandboxWait, req)
+        resp = await self._client.stub.SandboxWait(req)
 
         if resp.result.status:
             self._result = resp.result
@@ -638,9 +634,7 @@ class _Sandbox(_Object, type_prefix="sb"):
 
     async def _get_task_id(self) -> str:
         while not self._task_id:
-            resp = await retry_transient_errors(
-                self._client.stub.SandboxGetTaskId, api_pb2.SandboxGetTaskIdRequest(sandbox_id=self.object_id)
-            )
+            resp = await self._client.stub.SandboxGetTaskId(api_pb2.SandboxGetTaskIdRequest(sandbox_id=self.object_id))
             self._task_id = resp.task_id
             if not self._task_id:
                 await asyncio.sleep(0.5)
@@ -730,7 +724,7 @@ class _Sandbox(_Object, type_prefix="sb"):
             workdir=workdir,
             secret_ids=[secret.object_id for secret in secrets],
         )
-        resp = await retry_transient_errors(self._client.stub.ContainerExec, req)
+        resp = await self._client.stub.ContainerExec(req)
         by_line = bufsize == 1
         exec_deadline = time.monotonic() + int(timeout) + CONTAINER_EXEC_TIMEOUT_BUFFER if timeout else None
         return _ContainerProcess(
@@ -746,14 +740,14 @@ class _Sandbox(_Object, type_prefix="sb"):
     async def _experimental_snapshot(self) -> _SandboxSnapshot:
         await self._get_task_id()
         snap_req = api_pb2.SandboxSnapshotRequest(sandbox_id=self.object_id)
-        snap_resp = await retry_transient_errors(self._client.stub.SandboxSnapshot, snap_req)
+        snap_resp = await self._client.stub.SandboxSnapshot(snap_req)
 
         snapshot_id = snap_resp.snapshot_id
 
         # wait for the snapshot to succeed. this is implemented as a second idempotent rpc
         # because the snapshot itself may take a while to complete.
         wait_req = api_pb2.SandboxSnapshotWaitRequest(snapshot_id=snapshot_id, timeout=55.0)
-        wait_resp = await retry_transient_errors(self._client.stub.SandboxSnapshotWait, wait_req)
+        wait_resp = await self._client.stub.SandboxSnapshotWait(wait_req)
         if wait_resp.result.status != api_pb2.GenericResult.GENERIC_STATUS_SUCCESS:
             raise ExecutionError(wait_resp.result.exception)
 
@@ -793,9 +787,7 @@ class _Sandbox(_Object, type_prefix="sb"):
                 sandbox_name_override_type=api_pb2.SandboxRestoreRequest.SANDBOX_NAME_OVERRIDE_TYPE_STRING,
             )
         try:
-            restore_resp: api_pb2.SandboxRestoreResponse = await retry_transient_errors(
-                client.stub.SandboxRestore, restore_req
-            )
+            restore_resp: api_pb2.SandboxRestoreResponse = await client.stub.SandboxRestore(restore_req)
         except GRPCError as exc:
             if exc.status == Status.ALREADY_EXISTS:
                 raise AlreadyExistsError(exc.message)
@@ -806,7 +798,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         task_id_req = api_pb2.SandboxGetTaskIdRequest(
             sandbox_id=restore_resp.sandbox_id, wait_until_ready=True, timeout=55.0
         )
-        resp = await retry_transient_errors(client.stub.SandboxGetTaskId, task_id_req)
+        resp = await client.stub.SandboxGetTaskId(task_id_req)
         if resp.task_result.status not in [
             api_pb2.GenericResult.GENERIC_STATUS_UNSPECIFIED,
             api_pb2.GenericResult.GENERIC_STATUS_SUCCESS,
@@ -941,7 +933,7 @@ class _Sandbox(_Object, type_prefix="sb"):
 
             # Fetches a batch of sandboxes.
             try:
-                resp = await retry_transient_errors(client.stub.SandboxList, req)
+                resp = await client.stub.SandboxList(req)
             except GRPCError as exc:
                 raise InvalidError(exc.message) if exc.status == Status.INVALID_ARGUMENT else exc
 

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -15,7 +15,6 @@ from ._resolver import Resolver
 from ._runtime.execution_context import is_local
 from ._utils.async_utils import synchronize_api
 from ._utils.deprecation import deprecation_warning, warn_if_passing_namespace
-from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from ._utils.time_utils import as_timestamp, timestamp_to_localized_dt
 from .client import _Client
@@ -91,7 +90,7 @@ class _SecretManager:
             env_dict=env_dict,
         )
         try:
-            await retry_transient_errors(client.stub.SecretGetOrCreate, req)
+            await client.stub.SecretGetOrCreate(req)
         except GRPCError as exc:
             if exc.status == Status.ALREADY_EXISTS and not allow_existing:
                 raise AlreadyExistsError(exc.message)
@@ -143,7 +142,7 @@ class _SecretManager:
             req = api_pb2.SecretListRequest(
                 environment_name=_get_environment_name(environment_name), pagination=pagination
             )
-            resp = await retry_transient_errors(client.stub.SecretList, req)
+            resp = await client.stub.SecretList(req)
             items.extend(resp.items)
             finished = (len(resp.items) < max_page_size) or (max_objects is not None and len(items) >= max_objects)
             return finished
@@ -200,7 +199,7 @@ class _SecretManager:
                 raise
         else:
             req = api_pb2.SecretDeleteRequest(secret_id=obj.object_id)
-            await retry_transient_errors(obj._client.stub.SecretDelete, req)
+            await obj._client.stub.SecretDelete(req)
 
 
 SecretManager = synchronize_api(_SecretManager)
@@ -483,7 +482,7 @@ class _Secret(_Object, type_prefix="st"):
             object_creation_type=object_creation_type,
             env_dict=env_dict,
         )
-        resp = await retry_transient_errors(client.stub.SecretGetOrCreate, request)
+        resp = await client.stub.SecretGetOrCreate(request)
         return resp.secret_id
 
     @live_method

--- a/modal/snapshot.py
+++ b/modal/snapshot.py
@@ -6,7 +6,6 @@ from modal_proto import api_pb2
 from ._object import _Object
 from ._resolver import Resolver
 from ._utils.async_utils import synchronize_api
-from ._utils.grpc_utils import retry_transient_errors
 from .client import _Client
 
 
@@ -28,9 +27,7 @@ class _SandboxSnapshot(_Object, type_prefix="sn"):
             client = await _Client.from_env()
 
         async def _load(self: _SandboxSnapshot, resolver: Resolver, existing_object_id: Optional[str]):
-            await retry_transient_errors(
-                client.stub.SandboxSnapshotGet, api_pb2.SandboxSnapshotGetRequest(snapshot_id=sandbox_snapshot_id)
-            )
+            await client.stub.SandboxSnapshotGet(api_pb2.SandboxSnapshotGetRequest(snapshot_id=sandbox_snapshot_id))
 
         rep = "SandboxSnapshot()"
         obj = _SandboxSnapshot._from_loader(_load, rep)

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -59,7 +59,6 @@ from ._utils.blob_utils import (
     get_file_upload_spec_from_path,
 )
 from ._utils.deprecation import deprecation_warning, warn_if_passing_namespace
-from ._utils.grpc_utils import retry_transient_errors
 from ._utils.http_utils import ClientSessionRegistry
 from ._utils.name_utils import check_object_name
 from ._utils.time_utils import as_timestamp, timestamp_to_localized_dt
@@ -170,7 +169,7 @@ class _VolumeManager:
             version=version,
         )
         try:
-            await retry_transient_errors(client.stub.VolumeGetOrCreate, req)
+            await client.stub.VolumeGetOrCreate(req)
         except GRPCError as exc:
             if exc.status == Status.ALREADY_EXISTS and not allow_existing:
                 raise AlreadyExistsError(exc.message)
@@ -222,7 +221,7 @@ class _VolumeManager:
             req = api_pb2.VolumeListRequest(
                 environment_name=_get_environment_name(environment_name), pagination=pagination
             )
-            resp = await retry_transient_errors(client.stub.VolumeList, req)
+            resp = await client.stub.VolumeList(req)
             items.extend(resp.items)
             finished = (len(resp.items) < max_page_size) or (max_objects is not None and len(items) >= max_objects)
             return finished
@@ -280,7 +279,7 @@ class _VolumeManager:
                 raise
         else:
             req = api_pb2.VolumeDeleteRequest(volume_id=obj.object_id)
-            await retry_transient_errors(obj._client.stub.VolumeDelete, req)
+            await obj._client.stub.VolumeDelete(req)
 
 
 VolumeManager = synchronize_api(_VolumeManager)
@@ -560,7 +559,7 @@ class _Volume(_Object, type_prefix="vo"):
             object_creation_type=api_pb2.OBJECT_CREATION_TYPE_CREATE_FAIL_IF_EXISTS,
             version=version,
         )
-        resp = await retry_transient_errors(client.stub.VolumeGetOrCreate, request)
+        resp = await client.stub.VolumeGetOrCreate(request)
         return resp.volume_id
 
     @live_method
@@ -580,7 +579,7 @@ class _Volume(_Object, type_prefix="vo"):
     async def _do_reload(self, lock=True):
         async with (await self._get_lock()) if lock else asyncnullcontext():
             req = api_pb2.VolumeReloadRequest(volume_id=self.object_id)
-            _ = await retry_transient_errors(self._client.stub.VolumeReload, req)
+            _ = await self._client.stub.VolumeReload(req)
 
     @live_method
     async def commit(self):
@@ -593,7 +592,7 @@ class _Volume(_Object, type_prefix="vo"):
             req = api_pb2.VolumeCommitRequest(volume_id=self.object_id)
             try:
                 # TODO(gongy): only apply indefinite retries on 504 status.
-                resp = await retry_transient_errors(self._client.stub.VolumeCommit, req, max_retries=90)
+                resp = await self._client.stub.VolumeCommit(req, max_retries=90)
                 if not resp.skip_reload:
                     # Reload changes on successful commit.
                     await self._do_reload(lock=False)
@@ -689,7 +688,7 @@ class _Volume(_Object, type_prefix="vo"):
         req = api_pb2.VolumeGetFile2Request(volume_id=self.object_id, path=path)
 
         try:
-            response = await retry_transient_errors(self._client.stub.VolumeGetFile2, req)
+            response = await self._client.stub.VolumeGetFile2(req)
         except modal.exception.NotFoundError as exc:
             raise FileNotFoundError(exc.args[0])
 
@@ -724,7 +723,7 @@ class _Volume(_Object, type_prefix="vo"):
         req = api_pb2.VolumeGetFile2Request(volume_id=self.object_id, path=path)
 
         try:
-            response = await retry_transient_errors(self._client.stub.VolumeGetFile2, req)
+            response = await self._client.stub.VolumeGetFile2(req)
         except modal.exception.NotFoundError as exc:
             raise FileNotFoundError(exc.args[0])
 
@@ -772,10 +771,10 @@ class _Volume(_Object, type_prefix="vo"):
         try:
             if self._is_v1:
                 req = api_pb2.VolumeRemoveFileRequest(volume_id=self.object_id, path=path, recursive=recursive)
-                await retry_transient_errors(self._client.stub.VolumeRemoveFile, req)
+                await self._client.stub.VolumeRemoveFile(req)
             else:
                 req = api_pb2.VolumeRemoveFile2Request(volume_id=self.object_id, path=path, recursive=recursive)
-                await retry_transient_errors(self._client.stub.VolumeRemoveFile2, req)
+                await self._client.stub.VolumeRemoveFile2(req)
         except modal.exception.NotFoundError as exc:
             raise FileNotFoundError(exc.args[0])
 
@@ -814,12 +813,12 @@ class _Volume(_Object, type_prefix="vo"):
             request = api_pb2.VolumeCopyFilesRequest(
                 volume_id=self.object_id, src_paths=src_paths, dst_path=dst_path, recursive=recursive
             )
-            await retry_transient_errors(self._client.stub.VolumeCopyFiles, request, base_delay=1)
+            await self._client.stub.VolumeCopyFiles(request, base_delay=1)
         else:
             request = api_pb2.VolumeCopyFiles2Request(
                 volume_id=self.object_id, src_paths=src_paths, dst_path=dst_path, recursive=recursive
             )
-            await retry_transient_errors(self._client.stub.VolumeCopyFiles2, request, base_delay=1)
+            await self._client.stub.VolumeCopyFiles2(request, base_delay=1)
 
     @live_method
     async def batch_upload(self, force: bool = False) -> "_AbstractVolumeUploadContextManager":
@@ -849,9 +848,7 @@ class _Volume(_Object, type_prefix="vo"):
 
     @live_method
     async def _instance_delete(self):
-        await retry_transient_errors(
-            self._client.stub.VolumeDelete, api_pb2.VolumeDeleteRequest(volume_id=self.object_id)
-        )
+        await self._client.stub.VolumeDelete(api_pb2.VolumeDeleteRequest(volume_id=self.object_id))
 
     @staticmethod
     async def delete(name: str, client: Optional[_Client] = None, environment_name: Optional[str] = None):
@@ -880,7 +877,7 @@ class _Volume(_Object, type_prefix="vo"):
     ):
         obj = await _Volume.from_name(old_name, environment_name=environment_name).hydrate(client)
         req = api_pb2.VolumeRenameRequest(volume_id=obj.object_id, name=new_name)
-        await retry_transient_errors(obj._client.stub.VolumeRename, req)
+        await obj._client.stub.VolumeRename(req)
 
 
 Volume = synchronize_api(_Volume)
@@ -981,7 +978,7 @@ class _VolumeUploadContextManager(_AbstractVolumeUploadContextManager):
                 disallow_overwrite_existing_files=not self._force,
             )
             try:
-                await retry_transient_errors(self._client.stub.VolumePutFiles, request, base_delay=1)
+                await self._client.stub.VolumePutFiles(request, base_delay=1)
             except GRPCError as exc:
                 raise FileExistsError(exc.message) if exc.status == Status.ALREADY_EXISTS else exc
 
@@ -1041,7 +1038,7 @@ class _VolumeUploadContextManager(_AbstractVolumeUploadContextManager):
         remote_filename = file_spec.mount_filename
         progress_task_id = self._progress_cb(name=remote_filename, size=file_spec.size)
         request = api_pb2.MountPutFileRequest(sha256_hex=file_spec.sha256_hex)
-        response = await retry_transient_errors(self._client.stub.MountPutFile, request, base_delay=1)
+        response = await self._client.stub.MountPutFile(request, base_delay=1)
 
         start_time = time.monotonic()
         if not response.exists:
@@ -1065,7 +1062,7 @@ class _VolumeUploadContextManager(_AbstractVolumeUploadContextManager):
                 self._progress_cb(task_id=progress_task_id, complete=True)
 
             while (time.monotonic() - start_time) < VOLUME_PUT_FILE_CLIENT_TIMEOUT:
-                response = await retry_transient_errors(self._client.stub.MountPutFile, request2, base_delay=1)
+                response = await self._client.stub.MountPutFile(request2, base_delay=1)
                 if response.exists:
                     break
 
@@ -1225,7 +1222,7 @@ class _VolumeUploadContextManager2(_AbstractVolumeUploadContextManager):
             )
 
             try:
-                response = await retry_transient_errors(self._client.stub.VolumePutFiles2, request, base_delay=1)
+                response = await self._client.stub.VolumePutFiles2(request, base_delay=1)
             except GRPCError as exc:
                 raise FileExistsError(exc.message) if exc.status == Status.ALREADY_EXISTS else exc
 

--- a/test/container_app_test.py
+++ b/test/container_app_test.py
@@ -12,7 +12,6 @@ from google.protobuf.message import Message
 from modal import App, interact
 from modal._runtime.container_io_manager import ContainerIOManager
 from modal._utils.async_utils import synchronize_api
-from modal._utils.grpc_utils import retry_transient_errors
 from modal.exception import InvalidError
 from modal.running_app import RunningApp
 from modal_proto import api_pb2
@@ -64,7 +63,7 @@ def square(x):
 @synchronize_api
 async def stop_app(client, app_id):
     # helper to ensur we run the rpc from the synchronicity loop - otherwise we can run into weird deadlocks
-    return await retry_transient_errors(client.stub.AppStop, api_pb2.AppStopRequest(app_id=app_id))
+    return await client.stub.AppStop(api_pb2.AppStopRequest(app_id=app_id))
 
 
 @contextmanager

--- a/test/grpc_utils_test.py
+++ b/test/grpc_utils_test.py
@@ -9,7 +9,6 @@ from modal._utils.async_utils import synchronize_api
 from modal._utils.grpc_utils import (
     connect_channel,
     create_channel,
-    retry_transient_errors,
 )
 from modal_proto import api_grpc, api_pb2
 
@@ -69,7 +68,7 @@ async def test_retry_transient_errors(servicer, client):
 
     @synchronize_api
     async def wrapped_blob_create(req, **kwargs):
-        return await retry_transient_errors(client_stub.BlobCreate, req, **kwargs)
+        return await client_stub.BlobCreate(req, **kwargs)
 
     # Use the BlobCreate request for retries
     req = api_pb2.BlobCreateRequest()


### PR DESCRIPTION
## Describe your changes

This way we do not need to remember to call `retry_transient_errors` on the unary-unary rpcs. 

Defining a `_with_retires` was the simplest way I saw for getting types to work nicely.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>