### PR TITLE
add wait_until_running() function [ART-5]

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -320,7 +320,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         ] = None,  # Experimental controls over fine-grained scheduling (alpha).
         client: Optional[_Client] = None,
         environment_name: Optional[str] = None,  # *DEPRECATED* Optionally override the default environment
-        wait_until_running: bool = False,  # Enable waiting for the sandbox to be assigned to a worker before returning
+        wait_until_running: bool = False,  # Wait for the sandbox to start running before returning
     ) -> "_Sandbox":
         """
         Create a new Sandbox to run untrusted, arbitrary code.
@@ -421,7 +421,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         ] = None,  # Experimental controls over fine-grained scheduling (alpha).
         client: Optional[_Client] = None,
         verbose: bool = False,
-        wait_until_running: bool = False,  # Whether to wait for the sandbox to be assigned to a worker before returning
+        wait_until_running: bool = False,  # Wait for the sandbox to start running before returning
     ):
         # This method exposes some internal arguments (currently `mounts`) which are not in the public API
         # `mounts` is currently only used by modal shell (cli) to provide a function's mounts to the
@@ -499,7 +499,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         await resolver.load(obj)
 
         if wait_until_running:
-            await obj.wait_until_running()
+            await obj._get_task_id()
 
         return obj
 
@@ -705,11 +705,6 @@ class _Sandbox(_Object, type_prefix="sb"):
             if not self._task_id:
                 await asyncio.sleep(0.5)
         return self._task_id
-
-    async def wait_until_running(self) -> None:
-        """Allows user to check if the sandbox has been assigned to a worker."""
-
-        await self._get_task_id()
 
     @overload
     async def exec(


### PR DESCRIPTION
 to let user check if sandbox has been scheduled to a worker

**UPDATED: replacing `wait_for_scheduled` name with `wait_until_running`**
## Describe your changes

This PR provides a user facing API to check if their sandbox has been assigned onto a worker (Linear Issue ART-5 in agent runtime).
It exposes a `wait_until_running()` function that can be utilized to check if the sandbox has been assigned to a worker, raising an error if no worker is assigned and returning None if a worker gets assigned.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---
</details>

## Changelog

- Add a `wait_until_running()` function to Sandbox class that wraps the `_get_task_id()` function for a discoverable method to check if your sandbox has been assigned to a worker.

```python
import modal
import time
app = modal.App.lookup("my-app", create_if_missing=True)

sb = modal.Sandbox.create(app=app)
s=time.time()
sb.wait_until_running()
e=time.time()
print(f"Sandbox assigned in {e-s:.2f} seconds"
```
