### PR TITLE
Put all protos in the same Go package

### DIFF
--- a/modal_proto/task_command_router.proto
+++ b/modal_proto/task_command_router.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-option go_package = "github.com/modal-labs/modal/go/proto/task_command_router";
+option go_package = "github.com/modal-labs/modal/go/proto";
 
 import "modal_proto/api.proto";
 


### PR DESCRIPTION
## Describe your changes

This simplifies things a lot on the Go side, and works at least for now.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

</details>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Change `go_package` in `modal_proto/task_command_router.proto` to `github.com/modal-labs/modal/go/proto` to align with a single shared Go package.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09a12659604fc438ecff2d093a3d43ca8acb83f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->