### PR TITLE
Remove ability to reference methods as Functions directly on Cls

### DIFF
--- a/modal/cls.py
+++ b/modal/cls.py
@@ -863,16 +863,6 @@ More information on class parameterization can be found here: https://modal.com/
         )
 
     def __getattr__(self, k):
-        # TODO: remove this method - access to attributes on classes (not instances) should be discouraged
-        if not self._is_local() or k in self._method_partials:
-            # if not local (== k *could* be a method) or it is local and we know k is a method
-            deprecation_warning(
-                (2025, 1, 13),
-                "Calling a method on an uninstantiated class will soon be deprecated; "
-                "update your code to instantiate the class first, i.e.:\n"
-                f"{self._name}().{k} instead of {self._name}.{k}",
-            )
-            return getattr(self(), k)
         # non-method attribute access on local class - arguably shouldn't be used either:
         return getattr(self._user_cls, k)
 


### PR DESCRIPTION
This will now return a `PartialFunction` instead.

Not sure if we should be adding some helper `__getattr__` on `PartialFunction` to help users who will undoubtedly still make this mistake, thinking they have gotten a `Function` they can use?

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
