### PR TITLE
Speed up function_test.py

### DIFF
--- a/test/function_test.py
+++ b/test/function_test.py
@@ -279,7 +279,7 @@ async def test_call_function_locally(client, servicer):
 def test_map(client, servicer, slow_put_inputs):
     servicer.slow_put_inputs = slow_put_inputs
 
-    app = App()
+    app = App(include_source=False)
     dummy_modal = app.function()(dummy)
 
     assert len(servicer.cleared_function_calls) == 0
@@ -295,7 +295,7 @@ def test_map(client, servicer, slow_put_inputs):
 def test_map_input_plane(client, servicer, slow_put_inputs):
     servicer.slow_put_inputs = slow_put_inputs
 
-    app = App()
+    app = App(include_source=False)
     dummy_modal = app.function(experimental_options={"input_plane_region": "us-east"})(dummy)
 
     assert len(servicer.cleared_function_calls) == 0
@@ -305,7 +305,7 @@ def test_map_input_plane(client, servicer, slow_put_inputs):
 
 
 def test_nested_map(client):
-    app = App()
+    app = App(include_source=False)
     dummy_modal = app.function()(dummy)
 
     with app.run(client=client):
@@ -315,7 +315,7 @@ def test_nested_map(client):
 
 
 def test_nested_map_input_plane(client):
-    app = App()
+    app = App(include_source=False)
     dummy_modal = app.function(experimental_options={"input_plane_region": "us-east"})(dummy)
 
     with app.run(client=client):
@@ -333,7 +333,7 @@ def test_exception_in_input_iterator(client, map_type):
         yield 1
         raise CustomException()
 
-    app = App()
+    app = App(include_source=False)
     dummy_modal = app.function()(dummy)
 
     with app.run(client=client):
@@ -355,7 +355,7 @@ def test_exception_in_input_iterator_input_plane(client, map_type):
         yield 1
         raise CustomException()
 
-    app = App()
+    app = App(include_source=False)
     dummy_modal = app.function(experimental_options={"input_plane_region": "us-east"})(dummy)
 
     with app.run(client=client):
@@ -368,7 +368,7 @@ def test_exception_in_input_iterator_input_plane(client, map_type):
 
 @pytest.mark.asyncio
 async def test_map_async_generator(client):
-    app = App()
+    app = App(include_source=False)
     dummy_modal = app.function()(dummy)
 
     async def gen_num():
@@ -382,7 +382,7 @@ async def test_map_async_generator(client):
 
 @pytest.mark.asyncio
 async def test_map_async_generator_input_plane(client):
-    app = App()
+    app = App(include_source=False)
     dummy_modal = app.function(experimental_options={"input_plane_region": "us-east"})(dummy)
 
     async def gen_num():
@@ -418,7 +418,7 @@ def synchronicity_loop_delay_tracker():
 
 @pytest.mark.timeout(5)
 def test_map_empty_input(client):
-    app = App()
+    app = App(include_source=False)
 
     @app.function(serialized=True)
     def f():
@@ -431,7 +431,7 @@ def test_map_empty_input(client):
 
 
 def test_map_blocking_iterator_blocking_synchronicity_loop(client):
-    app = App()
+    app = App(include_source=False)
     SLEEP_DUR = 0.5
 
     def blocking_iter():
@@ -453,7 +453,7 @@ def test_map_blocking_iterator_blocking_synchronicity_loop(client):
 
 @pytest.mark.asyncio
 async def test_map_blocking_iterator_blocking_synchronicity_loop_async(client):
-    app = App()
+    app = App(include_source=False)
     SLEEP_DUR = 0.5
 
     def blocking_iter():
@@ -482,7 +482,7 @@ def side_effect(_):
 
 
 def test_for_each(client, servicer):
-    app = App()
+    app = App(include_source=False)
     servicer.function_body(side_effect)
     side_effect_modal = app.function()(side_effect)
     assert _side_effect_count == 0
@@ -498,7 +498,7 @@ def custom_function(x):
 
 
 def test_map_none_values(client, servicer):
-    app = App()
+    app = App(include_source=False)
     servicer.function_body(custom_function)
     custom_function_modal = app.function()(custom_function)
 
@@ -507,7 +507,7 @@ def test_map_none_values(client, servicer):
 
 
 def test_map_none_values_input_plane(client, servicer):
-    app = App()
+    app = App(include_source=False)
     servicer.function_body(custom_function)
     custom_function_modal = app.function(experimental_options={"input_plane_region": "us-east"})(custom_function)
 
@@ -516,7 +516,7 @@ def test_map_none_values_input_plane(client, servicer):
 
 
 def test_starmap(client):
-    app = App()
+    app = App(include_source=False)
 
     dummy_modal = app.function()(dummy)
     with app.run(client=client):
@@ -524,12 +524,12 @@ def test_starmap(client):
 
 
 def test_function_memory_request(client):
-    app = App()
+    app = App(include_source=False)
     app.function(memory=2048)(dummy)
 
 
 def test_function_memory_limit(client):
-    app = App()
+    app = App(include_source=False)
     f = app.function(memory=(2048, 4096))(dummy)
 
     with app.run(client=client):
@@ -541,7 +541,7 @@ def test_function_memory_limit(client):
 
 
 def test_function_cpu_request(client, servicer):
-    app = App()
+    app = App(include_source=False)
     f = app.function(cpu=2.0)(dummy)
 
     with app.run(client=client):
@@ -550,7 +550,7 @@ def test_function_cpu_request(client, servicer):
         assert servicer.app_functions["fu-1"].resources.milli_cpu_max == 0
     assert f.spec.cpu == 2.0
 
-    app = App()
+    app = App(include_source=False)
     g = app.function(cpu=7)(dummy)
 
     with app.run(client=client):
@@ -561,7 +561,7 @@ def test_function_cpu_request(client, servicer):
 
 
 def test_function_cpu_limit(client, servicer):
-    app = App()
+    app = App(include_source=False)
     f = app.function(cpu=(1, 3))(dummy)
     assert f.spec.cpu == (1, 3)
 
@@ -576,12 +576,12 @@ def test_function_cpu_limit(client, servicer):
 
 
 def test_function_disk_request(client):
-    app = App()
+    app = App(include_source=False)
     app.function(ephemeral_disk=1_000_000)(dummy)
 
 
 def test_scaledown_window_must_be_positive():
-    app = App()
+    app = App(include_source=False)
     with pytest.raises(InvalidError, match="must be > 0"):
         app.function(scaledown_window=0)(dummy)
 
@@ -591,7 +591,7 @@ def later():
 
 
 def test_function_spawn(client, servicer):
-    app = App()
+    app = App(include_source=False)
 
     servicer.function_body(later)
     later_modal = app.function()(later)
@@ -622,7 +622,7 @@ def test_function_spawn(client, servicer):
 
 @pytest.mark.asyncio
 async def test_function_future_async(client, servicer):
-    app = App()
+    app = App(include_source=False)
 
     servicer.function_body(later)
     later_modal = app.function()(later)
@@ -649,7 +649,7 @@ async def async_later_gen():
 
 @pytest.mark.asyncio
 async def test_generator(client, servicer):
-    app = App()
+    app = App(include_source=False)
 
     later_gen_modal = app.function()(later_gen)
 
@@ -674,7 +674,7 @@ async def test_generator(client, servicer):
 
 
 def test_generator_map_invalid(client, servicer):
-    app = App()
+    app = App(include_source=False)
 
     later_gen_modal = app.function()(later_gen)
 
@@ -695,7 +695,7 @@ def test_generator_map_invalid(client, servicer):
 
 # This test is somewhat redundant, but it's good to have when we remove the old python server.
 def test_generator_map_invalid_input_plane(client, servicer):
-    app = App()
+    app = App(include_source=False)
 
     later_gen_modal = app.function(experimental_options={"input_plane_region": "us-east"})(later_gen)
 
@@ -716,7 +716,7 @@ def test_generator_map_invalid_input_plane(client, servicer):
 
 @pytest.mark.asyncio
 async def test_generator_async(client, servicer):
-    app = App()
+    app = App(include_source=False)
 
     later_gen_modal = app.function()(async_later_gen)
 
@@ -742,7 +742,7 @@ async def test_generator_async(client, servicer):
 
 @pytest.mark.asyncio
 async def test_generator_future(client, servicer):
-    app = App()
+    app = App(include_source=False)
 
     servicer.function_body(later_gen)
     later_modal = app.function()(later_gen)
@@ -759,7 +759,7 @@ async def slo1(sleep_seconds):
 
 
 def test_sync_parallelism(client, servicer):
-    app = App()
+    app = App(include_source=False)
 
     servicer.function_body(slo1)
     slo1_modal = app.function()(slo1)
@@ -773,7 +773,7 @@ def test_sync_parallelism(client, servicer):
 
 
 def test_proxy(client, servicer):
-    app = App()
+    app = App(include_source=False)
 
     app.function(proxy=Proxy.from_name("my-proxy"))(dummy)
     with app.run(client=client):
@@ -789,7 +789,7 @@ def failure():
 
 
 def test_function_exception(client, servicer):
-    app = App()
+    app = App(include_source=False)
 
     servicer.function_body(failure)
     failure_modal = app.function()(failure)
@@ -801,7 +801,7 @@ def test_function_exception(client, servicer):
 
 @pytest.mark.asyncio
 async def test_function_exception_async(client, servicer):
-    app = App()
+    app = App(include_source=False)
 
     servicer.function_body(failure)
     failure_modal = app.function()(failure)
@@ -822,7 +822,7 @@ def custom_exception_function(x):
 
 
 def test_map_exceptions(client, servicer):
-    app = App()
+    app = App(include_source=False)
 
     servicer.function_body(custom_exception_function)
     custom_function_modal = app.function()(custom_exception_function)
@@ -847,7 +847,7 @@ def test_map_exceptions(client, servicer):
 
 
 def test_map_exceptions_input_plane(client, servicer):
-    app = App()
+    app = App(include_source=False)
 
     servicer.function_body(custom_exception_function)
     custom_function_modal = app.function(experimental_options={"input_plane_region": "us-east"})(
@@ -875,7 +875,7 @@ def test_map_exceptions_input_plane(client, servicer):
 
 @pytest.mark.asyncio
 async def test_async_map_wrapped_exception_warning(client, servicer):
-    app = App()
+    app = App(include_source=False)
 
     servicer.function_body(custom_exception_function)
     custom_function_modal = app.function()(custom_exception_function)
@@ -891,7 +891,7 @@ async def test_async_map_wrapped_exception_warning(client, servicer):
 # This test is somewhat redundant, but it's good to have when we remove the old python server.
 @pytest.mark.asyncio
 async def test_async_map_wrapped_exception_warning_input_plane(client, servicer):
-    app = App()
+    app = App(include_source=False)
 
     servicer.function_body(custom_exception_function)
     custom_function_modal = app.function(experimental_options={"input_plane_region": "us-east"})(
@@ -911,7 +911,7 @@ def import_failure():
 
 
 def test_function_relative_import_hint(client, servicer):
-    app = App()
+    app = App(include_source=False)
 
     servicer.function_body(import_failure)
     import_failure_modal = app.function()(import_failure)
@@ -923,7 +923,7 @@ def test_function_relative_import_hint(client, servicer):
 
 
 def test_nonglobal_function():
-    app = App()
+    app = App(include_source=False)
 
     with pytest.raises(InvalidError) as excinfo:
 
@@ -935,7 +935,7 @@ def test_nonglobal_function():
 
 
 def test_non_global_serialized_function():
-    app = App()
+    app = App(include_source=False)
 
     @app.function(serialized=True)
     def f():
@@ -943,7 +943,7 @@ def test_non_global_serialized_function():
 
 
 def test_closure_valued_serialized_function(client, servicer):
-    app = App()
+    app = App(include_source=False)
 
     def make_function(s):
         @app.function(name=f"ret_{s}", serialized=True)
@@ -966,7 +966,7 @@ def test_closure_valued_serialized_function(client, servicer):
 
 
 def test_custom_name_requires_serialized():
-    app = App()
+    app = App(include_source=False)
 
     with pytest.raises(InvalidError, match="`serialized=True`"):
         app.function(name="foo")(dummy)
@@ -978,7 +978,7 @@ def test_new_hydrated_internal(client, servicer):
 
 
 def test_from_id(client, servicer):
-    app = App()
+    app = App(include_source=False)
 
     @app.function(serialized=True)
     def foo():
@@ -1003,7 +1003,7 @@ def test_from_id(client, servicer):
 
 
 def test_local_execution_on_web_endpoint(client, servicer):
-    app = App()
+    app = App(include_source=False)
 
     @app.function(serialized=True)
     @fastapi_endpoint()
@@ -1023,7 +1023,7 @@ def test_local_execution_on_web_endpoint(client, servicer):
 def test_local_execution_on_asgi_app(client, servicer):
     from fastapi import FastAPI
 
-    app = App()
+    app = App(include_source=False)
 
     @app.function(serialized=True)
     @asgi_app()
@@ -1050,7 +1050,7 @@ def test_local_execution_on_asgi_app(client, servicer):
 
 @pytest.mark.parametrize("remote_executor", ["remote", "remote_gen", "spawn"])
 def test_invalid_remote_executor_on_web_endpoint(client, servicer, remote_executor):
-    app = App()
+    app = App(include_source=False)
 
     @app.function(serialized=True)
     @fastapi_endpoint()
@@ -1074,7 +1074,7 @@ def test_invalid_remote_executor_on_web_endpoint(client, servicer, remote_execut
 
 @pytest.mark.parametrize("remote_executor", ["remote", "remote_gen", "spawn"])
 def test_invalid_remote_executor_on_asgi_app(client, servicer, remote_executor):
-    app = App()
+    app = App(include_source=False)
 
     @app.function(serialized=True)
     @asgi_app()
@@ -1104,7 +1104,7 @@ def test_invalid_remote_executor_on_asgi_app(client, servicer, remote_executor):
     assert "webhook" in str(excinfo.value) and remote_executor in str(excinfo.value)
 
 
-lc_app = App()
+lc_app = App(include_source=False)
 
 
 @lc_app.function()
@@ -1115,7 +1115,7 @@ def f(x):
 def test_serialize_deserialize_function_handle(servicer, client):
     from modal._serialization import deserialize, serialize
 
-    app = App()
+    app = App(include_source=False)
 
     @app.function(serialized=True)
     @fastapi_endpoint()
@@ -1135,7 +1135,7 @@ def test_serialize_deserialize_function_handle(servicer, client):
 
 
 def test_default_cloud_provider(client, servicer, monkeypatch):
-    app = App()
+    app = App(include_source=False)
 
     monkeypatch.setenv("MODAL_DEFAULT_CLOUD", "xyz")
     app.function()(dummy)
@@ -1148,7 +1148,7 @@ def test_default_cloud_provider(client, servicer, monkeypatch):
 
 
 def test_autoscaler_settings(client, servicer):
-    app = App()
+    app = App(include_source=False)
 
     kwargs: dict[str, typing.Any] = dict(  # No idea why we need that type hint
         min_containers=2,
@@ -1175,14 +1175,14 @@ def test_autoscaler_settings(client, servicer):
     ],
 )
 def test_autoscaler_settings_deprecations(new, old):
-    app = App()
+    app = App(include_source=False)
 
     with pytest.warns(DeprecationError, match=f"{old} -> {new}"):
         app.function(**{old: 10})(dummy)  # type: ignore
 
 
 def test_timeout(servicer, client):
-    app = App()
+    app = App(include_source=False)
 
     with pytest.raises(InvalidError, match="cannot be set to None"):
 
@@ -1214,7 +1214,7 @@ def test_invalid_large_serialization(client):
         return big_data
 
     with pytest.warns(UserWarning, match="larger than the recommended limit"):
-        app = App()
+        app = App(include_source=False)
         app.function(serialized=True)(f)
         with app.run(client=client):
             pass
@@ -1225,7 +1225,7 @@ def test_invalid_large_serialization(client):
         return bigger_data
 
     with pytest.raises(InvalidError):
-        app = App()
+        app = App(include_source=False)
         app.function(serialized=True)(g)
         with app.run(client=client):
             pass
@@ -1237,7 +1237,7 @@ def test_call_unhydrated_function():
 
 
 def test_deps_explicit(client, servicer):
-    app = App()
+    app = App(include_source=False)
 
     image = Image.debian_slim()
     nfs_1 = NetworkFileSystem.from_name("nfs-1", create_if_missing=True)
@@ -1259,7 +1259,7 @@ def assert_is_wrapped_dict(some_arg):
 
 
 def test_calls_should_not_unwrap_modal_objects(servicer, client):
-    app = App()
+    app = App(include_source=False)
     foo = app.function()(assert_is_wrapped_dict)
     servicer.function_body(assert_is_wrapped_dict)
 
@@ -1283,7 +1283,7 @@ def assert_is_wrapped_dict_gen(some_arg):
 
 
 def test_calls_should_not_unwrap_modal_objects_gen(servicer, client):
-    app = App()
+    app = App(include_source=False)
     foo = app.function()(assert_is_wrapped_dict_gen)
     servicer.function_body(assert_is_wrapped_dict_gen)
 
@@ -1353,7 +1353,7 @@ async def test_map_large_inputs(client, servicer, monkeypatch, blob_server):
     #  by the test itself otherwise... Should move to its own thread.
     servicer.use_blob_outputs = True
     servicer.max_object_size_bytes = 1
-    app = App()
+    app = App(include_source=False)
     dummy_modal = app.function()(dummy)
 
     _, blobs, _, _ = blob_server
@@ -1469,7 +1469,7 @@ def test_function_decorator_on_method():
 
 
 def test_batch_function_invalid_error():
-    app = App()
+    app = App(include_source=False)
 
     with pytest.raises(InvalidError, match="must be a positive integer"):
         app.function(batched(max_batch_size=0, wait_ms=1))(dummy)
@@ -1499,7 +1499,7 @@ def test_batch_function_invalid_error():
 
 
 def test_experimental_spawn(client, servicer):
-    app = App()
+    app = App(include_source=False)
     dummy_modal = app.function()(dummy)
 
     with servicer.intercept() as ctx:
@@ -1574,7 +1574,7 @@ def test_map_retry_with_internal_error(client, servicer, monkeypatch, caplog):
     intended for RESOURCE_EXHAUSTED only. The warning is logged every 8 attempts, which is why we retry 10 times.
     """
     monkeypatch.setattr("modal.parallel_map.PUMP_INPUTS_MAX_RETRY_DELAY", 0.0001)
-    app = App()
+    app = App(include_source=False)
     pow2 = app.function()(_pow2)
     servicer.function_body(_pow2)
     servicer.fail_put_inputs_with_grpc_error = GrpcErrorAndCount(Status.INTERNAL, 10)
@@ -1594,7 +1594,7 @@ def test_map_retry_with_resource_exhausted(client, servicer, monkeypatch, caplog
     intended for RESOURCE_EXHAUSTED only. The warning is logged every 8 attempts, which is why we retry 10 times.
     """
     monkeypatch.setattr("modal.parallel_map.PUMP_INPUTS_MAX_RETRY_DELAY", 0.0001)
-    app = App()
+    app = App(include_source=False)
     pow2 = app.function()(_pow2)
     servicer.function_body(_pow2)
     servicer.fail_put_inputs_with_grpc_error = GrpcErrorAndCount(Status.RESOURCE_EXHAUSTED, 10)
@@ -1615,7 +1615,7 @@ def test_map_retry_with_stream_terminated_error(client, servicer, monkeypatch, c
     intended for RESOURCE_EXHAUSTED only. The warning is logged every 8 attempts, which is why we retry 10 times.
     """
     monkeypatch.setattr("modal.parallel_map.PUMP_INPUTS_MAX_RETRY_DELAY", 0.0001)
-    app = App()
+    app = App(include_source=False)
     pow2 = app.function()(_pow2)
     servicer.function_body(_pow2)
     servicer.fail_put_inputs_with_stream_terminated_error = 10
@@ -1676,7 +1676,7 @@ def test_concurrency_config_migration(client, servicer):
 
 @pytest.mark.usefixtures("set_env_client")
 def test_function_schema_recording(client, servicer):
-    app = App("app")
+    app = App("app", include_source=False)
 
     @app.function(name="f", serialized=True)
     def f(a: int) -> list[str]: ...
@@ -1708,7 +1708,7 @@ def test_function_schema_recording(client, servicer):
 
 @pytest.mark.usefixtures("set_env_client")
 def test_function_supported_input_formats(client, servicer):
-    app = App("app")
+    app = App("app", include_source=False)
 
     @app.function(serialized=True)
     def f(a): ...
@@ -1782,7 +1782,7 @@ def test_function_supported_input_formats(client, servicer):
 def test_function_schema_excludes_web_endpoints(client, servicer):
     # for now we exclude web endpoints since they don't use straight-forward arguments
     # in the same way as regular modal functions
-    app = App("app")
+    app = App("app", include_source=False)
 
     @app.function(name="f", serialized=True)
     @modal.fastapi_endpoint()
@@ -1796,7 +1796,7 @@ def test_function_schema_excludes_web_endpoints(client, servicer):
 @pytest.mark.usefixtures("set_env_client")
 def test_cbor_output_complex_data_types(client, servicer):
     """Test that a received cbor payload is decoded as such, even if the submitted input is pickle"""
-    app = App("app")
+    app = App("app", include_source=False)
 
     @app.function(serialized=True)
     def complex_cbor_function(data: list) -> dict:
@@ -1864,7 +1864,7 @@ def test_cbor_output_complex_data_types(client, servicer):
 @pytest.mark.usefixtures("set_env_client")
 def test_cbor_output_failed_result_handling(client, servicer):
     """Test that CBOR output format is handled correctly even when the result failed"""
-    app = App("app")
+    app = App("app", include_source=False)
 
     @app.function(serialized=True)
     def failing_cbor_function(x: int) -> int:
@@ -1960,7 +1960,7 @@ def test_cbor_input_only_function_uses_cbor_input(client, servicer):
 
 @pytest.mark.usefixtures("set_env_client")
 def test_class_schema_recording(client, servicer):
-    app = App("app")
+    app = App("app", include_source=False)
 
     @app.cls(serialized=True)
     class F:
@@ -2016,7 +2016,7 @@ def test_failed_lookup_error(client, servicer):
 
 @pytest.mark.parametrize("decorator", ["function", "cls"])
 def test_experimental_options(client, servicer, decorator):
-    app = App()
+    app = App(include_source=False)
 
     experimental_options = {"foo": 2, "bar": True}
 
@@ -2042,7 +2042,7 @@ def test_experimental_options(client, servicer, decorator):
 
 
 def test_restrict_modal_access(client, servicer):
-    app = App()
+    app = App(include_source=False)
 
     @app.function(serialized=True, restrict_modal_access=True)
     def f():
@@ -2158,7 +2158,7 @@ def test_function_call_iter(client, servicer):
         assert subset_results == expected_subset
 
 
-timeout_app = App("timeout-app")
+timeout_app = App("timeout-app", include_source=False)
 
 
 @timeout_app.function(startup_timeout=14)


### PR DESCRIPTION
## Describe your changes

Running `pytest test/function_test.py`, on `main` takes ~67s and ~22s with this PR.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace App() with App(include_source=False) across function tests to reduce overhead and improve runtime.
> 
> - **Tests (`test/function_test.py`)**:
>   - Initialize `App` with `include_source=False` across all tests (including global fixtures like `app`, `lc_app`, `timeout_app`, and named apps) to avoid source mounting.
>   - No test logic or assertions changed; only instantiation updated to improve performance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb88c354f025a52a3a53b985b2866609a961b4c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->