### PR TITLE
Update CI to use macos-15

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -91,10 +91,10 @@ jobs:
         os: ["ubuntu-24.04"]
         proto-version: ["latest"]
         include:
-          - os: "macos-13" # x86-64
+          - os: "macos-15-intel" # x86-64
             python-version: "3.10"
             proto-version: "latest"
-          - os: "macos-14" # ARM64 (M1)
+          - os: "macos-15" # ARM64 (M1)
             python-version: "3.10"
             proto-version: "latest"
           - os: "windows-latest"


### PR DESCRIPTION
## Describe your changes

Updates CI to use `macos-15-intel` for intel and `macos-15` for ARM64.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update CI matrix to use `macos-15-intel` for x86_64 and `macos-15` for ARM64 runners.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b928e701e07c4ff8be24dec5959c31fd0af25126. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->