### PR TITLE
Implement SandboxRouter protos

### DIFF
--- a/modal_proto/sandbox_router.proto
+++ b/modal_proto/sandbox_router.proto
@@ -1,0 +1,126 @@
+syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+import "modal_proto/api.proto";
+
+package modal.sandbox_router;
+
+enum SandboxExecStderrConfig {
+  // The output will be discarded.
+  SANDBOX_EXEC_STDERR_CONFIG_DEVNULL = 0;
+  // The output will be streamed to the client.
+  SANDBOX_EXEC_STDERR_CONFIG_PIPE = 1;
+  // A special value that can be used to indicate that the stderr stream should
+  // be merged with the stdout stream.
+  SANDBOX_EXEC_STDERR_CONFIG_STDOUT = 2;
+}
+
+enum SandboxExecStdioFileDescriptor {
+  // Read from stdout.
+  SANDBOX_EXEC_STDIO_FILE_DESCRIPTOR_STDOUT = 0;
+  // Read from stderr.
+  SANDBOX_EXEC_STDIO_FILE_DESCRIPTOR_STDERR = 1;
+}
+
+enum SandboxExecStdoutConfig {
+  // The output will be discarded.
+  SANDBOX_EXEC_STDOUT_CONFIG_DEVNULL = 0;
+  // The output will be streamed to the client.
+  SANDBOX_EXEC_STDOUT_CONFIG_PIPE = 1;
+}
+
+message SandboxExecStartRequest {
+  // The task ID of the sandbox to execute the command in.
+  string task_id = 1;
+  // Execution ID. This ID will be used to identify the execution for other
+  // requests and ensure exec commands are idempotent.
+  //
+  // TODO(saltzm): Could instead have a separate idempotency key from the exec_id
+  // like present day, and have the server generate the exec_id and return it in
+  // the ExecStartResponse.
+  string exec_id = 2;
+  // Command arguments to execute.
+  repeated string command_args= 3;
+  // Configures how the stdout of the command will be handled.
+  SandboxExecStdoutConfig stdout_config = 4;
+  // Configures how the stderr of the command will be handled.
+  SandboxExecStderrConfig stderr_config = 5;
+  // Deadline for the exec'd command to exit. If the command does not exit before
+  // the deadline, the command will be killed. This is NOT the deadline for the
+  // ExecStartRequest RPC to complete.
+  google.protobuf.Timestamp deadline = 6;
+  // Working directory for the command.
+  optional string workdir = 7;
+  // Secret IDs to mount into the sandbox.
+  repeated string secret_ids = 8;
+  // PTY info for the command.
+  optional modal.client.PTYInfo pty_info = 9;
+  // Enable debugging capabilities on the container runtime. Used only for
+  // internal debugging.
+  bool runtime_debug = 10;
+}
+
+message SandboxExecStartResponse { }
+
+message SandboxExecStdinWriteRequest {
+  // The task ID of the sandbox running the exec'd command.
+  string task_id = 1;
+  // The execution ID of the command to write to.
+  string exec_id = 2;
+  // The offset to start writing to. This is used to resume writing from the
+  // last write position if the connection is closed and reopened.
+  uint64 offset = 3;
+  bytes data = 4;
+  // If true, close the stdin stream after writing any provided data.
+  // This signals EOF to the exec'd process.
+  bool eof = 5;
+}
+
+message SandboxExecStdinWriteResponse { }
+
+
+message SandboxExecStdioReadRequest {
+  // The task ID of the sandbox running the exec'd command.
+  string task_id = 1;
+  // The execution ID of the command to read from.
+  string exec_id = 2;
+  // The offset to start reading from. This is used to resume reading from the
+  // last read position if the connection is closed and reopened.
+  uint64 offset = 3;
+  // Which file descriptor to read from.
+  SandboxExecStdioFileDescriptor file_descriptor = 4;
+}
+
+message SandboxExecStdioReadResponse {
+  // The data read from the file descriptor.
+  bytes data = 1;
+}
+
+message SandboxExecWaitRequest {
+  // The task ID of the sandbox running the exec'd command.
+  string task_id = 1;
+  // The execution ID of the command to wait on. 
+  string exec_id = 2;
+}
+
+message SandboxExecWaitResponse {
+  oneof exit_status {
+    // The exit code of the command.
+    int32 code = 3;
+    // The signal that terminated the command.
+    int32 signal = 4;
+  }
+  // TODO(saltzm): Give a way for the user to distinguish between normal exit
+  // and termination by Modal (due to sandbox idle timeout, exec exceeded deadline, etc.)  
+}
+
+service SandboxRouter {
+  // Execute a command in the sandbox.
+  rpc SandboxExecStart(SandboxExecStartRequest) returns (SandboxExecStartResponse);
+ // Write to the stdin stream of an exec'd command.
+  rpc SandboxExecStdinWrite(SandboxExecStdinWriteRequest) returns (SandboxExecStdinWriteResponse);
+  // Get a stream of output from the stdout or stderr stream of an exec'd command.
+  rpc SandboxExecStdioRead(SandboxExecStdioReadRequest) returns (stream SandboxExecStdioReadResponse);
+  // Wait for an exec'd command to exit and return the exit code.
+  rpc SandboxExecWait(SandboxExecWaitRequest) returns (SandboxExecWaitResponse);
+}

--- a/tasks.py
+++ b/tasks.py
@@ -55,13 +55,14 @@ def protoc(ctx):
 
     Generates Python stubs for api.proto and options.proto."""
     protoc_cmd = f"{sys.executable} -m grpc_tools.protoc"
-    input_files = "modal_proto/api.proto modal_proto/options.proto"
+    client_proto_files = "modal_proto/api.proto modal_proto/options.proto"
+    sandbox_router_proto_file = "modal_proto/sandbox_router.proto"
     py_protoc = (
         protoc_cmd + " --python_out=. --grpclib_python_out=." + " --grpc_python_out=. --mypy_out=. --mypy_grpc_out=."
     )
     print(py_protoc)
     # generate grpcio and grpclib proto files:
-    ctx.run(f"{py_protoc} -I . {input_files}")
+    ctx.run(f"{py_protoc} -I . {client_proto_files} {sandbox_router_proto_file}")
 
     # generate modal-specific wrapper around grpclib api stub using custom plugin:
     grpc_plugin_pyfile = Path("protoc_plugin/plugin.py")
@@ -69,7 +70,7 @@ def protoc(ctx):
     with python_file_as_executable(grpc_plugin_pyfile) as grpc_plugin_executable:
         ctx.run(
             f"{protoc_cmd} --plugin=protoc-gen-modal-grpclib-python={grpc_plugin_executable}"
-            + f" --modal-grpclib-python_out=. -I . {input_files}"
+            + f" --modal-grpclib-python_out=. -I . {client_proto_files}"
         )
 
 
@@ -83,13 +84,7 @@ def lint(ctx, fix=False):
     ctx.run(f"ruff check . {'--fix' if fix else ''}", pty=True)
 
 
-@task
-def lint_protos(ctx):
-    """Lint protocol buffer files.
-
-    Ensures imports/enums/messages/services are ordered correctly and RPCs are alphabetized.
-    """
-    proto_fname = "modal_proto/api.proto"
+def lint_protos_impl(ctx, proto_fname: str):
     with open(proto_fname) as f:
         proto_text = f.read()
 
@@ -131,6 +126,16 @@ def lint_protos(ctx):
                 console.print(f"\nThe {rpc_a} rpc proto is out of order relative to the {rpc_b} rpc.")
                 console.print("\nRPC definitions should be ordered within each service proto.", style="dim")
                 sys.exit(1)
+
+
+@task
+def lint_protos(ctx):
+    """Lint protocol buffer files.
+
+    Ensures imports/enums/messages/services are ordered correctly and RPCs are alphabetized.
+    """
+    lint_protos_impl(ctx, "modal_proto/api.proto")
+    lint_protos_impl(ctx, "modal_proto/sandbox_router.proto")
 
 
 @task
@@ -493,6 +498,7 @@ def show_deprecations(ctx):
     """Analyze Modal source code and display all deprecation warnings/errors.
 
     Shows deprecation date, level, location, function, and message in a formatted table."""
+
     def get_modal_source_files() -> list[str]:
         source_files: list[str] = []
         for root, _, files in os.walk("modal"):


### PR DESCRIPTION
## Describe your changes

This PR adds new proto definitions for a service that will run on the worker called the Sandbox Router Server. This service will accept sandbox-related commands and forward them to a Sandbox Command Server that runs in `modal-runtime`. The service currently is responsible for `exec` requests.

Follow-up PRs will create a new Python client object for accessing this service and integrate it into the Sandbox API.

<details> <summary>Checklists</summary>


</details>