### PR TITLE
increase gpu timeouts

### DIFF
--- a/modal/_runtime/gpu_memory_snapshot.py
+++ b/modal/_runtime/gpu_memory_snapshot.py
@@ -101,7 +101,7 @@ class CudaCheckpointProcess:
                 check=True,
                 capture_output=True,
                 text=True,
-                timeout=5 * 60,
+                timeout=60,
             )
             logger.debug(f"PID: {self.pid} Successfully toggled CUDA checkpoint state")
         except subprocess.CalledProcessError as e:
@@ -121,7 +121,7 @@ class CudaCheckpointProcess:
                 check=True,
                 capture_output=True,
                 text=True,
-                timeout=5 * 60,
+                timeout=60,
             )
 
             state_str = result.stdout.strip().lower()


### PR DESCRIPTION
increase gpu timeouts since these commands take longer for larger models to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase timeouts for `cuda-checkpoint` `--toggle` and `--get-state` calls in `modal/_runtime/gpu_memory_snapshot.py` to 60s.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04d8d19a07c3c0d24b66da5b948f26280dc711ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->