### PR TITLE
Split AutoscalerOverride out from AutoscalerSettings

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -658,7 +658,30 @@ message AutoscalerSettings {
   optional uint32 scaleup_window = 4;
   // Maximum amount of time a container can be idle before being scaled down, in seconds; pka "container_idle_timeout"
   optional uint32 scaledown_window = 5;
-  reserved 6;
+  reserved 6, 7, 8, 9, 10;  // reserved for compatibility with autoscaler overrides
+}
+
+message AutoscalerOverride {
+  // Autoscaler override contains settings
+  // As well as flags for clearing previous overrides and restoring defaults
+
+  // Minimum containers when scale-to-zero is not desired; pka "keep_warm" or "warm_pool_size"
+  optional uint32 min_containers = 1;
+  // Limit on the number of containers that can be running for each Function; pka "concurrency_limit"
+  optional uint32 max_containers = 2;
+  // Additional container to spin up when Function is active
+  optional uint32 buffer_containers = 3;
+  // Currently unused; a placeholder in case we decide to expose scaleup control to users
+  optional uint32 scaleup_window = 4;
+  // Maximum amount of time a container can be idle before being scaled down, in seconds; pka "container_idle_timeout"
+  optional uint32 scaledown_window = 5;
+
+  // Flags for clearing overrides and restoring defaults
+  optional bool clear_min_containers = 6;
+  optional bool clear_max_containers = 7;
+  optional bool clear_buffer_containers = 8;
+  optional bool clear_scaleup_window = 9;
+  optional bool clear_scaledown_window = 10;
 }
 
 // Used for flash autoscaling


### PR DESCRIPTION
## Describe your changes

- Adds a new AutoscalerOverrides protobuf to distinguish between settings and overrides
- Introduces clear flags for all AutoscalerSettings fields to support an instruction to revert to the function definition / modal default value 

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

