### PR TITLE
Adds cloud bucket mounts to with_options

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1199,8 +1199,10 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                 options_pb = api_pb2.FunctionOptions(
                     secret_ids=[s.object_id for s in options.secrets],
                     replace_secret_ids=bool(options.secrets),
-                    replace_volume_mounts=len(volume_mounts) > 0,
                     volume_mounts=volume_mounts,
+                    replace_volume_mounts=len(volume_mounts) > 0,
+                    cloud_bucket_mounts=cloud_bucket_mounts_to_proto(options.cloud_bucket_mounts),
+                    replace_cloud_bucket_mounts=bool(options.cloud_bucket_mounts),
                     resources=options.resources,
                     retry_policy=options.retry_policy,
                     concurrency_limit=options.max_containers,

--- a/modal/cloud_bucket_mount.py
+++ b/modal/cloud_bucket_mount.py
@@ -1,6 +1,6 @@
 # Copyright Modal Labs 2022
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Sequence
 from urllib.parse import urlparse
 
 from modal_proto import api_pb2
@@ -118,8 +118,13 @@ class _CloudBucketMount:
     read_only: bool = False
     requester_pays: bool = False
 
+    @property
+    def is_hydrated(self):
+        # Cloud bucket mounts do not have a server side representation.
+        return True
 
-def cloud_bucket_mounts_to_proto(mounts: list[tuple[str, _CloudBucketMount]]) -> list[api_pb2.CloudBucketMount]:
+
+def cloud_bucket_mounts_to_proto(mounts: Sequence[tuple[str, _CloudBucketMount]]) -> list[api_pb2.CloudBucketMount]:
     """Helper function to convert `CloudBucketMount` to a list of protobufs that can be passed to the server."""
     cloud_bucket_mounts: list[api_pb2.CloudBucketMount] = []
 

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -1,9 +1,9 @@
 # Copyright Modal Labs 2022
 import dataclasses
 import inspect
-import os
 import typing
 from collections.abc import Collection
+from pathlib import PurePosixPath
 from typing import Any, Callable, Optional, Sequence, TypeVar, Union
 
 from google.protobuf.message import Message
@@ -33,6 +33,7 @@ from ._utils.deprecation import (
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.mount_utils import validate_volumes
 from .client import _Client
+from .cloud_bucket_mount import _CloudBucketMount
 from .config import config
 from .exception import ExecutionError, InvalidError, NotFoundError
 from .gpu import GPU_T
@@ -95,6 +96,7 @@ class _ServiceOptions:
     batch_wait_ms: Optional[int] = None
     scheduler_placement: Optional[api_pb2.SchedulerPlacement] = None
     cloud: Optional[str] = None
+    cloud_bucket_mounts: typing.Sequence[tuple[str, _CloudBucketMount]] = ()
 
     def merge_options(self, new_options: "_ServiceOptions") -> "_ServiceOptions":
         """Implement protobuf-like MergeFrom semantics for this dataclass.
@@ -688,7 +690,7 @@ More information on class parameterization can be found here: https://modal.com/
         gpu: GPU_T = None,
         env: Optional[dict[str, Optional[str]]] = None,
         secrets: Optional[Collection[_Secret]] = None,
-        volumes: dict[Union[str, os.PathLike], _Volume] = {},
+        volumes: dict[Union[str, PurePosixPath], Union[_Volume, _CloudBucketMount]] = {},
         retries: Optional[Union[int, Retries]] = None,
         max_containers: Optional[int] = None,  # Limit on the number of containers that can be concurrently running.
         buffer_containers: Optional[int] = None,  # Additional containers to scale up while Function is active.
@@ -762,13 +764,22 @@ More information on class parameterization can be found here: https://modal.com/
         cls = _Cls._from_loader(_load_from_base, rep=f"{self._name}.with_options(...)", is_another_app=True, deps=_deps)
         cls._initialize_from_other(self)
 
+        # Validate volumes
+        validated_volumes = validate_volumes(volumes)
+        cloud_bucket_mounts = [(k, v) for k, v in validated_volumes if isinstance(v, _CloudBucketMount)]
+        validated_volumes_no_cloud_buckets = [(k, v) for k, v in validated_volumes if isinstance(v, _Volume)]
+
         secrets = secrets or []
         if env:
             secrets = [*secrets, _Secret.from_dict(env)]
 
+        if cloud_bucket_mounts:
+            secrets = [*secrets, *[mount.secret for _, mount in cloud_bucket_mounts if mount.secret]]
+
         new_options = _ServiceOptions(
             secrets=secrets,
-            validated_volumes=validate_volumes(volumes),
+            validated_volumes=validated_volumes_no_cloud_buckets,
+            cloud_bucket_mounts=cloud_bucket_mounts,
             resources=resources,
             retry_policy=retry_policy,
             max_containers=max_containers,

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1864,6 +1864,8 @@ message FunctionOptions {
   optional uint64 batch_linger_ms = 16;
   optional SchedulerPlacement scheduler_placement = 17;
   optional string cloud_provider_str = 18;
+  bool replace_cloud_bucket_mounts = 19;
+  repeated CloudBucketMount cloud_bucket_mounts = 20;
 }
 
 message FunctionPrecreateRequest {

--- a/test/cls_test.py
+++ b/test/cls_test.py
@@ -155,11 +155,15 @@ def test_call_class_sync(client, servicer, set_env_client):
 def test_class_with_options(client, servicer):
     unhydrated_volume = modal.Volume.from_name("some_volume", create_if_missing=True)
     unhydrated_secret = modal.Secret.from_dict({"foo": "bar"})
+    unhydrated_aws_secret = modal.Secret.from_dict(
+        {"AWS_ACCESS_KEY_ID": "my-key", "AWS_SECRET_ACCESS_KEY": "my-secret"}
+    )
+    cloud_bucket_mount = modal.CloudBucketMount(bucket_name="s3-bucket-name", secret=unhydrated_aws_secret)
     with servicer.intercept() as ctx:
         foo = Foo.with_options(  # type: ignore
             cpu=48,
             retries=5,
-            volumes={"/vol": unhydrated_volume},
+            volumes={"/vol": unhydrated_volume, "/cloud_mnt": cloud_bucket_mount},
             secrets=[unhydrated_secret],
             region="us-east-1",
             cloud="aws",
@@ -175,9 +179,14 @@ def test_class_with_options(client, servicer):
             assert function_bind_params.function_options.resources.milli_cpu == 48000
             assert function_bind_params.function_options.scheduler_placement.regions == ["us-east-1"]
             assert function_bind_params.function_options.cloud_provider_str == "aws"
+            assert function_bind_params.function_options.replace_cloud_bucket_mounts
+            cloud_bucket_mounts = function_bind_params.function_options.cloud_bucket_mounts
+            assert len(cloud_bucket_mounts) == 1
+            assert cloud_bucket_mounts[0].mount_path == "/cloud_mnt"
+            assert cloud_bucket_mounts[0].bucket_name == "s3-bucket-name"
 
             assert len(ctx.get_requests("VolumeGetOrCreate")) == 1
-            assert len(ctx.get_requests("SecretGetOrCreate")) == 1
+            assert len(ctx.get_requests("SecretGetOrCreate")) == 2
 
         with servicer.intercept() as ctx:
             res = foo.bar.remote(2)


### PR DESCRIPTION
## Describe your changes

- Adds cloud bucket mounts to `with_options`.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->

- `Cls.with_options` supports `CloudBucketMount` in `volumes`.

```python
cloud_bucket = modal.CloudBucketMount("my-bucket", secret=aws_secret)
MyClsCloud = modal.Cls.from_name("my-app", "MyCls").with_options(
        volumes={"/mnt": cloud_bucket}
)
```