### PR TITLE
Release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,26 +6,13 @@ This changelog documents user-facing updates (features, enhancements, fixes, and
 
 <!-- NEW CONTENT GENERATED BELOW. PLEASE PRESERVE THIS COMMENT. -->
 
-#### 1.2.7.dev7 (2025-12-18)
-
-- The `max_inputs` parameter in the `@app.function()` and `@app.cls` decorators has been renamed to `single_use_containers` and now takes a boolean value rather than an integer. Note that only `max_inputs=1` had been supported, so this has no functional implications. This change is being made to reduce confusion with `@modal.concurrent(max_inputs=...)` and so that Modal's autoscaler can provide better performance for Functions with single-use containers.
-
-
-#### 1.2.7.dev6 (2025-12-17)
-
-* Removed `replace_bytes` and `delete_bytes` from Sandbox FileIO
-
-
-#### 1.2.7.dev2 (2025-12-17)
+#### 1.3.0 (2025-12-19)
 
 - The Modal SDK will no longer propagate `grpclib.GRPCError` types out to the user; our own `modal.Error` subtypes will be used instead. To avoid disrupting user code that has relied on `GRPCError` exceptions for control flow, we are temporarily making some exception types subclass `GRPCError` so that they will also be caught by `except grpclib.GRPCError` statements. Accessing the `.status` attribute of the exception will issue a deprecation warning, but warnings cannot be issued if the exception object is only caught and there is no other interaction with it. We advise proactively migrating any exception handling to use Modal types. as we will remove the dependency on `grpclib` types entirely in the future.
-
-
-#### 1.2.7.dev1 (2025-12-16)
-
 - The minimum supported Python version is now 3.10, because Python 3.9 has reached EOL.
+- The `max_inputs` parameter in the `@app.function()` and `@app.cls` decorators has been renamed to `single_use_containers` and now takes a boolean value rather than an integer. Note that only `max_inputs=1` had been supported, so this has no functional implications. This change is being made to reduce confusion with `@modal.concurrent(max_inputs=...)` and so that Modal's autoscaler can provide better performance for Functions with single-use containers.
 - Images built with `modal.Image.micromamba()` using the 2023.12 [Image Builder Version](https://modal.com/docs/guide/images#image-builder-updates) will now use a Python version that matches their local environment by default, rather than defaulting to Python 3.9.
-
+* Removed `replace_bytes` and `delete_bytes` from Sandbox FileIO
 
 #### 1.2.6 (2025-12-16)
 

--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -1,4 +1,4 @@
 # Copyright Modal Labs 2025
 """Supplies the current version of the modal client library."""
 
-__version__ = "1.2.7.dev13"
+__version__ = "1.3.0"


### PR DESCRIPTION
## Describe your changes

Release v1.3.0

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [x] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [x] Changelog has been cleaned up and given an appropriate subhead

---

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps version to 1.3.0 and updates CHANGELOG with exception type changes, Python 3.10 minimum, `single_use_containers` rename, micromamba Python matching, and Sandbox FileIO removals.
> 
> - **Release 1.3.0**:
>   - **Exceptions**: SDK stops propagating `grpclib.GRPCError`; uses `modal.Error` subtypes (temporary subclassing for compatibility).
>   - **Python Support**: Minimum supported version now `3.10`.
>   - **API Rename**: `max_inputs` in `@app.function()`/`@app.cls` → `single_use_containers: bool`.
>   - **Images**: `Image.micromamba()` defaults Python to match local env for 2023.12 image builder.
>   - **Sandbox FileIO**: Removed `replace_bytes` and `delete_bytes`.
> - **Version**:
>   - Update `modal_version/__init__.py` `__version__` → `"1.3.0"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6f48f8b795de9f89ede89a7be97d363676072e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->