### PR TITLE
auth relay protobuf updates

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2671,6 +2671,16 @@ message SandboxCreateResponse {
   string sandbox_id = 1;
 }
 
+message SandboxCreateConnectCredentialsRequest {
+  string sandbox_id = 1;
+  string metadata = 2;
+}
+
+message SandboxCreateConnectCredentialsResponse {
+  string url = 1;
+  string token = 2;
+}
+
 message SandboxGetFromNameRequest {
   string sandbox_name = 1;
   string environment_name = 2;
@@ -3606,6 +3616,7 @@ service ModalClient {
 
   // Sandboxes
   rpc SandboxCreate(SandboxCreateRequest) returns (SandboxCreateResponse);
+  rpc SandboxCreateConnectCredentials(SandboxCreateConnectCredentialsRequest) returns (SandboxCreateConnectCredentialsResponse);
   rpc SandboxGetFromName(SandboxGetFromNameRequest) returns (SandboxGetFromNameResponse);
   rpc SandboxGetLogs(SandboxGetLogsRequest) returns (stream TaskLogsBatch);
   rpc SandboxGetResourceUsage(SandboxGetResourceUsageRequest) returns (SandboxGetResourceUsageResponse);


### PR DESCRIPTION
This adds protobuf types for creating connect credentials for a sandbox.

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>