### PR TITLE
Use Image.build for base image deployment

### DIFF
--- a/modal_global_objects/images/base_images.py
+++ b/modal_global_objects/images/base_images.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
     python_versions = SUPPORTED_PYTHON_SERIES[cast(ImageBuilderVersion, builder_version)]
 
     app = modal.App(f"build-{name.replace('_', '-')}-image")
-    with modal.enable_output(), app.run():
+    with app.run(), modal.enable_output():  # Image.build needs these in reverse of normal order to avoid duplicate logs
         images = asyncio.run(build_images(app, constructor, python_versions))
 
     table = Table(title=f"Images for {name} ({builder_version})")


### PR DESCRIPTION
https://modal-com.slack.com/archives/C056CGAANRM/p1762363883408299

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches base image deployment to async `Image.build` with concurrent builds across supported Python versions and streamlined output.
> 
> - **Images / Build script (`modal_global_objects/images/base_images.py`)**:
>   - Add async `build_images` to construct images for each supported Python version and build them concurrently via `image.build.aio(app)`.
>   - Replace function-registration runner with `with app.run(), modal.enable_output()` and `asyncio.run(build_images(...))`.
>   - Simplify result handling: collect built images and render table of `Python version` → `Image ID`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4921fac6b9fe620bd6a115ed9d118533b3fb7462. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->