### PR TITLE
Add tags to AppCreate protos

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -301,6 +301,7 @@ message AppCreateRequest {
   string description = 2;    // Human readable label for the app
   string environment_name = 5;
   AppState app_state = 6;
+  map<string, string> tags = 7;  // Additional metadata to attach to the App
 }
 
 message AppCreateResponse {


### PR DESCRIPTION
Send App tags in AppCreate too (just protos)

Part of SDK-639

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `tags` map to `AppCreateRequest` to attach metadata on app creation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a44cfaddc6c5d1a5c118a371dc79d0dac225a146. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->