### PR TITLE
Remove SandboxGetCommandRouterAccess protos

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2757,20 +2757,6 @@ message SandboxCreateResponse {
   string sandbox_id = 1;
 }
 
-// Used to get a JWT and URL for direct access to a sandbox router server
-// running on the modal-worker, so the client can issue exec commands (and other
-// operations as they become available) directly to the worker.
-// DEPRECATED: Use TaskGetCommandRouterAccessRequest instead.
-// TODO(saltzm): Remove this.
-message SandboxGetCommandRouterAccessRequest {
-  string sandbox_id = 1;
-}
-
-message SandboxGetCommandRouterAccessResponse {
-  string jwt = 1;
-  string url = 2;
-}
-
 message SandboxGetFromNameRequest {
   string sandbox_name = 1;
   string environment_name = 2;
@@ -3754,7 +3740,6 @@ service ModalClient {
   // Sandboxes
   rpc SandboxCreate(SandboxCreateRequest) returns (SandboxCreateResponse);
   rpc SandboxCreateConnectToken(SandboxCreateConnectTokenRequest) returns (SandboxCreateConnectTokenResponse);
-  rpc SandboxGetCommandRouterAccess(SandboxGetCommandRouterAccessRequest) returns (SandboxGetCommandRouterAccessResponse);
   rpc SandboxGetFromName(SandboxGetFromNameRequest) returns (SandboxGetFromNameResponse);
   rpc SandboxGetLogs(SandboxGetLogsRequest) returns (stream TaskLogsBatch);
   rpc SandboxGetResourceUsage(SandboxGetResourceUsageRequest) returns (SandboxGetResourceUsageResponse);


### PR DESCRIPTION
They were previously renamed to Task*

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove deprecated sandbox command router access protos and RPC from `modal_proto/api.proto`.
> 
> - **API (protobuf)**
>   - **Sandboxes**:
>     - Remove `SandboxGetCommandRouterAccessRequest` and `SandboxGetCommandRouterAccessResponse` messages.
>     - Remove RPC `SandboxGetCommandRouterAccess` from `service ModalClient`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1d01fcc9092faa5ae2544cdddf8584c85512d45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->