### PR TITLE
Adjust test_retry_transient_errors_grpc_retry as flaky test

### DIFF
--- a/test/grpc_utils_test.py
+++ b/test/grpc_utils_test.py
@@ -288,7 +288,9 @@ async def test_retry_transient_errors_grpc_retry(servicer, client, caplog, monke
     assert servicer.blob_create_metadata.get("x-throttle-retry-attempt") == "10"
 
     # With an interval of 0.3 sec and retrying for a 1.0 sec, warning message is shown at time 0.0, 0.3, 0.6, 0.9
-    assert caplog.text.count(f"foobar-message{os.linesep}Will retry in 0.10 seconds") == 4
+    message_count = caplog.text.count(f"foobar-message{os.linesep}Will retry in 0.10 seconds")
+    # Test can be flaky so we assert that there are 3 or 4 messages
+    assert message_count in (3, 4)
 
 
 @synchronize_api


### PR DESCRIPTION
## Describe your changes

I've seen `test_retry_transient_errors_grpc_retry` flake in https://github.com/modal-labs/modal-client/pull/3785 on Windows. This PR adjusts the count.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Relax flaky log count assertion in `test_retry_transient_errors_grpc_retry` to accept 3 or 4 messages instead of exactly 4.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c21646be169a474371b25966c58ca7ede5e6443. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->