### PR TITLE
Fix docstring and do a post release

### DIFF
--- a/modal/exception.py
+++ b/modal/exception.py
@@ -167,7 +167,7 @@ class ResourceExhaustedError(Error, _GRPCErrorWrapper):
 
 
 class ServiceError(Error, _GRPCErrorWrapper):
-    """Raised when an error occurs in basic client<>server communication."""
+    """Raised when an error occurs in basic client/server communication."""
 
 
 class UnimplementedError(Error, _GRPCErrorWrapper):

--- a/modal_version/__init__.py
+++ b/modal_version/__init__.py
@@ -1,4 +1,4 @@
 # Copyright Modal Labs 2025
 """Supplies the current version of the modal client library."""
 
-__version__ = "1.3.0"
+__version__ = "1.3.0.post1"


### PR DESCRIPTION
One of the new exception types has a `<>` in its docstring, which is breaking the frontend build. I'm fixing it as a "post release".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace angle brackets in `ServiceError` docstring and bump version to `1.3.0.post1`.
> 
> - **Exceptions**:
>   - Update `ServiceError` docstring in `modal/exception.py` to use `client/server` instead of `client<>server`.
> - **Versioning**:
>   - Bump client version in `modal_version/__init__.py` to `1.3.0.post1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb58153d475bcb378408f5c702c22b9cdedce39e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->