### PR TITLE
Exclude cursor comments from changelog extraction

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -459,7 +459,7 @@ def update_changelog(ctx, sha: str = ""):
     # Parse the PR description to get a changelog update, which is all text between
     # the changelog header and any auto comments appended by Cursor
 
-    changelog_pattern = r"## Changelog\s*(.+)(?:<!--\s*\w*CURSOR\w*\s*-->|$)"
+    changelog_pattern = r"## Changelog\s*(.+?)(?:<!--\s*\w*CURSOR\w*\s*-->|$)"
     m = re.search(changelog_pattern, pr_description, flags=re.DOTALL)
     if m:
         update = m.group(1).strip()

--- a/tasks.py
+++ b/tasks.py
@@ -456,11 +456,10 @@ def update_changelog(ctx, sha: str = ""):
         print("Aborting: No PR description in response from GitHub API")
         return
 
-    # Parse the PR description to get a changelog update
-    comment_pattern = r"<!--.+?-->"
-    pr_description = re.sub(comment_pattern, "", pr_description, flags=re.DOTALL)
+    # Parse the PR description to get a changelog update, which is all text between
+    # the changelog header and any auto comments appended by Cursor
 
-    changelog_pattern = r"## Changelog\s*(.+)$"
+    changelog_pattern = r"## Changelog\s*(.+)(?:<!--\s*\w*CURSOR\w*\s*-->|$)"
     m = re.search(changelog_pattern, pr_description, flags=re.DOTALL)
     if m:
         update = m.group(1).strip()
@@ -470,6 +469,10 @@ def update_changelog(ctx, sha: str = ""):
     if not update:
         print("Aborting: Empty changelog in PR description")
         return
+
+    # Remove any HTML comments
+    comment_pattern = r"<!--.+?-->"
+    update = re.sub(comment_pattern, "", update, flags=re.DOTALL)
 
     # Read the existing changelog and split after the header so we can prepend new content
     with open("CHANGELOG.md") as fid:


### PR DESCRIPTION
Alternate approach to https://github.com/modal-labs/modal-client/pull/3613

A little less robust since we're depending on Cursor identifying itself in the comment it adds. But OTOH it doesn't require us to carefully preserve any tokens while editing the changelog, which I was expecting to be a headache.

The risk of cursor changing something that breaks this is fairly low since the changelog updates get staged these days anyway.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts changelog parsing in `update_changelog` to ignore Cursor auto-comments and strip HTML comments from the extracted update.
> 
> - **Changelog parsing (`tasks.py:update_changelog`)**:
>   - Update regex to capture text after `## Changelog` up to a Cursor auto-comment or end: `r"## Changelog\s*(.+?)(?:<!--\s*\w*CURSOR\w*\s*-->|$)"`.
>   - Strip HTML comments from the extracted changelog section only (not the entire PR description).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62e4b7b7abdb4b5513e7f32d0a8225be5dc5c4c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->