### PR TITLE
[flash autoscaler] fix _compute_target_containers_internal

### DIFF
--- a/modal/experimental/flash.py
+++ b/modal/experimental/flash.py
@@ -282,7 +282,7 @@ class _FlashPrometheusAutoscaler:
             f"desired replicas: {desired_replicas}"
         )
 
-        desired_replicas = max(1, desired_replicas)
+        desired_replicas = max(1, min(desired_replicas, self.max_containers or 1000))
         return desired_replicas
 
     async def _compute_target_containers_prometheus(self, current_replicas: int) -> int:


### PR DESCRIPTION
Fixes
- correctly access `container_id`
- temp fix: add a max limit for containers to handle exponential container scale up ([Slack thread](https://modal-com.slack.com/archives/C091HLKH422/p1756923658214979))