### PR TITLE
Add go_package option to sandbox_router.proto

### DIFF
--- a/modal_proto/sandbox_router.proto
+++ b/modal_proto/sandbox_router.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-option go_package = "github.com/modal-labs/modal/go/proto/sandbox_router";
+option go_package = "github.com/modal-labs/modal/go/proto";
 
 import "modal_proto/api.proto";
 


### PR DESCRIPTION
## Describe your changes

The proto generation script in modal-go fails without it.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `go_package` option to `modal_proto/sandbox_router.proto` to enable Go proto generation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0add54741da663aa1832378b02931ec8d8b27c0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->