### PR TITLE
Add SandboxExecPoll to sandbox_router.proto

### DIFF
--- a/modal_proto/sandbox_router.proto
+++ b/modal_proto/sandbox_router.proto
@@ -28,6 +28,26 @@ enum SandboxExecStdoutConfig {
   SANDBOX_EXEC_STDOUT_CONFIG_PIPE = 1;
 }
 
+message SandboxExecPollRequest {
+  // The task ID of the sandbox running the exec'd command.
+  string task_id = 1;
+  // The execution ID of the command to wait on.
+  string exec_id = 2;
+}
+
+// The response to a SandboxExecPollRequest. If the exec'd command has not
+// completed, exit_status will be unset.
+message SandboxExecPollResponse {
+  oneof exit_status {
+    // The exit code of the command.
+    int32 code = 1;
+    // The signal that terminated the command.
+    int32 signal = 2;
+  }
+  // TODO(saltzm): Give a way for the user to distinguish between normal exit
+  // and termination by Modal (due to sandbox timeout, exec exceeded deadline, etc.)
+}
+
 message SandboxExecStartRequest {
   // The task ID of the sandbox to execute the command in.
   string task_id = 1;
@@ -105,15 +125,17 @@ message SandboxExecWaitRequest {
 message SandboxExecWaitResponse {
   oneof exit_status {
     // The exit code of the command.
-    int32 code = 3;
+    int32 code = 1;
     // The signal that terminated the command.
-    int32 signal = 4;
+    int32 signal = 2;
   }
   // TODO(saltzm): Give a way for the user to distinguish between normal exit
   // and termination by Modal (due to sandbox timeout, exec exceeded deadline, etc.)
 }
 
 service SandboxRouter {
+  // Poll for the exit status of an exec'd command.
+  rpc SandboxExecPoll(SandboxExecPollRequest) returns (SandboxExecPollResponse);
   // Execute a command in the sandbox.
   rpc SandboxExecStart(SandboxExecStartRequest) returns (SandboxExecStartResponse);
  // Write to the stdin stream of an exec'd command.


### PR DESCRIPTION
In the old implementation of ContainerProcess.poll, we'd send a ContainerExecWait RPC with a timeout of 0, where the timeout was a field in ContainerExecWaitRequest. That seemed a little odd to me so I just decided to make a new RPC explicitly for poll.

Also fixed some weird numbering from before in SandboxExecWaitResponse


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `SandboxExecPoll` RPC with request/response messages and renumber `exit_status` fields in `SandboxExecWaitResponse` to `code=1`, `signal=2`.
> 
> - **Proto updates** (`modal_proto/sandbox_router.proto`):
>   - **New polling API**:
>     - Add `SandboxExecPollRequest` and `SandboxExecPollResponse` messages.
>     - Add `SandboxExecPoll` RPC to `SandboxRouter`.
>   - **Field numbering**:
>     - In `SandboxExecWaitResponse.exit_status`, renumber `code` to `1` and `signal` to `2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f09dd3766cd5d40bed3485004c7081c4a5018598. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->