### PR TITLE
Accept `env` params in addition to `secrets`

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -700,7 +700,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         experimental_options: Optional[dict[str, str]] = None,
         _experimental_proxy_ip: Optional[str] = None,
         _experimental_custom_scaling_factor: Optional[float] = None,
-        env: Optional[dict[str, str]] = None,
+        env: Optional[dict[str, Optional[str]]] = None,
     ) -> "_Function":
         """mdmd:hidden"""
         # Needed to avoid circular imports
@@ -739,7 +739,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
 
         secrets = secrets or []
         if env:
-            secrets = [*secrets, _Secret.from_dict(dict(**env))]
+            secrets = [*secrets, _Secret.from_dict(env)]
 
         function_spec = _FunctionSpec(
             mounts=all_mounts,

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -661,6 +661,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         info: FunctionInfo,
         app,
         image: _Image,
+        env: Optional[dict[str, Optional[str]]] = None,
         secrets: Optional[Collection[_Secret]] = None,
         schedule: Optional[Schedule] = None,
         is_generator: bool = False,
@@ -700,9 +701,11 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         experimental_options: Optional[dict[str, str]] = None,
         _experimental_proxy_ip: Optional[str] = None,
         _experimental_custom_scaling_factor: Optional[float] = None,
-        env: Optional[dict[str, Optional[str]]] = None,
     ) -> "_Function":
-        """mdmd:hidden"""
+        """mdmd:hidden
+
+        Note: This is not intended to be public API.
+        """
         # Needed to avoid circular imports
         from ._partial_function import _find_partial_methods_for_user_cls, _PartialFunctionFlags
 

--- a/modal/app.py
+++ b/modal/app.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 import inspect
 import typing
-from collections.abc import AsyncGenerator, Coroutine, Sequence
+from collections.abc import AsyncGenerator, Collection, Coroutine, Sequence
 from pathlib import PurePosixPath
 from textwrap import dedent
 from typing import (
@@ -616,7 +616,8 @@ class _App:
         *,
         image: Optional[_Image] = None,  # The image to run as the container for the function
         schedule: Optional[Schedule] = None,  # An optional Modal Schedule for the function
-        secrets: Sequence[_Secret] = (),  # Optional Modal Secret objects with environment variables for the container
+        env: Optional[dict[str, str]] = None,  # Environment variables to set in the container
+        secrets: Optional[Collection[_Secret]] = None,  # Secrets to inject into the container as environment variables
         gpu: Union[
             GPU_T, list[GPU_T]
         ] = None,  # GPU request as string ("any", "T4", ...), object (`modal.GPU.A100()`, ...), or a list of either
@@ -694,6 +695,9 @@ class _App:
         if allow_cross_region_volumes is not None:
             deprecation_warning((2025, 4, 23), "The `allow_cross_region_volumes` parameter no longer has any effect.")
 
+        secrets = secrets or []
+        if env:
+            secrets = [*secrets, _Secret.from_dict(dict(**env))]
         secrets = [*self._secrets, *secrets]
 
         def wrapped(
@@ -846,7 +850,8 @@ class _App:
         _warn_parentheses_missing=None,  # mdmd:line-hidden
         *,
         image: Optional[_Image] = None,  # The image to run as the container for the function
-        secrets: Sequence[_Secret] = (),  # Optional Modal Secret objects with environment variables for the container
+        env: Optional[dict[str, str]] = None,  # Environment variables to set in the container
+        secrets: Optional[Collection[_Secret]] = None,  # Secrets to inject into the container as environment variables
         gpu: Union[
             GPU_T, list[GPU_T]
         ] = None,  # GPU request as string ("any", "T4", ...), object (`modal.GPU.A100()`, ...), or a list of either
@@ -919,6 +924,10 @@ class _App:
             )
         if allow_cross_region_volumes is not None:
             deprecation_warning((2025, 4, 23), "The `allow_cross_region_volumes` parameter no longer has any effect.")
+
+        secrets = secrets or []
+        if env:
+            secrets = [*secrets, _Secret.from_dict(dict(**env))]
 
         def wrapper(wrapped_cls: Union[CLS_T, _PartialFunction]) -> CLS_T:
             # Check if the decorated object is a class

--- a/modal/app.py
+++ b/modal/app.py
@@ -616,7 +616,7 @@ class _App:
         *,
         image: Optional[_Image] = None,  # The image to run as the container for the function
         schedule: Optional[Schedule] = None,  # An optional Modal Schedule for the function
-        env: Optional[dict[str, str]] = None,  # Environment variables to set in the container
+        env: Optional[dict[str, Optional[str]]] = None,  # Environment variables to set in the container
         secrets: Optional[Collection[_Secret]] = None,  # Secrets to inject into the container as environment variables
         gpu: Union[
             GPU_T, list[GPU_T]
@@ -697,7 +697,7 @@ class _App:
 
         secrets = secrets or []
         if env:
-            secrets = [*secrets, _Secret.from_dict(dict(**env))]
+            secrets = [*secrets, _Secret.from_dict(env)]
         secrets = [*self._secrets, *secrets]
 
         def wrapped(
@@ -850,7 +850,7 @@ class _App:
         _warn_parentheses_missing=None,  # mdmd:line-hidden
         *,
         image: Optional[_Image] = None,  # The image to run as the container for the function
-        env: Optional[dict[str, str]] = None,  # Environment variables to set in the container
+        env: Optional[dict[str, Optional[str]]] = None,  # Environment variables to set in the container
         secrets: Optional[Collection[_Secret]] = None,  # Secrets to inject into the container as environment variables
         gpu: Union[
             GPU_T, list[GPU_T]
@@ -927,7 +927,7 @@ class _App:
 
         secrets = secrets or []
         if env:
-            secrets = [*secrets, _Secret.from_dict(dict(**env))]
+            secrets = [*secrets, _Secret.from_dict(env)]
 
         def wrapper(wrapped_cls: Union[CLS_T, _PartialFunction]) -> CLS_T:
             # Check if the decorated object is a class

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -81,7 +81,7 @@ def _get_class_constructor_signature(user_cls: type) -> inspect.Signature:
 @dataclasses.dataclass()
 class _ServiceOptions:
     # Note that default values should always be "untruthy" so we can detect when they are not set
-    secrets: typing.Collection[_Secret] = ()
+    secrets: Collection[_Secret] = ()
     validated_volumes: typing.Sequence[tuple[str, _Volume]] = ()
     resources: Optional[api_pb2.Resources] = None
     retry_policy: Optional[api_pb2.FunctionRetryPolicy] = None
@@ -686,7 +686,8 @@ More information on class parameterization can be found here: https://modal.com/
         cpu: Optional[Union[float, tuple[float, float]]] = None,
         memory: Optional[Union[int, tuple[int, int]]] = None,
         gpu: GPU_T = None,
-        secrets: Collection[_Secret] = (),
+        env: Optional[dict[str, str]] = None,
+        secrets: Optional[Collection[_Secret]] = None,
         volumes: dict[Union[str, os.PathLike], _Volume] = {},
         retries: Optional[Union[int, Retries]] = None,
         max_containers: Optional[int] = None,  # Limit on the number of containers that can be concurrently running.
@@ -760,6 +761,10 @@ More information on class parameterization can be found here: https://modal.com/
 
         cls = _Cls._from_loader(_load_from_base, rep=f"{self._name}.with_options(...)", is_another_app=True, deps=_deps)
         cls._initialize_from_other(self)
+
+        secrets = secrets or []
+        if env:
+            secrets = [*secrets, _Secret.from_dict(dict(**env))]
 
         new_options = _ServiceOptions(
             secrets=secrets,

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -686,7 +686,7 @@ More information on class parameterization can be found here: https://modal.com/
         cpu: Optional[Union[float, tuple[float, float]]] = None,
         memory: Optional[Union[int, tuple[int, int]]] = None,
         gpu: GPU_T = None,
-        env: Optional[dict[str, str]] = None,
+        env: Optional[dict[str, Optional[str]]] = None,
         secrets: Optional[Collection[_Secret]] = None,
         volumes: dict[Union[str, os.PathLike], _Volume] = {},
         retries: Optional[Union[int, Retries]] = None,
@@ -764,7 +764,7 @@ More information on class parameterization can be found here: https://modal.com/
 
         secrets = secrets or []
         if env:
-            secrets = [*secrets, _Secret.from_dict(dict(**env))]
+            secrets = [*secrets, _Secret.from_dict(env)]
 
         new_options = _ServiceOptions(
             secrets=secrets,

--- a/modal/image.py
+++ b/modal/image.py
@@ -7,7 +7,7 @@ import shlex
 import sys
 import typing
 import warnings
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 from dataclasses import dataclass
 from inspect import isfunction
 from pathlib import Path, PurePosixPath
@@ -491,7 +491,7 @@ class _Image(_Object, type_prefix="im"):
         *,
         base_images: Optional[dict[str, "_Image"]] = None,
         dockerfile_function: Optional[Callable[[ImageBuilderVersion], DockerfileSpec]] = None,
-        secrets: Optional[Sequence[_Secret]] = None,
+        secrets: Optional[Collection[_Secret]] = None,
         gpu_config: Optional[api_pb2.GPUConfig] = None,
         build_function: Optional["modal._functions._Function"] = None,
         build_function_input: Optional[api_pb2.FunctionInput] = None,
@@ -877,8 +877,9 @@ class _Image(_Object, type_prefix="im"):
         pre: bool = False,  # Passes --pre (allow pre-releases) to pip install
         extra_options: str = "",  # Additional options to pass to pip install, e.g. "--no-build-isolation --no-clean"
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
-        secrets: Sequence[_Secret] = [],
+        secrets: Optional[Collection[_Secret]] = None,
         gpu: GPU_T = None,
+        env: Optional[dict[str, str]] = None,
     ) -> "_Image":
         """Install a list of Python packages using pip.
 
@@ -924,6 +925,10 @@ class _Image(_Object, type_prefix="im"):
                 commands = [cmd.strip() for cmd in commands]
             return DockerfileSpec(commands=commands, context_files={})
 
+        secrets = secrets or []
+        if env:
+            secrets = [*secrets, _Secret.from_dict(dict(**env))]
+
         gpu_config = parse_gpu_config(gpu)
         return _Image._from_args(
             base_images={"base": self},
@@ -943,8 +948,9 @@ class _Image(_Object, type_prefix="im"):
         pre: bool = False,  # Passes --pre (allow pre-releases) to pip install
         extra_options: str = "",  # Additional options to pass to pip install, e.g. "--no-build-isolation --no-clean"
         gpu: GPU_T = None,
-        secrets: Sequence[_Secret] = [],
+        secrets: Optional[Collection[_Secret]] = None,  # Secrets to inject into the container as environment variables
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
+        env: Optional[dict[str, str]] = None,  # Environment variables to set in the container
     ) -> "_Image":
         """
         Install a list of Python packages from private git repositories using pip.
@@ -977,6 +983,11 @@ class _Image(_Object, type_prefix="im"):
         )
         ```
         """
+
+        secrets = secrets or []
+        if env:
+            secrets = [*secrets, _Secret.from_dict(dict(**env))]
+
         if not secrets:
             raise InvalidError(
                 "No secrets provided to function. "
@@ -1044,10 +1055,15 @@ class _Image(_Object, type_prefix="im"):
         pre: bool = False,  # Passes --pre (allow pre-releases) to pip install
         extra_options: str = "",  # Additional options to pass to pip install, e.g. "--no-build-isolation --no-clean"
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
-        secrets: Sequence[_Secret] = [],
+        env: Optional[dict[str, str]] = None,
+        secrets: Optional[Collection[_Secret]] = None,
         gpu: GPU_T = None,
     ) -> "_Image":
         """Install a list of Python packages from a local `requirements.txt` file."""
+
+        secrets = secrets or []
+        if env:
+            secrets = [*secrets, _Secret.from_dict(dict(**env))]
 
         def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:
             requirements_txt_path = os.path.expanduser(requirements_txt)
@@ -1085,7 +1101,8 @@ class _Image(_Object, type_prefix="im"):
         pre: bool = False,  # Passes --pre (allow pre-releases) to pip install
         extra_options: str = "",  # Additional options to pass to pip install, e.g. "--no-build-isolation --no-clean"
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
-        secrets: Sequence[_Secret] = [],
+        env: Optional[dict[str, str]] = None,
+        secrets: Optional[Collection[_Secret]] = None,
         gpu: GPU_T = None,
     ) -> "_Image":
         """Install dependencies specified by a local `pyproject.toml` file.
@@ -1095,6 +1112,10 @@ class _Image(_Object, type_prefix="im"):
         (e.g. test, doc, experiment, etc). When provided,
         all of the packages in each listed section are installed as well.
         """
+
+        secrets = secrets or []
+        if env:
+            secrets = [*secrets, _Secret.from_dict(dict(**env))]
 
         def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:
             # Defer toml import so we don't need it in the container runtime environment
@@ -1147,8 +1168,9 @@ class _Image(_Object, type_prefix="im"):
         extra_options: str = "",  # Additional options to pass to pip install, e.g. "--no-build-isolation"
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
         uv_version: Optional[str] = None,  # uv version to use
-        secrets: Sequence[_Secret] = [],
+        secrets: Optional[Collection[_Secret]] = None,
         gpu: GPU_T = None,
+        env: Optional[dict[str, str]] = None,
     ) -> "_Image":
         """Install a list of Python packages using uv pip install.
 
@@ -1166,6 +1188,11 @@ class _Image(_Object, type_prefix="im"):
 
         Added in v1.1.0.
         """
+
+        secrets = secrets or []
+        if env:
+            secrets = [*secrets, _Secret.from_dict(dict(**env))]
+
         pkgs = _flatten_str_args("uv_pip_install", "packages", packages)
 
         if requirements is None or isinstance(requirements, list):
@@ -1261,7 +1288,8 @@ class _Image(_Object, type_prefix="im"):
         poetry_version: Optional[str] = "latest",  # Version of poetry to install, or None to skip installation
         # If set to True, use old installer. See https://github.com/python-poetry/poetry/issues/3336
         old_installer: bool = False,
-        secrets: Sequence[_Secret] = [],
+        env: Optional[dict[str, str]] = None,
+        secrets: Optional[Collection[_Secret]] = None,
         gpu: GPU_T = None,
     ) -> "_Image":
         """Install poetry *dependencies* specified by a local `pyproject.toml` file.
@@ -1276,6 +1304,10 @@ class _Image(_Object, type_prefix="im"):
         Note that the interpretation of `poetry_version="latest"` depends on the Modal Image Builder
         version, with versions 2024.10 and earlier limiting poetry to 1.x.
         """
+
+        secrets = secrets or []
+        if env:
+            secrets = [*secrets, _Secret.from_dict(dict(**env))]
 
         def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:
             context_files = {"/.pyproject.toml": os.path.expanduser(poetry_pyproject_toml)}
@@ -1346,7 +1378,8 @@ class _Image(_Object, type_prefix="im"):
         frozen: bool = True,  # If True, then we run `uv sync --frozen` when a uv.lock file is present
         extra_options: str = "",  # Extra options to pass to `uv sync`
         uv_version: Optional[str] = None,  # uv version to use
-        secrets: Sequence[_Secret] = [],
+        env: Optional[dict[str, str]] = None,
+        secrets: Optional[Collection[_Secret]] = None,
         gpu: GPU_T = None,
     ) -> "_Image":
         """Creates a virtual environment with the dependencies in a uv managed project with `uv sync`.
@@ -1361,6 +1394,10 @@ class _Image(_Object, type_prefix="im"):
 
         Added in v1.1.0.
         """
+
+        secrets = secrets or []
+        if env:
+            secrets = [*secrets, _Secret.from_dict(dict(**env))]
 
         def _normalize_items(items, name) -> list[str]:
             if items is None:
@@ -1494,12 +1531,13 @@ class _Image(_Object, type_prefix="im"):
         self,
         *dockerfile_commands: Union[str, list[str]],
         context_files: dict[str, str] = {},
-        secrets: Sequence[_Secret] = [],
+        secrets: Optional[Collection[_Secret]] = None,
         gpu: GPU_T = None,
         context_mount: Optional[_Mount] = None,  # Deprecated: the context is now inferred
         context_dir: Optional[Union[Path, str]] = None,  # Context for relative COPY commands
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
         ignore: Union[Sequence[str], Callable[[Path], bool]] = AUTO_DOCKERIGNORE,
+        env: Optional[dict[str, str]] = None,
     ) -> "_Image":
         """
         Extend an image with arbitrary Dockerfile-like commands.
@@ -1523,6 +1561,10 @@ class _Image(_Object, type_prefix="im"):
             ["COPY data /data"],
             ignore=lambda p: p.is_relative_to(".venv"),
         )
+
+        secrets = secrets or []
+        if env:
+            secrets = [*secrets, _Secret.from_dict(dict(**env))]
 
         image = modal.Image.debian_slim().dockerfile_commands(
             ["COPY data /data"],
@@ -1551,6 +1593,10 @@ class _Image(_Object, type_prefix="im"):
         cmds = _flatten_str_args("dockerfile_commands", "dockerfile_commands", dockerfile_commands)
         if not cmds:
             return self
+
+        secrets = secrets or []
+        if env:
+            secrets = [*secrets, _Secret.from_dict(dict(**env))]
 
         def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:
             return DockerfileSpec(commands=["FROM base", *cmds], context_files=context_files)
@@ -1595,11 +1641,17 @@ class _Image(_Object, type_prefix="im"):
     def run_commands(
         self,
         *commands: Union[str, list[str]],
-        secrets: Sequence[_Secret] = [],
+        secrets: Optional[Collection[_Secret]] = None,
         gpu: GPU_T = None,
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
+        env: Optional[dict[str, str]] = None,
     ) -> "_Image":
         """Extend an image with a list of shell commands to run."""
+
+        secrets = secrets or []
+        if env:
+            secrets = [*secrets, _Secret.from_dict(dict(**env))]
+
         cmds = _flatten_str_args("run_commands", "commands", commands)
         if not cmds:
             return self
@@ -1658,10 +1710,16 @@ class _Image(_Object, type_prefix="im"):
         # A list of Conda channels, eg. ["conda-forge", "nvidia"].
         channels: list[str] = [],
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
-        secrets: Sequence[_Secret] = [],
+        secrets: Optional[Collection[_Secret]] = None,
         gpu: GPU_T = None,
+        env: Optional[dict[str, str]] = None,
     ) -> "_Image":
         """Install a list of additional packages using micromamba."""
+
+        secrets = secrets or []
+        if env:
+            secrets = [*secrets, _Secret.from_dict(dict(**env))]
+
         pkgs = _flatten_str_args("micromamba_install", "packages", packages)
         if not pkgs and spec_file is None:
             return self
@@ -1909,7 +1967,8 @@ class _Image(_Object, type_prefix="im"):
         context_mount: Optional[_Mount] = None,  # Deprecated: the context is now inferred
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
         context_dir: Optional[Union[Path, str]] = None,  # Context for relative COPY commands
-        secrets: Sequence[_Secret] = [],
+        env: Optional[dict[str, str]] = None,
+        secrets: Optional[Collection[_Secret]] = None,
         gpu: GPU_T = None,
         add_python: Optional[str] = None,
         build_args: dict[str, str] = {},
@@ -1964,6 +2023,11 @@ class _Image(_Object, type_prefix="im"):
         )
         ```
         """
+
+        secrets = secrets or []
+        if env:
+            secrets = [*secrets, _Secret.from_dict(dict(**env))]
+
         if context_mount is not None:
             deprecation_warning(
                 (2025, 1, 13),
@@ -2078,8 +2142,9 @@ class _Image(_Object, type_prefix="im"):
         self,
         *packages: Union[str, list[str]],  # A list of packages, e.g. ["ssh", "libpq-dev"]
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
-        secrets: Sequence[_Secret] = [],
+        secrets: Optional[Collection[_Secret]] = None,
         gpu: GPU_T = None,
+        env: Optional[dict[str, str]] = None,
     ) -> "_Image":
         """Install a list of Debian packages using `apt`.
 
@@ -2103,6 +2168,10 @@ class _Image(_Object, type_prefix="im"):
             ]
             return DockerfileSpec(commands=commands, context_files={})
 
+        secrets = secrets or []
+        if env:
+            secrets = [*secrets, _Secret.from_dict(dict(**env))]
+
         return _Image._from_args(
             base_images={"base": self},
             dockerfile_function=build_dockerfile,
@@ -2115,7 +2184,8 @@ class _Image(_Object, type_prefix="im"):
         self,
         raw_f: Callable[..., Any],
         *,
-        secrets: Sequence[_Secret] = (),  # Optional Modal Secret objects with environment variables for the container
+        env: Optional[dict[str, str]] = None,  # Environment variables to set in the container
+        secrets: Optional[Collection[_Secret]] = None,  # Secrets to inject into the container as environment variables
         volumes: dict[Union[str, PurePosixPath], Union[_Volume, _CloudBucketMount]] = {},  # Volume mount paths
         network_file_systems: dict[Union[str, PurePosixPath], _NetworkFileSystem] = {},  # NFS mount paths
         gpu: Union[GPU_T, list[GPU_T]] = None,  # Requested GPU or or list of acceptable GPUs( e.g. ["A10", "A100"])
@@ -2157,6 +2227,11 @@ class _Image(_Object, type_prefix="im"):
         )
         ```
         """
+
+        secrets = secrets or []
+        if env:
+            secrets = [*secrets, _Secret.from_dict(dict(**env))]
+
         from ._functions import _Function
 
         if not callable(raw_f):

--- a/modal/image.py
+++ b/modal/image.py
@@ -877,9 +877,9 @@ class _Image(_Object, type_prefix="im"):
         pre: bool = False,  # Passes --pre (allow pre-releases) to pip install
         extra_options: str = "",  # Additional options to pass to pip install, e.g. "--no-build-isolation --no-clean"
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
+        env: Optional[dict[str, Optional[str]]] = None,
         secrets: Optional[Collection[_Secret]] = None,
         gpu: GPU_T = None,
-        env: Optional[dict[str, str]] = None,
     ) -> "_Image":
         """Install a list of Python packages using pip.
 
@@ -927,7 +927,7 @@ class _Image(_Object, type_prefix="im"):
 
         secrets = secrets or []
         if env:
-            secrets = [*secrets, _Secret.from_dict(dict(**env))]
+            secrets = [*secrets, _Secret.from_dict(env)]
 
         gpu_config = parse_gpu_config(gpu)
         return _Image._from_args(
@@ -948,9 +948,9 @@ class _Image(_Object, type_prefix="im"):
         pre: bool = False,  # Passes --pre (allow pre-releases) to pip install
         extra_options: str = "",  # Additional options to pass to pip install, e.g. "--no-build-isolation --no-clean"
         gpu: GPU_T = None,
+        env: Optional[dict[str, Optional[str]]] = None,  # Environment variables to set in the container
         secrets: Optional[Collection[_Secret]] = None,  # Secrets to inject into the container as environment variables
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
-        env: Optional[dict[str, str]] = None,  # Environment variables to set in the container
     ) -> "_Image":
         """
         Install a list of Python packages from private git repositories using pip.
@@ -986,7 +986,7 @@ class _Image(_Object, type_prefix="im"):
 
         secrets = secrets or []
         if env:
-            secrets = [*secrets, _Secret.from_dict(dict(**env))]
+            secrets = [*secrets, _Secret.from_dict(env)]
 
         if not secrets:
             raise InvalidError(
@@ -1055,7 +1055,7 @@ class _Image(_Object, type_prefix="im"):
         pre: bool = False,  # Passes --pre (allow pre-releases) to pip install
         extra_options: str = "",  # Additional options to pass to pip install, e.g. "--no-build-isolation --no-clean"
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
-        env: Optional[dict[str, str]] = None,
+        env: Optional[dict[str, Optional[str]]] = None,
         secrets: Optional[Collection[_Secret]] = None,
         gpu: GPU_T = None,
     ) -> "_Image":
@@ -1063,7 +1063,7 @@ class _Image(_Object, type_prefix="im"):
 
         secrets = secrets or []
         if env:
-            secrets = [*secrets, _Secret.from_dict(dict(**env))]
+            secrets = [*secrets, _Secret.from_dict(env)]
 
         def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:
             requirements_txt_path = os.path.expanduser(requirements_txt)
@@ -1101,7 +1101,7 @@ class _Image(_Object, type_prefix="im"):
         pre: bool = False,  # Passes --pre (allow pre-releases) to pip install
         extra_options: str = "",  # Additional options to pass to pip install, e.g. "--no-build-isolation --no-clean"
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
-        env: Optional[dict[str, str]] = None,
+        env: Optional[dict[str, Optional[str]]] = None,
         secrets: Optional[Collection[_Secret]] = None,
         gpu: GPU_T = None,
     ) -> "_Image":
@@ -1115,7 +1115,7 @@ class _Image(_Object, type_prefix="im"):
 
         secrets = secrets or []
         if env:
-            secrets = [*secrets, _Secret.from_dict(dict(**env))]
+            secrets = [*secrets, _Secret.from_dict(env)]
 
         def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:
             # Defer toml import so we don't need it in the container runtime environment
@@ -1168,9 +1168,9 @@ class _Image(_Object, type_prefix="im"):
         extra_options: str = "",  # Additional options to pass to pip install, e.g. "--no-build-isolation"
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
         uv_version: Optional[str] = None,  # uv version to use
+        env: Optional[dict[str, Optional[str]]] = None,
         secrets: Optional[Collection[_Secret]] = None,
         gpu: GPU_T = None,
-        env: Optional[dict[str, str]] = None,
     ) -> "_Image":
         """Install a list of Python packages using uv pip install.
 
@@ -1191,7 +1191,7 @@ class _Image(_Object, type_prefix="im"):
 
         secrets = secrets or []
         if env:
-            secrets = [*secrets, _Secret.from_dict(dict(**env))]
+            secrets = [*secrets, _Secret.from_dict(env)]
 
         pkgs = _flatten_str_args("uv_pip_install", "packages", packages)
 
@@ -1288,7 +1288,7 @@ class _Image(_Object, type_prefix="im"):
         poetry_version: Optional[str] = "latest",  # Version of poetry to install, or None to skip installation
         # If set to True, use old installer. See https://github.com/python-poetry/poetry/issues/3336
         old_installer: bool = False,
-        env: Optional[dict[str, str]] = None,
+        env: Optional[dict[str, Optional[str]]] = None,
         secrets: Optional[Collection[_Secret]] = None,
         gpu: GPU_T = None,
     ) -> "_Image":
@@ -1307,7 +1307,7 @@ class _Image(_Object, type_prefix="im"):
 
         secrets = secrets or []
         if env:
-            secrets = [*secrets, _Secret.from_dict(dict(**env))]
+            secrets = [*secrets, _Secret.from_dict(env)]
 
         def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:
             context_files = {"/.pyproject.toml": os.path.expanduser(poetry_pyproject_toml)}
@@ -1378,7 +1378,7 @@ class _Image(_Object, type_prefix="im"):
         frozen: bool = True,  # If True, then we run `uv sync --frozen` when a uv.lock file is present
         extra_options: str = "",  # Extra options to pass to `uv sync`
         uv_version: Optional[str] = None,  # uv version to use
-        env: Optional[dict[str, str]] = None,
+        env: Optional[dict[str, Optional[str]]] = None,
         secrets: Optional[Collection[_Secret]] = None,
         gpu: GPU_T = None,
     ) -> "_Image":
@@ -1397,7 +1397,7 @@ class _Image(_Object, type_prefix="im"):
 
         secrets = secrets or []
         if env:
-            secrets = [*secrets, _Secret.from_dict(dict(**env))]
+            secrets = [*secrets, _Secret.from_dict(env)]
 
         def _normalize_items(items, name) -> list[str]:
             if items is None:
@@ -1531,13 +1531,13 @@ class _Image(_Object, type_prefix="im"):
         self,
         *dockerfile_commands: Union[str, list[str]],
         context_files: dict[str, str] = {},
+        env: Optional[dict[str, Optional[str]]] = None,
         secrets: Optional[Collection[_Secret]] = None,
         gpu: GPU_T = None,
         context_mount: Optional[_Mount] = None,  # Deprecated: the context is now inferred
         context_dir: Optional[Union[Path, str]] = None,  # Context for relative COPY commands
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
         ignore: Union[Sequence[str], Callable[[Path], bool]] = AUTO_DOCKERIGNORE,
-        env: Optional[dict[str, str]] = None,
     ) -> "_Image":
         """
         Extend an image with arbitrary Dockerfile-like commands.
@@ -1592,7 +1592,7 @@ class _Image(_Object, type_prefix="im"):
 
         secrets = secrets or []
         if env:
-            secrets = [*secrets, _Secret.from_dict(dict(**env))]
+            secrets = [*secrets, _Secret.from_dict(env)]
 
         def build_dockerfile(version: ImageBuilderVersion) -> DockerfileSpec:
             return DockerfileSpec(commands=["FROM base", *cmds], context_files=context_files)
@@ -1637,16 +1637,16 @@ class _Image(_Object, type_prefix="im"):
     def run_commands(
         self,
         *commands: Union[str, list[str]],
+        env: Optional[dict[str, Optional[str]]] = None,
         secrets: Optional[Collection[_Secret]] = None,
         gpu: GPU_T = None,
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
-        env: Optional[dict[str, str]] = None,
     ) -> "_Image":
         """Extend an image with a list of shell commands to run."""
 
         secrets = secrets or []
         if env:
-            secrets = [*secrets, _Secret.from_dict(dict(**env))]
+            secrets = [*secrets, _Secret.from_dict(env)]
 
         cmds = _flatten_str_args("run_commands", "commands", commands)
         if not cmds:
@@ -1706,15 +1706,15 @@ class _Image(_Object, type_prefix="im"):
         # A list of Conda channels, eg. ["conda-forge", "nvidia"].
         channels: list[str] = [],
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
+        env: Optional[dict[str, Optional[str]]] = None,
         secrets: Optional[Collection[_Secret]] = None,
         gpu: GPU_T = None,
-        env: Optional[dict[str, str]] = None,
     ) -> "_Image":
         """Install a list of additional packages using micromamba."""
 
         secrets = secrets or []
         if env:
-            secrets = [*secrets, _Secret.from_dict(dict(**env))]
+            secrets = [*secrets, _Secret.from_dict(env)]
 
         pkgs = _flatten_str_args("micromamba_install", "packages", packages)
         if not pkgs and spec_file is None:
@@ -1963,7 +1963,7 @@ class _Image(_Object, type_prefix="im"):
         context_mount: Optional[_Mount] = None,  # Deprecated: the context is now inferred
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
         context_dir: Optional[Union[Path, str]] = None,  # Context for relative COPY commands
-        env: Optional[dict[str, str]] = None,
+        env: Optional[dict[str, Optional[str]]] = None,
         secrets: Optional[Collection[_Secret]] = None,
         gpu: GPU_T = None,
         add_python: Optional[str] = None,
@@ -2022,7 +2022,7 @@ class _Image(_Object, type_prefix="im"):
 
         secrets = secrets or []
         if env:
-            secrets = [*secrets, _Secret.from_dict(dict(**env))]
+            secrets = [*secrets, _Secret.from_dict(env)]
 
         if context_mount is not None:
             deprecation_warning(
@@ -2138,9 +2138,9 @@ class _Image(_Object, type_prefix="im"):
         self,
         *packages: Union[str, list[str]],  # A list of packages, e.g. ["ssh", "libpq-dev"]
         force_build: bool = False,  # Ignore cached builds, similar to 'docker build --no-cache'
+        env: Optional[dict[str, Optional[str]]] = None,
         secrets: Optional[Collection[_Secret]] = None,
         gpu: GPU_T = None,
-        env: Optional[dict[str, str]] = None,
     ) -> "_Image":
         """Install a list of Debian packages using `apt`.
 
@@ -2166,7 +2166,7 @@ class _Image(_Object, type_prefix="im"):
 
         secrets = secrets or []
         if env:
-            secrets = [*secrets, _Secret.from_dict(dict(**env))]
+            secrets = [*secrets, _Secret.from_dict(env)]
 
         return _Image._from_args(
             base_images={"base": self},
@@ -2180,7 +2180,7 @@ class _Image(_Object, type_prefix="im"):
         self,
         raw_f: Callable[..., Any],
         *,
-        env: Optional[dict[str, str]] = None,  # Environment variables to set in the container
+        env: Optional[dict[str, Optional[str]]] = None,  # Environment variables to set in the container
         secrets: Optional[Collection[_Secret]] = None,  # Secrets to inject into the container as environment variables
         volumes: dict[Union[str, PurePosixPath], Union[_Volume, _CloudBucketMount]] = {},  # Volume mount paths
         network_file_systems: dict[Union[str, PurePosixPath], _NetworkFileSystem] = {},  # NFS mount paths
@@ -2226,7 +2226,7 @@ class _Image(_Object, type_prefix="im"):
 
         secrets = secrets or []
         if env:
-            secrets = [*secrets, _Secret.from_dict(dict(**env))]
+            secrets = [*secrets, _Secret.from_dict(env)]
 
         from ._functions import _Function
 

--- a/modal/image.py
+++ b/modal/image.py
@@ -1562,10 +1562,6 @@ class _Image(_Object, type_prefix="im"):
             ignore=lambda p: p.is_relative_to(".venv"),
         )
 
-        secrets = secrets or []
-        if env:
-            secrets = [*secrets, _Secret.from_dict(dict(**env))]
-
         image = modal.Image.debian_slim().dockerfile_commands(
             ["COPY data /data"],
             ignore=FilePatternMatcher("**/*.txt"),

--- a/modal/image.py
+++ b/modal/image.py
@@ -984,15 +984,14 @@ class _Image(_Object, type_prefix="im"):
         ```
         """
 
-        secrets = secrets or []
-        if env:
-            secrets = [*secrets, _Secret.from_dict(env)]
-
         if not secrets:
             raise InvalidError(
                 "No secrets provided to function. "
                 "Installing private packages requires tokens to be passed via modal.Secret objects."
             )
+
+        if env:
+            secrets = [*secrets, _Secret.from_dict(env)]
 
         invalid_repos = []
         install_urls = []

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -817,7 +817,8 @@ class _Sandbox(_Object, type_prefix="sb"):
         stderr: StreamType = StreamType.PIPE,
         timeout: Optional[int] = None,
         workdir: Optional[str] = None,
-        secrets: Sequence[_Secret] = (),
+        env: Optional[dict[str, Optional[str]]] = None,
+        secrets: Optional[Collection[_Secret]] = None,
         text: bool = True,
         bufsize: Literal[-1, 1] = -1,
     ) -> Union[_ContainerProcess[bytes], _ContainerProcess[str]]:

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -279,6 +279,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         app: Optional["modal.app._App"] = None,
         name: Optional[str] = None,  # Optionally give the sandbox a name. Unique within an app.
         image: Optional[_Image] = None,  # The image to run as the container for the sandbox.
+        env: Optional[dict[str, Optional[str]]] = None,  # Environment variables to set in the Sandbox.
         secrets: Optional[Collection[_Secret]] = None,  # Secrets to inject into the Sandbox as environment variables.
         network_file_systems: dict[Union[str, os.PathLike], _NetworkFileSystem] = {},
         timeout: int = 300,  # Maximum lifetime of the sandbox in seconds.
@@ -320,7 +321,6 @@ class _Sandbox(_Object, type_prefix="sb"):
         ] = None,  # Experimental controls over fine-grained scheduling (alpha).
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,  # *DEPRECATED* Optionally override the default environment
-        env: Optional[dict[str, str]] = None,  # Environment variables to set in the Sandbox.
     ) -> "_Sandbox":
         """
         Create a new Sandbox to run untrusted, arbitrary code.
@@ -345,7 +345,7 @@ class _Sandbox(_Object, type_prefix="sb"):
 
         secrets = secrets or []
         if env:
-            secrets = [*secrets, _Secret.from_dict(dict(**env))]
+            secrets = [*secrets, _Secret.from_dict(env)]
 
         return await _Sandbox._create(
             *args,
@@ -384,6 +384,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         app: Optional["modal.app._App"] = None,
         name: Optional[str] = None,  # Optionally give the sandbox a name. Unique within an app.
         image: Optional[_Image] = None,  # The image to run as the container for the sandbox.
+        env: Optional[dict[str, Optional[str]]] = None,  # Environment variables to set in the Sandbox.
         secrets: Optional[Collection[_Secret]] = None,  # Secrets to inject into the Sandbox as environment variables.
         mounts: Sequence[_Mount] = (),
         network_file_systems: dict[Union[str, os.PathLike], _NetworkFileSystem] = {},
@@ -424,7 +425,6 @@ class _Sandbox(_Object, type_prefix="sb"):
         ] = None,  # Experimental controls over fine-grained scheduling (alpha).
         client: Optional[_Client] = None,
         verbose: bool = False,
-        env: Optional[dict[str, str]] = None,  # Environment variables to set in the Sandbox.
     ):
         # This method exposes some internal arguments (currently `mounts`) which are not in the public API
         # `mounts` is currently only used by modal shell (cli) to provide a function's mounts to the
@@ -440,7 +440,7 @@ class _Sandbox(_Object, type_prefix="sb"):
 
         secrets = secrets or []
         if env:
-            secrets = [*secrets, _Secret.from_dict(dict(**env))]
+            secrets = [*secrets, _Secret.from_dict(env)]
 
         # TODO(erikbern): Get rid of the `_new` method and create an already-hydrated object
         obj = _Sandbox._new(
@@ -718,11 +718,11 @@ class _Sandbox(_Object, type_prefix="sb"):
         stderr: StreamType = StreamType.PIPE,
         timeout: Optional[int] = None,
         workdir: Optional[str] = None,
+        env: Optional[dict[str, Optional[str]]] = None,
         secrets: Optional[Collection[_Secret]] = None,
         text: Literal[True] = True,
         bufsize: Literal[-1, 1] = -1,
         _pty_info: Optional[api_pb2.PTYInfo] = None,
-        env: Optional[dict[str, Union[str, None]]] = None,
     ) -> _ContainerProcess[str]: ...
 
     @overload
@@ -734,11 +734,11 @@ class _Sandbox(_Object, type_prefix="sb"):
         stderr: StreamType = StreamType.PIPE,
         timeout: Optional[int] = None,
         workdir: Optional[str] = None,
+        env: Optional[dict[str, Optional[str]]] = None,
         secrets: Optional[Collection[_Secret]] = None,
         text: Literal[False] = False,
         bufsize: Literal[-1, 1] = -1,
         _pty_info: Optional[api_pb2.PTYInfo] = None,
-        env: Optional[dict[str, Union[str, None]]] = None,
     ) -> _ContainerProcess[bytes]: ...
 
     async def exec(
@@ -749,6 +749,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         stderr: StreamType = StreamType.PIPE,
         timeout: Optional[int] = None,
         workdir: Optional[str] = None,
+        env: Optional[dict[str, Optional[str]]] = None,  # Environment variables to set during command execution.
         secrets: Optional[
             Collection[_Secret]
         ] = None,  # Secrets to inject as environment variables during command execution.
@@ -759,7 +760,6 @@ class _Sandbox(_Object, type_prefix="sb"):
         bufsize: Literal[-1, 1] = -1,
         # Internal option to set terminal size and metadata
         _pty_info: Optional[api_pb2.PTYInfo] = None,
-        env: Optional[dict[str, Union[str, None]]] = None,  # Environment variables to set during command execution.
     ):
         """Execute a command in the Sandbox and return a ContainerProcess handle.
 

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -133,7 +133,7 @@ class _Sandbox(_Object, type_prefix="sb"):
     def _new(
         args: Sequence[str],
         image: _Image,
-        secrets: Sequence[_Secret],
+        secrets: Collection[_Secret],
         name: Optional[str] = None,
         timeout: int = 300,
         idle_timeout: Optional[int] = None,
@@ -804,6 +804,7 @@ class _Sandbox(_Object, type_prefix="sb"):
             stderr=stderr,
             timeout=timeout,
             workdir=workdir,
+            env=env,
             secrets=secrets,
             text=text,
             bufsize=bufsize,

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -239,7 +239,7 @@ class _Secret(_Object, type_prefix="st"):
     @staticmethod
     def from_dict(
         env_dict: dict[
-            str, Union[str, None]
+            str, Optional[str]
         ] = {},  # dict of entries to be inserted as environment variables in functions using the secret
     ) -> "_Secret":
         """Create a secret from a str-str dictionary. Values can also be `None`, which is ignored.


### PR DESCRIPTION
## Describe your changes

Today you can pass environment variables via an ephemeral Secret using `secrets=[Secret.from_dict(dict(k="v"))]`, but it's not super discoverable, for a use case that is very common. This provides a simple convenience wrapper in the form of a separate `env` parameter.

Also changes the `secrets` params to `Collections` (because some already were, and we don't need them to be `Sequence`s), and removes the mutable default arguments.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

</details>

## Changelog

- Added `env` parameters to several methods, as a more discoverable convenience method for passing non-secret environment variables to containers.
