### PR TITLE
feat: Auto-set runc runtime when enable_docker is True

### DIFF
--- a/modal/sandbox.py
+++ b/modal/sandbox.py
@@ -232,6 +232,15 @@ class _Sandbox(_Object, type_prefix="sb"):
                 )
 
             ephemeral_disk = None  # Ephemeral disk requests not supported on Sandboxes.
+
+            # Determine runtime: explicit parameter > enable_docker auto-runc > config default
+            if runtime is None:
+                if experimental_options and experimental_options.get("enable_docker"):
+                    # Docker support requires runc runtime
+                    runtime = "runc"
+                else:
+                    runtime = config.get("function_runtime")
+
             definition = api_pb2.Sandbox(
                 entrypoint_args=args,
                 image_id=image.object_id,
@@ -245,7 +254,7 @@ class _Sandbox(_Object, type_prefix="sb"):
                 ),
                 cloud_provider_str=cloud if cloud else None,  # Supersedes cloud_provider
                 nfs_mounts=network_file_system_mount_protos(validated_network_file_systems),
-                runtime=runtime if runtime is not None else config.get("function_runtime"),
+                runtime=runtime,
                 runtime_debug=config.get("function_runtime_debug"),
                 cloud_bucket_mounts=cloud_bucket_mounts_to_proto(cloud_bucket_mounts),
                 volume_mounts=volume_mounts,


### PR DESCRIPTION
## Summary

Automatically set `runtime="runc"` when `experimental_options={"enable_docker": True}` is passed to `Sandbox.create()`.

## Motivation

Docker support in Modal sandboxes requires the `runc` runtime - it does not work with gvisor. Currently, users must:

1. Deploy their entire app with `MODAL_FUNCTION_RUNTIME=runc`, OR
2. Deploy a separate app without runc just for Docker-enabled sandboxes

This is confusing because:
- Users may not realize Docker requires runc until they hit cryptic iptables errors
- The `enable_docker` flag already signals the intent, so the runtime should follow automatically

## Changes

When `experimental_options` contains `enable_docker: True`, automatically override the runtime to `"runc"` regardless of the global `MODAL_FUNCTION_RUNTIME` setting.

```python
# Before: Users had to deploy with MODAL_FUNCTION_RUNTIME=runc
# After: Just works
sb = modal.Sandbox.create(
    "/start-dockerd.sh",
    app=app,
    image=image,
    experimental_options={"enable_docker": True},  # runtime auto-set to runc
)
```

## Error without this fix

Without runc, users see:
```
iptables v1.8.7 (legacy): can't initialize iptables table `nat': Table does not exist (do you need to insmod?)
```

This change eliminates that footgun.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `runtime` override to Sandbox APIs and auto-sets `runtime="runc"` when `experimental_options.enable_docker` is true, otherwise falls back to config.
> 
> - **Sandbox runtime selection**
>   - Introduces optional `runtime` param in `Sandbox.create`, `_create`, and `_new` in `modal/sandbox.py`.
>   - Runtime resolution order: explicit `runtime` > `experimental_options["enable_docker"]` => `"runc"` > `config["function_runtime"]`.
>   - Propagates resolved `runtime` into `api_pb2.Sandbox(runtime=...)`.
> - **API surface and docs**
>   - Public docstring/comments updated to document `runtime` and clarify Docker behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58897bcceee5031d6a416a543f95df7f4de196f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->