### PR TITLE
Speed up image_stability tests in image_test.py

### DIFF
--- a/test/image_test.py
+++ b/test/image_test.py
@@ -137,7 +137,7 @@ def test_dockerhub_python_version(builder_version):
 
 
 def test_image_base(builder_version, servicer, client, test_dir):
-    app = App()
+    app = App(include_source=False)
     constructors = [
         (Image.debian_slim, ()),
         (Image.from_registry, ("ubuntu",)),
@@ -671,7 +671,7 @@ def run_f_globals():
 def test_image_run_function_globals(builder_version, servicer, client):
     global VARIABLE_1, VARIABLE_2
 
-    app = App()
+    app = App(include_source=False)
     app.image = Image.debian_slim().run_function(run_f_globals)
     app.function()(dummy)
 


### PR DESCRIPTION
## Describe your changes

These stability tests are slow because they are mounting many files. We can use `include_source=False` to not include the source files and still do the hash checks.

With `pytest test/image_test.py -k image_stability` it takes ~1 sec using this PR and ~53 secs on `main`.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use App(include_source=False) in image stability and selected image tests to avoid source mounting and significantly speed execution.
> 
> - **Tests**:
>   - Use `App(include_source=False)` to skip source mounting in:
>     - Image stability tests for `2023.12`, `2024.04`, `2024.10`, `2025.06` (inner `get_hash` helpers).
>     - `test_image_base` and `test_image_run_function_globals`.
>   - Minor adjustments to reference `app.image.object_id` consistently in stability helpers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4083a4184e98313675ca88d0554ade5d2dd5a7d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->