### PR TITLE
update create_connect_token Changelog link and unhide create_connect_token reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,10 +38,10 @@ Other new features and improvements:
   creds = sb.create_connect_token(user_metadata={"user_id": "user123"})
 
   # Make an http request, passing the token in the authorization header
-  requests.get(creds.url, headers={"authorization": f"bearer {creds.token}"})
+  requests.get(creds.url, headers={"Authorization": f"Bearer {creds.token}"})
   ```
 
-  See the [Sandbox guide](https://modal.com/docs/guide/sandbox) for more information.
+  See the [Sandbox Networking guide](https://modal.com/docs/guide/sandbox-networking) for more information.
 
 - The new `modal.Image.build()` method allows you to eagerly trigger an Image build. This is particularly helpful when working with Sandboxes, as otherwise the Image build would happen lazily inside `modal.Sandbox.create()`:
 

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -669,11 +669,11 @@ class _Sandbox(_Object, type_prefix="sb"):
     async def create_connect_token(
         self, user_metadata: Optional[Union[str, dict[str, Any]]] = None
     ) -> SandboxConnectCredentials:
-        """mdmd:hidden
-        [Alpha] Create a token for making HTTP connections to the sandbox.
+        """
+        [Alpha] Create a token for making HTTP connections to the Sandbox.
 
         Also accepts an optional user_metadata string or dict to associate with the token. This metadata
-        will be added to the headers by the proxy when forwarding requests to the sandbox."""
+        will be added to the headers by the proxy when forwarding requests to the Sandbox."""
         if user_metadata is not None and isinstance(user_metadata, dict):
             try:
                 user_metadata = json.dumps(user_metadata)


### PR DESCRIPTION
This just updates the link in the `create_connect_token()` section of the Changelog and unhides the `create_connect_token()` reference.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects Authorization header example and link in CHANGELOG; unhides and tweaks Sandbox.create_connect_token docstring.
> 
> - **Docs**:
>   - **CHANGELOG**: Fix HTTP auth header casing in example (`Authorization: Bearer`); update link to the Sandbox Networking guide.
>   - **API Docstring**: Unhide and adjust wording/capitalization for `Sandbox.create_connect_token` (capitalize Sandbox).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de3dd08328aa894685f73cf8f9f2cb45aefb6835. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->