### PR TITLE
Simplify retry_transient_errors by having caller timeout

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -1908,8 +1908,7 @@ Use the `Function.get_web_url()` method instead.
     async def get_current_stats(self) -> FunctionStats:
         """Return a `FunctionStats` object describing the current function's queue and runner counts."""
         resp = await self.client.stub.FunctionGetCurrentStats(
-            api_pb2.FunctionGetCurrentStatsRequest(function_id=self.object_id),
-            retry=Retry(total_timeout=10.0),
+            api_pb2.FunctionGetCurrentStatsRequest(function_id=self.object_id)
         )
         return FunctionStats(backlog=resp.backlog, num_total_runners=resp.num_total_tasks)
 

--- a/modal/_output.py
+++ b/modal/_output.py
@@ -34,7 +34,7 @@ from rich.text import Text
 from modal._utils.time_utils import timestamp_to_localized_str
 from modal_proto import api_pb2
 
-from ._utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES, Retry
+from ._utils.grpc_utils import RETRYABLE_GRPC_STATUS_CODES
 from ._utils.shell_utils import stream_from_stdin, write_to_fd
 from .client import _Client
 from .config import logger
@@ -492,8 +492,7 @@ async def stream_pty_shell_input(client: _Client, exec_id: str, finish_event: as
         await client.stub.ContainerExecPutInput(
             api_pb2.ContainerExecPutInputRequest(
                 exec_id=exec_id, input=api_pb2.RuntimeInputMessage(message=data, message_index=message_index)
-            ),
-            retry=Retry(total_timeout=10),
+            )
         )
 
     async with stream_from_stdin(_handle_input, use_raw_terminal=True):

--- a/modal/dict.py
+++ b/modal/dict.py
@@ -9,7 +9,6 @@ from grpclib import GRPCError, Status
 from synchronicity import classproperty
 from synchronicity.async_wrap import asynccontextmanager
 
-from modal._utils.grpc_utils import Retry
 from modal_proto import api_pb2
 
 from ._load_context import LoadContext
@@ -328,7 +327,7 @@ class _Dict(_Object, type_prefix="di"):
             environment_name=_get_environment_name(environment_name),
             data=serialized,
         )
-        response = await client.stub.DictGetOrCreate(request, retry=Retry(total_timeout=10.0))
+        response = await client.stub.DictGetOrCreate(request)
         async with TaskContext() as tc:
             request = api_pb2.DictHeartbeatRequest(dict_id=response.dict_id)
             tc.infinite_loop(lambda: client.stub.DictHeartbeat(request), sleep=_heartbeat_sleep)


### PR DESCRIPTION
## Describe your changes

This PR updates `retry_transient_errors`:

- Removes the concept of `total_timeout` and allows the RPC to wait forever:
	- `ContainerExecPutInput`
	- `DictGetOrCreate`
	- `FunctionGetCurrentStats`
- `QueuePut` still has a timeout through `asyncio.timeout`. I added a unit test to assert that we continue to raise a `modal.exception.ConnectionError` when there is a timeout.
- Removes `attempt_timeout_floor` which was a lower bound on the timeout and only used by `QueuePut`. 

The biggest change is that we no longer pass a deadline to the server (which populates a `grpc-timeout` field in the header). The client will timeout which cancels the request on the server as well.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Eliminates global retry total timeouts in favor of caller-managed timeouts, updates call sites (incl. QueuePut with asyncio.timeout) and adjusts tests accordingly.
> 
> - **gRPC retry utils**
>   - Simplify `Retry`: remove `total_timeout` and `attempt_timeout_floor`; keep `attempt_timeout` only.
>   - Update `_retry_transient_errors` to pass `timeout=retry.attempt_timeout`, and compute `final_attempt` without total-deadline logic; throttle final-attempt now respects `config.max_throttle_wait` only.
> - **Client call sites**
>   - `modal/_functions.py`: `FunctionGetCurrentStats` no longer passes `Retry(total_timeout=...)`.
>   - `modal/_output.py`: `ContainerExecPutInput` no longer passes a `Retry`.
>   - `modal/dict.py`: `Dict.ephemeral` `DictGetOrCreate` call no longer passes a `Retry`.
> - **Queues**
>   - `Queue.put_many` (blocking): wrap `QueuePut` in `asyncio.timeout(timeout)` and raise `ConnectionError("Deadline exceeded")` on timeout; retain `Retry` for `RESOURCE_EXHAUSTED` without total timeout.
>   - Add `ConnectionError` import; minor plumbing for nonblocking path unchanged.
> - **Tests**
>   - Remove tests relying on `total_timeout` in retries; add `test_queue_timeout_error` asserting `ConnectionError` after ~given timeout.
>   - Keep retry behavior tests (metadata, throttle warnings) aligned with new logic; cleanup unused imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d98f84894bacb6a6fed2811a48216939d9df04ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->