### PR TITLE
modal volume get: Make parallelism configurable and shared across files

### DIFF
--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -1,4 +1,5 @@
 # Copyright Modal Labs 2022
+import multiprocessing
 import os
 import sys
 from pathlib import Path
@@ -75,6 +76,9 @@ async def get(
     local_destination: str = Argument("."),
     force: bool = False,
     env: Optional[str] = ENV_OPTION,
+    parallelism: int = Option(
+        default=multiprocessing.cpu_count(), help="Max number of parallel transfers; defaults to number of CPUs"
+    ),
 ):
     """Download files from a modal.Volume object.
 
@@ -96,7 +100,14 @@ async def get(
     console = make_console()
     progress_handler = ProgressHandler(type="download", console=console)
     with progress_handler.live:
-        await _volume_download(volume, remote_path, destination, force, progress_cb=progress_handler.progress)
+        await _volume_download(
+            volume=volume,
+            remote_path=remote_path,
+            local_destination=destination,
+            overwrite=force,
+            parallelism=parallelism,
+            progress_cb=progress_handler.progress,
+        )
     console.print(OutputManager.step_completed("Finished downloading files to local!"))
 
 

--- a/modal/volume.py
+++ b/modal/volume.py
@@ -670,7 +670,12 @@ class _Volume(_Object, type_prefix="vo"):
 
     @live_method
     async def read_file_into_fileobj(
-        self, path: str, fileobj: typing.IO[bytes], progress_cb: Optional[Callable[..., Any]] = None
+        self,
+        path: str,
+        fileobj: typing.IO[bytes],
+        parallelism: int = multiprocessing.cpu_count(),
+        download_semaphore: Optional[asyncio.Semaphore] = None,
+        progress_cb: Optional[Callable[..., Any]] = None,
     ) -> int:
         """mdmd:hidden
         Read volume file into file-like IO object.
@@ -687,8 +692,9 @@ class _Volume(_Object, type_prefix="vo"):
         except modal.exception.NotFoundError as exc:
             raise FileNotFoundError(exc.args[0])
 
-        # TODO(dflemstr): Sane default limit? Make configurable?
-        download_semaphore = asyncio.Semaphore(multiprocessing.cpu_count())
+        if download_semaphore is None:
+            download_semaphore = asyncio.Semaphore(parallelism)
+
         write_lock = asyncio.Lock()
         start_pos = fileobj.tell()
 


### PR DESCRIPTION
## Describe your changes

Hopefully, it speeds up file transfers of many small files in version 2 volumes by doing more file transfers in parallel.

We already have a reasonable parallel download approach in place when downloading each file from version 2 volumes, but this was handled entirely separately from the download parallelism across files.