### PR TITLE
Client Update for Multiple open StreamWriter's fix [ART-8]

### DIFF
--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
 import asyncio
 import time
+import uuid
 from collections.abc import AsyncGenerator, AsyncIterator
 from typing import (
     TYPE_CHECKING,
@@ -370,6 +371,7 @@ class _StreamWriter:
         self._client = client
         self._is_closed = False
         self._buffer = bytearray()
+        self.writer_id = str(uuid.uuid4())
 
     def _get_next_index(self) -> int:
         index = self._index
@@ -449,7 +451,11 @@ class _StreamWriter:
                 await retry_transient_errors(
                     self._client.stub.SandboxStdinWrite,
                     api_pb2.SandboxStdinWriteRequest(
-                        sandbox_id=self._object_id, index=index, eof=self._is_closed, input=data
+                        sandbox_id=self._object_id,
+                        index=index,
+                        eof=self._is_closed,
+                        input=data,
+                        writer_id=self.writer_id,
                     ),
                 )
             else:

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2606,6 +2606,7 @@ message RuntimeInputMessage {
   bytes message = 1;
   uint64 message_index = 2;
   bool eof = 3;
+  string writer_id = 4;
 }
 
 message RuntimeOutputBatch {
@@ -2876,6 +2877,7 @@ message SandboxStdinWriteRequest {
   bytes input = 2;
   uint32 index = 3;
   bool eof = 4;
+  string writer_id = 5;
 }
 
 message SandboxStdinWriteResponse {


### PR DESCRIPTION
## This issue fixes an issue in which multiple `stdin` StreamWriters cannot be opened to a Sandbox. Previously, only one StreamWriter could be opened to write messages to `stdin`. Our new fix, at a high level, more explicitly enforces only one open StreamWriter, assigning a `uuid` to each writer and adds an ephemeral `active_writer_id` attribute for sandboxes.

- _Provide Linear issue reference (e.g. CLI-1234) if available._

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
