### PR TITLE
check sandbox name length and warn

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -73,6 +73,12 @@ def _validate_exec_args(args: Sequence[str]) -> None:
         )
 
 
+def _validate_sandbox_name(name: str) -> None:
+    message = f"Invalid Sandbox name: '{name}'.\n\nSandbox names must be between 1 and 128 characters long."
+    if len(name) == 0 or len(name) > 128:
+        raise InvalidError(message)
+
+
 class DefaultSandboxNameOverride(str):
     """A singleton class that represents the default sandbox name override.
 
@@ -404,6 +410,8 @@ class _Sandbox(_Object, type_prefix="sb"):
         from .app import _App
 
         _validate_exec_args(args)
+        if name is not None:
+            _validate_sandbox_name(name)
 
         # TODO(erikbern): Get rid of the `_new` method and create an already-hydrated object
         obj = _Sandbox._new(
@@ -783,6 +791,9 @@ class _Sandbox(_Object, type_prefix="sb"):
         name: Optional[str] = _DEFAULT_SANDBOX_NAME_OVERRIDE,
     ):
         client = client or await _Client.from_env()
+
+        if name is not None and name != _DEFAULT_SANDBOX_NAME_OVERRIDE:
+            _validate_sandbox_name(name)
 
         if name is _DEFAULT_SANDBOX_NAME_OVERRIDE:
             restore_req = api_pb2.SandboxRestoreRequest(

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -24,6 +24,7 @@ from ._utils.async_utils import TaskContext, synchronize_api
 from ._utils.deprecation import deprecation_warning
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.mount_utils import validate_network_file_systems, validate_volumes
+from ._utils.name_utils import check_object_name
 from .client import _Client
 from .config import config
 from .container_process import _ContainerProcess
@@ -71,12 +72,6 @@ def _validate_exec_args(args: Sequence[str]) -> None:
             f"Total length of CMD arguments must be less than {ARG_MAX_BYTES} bytes (ARG_MAX). "
             f"Got {total_arg_len} bytes."
         )
-
-
-def _validate_sandbox_name(name: str) -> None:
-    message = f"Invalid Sandbox name: '{name}'.\n\nSandbox names must be between 1 and 128 characters long."
-    if len(name) == 0 or len(name) > 128:
-        raise InvalidError(message)
 
 
 class DefaultSandboxNameOverride(str):
@@ -411,7 +406,7 @@ class _Sandbox(_Object, type_prefix="sb"):
 
         _validate_exec_args(args)
         if name is not None:
-            _validate_sandbox_name(name)
+            check_object_name(name, "Sandbox")
 
         # TODO(erikbern): Get rid of the `_new` method and create an already-hydrated object
         obj = _Sandbox._new(
@@ -793,7 +788,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         client = client or await _Client.from_env()
 
         if name is not None and name != _DEFAULT_SANDBOX_NAME_OVERRIDE:
-            _validate_sandbox_name(name)
+            check_object_name(name, "Sandbox")
 
         if name is _DEFAULT_SANDBOX_NAME_OVERRIDE:
             restore_req = api_pb2.SandboxRestoreRequest(


### PR DESCRIPTION
## Describe your changes

This enforces Sandbox name length constraints on the client. Sandbox names must be between 1 and 128 characters.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>