### PR TITLE
[SVC-803 1/N] Add nonpreemptible field to SchedulerPlacement proto

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2983,12 +2983,11 @@ message Schedule {
 }
 
 message SchedulerPlacement {
-  bool nonpreemptible = 6; 
   repeated string regions = 4;
-  // TODO(irfansharif): Make these two repeated.
-  optional string _zone = 2; // admin-only
-  optional string _lifecycle = 3; // admin-only, "on-demand" or "spot", else ignored
-  repeated string _instance_types = 5; // admin-only
+  optional string _zone = 2; // TODO: Deprecate
+  optional string _lifecycle = 3; // TODO: Deprecate
+  repeated string _instance_types = 5; // TODO: Deprecate
+  bool nonpreemptible = 6;
 
   reserved 1;
 }


### PR DESCRIPTION
Adds a `nonpreemptible` boolean to `SchedulerPlacement` in modal_proto/api.proto.

This SchedulerPlacement is part of the function definition and is how the client indicates the Function's containers should be scheduled onto nonpreemptible instances.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

- [X] Client+Server: this change is compatible with old servers
- [X] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `nonpreemptible` boolean to `SchedulerPlacement` in `modal_proto/api.proto`.
> 
> - **Proto definitions**:
>   - `modal_proto/api.proto`:
>     - `SchedulerPlacement`: add boolean field `nonpreemptible` (`= 6`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f0331229178b0d3e789864f88099d55af1d2b6f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->