### PR TITLE
Adds container_process to type checks

### DIFF
--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -509,6 +509,13 @@ class _StreamReader(Generic[T]):
     ```
     """
 
+    _impl: Union[
+        _StreamReaderThroughServer,
+        _DevnullStreamReader,
+        _TextStreamReaderThroughCommandRouter,
+        _BytesStreamReaderThroughCommandRouter,
+    ]
+
     def __init__(
         self,
         file_descriptor: "api_pb2.FileDescriptor.ValueType",

--- a/tasks.py
+++ b/tasks.py
@@ -232,6 +232,7 @@ def type_check(ctx):
         "modal/config.py",
         "modal/object.py",
         "modal/_type_manager.py",
+        "modal/container_process.py",
     ]
     ctx.run(f"pyright {' '.join(pyright_allowlist)}", pty=True)
 


### PR DESCRIPTION
Mini cleanup

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tightens `container_process` exec ID handling and attach loop; adds `_StreamReader._impl` typing and includes `modal/container_process.py` in pyright checks.
> 
> - **Container process**:
>   - Add `assert self._process_id` before `poll()` and internal wait loop.
>   - Simplify `attach()` log loop by removing explicit `None`-chunk break.
> - **Streams/Types**:
>   - Add explicit `_impl` union type to `_StreamReader` in `modal/io_streams.py`.
> - **Tooling**:
>   - Include `modal/container_process.py` in Pyright allowlist in `tasks.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d403b3392d702b240f223125c41bf3c0f538d24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->