### PR TITLE
Add pathlib support to Sandbox FS operations

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -6,6 +6,7 @@ import time
 import uuid
 from collections.abc import AsyncGenerator, Collection, Sequence
 from dataclasses import dataclass
+from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any, AsyncIterator, Literal, Optional, Union, overload
 
 from ._pty import get_pty_info
@@ -1048,20 +1049,20 @@ class _Sandbox(_Object, type_prefix="sb"):
     @overload
     async def open(
         self,
-        path: str,
+        path: Union[str, PurePosixPath],
         mode: "_typeshed.OpenTextMode",
     ) -> _FileIO[str]: ...
 
     @overload
     async def open(
         self,
-        path: str,
+        path: Union[str, PurePosixPath],
         mode: "_typeshed.OpenBinaryMode",
     ) -> _FileIO[bytes]: ...
 
     async def open(
         self,
-        path: str,
+        path: Union[str, PurePosixPath],
         mode: Union["_typeshed.OpenTextMode", "_typeshed.OpenBinaryMode"] = "r",
     ):
         """[Alpha] Open a file in the Sandbox and return a FileIO handle.
@@ -1080,24 +1081,24 @@ class _Sandbox(_Object, type_prefix="sb"):
         task_id = await self._get_task_id()
         return await _FileIO.create(path, mode, self._client, task_id)
 
-    async def ls(self, path: str) -> list[str]:
+    async def ls(self, path: Union[str, PurePosixPath]) -> list[str]:
         """[Alpha] List the contents of a directory in the Sandbox."""
         task_id = await self._get_task_id()
         return await _FileIO.ls(path, self._client, task_id)
 
-    async def mkdir(self, path: str, parents: bool = False) -> None:
+    async def mkdir(self, path: Union[str, PurePosixPath], parents: bool = False) -> None:
         """[Alpha] Create a new directory in the Sandbox."""
         task_id = await self._get_task_id()
         return await _FileIO.mkdir(path, self._client, task_id, parents)
 
-    async def rm(self, path: str, recursive: bool = False) -> None:
+    async def rm(self, path: Union[str, PurePosixPath], recursive: bool = False) -> None:
         """[Alpha] Remove a file or directory in the Sandbox."""
         task_id = await self._get_task_id()
         return await _FileIO.rm(path, self._client, task_id, recursive)
 
     async def watch(
         self,
-        path: str,
+        path: Union[str, PurePosixPath],
         filter: Optional[list[FileWatchEventType]] = None,
         recursive: Optional[bool] = None,
         timeout: Optional[int] = None,


### PR DESCRIPTION
## Describe your changes

Adds `pathlib` support to `Sandbox` FS operations. Note that `PurePosixPath` is supported because containers are always posix paths.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->
- Adds support for `PurePosixPath` in Sandbox filesystem functions: `open`, `mkdir`, `ls`, and `watch`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add PurePosixPath support across Sandbox FileIO operations (open/ls/mkdir/rm/watch) with path normalization and tests.
> 
> - **File I/O (`modal/file_io.py`)**
>   - Accept `Union[str, PurePosixPath]` for `FileIO.create`, `ls`, `mkdir`, `rm`, `watch`.
>   - Add `_validate_path` to normalize `PurePosixPath` to POSIX string and validate inputs.
> - **Sandbox (`modal/sandbox.py`)**
>   - Update `open`, `ls`, `mkdir`, `rm`, `watch` to accept `Union[str, PurePosixPath]` and forward to `FileIO`.
> - **Tests (`test/file_io_test.py`)**
>   - Parameterize path inputs to test both `str` and `PurePosixPath`.
>   - Add invalid path test asserting `ValueError` for non-supported types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 563f337289e259f14be52ef5230a05d5c8169e7e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->