### PR TITLE
Align environment delete CLI with others

### DIFF
--- a/modal/cli/environment.py
+++ b/modal/cli/environment.py
@@ -8,7 +8,7 @@ from rich.text import Text
 
 from modal import environments
 from modal._utils.name_utils import check_environment_name
-from modal.cli.utils import display_table
+from modal.cli.utils import YES_OPTION, display_table
 from modal.config import config
 from modal.exception import InvalidError
 
@@ -80,9 +80,10 @@ Deletes all apps in the selected environment and deletes the environment irrevoc
 @environment_cli.command(name="delete", help=ENVIRONMENT_DELETE_HELP)
 def delete(
     name: str = typer.Argument(help="Name of the environment to be deleted. Case sensitive"),
-    confirm: bool = typer.Option(default=False, help="Set this flag to delete without prompting for confirmation"),
+    *,
+    yes: bool = YES_OPTION,
 ):
-    if not confirm:
+    if not yes:
         typer.confirm(
             (
                 f"Are you sure you want to irrevocably delete the environment '{name}' and"


### PR DESCRIPTION
## Describe your changes

The `--confirm`/`--no-confirm` option in `modal environment delete` was implemented backwards. Also, all similar CLIs use `--yes` for "force deletion". So I'm both fixing and aligning in one step. Given that the old spelling was broken I think better to just break it rather than keep the old broken behavior with a deprecation warning (or "fixing" the old broken behavior and adding a warning, which would have its own surprises).

Fixes SDK-451

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


</details>

## Changelog

- Replaced the `--no-confirm` option with `--yes` in the `modal environment delete` CLI to align with similar interfaces.