### PR TITLE
[SVC-933 18/N] Add current concurrent tasks and GPUs to `EnvironmentListItem`

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1291,6 +1291,8 @@ message EnvironmentListItem {
   string environment_id = 6;
   optional int32 max_concurrent_tasks = 7;
   optional int32 max_concurrent_gpus = 8;
+  int32 current_concurrent_tasks = 9;
+  int32 current_concurrent_gpus = 10;
 }
 
 message EnvironmentListResponse {


### PR DESCRIPTION
This is so that the frontend can display the current concurrent containers and GPUs for each environment.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [X] Client+Server: this change is compatible with old servers
- [X] Client forward compatibility: this change ensures client can accept data intended for later versions of itself