### PR TITLE
add concurrent_requests to http_server

### DIFF
--- a/modal/experimental/flash.py
+++ b/modal/experimental/flash.py
@@ -655,6 +655,7 @@ def _http_server(
     proxy_regions: list[str] = [],  # The regions to proxy the HTTP server to.
     startup_timeout: int = 30,  # Maximum number of seconds to wait for the HTTP server to start.
     exit_grace_period: Optional[int] = None,  # The time to wait for the HTTP server to exit gracefully.
+    concurrent_requests: Optional[int] = None,  # The target concurrent requests per upstream container.
 ):
     """Decorator for Flash-enabled HTTP servers on Modal classes.
 
@@ -663,6 +664,7 @@ def _http_server(
         proxy_regions: The regions to proxy the HTTP server to.
         startup_timeout: The maximum time to wait for the HTTP server to start.
         exit_grace_period: The time to wait for the HTTP server to exit gracefully.
+        concurrent_requests: The target concurrent requests per upstream container.
 
     """
     if port is None:
@@ -675,6 +677,8 @@ def _http_server(
         raise InvalidError("The `startup_timeout` argument of `@http_server` must be positive.")
     if exit_grace_period is not None and exit_grace_period < 0:
         raise InvalidError("The `exit_grace_period` argument of `@http_server` must be non-negative.")
+    if concurrent_requests is not None and concurrent_requests <= 0:
+        raise InvalidError("The `concurrent requests` argument of `@http_server` must be positive.")
 
     from modal._partial_function import _PartialFunction, _PartialFunctionParams
 
@@ -684,6 +688,7 @@ def _http_server(
             proxy_regions=proxy_regions,
             startup_timeout=startup_timeout or 0,
             exit_grace_period=exit_grace_period or 0,
+            concurrent_requests=concurrent_requests or 0,
         )
     )
 

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2104,6 +2104,7 @@ message HTTPConfig {
   repeated string proxy_regions = 2;
   uint32 startup_timeout = 3;
   uint32 exit_grace_period = 4;
+  uint32 concurrent_requests = 5;
 }
 
 message Image {


### PR DESCRIPTION
still discussing!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `concurrent_requests` option to the experimental `http_server` decorator and propagates it via `HTTPConfig`, with validation and tests.
> 
> - **Flash HTTP server config**:
>   - Add optional `concurrent_requests` to `modal/experimental/flash.py` `http_server(...)` decorator; validate positive ints; default to `0` when unset.
>   - Pass through to `api_pb2.HTTPConfig.concurrent_requests` when constructing params.
> - **Protocol**:
>   - Extend `modal_proto/api.proto` `HTTPConfig` with `uint32 concurrent_requests = 5`.
> - **Tests**:
>   - Update `test/flash_cls_test.py` to configure `concurrent_requests=20` and assert default behavior (`0` when unset) and configured value is propagated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fc6793490b61cafd5a55c37be8ff8ab268a8897. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->