### PR TITLE
Use uv to install python dependencies in tests

### DIFF
--- a/.github/actions/setup-cached-python/action.yml
+++ b/.github/actions/setup-cached-python/action.yml
@@ -14,7 +14,7 @@ runs:
       with:
         python-version: ${{ inputs.version }}
 
-    - name: Enable caching
+    - name: Setup uv with caching
       uses: astral-sh/setup-uv@85856786d1ce8acfbcc2f13a5f3fbd6b938f9f41 # v7.1.2
       with:
         enable-cache: true


### PR DESCRIPTION
## Describe your changes

I noticed that caching is not working for one of the [MacOS runners](https://github.com/modal-labs/modal-client/actions/runs/18985254764/job/54227357282). This PR changes the python setup code to use uv instead to see if it's better.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch CI Python dependency installation to uv with built-in caching, replacing actions/cache and pip install.
> 
> - **CI (GitHub Actions)**:
>   - **`/.github/actions/setup-cached-python/action.yml`**:
>     - Add `astral-sh/setup-uv` with caching (pin `v7.1.2`, `uv` `0.9.7`), caching based on `requirements.dev.txt` and `pyproject.toml`.
>     - Replace `pip install` with `uv pip install --system`.
>     - Remove explicit `actions/cache` step and `pip` upgrade/install steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0763714e9b0641fa823d30f2130f99520a0a58ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->