### PR TITLE
Add `image_delete` to `modal.experimental`

### DIFF
--- a/modal/experimental/__init__.py
+++ b/modal/experimental/__init__.py
@@ -392,10 +392,17 @@ async def image_delete(
     *,
     client: Optional[_Client] = None,
 ) -> None:
-    """Delete an image by its ID.
+    """Delete an Image by its ID.
 
-    Warning: This is an experimental API that may change.
     Deletion is irreversible and will prevent Apps from using the Image.
+
+    This is an experimental interface for a feature that we will be adding to
+    the main Image class. The stable form of this interface may look different.
+
+    Note: When building an Image, each chained method call will create an
+    intermediate Image layer, each with its own ID. Deleting an Image will not
+    delete any of its intermediate layers, only the image identified by the
+    provided ID.
     """
     if client is None:
         client = await _Client.from_env()

--- a/modal/experimental/__init__.py
+++ b/modal/experimental/__init__.py
@@ -384,3 +384,21 @@ async def update_autoscaler(
 
     request = api_pb2.FunctionUpdateSchedulingParamsRequest(function_id=f.object_id, settings=settings)
     await retry_transient_errors(client.stub.FunctionUpdateSchedulingParams, request)
+
+
+@synchronizer.create_blocking
+async def image_delete(
+    image_id: str,
+    *,
+    client: Optional[_Client] = None,
+) -> None:
+    """Delete an image by its ID.
+
+    Warning: This is an experimental API that may change.
+    Deletion is irreversible and will prevent Apps from using the Image.
+    """
+    if client is None:
+        client = await _Client.from_env()
+
+    req = api_pb2.ImageDeleteRequest(image_id=image_id)
+    await retry_transient_errors(client.stub.ImageDelete, req)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1490,7 +1490,13 @@ class MockClientServicer(api_grpc.ModalClientBase):
         request: api_pb2.ImageDeleteRequest = await stream.recv_message()
         if request.image_id not in self.images:
             raise GRPCError(Status.NOT_FOUND, f"Image {request.image_id} not found")
+
         self.images.pop(request.image_id)
+        self.image_build_function_ids.pop(request.image_id, None)
+        self.image_builder_versions.pop(request.image_id, None)
+        if request.image_id in self.force_built_images:
+            self.force_built_images.remove(request.image_id)
+
         await stream.send_message(Empty())
 
     ### Mount

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1486,6 +1486,13 @@ class MockClientServicer(api_grpc.ModalClientBase):
             )
         )
 
+    async def ImageDelete(self, stream):
+        request: api_pb2.ImageDeleteRequest = await stream.recv_message()
+        if request.image_id not in self.images:
+            raise GRPCError(Status.NOT_FOUND, f"Image {request.image_id} not found")
+        self.images.pop(request.image_id)
+        await stream.send_message(Empty())
+
     ### Mount
 
     async def MountPutFile(self, stream):


### PR DESCRIPTION
## Describe your changes

SDK-610

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

</details>

## Changelog

- Added `modal.experimental.image_delete()` to allow deleting Images (e.g. Sandbox FS snapshot images).
