### PR TITLE
Update aiohttp to `3.13.2` for Python 3.14 mounts

### DIFF
--- a/modal/builder/2025.06.txt
+++ b/modal/builder/2025.06.txt
@@ -1,7 +1,8 @@
 aiohappyeyeballs==2.6.1
 aiohttp==3.12.7 ; python_version < "3.14"
 aiohttp==3.13.2 ; python_version >= "3.14"
-aiosignal==1.3.2
+aiosignal==1.3.2 ; python_version < "3.14"
+aiosignal==1.4.0 ; python_version >= "3.14"
 async-timeout==5.0.1 ; python_version < "3.11"
 attrs==25.3.0
 cbor2==5.7.0


### PR DESCRIPTION
## Describe your changes

`aiohttp` is a compiled library that needs to be updated to `[3.13.2](https://pypi.org/project/aiohttp/3.13.2/#files)` to get Python 3.14 wheels.

I'm surprised that the CI did not catch this incompatibility. [Here is the Github action](https://github.com/modal-labs/modal-client/actions/runs/20383019162/job/58578386732) that first created the mount.

The Python 3.14 aiohttp mount somehow pulled in 311 wheel:

![Screenshot 2025-12-22 at 12 39 18 PM](https://github.com/user-attachments/assets/0e955499-44f0-4d1c-8f21-1940f7f95bd4)

This still works because aiohttp has a fallback to a Python implementation:

https://github.com/aio-libs/aiohttp/blob/963ca76708cd4bc52e726db10fd296c2025d003e/aiohttp/http_writer.py#L383-L390


<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add Python 3.14-specific pins for `aiohttp` (3.13.2) and `aiosignal` (1.4.0) in builder requirements.
> 
> - **Dependencies**:
>   - Update `modal/builder/2025.06.txt` to add Python-version-specific pins:
>     - `aiohttp`: `3.12.7` for `python_version < "3.14"`, `3.13.2` for `python_version >= "3.14"`.
>     - `aiosignal`: `1.3.2` for `python_version < "3.14"`, `1.4.0` for `python_version >= "3.14"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42b5eb325206f0be11fbc6d76dec72bf27d60575. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->