### PR TITLE
Implement exec in terms of task command router

### DIFF
--- a/modal/_utils/task_command_router_client.py
+++ b/modal/_utils/task_command_router_client.py
@@ -442,12 +442,10 @@ class TaskCommandRouterClient:
                 logger.debug(f"Cancelled JWT refresh loop for exec with task ID {self._task_id}")
                 break
             except Exception as e:
+                # Exceptions here can stem from non-transient errors against the server sending
+                # the TaskGetCommandRouterAccess RPC, for instance, if the task has finished.
                 logger.warning(f"Background JWT refresh failed for exec with task ID {self._task_id}: {e}")
-                try:
-                    await asyncio.sleep(1.0)
-                except Exception:
-                    # Ignore sleep issues; loop will re-check closed flag.
-                    pass
+                break
 
     async def _stream_stdio(
         self,

--- a/modal/container_process.py
+++ b/modal/container_process.py
@@ -273,6 +273,9 @@ class _ContainerProcessThroughCommandRouter(Generic[T]):
         )
         self._returncode = None
 
+    def __repr__(self) -> str:
+        return f"ContainerProcess(process_id={self._process_id!r})"
+
     @property
     def stdout(self) -> _StreamReader[T]:
         return self._stdout
@@ -314,7 +317,10 @@ class _ContainerProcessThroughCommandRouter(Generic[T]):
                 raise InvalidError("Unexpected exit status")
         except ExecTimeoutError:
             logger.debug(f"ContainerProcess poll for {self._process_id} did not complete within deadline")
-            return None
+            # TODO(saltzm): This is a weird API, but customers currently may rely on it. This
+            # should probably raise an ExecTimeoutError instead.
+            self._returncode = -1
+            return self._returncode
         except Exception as e:
             # Re-raise non-transient errors or errors resulting from exceeding retries on transient errors.
             logger.warning(f"ContainerProcess poll for {self._process_id} failed: {e}")

--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -553,7 +553,7 @@ class _StreamReader(Generic[T]):
                 # unimplemented for now.
                 if stream_type == StreamType.STDOUT:
                     raise NotImplementedError(
-                        "Currently only the PIPE stream type is supported when using exec "
+                        "Currently the STDOUT stream type is not supported when using exec "
                         "through a task command router, which is currently in beta."
                     )
                 params = _StreamReaderThroughCommandRouterParams(

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -3,6 +3,7 @@ import asyncio
 import json
 import os
 import time
+import uuid
 from collections.abc import AsyncGenerator, Collection, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, AsyncIterator, Literal, Optional, Union, overload
@@ -20,7 +21,7 @@ from modal._tunnel import Tunnel
 from modal.cloud_bucket_mount import _CloudBucketMount, cloud_bucket_mounts_to_proto
 from modal.mount import _Mount
 from modal.volume import _Volume
-from modal_proto import api_pb2
+from modal_proto import api_pb2, task_command_router_pb2 as sr_pb2
 
 from ._object import _get_environment_name, _Object
 from ._resolver import Resolver
@@ -30,6 +31,7 @@ from ._utils.deprecation import deprecation_warning
 from ._utils.grpc_utils import retry_transient_errors
 from ._utils.mount_utils import validate_network_file_systems, validate_volumes
 from ._utils.name_utils import is_valid_object_name
+from ._utils.task_command_router_client import TaskCommandRouterClient
 from .client import _Client
 from .container_process import _ContainerProcess
 from .exception import AlreadyExistsError, ExecutionError, InvalidError, SandboxTerminatedError, SandboxTimeoutError
@@ -121,9 +123,10 @@ class _Sandbox(_Object, type_prefix="sb"):
     _stdout: _StreamReader[str]
     _stderr: _StreamReader[str]
     _stdin: _StreamWriter
-    _task_id: Optional[str] = None
-    _tunnels: Optional[dict[int, Tunnel]] = None
-    _enable_snapshot: bool = False
+    _task_id: Optional[str]
+    _tunnels: Optional[dict[int, Tunnel]]
+    _enable_snapshot: bool
+    _command_router_client: Optional[TaskCommandRouterClient]
 
     @staticmethod
     def _default_pty_info() -> api_pb2.PTYInfo:
@@ -521,6 +524,10 @@ class _Sandbox(_Object, type_prefix="sb"):
         )
         self._stdin = StreamWriter(self.object_id, "sandbox", self._client)
         self._result = None
+        self._task_id = None
+        self._tunnels = None
+        self._enable_snapshot = False
+        self._command_router_client = None
 
     @staticmethod
     async def from_name(
@@ -730,6 +737,13 @@ class _Sandbox(_Object, type_prefix="sb"):
                 await asyncio.sleep(0.5)
         return self._task_id
 
+    async def _get_command_router_client(self, task_id: str) -> Optional[TaskCommandRouterClient]:
+        if self._command_router_client is None:
+            # Attempt to initialize a router client. Returns None if the new exec path not enabled
+            # for this sandbox.
+            self._command_router_client = await TaskCommandRouterClient.try_init(self._client, task_id)
+        return self._command_router_client
+
     @overload
     async def exec(
         self,
@@ -855,14 +869,49 @@ class _Sandbox(_Object, type_prefix="sb"):
         await TaskContext.gather(*secret_coros)
 
         task_id = await self._get_task_id()
+        kwargs = {
+            "task_id": task_id,
+            "pty_info": pty_info,
+            "stdout": stdout,
+            "stderr": stderr,
+            "timeout": timeout,
+            "workdir": workdir,
+            "secret_ids": [secret.object_id for secret in secrets],
+            "text": text,
+            "bufsize": bufsize,
+            "runtime_debug": config.get("function_runtime_debug"),
+        }
+        # NB: This must come after the task ID is set, since the sandbox must be
+        # scheduled before we can create a router client.
+        if (command_router_client := await self._get_command_router_client(task_id)) is not None:
+            kwargs["command_router_client"] = command_router_client
+            return await self._exec_through_command_router(*args, **kwargs)
+        else:
+            return await self._exec_through_server(*args, **kwargs)
+
+    async def _exec_through_server(
+        self,
+        *args: str,
+        task_id: str,
+        pty_info: Optional[api_pb2.PTYInfo] = None,
+        stdout: StreamType = StreamType.PIPE,
+        stderr: StreamType = StreamType.PIPE,
+        timeout: Optional[int] = None,
+        workdir: Optional[str] = None,
+        secret_ids: Optional[Collection[str]] = None,
+        text: bool = True,
+        bufsize: Literal[-1, 1] = -1,
+        runtime_debug: bool = False,
+    ) -> Union[_ContainerProcess[bytes], _ContainerProcess[str]]:
+        """Execute a command through the Modal server."""
         req = api_pb2.ContainerExecRequest(
             task_id=task_id,
             command=args,
             pty_info=pty_info,
-            runtime_debug=config.get("function_runtime_debug"),
+            runtime_debug=runtime_debug,
             timeout_secs=timeout or 0,
             workdir=workdir,
-            secret_ids=[secret.object_id for secret in secrets],
+            secret_ids=secret_ids,
         )
         resp = await retry_transient_errors(self._client.stub.ContainerExec, req)
         by_line = bufsize == 1
@@ -877,6 +926,75 @@ class _Sandbox(_Object, type_prefix="sb"):
             text=text,
             exec_deadline=exec_deadline,
             by_line=by_line,
+        )
+
+    async def _exec_through_command_router(
+        self,
+        *args: str,
+        task_id: str,
+        command_router_client: TaskCommandRouterClient,
+        pty_info: Optional[api_pb2.PTYInfo] = None,
+        stdout: StreamType = StreamType.PIPE,
+        stderr: StreamType = StreamType.PIPE,
+        timeout: Optional[int] = None,
+        workdir: Optional[str] = None,
+        secret_ids: Optional[Collection[str]] = None,
+        text: bool = True,
+        bufsize: Literal[-1, 1] = -1,
+        runtime_debug: bool = False,
+    ) -> Union[_ContainerProcess[bytes], _ContainerProcess[str]]:
+        """Execute a command through a task command router running on the Modal worker."""
+
+        # Generate a random process ID to use as a combination of idempotency key/process identifier.
+        process_id = str(uuid.uuid4())
+        if stdout == StreamType.PIPE:
+            stdout_config = sr_pb2.TaskExecStdoutConfig.TASK_EXEC_STDOUT_CONFIG_PIPE
+        elif stdout == StreamType.DEVNULL:
+            stdout_config = sr_pb2.TaskExecStdoutConfig.TASK_EXEC_STDOUT_CONFIG_DEVNULL
+        elif stdout == StreamType.STDOUT:
+            # TODO(saltzm): This is a behavior change from the old implementation. We should
+            # probably implement the old behavior of printing to stdout before moving out of beta.
+            raise NotImplementedError(
+                "Currently the STDOUT stream type is not supported when using exec "
+                "through a task command router, which is currently in beta."
+            )
+        else:
+            raise ValueError("Unsupported StreamType for stdout")
+
+        if stderr == StreamType.PIPE:
+            stderr_config = sr_pb2.TaskExecStderrConfig.TASK_EXEC_STDERR_CONFIG_PIPE
+        elif stderr == StreamType.DEVNULL:
+            stderr_config = sr_pb2.TaskExecStderrConfig.TASK_EXEC_STDERR_CONFIG_DEVNULL
+        elif stderr == StreamType.STDOUT:
+            stderr_config = sr_pb2.TaskExecStderrConfig.TASK_EXEC_STDERR_CONFIG_STDOUT
+        else:
+            raise ValueError("Unsupported StreamType for stderr")
+
+        # Start the process.
+        start_req = sr_pb2.TaskExecStartRequest(
+            task_id=task_id,
+            exec_id=process_id,
+            command_args=args,
+            stdout_config=stdout_config,
+            stderr_config=stderr_config,
+            timeout_secs=timeout,
+            workdir=workdir,
+            secret_ids=secret_ids,
+            pty_info=pty_info,
+            runtime_debug=runtime_debug,
+        )
+        _ = await command_router_client.exec_start(start_req)
+
+        return _ContainerProcess(
+            process_id,
+            task_id,
+            self._client,
+            command_router_client=command_router_client,
+            stdout=stdout,
+            stderr=stderr,
+            text=text,
+            by_line=bufsize == 1,
+            exec_deadline=time.monotonic() + int(timeout) if timeout else None,
         )
 
     async def _experimental_snapshot(self) -> _SandboxSnapshot:

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -9,8 +9,9 @@ from unittest import mock
 from modal import App, Image, NetworkFileSystem, Proxy, Sandbox, SandboxSnapshot, Secret, Volume
 from modal.exception import InvalidError
 from modal.stream_type import StreamType
-from modal_proto import api_pb2
+from modal_proto import api_pb2, task_command_router_pb2 as tcr_pb2
 
+from .conftest import FakeTaskCommandRouterClient
 from .supports.skip import skip_windows
 
 skip_non_subprocess = skip_windows("Needs subprocess support")
@@ -250,7 +251,8 @@ async def test_sandbox_async_for(app, servicer):
 
 
 @skip_non_subprocess
-def test_sandbox_exec_stdout_bytes_mode(app, servicer):
+@pytest.mark.parametrize("exec_backend", ["server", "router"], indirect=True)
+def test_sandbox_exec_stdout_bytes_mode(app, servicer, exec_backend):
     """Test that the stream reader works in bytes mode."""
 
     sb = Sandbox.create(app=app)
@@ -281,11 +283,14 @@ def test_app_sandbox(client, servicer):
 
 
 @skip_non_subprocess
-def test_sandbox_exec(app, servicer):
+@pytest.mark.parametrize("exec_backend", ["server", "router"], indirect=True)
+def test_sandbox_exec(app, servicer, exec_backend):
     sb = Sandbox.create("sleep", "infinity", app=app)
 
     cp = sb.exec("bash", "-c", "while read line; do echo $line; done")
-    assert str(cp) == "ContainerProcess(process_id='container_exec_id')"
+    # Accept either wrapper repr or impl repr depending on backend
+    s = str(cp)
+    assert s.startswith("ContainerProcess(process_id=")
 
     cp.stdin.write(b"foo\n")
     cp.stdin.write(b"bar\n")
@@ -296,7 +301,8 @@ def test_sandbox_exec(app, servicer):
 
 
 @skip_non_subprocess
-def test_sandbox_exec_wait(app, servicer):
+@pytest.mark.parametrize("exec_backend", ["server", "router"], indirect=True)
+def test_sandbox_exec_wait(app, servicer, exec_backend):
     sb = Sandbox.create("sleep", "infinity", app=app)
 
     cp = sb.exec("bash", "-c", "sleep 0.5 && exit 42")
@@ -312,7 +318,8 @@ def test_sandbox_exec_wait(app, servicer):
 
 @mock.patch("modal.sandbox.CONTAINER_EXEC_TIMEOUT_BUFFER", 0)
 @skip_non_subprocess
-def test_sandbox_exec_wait_timeout(app, servicer):
+@pytest.mark.parametrize("exec_backend", ["server", "router"], indirect=True)
+def test_sandbox_exec_wait_timeout(app, servicer, exec_backend):
     sb = Sandbox.create("sleep", "infinity", app=app)
 
     cp = sb.exec("sleep", "999", timeout=1)
@@ -323,7 +330,8 @@ def test_sandbox_exec_wait_timeout(app, servicer):
 
 @mock.patch("modal.sandbox.CONTAINER_EXEC_TIMEOUT_BUFFER", 0)
 @skip_non_subprocess
-def test_sandbox_exec_poll_timeout(app, servicer):
+@pytest.mark.parametrize("exec_backend", ["server", "router"], indirect=True)
+def test_sandbox_exec_poll_timeout(app, servicer, exec_backend):
     sb = Sandbox.create("sleep", "infinity", app=app)
 
     cp = sb.exec("sleep", "999", timeout=1)
@@ -334,7 +342,8 @@ def test_sandbox_exec_poll_timeout(app, servicer):
 
 @mock.patch("modal.sandbox.CONTAINER_EXEC_TIMEOUT_BUFFER", 0)
 @skip_non_subprocess
-def test_sandbox_exec_output_timeout(app, servicer):
+@pytest.mark.parametrize("exec_backend", ["server", "router"], indirect=True)
+def test_sandbox_exec_output_timeout(app, servicer, exec_backend):
     sb = Sandbox.create("sleep", "infinity", app=app)
 
     cp = sb.exec("sh", "-c", "echo hi; sleep 999", timeout=1)
@@ -345,7 +354,8 @@ def test_sandbox_exec_output_timeout(app, servicer):
 
 
 @skip_non_subprocess
-def test_sandbox_exec_output_double_read(app, servicer):
+@pytest.mark.parametrize("exec_backend", ["server", "router"], indirect=True)
+def test_sandbox_exec_output_double_read(app, servicer, exec_backend):
     sb = Sandbox.create("sleep", "infinity", app=app)
 
     cp = sb.exec("sh", "-c", "echo hi")
@@ -646,13 +656,34 @@ def test_sandbox_create_pty(app, servicer):
 
 
 @skip_non_subprocess
-def test_sandbox_exec_pty(app, servicer):
-    with servicer.intercept() as ctx:
-        sb = Sandbox.create("sleep", "infinity", app=app)
-        sb.exec("echo", "hello", pty=True)
-        req = ctx.pop_request("ContainerExec")
+@pytest.mark.parametrize("exec_backend", ["server", "router"], indirect=True)
+def test_sandbox_exec_pty(app, servicer, exec_backend, monkeypatch):
+    pty_info = None
+    if exec_backend == "server":
+        with servicer.intercept() as ctx:
+            sb = Sandbox.create("sleep", "infinity", app=app)
+            sb.exec("echo", "hello", pty=True)
+            req = ctx.pop_request("ContainerExec")
+            pty_info = req.pty_info
+    else:
+        captured_request = None
+        original = FakeTaskCommandRouterClient.exec_start
 
-        assert req.pty_info is not None
-        assert req.pty_info.enabled is True
-        assert req.pty_info.pty_type == api_pb2.PTYInfo.PTY_TYPE_SHELL
-        assert req.pty_info.no_terminate_on_idle_stdin is True
+        async def _exec_start(self, request: tcr_pb2.TaskExecStartRequest) -> tcr_pb2.TaskExecStartResponse:
+            nonlocal captured_request
+            captured_request = request
+            return await original(self, request)
+
+        monkeypatch.setattr(FakeTaskCommandRouterClient, "exec_start", _exec_start, raising=True)
+
+        # Router path: ensure exec succeeds with pty=True (pty details are handled on worker/router side).
+        sb = Sandbox.create("sleep", "infinity", app=app)
+        cp = sb.exec("echo", "hello", pty=True)
+        cp.wait()
+        assert captured_request is not None
+        pty_info = captured_request.pty_info
+
+    assert pty_info is not None
+    assert pty_info.enabled is True
+    assert pty_info.pty_type == api_pb2.PTYInfo.PTY_TYPE_SHELL
+    assert pty_info.no_terminate_on_idle_stdin is True


### PR DESCRIPTION
## Describe your changes

Selectively enable new exec path using task command router depending on result of TaskGetCommandAccess RPC.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.




</details>



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a worker-side command-router exec path (with server fallback), updates ContainerProcess behavior, and parametrizes tests to run against both backends.
> 
> - **Exec path selection (Sandbox)**:
>   - Introduce `TaskCommandRouterClient` and use `TaskGetCommandRouterAccess` to selectively route `Sandbox.exec` through a worker-side command router; fall back to existing server RPCs.
>   - Split exec into `_exec_through_command_router` (uses `sr_pb2.TaskExec*` APIs, UUID `process_id`, maps `StreamType`, disallows `STDOUT`) and `_exec_through_server` (prior logic).
>   - Track `_command_router_client` on `Sandbox`; hydrate defaults and lazy-init via `_get_command_router_client`.
> - **ContainerProcess**:
>   - Wrapper returns underlying impl `__repr__`; server impl now has `__repr__`.
>   - On poll timeout, return `-1` (instead of `None`) and cache as `_returncode`.
> - **Streams**:
>   - Add command-router-backed `_StreamReader`/`_StreamWriter` plumbing; refine error/message for unsupported `STDOUT` with command router.
> - **TaskCommandRouterClient**:
>   - Implement direct worker gRPC interactions (`exec_start`, stdio read/write, poll, wait) with transient/auth retry and JWT auto-refresh; on background refresh failure, exit loop early.
> - **Tests**:
>   - Add `FakeTaskCommandRouterClient` and `exec_backend` fixture to run tests against both "server" and "router" backends; adjust assertions (repr, PTY propagation, timeout semantics).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72042d928b4dbc2562bb2f9ac490e4c6699c8ddf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->