### PR TITLE
Adds test and fix for TaskContext.infinite_loops not getting cancelled

### DIFF
--- a/modal/_utils/async_utils.py
+++ b/modal/_utils/async_utils.py
@@ -184,6 +184,7 @@ class TaskContext:
 
                 # Cancel any remaining unfinished tasks.
                 task.cancel()
+                cancelled_tasks.append(task)
 
             cancellation_gather = asyncio.gather(*cancelled_tasks, return_exceptions=True)
             try:

--- a/test/async_utils_test.py
+++ b/test/async_utils_test.py
@@ -1460,3 +1460,68 @@ def test_volume_ephemeral_global_scope_no_errors():
     assert "exception" not in result.stderr
     assert "Traceback" not in result.stderr
     print(result.stderr)
+
+
+@pytest.mark.asyncio
+async def test_task_context_waits_for_cancellations():
+    """Test that TaskContext waits for async finalization logic in cancelled tasks.
+
+    When a task is cancelled, it may have cleanup logic in an except asyncio.CancelledError
+    block. TaskContext should wait up to 1 second for this cleanup to complete before exiting.
+    """
+    cleanup_state = []
+
+    async def task_with_cleanup():
+        try:
+            await asyncio.sleep(60)  # Long sleep that will be cancelled
+        except asyncio.CancelledError:
+            # Simulate async cleanup that takes some time
+            await asyncio.sleep(0.1)
+            cleanup_state.append("cleaned_up")
+            raise  # Re-raise to properly complete cancellation
+
+    t0 = time.time()
+    async with TaskContext() as task_context:
+        task_context.create_task(task_with_cleanup())
+
+    # The context manager should have waited for cleanup
+    assert cleanup_state == ["cleaned_up"]
+    # Should have waited at least 0.1 seconds for cleanup
+    assert time.time() - t0 >= 0.1
+    # But should have exited well before 60 seconds
+    assert time.time() - t0 < 1.0
+
+
+@pytest.mark.asyncio
+async def test_task_context_cancellation_timeout():
+    """Test that TaskContext times out after 1 second if cancellation cleanup takes too long.
+
+    If a task's cancellation cleanup takes longer than 1 second, the context manager
+    should exit anyway to prevent freezes.
+    """
+    cleanup_started = []
+    cleanup_finished = []
+
+    async def task_with_slow_cleanup():
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cleanup_started.append("started")
+            # This cleanup takes way too long (5 seconds)
+            await asyncio.sleep(5.0)
+            cleanup_finished.append("finished")
+            raise
+
+    t0 = time.time()
+    async with TaskContext() as task_context:
+        task_context.create_task(task_with_slow_cleanup())
+
+    elapsed = time.time() - t0
+
+    # Should have started cleanup
+    assert cleanup_started == ["started"]
+    # Should NOT have waited for the full cleanup
+    assert cleanup_finished == []
+    # Should have timed out around 1 second (the _cancellation_grace period)
+    # Allow some margin for timing variations
+    assert 0.9 < elapsed < 1.5


### PR DESCRIPTION
Driveby fix for issue with exit spam ClientClosed messages when there are cancelled TaskContext.infinite_loop instances with active rpc calls active when the interpreter exits (due to these cancellations not bubbling up in a prior event loop iteration)

The fix changes `TaskContext.__aexit__` in two ways:
1. actually cancel any ongoing infinite loops (not just by waiting for the next iteration of the loop to finish when grace is set). This was already the case for non-loop tasks
2. for any cancelled tasks, we now wait for the cancellation to fully take effect before returning so most async cancellation handling inside of tasks will have a chance to run (~1s of additional grace period)

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens TaskContext shutdown by cancelling unfinished (including infinite-loop) tasks and waiting up to 1s for their cancellation cleanup; adds tests covering clean exits and cancellation timing.
> 
> - **TaskContext shutdown behavior** (`modal/_utils/async_utils.py`):
>   - Cancel unfinished tasks, including `infinite_loop` tasks, on context exit.
>   - Add `_cancellation_grace = 1.0` to wait for cancellation handlers to complete; warn if timeout.
>   - Suppress `CancelledError` from grace `gather` and explicitly await cancelled tasks.
> - **Tests** (`test/async_utils_test.py`):
>   - Add `test_volume_ephemeral_global_scope_no_errors` to ensure no exit spam/errors.
>   - Add `test_task_context_waits_for_cancellations` to verify awaiting async cleanup.
>   - Add `test_task_context_cancellation_timeout` to verify 1s timeout for slow cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b93a7a56d5a9b37264c82b83655be04f19b84c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->