### PR TITLE
Improve error messages for Dict deserialization

### DIFF
--- a/test/dict_test.py
+++ b/test/dict_test.py
@@ -4,7 +4,8 @@ import sys
 import time
 
 from modal import Dict
-from modal.exception import AlreadyExistsError, DeprecationError, InvalidError, NotFoundError
+from modal._serialization import serialize
+from modal.exception import AlreadyExistsError, DeprecationError, DeserializationError, InvalidError, NotFoundError
 from modal_proto import api_pb2
 
 
@@ -141,3 +142,53 @@ def test_dict_pop(servicer, client):
 
         with pytest.raises(KeyError):
             d.pop("non_existent_key")
+
+
+def test_dict_deserialization_errors(servicer, client):
+    name = "test-dict-deserialization-errors"
+    d = Dict.from_name(name, create_if_missing=True, client=client)
+
+    key = "foo"
+    d[key] = "good"
+    value_error = rf"Failed to deserialize value for key {key!r} from Dict '{name}'"
+
+    with servicer.intercept() as ctx:
+        ctx.add_response("DictGet", api_pb2.DictGetResponse(found=True, value=b"bad"))
+        with pytest.raises(DeserializationError, match=value_error):
+            d.get(key)
+
+    with servicer.intercept() as ctx:
+        ctx.add_response("DictPop", api_pb2.DictPopResponse(found=True, value=b"bad"))
+        with pytest.raises(DeserializationError, match=value_error):
+            d.pop(key)
+
+    async def bad_values(servicer, stream):
+        await stream.recv_message()
+        await stream.send_message(api_pb2.DictEntry(key=serialize("foo"), value=b"bad"))
+
+    with servicer.intercept() as ctx:
+        ctx.set_responder("DictContents", bad_values)
+        with pytest.raises(DeserializationError, match=value_error):
+            list(d.values())
+
+    with servicer.intercept() as ctx:
+        ctx.set_responder("DictContents", bad_values)
+        with pytest.raises(DeserializationError, match=value_error):
+            list(d.items())
+
+    async def bad_keys(servicer, stream):
+        await stream.recv_message()
+        await stream.send_message(api_pb2.DictEntry(key=b"bad"))
+
+    key_error = rf"Failed to deserialize a key from Dict '{name}'"
+
+    with servicer.intercept() as ctx:
+        ctx.set_responder("DictContents", bad_keys)
+        error = rf"Failed to deserialize key from Dict '{name}'"
+        with pytest.raises(DeserializationError, match=key_error):
+            list(d.keys())
+
+    with servicer.intercept() as ctx:
+        ctx.set_responder("DictContents", bad_keys)
+        with pytest.raises(DeserializationError, match=key_error):
+            list(d.items())


### PR DESCRIPTION
Part of SDK-51. Thanks @howard36 for the good idea about how to approach this.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add contextual DeserializationError wrapping for Dict keys/values and update get/pop/keys/values/items to use it, with tests covering error cases.
> 
> - **Dict deserialization error handling**
>   - Introduce `_deserialize_dict_key` and `_deserialize_dict_value` to wrap `deserialize` with contextual `DeserializationError` messages including Dict identity and key.
>   - Update `get`, `pop`, `keys`, `values`, `items` to use the new helpers.
>   - `values` and `items` now attempt key deserialization to include the key in value error messages.
> - **Tests**
>   - Add `test_dict_deserialization_errors` to assert improved error messages for `get`, `pop`, `values`, `items`, and `keys`.
>   - Update imports to include `DeserializationError` and `serialize`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83e1ba4bd640a634fc11c829d004a25e374b1704. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->