### PR TITLE
Fix input plane attempt retry handling.

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -495,7 +495,7 @@ class _InputPlaneInvocation:
                     # We immediately retry internal failures and the failure doesn't count towards the retry policy.
                     self.attempt_token = await self._retry_input(metadata)
                     continue
-            elif delay_ms := user_retry_manager.get_delay_ms():
+            elif (delay_ms := user_retry_manager.get_delay_ms()) is not None:
                 # We still have user retries left, so sleep and retry.
                 await asyncio.sleep(delay_ms / 1000)
                 self.attempt_token = await self._retry_input(metadata)

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -477,34 +477,34 @@ class _InputPlaneInvocation:
                 metadata=metadata,
             )
 
-            if await_response.HasField("output"):
-                if await_response.output.result.status in TERMINAL_STATUSES:
-                    return await _process_result(
-                        await_response.output.result, await_response.output.data_format, self.client.stub, self.client
-                    )
+            # Keep awaiting until we get an output.
+            if not await_response.HasField("output"):
+                continue
 
-                if await_response.output.result.status == api_pb2.GenericResult.GENERIC_STATUS_INTERNAL_FAILURE:
-                    internal_failure_count += 1
-                    # Limit the number of times we retry
-                    if internal_failure_count < MAX_INTERNAL_FAILURE_COUNT:
-                        # For system failures on the server, we retry immediately,
-                        # and the failure does not count towards the retry policy.
-                        self.attempt_token = await self._retry_input(metadata)
-                        continue
+            # If we have a final output, return.
+            if await_response.output.result.status in TERMINAL_STATUSES:
+                return await _process_result(
+                    await_response.output.result, await_response.output.data_format, self.client.stub, self.client
+                )
 
-                # We add delays between retries for non-internal failures.
-                delay_ms = user_retry_manager.get_delay_ms()
-                if delay_ms is None:
-                    # No more retries either because we reached the retry limit or user didn't set a retry policy
-                    # and the limit defaulted to 0.
-                    # An unsuccessful status should raise an error when it's converted to an exception.
-                    # Note: Blob download is done on the control plane stub not the input plane stub!
-                    return await _process_result(
-                        await_response.output.result, await_response.output.data_format, self.client.stub, self.client
-                    )
+            # We have a failure (internal or application), so see if there are any retries left, and if so, retry.
+            if await_response.output.result.status == api_pb2.GenericResult.GENERIC_STATUS_INTERNAL_FAILURE:
+                internal_failure_count += 1
+                # Limit the number of times we retry internal failures.
+                if internal_failure_count < MAX_INTERNAL_FAILURE_COUNT:
+                    # We immediately retry internal failures and the failure doesn't count towards the retry policy.
+                    self.attempt_token = await self._retry_input(metadata)
+                    continue
+            elif delay_ms := user_retry_manager.get_delay_ms():
+                # We still have user retries left, so sleep and retry.
                 await asyncio.sleep(delay_ms / 1000)
+                self.attempt_token = await self._retry_input(metadata)
+                continue
 
-            await self._retry_input(metadata)
+            # No more retries left.
+            return await _process_result(
+                await_response.output.result, await_response.output.data_format, self.client.stub, self.client
+            )
 
     async def _retry_input(self, metadata: list[tuple[str, str]]) -> str:
         retry_request = api_pb2.AttemptRetryRequest(

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -513,7 +513,6 @@ class _InputPlaneInvocation:
             input=self.input_item,
             attempt_token=self.attempt_token,
         )
-        # TODO(ryan): Add exponential backoff?
         retry_response = await retry_transient_errors(
             self.stub.AttemptRetry,
             retry_request,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -316,12 +316,18 @@ class MockClientServicer(api_grpc.ModalClientBase):
         self.function_get_server_warnings = None
         self.resp_jitter_secs: float = 0.0
         self.port = port
-        # AttemptAwait will return a failure until this is 0. It is decremented by 1 each time AttemptAwait is called.
-        self.attempt_await_failures_remaining = 0
+        # Set a list of custom, fixed responses for the AttemptAwait RPC.
+        # This mock server will return responses in order. The regular behavior will resume once this list is exhausted.
+        self.attempt_await_responses: list[api_pb2.AttemptAwaitResponse] = []
         # Value returned by AuthTokenGet
         self.auth_token = jwt.encode({"exp": int(time.time()) + 3600}, "my-secret-key", algorithm="HS256")
         self.auth_tokens_generated = 0
         self.function_id_to_definition_id: dict[str, str] = {}
+        # Number of times AttemptAwait was called.
+        self.attempt_await_count = 0
+        # Number of times the user's function was called.
+        self.function_call_count = 0
+        self.function_call_result: Any = None
 
         @self.function_body
         def default_function_body(*args, **kwargs):
@@ -2319,28 +2325,29 @@ class MockClientServicer(api_grpc.ModalClientBase):
         )
 
     async def AttemptAwait(self, stream):
+        self.attempt_await_count += 1
         # TODO(dxia): implement attempt token logic
 
-        # To test client retries for internal failures, tests can configure outputs to fail some number of times.
+        if len(self.attempt_await_responses) > 0:
+            await stream.send_message(self.attempt_await_responses.pop(0))
+            return
+
         status = api_pb2.GenericResult.GENERIC_STATUS_SUCCESS
-        if self.attempt_await_failures_remaining > 0:
-            status = api_pb2.GenericResult.GENERIC_STATUS_INTERNAL_FAILURE
-            self.attempt_await_failures_remaining = self.attempt_await_failures_remaining - 1
 
         if self.function_call_inputs:
             function_call_id = f"fc-{self.fcidx}"
             (idx, input_id, retry_count), (args, kwargs) = self.function_call_inputs.pop(function_call_id)[0]
             self.fcidx -= 1
             try:
-                res = self._function_body(*args, **kwargs)
+                self.function_call_count += 1
+                self.function_call_result = self._function_body(*args, **kwargs)
             except Exception as e:
-                res = e
+                self.function_call_result = e
                 status = api_pb2.GenericResult.GENERIC_STATUS_FAILURE
         else:
             input_id = "in-1"
             idx = 0
             retry_count = 0
-            res = "attempt_await_bogus_response"
 
         await stream.send_message(
             api_pb2.AttemptAwaitResponse(
@@ -2349,7 +2356,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
                     idx=idx,
                     result=api_pb2.GenericResult(
                         status=status,
-                        data=serialize_data_format(res, api_pb2.DATA_FORMAT_PICKLE),
+                        data=serialize_data_format(self.function_call_result, api_pb2.DATA_FORMAT_PICKLE),
                     ),
                     data_format=api_pb2.DATA_FORMAT_PICKLE,
                     retry_count=retry_count,

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -6,20 +6,30 @@ import os
 import pytest
 import time
 import typing
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 
 from grpclib import Status
 from synchronicity.exceptions import UserCodeException
 
 import modal
 from modal import App, Image, NetworkFileSystem, Proxy, asgi_app, batched, fastapi_endpoint
+from modal._functions import MAX_INTERNAL_FAILURE_COUNT
 from modal._utils.async_utils import synchronize_api
 from modal._vendor import cloudpickle
-from modal.exception import DeprecationError, ExecutionError, InvalidError, NotFoundError
+from modal.client import Client
+from modal.exception import (
+    DeprecationError,
+    ExecutionError,
+    FunctionTimeoutError,
+    InternalFailure,
+    InvalidError,
+    NotFoundError,
+    RemoteError,
+)
 from modal.functions import Function, FunctionCall
 from modal.runner import deploy_app
 from modal_proto import api_pb2
-from test.conftest import GrpcErrorAndCount
+from test.conftest import GrpcErrorAndCount, MockClientServicer
 from test.helpers import deploy_app_externally
 
 app = App()
@@ -45,11 +55,202 @@ def dummy():
     pass  # not actually used in test (servicer returns sum of square of all args)
 
 
+@app.function(experimental_options={"input_plane_region": "us-east"})
+def input_plane_func():
+    return "DEADBEEF"
+
+
+@app.function(experimental_options={"input_plane_region": "us-east"}, retries=modal.Retries(max_retries=1))
+def input_plane_failing_func_with_retry():
+    raise ValueError()
+
+
+@app.function(
+    experimental_options={"input_plane_region": "us-east"},
+    retries=modal.Retries(max_retries=1, initial_delay=0, backoff_coefficient=1.0),
+)
+def input_plane_func_with_immediate_retry():
+    raise ValueError()
+
+
+# Set the timeout and sleep to more than the outputs_timeout_override of the
+# "long running" test_remote_input_plane() test case.
+@app.function(timeout=2, experimental_options={"input_plane_region": "us-east"})
+def input_plane_func_long_running():
+    time.sleep(2)
+    return "DEADBEEF"
+
+
 def test_run_function(client, servicer):
     assert len(servicer.cleared_function_calls) == 0
     with app.run(client=client):
         assert foo.remote(2, 4) == 20
         assert len(servicer.cleared_function_calls) == 1
+
+
+def _attempt_await_response(status: "api_pb2.GenericResult.GenericStatus.ValueType"):
+    """Helper function to create an AttemptAwaitResponse with a given GenericResult status."""
+    return api_pb2.AttemptAwaitResponse(
+        output=api_pb2.FunctionGetOutputsItem(result=api_pb2.GenericResult(status=status))
+    )
+
+
+@pytest.mark.parametrize(
+    "func, attempt_await_responses, outputs_timeout_override, expectation, attempt_await_count, function_call_count",
+    [
+        # If the function runs successfully the first time, the client should call the
+        # AttemptAwait RPC once and the user's function should be called once.
+        pytest.param(input_plane_func, [], None, nullcontext("DEADBEEF"), 1, 1, id="success"),
+        # The client should call the AttemptAwait RPC until it receives an AttemptAwaitResponse
+        # with an output attribute and then return a successful AttemptAwaitResponse.
+        pytest.param(
+            input_plane_func,
+            [api_pb2.AttemptAwaitResponse()] * 2,
+            None,
+            nullcontext("DEADBEEF"),
+            3,
+            1,
+            id="no output",
+        ),
+        # The client should raise a RemoteError if the AttemptAwaitResponse has a GENERIC_STATUS_TERMINATED status.
+        pytest.param(
+            input_plane_func,
+            [_attempt_await_response(api_pb2.GenericResult.GENERIC_STATUS_TERMINATED)],
+            None,
+            pytest.raises(RemoteError),
+            1,
+            0,
+            id="terminated",
+        ),
+        # The client should retry up to a MAX_INTERNAL_FAILURE_COUNT number of times when it receives an
+        # internal failure status.
+        pytest.param(
+            input_plane_func,
+            [_attempt_await_response(api_pb2.GenericResult.GENERIC_STATUS_INTERNAL_FAILURE)]
+            * (MAX_INTERNAL_FAILURE_COUNT - 1),
+            None,
+            nullcontext("DEADBEEF"),
+            MAX_INTERNAL_FAILURE_COUNT,
+            1,
+            id="internal failure",
+        ),
+        # The client should raise an InternalFailure if it receives more than MAX_INTERNAL_FAILURE_COUNT
+        # internal failure statuses.
+        pytest.param(
+            input_plane_func,
+            [_attempt_await_response(api_pb2.GenericResult.GENERIC_STATUS_INTERNAL_FAILURE)]
+            * MAX_INTERNAL_FAILURE_COUNT,
+            None,
+            pytest.raises(InternalFailure),
+            MAX_INTERNAL_FAILURE_COUNT,
+            0,
+            id="internal failure max",
+        ),
+        # The client should raise a RemoteError and not retry when it receives a GENERIC_STATUS_UNSPECIFIED status.
+        pytest.param(
+            input_plane_func,
+            [_attempt_await_response(api_pb2.GenericResult.GENERIC_STATUS_UNSPECIFIED)],
+            None,
+            pytest.raises(RemoteError),
+            1,
+            0,
+            id="unspecified",
+        ),
+        # The client should raise a RemoteError and not retry when it receives a GENERIC_STATUS_FAILURE status.
+        pytest.param(
+            input_plane_func,
+            [_attempt_await_response(api_pb2.GenericResult.GENERIC_STATUS_FAILURE)],
+            None,
+            pytest.raises(RemoteError),
+            1,
+            0,
+            id="failure",
+        ),
+        # The client should raise a FunctionTimeoutError and not retry when it receives a GENERIC_STATUS_TIMEOUT status.
+        pytest.param(
+            input_plane_func,
+            [_attempt_await_response(api_pb2.GenericResult.GENERIC_STATUS_TIMEOUT)],
+            None,
+            pytest.raises(FunctionTimeoutError),
+            1,
+            0,
+            id="timeout",
+        ),
+        # The client should raise a RemoteError and not retry when it receives a GENERIC_STATUS_INIT_FAILURE status.
+        pytest.param(
+            input_plane_func,
+            [_attempt_await_response(api_pb2.GenericResult.GENERIC_STATUS_INIT_FAILURE)],
+            None,
+            pytest.raises(RemoteError),
+            1,
+            0,
+            id="init failure",
+        ),
+        # The client should raise a RemoteError and not retry when it receives a GENERIC_STATUS_IDLE_TIMEOUT status.
+        pytest.param(
+            input_plane_func,
+            [_attempt_await_response(api_pb2.GenericResult.GENERIC_STATUS_IDLE_TIMEOUT)],
+            None,
+            pytest.raises(RemoteError),
+            1,
+            0,
+            id="idle timeout",
+        ),
+        # The client should retry up to user-specified number of retries when the user's function raises an exception.
+        pytest.param(
+            input_plane_failing_func_with_retry, [], None, pytest.raises(ValueError), 2, 2, id="honor user retry policy"
+        ),
+        # Internal failure retries shouldn't use up user-specified retries.
+        pytest.param(
+            input_plane_failing_func_with_retry,
+            [_attempt_await_response(api_pb2.GenericResult.GENERIC_STATUS_INTERNAL_FAILURE)]
+            * (MAX_INTERNAL_FAILURE_COUNT - 1),
+            None,
+            pytest.raises(ValueError),
+            MAX_INTERNAL_FAILURE_COUNT + 1,
+            2,
+            id="internal failure does not use up user retries",
+        ),
+        # The client should retry when the retry policy has an initial delay of 0 seconds.
+        pytest.param(
+            input_plane_func_with_immediate_retry, [], None, pytest.raises(ValueError), 2, 2, id="immediate retry"
+        ),
+        # The client should call AttemptAwait multiple times when a function call lasts longer than
+        # function_utils.OUTPUTS_TIMEOUT, but the client should not retry the function call itself.
+        pytest.param(
+            input_plane_func_long_running,
+            [],
+            1,
+            # Currently MockClientServicer returns this string instead of the function return value
+            # when the function call takes longer than function_utils.OUTPUTS_TIMEOUT to run.
+            nullcontext("DEADBEEF"),
+            2,
+            1,
+            id="long running",
+        ),
+    ],
+)
+def test_remote_input_plane(
+    client: Client,
+    servicer: MockClientServicer,
+    monkeypatch: pytest.MonkeyPatch,
+    func: Function,
+    attempt_await_responses: list[api_pb2.AttemptAwaitResponse],
+    outputs_timeout_override: typing.Optional[int],
+    expectation: typing.Any,
+    attempt_await_count: int,
+    function_call_count: int,
+):
+    if outputs_timeout_override is not None:
+        monkeypatch.setattr(modal._functions, "OUTPUTS_TIMEOUT", outputs_timeout_override)
+        monkeypatch.setattr(modal._functions, "ATTEMPT_TIMEOUT_GRACE_PERIOD", 0)
+
+    servicer.attempt_await_responses = attempt_await_responses
+    servicer.function_body(func.get_raw_f())
+    with app.run(client=client), expectation as e:
+        assert func.remote() == e
+    assert servicer.attempt_await_count == attempt_await_count
+    assert servicer.function_call_count == function_call_count
 
 
 def test_single_input_function_call_uses_single_rpc(client, servicer):
@@ -91,7 +292,7 @@ def test_map(client, servicer, slow_put_inputs):
 
 @pytest.mark.parametrize("slow_put_inputs", [False, True])
 @pytest.mark.timeout(120)
-def test_map_inputplane(client, servicer, slow_put_inputs):
+def test_map_input_plane(client, servicer, slow_put_inputs):
     servicer.slow_put_inputs = slow_put_inputs
 
     app = App()
@@ -113,7 +314,7 @@ def test_nested_map(client):
         assert final_results == [1, 16]
 
 
-def test_nested_map_inputplane(client):
+def test_nested_map_input_plane(client):
     app = App()
     dummy_modal = app.function(experimental_options={"input_plane_region": "us-east"})(dummy)
 
@@ -146,7 +347,7 @@ def test_exception_in_input_iterator(client, map_type):
 
 
 @pytest.mark.parametrize("map_type", ["map", "starmap"])
-def test_exception_in_input_iterator_inputplane(client, map_type):
+def test_exception_in_input_iterator_input_plane(client, map_type):
     class CustomException(Exception):
         pass
 
@@ -180,7 +381,7 @@ async def test_map_async_generator(client):
 
 
 @pytest.mark.asyncio
-async def test_map_async_generator_inputplane(client):
+async def test_map_async_generator_input_plane(client):
     app = App()
     dummy_modal = app.function(experimental_options={"input_plane_region": "us-east"})(dummy)
 
@@ -305,7 +506,7 @@ def test_map_none_values(client, servicer):
         assert list(custom_function_modal.map(range(4))) == [0, None, 2, None]
 
 
-def test_map_none_values_inputplane(client, servicer):
+def test_map_none_values_input_plane(client, servicer):
     app = App()
     servicer.function_body(custom_function)
     custom_function_modal = app.function(experimental_options={"input_plane_region": "us-east"})(custom_function)
@@ -493,7 +694,7 @@ def test_generator_map_invalid(client, servicer):
 
 
 # This test is somewhat redundant, but it's good to have when we remove the old python server.
-def test_generator_map_invalid_inputplane(client, servicer):
+def test_generator_map_invalid_input_plane(client, servicer):
     app = App()
 
     later_gen_modal = app.function(experimental_options={"input_plane_region": "us-east"})(later_gen)
@@ -645,7 +846,7 @@ def test_map_exceptions(client, servicer):
         assert type(res[4]) is CustomException and "bad" in str(res[4])
 
 
-def test_map_exceptions_inputplane(client, servicer):
+def test_map_exceptions_input_plane(client, servicer):
     app = App()
 
     servicer.function_body(custom_exception_function)
@@ -689,7 +890,7 @@ async def test_async_map_wrapped_exception_warning(client, servicer):
 
 # This test is somewhat redundant, but it's good to have when we remove the old python server.
 @pytest.mark.asyncio
-async def test_async_map_wrapped_exception_warning_inputplane(client, servicer):
+async def test_async_map_wrapped_exception_warning_input_plane(client, servicer):
     app = App()
 
     servicer.function_body(custom_exception_function)
@@ -1164,7 +1365,7 @@ async def test_non_aio_map_in_async_caller_error(client):
 
 # This test is somewhat redundant, but it's good to have when we remove the old python server.
 @pytest.mark.asyncio
-async def test_non_aio_map_in_async_caller_error_inputplane(client):
+async def test_non_aio_map_in_async_caller_error_input_plane(client):
     dummy_function = app.function(experimental_options={"input_plane_region": "us-east"})(dummy)
 
     with app.run(client=client):

--- a/test/input_plane_test.py
+++ b/test/input_plane_test.py
@@ -1,10 +1,7 @@
 # Copyright Modal Labs 2025
-import pytest
-
 import modal
 from modal import App
 from modal.client import Client
-from modal.exception import InternalFailure
 from modal.functions import Function
 from modal.runner import deploy_app
 from test.conftest import MockClientServicer
@@ -35,25 +32,3 @@ def test_lookup_foo(client: Client, servicer: MockClientServicer):
     assert f.remote() == "foo"
     assert f._get_metadata().input_plane_url is not None
     assert f._get_metadata().input_plane_region == "us-east"
-
-
-def test_retry_on_internal_error(client: Client, servicer: MockClientServicer):
-    # Tell the servicer to fail once, and then succeed. The client should retry the failed attempt.
-    servicer.attempt_await_failures_remaining = 1
-    servicer.function_body(foo.get_raw_f())
-    with app.run(client=client):
-        assert foo.remote() == "foo"
-    # We don't have a great way to verify the call was actually retried. We can at least check that the servicer
-    # decremented the attempts_to_fail counter, which indicates that the call was retried.
-    assert servicer.attempt_await_failures_remaining == 0
-
-
-def test_retry_limit_on_internal_error(client: Client, servicer: MockClientServicer, monkeypatch):
-    monkeypatch.setattr("modal._functions.MAX_INTERNAL_FAILURE_COUNT", 2)
-    # Tell the servicer to fail once, and then succeed. The client should retry the failed attempt.
-    servicer.attempt_await_failures_remaining = 3
-    with pytest.raises(InternalFailure):
-        with app.run(client=client):
-            foo.remote()
-    # Verify that the mock server's failure counter was decremented by 2.
-    assert servicer.attempt_await_failures_remaining == 1


### PR DESCRIPTION
## Describe your changes

We have a bug in which we create excessive input plane attempts due to accidentally submitting AttemptRetry on every AttemptAwait timeout of 55s. We haven't caught it because most input plane calls take less than a minute. This will be patched server-side.

Also fixes a separate bug where internal failures can eat into client specified retries.

SVC-863
