### PR TITLE
Run `ruff format` in `inv lint` task

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -81,13 +81,8 @@ def protoc(ctx):
 )
 def lint(ctx, fix=False):
     """Run linter on all files."""
-    check_cmd = f"ruff check {'--fix' if fix else ''}"
-    print(f"Running '{check_cmd}'")
-    ctx.run(check_cmd, pty=True)
-
-    format_cmd = f"ruff format {'' if fix else '--diff'}"
-    print(f"\nRunning '{format_cmd}'")
-    ctx.run(format_cmd, pty=True)
+    ctx.run(f"ruff check {'--fix' if fix else ''}", pty=True, echo=True)
+    ctx.run(f"ruff format {'' if fix else '--diff'}", pty=True, echo=True)
 
 
 def lint_protos_impl(ctx, proto_fname: str):

--- a/test/auth_token_manager_test.py
+++ b/test/auth_token_manager_test.py
@@ -24,6 +24,7 @@ def valid_jwt_token():
     payload = {"exp": exp, "type": "valid"}
     return jwt.encode(payload, "my-secret-key", algorithm="HS256")
 
+
 @pytest.fixture
 def another_valid_jwt_token():
     """Create a valid JWT token with expiry."""
@@ -31,6 +32,7 @@ def another_valid_jwt_token():
     exp = int(time.time()) + 3600
     payload = {"exp": exp, "type": "another_valid"}
     return jwt.encode(payload, "my-secret-key", algorithm="HS256")
+
 
 @pytest.fixture
 def expired_jwt_token():
@@ -268,9 +270,11 @@ def test_is_expired_false(auth_token_manager):
 async def test_multiple_refresh_cycles(auth_token_manager, servicer):
     """Test multiple refresh cycles work correctly."""
     exp = int(time.time()) + 3600
-    tokens = [jwt.encode({"exp": exp, "name": "t0"}, "my-secret-key", algorithm="HS256"),
-              jwt.encode({"exp": exp, "name": "t1"}, "my-secret-key", algorithm="HS256"),
-              jwt.encode({"exp": exp, "name": "t2"}, "my-secret-key", algorithm="HS256")]
+    tokens = [
+        jwt.encode({"exp": exp, "name": "t0"}, "my-secret-key", algorithm="HS256"),
+        jwt.encode({"exp": exp, "name": "t1"}, "my-secret-key", algorithm="HS256"),
+        jwt.encode({"exp": exp, "name": "t2"}, "my-secret-key", algorithm="HS256"),
+    ]
 
     @synchronize_api
     async def wrapped_get_token():
@@ -296,6 +300,7 @@ async def test_multiple_refresh_cycles(auth_token_manager, servicer):
     servicer.auth_token = tokens[2]
     token2 = await wrapped_get_token.aio()
     assert token2 == tokens[2]
+
 
 def exp_time(token: str):
     return jwt.decode(token, options={"verify_signature": False})["exp"]


### PR DESCRIPTION
## Describe your changes

I noticed a discrepancy between `.pre-commit-config.yaml`
which runs `ruff format` and `ci-cd.yml` which runs
`inv lint` which only runs `ruff check`.
    
This change makes CI/CD checks consistent with pre-commit checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> `inv lint` now runs `ruff format` (diff-only unless --fix) and echoes ruff commands; minor test formatting cleanups.
> 
> - **Tasks**:
>   - Update `lint` task in `tasks.py`:
>     - Run `ruff format` (uses `--diff` unless `--fix`).
>     - Echo ruff commands (`echo=True`).
>     - Adjust `ruff check` invocation (remove path arg).
> - **Tests**:
>   - Minor formatting in `test/auth_token_manager_test.py` (list formatting, spacing).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b57e56de4693095522a16d12ba9ed5fa06340414. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->