### PR TITLE
Use map token in client (instead of function call id)

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2409,12 +2409,12 @@ class MockClientServicer(api_grpc.ModalClientBase):
         # If map_token is provided, this is a continue request, otherwise it's a start
         if request.map_token:
             map_token = request.map_token
-            function_call_id = request.map_token[3:]
+            function_call_id = request.map_token.split(":")[1]
         else:
             self.fcidx += 1
             function_call_id = f"fc-{self.fcidx}"
             self.function_id_for_function_call[function_call_id] = request.function_id
-            map_token = f"mt-{function_call_id}"
+            map_token = f"test-map-token:{function_call_id}"
 
         # Process inputs and store them for MapAwait to pick up later
         attempt_tokens = []
@@ -2448,7 +2448,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def MapAwait(self, stream):
         request: api_pb2.MapAwaitRequest = await stream.recv_message()
-        function_call_id = request.map_token[3:]
+        function_call_id = request.map_token.split(":")[1]
 
         # Check if we have any function call inputs for this function call
         fc_inputs = self.function_call_inputs.setdefault(function_call_id, [])

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2409,12 +2409,10 @@ class MockClientServicer(api_grpc.ModalClientBase):
         # If map_token is provided, this is a continue request, otherwise it's a start
         if request.map_token:
             map_token = request.map_token
-            function_call_id = request.map_token.split(":")[1]
         else:
             self.fcidx += 1
-            function_call_id = f"fc-{self.fcidx}"
-            self.function_id_for_function_call[function_call_id] = request.function_id
-            map_token = f"test-map-token:{function_call_id}"
+            map_token = f"test-map-token:{self.fcidx}"
+            self.function_id_for_function_call[map_token] = request.function_id
 
         # Process inputs and store them for MapAwait to pick up later
         attempt_tokens = []
@@ -2426,15 +2424,15 @@ class MockClientServicer(api_grpc.ModalClientBase):
             # Store inputs for MapAwait to process
             input_id = f"in-{self.n_inputs}"
             self.n_inputs += 1
-            self.add_function_call_input(function_call_id, item.input, input_id, retry_count)
+            self.add_function_call_input(map_token, item.input, input_id, retry_count)
 
         # Get retry policy from function definition if available
         fn_definition = self.app_functions.get(request.function_id)
         retry_policy = fn_definition.retry_policy if fn_definition else None
 
+        # We don't send fcID since that is what the server will do eventually.
         response = api_pb2.MapStartOrContinueResponse(
             function_id=request.function_id,
-            function_call_id=function_call_id,
             map_token=map_token,
             max_inputs_outstanding=1000,
             attempt_tokens=attempt_tokens,
@@ -2448,10 +2446,10 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def MapAwait(self, stream):
         request: api_pb2.MapAwaitRequest = await stream.recv_message()
-        function_call_id = request.map_token.split(":")[1]
+        map_token = request.map_token
 
         # Check if we have any function call inputs for this function call
-        fc_inputs = self.function_call_inputs.setdefault(function_call_id, [])
+        fc_inputs = self.function_call_inputs.setdefault(map_token, [])
         outputs = []
 
         if fc_inputs and not self.function_is_running:
@@ -2468,7 +2466,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
                     count = 0
                     for item in res:
                         count += 1
-                        await self.fc_data_out[function_call_id].put(
+                        await self.fc_data_out[map_token].put(
                             api_pb2.DataChunk(
                                 data_format=api_pb2.DATA_FORMAT_PICKLE,
                                 data=serialize_data_format(item, api_pb2.DATA_FORMAT_PICKLE),


### PR DESCRIPTION
## Describe your changes

- SVC-840

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces function_call_id with map_token across input-plane map flows, updating RPC fields, state tracking, and tests.
> 
> - **Input-plane map client (`modal/parallel_map.py`)**:
>   - Replace `function_call_id` with `map_token` for `MapStartOrContinue` and `MapAwait` requests and internal state/events.
>   - Initialize and wait on `map_token` (`map_token_received`) from first response; propagate to subsequent requests.
>   - Update logging and counters to report `map_token`; keep retry policy/max concurrency handling unchanged.
> - **Test servicer (`test/conftest.py`)**:
>   - Update `MapStartOrContinue`/`MapAwait` to use `map_token` as the session identifier; responses now return `map_token` instead of `function_call_id`.
>   - Store inputs and data streams keyed by `map_token`; adjust attempt token parsing and queues.
>   - Minor associated renames and mappings (`function_id_for_function_call` now keyed by `map_token`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91dad3ff484f5d59cf5e25fb85199b4b7dab156a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->