### PR TITLE
Fix flaky test by appending trailing zeroes

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2771,7 +2771,8 @@ def blob_server_factory():
             block_id, start, length = rest
             start = int(start)
             length = int(length)
-            body = blocks[block_id][start : start + length]
+            block = blocks[block_id][start : start + length]
+            body = block.ljust(length, b"\0")
         else:
             return aiohttp.web.Response(status=404)
 

--- a/test/volume_test.py
+++ b/test/volume_test.py
@@ -119,7 +119,6 @@ def test_volume_commit(client, servicer, skip_reload):
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="TODO(dflemstr) this test has started flaking at a high rate recently")
 @pytest.mark.parametrize("version", VERSIONS)
 @pytest.mark.parametrize("file_contents_size", [100, 8 * 1024 * 1024, 16 * 1024 * 1024, 32 * 1024 * 1024 + 4711])
 async def test_volume_get(servicer, client, tmp_path, version, file_contents_size):


### PR DESCRIPTION
In 11f8552c14f237e19463f407a53917e6b7a8fad2 trailing zeroes was stripped away when uploading blocks. Append trailing zeroes when downloading blocks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pads v2 block download slices with zero bytes to match requested length and re-enables the `test_volume_get` test.
> 
> - **Test server (blob/block handling)**:
>   - Adjust `test/conftest.py` `get_block` for `v2` to pad returned block slices with trailing `\0` via `ljust` to the requested `length`.
> - **Tests**:
>   - Unskips `test_volume_get` in `test/volume_test.py`, restoring its execution across versions and large file sizes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 638eeaf78117e9e64625449c6592426151d8de47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->