### PR TITLE
Proto changes for custom function name witout serialization

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1552,6 +1552,10 @@ message Function {
   repeated DataFormat supported_input_formats = 87; // can be used as inputs
   repeated DataFormat supported_output_formats = 88;
   optional HTTPConfig http_config = 89;
+
+  // Attribute on the module with the implementation, which may differ from function_name
+  // when the user provided a custom name= for the Function inside the Application namespace
+  string implementation_name = 90;
 }
 
 message FunctionAsyncInvokeRequest {
@@ -1731,6 +1735,10 @@ message FunctionData {
   repeated DataFormat supported_input_formats = 37;
   repeated DataFormat supported_output_formats = 38;
   optional HTTPConfig http_config = 39;
+
+  // Attribute on the module with the implementation, which may differ from function_name
+  // when the user provided a custom name= for the Function inside the Application namespace
+  string implementation_name = 40;
 }
 
 message FunctionExtended {


### PR DESCRIPTION
See #3773 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an `implementation_name` field to `Function` and `FunctionData` to carry the module attribute name when it differs from `function_name`.
> 
> - **Proto (api.proto)**:
>   - Add `string implementation_name` to `Function` (field `90`).
>   - Add `string implementation_name` to `FunctionData` (field `40`).
>   - Include comments clarifying usage when implementation name differs from `function_name`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54137f34d651962704da50f7d11e6a7c44465109. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->