### PR TITLE
Downgrade warning to debug in JWT refresh loop

### DIFF
--- a/modal/_utils/task_command_router_client.py
+++ b/modal/_utils/task_command_router_client.py
@@ -444,7 +444,7 @@ class TaskCommandRouterClient:
             except Exception as e:
                 # Exceptions here can stem from non-transient errors against the server sending
                 # the TaskGetCommandRouterAccess RPC, for instance, if the task has finished.
-                logger.warning(f"Background JWT refresh failed for exec with task ID {self._task_id}: {e}")
+                logger.debug(f"Background JWT refresh failed for exec with task ID {self._task_id}: {e}")
                 break
 
     async def _stream_stdio(


### PR DESCRIPTION
## Describe your changes

Applied Compute asked about this warning log, but it's actually normal behavior, so downgrading to debug.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Downgrades the background JWT refresh failure log in `TaskCommandRouterClient._jwt_refresh_loop` from warning to debug.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d7e54345e315045fa7b348f8b535ea7c1dce301. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->