### PR TITLE
footgun warning for get_call_graph

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -2014,6 +2014,8 @@ class _FunctionCall(typing.Generic[ReturnType], _Object, type_prefix="fc"):
         """Returns a structure representing the call graph from a given root
         call ID, along with the status of execution for each node.
 
+        Not designed for high throughput, use sparingly.
+
         See [`modal.call_graph`](https://modal.com/docs/reference/modal.call_graph) reference page
         for documentation on the structure of the returned `InputInfo` items.
         """


### PR DESCRIPTION
## Describe your changes

footgun warning for get_call_graph

Context: https://modal-com.slack.com/archives/C07ML5EE6NM/p1758899617834759?thread_ts=1758897337.610719&cid=C07ML5EE6NM

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a docstring note to `get_call_graph` indicating it is not designed for high throughput and should be used sparingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d314dfafe48b3ce2bffa5d526a3b0d1f7459a4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->