### PR TITLE
Remove additional public APIs relating to modal.Mount

### DIFF
--- a/modal/mount.py
+++ b/modal/mount.py
@@ -413,39 +413,6 @@ class _Mount(_Object, type_prefix="mo"):
         )
 
     @staticmethod
-    def from_local_dir(
-        local_path: Union[str, Path],
-        *,
-        # Where the directory is placed within in the mount
-        remote_path: Union[str, PurePosixPath, None] = None,
-        # Predicate filter function for file selection, which should accept a filepath and return `True` for inclusion.
-        # Defaults to including all files.
-        condition: Optional[Callable[[str], bool]] = None,
-        # add files from subdirectories as well
-        recursive: bool = True,
-    ) -> "_Mount":
-        """
-        **Deprecated:** Use image.add_local_dir() instead
-
-        Create a `Mount` from a local directory.
-
-        **Usage**
-
-        ```python notest
-        assets = modal.Mount.from_local_dir(
-            "~/assets",
-            condition=lambda pth: not ".venv" in pth,
-            remote_path="/assets",
-        )
-        ```
-        """
-        deprecation_warning(
-            (2025, 1, 8),
-            MOUNT_DEPRECATION_MESSAGE_PATTERN.format(replacement="image.add_local_dir"),
-        )
-        return _Mount._from_local_dir(local_path, remote_path=remote_path, condition=condition, recursive=recursive)
-
-    @staticmethod
     def _from_local_dir(
         local_path: Union[str, Path],
         *,
@@ -479,29 +446,6 @@ class _Mount(_Object, type_prefix="mo"):
                 remote_path=PurePosixPath(remote_path),
             ),
         )
-
-    @staticmethod
-    def from_local_file(local_path: Union[str, Path], remote_path: Union[str, PurePosixPath, None] = None) -> "_Mount":
-        """
-        **Deprecated**: Use image.add_local_file() instead
-
-        Create a `Mount` mounting a single local file.
-
-        **Usage**
-
-        ```python notest
-        # Mount the DBT profile in user's home directory into container.
-        dbt_profiles = modal.Mount.from_local_file(
-            local_path="~/profiles.yml",
-            remote_path="/root/dbt_profile/profiles.yml",
-        )
-        ```
-        """
-        deprecation_warning(
-            (2025, 1, 8),
-            MOUNT_DEPRECATION_MESSAGE_PATTERN.format(replacement="image.add_local_file"),
-        )
-        return _Mount._from_local_file(local_path, remote_path)
 
     @staticmethod
     def _from_local_file(local_path: Union[str, Path], remote_path: Union[str, PurePosixPath, None] = None) -> "_Mount":
@@ -653,45 +597,6 @@ class _Mount(_Object, type_prefix="mo"):
 
         logger.debug(f"Uploaded {total_uploads} new files and {total_bytes} bytes in {time.monotonic() - t0}s")
         self._hydrate(resp.mount_id, resolver.client, resp.handle_metadata)
-
-    @staticmethod
-    def from_local_python_packages(
-        *module_names: str,
-        remote_dir: Union[str, PurePosixPath] = ROOT_DIR.as_posix(),
-        # Predicate filter function for file selection, which should accept a filepath and return `True` for inclusion.
-        # Defaults to including all files.
-        condition: Optional[Callable[[str], bool]] = None,
-        ignore: Optional[Union[Sequence[str], Callable[[Path], bool]]] = None,
-    ) -> "_Mount":
-        """
-        **Deprecated**: Use image.add_local_python_source instead
-
-        Returns a `modal.Mount` that makes local modules listed in `module_names` available inside the container.
-        This works by mounting the local path of each module's package to a directory inside the container
-        that's on `PYTHONPATH`.
-
-        **Usage**
-
-        ```python notest
-        import modal
-        import my_local_module
-
-        app = modal.App()
-
-        @app.function(mounts=[
-            modal.Mount.from_local_python_packages("my_local_module", "my_other_module"),
-        ])
-        def f():
-            my_local_module.do_stuff()
-        ```
-        """
-        deprecation_warning(
-            (2025, 1, 8),
-            MOUNT_DEPRECATION_MESSAGE_PATTERN.format(replacement="image.add_local_python_source"),
-        )
-        return _Mount._from_local_python_packages(
-            *module_names, remote_dir=remote_dir, condition=condition, ignore=ignore
-        )
 
     @staticmethod
     def _from_local_python_packages(


### PR DESCRIPTION
We removed `modal.Mount` as a public object in 1.0, but there were still a few non-removed parameters _accepting_ a `modal.Mount` type on the `modal.Image` class, and we had kept the public constructors with deprecation warnings. We can remove these now.

Part of SDK-634

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

- Final removal of the `context_mount=` parameter of some modal.Image methods.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `context_mount` support from `Image` build APIs and deletes deprecated `modal.Mount` public constructors.
> 
> - **API removals**:
>   - **Image**:
>     - Drop `context_mount` parameter from `Image.dockerfile_commands()` and `Image.from_dockerfile()`; remove related deprecation warnings.
>     - Simplify `_create_context_mount_function` by deleting `context_mount` handling; context is now inferred (with `AUTO_DOCKERIGNORE` support).
>   - **Mount**:
>     - Remove deprecated public constructors: `Mount.from_local_dir`, `Mount.from_local_file`, and `Mount.from_local_python_packages`.
> - **Cleanup**:
>   - Remove unused deprecation wiring/imports tied to the deleted parameters and methods.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e59d3e06092cf8c53892851e7049134ebf5dbe12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->