### PR TITLE
Less flaky test_heartbeats

### DIFF
--- a/test/live_reload_test.py
+++ b/test/live_reload_test.py
@@ -76,7 +76,7 @@ async def test_no_change(import_ref, server_url_env, token_env, servicer):
     assert servicer.app_client_disconnect_count == 1
 
 
-@pytest.mark.flaky(max_runs=2)
+@pytest.mark.flaky(max_runs=3)
 @pytest.mark.asyncio
 async def test_heartbeats(import_ref, server_url_env, token_env, servicer):
     with mock.patch("modal.runner.HEARTBEAT_INTERVAL", 1):


### PR DESCRIPTION
## Describe your changes

Saw this was flaky here: https://github.com/modal-labs/modal-client/actions/runs/19050723347/job/54410086297. With this PR w use 1s as the interval and only test for 3 heartbeats.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `test_heartbeats` to use a 1s heartbeat interval, waits ~2s for ~3 beats, adjusts assertion accordingly, and marks the test flaky (max_runs=3).
> 
> - **Tests**:
>   - `test/live_reload_test.py`:
>     - `test_heartbeats`: Patch `modal.runner.HEARTBEAT_INTERVAL` to `1`, sleep `2.1s`, and update heartbeat count assertion to match 1s ticks.
>     - Add `@pytest.mark.flaky(max_runs=3)` to reduce flakiness.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a58d41ba640cfa0e41e4c48d14af2d4a66acb8b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->