### PR TITLE
Adds region to `Proxy`

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2464,9 +2464,9 @@ message Proxy {
   string name = 1;
   double created_at = 2;
   string environment_name = 3;
+  repeated ProxyIp proxy_ips = 4;
   string proxy_id = 5;
   string region = 6;
-  repeated ProxyIp proxy_ips = 4;
 }
 
 message ProxyAddIpRequest {


### PR DESCRIPTION
Adds a `region` property to `Proxy` allowing for us to display this metadata in every user interface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `region` field to `modal_proto/api.proto`'s `Proxy` message and reorders `proxy_id` after `proxy_ips`.
> 
> - **Protobuf (`modal_proto/api.proto`)**:
>   - `Proxy` message:
>     - Add `string region = 6;`.
>     - Reorder fields so `proxy_id` follows `proxy_ips` (field numbers unchanged).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81161f9fab1663ab1549f436eda27e9576e79a76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->