### PR TITLE
Final removal of .lookup methods

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1429,40 +1429,6 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         warn_if_passing_namespace(namespace, "modal.Function.from_name")
         return cls._from_name(app_name, name, environment_name=environment_name)
 
-    @staticmethod
-    async def lookup(
-        app_name: str,
-        name: str,
-        namespace=None,  # mdmd:line-hidden
-        client: Optional[_Client] = None,
-        environment_name: Optional[str] = None,
-    ) -> "_Function":
-        """mdmd:hidden
-        Lookup a Function from a deployed App by its name.
-
-        DEPRECATED: This method is deprecated in favor of `modal.Function.from_name`.
-
-        In contrast to `modal.Function.from_name`, this is an eager method
-        that will hydrate the local object with metadata from Modal servers.
-
-        ```python notest
-        f = modal.Function.lookup("other-app", "function")
-        ```
-        """
-        deprecation_warning(
-            (2025, 1, 27),
-            "`modal.Function.lookup` is deprecated and will be removed in a future release."
-            " It can be replaced with `modal.Function.from_name`."
-            "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
-        )
-        warn_if_passing_namespace(namespace, "modal.Function.lookup")
-        obj = _Function.from_name(app_name, name, environment_name=environment_name)
-        if client is None:
-            client = await _Client.from_env()
-        resolver = Resolver(client=client)
-        await resolver.load(obj)
-        return obj
-
     @property
     def tag(self) -> str:
         """mdmd:hidden"""
@@ -1811,8 +1777,9 @@ Use the `Function.get_web_url()` method instead.
         # "user code" to run on the synchronicity thread, which seems bad
         if not self._is_local():
             msg = (
-                "The definition for this function is missing here so it is not possible to invoke it locally. "
-                "If this function was retrieved via `Function.lookup` you need to use `.remote()`."
+                "The definition for this Function is missing, so it is not possible to invoke it locally. "
+                "If this function was retrieved via `Function.from_name`, "
+                "you need to use one of the remote invocation methods instead."
             )
             raise ExecutionError(msg)
 

--- a/modal/cls.py
+++ b/modal/cls.py
@@ -32,7 +32,6 @@ from ._utils.deprecation import (
 )
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.mount_utils import validate_volumes
-from .client import _Client
 from .cloud_bucket_mount import _CloudBucketMount
 from .config import config
 from .exception import ExecutionError, InvalidError, NotFoundError
@@ -851,46 +850,6 @@ More information on class parameterization can be found here: https://modal.com/
         batching_options = _ServiceOptions(batch_max_size=max_batch_size, batch_wait_ms=wait_ms)
         cls._options.merge_options(batching_options)
         return cls
-
-    @staticmethod
-    async def lookup(
-        app_name: str,
-        name: str,
-        namespace=None,  # mdmd:line-hidden
-        client: Optional[_Client] = None,
-        environment_name: Optional[str] = None,
-    ) -> "_Cls":
-        """mdmd:hidden
-        Lookup a Cls from a deployed App by its name.
-
-        DEPRECATED: This method is deprecated in favor of `modal.Cls.from_name`.
-
-        In contrast to `modal.Cls.from_name`, this is an eager method
-        that will hydrate the local object with metadata from Modal servers.
-
-        ```python notest
-        Model = modal.Cls.from_name("other-app", "Model")
-        model = Model()
-        model.inference(...)
-        ```
-        """
-        deprecation_warning(
-            (2025, 1, 27),
-            "`modal.Cls.lookup` is deprecated and will be removed in a future release."
-            " It can be replaced with `modal.Cls.from_name`."
-            "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
-        )
-        warn_if_passing_namespace(namespace, "modal.Cls.lookup")
-        obj = _Cls.from_name(
-            app_name,
-            name,
-            environment_name=environment_name,
-        )
-        if client is None:
-            client = await _Client.from_env()
-        resolver = Resolver(client=client)
-        await resolver.load(obj)
-        return obj
 
     @synchronizer.no_input_translation
     def __call__(self, *args, **kwargs) -> _Obj:

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -384,47 +384,6 @@ class _Dict(_Object, type_prefix="di"):
         return _Dict._from_loader(_load, rep, is_another_app=True, hydrate_lazily=True, name=name)
 
     @staticmethod
-    async def lookup(
-        name: str,
-        data: Optional[dict] = None,
-        namespace=None,  # mdmd:line-hidden
-        client: Optional[_Client] = None,
-        environment_name: Optional[str] = None,
-        create_if_missing: bool = False,
-    ) -> "_Dict":
-        """mdmd:hidden
-        Lookup a named Dict.
-
-        DEPRECATED: This method is deprecated in favor of `modal.Dict.from_name`.
-
-        In contrast to `modal.Dict.from_name`, this is an eager method
-        that will hydrate the local object with metadata from Modal servers.
-
-        ```python
-        d = modal.Dict.from_name("my-dict")
-        d["xyz"] = 123
-        ```
-        """
-        deprecation_warning(
-            (2025, 1, 27),
-            "`modal.Dict.lookup` is deprecated and will be removed in a future release."
-            " It can be replaced with `modal.Dict.from_name`."
-            "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
-        )
-        warn_if_passing_namespace(namespace, "modal.Dict.lookup")
-        obj = _Dict.from_name(
-            name,
-            data=data,
-            environment_name=environment_name,
-            create_if_missing=create_if_missing,
-        )
-        if client is None:
-            client = await _Client.from_env()
-        resolver = Resolver(client=client)
-        await resolver.load(obj)
-        return obj
-
-    @staticmethod
     async def delete(
         name: str,
         *,

--- a/modal/environments.py
+++ b/modal/environments.py
@@ -11,7 +11,6 @@ from modal_proto import api_pb2
 from ._object import _Object
 from ._resolver import Resolver
 from ._utils.async_utils import synchronize_api, synchronizer
-from ._utils.deprecation import deprecation_warning
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from .client import _Client
@@ -78,25 +77,6 @@ class _Environment(_Object, type_prefix="en"):
 
         # TODO environment name (and id?) in the repr? (We should make reprs consistently more useful)
         return _Environment._from_loader(_load, "Environment()", is_another_app=True, hydrate_lazily=True)
-
-    @staticmethod
-    async def lookup(
-        name: str,
-        client: Optional[_Client] = None,
-        create_if_missing: bool = False,
-    ):
-        deprecation_warning(
-            (2025, 1, 27),
-            "`modal.Environment.lookup` is deprecated and will be removed in a future release."
-            " It can be replaced with `modal.Environment.from_name`."
-            "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
-        )
-        obj = _Environment.from_name(name, create_if_missing=create_if_missing)
-        if client is None:
-            client = await _Client.from_env()
-        resolver = Resolver(client=client)
-        await resolver.load(obj)
-        return obj
 
 
 Environment = synchronize_api(_Environment)

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -738,28 +738,6 @@ class _Mount(_Object, type_prefix="mo"):
 
         return _Mount._from_loader(_load, "Mount()", hydrate_lazily=True)
 
-    @classmethod
-    async def lookup(
-        cls: type["_Mount"],
-        name: str,
-        namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE,
-        client: Optional[_Client] = None,
-        environment_name: Optional[str] = None,
-    ) -> "_Mount":
-        """mdmd:hidden"""
-        deprecation_warning(
-            (2025, 1, 27),
-            "`modal.Mount.lookup` is deprecated and will be removed in a future release."
-            " It can be replaced with `modal.Mount.from_name`."
-            "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
-        )
-        obj = _Mount.from_name(name, namespace=namespace, environment_name=environment_name)
-        if client is None:
-            client = await _Client.from_env()
-        resolver = Resolver(client=client)
-        await resolver.load(obj)
-        return obj
-
     async def _deploy(
         self: "_Mount",
         deployment_name: Optional[str] = None,

--- a/modal/network_file_system.py
+++ b/modal/network_file_system.py
@@ -21,7 +21,7 @@ from ._object import (
 from ._resolver import Resolver
 from ._utils.async_utils import TaskContext, aclosing, async_map, sync_or_async_iter, synchronize_api
 from ._utils.blob_utils import LARGE_FILE_LIMIT, blob_iter, blob_upload_file
-from ._utils.deprecation import deprecation_warning, warn_if_passing_namespace
+from ._utils.deprecation import warn_if_passing_namespace
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.hash_utils import get_sha256_hex
 from ._utils.name_utils import check_object_name
@@ -170,45 +170,6 @@ class _NetworkFileSystem(_Object, type_prefix="sv"):
                 is_another_app=True,
                 rep="modal.NetworkFileSystem.ephemeral()",
             )
-
-    @staticmethod
-    async def lookup(
-        name: str,
-        namespace=None,  # mdmd:line-hidden
-        client: Optional[_Client] = None,
-        environment_name: Optional[str] = None,
-        create_if_missing: bool = False,
-    ) -> "_NetworkFileSystem":
-        """mdmd:hidden
-        Lookup a named NetworkFileSystem.
-
-        DEPRECATED: This method is deprecated in favor of `modal.NetworkFileSystem.from_name`.
-
-        In contrast to `modal.NetworkFileSystem.from_name`, this is an eager method
-        that will hydrate the local object with metadata from Modal servers.
-
-        ```python notest
-        nfs = modal.NetworkFileSystem.lookup("my-nfs")
-        print(nfs.listdir("/"))
-        ```
-        """
-        deprecation_warning(
-            (2025, 1, 27),
-            "`modal.NetworkFileSystem.lookup` is deprecated and will be removed in a future release."
-            " It can be replaced with `modal.NetworkFileSystem.from_name`."
-            "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
-        )
-        warn_if_passing_namespace(namespace, "modal.NetworkFileSystem.lookup")
-        obj = _NetworkFileSystem.from_name(
-            name,
-            environment_name=environment_name,
-            create_if_missing=create_if_missing,
-        )
-        if client is None:
-            client = await _Client.from_env()
-        resolver = Resolver(client=client)
-        await resolver.load(obj)
-        return obj
 
     @staticmethod
     async def create_deployed(

--- a/modal/queue.py
+++ b/modal/queue.py
@@ -389,45 +389,6 @@ class _Queue(_Object, type_prefix="qu"):
         return _Queue._from_loader(_load, rep, is_another_app=True, hydrate_lazily=True, name=name)
 
     @staticmethod
-    async def lookup(
-        name: str,
-        namespace=None,  # mdmd:line-hidden
-        client: Optional[_Client] = None,
-        environment_name: Optional[str] = None,
-        create_if_missing: bool = False,
-    ) -> "_Queue":
-        """mdmd:hidden
-        Lookup a named Queue.
-
-        DEPRECATED: This method is deprecated in favor of `modal.Queue.from_name`.
-
-        In contrast to `modal.Queue.from_name`, this is an eager method
-        that will hydrate the local object with metadata from Modal servers.
-
-        ```python notest
-        q = modal.Queue.lookup("my-queue")
-        q.put(123)
-        ```
-        """
-        deprecation_warning(
-            (2025, 1, 27),
-            "`modal.Queue.lookup` is deprecated and will be removed in a future release."
-            " It can be replaced with `modal.Queue.from_name`."
-            "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
-        )
-        warn_if_passing_namespace(namespace, "modal.Queue.lookup")
-        obj = _Queue.from_name(
-            name,
-            environment_name=environment_name,
-            create_if_missing=create_if_missing,
-        )
-        if client is None:
-            client = await _Client.from_env()
-        resolver = Resolver(client=client)
-        await resolver.load(obj)
-        return obj
-
-    @staticmethod
     async def delete(name: str, *, client: Optional[_Client] = None, environment_name: Optional[str] = None):
         """mdmd:hidden
         Delete a named Queue.

--- a/modal/secret.py
+++ b/modal/secret.py
@@ -413,35 +413,6 @@ class _Secret(_Object, type_prefix="st"):
         return _Secret._from_loader(_load, rep, hydrate_lazily=True, name=name)
 
     @staticmethod
-    async def lookup(
-        name: str,
-        namespace=None,  # mdmd:line-hidden
-        client: Optional[_Client] = None,
-        environment_name: Optional[str] = None,
-        required_keys: list[str] = [],
-    ) -> "_Secret":
-        """mdmd:hidden"""
-        deprecation_warning(
-            (2025, 1, 27),
-            "`modal.Secret.lookup` is deprecated and will be removed in a future release."
-            " It can be replaced with `modal.Secret.from_name`."
-            "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
-        )
-
-        warn_if_passing_namespace(namespace, "modal.Secret.lookup")
-
-        obj = _Secret.from_name(
-            name,
-            environment_name=environment_name,
-            required_keys=required_keys,
-        )
-        if client is None:
-            client = await _Client.from_env()
-        resolver = Resolver(client=client)
-        await resolver.load(obj)
-        return obj
-
-    @staticmethod
     async def create_deployed(
         deployment_name: str,
         env_dict: dict[str, str],

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -485,47 +485,6 @@ class _Volume(_Object, type_prefix="vo"):
             )
 
     @staticmethod
-    async def lookup(
-        name: str,
-        namespace=None,  # mdmd:line-hidden
-        client: Optional[_Client] = None,
-        environment_name: Optional[str] = None,
-        create_if_missing: bool = False,
-        version: "typing.Optional[modal_proto.api_pb2.VolumeFsVersion.ValueType]" = None,
-    ) -> "_Volume":
-        """mdmd:hidden
-        Lookup a named Volume.
-
-        DEPRECATED: This method is deprecated in favor of `modal.Volume.from_name`.
-
-        In contrast to `modal.Volume.from_name`, this is an eager method
-        that will hydrate the local object with metadata from Modal servers.
-
-        ```python notest
-        vol = modal.Volume.from_name("my-volume")
-        print(vol.listdir("/"))
-        ```
-        """
-        deprecation_warning(
-            (2025, 1, 27),
-            "`modal.Volume.lookup` is deprecated and will be removed in a future release."
-            " It can be replaced with `modal.Volume.from_name`."
-            "\n\nSee https://modal.com/docs/guide/modal-1-0-migration for more information.",
-        )
-        warn_if_passing_namespace(namespace, "modal.Volume.lookup")
-        obj = _Volume.from_name(
-            name,
-            environment_name=environment_name,
-            create_if_missing=create_if_missing,
-            version=version,
-        )
-        if client is None:
-            client = await _Client.from_env()
-        resolver = Resolver(client=client)
-        await resolver.load(obj)
-        return obj
-
-    @staticmethod
     async def create_deployed(
         deployment_name: str,
         namespace=None,  # mdmd:line-hidden

--- a/test/secret_test.py
+++ b/test/secret_test.py
@@ -118,11 +118,8 @@ def test_secret_namespace_deprecated(servicer, client):
             "my-secret", {"FOO": "123"}, namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, client=client
         )
 
-    with pytest.warns() as record:
-        Secret.lookup("my-secret", namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE, client=client)
-    # Should warn about both the deprecated lookup method and the deprecated namespace parameter
-    assert len(record) >= 2
-    assert any(isinstance(w.message, DeprecationError) for w in record)
+    with pytest.warns(DeprecationError, match="The `namespace` parameter"):
+        Secret.from_name("my-secret", namespace=api_pb2.DEPLOYMENT_NAMESPACE_WORKSPACE)
 
 
 def test_secret_list(servicer, client):


### PR DESCRIPTION
## Describe your changes

These began warning in 0.72 and 0.73 is now the minimally supported version, so there should be no surprises for anyone.

- Part of SDK-634

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

- Removed previously deprecated `.lookup` methods from most Modal object classes (but not `modal.App.lookup`, which remains supported). The lazy `.from_name()` method is recommended for accessing deployed objects going forward.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes all deprecated `.lookup` methods across core objects, updates error messaging to reference `.from_name`, and adjusts tests accordingly.
> 
> - **API removals (deprecated)**:
>   - Drop `.lookup` for: `modal.Function`, `modal.Cls`, `modal.Dict`, `modal.Environment`, `modal.Mount`, `modal.NetworkFileSystem`, `modal.Queue`, `modal.Secret`, `modal.Volume`.
> - **Behavior/messaging**:
>   - `Function.local()` error now references `Function.from_name` and using remote invocation methods.
>   - Minor import cleanups related to deprecation utilities.
> - **Tests**:
>   - Remove/adjust tests that used `.lookup` (e.g., `test_lookup` in `cls_test.py`).
>   - Update `Secret` tests to warn only on deprecated `namespace` param and use `.from_name`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b298b465535755278f312f1afc8006458219daaf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->