### PR TITLE
Add missing status checks

### DIFF
--- a/modal/volume.py
+++ b/modal/volume.py
@@ -655,6 +655,7 @@ class _Volume(_Object, type_prefix="vo"):
         @retry(n_attempts=5, base_delay=0.1, timeout=None)
         async def read_block(block_url: str) -> bytes:
             async with ClientSessionRegistry.get_session().get(block_url) as get_response:
+                get_response.raise_for_status()
                 return await get_response.content.read()
 
         async def iter_urls() -> AsyncGenerator[str]:
@@ -716,6 +717,7 @@ class _Volume(_Object, type_prefix="vo"):
             num_bytes_written = 0
 
             async with download_semaphore, ClientSessionRegistry.get_session().get(url) as get_response:
+                get_response.raise_for_status()
                 async for chunk in get_response.content.iter_any():
                     num_chunk_bytes_written = 0
 


### PR DESCRIPTION
These need some regression tests. To be added in the future.

## Changelog

* Fixed a bug where the status code was not checked when downloading a file from a volume.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds HTTP status checks (`raise_for_status()`) during volume file downloads to fail fast on bad responses.
> 
> - **Volume file download**:
>   - In `read_file()` and `_read_file_into_fileobj()`, call `get_response.raise_for_status()` on HTTP GET responses for block URLs before reading content.
>   - Ensures non-2xx responses are surfaced as errors during block downloads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04265496f5fc0c8149a8486b6a8efc182dd61b22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->