### PR TITLE
Don't show spinner in `modal run --interactive`

### DIFF
--- a/modal/runner.py
+++ b/modal/runner.py
@@ -360,8 +360,12 @@ async def _run_app(
 
             # Yield to context
             if output_mgr := _get_output_manager():
-                with output_mgr.show_status_spinner():
+                # Don't show status spinner in interactive mode to avoid interfering with breakpoints
+                if interactive:
                     yield app
+                else:
+                    with output_mgr.show_status_spinner():
+                        yield app
             else:
                 yield app
             # successful completion!

--- a/test/runner_test.py
+++ b/test/runner_test.py
@@ -164,3 +164,20 @@ def test_deploy_app_namespace_deprecated(servicer, client):
     # Filter out any unrelated warnings
     namespace_warnings = [w for w in record if "namespace" in str(w.message).lower()]
     assert len(namespace_warnings) == 0
+
+
+def test_run_app_interactive_no_spinner(servicer, client):
+    """Don't show status spinner in interactive mode to avoid interfering with breakpoints."""
+    app = modal.App()
+
+    with mock.patch("modal._output.OutputManager.show_status_spinner") as mock_spinner:
+        with modal.enable_output():
+            with run_app(app, client=client, interactive=True):
+                pass
+        mock_spinner.return_value.__enter__.assert_not_called()
+
+    with mock.patch("modal._output.OutputManager.show_status_spinner") as mock_spinner:
+        with modal.enable_output():
+            with run_app(app, client=client, interactive=False):
+                pass
+        mock_spinner.return_value.__enter__.assert_called_once()


### PR DESCRIPTION
## Describe your changes

Don't show spinner in `modal run --interactive`. This interferes with debuggers if you add breakpoints to local entrypoint functions. Can be reproduced with:

```
import modal

app = modal.App("breakpoint-spinner")


@app.local_entrypoint()
def main():
    breakpoint()
    print("Hello, from Local Entrypoint!")
```

SDK-617

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


</details>

## Changelog

- Hide the CLI spinner in interactive mode, so `modal run --interactive` now works better with breakpoints in local entrypoint functions.
