### PR TITLE
Updated docstring for uv_sync

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -1441,10 +1441,12 @@ class _Image(_Object, type_prefix="im"):
         The `pyproject.toml` and `uv.lock` in `uv_project_dir` are automatically added to the build context. The
         `uv_project_dir` is relative to the current working directory of where `modal` is called.
 
-        NOTE: This does *not* install the project or workspace itself into the environment (this is equivalent to the
-        `--no-install-workspace` flag in the `uv sync` command) and you would be expected to add any local python source
-        files using `Image.add_local_python_source` or similar methods after this call. This ensures that updates to
-        your code wouldn't invalidate the uv_sync image cache.
+        NOTE: This does *not* install the project itself into the environment (this is equivalent to the
+        `--no-install-project` flag in the `uv sync` command) and you would be expected to add any local python source
+        files using `Image.add_local_python_source` or similar methods after this call.
+
+        This ensures that updates to your project code wouldn't require reinstalling third-party dependencies
+        after every change.
 
         Added in v1.1.0.
         """

--- a/modal/image.py
+++ b/modal/image.py
@@ -1441,6 +1441,11 @@ class _Image(_Object, type_prefix="im"):
         The `pyproject.toml` and `uv.lock` in `uv_project_dir` are automatically added to the build context. The
         `uv_project_dir` is relative to the current working directory of where `modal` is called.
 
+        NOTE: This does *not* install the project or workspace itself into the environment (this is equivalent to the
+        `--no-install-workspace` flag in the `uv sync` command) and you would be expected to add any local python source
+        files using `Image.add_local_python_source` or similar methods after this call. This ensures that updates to
+        your code wouldn't invalidate the uv_sync image cache.
+
         Added in v1.1.0.
         """
 

--- a/modal/image.py
+++ b/modal/image.py
@@ -1448,6 +1448,8 @@ class _Image(_Object, type_prefix="im"):
         This ensures that updates to your project code wouldn't require reinstalling third-party dependencies
         after every change.
 
+        uv workspaces are currently not supported.
+
         Added in v1.1.0.
         """
 


### PR DESCRIPTION
Updated after some user feedback on this being confusing (which I agree it is)

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies uv_sync docstring: it does not install the project itself, suggests adding local Python sources separately, explains dependency rebuild avoidance, and notes uv workspaces aren’t supported.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce8cc6bebc4cae5cd8964ed9277bcfa36947ed6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->