### PR TITLE
rename SandboxCreateConnectCredentials to SandboxCreateConnectToken

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2667,12 +2667,12 @@ message Sandbox {
   optional uint32 idle_timeout_secs = 33;
 }
 
-message SandboxCreateConnectCredentialsRequest {
+message SandboxCreateConnectTokenRequest {
   string sandbox_id = 1;
   string metadata = 2;
 }
 
-message SandboxCreateConnectCredentialsResponse {
+message SandboxCreateConnectTokenResponse {
   string url = 1;
   string token = 2;
 }
@@ -3622,7 +3622,7 @@ service ModalClient {
 
   // Sandboxes
   rpc SandboxCreate(SandboxCreateRequest) returns (SandboxCreateResponse);
-  rpc SandboxCreateConnectCredentials(SandboxCreateConnectCredentialsRequest) returns (SandboxCreateConnectCredentialsResponse);
+  rpc SandboxCreateConnectToken(SandboxCreateConnectTokenRequest) returns (SandboxCreateConnectTokenResponse);
   rpc SandboxGetFromName(SandboxGetFromNameRequest) returns (SandboxGetFromNameResponse);
   rpc SandboxGetLogs(SandboxGetLogsRequest) returns (stream TaskLogsBatch);
   rpc SandboxGetResourceUsage(SandboxGetResourceUsageRequest) returns (SandboxGetResourceUsageResponse);


### PR DESCRIPTION
This changes some of the naming for the new (and heretofore unused) `SandboxCreateConnectCredentials` messages and endpoints to `SandboxCreateConnectToken`. These messages and endpoints have never been used, so this change should be fine (unless I'm missing somethings?).

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

---

</details>