### PR TITLE
Add a little more context when code and def disagree about dependencies

### DIFF
--- a/modal/_container_entrypoint.py
+++ b/modal/_container_entrypoint.py
@@ -450,7 +450,10 @@ def main(container_args: api_pb2.ContainerArguments, client: Client):
                     f"Function has {len(service.service_deps)} dependencies"
                     f" but container got {len(dep_object_ids)} object ids.\n"
                     f"Code deps: {service.service_deps}\n"
-                    f"Object ids: {dep_object_ids}"
+                    f"Object ids: {dep_object_ids}\n"
+                    "\n"
+                    "This can happen if you are defining Modal objects under a conditional statement "
+                    "that evaluates differently in the local and remote environments."
                 )
             for object_id, obj in zip(dep_object_ids, service.service_deps):
                 metadata: Message = container_app.object_handle_metadata[object_id]


### PR DESCRIPTION
Small improvement to make this container entrypoint error a little bit more actionable / debuggable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances the dependency mismatch ExecutionError message with clearer details and guidance about conditionally defined objects.
> 
> - **Error handling**:
>   - In `modal/_container_entrypoint.py`, expands the `ExecutionError` thrown when `service.service_deps` count mismatches object IDs, adding clearer formatting and a note that conditional object definitions may evaluate differently locally vs. remotely.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f637674d7e3404b56802494fe5a5e428d47645d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->