### PR TITLE
Reorder changelog processing

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -462,17 +462,18 @@ def update_changelog(ctx, sha: str = ""):
     changelog_pattern = r"## Changelog\s*(.+?)(?:<!--\s*\w*CURSOR\w*\s*-->|$)"
     m = re.search(changelog_pattern, pr_description, flags=re.DOTALL)
     if m:
-        update = m.group(1).strip()
+        update = m.group(1)
     else:
         print("Aborting: No changelog section in PR description")
-        return
-    if not update:
-        print("Aborting: Empty changelog in PR description")
         return
 
     # Remove any HTML comments
     comment_pattern = r"<!--.+?-->"
-    update = re.sub(comment_pattern, "", update, flags=re.DOTALL)
+    update = re.sub(comment_pattern, "", update, flags=re.DOTALL).strip()
+
+    if not update:
+        print("Aborting: Empty changelog in PR description")
+        return
 
     # Read the existing changelog and split after the header so we can prepend new content
     with open("CHANGELOG.md") as fid:


### PR DESCRIPTION
Followup to #3635; the fight against slop continues. We're no longer adding cursor comments to the changelog, but we are now creating empty changelog entries because I incorrectly adjusted the order of operations around removing comments and checking if the update is empty.