### PR TITLE
Add comment to `modal.Cls.with_options.timeout`

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -694,7 +694,7 @@ More information on class parameterization can be found here: https://modal.com/
         max_containers: Optional[int] = None,  # Limit on the number of containers that can be concurrently running.
         buffer_containers: Optional[int] = None,  # Additional containers to scale up while Function is active.
         scaledown_window: Optional[int] = None,  # Max amount of time a container can remain idle before scaling down.
-        timeout: Optional[int] = None,
+        timeout: Optional[int] = None,  # Max execution time for inputs and startup in seconds. None results in 300s.
         region: Optional[Union[str, Sequence[str]]] = None,  # Region or regions to run the function on.
         cloud: Optional[str] = None,  # Cloud provider to run the function on. Possible values are aws, gcp, oci, auto.
         # The following parameters are deprecated


### PR DESCRIPTION
stating that `None` results in the default timeout of 300 seconds as [documented elsewhere][1].

[1]: https://modal.com/docs/guide/timeouts#timeouts:~:text=All%20Modal%20Function%20executions%20have%20a%20default%20execution%20timeout%20of%20300%20seconds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an inline comment to `Cls.with_options(timeout)` noting it’s the max execution time and that `None` uses the 300s default.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f578a89ce29a81c139508792e486a6882cc7e2ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->