### PR TITLE
Add a private method _exec to use with `modal {shell,run}`

### DIFF
--- a/modal/runner.py
+++ b/modal/runner.py
@@ -607,12 +607,12 @@ async def _interactive_shell(
 
         try:
             if pty:
-                container_process = await sandbox.exec(
+                container_process = await sandbox._exec(
                     *sandbox_cmds, pty_info=get_pty_info(shell=True) if pty else None
                 )
                 await container_process.attach()
             else:
-                container_process = await sandbox.exec(
+                container_process = await sandbox._exec(
                     *sandbox_cmds, stdout=StreamType.STDOUT, stderr=StreamType.STDOUT
                 )
                 await container_process.wait()

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2375,6 +2375,7 @@ message PTYInfo {
     PTY_TYPE_SHELL = 2;  // Replace function with shell
   }
   PTYType pty_type = 7;
+  bool no_terminate_on_idle_stdin = 8;
 }
 
 message PortSpec {


### PR DESCRIPTION
## Describe your changes

This PR:

- Switches `modal shell` and `modal run -i` to use `_exec`, so it can pass in ` pty_info`.
- Requires proto changes https://github.com/modal-labs/modal-client/pull/3555
- This does not change the public API yet, we'll need https://github.com/modal-labs/modal-client/pull/3550 to update the public API.
- See https://github.com/modal-labs/modal/pull/27056 for details

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>