### PR TITLE
Fix flaky test_sandbox_exec_poll_timeout

### DIFF
--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -349,8 +349,8 @@ def test_sandbox_exec_poll_timeout(app, servicer, exec_backend):
 def test_sandbox_exec_output_timeout(app, servicer, exec_backend):
     sb = Sandbox.create("sleep", "infinity", app=app)
 
-    cp = sb.exec("sh", "-c", "echo hi; sleep 999", timeout=1)
     t1 = time.monotonic()
+    cp = sb.exec("sh", "-c", "echo hi; sleep 999", timeout=1)
     assert cp.stdout.read() == "hi\n"
     assert 1 < time.monotonic() - t1 < 2.0
     assert cp.wait() == -1


### PR DESCRIPTION
## Describe your changes

The issue was that the deadline gets set inside the call to `exec` to 1s in the future, but then we were starting the timer after that, so sometimes the assertion would fail when the `read()` call took just a hair under 1s. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Start timing before `sb.exec(...)` in `test_sandbox_exec_output_timeout` to avoid flaky timeout assertions.
> 
> - **Tests**:
>   - In `test/sandbox_test.py`, adjust `test_sandbox_exec_output_timeout` to record `time.monotonic()` before calling `sb.exec(...)`, ensuring stable timeout measurement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08966895881cd2374edf40671b5503299e6bb4f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->