### PR TITLE
Add get_tags method to Sandbox

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -574,12 +574,14 @@ class _Sandbox(_Object, type_prefix="sb"):
 
     async def set_tags(self, tags: dict[str, str], *, client: Optional[_Client] = None) -> None:
         """Set tags (key-value pairs) on the Sandbox. Tags can be used to filter results in `Sandbox.list`."""
+        environment_name = _get_environment_name()
         if client is None:
             client = await _Client.from_env()
 
         tags_list = [api_pb2.SandboxTag(tag_name=name, tag_value=value) for name, value in tags.items()]
 
         req = api_pb2.SandboxTagsSetRequest(
+            environment_name=environment_name,
             sandbox_id=self.object_id,
             tags=tags_list,
         )

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -564,11 +564,7 @@ class _Sandbox(_Object, type_prefix="sb"):
 
     async def get_tags(self):
         """Fetches any tags (key-value pairs) attached to this Sandbox from the server."""
-        environment_name = _get_environment_name()
-        req = api_pb2.SandboxTagsGetRequest(
-            sandbox_id=self.object_id,
-            environment_name=environment_name,
-        )
+        req = api_pb2.SandboxTagsGetRequest(sandbox_id=self.object_id)
         try:
             resp = await retry_transient_errors(self._client.stub.SandboxTagsGet, req)
         except GRPCError as exc:

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -562,7 +562,7 @@ class _Sandbox(_Object, type_prefix="sb"):
 
         return obj
 
-    async def get_tags(self):
+    async def get_tags(self) -> dict[str, str]:
         """Fetches any tags (key-value pairs) currently attached to this Sandbox from the server."""
         req = api_pb2.SandboxTagsGetRequest(sandbox_id=self.object_id)
         try:
@@ -572,7 +572,7 @@ class _Sandbox(_Object, type_prefix="sb"):
 
         return {tag.tag_name: tag.tag_value for tag in resp.tags}
 
-    async def set_tags(self, tags: dict[str, str], *, client: Optional[_Client] = None):
+    async def set_tags(self, tags: dict[str, str], *, client: Optional[_Client] = None) -> None:
         """Set tags (key-value pairs) on the Sandbox. Tags can be used to filter results in `Sandbox.list`."""
         if client is None:
             client = await _Client.from_env()

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -563,7 +563,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         return obj
 
     async def get_tags(self):
-        """Fetches any tags (key-value pairs) attached to this Sandbox from the server."""
+        """Fetches any tags (key-value pairs) currently attached to this Sandbox from the server."""
         req = api_pb2.SandboxTagsGetRequest(sandbox_id=self.object_id)
         try:
             resp = await retry_transient_errors(self._client.stub.SandboxTagsGet, req)

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -562,18 +562,15 @@ class _Sandbox(_Object, type_prefix="sb"):
 
         return obj
 
-    async def get_tags(self, client: Optional[_Client] = None):
+    async def get_tags(self):
         """Fetches any tags (key-value pairs) attached to this Sandbox from the server."""
         environment_name = _get_environment_name()
-        if client is None:
-            client = await _Client.from_env()
-
         req = api_pb2.SandboxTagsGetRequest(
             sandbox_id=self.object_id,
             environment_name=environment_name,
         )
         try:
-            resp = await retry_transient_errors(client.stub.SandboxTagsGet, req)
+            resp = await retry_transient_errors(self._client.stub.SandboxTagsGet, req)
         except GRPCError as exc:
             raise InvalidError(exc.message) if exc.status == Status.INVALID_ARGUMENT else exc
 

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -574,14 +574,12 @@ class _Sandbox(_Object, type_prefix="sb"):
 
     async def set_tags(self, tags: dict[str, str], *, client: Optional[_Client] = None):
         """Set tags (key-value pairs) on the Sandbox. Tags can be used to filter results in `Sandbox.list`."""
-        environment_name = _get_environment_name()
         if client is None:
             client = await _Client.from_env()
 
         tags_list = [api_pb2.SandboxTag(tag_name=name, tag_value=value) for name, value in tags.items()]
 
         req = api_pb2.SandboxTagsSetRequest(
-            environment_name=environment_name,
             sandbox_id=self.object_id,
             tags=tags_list,
         )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1733,6 +1733,13 @@ class MockClientServicer(api_grpc.ModalClientBase):
             )
         )
 
+    async def SandboxTagsGet(self, stream):
+        _request: api_pb2.SandboxTagsGetRequest = await stream.recv_message()
+        tags = getattr(self, "sandbox_tags", {})
+        await stream.send_message(
+            api_pb2.SandboxTagsGetResponse(tags=[api_pb2.SandboxTag(tag_name=k, tag_value=v) for k, v in tags.items()])
+        )
+
     async def SandboxTagsSet(self, stream):
         request: api_pb2.SandboxTagsSetRequest = await stream.recv_message()
         self.sandbox_tags = {tag.tag_name: tag.tag_value for tag in request.tags}

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -408,6 +408,8 @@ def test_sandbox_list_app(client, servicer):
 def test_sandbox_list_tags(app, client, servicer):
     sb = Sandbox.create("bash", "-c", "sleep 10000", app=app)
     sb.set_tags({"foo": "bar", "baz": "qux"}, client=client)
+    assert sb.get_tags(client=client) == {"foo": "bar", "baz": "qux"}
+
     assert len(list(Sandbox.list(tags={"foo": "bar"}, client=client))) == 1
     assert not list(Sandbox.list(tags={"foo": "notbar"}, client=client))
     sb.terminate()

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -407,6 +407,7 @@ def test_sandbox_list_app(client, servicer):
 @skip_non_subprocess
 def test_sandbox_list_tags(app, client, servicer):
     sb = Sandbox.create("bash", "-c", "sleep 10000", app=app)
+    assert sb.get_tags() == {}
     sb.set_tags({"foo": "bar", "baz": "qux"}, client=client)
     assert sb.get_tags() == {"foo": "bar", "baz": "qux"}
 

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -408,7 +408,7 @@ def test_sandbox_list_app(client, servicer):
 def test_sandbox_list_tags(app, client, servicer):
     sb = Sandbox.create("bash", "-c", "sleep 10000", app=app)
     sb.set_tags({"foo": "bar", "baz": "qux"}, client=client)
-    assert sb.get_tags(client=client) == {"foo": "bar", "baz": "qux"}
+    assert sb.get_tags() == {"foo": "bar", "baz": "qux"}
 
     assert len(list(Sandbox.list(tags={"foo": "bar"}, client=client))) == 1
     assert not list(Sandbox.list(tags={"foo": "notbar"}, client=client))


### PR DESCRIPTION
## Describe your changes

This allows retrieve tags previously set on a Sandbox using `.set_tags()`.

Depends on modal-labs/modal-client#3569 and modal-labs/modal#27283.

Partly resolves SDK-457.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

</details>

## Changelog

- Added a `.get_tags()` method to Sandbox, enabling fetching tags that were previously set using `.set_tags()`.

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
