### PR TITLE
Add volume mounts proto to image run_commands

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2067,6 +2067,8 @@ message Image {
 
   // Build arguments for the image (--build-arg) for ARG substitution in Dockerfile.
   map<string, string> build_args = 22;
+
+  repeated VolumeMount volume_mounts = 23;
 }
 
 message ImageContextFile {

--- a/test/image_test.py
+++ b/test/image_test.py
@@ -557,6 +557,31 @@ def test_run_commands(builder_version, servicer, client):
                 assert layers[0].dockerfile_commands[i] == f"RUN {cmd}"
 
 
+def test_run_commands_with_volume(servicer, client):
+    vol = modal.Volume.from_name("xyz", create_if_missing=True)
+
+    app = modal.App()
+    image = modal.Image.debian_slim().run_commands("echo 'Hello Modal'", volumes={"/root/foo": vol})
+
+    with servicer.intercept():
+        with app.run(client=client):
+            image.build(app)
+        layers = get_image_layers(image.object_id, servicer)
+
+    volume_mount = layers[0].volume_mounts[0]
+    assert volume_mount.mount_path == "/root/foo"
+    assert volume_mount.volume_id == vol.object_id
+
+
+def test_run_commands_with_cloud_bucket_mnt_error(servicer, client):
+    secret = modal.Secret.from_dict({"AWS_ACCESS_KEY_ID": "1", "AWS_SECRET_ACCESS_KEY": "2"})
+    cld_bckt_mnt = modal.CloudBucketMount(bucket_name="foo", secret=secret)
+
+    msg = "Image builds only support mounting modal.Volume"
+    with pytest.raises(InvalidError, match=msg):
+        modal.Image.debian_slim().run_commands("echo 'hello'", volumes={"/root/foo": cld_bckt_mnt})  # type: ignore
+
+
 def test_dockerhub_install(builder_version, servicer, client):
     app = App(image=Image.from_registry("gisops/valhalla:latest", setup_dockerfile_commands=["RUN apt-get update"]))
     app.function()(dummy)


### PR DESCRIPTION
## Describe your changes

Implementing for adding `Image.run_commands`

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->

- `Image.run_commands` supports `volumes` for mounting a volume for build caching

```python
cache_vol = modal.Volume.from_name("cache-mount")
cmd_using_cache = "..."
image = modal.Image.debian_slim().run_commands(cmd_using_cache, volumes={"/cache": cache_vol})
```
