### PR TITLE
Improve error message for using __init__ for all objects

### DIFF
--- a/modal/_object.py
+++ b/modal/_object.py
@@ -61,7 +61,20 @@ class _Object:
 
     def __init__(self, *args, **kwargs):
         """mdmd:hidden"""
-        raise InvalidError(f"Class {type(self).__name__} has no constructor. Use class constructor methods instead.")
+        constructor_methods = ["from_name", "from_id", "ephemeral"]
+
+        valid_constructor_methods = []
+        class_name = type(self).__name__.lstrip("_")
+        for method in constructor_methods:
+            if hasattr(self, method):
+                valid_constructor_methods.append(f"`{class_name}.{method}`")
+
+        valid_methods_msg = ""
+        if valid_constructor_methods:
+            valid_methods = ", ".join(valid_constructor_methods)
+            valid_methods_msg = f"Please use {valid_methods} instead"
+
+        raise InvalidError(f"{class_name}(...) is not allowed. {valid_methods_msg}")
 
     def _init(
         self,

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -258,12 +258,6 @@ class _Dict(_Object, type_prefix="di"):
     _name: Optional[str] = None
     _metadata: Optional[api_pb2.DictMetadata] = None
 
-    def __init__(self, data={}):
-        """mdmd:hidden"""
-        raise RuntimeError(
-            "`Dict(...)` constructor is not allowed. Please use `Dict.from_name` or `Dict.ephemeral` instead"
-        )
-
     @classproperty
     def objects(cls) -> _DictManager:
         return _DictManager

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -286,10 +286,6 @@ class _Queue(_Object, type_prefix="qu"):
 
     _metadata: Optional[api_pb2.QueueMetadata] = None
 
-    def __init__(self):
-        """mdmd:hidden"""
-        raise RuntimeError("Queue() is not allowed. Please use `Queue.from_name(...)` or `Queue.ephemeral()` instead.")
-
     @classproperty
     def objects(cls) -> _QueueManager:
         return _QueueManager

--- a/test/object_test.py
+++ b/test/object_test.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 import pytest
 
-from modal import Secret
+from modal import Image, Queue, Secret, Volume
 from modal._object import _Object
 from modal.dict import Dict, _Dict
 from modal.exception import InvalidError
@@ -41,3 +41,18 @@ def test_types():
     assert not _Dict._is_id_type("qu-123")
     assert _Queue._is_id_type("qu-123")
     assert not _Queue._is_id_type("di-123")
+
+
+@pytest.mark.parametrize(
+    "Kls, msg",
+    [
+        (Image, r"Please use `Image\.from_id` instead"),
+        (Dict, r"Please use `Dict\.from_name`, `Dict\.ephemeral` instead"),
+        (Volume, r"Please use `Volume\.from_name`, `Volume\.ephemeral` instead"),
+        (Queue, r"Please use `Queue\.from_name`, `Queue\.ephemeral` instead"),
+        (Secret, r"Please use `Secret\.from_name` instead"),
+    ],
+)
+def test_improve_error_messaage(Kls, msg):
+    with pytest.raises(InvalidError, match=msg):
+        _ = Kls()


### PR DESCRIPTION
## Describe your changes

- Improves error message for all objects when trying to use `__init__`.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>