### PR TITLE
Fix LoadContext.environment_name and some arising issues

### DIFF
--- a/modal/_load_context.py
+++ b/modal/_load_context.py
@@ -68,7 +68,7 @@ class LoadContext:
 
         return LoadContext(
             client=await _Client.from_env() if self._client is None else self.client,
-            environment_name=config.get("environment") if self._environment_name is None else self._environment_name,
+            environment_name=self._environment_name or config.get("environment") or "",
             app_id=self._app_id,
         )
 
@@ -100,6 +100,6 @@ class LoadContext:
             ...
         """
         self._client = self._client or client or await _Client.from_env()
-        self._environment_name = self._environment_name or environment_name or config.get("environment")
+        self._environment_name = self._environment_name or environment_name or config.get("environment") or ""
         self._app_id = self._app_id or app_id
         return self

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -204,10 +204,10 @@ class GrpcErrorAndCount:
     count: int
 
 
-# TODO: Isolate all test config from the host
 @pytest.fixture(scope="function", autouse=True)
 def set_env(monkeypatch):
-    monkeypatch.setenv("MODAL_ENVIRONMENT", "main")
+    # We seem to be leaking this across tests, probably because of `ensure_env`?
+    monkeypatch.delenv("MODAL_ENVIRONMENT", raising=False)
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -620,7 +620,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
         return res
 
     def get_environment(self, environment_name: Optional[str] = None) -> str:
-        if environment_name is None:
+        if not environment_name:
             return next(iter(self.environments))  # Use first environment as default
         return environment_name
 
@@ -765,6 +765,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
             current_version = current_history[-1]["version"]
         else:
             current_version = 0
+
         self.app_deployment_history[request.app_id].append(
             {
                 "app_id": request.app_id,
@@ -1033,7 +1034,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def DictGetOrCreate(self, stream):
         request: api_pb2.DictGetOrCreateRequest = await stream.recv_message()
-        k = (request.deployment_name, request.environment_name)
+        k = (request.deployment_name, self.get_environment(request.environment_name))
         if k in self.deployed_dicts:
             if request.object_creation_type == api_pb2.OBJECT_CREATION_TYPE_CREATE_FAIL_IF_EXISTS:
                 raise GRPCError(Status.ALREADY_EXISTS, f"Dict {k[0]!r} already exists")
@@ -1082,9 +1083,10 @@ class MockClientServicer(api_grpc.ModalClientBase):
     async def DictList(self, stream):
         request: api_pb2.DictListRequest = await stream.recv_message()
         dicts = []
+        environment = self.get_environment(request.environment_name)
         for (name, environment_name), obj_id in self.deployed_dicts.items():
             timestamp = self.resource_creation_timestamps[obj_id]
-            if request.environment_name and environment_name != request.environment_name:
+            if environment_name != environment:
                 continue
             elif timestamp >= request.pagination.created_before:
                 continue
@@ -1722,7 +1724,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def QueueGetOrCreate(self, stream):
         request: api_pb2.QueueGetOrCreateRequest = await stream.recv_message()
-        k = (request.deployment_name, request.environment_name)
+        k = (request.deployment_name, self.get_environment(request.environment_name))
         if k in self.deployed_queues:
             if request.object_creation_type == api_pb2.OBJECT_CREATION_TYPE_CREATE_FAIL_IF_EXISTS:
                 raise GRPCError(Status.ALREADY_EXISTS, f"Queue {k[0]!r} already exists")
@@ -1787,9 +1789,10 @@ class MockClientServicer(api_grpc.ModalClientBase):
         # So there is a mismatch and I am not implementing a mock for the num_partitions / total_size
         request: api_pb2.QueueListRequest = await stream.recv_message()
         queues = []
+        environment = self.get_environment(request.environment_name)
         for (name, environment_name), obj_id in self.deployed_queues.items():
             timestamp = self.resource_creation_timestamps[obj_id]
-            if request.environment_name and environment_name != request.environment_name:
+            if environment_name != environment:
                 continue
             elif timestamp >= request.pagination.created_before:
                 continue
@@ -1972,7 +1975,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def SecretGetOrCreate(self, stream):
         request: api_pb2.SecretGetOrCreateRequest = await stream.recv_message()
-        k = (request.deployment_name, request.environment_name)
+        k = (request.deployment_name, self.get_environment(request.environment_name))
         if request.object_creation_type == api_pb2.OBJECT_CREATION_TYPE_ANONYMOUS_OWNED_BY_APP:
             secret_id = "st-" + str(len(self.secrets))
             self.secrets[secret_id] = request.env_dict
@@ -2007,11 +2010,11 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def SecretList(self, stream):
         req: api_pb2.SecretListRequest = await stream.recv_message()
-
+        environment = self.get_environment(req.environment_name)
         secrets = []
         for (name, environment_name), obj_id in self.deployed_secrets.items():
             timestamp = self.resource_creation_timestamps[obj_id]
-            if req.environment_name and environment_name != req.environment_name:
+            if environment_name != environment:
                 continue
             elif timestamp >= req.pagination.created_before:
                 continue
@@ -2041,7 +2044,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
 
     async def SharedVolumeGetOrCreate(self, stream):
         request: api_pb2.SharedVolumeGetOrCreateRequest = await stream.recv_message()
-        k = (request.deployment_name, request.environment_name)
+        k = (request.deployment_name, self.get_environment(request.environment_name))
         if request.object_creation_type == api_pb2.OBJECT_CREATION_TYPE_UNSPECIFIED:
             if k not in self.deployed_nfss:
                 if k in self.deployed_volumes:
@@ -2076,8 +2079,9 @@ class MockClientServicer(api_grpc.ModalClientBase):
     async def SharedVolumeList(self, stream):
         req = await stream.recv_message()
         items = []
+        environment = self.get_environment(req.environment_name)
         for (name, env_name), volume_id in self.deployed_nfss.items():
-            if env_name != req.environment_name:
+            if env_name != environment:
                 continue
             items.append(api_pb2.SharedVolumeListItem(label=name, shared_volume_id=volume_id, created_at=1))
         resp = api_pb2.SharedVolumeListResponse(items=items, environment_name=req.environment_name)
@@ -2165,7 +2169,7 @@ class MockClientServicer(api_grpc.ModalClientBase):
     ### Volume
     async def VolumeGetOrCreate(self, stream):
         request: api_pb2.VolumeGetOrCreateRequest = await stream.recv_message()
-        k = (request.deployment_name, request.environment_name)
+        k = (request.deployment_name, self.get_environment(request.environment_name))
         if request.object_creation_type == api_pb2.OBJECT_CREATION_TYPE_UNSPECIFIED:
             if k not in self.deployed_volumes:
                 raise GRPCError(Status.NOT_FOUND, f"Volume {k} not found")
@@ -2199,9 +2203,10 @@ class MockClientServicer(api_grpc.ModalClientBase):
     async def VolumeList(self, stream):
         request: api_pb2.VolumeListRequest = await stream.recv_message()
         volumes = []
+        environment = self.get_environment(request.environment_name)
         for (name, environment_name), obj_id in self.deployed_volumes.items():
             timestamp = self.resource_creation_timestamps[obj_id]
-            if request.environment_name and environment_name != request.environment_name:
+            if environment_name != environment:
                 continue
             elif timestamp >= request.pagination.created_before:
                 continue


### PR DESCRIPTION
Fixes a bug introduced in #3669, because `environment_name` is not always resolved to a non-null value. This wasn't caught in unit tests because of a fixture that set `MODAL_ENVIRONMENT` for all tests. Removing that fixture surfaced some other issues were the mock servicer was not correctly mocking some environment-related behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Guarantees `environment_name` is always resolved (defaulting to empty string) and standardizes mock servicer environment defaults/filtering; tests stop leaking `MODAL_ENVIRONMENT`.
> 
> - **Core**:
>   - `LoadContext.apply_defaults` and `in_place_upgrade` now resolve `environment_name` via `self._environment_name or config.get("environment") or ""` to avoid `None`.
> - **Test Servicer**:
>   - Add `get_environment()` to normalize environment resolution (default to first when unset/falsy).
>   - Use `get_environment` across RPCs for environment-aware keys/filtering: `App*` (create/get-by-name/list), `ClassGet`, `FunctionGet`, `Dict*`, `Queue*`, `Secret*`, `SharedVolume*`, `Volume*` list/get-or-create operations.
> - **Tests**:
>   - Remove global `MODAL_ENVIRONMENT` setting; fixture now deletes it to prevent leakage across tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48444ec3339e52cf512079da5a95e2653365ed1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->