### PR TITLE
Remove experimental.update_autoscaler

### DIFF
--- a/modal/experimental/__init__.py
+++ b/modal/experimental/__init__.py
@@ -13,11 +13,10 @@ from .._object import _get_environment_name
 from .._partial_function import _clustered
 from .._runtime.container_io_manager import _ContainerIOManager
 from .._utils.async_utils import synchronize_api, synchronizer
-from .._utils.deprecation import deprecation_warning
 from .._utils.grpc_utils import retry_transient_errors
 from ..app import _App
 from ..client import _Client
-from ..cls import _Cls, _Obj
+from ..cls import _Cls
 from ..exception import InvalidError
 from ..image import DockerfileSpec, ImageBuilderVersion, _Image, _ImageRegistryConfig
 from ..secret import _Secret
@@ -338,52 +337,6 @@ async def notebook_base_image(*, python_version: Optional[str] = None, force_bui
         force_build=force_build,
         _namespace=api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL,
     )
-
-
-@synchronizer.create_blocking
-async def update_autoscaler(
-    obj: Union[_Function, _Obj],
-    *,
-    min_containers: Optional[int] = None,
-    max_containers: Optional[int] = None,
-    buffer_containers: Optional[int] = None,
-    scaledown_window: Optional[int] = None,
-    client: Optional[_Client] = None,
-) -> None:
-    """Update the autoscaler settings for a Function or Obj (instance of a Cls).
-
-    This is an experimental interface for a feature that we will be adding to
-    replace the existing `.keep_warm()` method. The stable form of this interface
-    may look different (i.e., it may be a standalone function or a method).
-
-    """
-    deprecation_warning(
-        (2025, 5, 5),
-        "The modal.experimental.update_autoscaler(...) function is now deprecated in favor of"
-        " a stable `.update_autoscaler(...) method on the corresponding object.",
-        show_source=True,
-    )
-
-    settings = api_pb2.AutoscalerSettings(
-        min_containers=min_containers,
-        max_containers=max_containers,
-        buffer_containers=buffer_containers,
-        scaledown_window=scaledown_window,
-    )
-
-    if client is None:
-        client = await _Client.from_env()
-
-    if isinstance(obj, _Function):
-        f = obj
-    else:
-        assert obj._cls._class_service_function is not None
-        await obj._cls._class_service_function.hydrate(client=client)
-        f = obj._cached_service_function()
-    await f.hydrate(client=client)
-
-    request = api_pb2.FunctionUpdateSchedulingParamsRequest(function_id=f.object_id, settings=settings)
-    await retry_transient_errors(client.stub.FunctionUpdateSchedulingParams, request)
 
 
 @synchronizer.create_blocking

--- a/test/experimental_test.py
+++ b/test/experimental_test.py
@@ -1,10 +1,9 @@
 # Copyright Modal Labs 2025
 import pytest
-from typing import Union, cast
 
 import modal
 import modal.experimental
-from modal.exception import DeprecationError, NotFoundError
+from modal.exception import NotFoundError
 
 app = modal.App(include_source=False)
 
@@ -19,67 +18,6 @@ class C:
     @modal.method()
     def method(self):
         pass
-
-
-@pytest.mark.parametrize("which", ["function", "cls"])
-def test_update_autoscaler(client, servicer, which):
-    overrides = {
-        "min_containers": 1,
-        "max_containers": 5,
-        "buffer_containers": 2,
-        "scaledown_window": 10,
-    }
-
-    with app.run(client=client):
-        obj: Union[modal.Function, modal.cls.Obj]
-        # Hardcode the object ID based on what we expect from the mock servicer
-        # which is pretty janky, but avoids hydrating the object in the test so that
-        # we can properly assert that update_autoscaler handles unhydrated objects correctly.
-        if which == "function":
-            obj, obj_id = f, "fu-1"
-        else:
-            obj, obj_id = cast(modal.cls.Obj, C()), "fu-2"
-
-        with pytest.warns(DeprecationError):
-            modal.experimental.update_autoscaler(obj, client=client, **overrides)  # type: ignore
-
-        settings = servicer.app_functions[obj_id].autoscaler_settings  # type: ignore
-        assert settings.min_containers == overrides["min_containers"]
-        assert settings.max_containers == overrides["max_containers"]
-        assert settings.buffer_containers == overrides["buffer_containers"]
-        assert settings.scaledown_window == overrides["scaledown_window"]
-
-
-@pytest.mark.parametrize("which", ["function", "cls"])
-def test_update_autoscaler_after_lookup(client, servicer, which):
-    app.deploy(name="test", client=client)
-
-    overrides = {
-        "min_containers": 1,
-        "max_containers": 5,
-        "buffer_containers": 2,
-        "scaledown_window": 10,
-    }
-
-    # See above for why we're hardcoding the object IDs.
-    # Would be much nicer to be able to look up the internal definition by the *name*...
-    obj: Union[modal.Function, modal.cls.Obj]
-    if which == "function":
-        obj = modal.Function.from_name("test", "f")
-        obj_id = "fu-1"
-    else:
-        C = modal.Cls.from_name("test", "C")
-        obj = C()
-        obj_id = "fu-2"
-
-    with pytest.warns(DeprecationError):
-        modal.experimental.update_autoscaler(obj, client=client, **overrides)  # type: ignore
-
-    settings = servicer.app_functions[obj_id].autoscaler_settings  # type: ignore
-    assert settings.min_containers == overrides["min_containers"]
-    assert settings.max_containers == overrides["max_containers"]
-    assert settings.buffer_containers == overrides["buffer_containers"]
-    assert settings.scaledown_window == overrides["scaledown_window"]
 
 
 def test_app_get_objects(client, servicer):


### PR DESCRIPTION
## Describe your changes

- This feature was only in "experimental" status for a short interval and it's had a deprecation warning since May; I think it's fine to remove.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

- Removed the `modal.experimental.update_autoscaler` function; this functionality now has a stable API as `modal.Function.update_autoscaler`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove `modal.experimental.update_autoscaler` and delete its associated tests; keep image deletion and app object listing unchanged.
> 
> - **API Removal**:
>   - Delete `modal.experimental.update_autoscaler` and related deprecation path.
> - **Tests**:
>   - Remove `test_update_autoscaler*` suites and deprecation assertions.
> - **Misc**:
>   - Adjust imports and types to reflect the API removal.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7dcaae12b35ffcac9123e5f0d9c615638acbcbc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->