### PR TITLE
Add protos for App.set_tags() / App.get_tags()

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -399,6 +399,14 @@ message AppGetOrCreateResponse {
   string app_id = 1;
 }
 
+message AppGetTagsRequest {
+  string app_id = 1;
+}
+
+message AppGetTagsResponse {
+  map<string, string> tags = 1;
+}
+
 message AppHeartbeatRequest {
   string app_id = 1;
 }
@@ -467,6 +475,12 @@ message AppSetObjectsRequest {
   AppState new_app_state = 5; // promotes an app from initializing to this new state
   reserved 6;
 }
+
+message AppSetTagsRequest {
+  string app_id = 1;
+  map<string, string> tags = 2;
+}
+
 
 message AppStopRequest {
   string app_id = 1 [ (modal.options.audit_target_attr) = true ];
@@ -3582,12 +3596,14 @@ service ModalClient {
   rpc AppGetLogs(AppGetLogsRequest) returns (stream TaskLogsBatch);
   rpc AppGetObjects(AppGetObjectsRequest) returns (AppGetObjectsResponse);
   rpc AppGetOrCreate(AppGetOrCreateRequest) returns (AppGetOrCreateResponse);
+  rpc AppGetTags(AppGetTagsRequest) returns (AppGetTagsResponse);
   rpc AppHeartbeat(AppHeartbeatRequest) returns (google.protobuf.Empty);
   rpc AppList(AppListRequest) returns (AppListResponse);
   rpc AppLookup(AppLookupRequest) returns (AppLookupResponse);
   rpc AppPublish(AppPublishRequest) returns (AppPublishResponse);
   rpc AppRollback(AppRollbackRequest) returns (google.protobuf.Empty);
   rpc AppSetObjects(AppSetObjectsRequest) returns (google.protobuf.Empty);
+  rpc AppSetTags(AppSetTagsRequest) returns (google.protobuf.Empty);
   rpc AppStop(AppStopRequest) returns (google.protobuf.Empty);
 
   // Input Plane


### PR DESCRIPTION
Proto changes isolated from https://github.com/modal-labs/modal-client/pull/3641

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds proto messages and RPCs to get and set app tags.
> 
> - **API (Protobuf)** in `modal_proto/api.proto`:
>   - **New messages**:
>     - `AppGetTagsRequest`/`AppGetTagsResponse` (returns `map<string, string> tags`).
>     - `AppSetTagsRequest` (accepts `map<string, string> tags`).
>   - **Service changes** (`ModalClient`):
>     - Add RPCs `AppGetTags(AppGetTagsRequest) -> AppGetTagsResponse` and `AppSetTags(AppSetTagsRequest) -> google.protobuf.Empty`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6128fe0cd0ec28a14cbfb4dfdc5e70a6ee61a38e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->