### PR TITLE
Add WorkerType to be shared between solver serialization and internal dashboard

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -3517,6 +3517,14 @@ message WebhookConfig {
   bool requires_proxy_auth = 10;
 }
 
+message WorkerType {
+  string cloud = 1;
+  string region = 2;
+  string zone = 3;
+  bool spot = 4;
+  string instance_type = 5;
+}
+
 message WorkspaceNameLookupResponse {
   string workspace_name = 1 [deprecated=true];
   string username = 2;


### PR DESCRIPTION
Previously, for the Solver's internal visualization dashboard, we want to show the WorkerType and corresponding solver tasks. Now, we also want to add a new internal change that would require adding WorkerType to proto. Instead of duplicating in both `public_api.proto` and `internal_api.proto`, we will pull it out to `api.proto` so it can be shared.