### PR TITLE
Add `_restore_instance_type` to Sandbox definition

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2793,6 +2793,11 @@ message Sandbox {
   // Exec commands for the sandbox will be issued directly to the sandbox
   // command router running on the Modal worker.
   bool direct_sandbox_commands_enabled = 34;
+
+  // Internal: restricts sandbox to run on this specific instance type.
+  // Set by server during SandboxRestore to ensure the restored sandbox runs
+  // on the same instance type as the original snapshot.
+  string _restore_instance_type = 35;
 }
 
 message SandboxCreateConnectTokenRequest {


### PR DESCRIPTION
I want to fully deprecate the `_instance_types` field on the `SchedulerPlacement` proto so that `SchedulerPlacement` is only used for user-specified scheduling constraints.

The final only place it is being used is in `SandboxRestore` to restrict a restored Sandbox to run on the same instance type as where the snapshot was taken. Let's instead have an internal field on the Sandbox definition.

Server PR #30338 modifies `SandboxRestore` to set this field.