### PR TITLE
Change image build error message to account for logs URL from server

### DIFF
--- a/modal/image.py
+++ b/modal/image.py
@@ -662,13 +662,16 @@ class _Image(_Object, type_prefix="im"):
                     metadata = resp.metadata
 
             if result.status == api_pb2.GenericResult.GENERIC_STATUS_FAILURE:
+                msg = f"Image build for {image_id} failed"
                 if result.exception:
-                    raise RemoteError(f"Image build for {image_id} failed with the exception:\n{result.exception}")
+                    msg += f":\n{result.exception}\n"
                 else:
-                    msg = f"Image build for {image_id} failed. See build logs for more details."
-                    if not _get_output_manager():
-                        msg += " (Hint: Use `modal.enable_output()` to see logs from the process building the Image.)"
-                    raise RemoteError(msg)
+                    msg += ". See the build logs for more details. "
+
+                if not _get_output_manager():
+                    msg += "Hint: Use `modal.enable_output()` to see logs from the process building the Image."
+
+                raise RemoteError(msg.rstrip())
             elif result.status == api_pb2.GenericResult.GENERIC_STATUS_TERMINATED:
                 msg = f"Image build for {image_id} terminated due to external shut-down. Please try again."
                 if result.exception:


### PR DESCRIPTION
## Describe your changes

The server will start sending a URL to the build logs on the web. This tweaks the format on the client side to match:

<img width="1415" height="67" alt="image" src="https://github.com/user-attachments/assets/adcf011b-1fdb-47e3-a1cf-cc48ed076814" />

With old clients it will instead look like:
<img width="1415" height="66" alt="image" src="https://github.com/user-attachments/assets/b4d19f11-44b3-4574-9257-f987463f0ec5" />


<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

</details>

## Changelog

- If an Image build fails, we now display a URL linking straight to the build logs in the web dashboard.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors image build failure handling to include logs reference (and hint to enable output) with unified message construction.
> 
> - **Image build failure handling (`modal/image.py`)**
>   - Refactors `GENERIC_STATUS_FAILURE` path to build a single consolidated error message.
>     - Includes exception details when present; otherwise references build logs.
>     - Adds hint to use `modal.enable_output()` when no output manager is active.
>     - Trims trailing whitespace and raises once with the composed message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a26a6f6e3d89ce02d6feb3046b42cd7d469c9f78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->