### PR TITLE
Updates proto to support region definition

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2461,6 +2461,7 @@ message ProxyAddIpResponse {
 message ProxyCreateRequest {
   string name = 1;
   string environment_name = 2;
+  string region = 3;
 }
 
 message ProxyCreateResponse {


### PR DESCRIPTION
We want to allow users to run Proxy servers in select regions. This adds the `region` parameter to support the functionality.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `region` to `ProxyCreateRequest` to specify proxy region on creation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c08a0583841902002bb22d60e04d6b4bceb370f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->