### PR TITLE
Declare us statically as not-compatible with Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "modal"
 description = "Python client library for Modal"
 readme = "README.md"
 dynamic = ["version"]
-requires-python = ">=3.9"
+requires-python = ">=3.9,<3.14"
 license = {text = "Apache-2.0"}
 
 authors = [


### PR DESCRIPTION
Currently using the modal SDK on an unsupported new Python version raises a noisy runtime error. We can do better by including the upper bound in our pyproject.toml metadata.

In practice, I think that users on 3.14 will just get the oldest version of the client without this change. But it sets a precedent that we can follow in the future.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets an upper bound on supported Python versions (<3.14) in project metadata.
> 
> - **Project metadata**:
>   - Update `pyproject.toml` `requires-python` to `>=3.9,<3.14` to declare incompatibility with Python 3.14.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 053789390f43f7de1b83940430bd64345b9b48c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->