### PR TITLE
[GPU Snapshot] Remove unnecessary CUDA state checks and increase `cuda-checkpoint` timeout

### DIFF
--- a/modal/_runtime/gpu_memory_snapshot.py
+++ b/modal/_runtime/gpu_memory_snapshot.py
@@ -61,9 +61,9 @@ class CudaCheckpointProcess:
         max_retries = 3
 
         attempts = 0
-        while self._should_continue_toggle(target_state, start_time):
-            if not (skip_first_refresh and attempts == 0):
-                self.refresh_state()
+        while self._should_continue_toggle(
+            target_state, start_time, refresh=not (skip_first_refresh and attempts == 0)
+        ):
             attempts += 1
             try:
                 self._execute_toggle_command()
@@ -82,8 +82,13 @@ class CudaCheckpointProcess:
 
         logger.debug(f"PID: {self.pid} Target state {target_state.value} reached")
 
-    def _should_continue_toggle(self, target_state: CudaCheckpointState, start_time: float) -> bool:
+    def _should_continue_toggle(
+        self, target_state: CudaCheckpointState, start_time: float, refresh: bool = True
+    ) -> bool:
         """Check if toggle operation should continue based on current state and timeout."""
+        if refresh:
+            self.refresh_state()
+
         if self.state == target_state:
             return False
 


### PR DESCRIPTION
It is **impossible** for a snapshotted container to have any processes with any CUDA state other than `checkpointed`. This is because we assert that the CUDA state is `checkpointed` for all saved CUDA pids before taking the memory snapshot (we raise otherwise, after retrying 3 times). The current code, on restore, checks that the PID is `checkpointed` before restoring it, _twice_. This is a costly unnecessary check:

Statistics for a _single_ CUDA state check of a process that allocated a 2GiB random tensor.
```
Mean:   2.66884
Var:    1.969
Min:    0.383
Max:    7.119
Median: 2.525
Sample: 25
```

This PR also increases the timeout on running `cuda-checkpoint`. We have found that for large checkpoints, cuda-checkpoint requires a long time to run. Cuda-checkpoint taking a while is not a signal that it will fail.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes restore-time CUDA state validations and first refresh, and introduces higher, centralized timeouts for cuda-checkpoint operations.
> 
> - **Runtime: GPU memory snapshot (`modal/_runtime/gpu_memory_snapshot.py`)**
>   - **Timeouts**:
>     - Add `CUDA_CHECKPOINT_TOGGLE_TIMEOUT` and `CUDA_CHECKPOINT_TIMEOUT`; use them for toggle loop and subprocess calls.
>     - Replace per-call constants (`30s`/`10s`) with `CUDA_CHECKPOINT_TIMEOUT`; enforce overall toggle limit via `CUDA_CHECKPOINT_TOGGLE_TIMEOUT`.
>   - **Toggle behavior**:
>     - Change `toggle(...)` signature: remove `timeout_secs`, add `skip_first_refresh`.
>     - `_should_continue_toggle(...)` now supports optional refresh and uses global toggle timeout.
>   - **Restore flow**:
>     - Remove pre-restore state validation loop; call `toggle(RUNNING, skip_first_refresh=True)` per process.
>   - **Misc**:
>     - Note quick 5s state check in `_check_cuda_session` comment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52a791bf48c03862b26d13216aa6f11835e11556. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->