### PR TITLE
Fix UnicodeDecodeError in `modal shell`

### DIFF
--- a/modal/runner.py
+++ b/modal/runner.py
@@ -628,7 +628,7 @@ async def _interactive_shell(
         try:
             if pty:
                 container_process = await sandbox._exec(
-                    *sandbox_cmds, pty_info=get_pty_info(shell=True) if pty else None
+                    *sandbox_cmds, pty_info=get_pty_info(shell=True) if pty else None, text=False
                 )
                 await container_process.attach()
             else:


### PR DESCRIPTION
## Describe your changes

Running e.g. `vi` from a `modal shell --image ubuntu` was failing since 6133e0916824830af73380060645b2908e5876a8, because we try to parse the control characters as unicode.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

</details>

## Changelog

- Fixed a bug in `modal shell` that caused e.g. `vi` to fail with unicode decode errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pass `text=False` to `sandbox._exec` when using a PTY in `_interactive_shell` to avoid Unicode decoding of control characters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cfb1958281470961b149744380a5d9054ca39fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->