### PR TITLE
Add allow_override in _create_client_dependency_mounts

### DIFF
--- a/modal/mount.py
+++ b/modal/mount.py
@@ -860,6 +860,7 @@ async def _create_client_dependency_mounts(
     coros = []
     for python_version in python_versions:
         for builder_version in builder_versions:
+            builder_is_preview = builder_version == "PREVIEW"
             for platform, uv_python_platform in platform_tags:
                 coros.append(
                     _create_single_client_dependency_mount(
@@ -872,8 +873,8 @@ async def _create_client_dependency_mounts(
                         # This check_if_exists / allow_overwrite parameterization is very awkward
                         # Also it doesn't provide a hook for overwriting a non-preview version, which
                         # in theory we may need to do at some point (hopefully not, but...)
-                        check_if_exists=check_if_exists and builder_version != "PREVIEW",
-                        allow_overwrite=allow_overwrite or builder_version == "PREVIEW",
+                        check_if_exists=check_if_exists and not builder_is_preview,
+                        allow_overwrite=allow_overwrite or builder_is_preview,
                         dry_run=dry_run,
                     )
                 )


### PR DESCRIPTION
## Describe your changes

With this option, we can manually call `_create_client_dependency_mounts` with `_allow_override=True`

<details> <summary>Checklists</summary>

---

## Compatibility checklist

Check these boxes or delete any item (or this section) if not relevant for this PR.

- [ ] Client+Server: this change is compatible with old servers
- [ ] Client forward compatibility: this change ensures client can accept data intended for later versions of itself

Note on protobuf: protobuf message changes in one place may have impact to
multiple entities (client, server, worker, database). See points above.


---

## Release checklist

If you intend for this commit to trigger a full release to PyPI, please ensure that the following steps have been taken:

- [ ] Version file (`modal_version/__init__.py`) has been updated with the next logical version
- [ ] Changelog has been cleaned up and given an appropriate subhead

---

</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allows explicitly overwriting client dependency mounts and simplifies preview logic.
> 
> - Adds `allow_overwrite` option to `_create_client_dependency_mounts` and threads it to `_create_single_client_dependency_mount`
> - Refactors preview handling (`builder_is_preview`) so `check_if_exists` is skipped for preview builds and `allow_overwrite` is enabled when preview or explicitly requested
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9eee25c321d8fd81be3989b21b9b1c2b13175749. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->