### PR TITLE
Add generator output format to generators for correctness

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -845,7 +845,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                         method_output_formats = [api_pb2.DATA_FORMAT_CBOR]
                     else:
                         method_output_formats = [api_pb2.DATA_FORMAT_PICKLE, api_pb2.DATA_FORMAT_CBOR]
-                    if is_generator:
+                    if partial_function.params.is_generator:
                         method_output_formats.append(api_pb2.DATA_FORMAT_GENERATOR_DONE)
 
                 method_definition = api_pb2.MethodDefinition(

--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -845,6 +845,8 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                         method_output_formats = [api_pb2.DATA_FORMAT_CBOR]
                     else:
                         method_output_formats = [api_pb2.DATA_FORMAT_PICKLE, api_pb2.DATA_FORMAT_CBOR]
+                    if is_generator:
+                        method_output_formats.append(api_pb2.DATA_FORMAT_GENERATOR_DONE)
 
                 method_definition = api_pb2.MethodDefinition(
                     webhook_config=partial_function.params.webhook_config,
@@ -889,6 +891,8 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                 supported_output_formats = [api_pb2.DATA_FORMAT_CBOR]
             else:
                 supported_output_formats = [api_pb2.DATA_FORMAT_PICKLE, api_pb2.DATA_FORMAT_CBOR]
+            if is_generator:
+                supported_output_formats.append(api_pb2.DATA_FORMAT_GENERATOR_DONE)
 
         async def _preload(self: _Function, resolver: Resolver, existing_object_id: Optional[str]):
             assert resolver.client and resolver.client.stub

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -1731,13 +1731,21 @@ def test_function_supported_input_formats(client, servicer):
         @modal.web_server(8080)
         def web_f(self): ...
 
+        @modal.method()
+        def g(self):
+            yield 1
+
     deploy_app(app, client=client)
     f_metadata = f._get_metadata()
     assert set(f_metadata.supported_input_formats) == {api_pb2.DATA_FORMAT_PICKLE, api_pb2.DATA_FORMAT_CBOR}
     assert set(f_metadata.supported_output_formats) == {api_pb2.DATA_FORMAT_PICKLE, api_pb2.DATA_FORMAT_CBOR}
     g_metadata = g._get_metadata()
     assert set(g_metadata.supported_input_formats) == {api_pb2.DATA_FORMAT_PICKLE, api_pb2.DATA_FORMAT_CBOR}
-    assert set(g_metadata.supported_output_formats) == {api_pb2.DATA_FORMAT_PICKLE, api_pb2.DATA_FORMAT_CBOR}
+    assert set(g_metadata.supported_output_formats) == {
+        api_pb2.DATA_FORMAT_PICKLE,
+        api_pb2.DATA_FORMAT_CBOR,
+        api_pb2.DATA_FORMAT_GENERATOR_DONE,
+    }
     web_f_metadata = web_f._get_metadata()
     assert set(web_f_metadata.supported_input_formats) == {api_pb2.DATA_FORMAT_ASGI}
     assert web_f_metadata.supported_output_formats == [api_pb2.DATA_FORMAT_ASGI]
@@ -1756,6 +1764,15 @@ def test_function_supported_input_formats(client, servicer):
     }
     assert cls_metadata.method_handle_metadata["web_f"].supported_input_formats == [api_pb2.DATA_FORMAT_ASGI]
     assert cls_metadata.method_handle_metadata["web_f"].supported_output_formats == [api_pb2.DATA_FORMAT_ASGI]
+    assert set(cls_metadata.method_handle_metadata["g"].supported_input_formats) == {
+        api_pb2.DATA_FORMAT_PICKLE,
+        api_pb2.DATA_FORMAT_CBOR,
+    }
+    assert set(cls_metadata.method_handle_metadata["g"].supported_output_formats) == {
+        api_pb2.DATA_FORMAT_PICKLE,
+        api_pb2.DATA_FORMAT_CBOR,
+        api_pb2.DATA_FORMAT_GENERATOR_DONE,
+    }
 
 
 @pytest.mark.usefixtures("set_env_client")


### PR DESCRIPTION
Since generators output both PICKLE/CBOR and GENERATOR_DONE (proto) outputs, it should be present in supported_output_formats if we want to be strict about it. Among other things, it simplifies output format validation in the worker if we can look at *only* supported_output_formats to determine what is allowed

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
