### PR TITLE
Add force_path_style to CloudBucketMount

### DIFF
--- a/modal/cloud_bucket_mount.py
+++ b/modal/cloud_bucket_mount.py
@@ -117,6 +117,7 @@ class _CloudBucketMount:
 
     read_only: bool = False
     requester_pays: bool = False
+    force_path_style: bool = False
 
 
 def cloud_bucket_mounts_to_proto(mounts: Sequence[tuple[str, _CloudBucketMount]]) -> list[api_pb2.CloudBucketMount]:
@@ -159,6 +160,7 @@ def cloud_bucket_mounts_to_proto(mounts: Sequence[tuple[str, _CloudBucketMount]]
             requester_pays=mount.requester_pays,
             key_prefix=key_prefix,
             oidc_auth_role_arn=mount.oidc_auth_role_arn,
+            force_path_style=mount.force_path_style,
         )
         cloud_bucket_mounts.append(cloud_bucket_mount)
 


### PR DESCRIPTION
## Describe your changes

Adds `force_path_style` to `CloudBucketMount`.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
- `CloudBucketMount` now supports `force_path_style=True` to disable virtual-host-style addressing. See [mountpoint-s3 endpoints docs](https://github.com/awslabs/mountpoint-s3/blob/main/doc/CONFIGURATION.md#endpoints-and-aws-privatelink) for details.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `force_path_style` option to `CloudBucketMount` and passes it through to the protobuf message.
> 
> - **Cloud bucket mounts**:
>   - Add `force_path_style: bool = False` to `_CloudBucketMount`.
>   - Propagate `force_path_style` in `cloud_bucket_mounts_to_proto` to `api_pb2.CloudBucketMount`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7fabcccdbfe77d82dd5db5225ef07c61d324b48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->