### PR TITLE
Document new throttle config

### DIFF
--- a/modal/_utils/grpc_utils.py
+++ b/modal/_utils/grpc_utils.py
@@ -292,6 +292,8 @@ def process_exception_before_retry(
             # StreamTerminatedError are not properly raised in grpclib<=0.4.7
             # fixed in https://github.com/vmagamedov/grpclib/issues/185
             # TODO: update to newer version (>=0.4.8) once stable
+            # Also be sure to remove the AttributeError from the set of exceptions
+            # we handle in the retry logic once we drop this check!
             raise exc
 
     logger.debug(f"Retryable failure {repr(exc)} {n_retries=} {delay=} for {fn_name} ({idempotency_key[:8]})")

--- a/modal/config.py
+++ b/modal/config.py
@@ -52,7 +52,7 @@ Other possible configuration options are:
   Number of seconds to wait for logs to drain when closing the session,
   before giving up.
 * `max_throttle_wait` (in the .toml file) / `MODAL_MAX_THROTTLE_WAIT` (as an env var).
-  Defaults to None.
+  Defaults to None (no limit).
   Maximum number of seconds to wait when requests are being throttled (i.e., due
   to rate limiting or other cases that can normally be resolved through backoff).
 * `force_build` (in the .toml file) / `MODAL_FORCE_BUILD` (as an env var).


### PR DESCRIPTION
The docstring of `modal.config` [ends up on the website](https://modal.com/docs/reference/modal.config) as the source of truth for environment variable documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `max_throttle_wait` config and uses it to cap server-throttled gRPC retries; tweaks retry warning text and clarifies AttributeError handling comments.
> 
> - **Retry logic (`modal/_utils/grpc_utils.py`)**:
>   - Respect `config.get("max_throttle_wait")` to set a total deadline when server returns retry-after (throttling).
>   - Refine warning message wording when receiving server retry status.
>   - Add clarifying comments around temporary `AttributeError` catch for grpclib<=0.4.7.
> - **Config (`modal/config.py`)**:
>   - Document and expose new `max_throttle_wait` (`.toml`/`MODAL_MAX_THROTTLE_WAIT`).
>   - Add `_SETTINGS["max_throttle_wait"]` with int-or-None parsing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7060a28dc6e4d85cd776bd56672038b61815a2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->