### PR TITLE
Lower concurrent `MountPutFile` to 64

### DIFF
--- a/modal/mount.py
+++ b/modal/mount.py
@@ -552,7 +552,7 @@ class _Mount(_Object, type_prefix="mo"):
             raise modal.exception.MountUploadTimeoutError(f"Mounting of {file_spec.source_description} timed out")
 
         # Upload files, or check if they already exist.
-        n_concurrent_uploads = 512
+        n_concurrent_uploads = 64
         files: list[api_pb2.MountFile] = []
         async with aclosing(
             async_map(_Mount._get_files(self._entries), _put_file, concurrency=n_concurrent_uploads)


### PR DESCRIPTION
See [internal discussion](https://modal-com.slack.com/archives/C07ML5EE6NM/p1761411975151249).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduces concurrent `MountPutFile` uploads during mount creation from 512 to 64.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98b1373ab1aa947f1e5818d2ef95e9fd8b9b9c47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->