### PR TITLE
Enable C901 ruff linting rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ exclude = [
 ]
 line-length = 120
 lint.ignore = ['E741']
-lint.select = ['E', 'F', 'W', 'I']
+lint.select = ['E', 'F', 'W', 'I', 'C901']
 
 [tool.ruff.lint.per-file-ignores]
 "*_test.py" = ['E712']


### PR DESCRIPTION
> Checks for functions with a high McCabe complexity

https://docs.astral.sh/ruff/rules/complex-structure/

Motivated by bugs like the one introduced in #3456 and fixed
in #3565.

Ignore existing Ruff C901 violations.
