### PR TITLE
add TaskMountDirectory and TaskSnapshotDirectory rpc protos

### DIFF
--- a/modal_proto/task_command_router.proto
+++ b/modal_proto/task_command_router.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 option go_package = "github.com/modal-labs/modal/go/proto";
 
+import "google/protobuf/empty.proto";
 import "modal_proto/api.proto";
 
 package modal.task_command_router;
@@ -130,6 +131,21 @@ message TaskExecWaitResponse {
   // and termination by Modal (due to task timeout, exec exceeded deadline, etc.)
 }
 
+message TaskMountDirectoryRequest {
+  string task_id = 1;
+  bytes path = 2;
+  string image_id = 3;
+}
+
+message TaskSnapshotDirectoryRequest {
+  string task_id = 1;
+  bytes path = 2;
+}
+
+message TaskSnapshotDirectoryResponse {
+  string image_id = 1;
+}
+
 service TaskCommandRouter {
   // Poll for the exit status of an exec'd command.
   rpc TaskExecPoll(TaskExecPollRequest) returns (TaskExecPollResponse);
@@ -141,4 +157,8 @@ service TaskCommandRouter {
   rpc TaskExecStdioRead(TaskExecStdioReadRequest) returns (stream TaskExecStdioReadResponse);
   // Wait for an exec'd command to exit and return the exit code.
   rpc TaskExecWait(TaskExecWaitRequest) returns (TaskExecWaitResponse);
+  // Mount an image at a directory in the container.
+  rpc TaskMountDirectory(TaskMountDirectoryRequest) returns (google.protobuf.Empty);
+  // Snapshot a directory with a mounted image, including any local changes, into a new image.
+  rpc TaskSnapshotDirectory(TaskSnapshotDirectoryRequest) returns (TaskSnapshotDirectoryResponse);
 }


### PR DESCRIPTION
## Describe your changes

Proto changes from https://github.com/modal-labs/modal-client/pull/3791

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

## Changelog

<!--
If relevant, include a brief user-facing description of what's new in this version.

Format the changelog updates using bullet points.
See https://modal.com/docs/reference/changelog for examples and try to use a consistent style.

Provide short code examples, indented under the relevant bullet point, if they would be helpful.
Cross-linking to relevant documentation is also encouraged.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds new proto messages and RPCs to mount an image at a directory and snapshot it into a new image.
> 
> - **Proto updates (`modal_proto/task_command_router.proto`)**:
>   - **Service `TaskCommandRouter`**:
>     - Add `TaskMountDirectory(TaskMountDirectoryRequest) -> google.protobuf.Empty`.
>     - Add `TaskSnapshotDirectory(TaskSnapshotDirectoryRequest) -> TaskSnapshotDirectoryResponse`.
>   - **Messages**:
>     - `TaskMountDirectoryRequest { task_id, path, image_id }`.
>     - `TaskSnapshotDirectoryRequest { task_id, path }`.
>     - `TaskSnapshotDirectoryResponse { image_id }`.
>   - Import `google/protobuf/empty.proto` for `Empty` return type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 554067a2c58573fec0727b725904293466100df0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->