### PR TITLE
Fix modal launch description

### DIFF
--- a/modal/cli/launch.py
+++ b/modal/cli/launch.py
@@ -23,8 +23,7 @@ launch_cli = Typer(
     no_args_is_help=True,
     rich_markup_mode="markdown",
     help="""
-    Open a serverless app instance on Modal.
-    >⚠️  `modal launch` is **experimental** and may change in the future.
+    [Experimental] Open a serverless app instance on Modal.
     """,
 )
 


### PR DESCRIPTION
Noticed that the extra text was causing this to wrap oddly and make the main `modal -h` panel look weird.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Condenses `modal launch` CLI help into a single “[Experimental] Open a serverless app instance on Modal.” line.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 532c145aa52009f541194d74bd97ada377e447a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->