### PR TITLE
Add regression tests for http status error on volume download

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2757,6 +2757,12 @@ def blob_server_factory():
         if magic != "test-get-request":
             return aiohttp.web.Response(status=400, text="bad token")
 
+        # Special versions for testing HTTP error handling
+        if version == "error-404":
+            return aiohttp.web.Response(status=404, text="block not found")
+        if version == "error-500":
+            return aiohttp.web.Response(status=500, text="internal server error")
+
         if version == "v1":
             file_sha256_hex, block_idx, start, length = rest
             start = BLOCK_SIZE * int(block_idx) + int(start)


### PR DESCRIPTION
This adds regression tests for fix from c476750c794d543e89b82ef3400cb4fd848c9e79.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds tests ensuring 404/500 HTTP errors surface when reading volume files, and updates the mock blob server to emit those errors via special get_block tokens.
> 
> - **Tests (volume)**:
>   - Add `test_volume_read_file_http_500_error` validating `vol.read_file` raises `aiohttp.ClientResponseError` 500.
>   - Add `test_volume_read_file_into_fileobj_http_404_error` validating `read_file_into_fileobj` raises `aiohttp.ClientResponseError` 404.
> - **Test server (blob get_block)**:
>   - Support special tokens `error-404` and `error-500` to return corresponding HTTP statuses for regression testing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1711b2a9c0e5ec77d4b49c0dd81fa4ce8efc6e23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->