### PR TITLE
Fix StreamType STDOUT for stderr

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -938,7 +938,8 @@ class _Sandbox(_Object, type_prefix="sb"):
         elif stderr == StreamType.DEVNULL:
             stderr_config = sr_pb2.TaskExecStderrConfig.TASK_EXEC_STDERR_CONFIG_DEVNULL
         elif stderr == StreamType.STDOUT:
-            stderr_config = sr_pb2.TaskExecStderrConfig.TASK_EXEC_STDERR_CONFIG_STDOUT
+            # Stream stderr to the client so that it can be printed locally in the reader.
+            stderr_config = sr_pb2.TaskExecStderrConfig.TASK_EXEC_STDERR_CONFIG_PIPE
         else:
             raise ValueError("Unsupported StreamType for stderr")
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -66,6 +66,9 @@ class FakeTaskCommandRouterClient:
         self._stdin_offsets: dict[str, int] = {}
 
     async def exec_start(self, request: sr_pb2.TaskExecStartRequest) -> sr_pb2.TaskExecStartResponse:
+        # Mimic task_command_router behavior - we should remove this proto variant though.
+        # TODO(saltzm): Remove the proto variant.
+        assert request.stderr_config != sr_pb2.TaskExecStderrConfig.TASK_EXEC_STDERR_CONFIG_STDOUT
         # Spawn the command locally.
         proc = await asyncio.subprocess.create_subprocess_exec(
             *list(request.command_args),

--- a/test/sandbox_test.py
+++ b/test/sandbox_test.py
@@ -526,6 +526,17 @@ def test_sandbox_exec_with_streamtype_stdout_and_text_true_prints_to_stdout(app,
 
 @skip_non_subprocess
 @pytest.mark.parametrize("exec_backend", ["server", "router"], indirect=True)
+def test_sandbox_exec_with_streamtype_stderr_and_text_true_prints_to_stdout(app, servicer, exec_backend, capsys):
+    sb = Sandbox.create("sleep", "infinity", app=app)
+
+    cp = sb.exec("bash", "-c", "echo hi >&2", stderr=StreamType.STDOUT)
+    cp.wait()
+
+    assert capsys.readouterr().out == "hi\n"
+
+
+@skip_non_subprocess
+@pytest.mark.parametrize("exec_backend", ["server", "router"], indirect=True)
 def test_sandbox_exec_with_streamtype_stdout_and_text_true_and_bufsize_1_prints_to_stdout(
     app, servicer, exec_backend, capsys
 ):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes STDOUT stream routing in command-router exec (maps to PIPE) and adds tests, including stderr->STDOUT behavior.
> 
> - **Sandbox exec (router path)**
>   - Map `stdout=StreamType.STDOUT` and `stderr=StreamType.STDOUT` to `*_PIPE` configs in `_exec_through_command_router` to stream to client readers (`modal/sandbox.py`).
> - **Tests**
>   - Add assertion in `FakeTaskCommandRouterClient.exec_start` to disallow legacy `TASK_EXEC_STDERR_CONFIG_STDOUT` (`test/conftest.py`).
>   - Add test `test_sandbox_exec_with_streamtype_stderr_and_text_true_prints_to_stdout` validating `stderr=StreamType.STDOUT` prints to stdout (`test/sandbox_test.py`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2f377beec6ea0c021b7088fb65659d132c07856. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->