### PR TITLE
Add flag to do a gapless read for GetData requests.

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1603,7 +1603,7 @@ message FunctionCallGetDataRequest {
     string attempt_token = 3;
   }
   uint64 last_index = 2;
-  bool use_gapless_read = 3;
+  bool use_gapless_read = 4;
 }
 
 message FunctionCallInfo {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a `use_gapless_read` boolean to `FunctionCallGetDataRequest` to support gapless reads in GetData streams.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2eb3398c2dfec44f985ee44bc180d05891d6d7e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->