### PR TITLE
Driveby fix: blobify container startup exceptions 

### DIFF
--- a/modal/_runtime/container_io_manager.py
+++ b/modal/_runtime/container_io_manager.py
@@ -914,10 +914,12 @@ class _ContainerIOManager:
             print_exception(type(exc), exc, exc.__traceback__)
 
             serialized_tb, tb_line_cache = pickle_traceback(exc, self.task_id)
-
+            data_or_blob = await format_blob_data(pickle_exception(exc), self._client.stub)
             result = api_pb2.GenericResult(
                 status=api_pb2.GenericResult.GENERIC_STATUS_FAILURE,
-                data=pickle_exception(exc),
+                **data_or_blob,
+                # TODO: there is no way to communicate the data format here
+                #   since it usually goes on the envelope outside of GenericResult
                 exception=repr(exc),
                 traceback="".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
                 serialized_tb=serialized_tb or b"",

--- a/modal/_runtime/container_io_manager.py
+++ b/modal/_runtime/container_io_manager.py
@@ -914,6 +914,7 @@ class _ContainerIOManager:
             print_exception(type(exc), exc, exc.__traceback__)
 
             serialized_tb, tb_line_cache = pickle_traceback(exc, self.task_id)
+
             data_or_blob = await format_blob_data(pickle_exception(exc), self._client.stub)
             result = api_pb2.GenericResult(
                 status=api_pb2.GenericResult.GENERIC_STATUS_FAILURE,

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -668,6 +668,20 @@ def test_startup_failure(servicer, capsys):
 
 
 @skip_github_non_linux
+def test_startup_failure_big_exception(servicer, capsys):
+    _run_container(servicer, "test.supports.startup_failure_bigexception", "f")
+
+    assert servicer.task_result.status == api_pb2.GenericResult.GENERIC_STATUS_FAILURE
+
+    assert servicer.task_result.data == b""
+    assert servicer.task_result.data_blob_id
+    blob_data = servicer.blobs[servicer.task_result.data_blob_id]
+    exc = deserialize(blob_data, None)
+    assert len(exc.full_message) == 5_000_000
+    assert "BigException: aaaaaaaaaa" in capsys.readouterr().err
+
+
+@skip_github_non_linux
 def test_from_local_python_packages_inside_container(servicer):
     """`from_local_python_packages` shouldn't actually collect modules inside the container, because it's possible
     that there are modules that were present locally for the user that didn't get mounted into

--- a/test/supports/startup_failure_bigexception.py
+++ b/test/supports/startup_failure_bigexception.py
@@ -1,0 +1,20 @@
+# Copyright Modal Labs 2022
+import modal
+
+app = modal.App("hello-world")
+
+
+class BigException(Exception):
+    def __init__(self, message):
+        self.full_message = message
+        self.message = message[:10]
+        super().__init__(self.message)
+
+
+if not modal.is_local():
+    raise BigException("a" * 5_000_000)
+
+
+@app.function()
+def f(i):
+    pass


### PR DESCRIPTION
Inputs properly blobify their exceptions in case they are big, but we didn't do that for startup exceptions which can lead to issues that we previously had for input exceptions

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Blobify container startup exception payloads to handle large errors, with tests verifying blob-backed serialization.
> 
> - **Runtime**
>   - Blobify startup exception data in `modal/_runtime/container_io_manager.py` by using `format_blob_data(pickle_exception(...))` and passing `**data_or_blob` to `api_pb2.GenericResult`.
> - **Tests**
>   - Add `test_startup_failure_big_exception` validating blob-backed exception (`data==b""`, `data_blob_id` set, 5M-char message).
>   - Add support module `test/supports/startup_failure_bigexception.py` raising a large `BigException` when not local.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6d66af222c8f2ea9bf96cf5cde49db44454a2b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->