### PR TITLE
Add modal logo to setup

### DIFF
--- a/modal/cli/entry_point.py
+++ b/modal/cli/entry_point.py
@@ -85,6 +85,8 @@ def check_path():
 
 @synchronizer.create_blocking
 async def setup(profile: Optional[str] = None):
+    check_path()
+
     art = """
            #############        #############
           ####         ##      ####         ##
@@ -107,7 +109,6 @@ async def setup(profile: Optional[str] = None):
 
     console = make_console()
     console.print(art, style="green")
-    check_path()
 
     # Fetch a new token (same as `modal token new` but redirect to /home once finishes)
     await _new_token(profile=profile, next_url="/home")


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Show a green ASCII Modal logo during `modal setup` before fetching a token.
> 
> - **CLI**:
>   - **Setup (`modal/cli/entry_point.py::setup`)**: Print a green ASCII Modal logo via `console.print(...)` before calling `_new_token()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 018fc63ffc7faccf57d8d116375b04d6447dffc5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->