### PR TITLE
Make entrypoint logic around new function_def.implementation_name safer

### DIFF
--- a/modal/_runtime/user_code_imports.py
+++ b/modal/_runtime/user_code_imports.py
@@ -465,7 +465,10 @@ def import_single_function_service(
     else:
         # Load the module dynamically
         module = importlib.import_module(function_def.module_name)
-        qual_name: str = function_def.implementation_name
+
+        # Fall back to function_name just to be safe around the migration
+        # Going forward, implementation_name should always be set
+        qual_name: str = function_def.implementation_name or function_def.function_name
 
         if not is_global_object(qual_name):
             raise LocalFunctionError("Attempted to load a function defined in a function scope")


### PR DESCRIPTION
Just matters during the rollout really

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use `function_def.function_name` as a fallback when `implementation_name` is unset during dynamic import for safer rollout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26d3bd2bbfb83f3a52a6ce900c99791b04f73cad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->