### PR TITLE
Add metadata_ttl_oneof proto to CloudBucketMount

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -850,8 +850,9 @@ message CloudBucketMount {
   }
 
   enum MetadataTTLType {
-    METADATA_TTL_TYPE_MINIMAL = 0;
-    METADATA_TTL_TYPE_INDEFINITE = 1;
+    METADATA_TTL_TYPE_UNSPECIFIED = 0;
+    METADATA_TTL_TYPE_MINIMAL = 1;
+    METADATA_TTL_TYPE_INDEFINITE = 2;
   }
 
   string bucket_name = 1;


### PR DESCRIPTION
## Describe your changes

Towards https://linear.app/modal-labs/issue/SDK-660/add-metadata-ttl-to-cloudbucketmount

This proto supports all the options from `--metadata-ttl`: https://github.com/awslabs/mountpoint-s3/blob/main/doc/CONFIGURATION.md#metadata-cache .

As an MVP, I'm also okay with adding just seconds. Although, it'll be a little more annoying to retroactively add `minimal` + `indefinite`.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add metadata TTL configuration to `CloudBucketMount` via `metadata_ttl_oneof` with `MetadataTTLType` or `metadata_ttl_seconds`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ac9d67cdb86a81de7a62ce2f8e710ca600c48be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->