### PR TITLE
Fix import lint

### DIFF
--- a/modal/mount.py
+++ b/modal/mount.py
@@ -24,7 +24,6 @@ from ._object import _get_environment_name, _Object
 from ._resolver import Resolver
 from ._utils.async_utils import TaskContext, aclosing, async_map, synchronize_api
 from ._utils.blob_utils import FileUploadSpec, blob_upload_file, get_file_upload_spec_from_path
-from ._utils.deprecation import deprecation_warning
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.name_utils import check_object_name
 from ._utils.package_utils import get_module_mount_info


### PR DESCRIPTION
Had two parallel PRs that removed dependencies on an imported name, causing the name to be dangling once both were merged and failing the lint check on main. Sorry!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes an unused `deprecation_warning` import from `modal/mount.py` to satisfy lint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba0fdb4068343a91e5289d8345cc0cf502b83be4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->