### PR TITLE
Adjust timing for flaky `test_set_local_input_concurrency` test

### DIFF
--- a/test/container_test.py
+++ b/test/container_test.py
@@ -2536,7 +2536,7 @@ def test_set_local_input_concurrency(servicer, deployed_support_function_definit
     )
 
     outputs = [deserialize(item.result.data, ret.client) for item in ret.items]
-    assert outputs == pytest.approx([0.1] * 3 + [0.2] * 3, abs=0.05)
+    assert outputs == pytest.approx([0.2] * 3 + [0.4] * 3, abs=0.1)
 
 
 @skip_github_non_linux

--- a/test/supports/functions.py
+++ b/test/supports/functions.py
@@ -667,7 +667,7 @@ def get_input_concurrency(timeout: int):
 @modal.concurrent(target_inputs=3, max_inputs=6)
 def set_input_concurrency(start: float):
     set_local_input_concurrency(3)
-    time.sleep(0.1)
+    time.sleep(0.2)
     return time.time() - start
 
 


### PR DESCRIPTION
## Describe your changes

I saw this test fail once locally. This PR adjusts the test to be more lenient in the timing.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase sleep in `set_input_concurrency` and update test expectations/tolerances to reduce flakiness.
> 
> - **Tests**:
>   - Update `test_container_test.py::test_set_local_input_concurrency` expected durations from `[0.1, 0.1, 0.1, 0.2, 0.2, 0.2]` to `[0.2, 0.2, 0.2, 0.4, 0.4, 0.4]` and relax tolerance (`abs=0.1`).
>   - Modify support function `test/supports/functions.py::set_input_concurrency` to sleep `0.2` (was `0.1`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82dd9798b3e490c615860edcc427117fbdf0775d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->