### PR TITLE
proto for experimental http_server h2_enabled

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2104,6 +2104,7 @@ message HTTPConfig {
   repeated string proxy_regions = 2;
   uint32 startup_timeout = 3;
   uint32 exit_grace_period = 4;
+  bool h2_enabled = 5;
 }
 
 message Image {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a new `h2_enabled` boolean field to `HTTPConfig` to toggle HTTP/2 support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9861fcd33ebbb6c1f0a7be578246e5eed2c6bc6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->