### PR TITLE
Speed up test_mid_build_modifications tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1655,9 +1655,6 @@ class MockClientServicer(api_grpc.ModalClientBase):
     async def MountPutFile(self, stream):
         request: api_pb2.MountPutFileRequest = await stream.recv_message()
         if request.WhichOneof("data_oneof") is not None:
-            if request.data.startswith(b"large"):
-                # Useful for simulating a slow upload, e.g. to test our checks for mid-deploy modifications
-                await asyncio.sleep(2)
             self.files_sha2data[request.sha256_hex] = {"data": request.data, "data_blob_id": request.data_blob_id}
             self.n_mount_files += 1
             await stream.send_message(api_pb2.MountPutFileResponse(exists=True))

--- a/test/runner_test.py
+++ b/test/runner_test.py
@@ -126,8 +126,7 @@ async def test_mid_build_modifications(servicer, client, tmp_path, monkeypatch, 
     monkeypatch.setattr("modal.runner.Resolver", PatchedResolver)
 
     (large_dir := tmp_path / "large_files").mkdir()
-    for i in range(8 + 1):  # Equivalent to file upload concurrency
-        (large_dir / f"{i:02d}.txt").write_bytes(f"large {i:02d}".encode())
+    (large_dir / "1.txt").write_bytes("large 1".encode())
 
     image = modal.Image.debian_slim().add_local_dir(large_dir, "/root/large_files")
 


### PR DESCRIPTION
## Describe your changes

This speeds up `test_mid_build_modifications`, by patching the resolver with a build_time that is always older than any file. When running:

```bash
pytest test/runner_test.py::test_mid_build_modifications
```

I get ~26s on main and 4s with this PR.

I'm a little skeptical of this PR, because it changes the nature of the test by pretending that the app started at a later time. (But saving ~22s is pretty good.)

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Patches `Resolver` to force old build start and simplifies test data, while removing the simulated upload delay from the mock `MountPutFile`.
> 
> - **Tests**:
>   - Patch `modal.runner.Resolver` in `test_mid_build_modifications` to return an old `build_start`, triggering validation deterministically.
>   - Reduce test data in `large_files` to a single file and remove delayed file-touch logic; simplify run context.
> - **Test server/mock**:
>   - Remove simulated slow upload (previous 2s sleep for data starting with `b"large"`) from `MockClientServicer.MountPutFile` in `test/conftest.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfe733cba8ded5580edb8d4aa1861bf5c5fc9865. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->