### PR TITLE
Speed up file_io test and expand to more chunks

### DIFF
--- a/test/file_io_test.py
+++ b/test/file_io_test.py
@@ -132,9 +132,16 @@ def test_file_write(servicer, client):
         f.close()
 
 
-def test_file_write_large(servicer, client):
+@pytest.mark.parametrize(
+    "file_size, expected_counter",
+    [
+        (int(5.5 * WRITE_CHUNK_SIZE), 6),
+        (int(2 * WRITE_CHUNK_SIZE), 2),
+    ],
+)
+def test_file_write_chunks(servicer, client, file_size, expected_counter):
     """Test file write chunking logic."""
-    content = "A" * WRITE_FILE_SIZE_LIMIT
+    content = "A" * file_size
     write_counter = 0
 
     async def container_filesystem_exec_get_output(servicer, stream):
@@ -150,7 +157,7 @@ def test_file_write_large(servicer, client):
 
         f = FileIO.create("/test.txt", "a+", client, "task-123")
         f.write(content)
-        assert write_counter == WRITE_FILE_SIZE_LIMIT // WRITE_CHUNK_SIZE
+        assert write_counter == expected_counter
         f.close()
 
 


### PR DESCRIPTION
## Describe your changes

This PR speeds up a `test/file_io_test.py` test and expand it's coverage. With this PR:

```bash
pytest test/file_io_test.py::test_file_write_chunks
```

takes 2 s

On main:

```
pytest test/file_io_test.py::test_file_write_large
```

takes 8.6s.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Parameterizes the file write chunking test to cover multiple chunk counts while reducing test runtime.
> 
> - **Tests**:
>   - Replace `test_file_write_large` with parameterized `test_file_write_chunks` in `test/file_io_test.py`:
>     - Varies `file_size` across multiples of `WRITE_CHUNK_SIZE` and asserts `write_counter` equals expected chunk count.
>     - Reduces data written per test while expanding coverage of chunking behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e966959508eb184d0808ed0f52792502d127efd5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->