### PR TITLE
Stop changelog extraction at end marker

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -456,10 +456,12 @@ def update_changelog(ctx, sha: str = ""):
         return
 
     # Parse the PR description to get a changelog update
-    comment_pattern = r"<!--.+?-->"
+    # Remove HTML comments except for end-changelog markers
+    comment_pattern = r"<!--(?!\s*end-changelog\s*).+?-->"
     pr_description = re.sub(comment_pattern, "", pr_description, flags=re.DOTALL)
 
-    changelog_pattern = r"## Changelog\s*(.+)$"
+    # Extract changelog content, optionally stopping at end marker
+    changelog_pattern = r"## Changelog\s*(.+?)(?:<!--\s*end-changelog\s*-->|$)"
     m = re.search(changelog_pattern, pr_description, flags=re.DOTALL)
     if m:
         update = m.group(1).strip()


### PR DESCRIPTION
## Describe your changes

Instead of making the bots adapt to our process, make our process adapt to any description-appending bot?

By stopping changelog extraction at `<!-- end-changelog -->`.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->

<!-- end-changelog -->
