### PR TITLE
Fix doc string for image_delete

### DIFF
--- a/modal/experimental/__init__.py
+++ b/modal/experimental/__init__.py
@@ -364,7 +364,8 @@ async def image_delete(
 ) -> None:
     """Delete an Image by its ID.
 
-    Deletion is irreversible and will prevent Apps from using the Image.
+    Deletion is irreversible and will prevent Functions/Sandboxes from using
+    the Image.
 
     This is an experimental interface for a feature that we will be adding to
     the main Image class. The stable form of this interface may look different.


### PR DESCRIPTION

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update image_delete docstring to note deletion prevents Functions/Sandboxes from using the image.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb7428a820aa1e45af21c2595253b80f3cc97801. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->