### PR TITLE
WebhookConfig proto for ephemeral URL suffix

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -3565,13 +3565,14 @@ message WebUrlInfo {
 message WebhookConfig {
   WebhookType type = 1;
   string method = 2;
-  string requested_suffix = 4;
+  string requested_suffix = 4;  // User-supplied "label" component of URL
   WebhookAsyncMode async_mode = 5;
   repeated CustomDomainConfig custom_domains = 6;
   uint32 web_server_port = 7;
   float web_server_startup_timeout = 8;
   bool web_endpoint_docs = 9;
   bool requires_proxy_auth = 10;
+  string ephemeral_suffix = 11;  // Additional URL suffix added for ephemeral Apps
 }
 
 


### PR DESCRIPTION
## Describe your changes

Pulling the proto part out of https://github.com/modal-labs/modal-client/pull/3660

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `WebhookConfig.ephemeral_suffix` for ephemeral app URLs and clarifies `requested_suffix` as the user-supplied label.
> 
> - **Proto: `modal_proto/api.proto`**
>   - **`WebhookConfig`**:
>     - Add `string ephemeral_suffix = 11` for additional URL suffix in ephemeral Apps.
>     - Document `requested_suffix` as the user-supplied label component of the URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3036195bd8a2d71d12d2fcf3fce43060629ccf9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->