### PR TITLE
Reject null timeout values

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -736,6 +736,9 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
             if is_generator:
                 raise InvalidError("Generator functions do not support retries.")
 
+        if timeout is None:  # type: ignore[unreachable]  # Help users who aren't using type checkers
+            raise InvalidError("The `timeout` parameter cannot be set to None.")
+
         secrets = secrets or []
         if env:
             secrets = [*secrets, _Secret.from_dict(env)]

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -1181,6 +1181,27 @@ def test_autoscaler_settings_deprecations(new, old):
         app.function(**{old: 10})(dummy)  # type: ignore
 
 
+def test_timeout(servicer, client):
+    app = App()
+
+    with pytest.raises(InvalidError, match="cannot be set to None"):
+
+        @app.function(serialized=True, timeout=None)
+        def f():
+            pass
+
+    @app.function(serialized=True)
+    def g():
+        pass
+
+    with servicer.intercept() as ctx:
+        with app.run(client=client):
+            pass
+
+    req = ctx.pop_request("FunctionCreate")
+    assert req.function.timeout_secs == 300
+
+
 def test_not_hydrated():
     with pytest.raises(ExecutionError):
         assert foo.remote(2, 4) == 20


### PR DESCRIPTION
We don't currently support an unbounded Function timeout, and if you set `timeout=None` in the Function decorator, it will fall back to the default of 300s in the server. The parameter has an int type, so type checkers should catch this But if you're not type checking your Modal integration it's an understandable mistake to think that this is an effective way of disabling the timeout. Doing a client-side runtime check and raising to help users avoid the footgun provides some value.