### PR TITLE
Add secret to sandbox definition and SandboxGetDirectAccess protos

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2704,12 +2704,6 @@ message Sandbox {
 
   // Optional idle timeout in seconds. If set, the sandbox will be terminated after being idle for this duration.
   optional uint32 idle_timeout_secs = 33;
-
-  // Set only by the server. Must not be transmitted to the client. Used to
-  // authenticate the client when directly connecting to a sandbox server running on
-  // the modal-worker to issue exec commands (and other operations as they
-  // become available).
-  optional bytes sandbox_command_router_auth_secret = 34;
 }
 
 message SandboxCreateConnectTokenRequest {
@@ -2735,11 +2729,11 @@ message SandboxCreateResponse {
 // Used to get a JWT and URL for direct access to a sandbox router server
 // running on the modal-worker, so the client can issue exec commands (and other
 // operations as they become available) directly to the worker.
-message SandboxGetCommandRouterAccessInfoRequest {
+message SandboxGetCommandRouterAccessRequest {
   string sandbox_id = 1;
 }
 
-message SandboxGetCommandRouterAccessInfoResponse {
+message SandboxGetCommandRouterAccessResponse {
   string jwt = 1;
   string url = 2;
 }
@@ -3694,7 +3688,7 @@ service ModalClient {
   // Sandboxes
   rpc SandboxCreate(SandboxCreateRequest) returns (SandboxCreateResponse);
   rpc SandboxCreateConnectToken(SandboxCreateConnectTokenRequest) returns (SandboxCreateConnectTokenResponse);
-  rpc SandboxGetCommandRouterAccessInfo(SandboxGetCommandRouterAccessInfoRequest) returns (SandboxGetCommandRouterAccessInfoResponse);
+  rpc SandboxGetCommandRouterAccess(SandboxGetCommandRouterAccessRequest) returns (SandboxGetCommandRouterAccessResponse);
   rpc SandboxGetFromName(SandboxGetFromNameRequest) returns (SandboxGetFromNameResponse);
   rpc SandboxGetLogs(SandboxGetLogsRequest) returns (stream TaskLogsBatch);
   rpc SandboxGetResourceUsage(SandboxGetResourceUsageRequest) returns (SandboxGetResourceUsageResponse);


### PR DESCRIPTION
## Describe your changes
[Architectural context](https://www.notion.so/modal-com/Client-to-Sandbox-Direct-Communication-v2-2631e7f16949807ba5a9f329200ccb12?source=copy_link#2631e7f169498038a6f3e25bc8efbeb1)

My biggest concern here is one @rolyatmax brought up, which is whether it's a good idea to store the auth secret in the Sandbox definition. Currently we never send the Sandbox definition back to the client, it's only used for Sandbox creation, but if we ever did in the future, we'd need to make sure not to return this secret.

In addition, the way the secret will be communicated to the worker is through its receipt of the Sandbox definition. Is this secure enough? I don't know - would love reviewer input


<details> <summary>Checklists</summary>.


---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.