### PR TITLE
Minor doctest speedups

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -19,19 +19,21 @@ def pytest_markdown_docs_globals():
 
     return {
         "modal": modal,
-        "app": modal.App("pytest-markdown-docs-app"),
+        "app": modal.App("pytest-markdown-docs-app", include_source=False),
         "math": math,
         "__name__": "runtest",
-        "fastapi_endpoint": modal.fastapi_endpoint,
-        "asgi_app": modal.asgi_app,
-        "wsgi_app": modal.wsgi_app,
         "__file__": "xyz.py",
     }
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def running_app():
     return modal.App.lookup("pytest-markdown-docs-running-app", create_if_missing=True)
+
+
+@pytest.fixture(scope="session")
+def sandbox(running_app):
+    return modal.Sandbox.create("sleep", "infinity", app=running_app)
 
 
 @register_runner()

--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -492,21 +492,6 @@ class _StreamReader(Generic[T]):
 
     As an asynchronous iterable, the object supports the `for` and `async for`
     statements. Just loop over the object to read in chunks.
-
-    **Usage**
-
-    ```python fixture:running_app
-    from modal import Sandbox
-
-    sandbox = Sandbox.create(
-        "bash",
-        "-c",
-        "for i in $(seq 1 10); do echo foo; sleep 0.1; done",
-        app=running_app,
-    )
-    for message in sandbox.stdout:
-        print(f"Message: {message}")
-    ```
     """
 
     _impl: Union[
@@ -574,19 +559,7 @@ class _StreamReader(Generic[T]):
         return self._impl.file_descriptor
 
     async def read(self) -> T:
-        """Fetch the entire contents of the stream until EOF.
-
-        **Usage**
-
-        ```python fixture:running_app
-        from modal import Sandbox
-
-        sandbox = Sandbox.create("echo", "hello", app=running_app)
-        sandbox.wait()
-
-        print(sandbox.stdout.read())
-        ```
-        """
+        """Fetch the entire contents of the stream until EOF."""
         return await self._impl.read()
 
     # TODO(saltzm): I'd prefer to have the implementation classes only implement __aiter__
@@ -757,21 +730,16 @@ class _StreamWriter:
 
         **Usage**
 
-        ```python fixture:running_app
-        from modal import Sandbox
-
-        sandbox = Sandbox.create(
+        ```python fixture:sandbox
+        proc = sandbox.exec(
             "bash",
             "-c",
             "while read line; do echo $line; done",
-            app=running_app,
         )
-        sandbox.stdin.write(b"foo\\n")
-        sandbox.stdin.write(b"bar\\n")
-        sandbox.stdin.write_eof()
-
-        sandbox.stdin.drain()
-        sandbox.wait()
+        proc.stdin.write(b"foo\\n")
+        proc.stdin.write(b"bar\\n")
+        proc.stdin.write_eof()
+        proc.stdin.drain()
         ```
         """
         self._impl.write(data)

--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -805,13 +805,8 @@ class _Sandbox(_Object, type_prefix="sb"):
 
         **Usage**
 
-        ```python
-        app = modal.App.lookup("my-app", create_if_missing=True)
-
-        sandbox = modal.Sandbox.create("sleep", "infinity", app=app)
-
-        process = sandbox.exec("bash", "-c", "for i in $(seq 1 10); do echo foo $i; sleep 0.5; done")
-
+        ```python fixture:sandbox
+        process = sandbox.exec("bash", "-c", "for i in $(seq 1 3); do echo foo $i; sleep 0.1; done")
         for line in process.stdout:
             print(line)
         ```


### PR DESCRIPTION
Saves ≈15s or so on my devbox, mainly by not doing pointless stuff in the Sandbox examples. Also does a little cleanup. I think the Sandbox usage docs could benefit from a much more thorough set of improvements but that'll come later.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Speeds up markdown doctests by introducing session-scoped `running_app`/`sandbox` fixtures and simplifying Sandbox IO examples; also removes unused globals and verbose docstrings.
> 
> - **Tests/fixtures**:
>   - Make `running_app` and new `sandbox` fixtures session-scoped; create a long-lived sandbox (`sleep infinity`).
>   - Initialize `app` with `include_source=False`.
> - **Docs/examples**:
>   - Trim verbose `StreamReader.read` and `_StreamReader` docstrings; update `StreamWriter.write` and `Sandbox.exec` examples to use `fixture:sandbox` and shorter loops.
> - **Cleanup**:
>   - Remove unused globals (`fastapi_endpoint`, `asgi_app`, `wsgi_app`) from `pytest_markdown_docs_globals()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39efffa33b769ad1045f9577ca3b328ed9ca71f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->