### PR TITLE
Start `modal shell`s with /bin/sh instead of bash, so it works with Alpine images

### DIFF
--- a/modal/cli/shell.py
+++ b/modal/cli/shell.py
@@ -232,6 +232,7 @@ def shell(
             pty=pty,
         )
 
-    # NB: invoking under bash makes --cmd a lot more flexible.
-    cmds = shlex.split(f'/bin/bash -c "{cmd}"')
+    # Invoking under sh makes --cmd a lot more flexible.
+    # We use /bin/sh rather than bash because e.g. alpine images don't come with bash.
+    cmds = ["/bin/sh", "-c", cmd]
     start_shell(app, cmds=cmds, environment_name=env, timeout=3600)

--- a/modal/runner.py
+++ b/modal/runner.py
@@ -587,7 +587,7 @@ async def _interactive_shell(
 
     This is useful for online debugging and interactive exploration of the
     contents of this image. If `cmd` is optionally provided, it will be run
-    instead of the default shell inside this image.
+    instead of /bin/sh inside this image.
 
     **Example**
 
@@ -608,7 +608,7 @@ async def _interactive_shell(
 
     client = await _Client.from_env()
     async with _run_app(_app, client=client, environment_name=environment_name):
-        sandbox_cmds = cmds if len(cmds) > 0 else ["/bin/bash"]
+        sandbox_cmds = cmds if len(cmds) > 0 else ["/bin/sh"]
         sandbox_env = {
             "MODAL_TOKEN_ID": config["token_id"],
             "MODAL_TOKEN_SECRET": config["token_secret"],


### PR DESCRIPTION
## Describe your changes

Before this, you'd get:
```
> modal shell --image alpine
Failed to run command: No such file or directory

> modal shell --image alpine --cmd "echo hello"
Failed to run command: No such file or directory

> modal shell --image alpine --cmd /bin/sh
Failed to run command: No such file or directory
```

Now you get:
```
> modal shell --image alpine
/bin/sh: /bin/bash: not found

> modal shell --image alpine --cmd /bin/sh
/ #

> modal shell --image ubuntu
root@modal:/# echo $SHELL
/bin/bash
```

## Changelog

- Changed `modal shell` to use `/bin/sh` for executing commands, so it works with Alpine images that don't come with bash.

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch default shell to `/bin/sh` and execute `--cmd` via `sh -c` for broader image compatibility.
> 
> - **CLI (`modal/cli/shell.py`)**
>   - Invoke commands via `['/bin/sh', '-c', cmd]` instead of wrapping with bash, improving compatibility with images lacking bash (e.g., Alpine).
> - **Runner (`modal/runner.py`)**
>   - Default interactive shell fallback changed from `'/bin/bash'` to `'/bin/sh'`.
>   - Docstrings updated to reflect `/bin/sh` default.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 995eff893bf9294d32e6e3d5d1fc67d3039f6862. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->