### PR TITLE
Add direct_sandbox_commands_enabled field to sandbox definition

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2707,6 +2707,11 @@ message Sandbox {
 
   // Optional idle timeout in seconds. If set, the sandbox will be terminated after being idle for this duration.
   optional uint32 idle_timeout_secs = 33;
+
+  // If set, the sandbox will be created with direct sandbox commands enabled.
+  // Exec commands for the sandbox will be issued directly to the sandbox
+  // command router running on the Modal worker.
+  bool direct_sandbox_commands_enabled = 34;
 }
 
 message SandboxCreateConnectTokenRequest {


### PR DESCRIPTION
## Describe your changes

We want to decide on sandbox creation whether to use the sandbox command router for exec commands or not based on a config parameter - we need to store this decision in the definition. Otherwise we could swap exec implementations even within the same sandbox which sounds confusing.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

