### PR TITLE
add retry=None to FlashContainerRegister RPC

### DIFF
--- a/modal/experimental/flash.py
+++ b/modal/experimental/flash.py
@@ -112,6 +112,7 @@ class _FlashManager:
                             port=port,
                         ),
                         timeout=10,
+                        retry=None,
                     )
                     self.num_failures = 0
                     if first_registration:
@@ -145,9 +146,7 @@ class _FlashManager:
 
     async def stop(self):
         self.heartbeat_task.cancel()
-        await self.client.stub.FlashContainerDeregister(
-            api_pb2.FlashContainerDeregisterRequest(),
-        )
+        await self.client.stub.FlashContainerDeregister(api_pb2.FlashContainerDeregisterRequest())
 
         self.stopped = True
         logger.warning(f"[Modal Flash] No longer accepting new requests on {self.tunnel.url}.")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Disables retries for FlashContainerRegister during heartbeat registration in modal/experimental/flash.py.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 830b6aa71ac8a6389cbae804dea96407dc2c839d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->