### PR TITLE
modal shell: enable setting custom mount paths

### DIFF
--- a/modal/cli/shell.py
+++ b/modal/cli/shell.py
@@ -1,6 +1,7 @@
 # Copyright Modal Labs 2022
 import inspect
 import platform
+import posixpath
 import shlex
 from pathlib import Path, PurePosixPath
 from typing import Any, Callable, Optional
@@ -181,6 +182,7 @@ def _start_shell_from_image(
         vol_name, mount_path = _parse_mount(vol_arg)
         if not mount_path:
             mount_path = f"/mnt/{vol_name}"
+        mount_path = posixpath.normpath(mount_path)  # normalize e.g. /mnt/x/ -> /mnt/x, /mnt/../x -> /x
         mount_paths.append(mount_path)
         volumes[mount_path] = Volume.from_name(vol_name)
 
@@ -191,8 +193,9 @@ def _start_shell_from_image(
         if not mount_path:
             mount_path = f"/mnt/{local_path.name}"
 
+        mount_path = posixpath.normpath(mount_path)
         remote_path = PurePosixPath(mount_path)
-        mount_paths.append(str(remote_path))
+        mount_paths.append(mount_path)
         if local_path.is_dir():
             m = _Mount._from_local_dir(local_path, remote_path=remote_path)
         else:

--- a/test/cli_shell_test.py
+++ b/test/cli_shell_test.py
@@ -185,6 +185,24 @@ def test_shell_mount_path_conflict(servicer, set_env_client):
         expected_stderr="Mount path conflict",
     )
 
+    run_cli_command(
+        ["shell", "--volume", "a:/mnt/x/", "--volume", "b:/mnt/x"],
+        expected_exit_code=1,
+        expected_stderr="Mount path conflict",
+    )
+
+    run_cli_command(
+        ["shell", "--volume", "a:/mnt/./x", "--volume", "b:/mnt/x"],
+        expected_exit_code=1,
+        expected_stderr="Mount path conflict",
+    )
+
+    run_cli_command(
+        ["shell", "--volume", "a:/mnt/foo/../x", "--volume", "b:/mnt/x"],
+        expected_exit_code=1,
+        expected_stderr="Mount path conflict",
+    )
+
 
 def test_shell_all_shell_command_params_have_explicit_param_decls():
     sig = inspect.signature(shell)


### PR DESCRIPTION
## Describe your changes

Enable setting custom mount paths, e.g. `modal shell --volume vol:/mnt/x --add-local file.txt:/mnt/y.txt`, and warns if multiple volumes/local files would be mounted at the same path. Follow-up from https://github.com/modal-labs/modal-client/pull/3800#discussion_r2611095882.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

</details>

## Changelog

- Enabled setting custom mount paths when using `modal shell`, e.g. `modal shell --volume volume:/mnt/x --add-local file.txt:/mnt/y.txt`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support for specifying custom mount paths for volumes and local mounts in `modal shell`, with normalization and conflict detection.
> 
> - **CLI (shell)**:
>   - Add `_parse_mount` to parse `source[:mount_path]`, handling Windows drive letters.
>   - Support custom mount paths for `--volume` and `--add-local`; default to `/mnt/{name}` and `/mnt/{basename}` if unspecified.
>   - Normalize mount paths via `posixpath.normpath` and build `volumes` keyed by mount path.
>   - Detect duplicate/conflicting mount paths across volumes/locals and raise a `ClickException`.
> - **Tests**:
>   - Add `test_shell_mount_path_conflict` covering various conflict/normalization cases.
>   - Add `test_parse_mount` for parsing behavior; update imports accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a85e6117a8127981b7c7a3c7c5b44402979acfaf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->