### PR TITLE
Increase timeout for GPU memory snapshot operations

### DIFF
--- a/modal/_runtime/container_io_manager.py
+++ b/modal/_runtime/container_io_manager.py
@@ -991,12 +991,10 @@ class _ContainerIOManager:
         # Busy-wait for restore. `/__modal/restore-state.json` is created
         # by the worker process with updates to the container config.
         restored_path = Path(config.get("restore_state_path"))
-        start = time.perf_counter()
+        logger.debug("Waiting for restore")
         while not restored_path.exists():
-            logger.debug(f"Waiting for restore (elapsed={time.perf_counter() - start:.3f}s)")
             await asyncio.sleep(0.01)
             continue
-
         logger.debug("Container: restored")
 
         # Look for state file and create new client with updated credentials.


### PR DESCRIPTION
This increases the timeout on each invocation of `cuda-checkpoint --toggle`, which ensures that larger checkpoints have enough time to restore. In the worst case, 0% of the checkpoint file is preloaded from the network, and at a degraded 200MB/s download this timeout allows for a ~36GB checkpoint, as opposed to an ~18GB one.

This also increases the timeout on the first `cuda-checkpoint --get-state`, which, as per the old comment, "should be quick" which in fact is not the case; we've seen many instances of this 5s timeout being hit in production.

Unrelated, this also fixes a bug where the `Waiting for restore` logline floods the screen by printing every 10ms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase CUDA checkpoint timeouts and retries (including get-state), and log restore wait only once to avoid flooding.
> 
> - **GPU memory snapshot (`modal/_runtime/gpu_memory_snapshot.py`)**:
>   - Increase per-invocation timeout: set `CUDA_CHECKPOINT_TIMEOUT` to 3m.
>   - Add `CUDA_CHECKPOINT_TOGGLE_NUM_RETRIES=3` and derive `CUDA_CHECKPOINT_TOGGLE_TIMEOUT` from it.
>   - Use new constants in toggle logic and apply extended timeout to `--get-state` checks.
> - **Container runtime (`modal/_runtime/container_io_manager.py`)**:
>   - Avoid log spam by logging `"Waiting for restore"` once while polling for the restore state file.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc11dcd8c2855e4327ba60054e6c1dbf4d9a2e4d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->