### PR TITLE
Add lints to catch stray `print`s and `breakpoint()`s

### DIFF
--- a/modal/_output.py
+++ b/modal/_output.py
@@ -556,7 +556,7 @@ async def get_app_logs_loop(
     async def stop_pty_shell():
         nonlocal pty_shell_finish_event, pty_shell_input_task
         if pty_shell_finish_event:
-            print("\r", end="")  # move cursor to beginning of line
+            print("\r", end="")  # move cursor to beginning of line # noqa: T201
             pty_shell_finish_event.set()
             pty_shell_finish_event = None
 
@@ -623,7 +623,7 @@ async def get_app_logs_loop(
                 # This corresponds to the `modal run -i` use case where a breakpoint
                 # triggers and the task drops into an interactive PTY mode
                 if pty_shell_finish_event:
-                    print("ERROR: concurrent PTY shells are not supported.")
+                    print("ERROR: concurrent PTY shells are not supported.")  # noqa: T201
                 else:
                     pty_shell_stdout = output_mgr._stdout
                     pty_shell_finish_event = asyncio.Event()

--- a/modal/_runtime/container_io_manager.py
+++ b/modal/_runtime/container_io_manager.py
@@ -1007,7 +1007,7 @@ class _ContainerIOManager:
         # Start a debugger if the worker tells us to
         if int(restored_state.get("snapshot_debug", 0)):
             logger.debug("Entering snapshot debugger")
-            breakpoint()
+            breakpoint()  # noqa: T100
 
         # Local ContainerIOManager state.
         for key in ["task_id", "function_id"]:

--- a/modal/_runtime/user_code_imports.py
+++ b/modal/_runtime/user_code_imports.py
@@ -243,7 +243,7 @@ def create_breakpoint_wrapper(container_io_manager: "modal._runtime.container_io
     def breakpoint_wrapper():
         # note: it would be nice to not have breakpoint_wrapper() included in the backtrace
         container_io_manager.interact(from_breakpoint=True)
-        import pdb
+        import pdb  # noqa: T100
 
         current_frame = inspect.currentframe()
         if current_frame is not None:

--- a/modal/_traceback.py
+++ b/modal/_traceback.py
@@ -119,7 +119,7 @@ def print_exception(exc: Optional[type[BaseException]], value: Optional[BaseExce
     traceback.print_exception(exc, value, tb)
     if sys.version_info < (3, 11) and value is not None:  # type: ignore
         notes = getattr(value, "__notes__", [])
-        print(*notes, sep="\n", file=sys.stderr)
+        print(*notes, sep="\n", file=sys.stderr)  # noqa: T201
 
 
 def print_server_warnings(server_warnings: Iterable[api_pb2.Warning]):

--- a/modal/cli/network_file_system.py
+++ b/modal/cli/network_file_system.py
@@ -102,7 +102,7 @@ async def ls(
         console.print(table)
     else:
         for entry in entries:
-            print(entry.path)
+            print(entry.path)  # noqa: T201
 
 
 @nfs_cli.command(

--- a/modal/cli/run.py
+++ b/modal/cli/run.py
@@ -292,7 +292,7 @@ def _get_click_command_for_local_entrypoint(app: App, entrypoint: LocalEntrypoin
     @click.pass_context
     def f(ctx, *args, **kwargs):
         if ctx.obj["detach"]:
-            print(
+            print(  # noqa: T201
                 "Note that running a local entrypoint in detached mode only keeps the last "
                 "triggered Modal function alive after the parent process has been killed or disconnected."
             )

--- a/modal/cli/volume.py
+++ b/modal/cli/volume.py
@@ -148,7 +148,7 @@ async def ls(
     if not json and not sys.stdout.isatty():
         # Legacy behavior -- I am not sure why exactly we did this originally but I don't want to break it
         for entry in entries:
-            print(entry.path)
+            print(entry.path)  # noqa: T201
     else:
         rows = []
         for entry in entries:

--- a/modal/container_process.py
+++ b/modal/container_process.py
@@ -146,7 +146,7 @@ class _ContainerProcessThroughServer(Generic[T]):
     async def attach(self):
         """mdmd:hidden"""
         if platform.system() == "Windows":
-            print("interactive exec is not currently supported on Windows.")
+            print("interactive exec is not currently supported on Windows.")  # noqa: T201
             return
 
         from ._output import make_console
@@ -347,7 +347,7 @@ class _ContainerProcessThroughCommandRouter(Generic[T]):
 
     async def attach(self):
         if platform.system() == "Windows":
-            print("interactive exec is not currently supported on Windows.")
+            print("interactive exec is not currently supported on Windows.")  # noqa: T201
             return
 
         from ._output import make_console

--- a/modal/io_streams.py
+++ b/modal/io_streams.py
@@ -183,7 +183,7 @@ class _StreamReaderThroughServer(Generic[T]):
                 async for message, batch_index in iterator:
                     if self._stream_type == StreamType.STDOUT and message:
                         # TODO: rearchitect this, since these bytes aren't necessarily decodable
-                        print(message.decode("utf-8"), end="")
+                        print(message.decode("utf-8"), end="")  # noqa: T201
                     elif self._stream_type == StreamType.PIPE:
                         self._container_process_buffer.append(message)
 

--- a/modal/mount.py
+++ b/modal/mount.py
@@ -769,13 +769,13 @@ async def _create_single_client_dependency_mount(
     if check_if_exists:
         try:
             await Mount.from_name(mount_name, namespace=api_pb2.DEPLOYMENT_NAMESPACE_GLOBAL).hydrate.aio(client)
-            print(f"➖ Found existing mount {mount_name} in global namespace.")
+            print(f"➖ Found existing mount {mount_name} in global namespace.")  # noqa: T201
             return
         except modal.exception.NotFoundError:
             pass
 
     with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpd:
-        print(f"📦 Building {mount_name}.")
+        print(f"📦 Building {mount_name}.")  # noqa: T201
         requirements = os.path.join(os.path.dirname(__file__), f"builder/{builder_version}.txt")
         cmd = " ".join(
             [
@@ -804,11 +804,11 @@ async def _create_single_client_dependency_mount(
         await proc.wait()
         if proc.returncode:
             stdout, stderr = await proc.communicate()
-            print(stdout.decode("utf-8"))
-            print(stderr.decode("utf-8"))
+            print(stdout.decode("utf-8"))  # noqa: T201
+            print(stderr.decode("utf-8"))  # noqa: T201
             raise RuntimeError(f"Subprocess failed with {proc.returncode}")
 
-        print(f"🌐 Downloaded and unpacked {mount_name} packages to {tmpd}.")
+        print(f"🌐 Downloaded and unpacked {mount_name} packages to {tmpd}.")  # noqa: T201
 
         python_mount = Mount._from_local_dir(tmpd, remote_path=REMOTE_PACKAGES_PATH)
 
@@ -832,11 +832,11 @@ async def _create_single_client_dependency_mount(
                         allow_overwrite=allow_overwrite,
                         client=client,
                     )
-                    print(f"✅ Deployed mount {mount_name} to global namespace.")
+                    print(f"✅ Deployed mount {mount_name} to global namespace.")  # noqa: T201
                 except GRPCError as e:
-                    print(f"⚠️ Mount creation failed with {e.status}: {e.message}")
+                    print(f"⚠️ Mount creation failed with {e.status}: {e.message}")  # noqa: T201
             else:
-                print(f"Dry run - skipping deployment of mount {mount_name}")
+                print(f"Dry run - skipping deployment of mount {mount_name}")  # noqa: T201
 
 
 async def _create_client_dependency_mounts(

--- a/modal_version/__main__.py
+++ b/modal_version/__main__.py
@@ -2,4 +2,4 @@
 from . import __version__
 
 if __name__ == "__main__":
-    print(__version__)
+    print(__version__)  # noqa: T201

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,14 +104,23 @@ select = [
     'W',
     'I',
     'RUF006', # asyncio-dangling-task
+    'T10',  # flake8-debugger
+    'T20',  # flake8-print
 ]
 preview = true
 explicit-preview-rules = true
 extend-select = ['PLR1702']
 
 [tool.ruff.lint.per-file-ignores]
-"*_test.py" = ['E712']
+"*_test.py" = ['E712', 'T201']
+"test/**" = ['T201']
 "test/supports/notebooks/*.py" = ['E402']
+"modal/cli/programs/*" = ['T201']
+"modal_docs/**" = ['T201']
+"modal_global_objects/**" = ['T201']
+"tasks.py" = ['T201']
+"modal/__init__.py" = ['T201']
+"modal/experimental/ipython.py" = ['T201']
 
 [tool.ruff.lint.isort]
 combine-as-imports = true


### PR DESCRIPTION
To auto-catch when [debug stuff lingers](https://github.com/modal-labs/modal-client/pull/3815#discussion_r2614253791).

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable Ruff T10/T20 to flag breakpoint/print; add targeted per-file ignores and # noqa annotations on intentional prints/breakpoints.
> 
> - **Lint configuration (pyproject.toml)**:
>   - Enable Ruff rules `T10` (flake8-debugger) and `T20` (flake8-print).
>   - Add per-file ignores for `T201` (print) across tests and specific module paths; extend existing ignores.
> - **Codebase annotations**:
>   - Add `# noqa: T201` to intentional `print` usages in `modal/_output.py`, `modal/_traceback.py`, `modal/cli/*`, `modal/container_process.py`, `modal/io_streams.py`, `modal/mount.py`, `modal_version/__main__.py`.
>   - Add `# noqa: T100` for intentional `breakpoint()`/`pdb` imports in `modal/_runtime/container_io_manager.py` and `modal/_runtime/user_code_imports.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5fe6232c186c391b44b59808ca67b123545637ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->