### PR TITLE
Ignore a deprecation warning currently triggered by pytest-freezegun

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ filterwarnings = [
     "ignore:Type google._upb.*MapContainer uses PyType_Spec.*Python 3.14:DeprecationWarning",
     "error::modal.exception.DeprecationError",
     "ignore:There is no current event loop:DeprecationWarning",  # pytest-asyncio internals
+    "ignore:distutils Version classes are deprecated:DeprecationWarning",  # pytest-freezegun internals
 ]
 
 [tool.ruff]


### PR DESCRIPTION
Popped up after we narrowed the filters in https://github.com/modal-labs/modal-client/pull/3809

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a pytest filter to ignore the deprecated distutils Version warning emitted by pytest-freezegun.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a1b4c8ef77a6751b8e667dc5c46e6710654656b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->