### PR TITLE
[flash] scale up more when containers can't hit /metrics

### DIFF
--- a/modal/experimental/flash.py
+++ b/modal/experimental/flash.py
@@ -275,7 +275,7 @@ class _FlashPrometheusAutoscaler:
 
         # Scale up / down conservatively: Any container that is missing the metric is assumed to be at the minimum
         # value of the metric when scaling up and the maximum value of the metric when scaling down.
-        scale_up_target_metric_value = sum_metric / (containers_with_metrics if containers_with_metrics > 0 else 1)
+        scale_up_target_metric_value = sum_metric / (containers_with_metrics or 1)
         scale_down_target_metric_value = (
             sum_metric + n_containers_missing_metric * target_metric_value
         ) / current_replicas

--- a/modal/experimental/flash.py
+++ b/modal/experimental/flash.py
@@ -303,7 +303,7 @@ class _FlashPrometheusAutoscaler:
 
         # Fetch the metrics from the endpoint
         try:
-            response = await asyncio.wait_for(self.http_client.get(url), timeout=5)
+            response = await self.http_client.get(url, timeout=5)
             response.raise_for_status()
         except asyncio.TimeoutError:
             logger.warning(f"[Modal Flash] Timeout getting metrics from {url}")

--- a/modal/experimental/flash.py
+++ b/modal/experimental/flash.py
@@ -303,7 +303,7 @@ class _FlashPrometheusAutoscaler:
 
         # Fetch the metrics from the endpoint
         try:
-            response = await self.http_client.get(url, timeout=5)
+            response = await self.http_client.get(url, timeout=3)
             response.raise_for_status()
         except asyncio.TimeoutError:
             logger.warning(f"[Modal Flash] Timeout getting metrics from {url}")


### PR DESCRIPTION
Prometheus can't hit `/metrics` when containers are overloaded. We want to just mark containers that time out or error when hitting `/metrics` as "unhealthy" and scale up more based on that.