### PR TITLE
Add UnaryUnaryWrapper typing overload for __call__

### DIFF
--- a/modal/_grpc_client.py
+++ b/modal/_grpc_client.py
@@ -86,17 +86,7 @@ class UnaryUnaryWrapper(Generic[RequestType, ResponseType]):
         req: RequestType,
         *,
         retry: None,
-        timeout: float,
-        metadata: Optional[list[tuple[str, str]]] = None,
-    ) -> ResponseType: ...
-
-    @overload
-    async def __call__(
-        self,
-        req: RequestType,
-        *,
-        retry: None,
-        timeout: None,
+        timeout: Optional[float] = None,
         metadata: Optional[list[tuple[str, str]]] = None,
     ) -> ResponseType: ...
 


### PR DESCRIPTION
## Describe your changes

This PR adds typing overloads to `__call__` so that typing checking errors when `timeout` and `retry` are both `None`.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `UnaryUnaryWrapper.__call__` typing overloads and a shared `_DEFAULT_RETRY` constant to clarify retry/timeout behavior.
> 
> - **Typing updates in `modal/_grpc_client.py`**:
>   - Add `overload` import and two `__call__` overloads to `UnaryUnaryWrapper` to model mutually exclusive `retry`/`timeout` usage.
>   - Introduce `_DEFAULT_RETRY = Retry()` and use it as the default `retry` value instead of instantiating per-call.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be47f086b699affd4b077318cb6615b28b9f2f23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->