### PR TITLE
Patch options_pb2 based on protobuf version

### DIFF
--- a/protoc_plugin/options_pb2.py.patch
+++ b/protoc_plugin/options_pb2.py.patch
@@ -1,0 +1,30 @@
+import google.protobuf
+try:
+  pb_older_than_5 = int(google.protobuf.__version__.split(".")[0]) < 5
+except Exception:
+  pb_older_than_5 = False
+
+if pb_older_than_5:
+  AUDIT_TARGET_ATTR_FIELD_NUMBER = 50000
+  audit_target_attr = DESCRIPTOR.extensions_by_name['audit_target_attr']
+  AUDIT_EVENT_NAME_FIELD_NUMBER = 50000
+  audit_event_name = DESCRIPTOR.extensions_by_name['audit_event_name']
+  AUDIT_EVENT_DESCRIPTION_FIELD_NUMBER = 50001
+  audit_event_description = DESCRIPTOR.extensions_by_name['audit_event_description']
+
+  if _descriptor._USE_C_DESCRIPTORS == False:
+    google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(audit_target_attr)
+    google_dot_protobuf_dot_descriptor__pb2.MethodOptions.RegisterExtension(audit_event_name)
+    google_dot_protobuf_dot_descriptor__pb2.MethodOptions.RegisterExtension(audit_event_description)
+
+    DESCRIPTOR._options = None
+    DESCRIPTOR._serialized_options = b'Z$github.com/modal-labs/modal/go/proto'
+else:
+  from google.protobuf.internal import builder as _builder
+  _globals = globals()
+  _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
+  _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'modal_proto.options_pb2', _globals)
+  if _descriptor._USE_C_DESCRIPTORS == False:
+    DESCRIPTOR._options = None
+    DESCRIPTOR._serialized_options = b'Z$github.com/modal-labs/modal/go/proto'
+# @@protoc_insertion_point(module_scope)


### PR DESCRIPTION
## Describe your changes

- Fixes https://linear.app/modal-labs/issue/SDK-38/modal-import-fails-on-some-systems-with-protobuf-5

I tested using:

```python
import modal

image = modal.Image.debian_slim().env({"PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": "python"})
app = modal.App(image=image)


@app.function()
def check_protobuf():
    import google.protobuf as pb

    print(pb.__version__)
    return pb.__version__
```

Which works with this PR and `MODAL_SYNC_ENTRYPOINT=1`

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
- Improves compatibility with protobuf >= 5.