### PR TITLE
Add App constructor tags

### DIFF
--- a/modal/_utils/name_utils.py
+++ b/modal/_utils/name_utils.py
@@ -31,10 +31,25 @@ def is_valid_environment_name(name: str) -> bool:
     return len(name) <= 64 and re.match(r"^[a-zA-Z0-9][a-zA-Z0-9-_.]+$", name) is not None
 
 
-def is_valid_tag(tag: str) -> bool:
-    """Tags are alphanumeric, dashes, periods, and underscores, and must be 50 characters or less"""
-    pattern = r"^[a-zA-Z0-9._-]{1,50}$"
+def is_valid_tag(tag: str, max_length: int = 50) -> bool:
+    """Tags are alphanumeric, dashes, periods, and underscores, and not longer than the max_length."""
+    pattern = rf"^[a-zA-Z0-9._-]{{1,{max_length}}}$"
     return bool(re.match(pattern, tag))
+
+
+def check_tag_dict(tags: dict[str, str]) -> dict[str, str]:
+    rules = (
+        "\n\nTags may contain only alphanumeric characters, dashes, periods, or underscores, "
+        "and must be 63 characters or less."
+    )
+    max_length = 63
+    for key, value in tags.items():
+        if not is_valid_tag(key, max_length):
+            raise InvalidError(f"Invalid tag key: {key!r}.{rules}")
+        if not is_valid_tag(value, max_length):
+            raise InvalidError(f"Invalid tag value: {value!r}.{rules}")
+
+    return tags
 
 
 def check_object_name(name: str, object_type: str) -> None:

--- a/modal/app.py
+++ b/modal/app.py
@@ -35,7 +35,7 @@ from ._utils.deprecation import (
 from ._utils.function_utils import FunctionInfo, is_global_object, is_method_fn
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.mount_utils import validate_volumes
-from ._utils.name_utils import check_object_name
+from ._utils.name_utils import check_object_name, check_tag_dict
 from .client import _Client
 from .cloud_bucket_mount import _CloudBucketMount
 from .cls import _Cls, parameter
@@ -193,7 +193,7 @@ class _App:
 
         self._name = name
         self._description = name
-        self._tags = tags or {}
+        self._tags = check_tag_dict(tags or {})
         self._include_source_default = include_source
 
         check_sequence(secrets, _Secret, "`secrets=` has to be a list or tuple of `modal.Secret` objects")

--- a/modal/app.py
+++ b/modal/app.py
@@ -1048,7 +1048,7 @@ class _App:
 
         return wrapper
 
-    def include(self, /, other_app: "_App") -> typing_extensions.Self:
+    def include(self, /, other_app: "_App", inherit_tags: bool = True) -> typing_extensions.Self:
         """Include another App's objects in this one.
 
         Useful for splitting up Modal Apps across different self-contained files.
@@ -1071,6 +1071,10 @@ class _App:
             # use function declared on the included app
             bar.remote()
         ```
+
+        When `inherit_tags=True` any tags set on the other App will be inherited by this App
+        (with this App's tags taking precedence in the case of conflicts).
+
         """
         for tag, function in other_app._functions.items():
             self._add_function(function, False)  # TODO(erikbern): webhook config?
@@ -1084,6 +1088,10 @@ class _App:
                 )
 
             self._add_class(tag, cls)
+
+        if inherit_tags:
+            self._tags = {**other_app._tags, **self._tags}
+
         return self
 
     async def _logs(self, client: Optional[_Client] = None) -> AsyncGenerator[str, None]:

--- a/modal/app.py
+++ b/modal/app.py
@@ -151,6 +151,8 @@ class _App:
 
     _name: Optional[str]
     _description: Optional[str]
+    _tags: dict[str, str]
+
     _functions: dict[str, _Function]
     _classes: dict[str, _Cls]
 
@@ -171,6 +173,7 @@ class _App:
         self,
         name: Optional[str] = None,
         *,
+        tags: Optional[dict[str, str]] = None,  # Additional metadata to set on the App
         image: Optional[_Image] = None,  # Default Image for the App (otherwise default to `modal.Image.debian_slim()`)
         secrets: Sequence[_Secret] = [],  # Secrets to add for all Functions in the App
         volumes: dict[Union[str, PurePosixPath], _Volume] = {},  # Volume mounts to use for all Functions
@@ -190,6 +193,7 @@ class _App:
 
         self._name = name
         self._description = name
+        self._tags = tags or {}
         self._include_source_default = include_source
 
         check_sequence(secrets, _Secret, "`secrets=` has to be a list or tuple of `modal.Secret` objects")
@@ -371,8 +375,8 @@ class _App:
         *,
         name: Optional[str] = None,  # Name for the deployment, overriding any set on the App
         environment_name: Optional[str] = None,  # Environment to deploy the App in
-        tag: str = "",  # Optional metadata that will be visible in the deployment history
-        client: Optional[_Client] = None,  # Alternate client to use for RPCs
+        tag: str = "",  # Optional metadata that is specific to this deployment
+        client: Optional[_Client] = None,  # Alternate client to use for communication with the server
     ) -> typing_extensions.Self:
         """Deploy the App so that it is available persistently.
 

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -506,7 +506,7 @@ async def _deploy_app(
     else:
         check_object_name(name, "App")
 
-    if tag and not is_valid_tag(tag):
+    if tag and not is_valid_tag(tag, max_length=50):
         raise InvalidError(
             f"Deployment tag {tag!r} is invalid."
             "\n\nTags may only contain alphanumeric characters, dashes, periods, and underscores, "

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -477,6 +477,14 @@ def test_tags(servicer, client, mode):
     assert request.tags == tags
 
 
+@pytest.mark.parametrize("s", ["a:b", "x/y", "a b", "a" * 65])
+def test_invalid_tags(s):
+    with pytest.raises(InvalidError, match=f"Invalid tag key: {s!r}"):
+        App(tags={s: "bar"})
+    with pytest.raises(InvalidError, match=f"Invalid tag value: {s!r}"):
+        App(tags={"foo": s})
+
+
 @pytest.mark.parametrize("inherit_tags", [True, False])
 def test_app_composition_tags(servicer, client, inherit_tags):
     base_app = App(tags={"foo": "bar", "baz": "bum"})


### PR DESCRIPTION
Minimal client-side implementation of SDK-622.

This only lets you define tags in the App constructor.

I think it would also make sense to let you supply tags when programmatically running or deploying the App. This will support some workflows that have a shared App codebase that's used by different people or for different workflows such that it would be helpful to define the tags dynamically. The main reason I held off was lack of clarity about needing to have `tags: dict[str, str]` and `tag: str` in the same Function signature 😬.


<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


</details>

## Changelog

- Arbitrary key-value metadata can now be attached to Apps by setting `modal.App(tags={...})`. The tags can be useful for tracking information that may be relevant to your organization, such as the team that owns the App. We'll support the inclusion of tags in some forthcoming APIs related to cost insights.