### PR TITLE
DOC Adds comment to why is_notebook is used

### DIFF
--- a/modal/app.py
+++ b/modal/app.py
@@ -509,6 +509,8 @@ class _App:
             if old_function is function:
                 return  # already added the same exact instance, ignore
 
+            # In notebooks, re-registering the same function with the same app will cause a named collision.
+            # This is common notebook coding behavior, so we hide the warning.
             if not is_notebook():
                 logger.warning(
                     f"Warning: function name '{function.tag}' collision!"


### PR DESCRIPTION
## Describe your changes

Adds short comment on why `is_notebook` is used

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a brief comment explaining why `is_notebook()` suppresses function name-collision warnings in `_add_function`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d7c78fd546d7ad4039632e5cf4502d0eb43d4b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->