### PR TITLE
Add protos for billing report API

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -7,6 +7,7 @@ package modal.client;
 import "modal_proto/options.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 
 enum AppDeployVisibility {
@@ -3546,6 +3547,24 @@ message WebhookConfig {
   bool requires_proxy_auth = 10;
 }
 
+
+message WorkspaceBillingReportItem {
+  string object_id = 1;
+  string description = 2;
+  string environment_name = 3;
+  google.protobuf.Timestamp interval = 4;
+  string cost = 5;
+  map<string, string> tags = 6;
+}
+
+message WorkspaceBillingReportRequest {
+  // Workspace ID will be implicit in the request metadata
+  google.protobuf.Timestamp start_timestamp = 1;
+  google.protobuf.Timestamp end_timestamp = 2;
+  string resolution = 3;  // e.g. 'd' or 'h'; server defines what we accept
+  repeated string tag_names = 4;
+}
+
 message WorkspaceNameLookupResponse {
   string workspace_name = 1 [deprecated=true];
   string username = 2;
@@ -3777,5 +3796,6 @@ service ModalClient {
   rpc VolumeRename(VolumeRenameRequest) returns (google.protobuf.Empty);
 
   // Workspaces
+  rpc WorkspaceBillingReport(WorkspaceBillingReportRequest) returns (stream WorkspaceBillingReportItem);
   rpc WorkspaceNameLookup(google.protobuf.Empty) returns (WorkspaceNameLookupResponse);
 }


### PR DESCRIPTION
Part of SDK-624


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a streaming workspace billing report API with new request/item messages and timestamp import.
> 
> - **API (protobuf)**:
>   - **Billing report**:
>     - Add messages `WorkspaceBillingReportItem` and `WorkspaceBillingReportRequest` (uses `google.protobuf.Timestamp`).
>     - Add RPC `WorkspaceBillingReport(WorkspaceBillingReportRequest) -> stream WorkspaceBillingReportItem` to `service ModalClient`.
>   - Add import `google/protobuf/timestamp.proto` in `modal_proto/api.proto`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa4825efec8a0359f3cc3887ae3674d4ff6e75af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->