### PR TITLE
Experimental http_server h2 support

### DIFF
--- a/modal/experimental/flash.py
+++ b/modal/experimental/flash.py
@@ -655,6 +655,7 @@ def _http_server(
     proxy_regions: list[str] = [],  # The regions to proxy the HTTP server to.
     startup_timeout: int = 30,  # Maximum number of seconds to wait for the HTTP server to start.
     exit_grace_period: Optional[int] = None,  # The time to wait for the HTTP server to exit gracefully.
+    h2_enabled: bool = False,  # Whether to enable HTTP/2 support.
 ):
     """Decorator for Flash-enabled HTTP servers on Modal classes.
 
@@ -684,6 +685,7 @@ def _http_server(
             proxy_regions=proxy_regions,
             startup_timeout=startup_timeout or 0,
             exit_grace_period=exit_grace_period or 0,
+            h2_enabled=h2_enabled,
         )
     )
 
@@ -722,6 +724,7 @@ class _FlashContainerEntry:
                 self.http_config.port,
                 startup_timeout=self.http_config.startup_timeout,
                 exit_grace_period=self.http_config.exit_grace_period,
+                h2_enabled=self.http_config.h2_enabled,
             )
 
     def stop(self):

--- a/test/container_test.py
+++ b/test/container_test.py
@@ -2246,6 +2246,7 @@ def test_flash_container_entry_lifecycle(servicer, tmp_path):
         port=8001,
         startup_timeout=5,
         exit_grace_period=0,
+        h2_enabled=False,
     )
 
     container_process = _run_container_process(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `h2_enabled` option to experimental `http_server`, plumbs it through `HTTPConfig` to `flash_forward`/tunnel, and updates tests.
> 
> - **Experimental Flash/http_server**
>   - Add `h2_enabled` flag to `_http_server(...)` and include in `api_pb2.HTTPConfig`.
>   - Propagate `h2_enabled` to `flash_forward`/`tunnel` via `_FlashContainerEntry.enter()`.
> - **Tests**
>   - Update `test_flash_container_entry_lifecycle` to set `HTTPConfig(h2_enabled=False)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcf635973883958bf8ae04cd0dde311a73797558. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->