### PR TITLE
Add config field for customizing the suffix on an ephemeral App

### DIFF
--- a/modal/_partial_function.py
+++ b/modal/_partial_function.py
@@ -19,7 +19,7 @@ from ._functions import _Function
 from ._utils.async_utils import synchronizer
 from ._utils.deprecation import deprecation_warning
 from ._utils.function_utils import callable_has_non_self_params
-from .config import logger
+from .config import config, logger
 from .exception import InvalidError
 
 MAX_MAX_BATCH_SIZE = 1000
@@ -378,6 +378,7 @@ def _fastapi_endpoint(
         method=method,
         web_endpoint_docs=docs,
         requested_suffix=label or "",
+        ephemeral_suffix=config.get("dev_suffix"),
         async_mode=api_pb2.WEBHOOK_ASYNC_MODE_AUTO,
         custom_domains=_parse_custom_domains(custom_domains),
         requires_proxy_auth=requires_proxy_auth,
@@ -446,6 +447,7 @@ def _web_endpoint(
         method=method,
         web_endpoint_docs=docs,
         requested_suffix=label or "",
+        ephemeral_suffix=config.get("dev_suffix"),
         async_mode=api_pb2.WEBHOOK_ASYNC_MODE_AUTO,
         custom_domains=_parse_custom_domains(custom_domains),
         requires_proxy_auth=requires_proxy_auth,
@@ -505,6 +507,7 @@ def _asgi_app(
     webhook_config = api_pb2.WebhookConfig(
         type=api_pb2.WEBHOOK_TYPE_ASGI_APP,
         requested_suffix=label or "",
+        ephemeral_suffix=config.get("dev_suffix"),
         async_mode=api_pb2.WEBHOOK_ASYNC_MODE_AUTO,
         custom_domains=_parse_custom_domains(custom_domains),
         requires_proxy_auth=requires_proxy_auth,
@@ -562,6 +565,7 @@ def _wsgi_app(
     webhook_config = api_pb2.WebhookConfig(
         type=api_pb2.WEBHOOK_TYPE_WSGI_APP,
         requested_suffix=label or "",
+        ephemeral_suffix=config.get("dev_suffix"),
         async_mode=api_pb2.WEBHOOK_ASYNC_MODE_AUTO,
         custom_domains=_parse_custom_domains(custom_domains),
         requires_proxy_auth=requires_proxy_auth,
@@ -623,6 +627,7 @@ def _web_server(
     webhook_config = api_pb2.WebhookConfig(
         type=api_pb2.WEBHOOK_TYPE_WEB_SERVER,
         requested_suffix=label or "",
+        ephemeral_suffix=config.get("dev_suffix"),
         async_mode=api_pb2.WEBHOOK_ASYNC_MODE_AUTO,
         custom_domains=_parse_custom_domains(custom_domains),
         web_server_port=port,

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -496,6 +496,12 @@ def serve(
     ```
     modal serve hello_world.py
     ```
+
+    Modal-generated URLs will have a `-dev` suffix appended to them when running with `modal serve`.
+    To customize this suffix (i.e., to avoid collisions with other users in your workspace who are
+    concurrently serving the App), you can set the `dev_suffix` in your `.modal.toml` file or the
+    `MODAL_DEV_SUFFIX` environment variable.
+
     """
     env = ensure_env(env)
     import_ref = parse_import_ref(app_ref, use_module_mode=use_module_mode)

--- a/modal/config.py
+++ b/modal/config.py
@@ -71,6 +71,10 @@ Other possible configuration options are:
   The log formatting pattern that will be used by the modal client itself.
   See https://docs.python.org/3/library/logging.html#logrecord-attributes for available
   log attributes.
+* `dev_suffix` (in the .toml file) / `MODAL_DEV_SUFFIX` (as an env var).
+  Overrides the default `-dev` suffix added to URLs generated for web endpoints
+  when the App is ephemeral (i.e., created via `modal serve`). Must be a short
+  alphanumeric string.
 
 Meta-configuration
 ------------------
@@ -85,6 +89,7 @@ Some "meta-options" are set using environment variables only:
 
 import logging
 import os
+import re
 import typing
 import warnings
 from typing import Any, Callable, Optional
@@ -206,6 +211,12 @@ def _check_value(options: list[str]) -> Callable[[str], str]:
     return checker
 
 
+def _enforce_suffix_rules(x: str) -> str:
+    if x and not re.match(r"^[a-zA-Z0-9]{1,8}$", x):
+        raise ValueError("Suffix must be an alphanumeric string of no more than 8 characters.")
+    return x
+
+
 class _Setting(typing.NamedTuple):
     default: typing.Any = None
     transform: typing.Callable[[str], typing.Any] = lambda x: x  # noqa: E731
@@ -244,6 +255,7 @@ _SETTINGS = {
         "pickle",
         transform=lambda s: _check_value(["pickle", "cbor"])(s.lower()),
     ),
+    "dev_suffix": _Setting("", transform=_enforce_suffix_rules),
 }
 
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -3575,7 +3575,6 @@ message WebhookConfig {
   string ephemeral_suffix = 11;  // Additional URL suffix added for ephemeral Apps
 }
 
-
 message WorkspaceBillingReportItem {
   string object_id = 1;
   string description = 2;

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -178,3 +178,14 @@ def test_malformed_config_better(modal_config):
     with pytest.raises(InvalidError, match="Key name found without value"):
         with modal_config(modal_toml):
             pass
+
+
+@pytest.mark.parametrize("suffix", ["a" * 9, "abc-xyz"])
+def test_dev_suffix_rules(modal_config, suffix):
+    modal_toml = f"""
+    [default]
+    dev_suffix = "{suffix}"
+    """
+    with modal_config(modal_toml):
+        with pytest.raises(InvalidError, match="alphanumeric string"):
+            Config().get("dev_suffix")


### PR DESCRIPTION
## Describe your changes

- Client side of SDK-362. See also https://github.com/modal-labs/modal/pull/28352

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


</details>

## Changelog

- It's now possible to override the default `-dev` suffix applied to the autogenerated URLs for ephemeral Apps (i.e., when using `modal serve`) via a new `dev_suffix` field in the `.modal.toml` config file, or equivalently with the `MODAL_DEV_SUFFIX` environment variable. This can help avoid collisions when multiple users of a workspace are working on the same codebase simultaneously.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a configurable `dev_suffix` (via config or MODAL_DEV_SUFFIX) and wires it into all web endpoint URL generation for ephemeral Apps; includes docs and tests.
> 
> - **Config**:
>   - New `dev_suffix` setting (or `MODAL_DEV_SUFFIX` env var) with validation (alphanumeric, max 8 chars) in `modal/config.py` and docs.
> - **Web endpoints**:
>   - Pass `config.get("dev_suffix")` as `ephemeral_suffix` in `WebhookConfig` for `fastapi_endpoint`, `web_endpoint`, `asgi_app`, `wsgi_app`, and `web_server` in `modal/_partial_function.py`.
> - **CLI**:
>   - Update `modal serve` help to explain the URL `-dev` suffix and how to customize it.
> - **Tests**:
>   - Add validation tests for `dev_suffix` in `test/config_test.py`.
>   - Add propagation test ensuring `ephemeral_suffix` is set on function creation in `test/webhook_test.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f345890c54f89736fd5ad68e4cfeb38042880c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->