### PR TITLE
Suggest CLI commands for detached Apps

### DIFF
--- a/modal/runner.py
+++ b/modal/runner.py
@@ -355,6 +355,14 @@ async def _run_app(
             await _status_based_disconnect(client, running_app.app_id, e)
             raise
 
+        detached_disconnect_msg = (
+            "The detached App will keep running. You can track its progress on the Dashboard: "
+            f"[magenta underline]{running_app.app_page_url}[/magenta underline]"
+            "\n"
+            f"\nStream logs: [green]modal app logs {running_app.app_id}[/green]"
+            f"\nStop the App: [green]modal app stop {running_app.app_id}[/green]"
+        )
+
         try:
             # Show logs from dynamically created images.
             # TODO: better way to do this
@@ -377,11 +385,7 @@ async def _run_app(
             if detach:
                 if output_mgr := _get_output_manager():
                     output_mgr.print(output_mgr.step_completed("Shutting down Modal client."))
-                    output_mgr.print(
-                        "The detached app keeps running. You can track its progress at: "
-                        f"[magenta]{running_app.app_page_url}[/magenta]"
-                        ""
-                    )
+                    output_mgr.print(detached_disconnect_msg)
                 if logs_loop:
                     logs_loop.cancel()
                 await _status_based_disconnect(client, running_app.app_id, e)
@@ -409,10 +413,8 @@ async def _run_app(
             # If we lose connection to the server after a detached App has started running, it will continue
             # I think we can only exit "nicely" if we are able to print output though, otherwise we should raise
             if detach and (output_mgr := _get_output_manager()):
-                output_mgr.print(
-                    "Connection lost, but detached App will continue running: "
-                    f"[magenta]{running_app.app_page_url}[/magenta]"
-                )
+                output_mgr.print(":white_exclamation_mark: Connection lost!")
+                output_mgr.print(detached_disconnect_msg)
                 return
             raise
         except BaseException as e:

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -1257,7 +1257,9 @@ def test_keyboard_interrupt_during_app_run_detach(servicer, server_url_env, toke
         out, err = p.communicate(timeout=5)
         print(out)
         assert "Shutting down Modal client." in out
-        assert "The detached app keeps running. You can track its progress at:" in out
+        assert "track its progress" in out
+        assert "modal app stop" in out
+        assert "modal app logs" in out
         assert "Traceback" not in err
 
 


### PR DESCRIPTION
Small improvement to the detached App disconnection experience

<img width="677" height="107" alt="image" src="https://github.com/user-attachments/assets/cb9ffdef-ab0a-4c6a-93be-1fdb06432143" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a consolidated message for detached Apps with dashboard link and `modal app logs/stop` hints, and updates tests accordingly.
> 
> - **Runner (`modal/runner.py`)**:
>   - Introduces `detached_disconnect_msg` containing dashboard URL plus suggestions to stream logs (`modal app logs <id>`) and stop the app (`modal app stop <id>`).
>   - Uses this message on `KeyboardInterrupt` and when a `ConnectionError` occurs in detached mode; also prints a concise connection-lost notice.
> - **Tests (`test/cli_test.py`)**:
>   - Updates `test_keyboard_interrupt_during_app_run_detach` assertions to match the new detached message content (progress tracking, `modal app logs`, `modal app stop`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae375283fcdca27152de545da624ec78183c1fb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->