### PR TITLE
Add image_id to SandboxInfo

### DIFF
--- a/modal_proto/api.proto
+++ b/modal_proto/api.proto
@@ -2886,7 +2886,7 @@ message SandboxInfo {
   string app_id = 5;
   repeated SandboxTag tags = 6; // TODO: Not yet exposed in client library.
   string name = 7;
-
+  string image_id = 8;
   reserved 2; // modal.client.Sandbox definition
 }
 


### PR DESCRIPTION
Needed to show image ID in the sandbox drawer

From Figma:
<img width="588" height="329" alt="Screenshot 2025-12-23 at 10 30 19 AM" src="https://github.com/user-attachments/assets/092d2dc9-af64-44d1-bc57-d170202c6d6e" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Exposes the image ID in sandbox metadata.
> 
> - Adds `image_id` (field 8) to `SandboxInfo` so clients/UIs can read a sandbox's image ID
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0be94795206207f61529607ffbc337d57658c698. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->