### PR TITLE
Enable Ruff PLR1702 too many nested blocks rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,14 +98,19 @@ exclude = [
     'modal/_vendor',
 ]
 line-length = 120
-lint.ignore = ['E741']
-lint.select = [
+
+[tool.ruff.lint]
+ignore = ['E741', 'F841']
+select = [
     'E',
     'F',
     'W',
     'I',
     'RUF006', # asyncio-dangling-task
 ]
+preview = true
+explicit-preview-rules = true
+extend-select = ['PLR1702']
 
 [tool.ruff.lint.per-file-ignores]
 "*_test.py" = ['E712']
@@ -120,6 +125,9 @@ known-first-party = [
     "modal_version",
 ]
 extra-standard-library = ["pytest"]
+
+[tool.ruff.lint.pylint]
+max-nested-blocks = 7
 
 [tool.pyright]
 reportUnnecessaryComparison = true


### PR DESCRIPTION
Set a max-nested-blocks to 7 instead of default of 5. Ignore existing
violations. Motivated by bugs like the one introduced in
modal-labs/modal-client#3456 and fixed in modal-labs/modal-client#3565.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reorganizes Ruff settings, enables preview rules including PLR1702, adds F841 to ignores, and configures pylint max-nested-blocks=7.
> 
> - **Linting (Ruff)**:
>   - Move `lint.*` settings under `[tool.ruff.lint]`.
>   - Enable `preview = true` and `explicit-preview-rules = true`.
>   - `extend-select = ['PLR1702']` to check for too many nested blocks.
>   - Update ignores to include `E741` and `F841`.
> - **Pylint (via Ruff)**:
>   - Add `[tool.ruff.lint.pylint]` with `max-nested-blocks = 7`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e43f635d0138e73891ef411552a4c6eeb8dccb6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->