### PR TITLE
call FlashSetTargetSlots from client

### DIFF
--- a/modal/experimental/flash.py
+++ b/modal/experimental/flash.py
@@ -307,6 +307,7 @@ class _FlashPrometheusAutoscaler:
                 await self.autoscaling_decisions_dict.put("current_replicas", actual_target_containers)
 
                 await self.cls.update_autoscaler(min_containers=actual_target_containers)
+                # await self.cls.uses(target_slots=actual_target_containers)
 
                 if time.time() - autoscaling_time < self.autoscaling_interval_seconds:
                     await asyncio.sleep(self.autoscaling_interval_seconds - (time.time() - autoscaling_time))

--- a/modal/experimental/flash.py
+++ b/modal/experimental/flash.py
@@ -306,8 +306,8 @@ class _FlashPrometheusAutoscaler:
                 )
                 await self.autoscaling_decisions_dict.put("current_replicas", actual_target_containers)
 
-                await self.cls.update_autoscaler(min_containers=actual_target_containers)
-                # await self.cls.uses(target_slots=actual_target_containers)
+                # await self.cls.update_autoscaler(min_containers=actual_target_containers)
+                await self._set_target_slots(actual_target_containers)
 
                 if time.time() - autoscaling_time < self.autoscaling_interval_seconds:
                     await asyncio.sleep(self.autoscaling_interval_seconds - (time.time() - autoscaling_time))
@@ -488,6 +488,11 @@ class _FlashPrometheusAutoscaler:
         req = api_pb2.FlashContainerListRequest(function_id=self.fn.object_id)
         resp = await retry_transient_errors(self.client.stub.FlashContainerList, req)
         return resp.containers
+
+    async def _set_target_slots(self, target_slots: int):
+        req = api_pb2.FlashSetTargetSlotsMetricsRequest(function_id=self.fn.object_id, target_slots=target_slots)
+        await retry_transient_errors(self.client.stub.FlashSetTargetSlotsMetrics, req)
+        return
 
     def _make_scaling_decision(
         self,

--- a/modal/experimental/flash.py
+++ b/modal/experimental/flash.py
@@ -521,30 +521,6 @@ class _FlashPrometheusAutoscaler:
             The target number of containers.
         """
 
-        # Look inside of autoscaling_decisions, if it has been 1 min since the last change to a different number,
-        # set it to a random number between 1 and 5.
-
-        import random
-
-        if autoscaling_decisions:
-            # Sort by timestamp to ensure order
-            autoscaling_decisions.sort(key=lambda rec: rec[0])
-            last_ts, last_val = autoscaling_decisions[-1]
-            # Find the last time the value changed
-            prev_val = last_val
-            last_change_ts = last_ts
-            for ts, val in reversed(autoscaling_decisions):
-                if val != prev_val:
-                    last_change_ts = ts
-                    prev_val = val
-            # If it has been >= 60 seconds since the last change to a different number
-            now_ts = autoscaling_decisions[-1][0]
-            if now_ts - last_change_ts < 60:
-                return last_val
-
-        random_number = random.randint(1, 5)
-        return random_number
-
         if not autoscaling_decisions:
             # Without data we can’t make a new decision – stay where we are.
             return current_replicas


### PR DESCRIPTION
modify client code to set target slots via targetslot rpc instead of using min_containers path

tested this on dev cluster by setting target_containers to random numbers every minute and seeing whether the scheduler picked up the requests:
<img width="749" height="242" alt="image" src="https://github.com/user-attachments/assets/6a00bd9a-640e-4403-ae07-cdf9cb820995" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use a new RPC to set target slots in the Flash autoscaler, replacing the prior min_containers path.
> 
> - **Flash autoscaler**:
>   - Replace `self.cls.update_autoscaler(min_containers=...)` with `self._set_target_slots(...)` to control capacity via target slots.
>   - Add `/_set_target_slots/` helper that issues `FlashSetTargetSlotsMetricsRequest` via `FlashSetTargetSlotsMetrics` RPC.
>   - Persist autoscaling decisions and `current_replicas` unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7153ceba497775fb75548d31551dcae51772816d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->