### PR TITLE
Make deprecation warning ignores narrower

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ filterwarnings = [
     "error::DeprecationWarning",
     "ignore:Type google._upb.*MapContainer uses PyType_Spec.*Python 3.14:DeprecationWarning",
     "error::modal.exception.DeprecationError",
+    "ignore:There is no current event loop:DeprecationWarning",  # pytest-asyncio internals
 ]
 
 [tool.ruff]


### PR DESCRIPTION
## Describe your changes

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

</details>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tightens pytest deprecation warning handling by removing two ignores and adding a targeted ignore for pytest-asyncio's event loop warning.
> 
> - **Testing**:
>   - Update `pyproject.toml` `pytest` `filterwarnings`:
>     - Remove ignores for `DeprecationWarning:pytest.*` and `DeprecationWarning:google.rpc.*`.
>     - Add ignore for `DeprecationWarning: There is no current event loop` (pytest-asyncio internals).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0467927886dba32b7b89cdc84c5823379972460a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->