### PR TITLE
Deprecate `client` in Sandbox `set_tags()`

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -575,8 +575,12 @@ class _Sandbox(_Object, type_prefix="sb"):
     async def set_tags(self, tags: dict[str, str], *, client: Optional[_Client] = None) -> None:
         """Set tags (key-value pairs) on the Sandbox. Tags can be used to filter results in `Sandbox.list`."""
         environment_name = _get_environment_name()
-        if client is None:
-            client = await _Client.from_env()
+        if client is not None:
+            deprecation_warning(
+                (2025, 9, 18),
+                "The `client` parameter is deprecated. Set `client` when creating the Sandbox instead "
+                "(in e.g. `Sandbox.create()`/`.from_id()`/`.from_name()`).",
+            )
 
         tags_list = [api_pb2.SandboxTag(tag_name=name, tag_value=value) for name, value in tags.items()]
 
@@ -586,7 +590,7 @@ class _Sandbox(_Object, type_prefix="sb"):
             tags=tags_list,
         )
         try:
-            await retry_transient_errors(client.stub.SandboxTagsSet, req)
+            await retry_transient_errors(self._client.stub.SandboxTagsSet, req)
         except GRPCError as exc:
             raise InvalidError(exc.message) if exc.status == Status.INVALID_ARGUMENT else exc
 

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -408,7 +408,7 @@ def test_sandbox_list_app(client, servicer):
 def test_sandbox_list_tags(app, client, servicer):
     sb = Sandbox.create("bash", "-c", "sleep 10000", app=app)
     assert sb.get_tags() == {}
-    sb.set_tags({"foo": "bar", "baz": "qux"}, client=client)
+    sb.set_tags({"foo": "bar", "baz": "qux"})
     assert sb.get_tags() == {"foo": "bar", "baz": "qux"}
 
     assert len(list(Sandbox.list(tags={"foo": "bar"}, client=client))) == 1


### PR DESCRIPTION
<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

</details>

## Changelog

- Deprecated the `client` parameter to `Sandbox.set_tags()`, and the `environment_name` parameter to `Sandbox.from_name()`.