### PR TITLE
volume: Increase the max number of retries for put_missing_block_attempt

### DIFF
--- a/modal/volume.py
+++ b/modal/volume.py
@@ -1263,7 +1263,7 @@ async def _put_missing_blocks(
         file_progress.pending_blocks.add(missing_block.block_index)
         task_progress_cb = functools.partial(progress_cb, task_id=file_progress.task_id)
 
-        @retry(n_attempts=5, base_delay=0.5, timeout=None)
+        @retry(n_attempts=11, base_delay=0.5, timeout=None)
         async def put_missing_block_attempt(payload: BytesIOSegmentPayload) -> bytes:
             with payload.reset_on_error(subtract_progress=True):
                 async with ClientSessionRegistry.get_session().put(


### PR DESCRIPTION
Adding more retries to this operation should allow us to tolerate more transient errors when uploading blocks. The block upload service (clobber-worker) is distributed across CDN PoPs, so there's no additional layer between the client and the service where we could inject other logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase retry attempts from 5 to 11 for HTTP PUT of missing blocks during Volume V2 batch uploads to improve robustness.
> 
> - **Volume V2 uploads**:
>   - Increase retries in `modal/volume.py` for `put_missing_block_attempt` from `n_attempts=5` to `n_attempts=11` when PUT-ing missing block payloads (`_put_missing_blocks`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7be5e7534c9adc57adf853b8b76eb53b9effef1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->