### PR TITLE
Add AutoscalerConfiguration proto

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -628,23 +628,6 @@ message AuthTokenGetResponse {
   string token = 1;
 }
 
-message AutoscalerSettings {
-  // A collection of user-configurable settings for Function autoscaling
-  // These are used for static configuration and for dynamic autoscaler updates
-
-  // Minimum containers when scale-to-zero is not desired; pka "keep_warm" or "warm_pool_size"
-  optional uint32 min_containers = 1;
-  // Limit on the number of containers that can be running for each Function; pka "concurrency_limit"
-  optional uint32 max_containers = 2;
-  // Additional container to spin up when Function is active
-  optional uint32 buffer_containers = 3;
-  // Currently unused; a placeholder in case we decide to expose scaleup control to users
-  optional uint32 scaleup_window = 4;
-  // Maximum amount of time a container can be idle before being scaled down, in seconds; pka "container_idle_timeout"
-  optional uint32 scaledown_window = 5;
-  reserved 6;
-}
-
 // Message representing the current (coalesced) state of the autoscaler configuration
 // As well as the different sources that were used to create it.
 message AutoscalerConfiguration {
@@ -664,6 +647,23 @@ message AutoscalerConfiguration {
   modal.client.AutoscalerSettings static_settings = 4;
   // The merge of all overrides that were used to create the current configuration.
   modal.client.AutoscalerSettings override_settings = 5;
+}
+
+message AutoscalerSettings {
+  // A collection of user-configurable settings for Function autoscaling
+  // These are used for static configuration and for dynamic autoscaler updates
+
+  // Minimum containers when scale-to-zero is not desired; pka "keep_warm" or "warm_pool_size"
+  optional uint32 min_containers = 1;
+  // Limit on the number of containers that can be running for each Function; pka "concurrency_limit"
+  optional uint32 max_containers = 2;
+  // Additional container to spin up when Function is active
+  optional uint32 buffer_containers = 3;
+  // Currently unused; a placeholder in case we decide to expose scaleup control to users
+  optional uint32 scaleup_window = 4;
+  // Maximum amount of time a container can be idle before being scaled down, in seconds; pka "container_idle_timeout"
+  optional uint32 scaledown_window = 5;
+  reserved 6;
 }
 
 // Used for flash autoscaling

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -632,7 +632,7 @@ message AutoscalerSettings {
   // A collection of user-configurable settings for Function autoscaling
   // These are used for static configuration and for dynamic autoscaler updates
 
-  // Minimum containers when scale-to-zero is not deisired; pka "keep_warm" or "warm_pool_size"
+  // Minimum containers when scale-to-zero is not desired; pka "keep_warm" or "warm_pool_size"
   optional uint32 min_containers = 1;
   // Limit on the number of containers that can be running for each Function; pka "concurrency_limit"
   optional uint32 max_containers = 2;
@@ -643,6 +643,27 @@ message AutoscalerSettings {
   // Maximum amount of time a container can be idle before being scaled down, in seconds; pka "container_idle_timeout"
   optional uint32 scaledown_window = 5;
   reserved 6;
+}
+
+// Message representing the current (coalesced) state of the autoscaler configuration
+// As well as the different sources that were used to create it.
+message AutoscalerConfiguration {
+  // Used for capturing context about an action performed by a user
+  message UserActionInfo {
+    string user_id = 1;
+    double timestamp = 2;
+  }
+
+  // The settings that are currently in effect.
+  modal.client.AutoscalerSettings settings = 1;
+  // For tracking the source of the overridden value; keys correspond to fields in `settings`.
+  map<string, UserActionInfo> override_events = 2;
+  // The default settings that are used when no static settings are provided and no overrides are in effect.
+  modal.client.AutoscalerSettings default_settings = 3;
+  // The static settings that were used to initialize the configuration.
+  modal.client.AutoscalerSettings static_settings = 4;
+  // The merge of all overrides that were used to create the current configuration.
+  modal.client.AutoscalerSettings override_settings = 5;
 }
 
 // Used for flash autoscaling

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -631,22 +631,16 @@ message AuthTokenGetResponse {
 // Message representing the current (coalesced) state of the autoscaler configuration
 // As well as the different sources that were used to create it.
 message AutoscalerConfiguration {
-  // Used for capturing context about an action performed by a user
-  message UserActionInfo {
-    string user_id = 1;
-    double timestamp = 2;
-  }
-
   // The settings that are currently in effect.
-  modal.client.AutoscalerSettings settings = 1;
+  AutoscalerSettings settings = 1;
   // For tracking the source of the overridden value; keys correspond to fields in `settings`.
   map<string, UserActionInfo> override_events = 2;
   // The default settings that are used when no static settings are provided and no overrides are in effect.
-  modal.client.AutoscalerSettings default_settings = 3;
+  AutoscalerSettings default_settings = 3;
   // The static settings that were used to initialize the configuration.
-  modal.client.AutoscalerSettings static_settings = 4;
+  AutoscalerSettings static_settings = 4;
   // The merge of all overrides that were used to create the current configuration.
-  modal.client.AutoscalerSettings override_settings = 5;
+  AutoscalerSettings override_settings = 5;
 }
 
 message AutoscalerSettings {
@@ -3220,6 +3214,12 @@ message TunnelStopResponse {
 
 message UploadUrlList {
   repeated string items = 1;
+}
+
+// Used for capturing context about an action performed by a user
+message UserActionInfo {
+  string user_id = 1;
+  double timestamp = 2;
 }
 
 message VolumeCommitRequest {


### PR DESCRIPTION
## Describe your changes

- PRD-751 Allow autoscaler overrides from the web app

Introduces a new `AutoscalerConfiguration` message that represents the coalesced state of autoscaler settings. This includes tracking current settings, defaults, static initialization values, overrides, and metadata (UserActionInfo) about who applied overrides and when.

This is not used by the client currently, but added here in anticipation of future use, and to centralize autoscaler related protos.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


</details>
