### PR TITLE
Speed up container_test

### DIFF
--- a/test/container_test.py
+++ b/test/container_test.py
@@ -1474,7 +1474,7 @@ def test_image_run_function_no_warn(servicer, caplog):
     assert len(caplog.messages) == 0
 
 
-SLEEP_TIME = 0.7
+SLEEP_TIME = 0.1
 
 
 def _unwrap_concurrent_input_outputs(n_inputs: int, n_parallel: int, ret: ContainerResult):
@@ -1505,7 +1505,7 @@ def test_concurrent_inputs_sync_function(servicer, deployed_support_function_def
     t0 = time.time()
     ret = _run_container_auto(
         servicer,
-        "sleep_700_sync",
+        "sleep_100_sync",
         deployed_support_function_definitions,
         inputs=_get_inputs(n=n_inputs),
     )
@@ -1527,7 +1527,7 @@ def test_concurrent_inputs_async_function(servicer, deployed_support_function_de
     t0 = time.time()
     ret = _run_container_auto(
         servicer,
-        "sleep_700_async",
+        "sleep_100_async",
         deployed_support_function_definitions,
         inputs=_get_inputs(n=n_inputs),
     )
@@ -2343,11 +2343,11 @@ def test_sigint_termination_exit_handler(servicer, tmp_path, exit_type):
             "test.supports.functions",
             "LifecycleCls.*",
             inputs=[("delay", (0,), {})],
-            cls_params=((), {"print_at_exit": 1, f"{exit_type}_duration": 2}),
+            cls_params=((), {"print_at_exit": 1, f"{exit_type}_duration": 0.5}),
             is_class=True,
         )
         outputs.wait()  # wait for first output to be emitted
-    time.sleep(1)  # give some time for container to end up in the exit handler
+    time.sleep(0.25)  # give some time for container to end up in the exit handler
     os.kill(container_process.pid, signal.SIGINT)
 
     stdout, stderr = container_process.communicate(timeout=5)

--- a/test/supports/class_with_image.py
+++ b/test/supports/class_with_image.py
@@ -2,7 +2,7 @@
 import modal
 
 image = modal.Image.debian_slim()
-app = modal.App(image=image)
+app = modal.App(image=image, include_source=False)
 
 
 @app.cls()

--- a/test/supports/functions.py
+++ b/test/supports/functions.py
@@ -28,7 +28,7 @@ from modal.queue import Queue
 
 SLEEP_DELAY = 0.1
 
-app = App()
+app = App(include_source=False)
 
 
 @app.function()
@@ -508,15 +508,15 @@ class LifecycleCls:
 
 @app.function()
 @concurrent(max_inputs=6)
-def sleep_700_sync(x):
-    time.sleep(0.7)
+def sleep_100_sync(x):
+    time.sleep(0.1)
     return x * x, current_input_id(), current_function_call_id()
 
 
 @app.function()
 @concurrent(max_inputs=6)
-async def sleep_700_async(x):
-    await asyncio.sleep(0.7)
+async def sleep_100_async(x):
+    await asyncio.sleep(0.1)
     return x * x, current_input_id(), current_function_call_id()
 
 
@@ -652,7 +652,7 @@ def is_local_f(x):
 
 @app.function()
 def raise_large_unicode_exception():
-    byte_str = (b"k" * 120_000_000) + b"\x99"
+    byte_str = (b"k" * 3_000_000) + b"\x99"
     byte_str.decode("utf-8")
 
 

--- a/test/supports/image_run_function.py
+++ b/test/supports/image_run_function.py
@@ -1,8 +1,8 @@
 # Copyright Modal Labs 2022
 import modal
 
-app = modal.App("a")
-other = modal.App("b")
+app = modal.App("a", include_source=False)
+other = modal.App("b", include_source=False)
 
 
 def builder_function():

--- a/test/supports/lazy_hydration.py
+++ b/test/supports/lazy_hydration.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2024
 from modal import App, Image, Queue, Volume
 
-app = App()
+app = App(include_source=False)
 
 image = Image.debian_slim().pip_install("xyz")
 volume = Volume.from_name("my-vol")

--- a/test/supports/missing_main_conditional.py
+++ b/test/supports/missing_main_conditional.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 import modal
 
-app = modal.App()
+app = modal.App(include_source=False)
 
 
 @app.function()

--- a/test/supports/modal_run_from_function.py
+++ b/test/supports/modal_run_from_function.py
@@ -1,9 +1,9 @@
 # Copyright Modal Labs 2025
 import modal
 
-app = modal.App("app1")
+app = modal.App("app1", include_source=False)
 
-app2 = modal.App("app2")
+app2 = modal.App("app2", include_source=False)
 
 
 @app2.function()

--- a/test/supports/multiapp.py
+++ b/test/supports/multiapp.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2023
 import modal
 
-a = modal.App()
+a = modal.App(include_source=False)
 
 
 @a.function()

--- a/test/supports/multiapp_privately_decorated.py
+++ b/test/supports/multiapp_privately_decorated.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2023
 import modal
 
-app = modal.App()
+app = modal.App(include_source=False)
 
 
 def foo(i):

--- a/test/supports/multiapp_privately_decorated_named_app.py
+++ b/test/supports/multiapp_privately_decorated_named_app.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2023
 import modal
 
-app = modal.App("dummy")
+app = modal.App("dummy", include_source=False)
 
 
 def foo(i):

--- a/test/supports/multiapp_same_name.py
+++ b/test/supports/multiapp_same_name.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2023
 import modal
 
-app = modal.App("dummy")
+app = modal.App("dummy", include_source=False)
 
 
 def foo(i):

--- a/test/supports/multiapp_serialized_func.py
+++ b/test/supports/multiapp_serialized_func.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2023
 import modal
 
-app = modal.App()
+app = modal.App(include_source=False)
 
 
 def foo(x):

--- a/test/supports/package_mount.py
+++ b/test/supports/package_mount.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 from modal import App, Image
 
-app = App()
+app = App(include_source=False)
 
 # just make sure that non-existing package doesn't cause this to crash in containers:
 image = Image.debian_slim().add_local_python_source("non_existing_package_123154")

--- a/test/supports/sibling_hydration_app.py
+++ b/test/supports/sibling_hydration_app.py
@@ -2,7 +2,7 @@
 import modal
 from modal import asgi_app, enter, fastapi_endpoint, method
 
-app = modal.App()
+app = modal.App(include_source=False)
 
 
 @app.function()

--- a/test/supports/startup_failure.py
+++ b/test/supports/startup_failure.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 import modal
 
-app = modal.App("hello-world")
+app = modal.App("hello-world", include_source=False)
 
 if not modal.is_local():
     import nonexistent_package  # noqa

--- a/test/supports/startup_failure_bigexception.py
+++ b/test/supports/startup_failure_bigexception.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2022
 import modal
 
-app = modal.App("hello-world")
+app = modal.App("hello-world", include_source=False)
 
 
 class BigException(Exception):

--- a/test/supports/user_code_import_samples/cls.py
+++ b/test/supports/user_code_import_samples/cls.py
@@ -2,7 +2,7 @@
 import modal
 from modal import App
 
-app = App()
+app = App(include_source=False)
 
 
 class C:

--- a/test/supports/volume_local.py
+++ b/test/supports/volume_local.py
@@ -1,7 +1,7 @@
 # Copyright Modal Labs 2024
 from modal import App, Volume
 
-app2 = App()
+app2 = App(include_source=False)
 
 
 @app2.function(volumes={"/foo": Volume.from_name("my-vol")})


### PR DESCRIPTION
## Describe your changes

When running `pytest test/container_test.py`, main takes ~82s and this PR takes ~37s.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduce sleeps and payload sizes, update function names, and set include_source=False across support apps to significantly speed up container tests.
> 
> - **Test performance improvements**:
>   - Shorten sleep durations and expectations:
>     - Replace `SLEEP_TIME = 0.7` with `0.1` and update concurrent tests to use `sleep_100_sync`/`sleep_100_async`.
>     - Adjust lifecycle SIGINT exit handler timings (`*_duration` from `2` to `0.5` and intermediate sleeps to `0.25`).
>   - Reduce large exception payload size in `raise_large_unicode_exception` from ~120MB to ~3MB.
> - **Support apps/config**:
>   - Set `include_source=False` for many test support `App` definitions (e.g., `test/supports/*`, `image_run_function`, `lazy_hydration`, `startup_failure*`, multiapp variants, etc.).
> - **Function updates**:
>   - Implement new `sleep_100_sync`/`sleep_100_async` functions with 0.1s delays and use them in tests.
>   - Minor adjustments to image/class tests (e.g., `class_with_image` using `App(image=..., include_source=False)`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af8e41859990b7b2a0eab148f7c40a07309adb63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->