### PR TITLE
Don't warn on unrecognized Cloud Bucket Mount URL

### DIFF
--- a/modal/cloud_bucket_mount.py
+++ b/modal/cloud_bucket_mount.py
@@ -133,7 +133,7 @@ def cloud_bucket_mounts_to_proto(mounts: Sequence[tuple[str, _CloudBucketMount]]
             elif parse_result.hostname.endswith("storage.googleapis.com"):
                 bucket_type = api_pb2.CloudBucketMount.BucketType.GCP
             else:
-                logger.warning(
+                logger.info(
                     "CloudBucketMount received unrecognized bucket endpoint URL. "
                     "Assuming AWS S3 configuration as fallback."
                 )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Lower the log level to info when an unrecognized cloud bucket endpoint URL is detected, still defaulting bucket type to S3.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3907f49636f8d69f35087d999de413a68e6ab8d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->