### PR TITLE
Surface cluster ID for clustered functions

### DIFF
--- a/modal/_clustered_functions.py
+++ b/modal/_clustered_functions.py
@@ -14,6 +14,7 @@ from modal_proto import api_pb2
 @dataclass
 class ClusterInfo:
     rank: int
+    cluster_id: str
     container_ips: list[str]
     container_ipv4_ips: list[str]
 
@@ -69,12 +70,14 @@ async def _initialize_clustered_function(client: _Client, task_id: str, world_si
         )
         cluster_info = ClusterInfo(
             rank=resp.cluster_rank,
+            cluster_id=resp.cluster_id,
             container_ips=resp.container_ips,
             container_ipv4_ips=resp.container_ipv4_ips,
         )
     else:
         cluster_info = ClusterInfo(
             rank=0,
+            cluster_id="",  # No cluster ID for single-node  # TODO(irfansharif): Is this right?
             container_ips=[container_ip],
             container_ipv4_ips=[],  # No IPv4 IPs for single-node
         )


### PR DESCRIPTION
## Describe your changes

We already pass it back down from the server. Include it in the client object. Useful now that we're looking at single-function, multiple clusters.


<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>

## Changelog

The type returned by `modal.experimental.get_cluster_info()` now also includes the cluster ID - shared across the set of tasks that spin up in tandem when using the `@clustered` decorator.