### PR TITLE
Rename TaskRouter -> TaskCommandRouter

### DIFF
--- a/modal_proto/task_command_router.proto
+++ b/modal_proto/task_command_router.proto
@@ -130,7 +130,7 @@ message TaskExecWaitResponse {
   // and termination by Modal (due to task timeout, exec exceeded deadline, etc.)
 }
 
-service TaskRouter {
+service TaskCommandRouter {
   // Poll for the exit status of an exec'd command.
   rpc TaskExecPoll(TaskExecPollRequest) returns (TaskExecPollResponse);
   // Execute a command in the task.


### PR DESCRIPTION
Sorry, forgot this bit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rename proto service `TaskRouter` to `TaskCommandRouter`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5fe1ba974fe153d31a2d717cc7f7a32c9255d2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->