### PR TITLE
Add function_call_id to App._logs

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -1104,6 +1104,9 @@ class _App:
         if not self._app_id:
             raise InvalidError("`app._logs` requires a running/stopped app.")
 
+        if function_call_id is not None and not function_call_id.startswith("fc"):
+            raise InvalidError(f"function_call_id must start with 'fc' got {function_call_id}")
+
         client = client or self._client or await _Client.from_env()
 
         last_log_batch_entry_id: Optional[str] = None

--- a/test/app_test.py
+++ b/test/app_test.py
@@ -358,6 +358,19 @@ def test_app_logs(servicer, client):
     assert logs == ["hello, world (1)\n"]
 
 
+def test_app_logs_error(servicer, client):
+    app = App()
+
+    f = app.function()(dummy)
+
+    with app.run(client=client):
+        f.remote()
+
+    msg = "function_call_id must start with 'fc'"
+    with pytest.raises(InvalidError, match=msg):
+        next(app._logs(client=client, function_call_id="ts-231232132"))
+
+
 def test_app_interactive(servicer, client, capsys):
     app = App()
 


### PR DESCRIPTION
## Describe your changes

This way you can spawn a function and then get the logs from there. Tested with

```python
import modal

app = modal.App("stream-logs")


@app.function()
def show_stuff(start):
    import time

    print("starting stream")
    for i in range(start, start + 20):
        time.sleep(1)
        print(f"Counting {i}")


if __name__ == "__main__":
    my_func = modal.Function.from_name("stream-logs", "show_stuff")
    f_call = my_func.spawn(100)
    f_call_2 = my_func.spawn(3000)

    my_app = modal.App.lookup("stream-logs")
    for line in my_app._logs(function_call_id=f_call.object_id):
        print(line, end="")
```

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>