### PR TITLE
Suppress pkg_resources deprecation warning in `inv protoc`

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -54,6 +54,9 @@ def protoc(ctx):
     """Compile protocol buffer files for gRPC and Modal-specific wrappers.
 
     Generates Python stubs for api.proto."""
+    # Suppress pkg_resources deprecation warning from grpcio-tools
+    # See: https://github.com/grpc/grpc/issues/33570
+    protoc_env = {"PYTHONWARNINGS": "ignore:pkg_resources is deprecated"}
     protoc_cmd = f"{sys.executable} -m grpc_tools.protoc"
     client_proto_files = "modal_proto/api.proto"
     task_command_router_proto_file = "modal_proto/task_command_router.proto"
@@ -62,7 +65,7 @@ def protoc(ctx):
     )
     print(py_protoc)
     # generate grpcio and grpclib proto files:
-    ctx.run(f"{py_protoc} -I . {client_proto_files} {task_command_router_proto_file}")
+    ctx.run(f"{py_protoc} -I . {client_proto_files} {task_command_router_proto_file}", env=protoc_env)
 
     # generate modal-specific wrapper around grpclib api stub using custom plugin:
     grpc_plugin_pyfile = Path("protoc_plugin/plugin.py")
@@ -70,7 +73,8 @@ def protoc(ctx):
     with python_file_as_executable(grpc_plugin_pyfile) as grpc_plugin_executable:
         ctx.run(
             f"{protoc_cmd} --plugin=protoc-gen-modal-grpclib-python={grpc_plugin_executable}"
-            + f" --modal-grpclib-python_out=. -I . {client_proto_files}"
+            + f" --modal-grpclib-python_out=. -I . {client_proto_files}",
+            env=protoc_env,
         )
 
 


### PR DESCRIPTION
## Describe your changes

Suppress pkg_resources deprecation warning from grpcio-tools in `inv protoc`:

```
client/.venv/bin/python3 -m grpc_tools.protoc --python_out=. --grpclib_python_out=. --grpc_python_out=. --mypy_out=. --mypy_grpc_out=.
client/.venv/lib/python3.11/site-packages/grpc_tools/protoc.py:21: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
Writing mypy to modal_proto/api_pb2.pyi
Writing mypy to modal_proto/task_command_router_pb2.pyi
Writing mypy to modal_proto/api_pb2_grpc.pyi
Writing mypy to modal_proto/task_command_router_pb2_grpc.pyi
client/.venv/lib/python3.11/site-packages/grpc_tools/protoc.py:21: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
```

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Suppress grpcio-tools pkg_resources deprecation warnings in `inv protoc` by setting PYTHONWARNINGS and passing it to protoc runs.
> 
> - **Tasks**:
>   - **`protoc` (`tasks.py`)**:
>     - Add `protoc_env = {"PYTHONWARNINGS": "ignore:pkg_resources is deprecated"}`.
>     - Pass `env=protoc_env` to both `ctx.run` invocations generating Python/grpc stubs and Modal grpclib wrappers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a87b7e7bdcccf145ed08806e41a6b20513df7c38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->