### PR TITLE
Allow modal.forward to open H2 tunnels

### DIFF
--- a/modal/experimental/flash.py
+++ b/modal/experimental/flash.py
@@ -30,13 +30,14 @@ class _FlashManager:
         port: int,
         process: Optional[subprocess.Popen] = None,
         health_check_url: Optional[str] = None,
+        h2_enabled: bool = False,
     ):
         self.client = client
         self.port = port
         # Health check is not currently being used
         self.health_check_url = health_check_url
         self.process = process
-        self.tunnel_manager = _forward_tunnel(port, client=client)
+        self.tunnel_manager = _forward_tunnel(port, h2_enabled=h2_enabled, client=client)
         self.stopped = False
         self.num_failures = 0
         self.task_id = os.environ["MODAL_TASK_ID"]
@@ -170,6 +171,7 @@ async def flash_forward(
     port: int,
     process: Optional[subprocess.Popen] = None,
     health_check_url: Optional[str] = None,
+    h2_enabled: bool = False,
 ) -> _FlashManager:
     """
     Forward a port to the Modal Flash service, exposing that port as a stable web endpoint.
@@ -178,7 +180,7 @@ async def flash_forward(
     """
     client = await _Client.from_env()
 
-    manager = _FlashManager(client, port, process=process, health_check_url=health_check_url)
+    manager = _FlashManager(client, port, process=process, health_check_url=health_check_url, h2_enabled=h2_enabled)
     await manager._start()
     return manager
 


### PR DESCRIPTION
We already have this behavior for Sandbox tunnels, so I'm replicating for forward. This is required so that Flash can load balancer GRPC connections.

## Describe your changes

- _Provide Linear issue reference (e.g. CLI-1234) if available._

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

</details>

## Changelog

Adds a new h2_enabled field to modal.forward which enables HTTP/2 advertisement in TLS establishment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `h2_enabled` to `modal.forward` and Flash to advertise HTTP/2 over TLS, with validation and updated tunnel start requests.
> 
> - **Tunneling**:
>   - Add `h2_enabled` to `_forward(port, ...)` in `modal/_tunnel.py` to advertise HTTP/2 over TLS.
>   - Validate `h2_enabled` cannot be combined with `unencrypted`.
>   - Set `tunnel_type` (`TUNNEL_TYPE_H2` vs `UNSPECIFIED`) and include it in `TunnelStartRequest`.
> - **Flash integration**:
>   - Add `h2_enabled` to `flash_forward(...)` and `_FlashManager` in `modal/experimental/flash.py`.
>   - Propagate `h2_enabled` to `_forward_tunnel(...)` so Flash tunnels can use HTTP/2.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e62d563bc34e46053bedde6a381527be04b974ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->