### PR TITLE
Add volume mounts proto to image run_commands

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2067,6 +2067,8 @@ message Image {
 
   // Build arguments for the image (--build-arg) for ARG substitution in Dockerfile.
   map<string, string> build_args = 22;
+
+  repeated VolumeMount volume_mounts = 23;
 }
 
 message ImageContextFile {


### PR DESCRIPTION
## Describe your changes

- Adds proto for volume mounting in `Image.run_commands`.
- Towards https://linear.app/modal-labs/issue/SDK-599/feature-request-for-build-cache-mounts-for-improved-build-efficiency

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>