### PR TITLE
Ensure test file is closed

### DIFF
--- a/test/blob_test.py
+++ b/test/blob_test.py
@@ -64,7 +64,8 @@ async def test_blob_multipart(servicer, blob_server, client, monkeypatch, tmp_pa
     data = random.randbytes(data_len)  # random data will not hide byte re-ordering corruption
     data_filepath = tmp_path / "temp.bin"
     data_filepath.write_bytes(data)
-    blob_id = await blob_upload_file.aio(data_filepath.open("rb"), client.stub)
+    with data_filepath.open("rb") as f:
+        blob_id = await blob_upload_file.aio(f, client.stub)
     assert await blob_download.aio(blob_id, client.stub) == data
 
 


### PR DESCRIPTION
## Describe your changes

Fixes warning in CI:

```
Unexpected warnings: ['{message : ResourceWarning("unclosed file <_io.BufferedReader
  name=\'/tmp/pytest-of-runner/pytest-0/test_blob_multipart0/temp.bin\'>"), category : \'ResourceWarning\', filename :
  \'/opt/hostedtoolcache/Python/3.13.7/x64/lib/python3.13/asyncio/base_events.py\', lineno : 823, line : None}']
```

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


</details>
