### PR TITLE
Minor README edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Modal Python Library
+# Modal Python SDK
 
 [![PyPI Version](https://img.shields.io/pypi/v/modal.svg)](https://pypi.org/project/modal/)
 [![License](https://img.shields.io/badge/license-apache_2.0-darkviolet.svg)](https://github.com/modal-labs/modal-client/blob/master/LICENSE)
 [![Tests](https://github.com/modal-labs/modal-client/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/modal-labs/modal-client/actions/workflows/ci-cd.yml)
 [![Slack](https://img.shields.io/badge/slack-join-blue.svg?logo=slack)](https://modal.com/slack)
 
-The [Modal](https://modal.com/) Python library provides convenient, on-demand
+The [Modal](https://modal.com/) Python SDK provides convenient, on-demand
 access to serverless cloud compute from Python scripts on your local computer.
 
 ## Documentation
@@ -19,10 +19,10 @@ a [user guide](https://modal.com/docs/guide), and the detailed
 
 **This library requires Python 3.9 – 3.13.**
 
-Install the package with `pip`:
+Install the package with `uv` or `pip`:
 
 ```bash
-pip install modal
+uv pip install modal
 ```
 
 You can create a Modal account (or link your existing one) directly on the


### PR DESCRIPTION
I think there are more improvements that we could make to the README to help educate users who land here first. But there's also a bit of low-hanging fruit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update README to call it the Python SDK and include uv-based installation alongside pip.
> 
> - **README**:
>   - Rename references from `Python library` to `Python SDK`.
>   - Installation: mention `uv` alongside `pip`; change example command to `uv pip install modal`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acef4663185714dd31b63bac551dd4193c7108ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->