### PR TITLE
Remove @build compatibility code

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -437,9 +437,9 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
                         param_kwargs,
                     )
                 else:
+                    assert ser_usr_cls is None
                     service = import_single_function_service(
                         function_def,
-                        ser_usr_cls,
                         ser_fun,
                     )
 

--- a/modal/_runtime/user_code_imports.py
+++ b/modal/_runtime/user_code_imports.py
@@ -93,9 +93,9 @@ def construct_webhook_callable(
 
 @dataclass
 class ImportedFunction(Service):
-    user_cls_instance: Any
     app: modal.app._App
     service_deps: Optional[Sequence["modal._object._Object"]]
+    user_cls_instance = None
 
     _user_defined_callable: Callable[..., Any]
 
@@ -199,7 +199,6 @@ def get_user_class_instance(_cls: modal.cls._Cls, args: tuple[Any, ...], kwargs:
 
 def import_single_function_service(
     function_def: api_pb2.Function,
-    ser_cls: Optional[type],  # used only for @build functions
     ser_fun: Optional[Callable[..., Any]],
 ) -> Service:
     """Imports a function dynamically, and locates the app.
@@ -228,12 +227,9 @@ def import_single_function_service(
     service_deps: Optional[Sequence["modal._object._Object"]] = None
     active_app: modal.app._App
 
-    user_cls_or_cls: typing.Union[None, type, modal.cls.Cls]
-    user_cls_instance = None
-
     if ser_fun is not None:
         # This is a serialized function we already fetched from the server
-        user_cls_or_cls, user_defined_callable = ser_cls, ser_fun
+        user_defined_callable = ser_fun
         active_app = get_active_app_fallback(function_def)
     else:
         # Load the module dynamically
@@ -244,58 +240,22 @@ def import_single_function_service(
             raise LocalFunctionError("Attempted to load a function defined in a function scope")
 
         parts = qual_name.split(".")
-        if len(parts) == 1:
-            # This is a function
-            user_cls_or_cls = None
-            f = getattr(module, qual_name)
-            if isinstance(f, Function):
-                _function: modal._functions._Function[Any, Any, Any] = synchronizer._translate_in(f)  # type: ignore
-                service_deps = _function.deps(only_explicit_mounts=True)
-                user_defined_callable = _function.get_raw_f()
-                assert _function._app  # app should always be set on a decorated function
-                active_app = _function._app
-            else:
-                user_defined_callable = f
-                active_app = get_active_app_fallback(function_def)
-
-        elif len(parts) == 2:
-            # This path should only be triggered by @build class builder methods and can be removed
-            # once @build is deprecated.
-            assert not function_def.use_method_name  # new "placeholder methods" should not be invoked directly!
-            assert function_def.is_builder_function
-            cls_name, fun_name = parts
-            user_cls_or_cls = getattr(module, cls_name)
-            if isinstance(user_cls_or_cls, modal.cls.Cls):
-                # The cls decorator is in global scope
-                _cls = typing.cast(modal.cls._Cls, synchronizer._translate_in(user_cls_or_cls))
-                user_defined_callable = _cls._callables[fun_name]
-                # Intentionally not including these, since @build functions don't actually
-                # forward the information from their parent class.
-                # service_deps = _cls._get_class_service_function().deps(only_explicit_mounts=True)
-                assert _cls._app
-                active_app = _cls._app
-            else:
-                # This is non-decorated class
-                user_defined_callable = getattr(user_cls_or_cls, fun_name)  # unbound method
-                active_app = get_active_app_fallback(function_def)
-        else:
+        if len(parts) != 1:
             raise InvalidError(f"Invalid function qualname {qual_name}")
 
-    # Instantiate the class if it's defined
-    if user_cls_or_cls:
-        if isinstance(user_cls_or_cls, modal.cls.Cls):
-            # This code is only used for @build methods on classes
-            _cls = typing.cast(modal.cls._Cls, user_cls_or_cls)
-            user_cls_instance = get_user_class_instance(_cls, (), {})
-            # Bind the unbound method to the instance as self (using the descriptor protocol!)
+        f = getattr(module, qual_name)
+        if isinstance(f, Function):
+            _function: modal._functions._Function[Any, Any, Any] = synchronizer._translate_in(f)  # type: ignore
+            service_deps = _function.deps(only_explicit_mounts=True)
+            user_defined_callable = _function.get_raw_f()
+            assert _function._app  # app should always be set on a decorated function
+            active_app = _function._app
         else:
-            # serialized=True or "undecorated"
-            user_cls_instance = user_cls_or_cls()
-
-        user_defined_callable = user_defined_callable.__get__(user_cls_instance)
+            # function isn't decorated in global scope
+            user_defined_callable = f
+            active_app = get_active_app_fallback(function_def)
 
     return ImportedFunction(
-        user_cls_instance,
         active_app,
         service_deps,
         user_defined_callable,

--- a/test/user_code_import_test.py
+++ b/test/user_code_import_test.py
@@ -13,7 +13,6 @@ def test_import_function(supports_dir, monkeypatch):
     service = user_code_imports.import_single_function_service(
         fun,
         None,
-        None,
     )
     assert len(service.service_deps) == 1
     assert type(service.service_deps[0]) is _Image
@@ -44,7 +43,6 @@ def test_import_function_undecorated(monkeypatch, supports_on_path):
     )
     service = user_code_imports.import_single_function_service(
         fun,
-        None,
         None,
     )
     assert service.service_deps is None  # undecorated - can't get code deps


### PR DESCRIPTION
This code was only used for importing @build methods on classes, which we have deprecated.
Nice to remove a bunch of dead code.

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
