### PR TITLE
Call SandboxGetCommandRouterAccess and swap exec implementation accordingly

### DIFF
--- a/modal/_utils/sandbox_utils.py
+++ b/modal/_utils/sandbox_utils.py
@@ -1,0 +1,8 @@
+# Copyright Modal Labs 2025
+from dataclasses import dataclass
+
+
+@dataclass
+class SandboxCommandRouterAccess:
+    url: str
+    jwt: str

--- a/modal/_utils/sandbox_utils.py
+++ b/modal/_utils/sandbox_utils.py
@@ -1,8 +1,0 @@
-# Copyright Modal Labs 2025
-from dataclasses import dataclass
-
-
-@dataclass
-class SandboxCommandRouterAccess:
-    url: str
-    jwt: str

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -30,6 +30,7 @@ from ._utils.deprecation import deprecation_warning
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.mount_utils import validate_network_file_systems, validate_volumes
 from ._utils.name_utils import is_valid_object_name
+from ._utils.sandbox_utils import SandboxCommandRouterAccess
 from .client import _Client
 from .container_process import _ContainerProcess
 from .exception import AlreadyExistsError, ExecutionError, InvalidError, SandboxTerminatedError, SandboxTimeoutError
@@ -121,9 +122,10 @@ class _Sandbox(_Object, type_prefix="sb"):
     _stdout: _StreamReader[str]
     _stderr: _StreamReader[str]
     _stdin: _StreamWriter
-    _task_id: Optional[str] = None
-    _tunnels: Optional[dict[int, Tunnel]] = None
-    _enable_snapshot: bool = False
+    _task_id: Optional[str]
+    _tunnels: Optional[dict[int, Tunnel]]
+    _enable_snapshot: bool
+    _command_router_access: Optional[SandboxCommandRouterAccess]
 
     @staticmethod
     def _default_pty_info() -> api_pb2.PTYInfo:
@@ -521,6 +523,10 @@ class _Sandbox(_Object, type_prefix="sb"):
         )
         self._stdin = StreamWriter(self.object_id, "sandbox", self._client)
         self._result = None
+        self._task_id = None
+        self._tunnels = None
+        self._enable_snapshot = False
+        self._command_router_access = None
 
     @staticmethod
     async def from_name(
@@ -729,6 +735,38 @@ class _Sandbox(_Object, type_prefix="sb"):
                 await asyncio.sleep(0.5)
         return self._task_id
 
+    async def _get_command_router_access(self) -> Optional[SandboxCommandRouterAccess]:
+        """
+        Fetch a URL and JWT for direct access to a sandbox router server running
+        on the modal-worker.  This is used to issue exec commands (and other
+        operations as they become available) directly to the worker.
+
+        Returns a `SandboxCommandRouterAccess` object if the sandbox has command
+        router access (conditionally enabled by the server for gradual rollout),
+        otherwise returns `None`.
+        """
+        # TODO(saltzm): We'll need to bypass this if we need to retry when token expires.
+        if self._command_router_access is not None:
+            return self._command_router_access
+
+        try:
+            # This will retry until the sandbox has been scheduled or an error
+            # is thrown indicating that command router access is not enabled for this
+            # sandbox.
+            resp = await retry_transient_errors(
+                self._client.stub.SandboxGetCommandRouterAccess,
+                api_pb2.SandboxGetCommandRouterAccessRequest(sandbox_id=self.object_id),
+            )
+        except GRPCError as exc:
+            if exc.status == Status.FAILED_PRECONDITION:
+                # Command router access is not enabled for this sandbox.
+                return None
+            else:
+                raise exc
+
+        self._command_router_access = SandboxCommandRouterAccess(resp.url, resp.jwt)
+        return self._command_router_access
+
     @overload
     async def exec(
         self,
@@ -854,6 +892,52 @@ class _Sandbox(_Object, type_prefix="sb"):
         await TaskContext.gather(*secret_coros)
 
         task_id = await self._get_task_id()
+        # NB: This must come after the task ID is set, since the sandbox must be
+        # scheduled before we can get command router access.
+        command_router_access = await self._get_command_router_access()
+
+        if command_router_access is not None:
+            return await self._exec_through_command_router(
+                *args,
+                task_id=task_id,
+                command_router_access=command_router_access,
+                pty_info=pty_info,
+                stdout=stdout,
+                stderr=stderr,
+                timeout=timeout,
+                workdir=workdir,
+                secrets=secrets,
+                text=text,
+                bufsize=bufsize,
+            )
+        else:
+            return await self._exec_through_server(
+                *args,
+                task_id=task_id,
+                pty_info=pty_info,
+                stdout=stdout,
+                stderr=stderr,
+                timeout=timeout,
+                workdir=workdir,
+                secrets=secrets,
+                text=text,
+                bufsize=bufsize,
+            )
+
+    async def _exec_through_server(
+        self,
+        *args: str,
+        task_id: str,
+        pty_info: Optional[api_pb2.PTYInfo] = None,
+        stdout: StreamType = StreamType.PIPE,
+        stderr: StreamType = StreamType.PIPE,
+        timeout: Optional[int] = None,
+        workdir: Optional[str] = None,
+        secrets: Optional[Collection[_Secret]] = None,
+        text: bool = True,
+        bufsize: Literal[-1, 1] = -1,
+    ) -> Union[_ContainerProcess[bytes], _ContainerProcess[str]]:
+        """Execute a command through the Modal server."""
         req = api_pb2.ContainerExecRequest(
             task_id=task_id,
             command=args,
@@ -876,6 +960,23 @@ class _Sandbox(_Object, type_prefix="sb"):
             exec_deadline=exec_deadline,
             by_line=by_line,
         )
+
+    async def _exec_through_command_router(
+        self,
+        *args: str,
+        task_id: str,
+        command_router_access: SandboxCommandRouterAccess,
+        pty_info: Optional[api_pb2.PTYInfo] = None,
+        stdout: StreamType = StreamType.PIPE,
+        stderr: StreamType = StreamType.PIPE,
+        timeout: Optional[int] = None,
+        workdir: Optional[str] = None,
+        secrets: Optional[Collection[_Secret]] = None,
+        text: bool = True,
+        bufsize: Literal[-1, 1] = -1,
+    ) -> Union[_ContainerProcess[bytes], _ContainerProcess[str]]:
+        """Execute a command through a sandbox command router running on the Modal worker."""
+        raise NotImplementedError("Exec through command router is not implemented yet.")
 
     async def _experimental_snapshot(self) -> _SandboxSnapshot:
         await self._get_task_id()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1811,6 +1811,12 @@ class MockClientServicer(api_grpc.ModalClientBase):
         _request: api_pb2.SandboxRestoreRequest = await stream.recv_message()
         await stream.send_message(api_pb2.SandboxRestoreResponse(sandbox_id="sb-123"))
 
+    async def SandboxGetCommandRouterAccess(self, stream):
+        # In tests, we disable command router access so client falls back to server RPCs
+        # TODO(saltzm): Add client tests for exec via command router.
+        _request: api_pb2.SandboxGetCommandRouterAccessRequest = await stream.recv_message()
+        raise GRPCError(Status.FAILED_PRECONDITION, "Command router access not enabled in tests")
+
     async def SandboxGetTaskId(self, stream):
         # only used for `modal shell` / `modal container exec`
         _request: api_pb2.SandboxGetTaskIdRequest = await stream.recv_message()


### PR DESCRIPTION
## Describe your changes

Corresponding server changes: https://github.com/modal-labs/modal/pull/27621

I realize it's unconventional to check something in that's not implemented, but I'm making a lot of new additions here and felt that it'll be easier to review thoroughly piecemeal. Let me know if this isn't acceptable.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds sandbox command-router access retrieval and routes `exec` via the worker when available, falling back to server RPCs; tests disable router access.
> 
> - **Sandbox client**:
>   - Introduces `_SandboxCommandRouterAccess` (URL + JWT) and caches it per sandbox via `_get_command_router_access()` (calls `SandboxGetCommandRouterAccess`, handles `FAILED_PRECONDITION`).
>   - Refactors `exec` flow: selects between `_exec_through_command_router` (stubbed) and `_exec_through_server` (existing ContainerExec RPC) based on router access.
>   - Initializes `_task_id`, `_tunnels`, `_enable_snapshot`, and `_command_router_access` in `_hydrate_metadata`.
> - **Tests**:
>   - Mocks `SandboxGetCommandRouterAccess` to raise `FAILED_PRECONDITION`, forcing fallback to server RPCs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52b91347442d24fadce7044064f9228fbc6907cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->