### PR TITLE
feat: Add runtime parameter to Sandbox.create

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -149,6 +149,7 @@ class _Sandbox(_Object, type_prefix="sb"):
         experimental_options: Optional[dict[str, bool]] = None,
         enable_snapshot: bool = False,
         verbose: bool = False,
+        runtime: Optional[str] = None,
     ) -> "_Sandbox":
         """mdmd:hidden"""
 
@@ -466,6 +467,7 @@ class _Sandbox(_Object, type_prefix="sb"):
             experimental_options=experimental_options,
             enable_snapshot=_experimental_enable_snapshot,
             verbose=verbose,
+            runtime=runtime,
         )
         obj._enable_snapshot = _experimental_enable_snapshot
 


### PR DESCRIPTION
## Summary

Add a `runtime` parameter to `Sandbox.create()` that allows specifying the container runtime (`"runc"` or `"gvisor"`) on a per-sandbox basis.

## Motivation

Currently, the container runtime for sandboxes is determined globally by the `MODAL_FUNCTION_RUNTIME` environment variable at deployment time. This means if you deploy a function with gvisor (the default), all sandboxes created by that function will also use gvisor.

However, some use cases require Docker support inside sandboxes (e.g., running Postgres/Temporal containers for testing). Docker requires the `runc` runtime with `experimental_options={"enable_docker": True}`.

Without this change, users must deploy a completely separate Modal app without runc just to create Docker-enabled sandboxes, adding significant operational complexity.

## Changes

- Add `runtime: Optional[str] = None` parameter to `Sandbox.create()` and `_Sandbox._create()`
- When `runtime` is specified, use it; otherwise fall back to the global `function_runtime` config

## Usage

```python
# Create a sandbox with runc runtime (for Docker support)
sb = modal.Sandbox.create(
    "/start-dockerd.sh",
    app=app,
    image=image,
    runtime="runc",
    experimental_options={"enable_docker": True},
)
```

## Notes

The proto already supports the `runtime` field (`optional string runtime = 28` in `SandboxDefinition`), so no backend changes are needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional `runtime` to `Sandbox.create` and internals, using it in the sandbox definition or falling back to `function_runtime` config.
> 
> - **Sandbox API**
>   - Add `runtime: Optional[str]` to `Sandbox.create`, `_Sandbox._create`, and `_Sandbox._new` (supports "runc" or "gvisor").
> - **Behavior**
>   - Populate `definition.runtime` with provided `runtime`; otherwise fall back to `config.get("function_runtime")`.
>   - Thread `runtime` through creation paths when constructing the `Sandbox`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f808110b09bc3c973e005736f525c4e0c0a51d28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->