### PR TITLE
Send tags in AppCreate too

### DIFF
--- a/test/app_test.py
+++ b/test/app_test.py
@@ -473,6 +473,9 @@ def test_tags(servicer, client, mode):
             with app.run(client=client):
                 pass
 
+    request = ctx.pop_request("AppCreate")
+    assert request.tags == tags
+
     request = ctx.pop_request("AppPublish")
     assert request.tags == tags
 


### PR DESCRIPTION
Closes SDK-639


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Propagates app tags into AppCreate for run/deploy by plumbing tags through init paths and updates tests to assert tags on AppCreate.
> 
> - **runner**:
>   - Include `tags` in `AppCreateRequest` by updating `_init_local_app_new(description, tags, ...)` and `_init_local_app_from_name(name, tags, ...)` to accept/pass `tags`.
>   - `run` path: capture `local_app_state` early and pass `local_app_state.tags` to `_init_local_app_new`.
>   - `deploy` path: capture `local_app_state` early; pass `local_app_state.tags` to `_init_local_app_from_name`; consistently pass `local_app_state` to `_create_all_objects`/`_publish_app`.
> - **tests**:
>   - `test_tags`: now asserts `AppCreate` request includes `tags` in addition to `AppPublish`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5a69e006373f15e585c388030e1f4f85e73781f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Changelog

- Fixed a bug where App tags were not attached to Image builds that occur when running or first deploying the App.