### PR TITLE
Upgraded mypy in case someone runs with an updated synchronicity

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -11,7 +11,7 @@ grpclib==0.4.7
 httpx~=0.23.0
 invoke~=2.2
 pyjwt==2.10.1
-mypy~=1.11.2
+mypy~=1.18.2
 mypy-protobuf~=3.3.0  # TODO: can't use mypy-protobuf>=3.4 because of protobuf==3.19 support
 pre-commit>=2.21,<4
 packaging>=24.2

--- a/tasks.py
+++ b/tasks.py
@@ -571,16 +571,20 @@ def show_deprecations(ctx):
                     # Handle a few different ways that the message can get passed to the deprecation helper
                     # since it's not always a literal string (e.g. it's often a functions .__doc__ attribute)
                     if isinstance(message, ast.Name):
-                        message = self.assignments.get(message.id, "")
+                        assert message  # mypy apparently thinks message can be None here
+                        message_str = self.assignments.get(message.id, "")
                     if isinstance(message, ast.Attribute):
-                        message = self.assignments.get(message.attr, "")
+                        assert message  # mypy apparently thinks message can be None here
+                        message_str = self.assignments.get(message.attr, "")
                     if isinstance(message, ast.Constant):
-                        message = message.s
+                        assert message  # mypy apparently thinks message can be None here
+                        message_str = str(message.s)
                     elif isinstance(message, ast.JoinedStr):
-                        message = "".join(v.s for v in message.values if isinstance(v, ast.Constant))
+                        assert message  # mypy apparently thinks message can be None here
+                        message_str = "".join(str(v.s) for v in message.values if isinstance(v, ast.Constant))
                     else:
-                        message = str(message)
-                    message = message.replace("\n", " ")
+                        message_str = str(message)
+                    message = message_str.replace("\n", " ")
                     if len(message) > (max_length := 80):
                         message = message[:max_length] + "..."
 


### PR DESCRIPTION
Synchronicity is pinned in requirements.dev.txt but not in the package itself, so to prevent anyone running into issues with type check locally with a synchronicity 0.10.4, I'm preemptively updating to a compatible mypy version in requirements.dev.txt.

The bump in min synchronicity version to the "breaking" version will come in #3750 

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps mypy in dev requirements and updates `show_deprecations` message parsing to satisfy stricter typing.
> 
> - **Tooling**:
>   - Bump `mypy` in `requirements.dev.txt` to `~=1.18.2`.
> - **Tasks**:
>   - Refine `show_deprecations` parsing in `tasks.py`:
>     - Add assertions and use `message_str` to avoid overwriting AST nodes and comply with newer typing.
>     - Normalize message construction across `Name`/`Attribute`/`Constant`/`JoinedStr` cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f64abb3d5596a1e5cd7d743135ffbf7b780c420b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->