### PR TITLE
[SVC-933 8/N] Protobuf changes to support reading/writing max concurrent tasks and GPUs for environments

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1289,8 +1289,8 @@ message EnvironmentListItem {
   bool default = 4;
   bool is_managed = 5;
   string environment_id = 6;
-  google.protobuf.Int32Value max_concurrent_tasks = 7;
-  google.protobuf.Int32Value max_concurrent_gpus = 8;
+  optional int32 max_concurrent_tasks = 7;
+  optional int32 max_concurrent_gpus = 8;
 }
 
 message EnvironmentListResponse {
@@ -1314,8 +1314,8 @@ message EnvironmentUpdateRequest {
   string current_name = 1;
   google.protobuf.StringValue name = 2;
   google.protobuf.StringValue web_suffix = 3;
-  google.protobuf.Int32Value max_concurrent_tasks = 4;
-  google.protobuf.Int32Value max_concurrent_gpus = 5;
+  optional int32 max_concurrent_tasks = 4;
+  optional int32 max_concurrent_gpus = 5;
 }
 
 // A file entry when listing files in a volume or network file system.


### PR DESCRIPTION
## Describe your changes

Proto changes to support reading and writing the max concurrent tasks and GPUs for each environment.

Using `google.protobuf.Int32Value` so we can distinguish between the field being un-set (unlimited tasks/gpus for environment) and `0` (enforce max 0 tasks/gpus for environment).

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [X] Client+Server: this change is compatible with old servers
- [X] Client forward compatibility: this change ensures client can accept data intended for later versions of itself