### PR TITLE
Set output_created_at on failed and terminated outputs

### DIFF
--- a/modal/_runtime/container_io_manager.py
+++ b/modal/_runtime/container_io_manager.py
@@ -283,6 +283,7 @@ class IOContext:
             api_pb2.FunctionPutOutputsItem(
                 input_id=input_id,
                 input_started_at=started_at,
+                output_created_at=time.time(),
                 result=api_pb2.GenericResult(status=api_pb2.GenericResult.GENERIC_STATUS_TERMINATED),
                 retry_count=retry_count,
             )
@@ -358,6 +359,7 @@ class IOContext:
             api_pb2.FunctionPutOutputsItem(
                 input_id=input_id,
                 input_started_at=started_at,
+                output_created_at=time.time(),
                 retry_count=retry_count,
                 **data_format_specific_output(function_input.data_format),
             )


### PR DESCRIPTION
The `output_created_at` field is being set on `FunctionGetOutputsItem` when the output is successful, but not when the output is failed or terminated. We should set in those case too. That field is used to populated the `finished_at` and `event_time` fields in the Input Events that go to clickhouse. If those fields aren't set it will break things in the UI, and anything else powered by input events. 


## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
