### PR TITLE
Rename max_inputs -> single_use_containers

### DIFF
--- a/modal/_functions.py
+++ b/modal/_functions.py
@@ -694,7 +694,7 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
         # Experimental: Clustered functions
         cluster_size: Optional[int] = None,
         rdma: Optional[bool] = None,
-        single_use: bool = False,
+        single_use_containers: bool = False,
         ephemeral_disk: Optional[int] = None,
         include_source: bool = True,
         experimental_options: Optional[dict[str, str]] = None,
@@ -1016,8 +1016,8 @@ class _Function(typing.Generic[P, ReturnType, OriginalReturnType], _Object, type
                     object_dependencies=object_dependencies,
                     block_network=block_network,
                     untrusted=restrict_modal_access,
-                    single_use=single_use,
-                    max_inputs=int(single_use),  # TODO(michael) remove after worker rollover
+                    single_use_containers=single_use_containers,
+                    max_inputs=int(single_use_containers),  # TODO(michael) remove after worker rollover
                     cloud_bucket_mounts=cloud_bucket_mounts_to_proto(cloud_bucket_mounts),
                     scheduler_placement=scheduler_placement,
                     is_class=info.is_service_class(),

--- a/modal/_runtime/container_io_manager.py
+++ b/modal/_runtime/container_io_manager.py
@@ -846,8 +846,8 @@ class _ContainerIOManager:
                     yielded = True
 
                     # TODO(michael): Remove use of max_inputs after worker rollover
-                    single_use = self.function_def.single_use or self.function_def.max_inputs == 1
-                    if final_input_received or single_use:
+                    single_use_container = self.function_def.single_use_containers or self.function_def.max_inputs == 1
+                    if final_input_received or single_use_container:
                         return
             finally:
                 if not yielded:

--- a/modal/app.py
+++ b/modal/app.py
@@ -725,7 +725,7 @@ class _App:
         enable_memory_snapshot: bool = False,  # Enable memory checkpointing for faster cold starts.
         block_network: bool = False,  # Whether to block network access
         restrict_modal_access: bool = False,  # Whether to allow this function access to other Modal resources
-        single_use: bool = False,  # When True, containers will shut down after handling a single input
+        single_use_containers: bool = False,  # When True, containers will shut down after handling a single input
         i6pn: Optional[bool] = None,  # Whether to enable IPv6 container networking within the region.
         # Whether the file or directory containing the Function's source should automatically be included
         # in the container. When unset, falls back to the App-level configuration, or is otherwise True by default.
@@ -740,7 +740,7 @@ class _App:
         concurrency_limit: Optional[int] = None,  # Replaced with `max_containers`
         container_idle_timeout: Optional[int] = None,  # Replaced with `scaledown_window`
         allow_concurrent_inputs: Optional[int] = None,  # Replaced with the `@modal.concurrent` decorator
-        max_inputs: Optional[int] = None,  # Replaced with `single_use`
+        max_inputs: Optional[int] = None,  # Replaced with `single_use_containers`
         _experimental_buffer_containers: Optional[int] = None,  # Now stable API with `buffer_containers`
         _experimental_scheduler_placement: Optional[SchedulerPlacement] = None,  # Replaced in favor of
         # using `region` and `nonpreemptible`
@@ -772,10 +772,10 @@ class _App:
                 raise InvalidError("Only `max_inputs=1` is currently supported")
             deprecation_warning(
                 (2025, 12, 16),
-                "The `max_inputs` parameter is deprecated. Please set `single_use=True` instead.",
+                "The `max_inputs` parameter is deprecated. Please set `single_use_containers=True` instead.",
                 pending=True,
             )
-            single_use = max_inputs == 1
+            single_use_containers = max_inputs == 1
 
         if _experimental_scheduler_placement is not None:
             deprecation_warning(
@@ -925,7 +925,7 @@ class _App:
                 enable_memory_snapshot=enable_memory_snapshot,
                 block_network=block_network,
                 restrict_modal_access=restrict_modal_access,
-                single_use=single_use,
+                single_use_containers=single_use_containers,
                 i6pn_enabled=i6pn_enabled,
                 cluster_size=cluster_size,  # Experimental: Clustered functions
                 rdma=rdma,
@@ -982,7 +982,7 @@ class _App:
         enable_memory_snapshot: bool = False,  # Enable memory checkpointing for faster cold starts.
         block_network: bool = False,  # Whether to block network access
         restrict_modal_access: bool = False,  # Whether to allow this class access to other Modal resources
-        single_use: bool = False,  # When True, containers will shut down after handling a single input
+        single_use_containers: bool = False,  # When True, containers will shut down after handling a single input
         i6pn: Optional[bool] = None,  # Whether to enable IPv6 container networking within the region.
         include_source: Optional[bool] = None,  # When `False`, don't automatically add the App source to the container.
         experimental_options: Optional[dict[str, Any]] = None,
@@ -995,7 +995,7 @@ class _App:
         concurrency_limit: Optional[int] = None,  # Replaced with `max_containers`
         container_idle_timeout: Optional[int] = None,  # Replaced with `scaledown_window`
         allow_concurrent_inputs: Optional[int] = None,  # Replaced with the `@modal.concurrent` decorator
-        max_inputs: Optional[int] = None,  # Replaced with `single_use`
+        max_inputs: Optional[int] = None,  # Replaced with `single_use_containers`
         _experimental_buffer_containers: Optional[int] = None,  # Now stable API with `buffer_containers`
         _experimental_scheduler_placement: Optional[SchedulerPlacement] = None,  # Replaced in favor of
         # using `region` and `nonpreemptible`
@@ -1023,10 +1023,10 @@ class _App:
                 raise InvalidError("Only `max_inputs=1` is currently supported")
             deprecation_warning(
                 (2025, 12, 16),
-                "The `max_inputs` parameter is deprecated. Please set `single_use=True` instead.",
+                "The `max_inputs` parameter is deprecated. Please set `single_use_containers=True` instead.",
                 pending=True,
             )
-            single_use = max_inputs == 1
+            single_use_containers = max_inputs == 1
 
         if _experimental_scheduler_placement is not None:
             deprecation_warning(
@@ -1165,7 +1165,7 @@ class _App:
                 enable_memory_snapshot=enable_memory_snapshot,
                 block_network=block_network,
                 restrict_modal_access=restrict_modal_access,
-                single_use=single_use,
+                single_use_containers=single_use_containers,
                 http_config=http_config,
                 i6pn_enabled=i6pn_enabled,
                 cluster_size=cluster_size,

--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -1470,7 +1470,7 @@ message Function {
   bool block_network = 44;
 
   // In the SDK, we've deprecated `max_inputs` (which only every implemented `max_inputs=1`)
-  // in favor of a boolean `single_use` parameter.
+  // in favor of a boolean `single_use_containers` parameter.
   uint32 max_inputs = 46;
 
   repeated S3Mount s3_mounts = 47;
@@ -1559,7 +1559,7 @@ message Function {
   // when the user provided a custom name= for the Function inside the Application namespace
   string implementation_name = 90;
 
-  bool single_use = 91; // When True, containers will shut down after handling a single input
+  bool single_use_containers = 91; // When True, containers will shut down after handling a single input
 
 }
 

--- a/test/function_test.py
+++ b/test/function_test.py
@@ -2107,10 +2107,10 @@ def test_restrict_modal_access(client, servicer):
     assert ctx.get_requests("FunctionCreate")[0].function.untrusted == False
 
 
-def test_single_use(client, servicer):
+def test_single_use_containers(client, servicer):
     app = App(include_source=False)
 
-    @app.function(serialized=True, single_use=True)
+    @app.function(serialized=True, single_use_containers=True)
     def f():
         pass
 
@@ -2120,13 +2120,13 @@ def test_single_use(client, servicer):
 
     request = ctx.pop_request("FunctionCreate")
     assert request.function.max_inputs == 1
-    assert request.function.single_use == True
+    assert request.function.single_use_containers == True
 
 
 def test_max_inputs(client, servicer):
     app = App(include_source=False)
 
-    with pytest.warns(PendingDeprecationError, match=r"`max_inputs`.+`single_use=True`"):
+    with pytest.warns(PendingDeprecationError, match=r"`max_inputs`.+`single_use_containers=True`"):
         decorator = app.function(serialized=True, max_inputs=1)
 
     @decorator
@@ -2139,7 +2139,7 @@ def test_max_inputs(client, servicer):
 
     request = ctx.pop_request("FunctionCreate")
     assert request.function.max_inputs == 1
-    assert request.function.single_use == True
+    assert request.function.single_use_containers == True
 
     with pytest.raises(InvalidError, match="`max_inputs=1`"):
         app.function(max_inputs=2)


### PR DESCRIPTION
## Describe your changes

- Closes SDK-665

This contains both proto changes and logic changes in one PR. The reads in the container entrypoint are designed to be forward and backward compatible so that it is not necessary to wait for worker rollover.

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [x] Client+Server: this change is compatible with old servers
- [x] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.

</details>

## Changelog

- The `max_inputs` parameter in the `@app.function()` and `@app.cls` decorators has been renamed to `single_use_containers` and now takes a boolean value rather than an integer. Note that only `max_inputs=1` had been supported, so this has no functional implications. This change is being made to reduce confusion with `@modal.concurrent(max_inputs=...)` and so that Modal's autoscaler can provide better performance for Functions with single-use containers.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce single_use_containers boolean (deprecating max_inputs) and wire it through decorators, protobuf, function creation, and container runtime with rollout-safe compatibility.
> 
> - **API (Decorators)**:
>   - Add `single_use_containers` to `@app.function()` and `@app.cls()`; validate and set single-use behavior.
>   - Deprecate `max_inputs` with warnings; map `max_inputs=1` to `single_use_containers=True`.
> - **Function creation**:
>   - Send `function.single_use_containers` and temporarily also `max_inputs=int(single_use_containers)` for compatibility.
> - **Runtime**:
>   - Containers terminate after one input when `function_def.single_use_containers` (or legacy `max_inputs==1`).
> - **Protobuf**:
>   - Add `Function.single_use_containers` (field 91); retain `max_inputs` with deprecation note.
> - **Tests**:
>   - Add tests covering `single_use_containers`, deprecated `max_inputs`, and request proto assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e304b98585cfd48729045e7f41ff37e3c85cbf0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->