### PR TITLE
Fix minor error message formatting bug

### DIFF
--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -467,11 +467,10 @@ def deploy(
     if not name:
         raise ExecutionError(
             "You need to either supply an explicit deployment name on the command line "
-            "or have a name set on the app.\n"
+            "or have a name set on the App.\n"
             "\n"
             "Examples:\n"
-            'app = modal.App("some-name")'
-            "or\n"
+            'app = modal.App("some-name")\n'
             "modal deploy ... --name=some-name"
         )
 


### PR DESCRIPTION
Was previously a bit garbled

<img width="961" height="118" alt="image" src="https://github.com/user-attachments/assets/cc1e1d5a-1770-4354-b649-b475b849cf38" />

Also Jonoified the message