### PR TITLE
Release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,28 +6,23 @@ This changelog documents user-facing updates (features, enhancements, fixes, and
 
 <!-- NEW CONTENT GENERATED BELOW. PLEASE PRESERVE THIS COMMENT. -->
 
-#### 1.2.7.dev7 (2025-12-18)
+### 1.3.0 (2025-12-19)
 
-- The `max_inputs` parameter in the `@app.function()` and `@app.cls` decorators has been renamed to `single_use_containers` and now takes a boolean value rather than an integer. Note that only `max_inputs=1` had been supported, so this has no functional implications. This change is being made to reduce confusion with `@modal.concurrent(max_inputs=...)` and so that Modal's autoscaler can provide better performance for Functions with single-use containers.
+Modal now supports Python 3.14. Support for Python 3.14t (the free-threading build) is still experimental; please report any issues you encounter using Modal with free-threading Python. Additionally, Modal no longer supports Python 3.9, which has reached [end-of-life](https://devguide.python.org/versions).
 
+We are adding experimental support for detecting cases where Modal's blocking APIs are used in async contexts (which can be a source of bugs or performance issues). You can opt into runtime warnings by setting `MODAL_ASYNC_WARNINGS=1` as an environment variable or `async_warnings = true` as a config field. We will enable these warnings by default in the future; please report any apparent false positives or other issues while support is experimental.
 
-#### 1.2.7.dev6 (2025-12-17)
+This release also includes a small number of deprecations and behavioral changes:
 
-* Removed `replace_bytes` and `delete_bytes` from Sandbox FileIO
-
-
-#### 1.2.7.dev2 (2025-12-17)
-
-- The Modal SDK will no longer propagate `grpclib.GRPCError` types out to the user; our own `modal.Error` subtypes will be used instead. To avoid disrupting user code that has relied on `GRPCError` exceptions for control flow, we are temporarily making some exception types subclass `GRPCError` so that they will also be caught by `except grpclib.GRPCError` statements. Accessing the `.status` attribute of the exception will issue a deprecation warning, but warnings cannot be issued if the exception object is only caught and there is no other interaction with it. We advise proactively migrating any exception handling to use Modal types. as we will remove the dependency on `grpclib` types entirely in the future.
-
-
-#### 1.2.7.dev1 (2025-12-16)
-
-- The minimum supported Python version is now 3.10, because Python 3.9 has reached EOL.
+- The Modal SDK will no longer propagate `grpclib.GRPCError` types out to the user; our own `modal.Error` subtypes will be used instead. To avoid disrupting user code that has relied on `GRPCError` exceptions for control flow, we are temporarily making some exception types inherit from `GRPCError` so that they will also be caught by `except grpclib.GRPCError` statements. Accessing the `.status` attribute of the exception will issue a deprecation warning, but warnings cannot be issued if the exception object is only caught and there is no other interaction with it. We advise proactively migrating any exception handling to use Modal types, as we will remove the dependency on `grpclib` types entirely in the future. See the [`modal.exception`](https://modal.com/docs/reference/modal.exception) docs for the mapping from gRPC status codes to Modal exception types.
+- The `max_inputs` parameter in the `@app.function()` and `@app.cls` decorators has been renamed to `single_use_containers` and now takes a boolean value rather than an integer. Note that only `max_inputs=1` has been supported, so this has no functional implications. This change is being made to reduce confusion with `@modal.concurrent(max_inputs=...)` and so that Modal's autoscaler can provide better performance for Functions with single-use containers.
+- The async (`.aio`) interface has been deprecated from `modal.FunctionCall.from_id`, `modal.Image.from_id`, and `modal.SandboxSnapshot.from_id`, because these methods do not perform I/O.
+- The `replace_bytes` and `delete_bytes` methods have been removed from the `modal.file_io` filesystem interface.
 - Images built with `modal.Image.micromamba()` using the 2023.12 [Image Builder Version](https://modal.com/docs/guide/images#image-builder-updates) will now use a Python version that matches their local environment by default, rather than defaulting to Python 3.9.
 
+## 1.2
 
-#### 1.2.6 (2025-12-16)
+### 1.2.6 (2025-12-16)
 
 - Fixed bug where iterating on a `modal.Sandbox.exec` output stream could raise unauthenticated errors.
 

--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -1,4 +1,4 @@
 # Copyright Modal Labs 2025
 """Supplies the current version of the modal client library."""
 
-__version__ = "1.2.7.dev14"
+__version__ = "1.3.0"


### PR DESCRIPTION
## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [x] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [x] Changelog has been cleaned up and given an appropriate subhead

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps version to 1.3.0 and updates CHANGELOG with Python 3.14 support, Python 3.9 removal, async-usage warnings, and several deprecations/renames.
> 
> - **Release**:
>   - Bump client version to `1.3.0` in `modal_version/__init__.py`.
> - **Changelog** (`CHANGELOG.md`):
>   - Add notes for `1.3.0 (2025-12-19)`.
>     - Support Python `3.14`; drop Python `3.9`.
>     - Experimental async-context warnings via `MODAL_ASYNC_WARNINGS`/`async_warnings`.
>     - Deprecations/changes:
>       - Stop propagating `grpclib.GRPCError`; use `modal.Error` subtypes (temporary inheritance for compatibility; deprecate `.status`).
>       - Rename `max_inputs` to boolean `single_use_containers` in `@app.function()` / `@app.cls`.
>       - Deprecate async `.aio` interface on `FunctionCall.from_id`, `Image.from_id`, `SandboxSnapshot.from_id`.
>       - Remove `modal.file_io` methods `replace_bytes` and `delete_bytes`.
>       - `Image.micromamba()` (2023.12) defaults Python to match local env.
>   - Normalize headings under `1.2` (e.g., `### 1.2.6`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5277398796a059090e6fb3854ca1ece9d25b579. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->