### PR TITLE
Aio warnings: Make SandboxSnapshot.from_id sync

### DIFF
--- a/modal/snapshot.py
+++ b/modal/snapshot.py
@@ -1,12 +1,15 @@
 # Copyright Modal Labs 2024
-from typing import Optional
+from typing import Optional, cast
 
+import typing_extensions
+
+import modal.client
 from modal_proto import api_pb2
 
 from ._load_context import LoadContext
 from ._object import _Object
 from ._resolver import Resolver
-from ._utils.async_utils import synchronize_api
+from ._utils.async_utils import deprecate_aio_usage, synchronize_api, synchronizer
 from .client import _Client
 
 
@@ -19,27 +22,35 @@ class _SandboxSnapshot(_Object, type_prefix="sn"):
     the original Sandbox at the time the snapshot was taken.
     """
 
-    @staticmethod
-    async def from_id(sandbox_snapshot_id: str, client: Optional[_Client] = None):
+    @deprecate_aio_usage((2025, 12, 5), "SandboxSnapshot.from_id")
+    @classmethod
+    def from_id(
+        cls, sandbox_snapshot_id: str, client: Optional["modal.client.Client"] = None
+    ) -> typing_extensions.Self:
         """
         Construct a `SandboxSnapshot` object from a sandbox snapshot ID.
         """
-        # TODO: remove this - from_id constructor should not do io:
-        client = client or await _Client.from_env()
+        _client = cast(_Client, synchronizer._translate_in(client))
 
         async def _load(
             self: _SandboxSnapshot, resolver: Resolver, load_context: LoadContext, existing_object_id: Optional[str]
         ):
-            await load_context.client.stub.SandboxSnapshotGet(
+            # hydration doesn't actually do much apart from validating the existance of the id
+            # which is implicitly done by trying to start a sandbox from the snapshot as well
+            resp: api_pb2.SandboxSnapshotGetResponse = await load_context.client.stub.SandboxSnapshotGet(
                 api_pb2.SandboxSnapshotGetRequest(snapshot_id=sandbox_snapshot_id)
             )
+            self._hydrate(resp.snapshot_id, load_context.client, None)
 
         rep = "SandboxSnapshot()"
-        obj = _SandboxSnapshot._from_loader(_load, rep, load_context_overrides=LoadContext(client=client))
-        # TODO: should this be a _Object._new_hydrated instead?
-        obj._hydrate(sandbox_snapshot_id, client, None)
-
-        return obj
+        obj = _SandboxSnapshot._from_loader(
+            _load, rep, load_context_overrides=LoadContext(client=_client), hydrate_lazily=True
+        )
+        # Setting the object id directly is a bit hacky, but
+        # it avoids hydrating the object fully if it's going
+        # to be used only for its object id anyway
+        obj._object_id = sandbox_snapshot_id
+        return cast(typing_extensions.Self, synchronizer._translate_out(obj))
 
 
 SandboxSnapshot = synchronize_api(_SandboxSnapshot)


### PR DESCRIPTION
Also makes the hydration logic actually do something, if a user potentially calls .hydrate()

It's still a bit weird that for the standard use case of passing SandboxSnapshot.from_id into a Sandbox.from_snapshot call, the hydration isn't actually used - only the object_id, so for most purposes `SandboxSnapshot` could just as well have been a string or a dataclass or something...

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add async-context blocking warnings, deprecate .aio constructors, refactor `Volume.batch_upload` to an async context manager, and modernize `from_id` APIs; also upgrade synchronicity and tests.
> 
> - **Async utils & warnings**:
>   - Add `BlockingInAsyncContextWarning` and intelligent code rewrite suggestions; configure `synchronizer` with blocking-in-async callback.
>   - Detect interactive IPython via new `is_interactive_ipython()`; suppress warnings in notebooks.
> - **API deprecations & constructors**:
>   - Introduce `deprecate_aio_usage` decorator; deprecate `.aio` variants of constructors.
>   - Make `FunctionCall.from_id`, `Image.from_id`, and `SandboxSnapshot.from_id` synchronous classmethods returning wrapped types; adjust client translation.
> - **Volume**:
>   - Add `live_method_contextmanager`; make `Volume.batch_upload` an async context manager (no manual `__aenter__/__aexit__`); minor typing tweaks (`read_file`).
> - **Client & GRPC testing**:
>   - Refine `_Client` typing/fields; ensure task context loop handling; improve mock servicer fallbacks with method names.
> - **App/notebook behavior**:
>   - Use `is_interactive_ipython()` to hide duplicate function warnings in notebooks; add notebook tests.
> - **Tests**:
>   - Widespread updates to async usage (`async with`/`await`), new tests for sync-in-async rewrite logic and IPython detection; adjust expectations.
> - **Tooling/CI**:
>   - Bump `synchronicity` to `0.10.4`; update `mypy`, `nbclient`, `jupytext`; workflows install new versions.
>   - pytest config treats `BlockingInAsyncContextWarning` as error by default.
> - **Misc**:
>   - Small fixes in `tasks.py` (venv path match, deprecation message handling).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66a3e6a797c0b9e51b9417e6c83a3780620b9de5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->