### PR TITLE
Update python-build-standalone to latest (after 2 years)

### DIFF
--- a/modal/mount.py
+++ b/modal/mount.py
@@ -41,11 +41,11 @@ MOUNT_PUT_FILE_CLIENT_TIMEOUT = 10 * 60  # 10 min max for transferring files
 # These can be updated safely, but changes will trigger a rebuild for all images
 # that rely on `add_python()` in their constructor.
 PYTHON_STANDALONE_VERSIONS: dict[str, tuple[str, str]] = {
-    "3.9": ("20230826", "3.9.18"),
-    "3.10": ("20230826", "3.10.13"),
-    "3.11": ("20230826", "3.11.5"),
-    "3.12": ("20240107", "3.12.1"),
-    "3.13": ("20241008", "3.13.0"),
+    "3.9": ("20250918", "3.9.18"),
+    "3.10": ("20250918", "3.10.13"),
+    "3.11": ("20250918", "3.11.5"),
+    "3.12": ("20250918", "3.12.1"),
+    "3.13": ("20250918", "3.13.0"),
 }
 
 MOUNT_DEPRECATION_MESSAGE_PATTERN = """modal.Mount usage will soon be deprecated.


### PR DESCRIPTION
## Describe your changes

Zanie from Astral linked to https://github.com/astral-sh/python-build-standalone/issues/683#issuecomment-3348110820

Astral has automation around this, https://github.com/astral-sh/uv/blob/main/.github/workflows/sync-python-releases.yml.
But I don't have time to see automation through, so I've just done a manual bump here.

As helpfully marked out by code comments, this will trigger image rebuilds for users when they upgrade their client.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog


* `modal.Image`'s `add_python` will now use September 2025 builds of the Python interpreter. Any Images using  `add_python` will _**rebuild**_ after upgrading to this client version. 