### PR TITLE
add concurrent requests as metric

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -669,6 +669,7 @@ message AutoscalingMetrics {
   double memory_usage_percent = 2;
   uint32 concurrent_requests = 3;
   double timestamp = 4;
+  uint32 num_concurrent_requests = 5;
 }
 
 message BaseImage {


### PR DESCRIPTION
add concurrent requests as part of existing metrics

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `num_concurrent_requests` field to `AutoscalingMetrics` in `modal_proto/api.proto`.
> 
> - **Proto changes**:
>   - Update `modal_proto/api.proto`:
>     - `AutoscalingMetrics`: add `uint32 num_concurrent_requests = 5;`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43beb8c30f3e1e791d2bc98fe6e7f22fad108c78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->