### PR TITLE
Accept -h as a help alias

### DIFF
--- a/modal/cli/entry_point.py
+++ b/modal/cli/entry_point.py
@@ -36,6 +36,7 @@ entrypoint_cli_typer = typer.Typer(
     no_args_is_help=False,
     add_completion=False,
     rich_markup_mode="markdown",
+    context_settings={"help_option_names": ["-h", "--help"]},
     help="""
     Modal is the fastest way to run code in the cloud.
 


### PR DESCRIPTION
Apparently this needs to be explicitly enabled in Typer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable `-h` as a help flag by setting Typer `context_settings` with `help_option_names`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1580b30a216b344de1429d0c0489d4103ec0da67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->