### PR TITLE
Add [Alpha] tag to `sb.create_connect_token()` docstring and hide from docs

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -669,7 +669,8 @@ class _Sandbox(_Object, type_prefix="sb"):
     async def create_connect_token(
         self, user_metadata: Optional[Union[str, dict[str, Any]]] = None
     ) -> SandboxConnectCredentials:
-        """[Alpha] Create a token for making HTTP connections to the sandbox.
+        """mdmd:hidden
+        [Alpha] Create a token for making HTTP connections to the sandbox.
 
         Also accepts an optional user_metadata string or dict to associate with the token. This metadata
         will be added to the headers by the proxy when forwarding requests to the sandbox."""

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -669,7 +669,7 @@ class _Sandbox(_Object, type_prefix="sb"):
     async def create_connect_token(
         self, user_metadata: Optional[Union[str, dict[str, Any]]] = None
     ) -> SandboxConnectCredentials:
-        """Create a token for making HTTP connections to the sandbox.
+        """[Alpha] Create a token for making HTTP connections to the sandbox.
 
         Also accepts an optional user_metadata string or dict to associate with the token. This metadata
         will be added to the headers by the proxy when forwarding requests to the sandbox."""


### PR DESCRIPTION
This updates the `sandbox.create_connect_token()` docstring to include an `[Alpha]` tag. Also hides the function from the docs.